### PR TITLE
 Documentaton: Add space-usage documentation; Fix #329 

### DIFF
--- a/tools/space-usage/README.rst
+++ b/tools/space-usage/README.rst
@@ -1,0 +1,39 @@
+Space Reporting in JSON Format
+==============================
+
+If a site uses XRootD and WebDAV doors provided by native software (e.g. `XRootD <http://xrootd.org/>`_)
+without running a full suite of Grid middleware (such as `dCache <https://www.dcache.org/>`_), space reporting has to be provided externally.
+
+This is facilitated with a JSON file which the site has to update at least every 2 hours (e.g. via cron job).
+
+
+Generating the file
+-------------------
+Sample content of this file is provided within this folder of the repository in
+`space-usage-sample.json <https://github.com/rucio/rucio/blob/master/tools/space-usage/space-usage-sample.json>`_.
+
+The approach to retrieve the space-usage data is necessarily site-specific, if the underlying file system is a POSIX parallel cluster filesystem (e.g. BeeGFS, Lustre), the best performing way is usually to rely on the quota accounting provided by the file system.
+
+It should be noted that the ``num_files`` field is optional, which may help in the situation that no central accounting is available and the full file tree has to be walked to extract the space usage information.
+
+All units in the `space-usage-sample.json <https://github.com/rucio/rucio/blob/master/tools/space-usage/space-usage-sample.json>`_ file are in *bytes*. A Python script and schema for easy validation are also provided.
+
+
+Providing the File
+------------------
+The space usage file has to be provided via HTTPS, usually this can be easily done using an existing WebDAVs door.
+For example, the file can be exported from the exported endpoint directory.
+
+An ATLAS specific example including AGIS setup is provided on `ATLAS Computing twiki <https://twiki.cern.ch/twiki/bin/view/AtlasComputing/DDMOperationsGroup#SRM_less_space_reporting>`_.
+
+
+Testing it works
+----------------
+You should test your created JSON file against the JSON schema provided in this repository (`space-usage-schema.json <https://github.com/rucio/rucio/blob/master/tools/space-usage/space-usage-schema.json>`_).
+A Python script `validate-space-usage-json-file <https://github.com/rucio/rucio/blob/master/tools/space-usage/validate-space-usage-json-file>`_ is provided for convenience.
+
+To test the new space reporting is picked up, you can use the command::
+
+  rucio-admin rse info NAME_OF_SPACETOKEN
+
+Additionally, the monitoring information should show up at `ADC DDM Mon <http://adc-ddm-mon.cern.ch/ddmusr01/>`_.

--- a/tools/space-usage/space-usage-sample.json
+++ b/tools/space-usage/space-usage-sample.json
@@ -1,33 +1,32 @@
 {
    "ATLASLOCALGROUPDISK":{
       "status":"online",
-      "total_space":5000000000,
+      "total_space":50000000000000,
       "list_of_paths":[
          "/castor/ads.rl.ac.uk/prod/atlas/stripInput/atlasdatadisk/"
       ],
-      "used_space":2000000000,
+      "used_space":1270000000000,
       "num_files":123456,
       "time_stamp":1447936989,
       "status_message":"The report can not be created because ..."
    },
    "ATLASSCRATCHDISK":{
       "status":"offline",
-      "total_space":5000000000,
+      "total_space":50000000000000,
       "list_of_paths":[
          "/castor/ads.rl.ac.uk/prod/atlas/stripInput/atlasdatadisk/"
       ],
-      "used_space":2000000000,
-      "num_files":123456,
+      "used_space":1270000000000,
       "time_stamp":1447936989,
       "status_message":"The report can not be created because ..."
    },
    "ATLASDATADISK":{
       "status":"online",
-      "total_space":5000000000,
+      "total_space":100000000000000,
       "list_of_paths":[
          "/castor/ads.rl.ac.uk/prod/atlas/stripInput/atlasdatadisk/"
       ],
-      "used_space":2000000000,
+      "used_space":4270000000000,
       "num_files":123456,
       "time_stamp":1447936989,
       "status_message":"The report can not be created because ..."

--- a/tools/space-usage/space-usage-schema.json
+++ b/tools/space-usage/space-usage-schema.json
@@ -15,24 +15,30 @@
                "type":"string"
             },
             "total_space":{
-               "type":"integer"
+               "type":"integer",
+               "description":"total available space in bytes"
             },
             "used_space":{
-               "type":"integer"
+               "type":"integer",
+               "description":"total used space in bytes"
             },
             "num_files":{
-               "type":"integer"
+               "type":"integer",
+               "description":"total files (optional field)"
             },
             "time_stamp":{
-               "type":"integer"
+               "type":"integer",
+               "description":"UNIX timestamp of last update"
             },
             "list_of_paths":{
                "type":"array",
                "items":{
                   "type":"string"
-               }
+               },
+               "description":"list of storage paths"
             }
-         }
+         },
+         "required": ["status", "status_message", "total_space", "used_space", "time_stamp", "list_of_paths"]
       }
    },
    "additionalProperties":false


### PR DESCRIPTION
This improves on the numbers provided in the `space-usage-sample.json` to be more realistic and reduce the probability of confusing the units, and adds a new `README.rst` detailing the setup of JSON space reporting for a site. 

Please let me know if the documentation is fine, or something should be changed / added to establish best practices. 