### PR TITLE
[client] Automatically discover X509 proxy using GSI rules.  Fix #323

### DIFF
--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -12,6 +12,7 @@
 # - Ralph Vigne, <ralph.vigne@cern.ch>, 2015
 # - Martin Barisits, <martin.barisits@cern.ch>, 2017
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2017
+# - Brian Bockelman, <bbockelm@cse.unl.edu>, 2017
 #
 # Client class for callers of the Rucio system
 

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -25,7 +25,7 @@ from rucio.common.utils import build_url, get_tmp_dir, my_key_generator, parse_r
 from rucio import version
 
 from logging import getLogger, StreamHandler, ERROR
-from os import environ, fdopen, path, makedirs
+from os import environ, fdopen, path, makedirs, geteuid
 from shutil import move
 from tempfile import mkstemp
 from urlparse import urlparse
@@ -136,7 +136,22 @@ class BaseClient(object):
                     self.creds['client_cert'] = path.abspath(path.expanduser(path.expandvars(config_get('client', 'client_cert'))))
                     self.creds['client_key'] = path.abspath(path.expanduser(path.expandvars(config_get('client', 'client_key'))))
                 elif self.auth_type == 'x509_proxy':
-                    self.creds['client_proxy'] = path.abspath(path.expanduser(path.expandvars(config_get('client', 'client_x509_proxy'))))
+                    try:
+                        self.creds['client_proxy'] = path.abspath(path.expanduser(path.expandvars(config_get('client', 'client_x509_proxy'))))
+                    except NoOptionError as error:
+                        # Recreate the classic GSI logic for locating the proxy:
+                        # - $X509_USER_PROXY, if it is set.
+                        # - /tmp/x509up_u`id -u` otherwise.
+                        # If neither exists (at this point, we don't care if it exists but is invalid), then rethrow
+                        if 'X509_USER_PROXY' in environ:
+                            self.creds['client_proxy'] = environ['X509_USER_PROXY']
+                        else:
+                            fname = '/tmp/x509up_u%d' % geteuid()
+                            if path.exists(fname):
+                                self.creds['client_proxy'] = path
+                            else:
+                                raise MissingClientParameter('Cannot find a valid X509 proxy; not in %s, $X509_USER_PROXY not set, and '
+                                                             '\'x509_proxy\' not set in the configuration file.' % fname)
                 elif self.auth_type == 'ssh':
                     self.creds['ssh_private_key'] = path.abspath(path.expanduser(path.expandvars(config_get('client', 'ssh_private_key'))))
             except (NoOptionError, NoSectionError) as error:


### PR DESCRIPTION
With this, the rucio client will automatically discover the X509 proxy when not in `rucio.cfg`, using the classic GSI rules:
- `$X509_USER_PROXY` if set,
- `/tmp/x509up_u$(id -u)` if it exists.

If none of these work, the client will give an error along the following lines:

```
2017-12-11 11:23:19,385 ERROR [Client parameters are missing.
Details: Cannot find a valid X509 proxy; not in /tmp/x509up_u1221, $X509_USER_PROXY not set, and 'x509_proxy' not set in the configuration file.]
```

Equivalent to #324 for the `next` branch.