### PR TITLE
Allow more explicit control of the LFN and PFN.

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -901,7 +901,6 @@ def upload(args):
         return FAILURE
     list_files = []
     files_to_list = []
-    lfns = {}
     revert_dict = {}
     if args.scope:
         fscope = args.scope
@@ -968,9 +967,6 @@ def upload(args):
                 logger.debug('Automatically setting new GUID')
                 current_file_info['meta']['guid'] = generate_uuid()
             list_files.append(current_file_info)
-            directory_worklist = lfns.setdefault(dir_name, [])
-            # TODO: why is this different from current_file_info?
-            directory_worklist.append({'filename': base_name, 'name': name, 'scope': fscope, 'adler32': checksum, 'filesize': size})
             revert_dict[fscope, name] = dir_name
 
         except OSError as error:

--- a/bin/rucio
+++ b/bin/rucio
@@ -932,24 +932,24 @@ def upload(args):
         logger.error("A single GUID was specified on the command line, but there are multiple files to upload.")
         logger.error("If GUID auto-detection is not used, only one file may be uploaded at a time")
         return FAILURE
-    if len(files) > 1 and args.lfn:
+    if len(files) > 1 and args.name:
         logger.error("A single LFN was specified on the command line, but there are multiple files to upload.")
         logger.error("If LFN auto-detection is not used, only one file may be uploaded at a time")
         return FAILURE
-    for name in files:
+    for filename in files:
         try:
-            size = os.stat(name).st_size
-            checksum = adler32(name)
-            base_name = os.path.basename(name)
-            dir_name = os.path.dirname(name)
-            lfn = base_name
-            if args.lfn:
-                lfn = args.lfn
-            logger.debug('Extracting filesize (%s) and checksum (%s) for file %s:%s' % (str(size), checksum, fscope, lfn))
-            files_to_list.append({'scope': fscope, 'lfn': lfn, 'name': base_name})
-            current_file_info = {'scope': fscope, 'name': base_name, 'lfn': lfn, 'bytes': size, 'adler32': checksum, 'state': 'C', 'meta': {}}
-            if not args.guid and 'pool.root' in name.lower() and not args.no_register:  # is a root file, getting the GUID
-                status, output, err = execute('pool_extractFileIdentifier {0}'.format(name))
+            size = os.stat(filename).st_size
+            checksum = adler32(filename)
+            base_name = os.path.basename(filename)
+            dir_name = os.path.dirname(filename)
+            name = base_name
+            if args.name:
+                name = args.name
+            logger.debug('Extracting filesize (%s) and checksum (%s) for file %s:%s' % (str(size), checksum, fscope, name))
+            files_to_list.append({'scope': fscope, 'lfn': name, 'name': base_name})
+            current_file_info = {'scope': fscope, 'name': base_name, 'lfn': name, 'bytes': size, 'adler32': checksum, 'state': 'C', 'meta': {}}
+            if not args.guid and 'pool.root' in filename.lower() and not args.no_register:  # is a root file, getting the GUID
+                status, output, err = execute('pool_extractFileIdentifier {0}'.format(filename))
                 if status != 0:
                     logger.error('Trying to upload ROOT files but pool_extractFileIdentifier tool can not be found.')
                     logger.error('Setup your ATHENA environment and try again.')
@@ -970,8 +970,8 @@ def upload(args):
             list_files.append(current_file_info)
             directory_worklist = lfns.setdefault(dir_name, [])
             # TODO: why is this different from current_file_info?
-            directory_worklist.append({'name': base_name, 'lfn': lfn, 'scope': fscope, 'adler32': checksum, 'filesize': size})
-            revert_dict[fscope, lfn] = dir_name
+            directory_worklist.append({'name': base_name, 'lfn': name, 'scope': fscope, 'adler32': checksum, 'filesize': size})
+            revert_dict[fscope, name] = dir_name
 
         except OSError as error:
             logger.error(error)
@@ -2667,7 +2667,7 @@ Commands:
     upload_parser.add_argument('--guid', dest='guid', action='store', help='Manually specify the GUID for the file.')
     upload_parser.add_argument('--protocol', action='store', help='Force the protocol to use')
     upload_parser.add_argument('--pfn', dest='pfn', action='store', help='Specify the exact PFN for the upload.')
-    upload_parser.add_argument('--lfn', dest='lfn', action='store', help='Specify the exact LFN for the upload.')
+    upload_parser.add_argument('--name', dest='name', action='store', help='Specify the exact LFN for the upload.')
     upload_parser.add_argument(dest='args', action='store', nargs='+', help='files and datasets.')
 
     # The download subparser

--- a/bin/rucio
+++ b/bin/rucio
@@ -946,8 +946,8 @@ def upload(args):
             if args.name:
                 name = args.name
             logger.debug('Extracting filesize (%s) and checksum (%s) for file %s:%s' % (str(size), checksum, fscope, name))
-            files_to_list.append({'scope': fscope, 'lfn': name, 'name': base_name})
-            current_file_info = {'scope': fscope, 'name': base_name, 'lfn': name, 'bytes': size, 'adler32': checksum, 'state': 'C', 'meta': {}}
+            files_to_list.append({'scope': fscope, 'name': name, 'filename': base_name})
+            current_file_info = {'scope': fscope, 'filename': base_name, 'name': name, 'bytes': size, 'adler32': checksum, 'state': 'C', 'meta': {}}
             if not args.guid and 'pool.root' in filename.lower() and not args.no_register:  # is a root file, getting the GUID
                 status, output, err = execute('pool_extractFileIdentifier {0}'.format(filename))
                 if status != 0:
@@ -970,7 +970,7 @@ def upload(args):
             list_files.append(current_file_info)
             directory_worklist = lfns.setdefault(dir_name, [])
             # TODO: why is this different from current_file_info?
-            directory_worklist.append({'name': base_name, 'lfn': name, 'scope': fscope, 'adler32': checksum, 'filesize': size})
+            directory_worklist.append({'filename': base_name, 'name': name, 'scope': fscope, 'adler32': checksum, 'filesize': size})
             revert_dict[fscope, name] = dir_name
 
         except OSError as error:
@@ -1024,36 +1024,36 @@ def upload(args):
         transform it to a DID that can be registered with Rucio.
         """
         lfn_copy = dict(lfn_dict)
-        lfn_copy['name'] = lfn_copy.get('lfn', lfn_copy['name'])
-        del lfn_copy['lfn']
+        lfn_copy['name'] = lfn_copy.get('name', lfn_copy['filename'])
+        del lfn_copy['filename']
         return lfn_copy
 
     # Adding files to the catalog
     for f in list_files:
-        logger.debug("Processing file %s:%s for upload" % (f['scope'], f['lfn']))
+        logger.debug("Processing file %s:%s for upload" % (f['scope'], f['name']))
         try:  # If the did already exist in the catalog, only should be upload if the checksum is the same
-            meta = client.get_metadata(f['scope'], f['lfn'])
-            replicastate = [rep for rep in client.list_replicas([{'scope': f['scope'], 'name': f['lfn']}], all_states=True)]
+            meta = client.get_metadata(f['scope'], f['name'])
+            replicastate = [rep for rep in client.list_replicas([{'scope': f['scope'], 'name': f['name']}], all_states=True)]
             if args.rse not in replicastate[0]['rses']:
                 try:
                     client.add_replicas(files=[f], rse=args.rse)
                 except RucioException:
                     logger.error("A Rucio exception occurred when registering a file replica in Rucio.")
                     raise
-            # logger.warning("The file {0}:{1} already exist in the catalog and will not be added.".format(f['scope'], f['lfn']))
-            if rsemgr.exists(rse_settings=rse_settings, files={'name': f['lfn'], 'scope': f['scope']}):
-                logger.warning('File {0}:{1} already exists on RSE. Will not try to reupload'.format(f['scope'], f['lfn']))
+            # logger.warning("The file {0}:{1} already exist in the catalog and will not be added.".format(f['scope'], f['name']))
+            if rsemgr.exists(rse_settings=rse_settings, files={'name': f['name'], 'scope': f['scope']}):
+                logger.warning('File {0}:{1} already exists on RSE. Will not try to reupload'.format(f['scope'], f['name']))
             else:
                 if meta['adler32'] == f['adler32']:
-                    logger.info('Local files and file %s:%s recorded in Rucio have the same checksum. Will try the upload' % (f['scope'], f['lfn']))
-                    directory = revert_dict[f['scope'], f['lfn']]
+                    logger.info('Local files and file %s:%s recorded in Rucio have the same checksum. Will try the upload' % (f['scope'], f['name']))
+                    directory = revert_dict[f['scope'], f['name']]
                     trace['remoteSite'] = rse_settings['rse']
                     trace['protocol'] = rse_settings['protocols'][0]['scheme']
                     trace['filesize'] = f['bytes']
                     trace['transferStart'] = time.time()
                     f['upstate'] = rsemgr.upload(rse_settings=rse_settings,
-                                                 lfns=[{'name': f['name'],
-                                                        'lfn': f['lfn'],
+                                                 lfns=[{'filename': f['filename'],
+                                                        'name': f['name'],
                                                         'scope': f['scope'],
                                                         'adler32': f['adler32'],
                                                         'filesize': f['bytes']}],
@@ -1061,7 +1061,7 @@ def upload(args):
                                                  force_pfn=args.pfn)
                     trace['transferEnd'] = time.time()
                     trace['clientState'] = 'DONE'
-                    logger.info('File %s:%s successfully uploaded on the storage' % (f['scope'], f['lfn']))
+                    logger.info('File %s:%s successfully uploaded on the storage' % (f['scope'], f['name']))
                     send_trace(trace, client.host, args.user_agent)
                     summary.append(deepcopy(f))
                     f.pop('upstate', None)
@@ -1081,24 +1081,25 @@ def upload(args):
                     try:
                         client.add_replicas(files=[make_valid_did(f)], rse=args.rse)
                     except RucioException:
-                        logger.error("A Rucio exception occurred when adding replicas for %s:%s" % (f['scope'], f['lfn']))
+                        logger.error("A Rucio exception occurred when adding replicas for %s:%s" % (f['scope'], f['name']))
                         raise
                     logger.info('Replicas successfully added')
                     if not dsscope:
                         # only need to add rules for files if no dataset is given
-                        logger.info('Adding replication rule on RSE {0} for the file {1}:{2}'.format(args.rse, f['scope'], f['lfn']))
+                        logger.info('Adding replication rule on RSE {0} for the file {1}:{2}'.format(args.rse, f['scope'], f['name']))
                         try:
                             client.add_replication_rule([make_valid_did(f)], copies=1, rse_expression=args.rse, lifetime=args.lifetime)
                         except RucioException:
-                            logger.error("A Rucio exception occurred when adding a replication rule for %s:%s" % (f['scope'], f['lfn']))
-                directory = revert_dict[f['scope'], f['lfn']]
+                            logger.error("A Rucio exception occurred when adding a replication rule for %s:%s" % (f['scope'], f['name']))
+                directory = revert_dict[f['scope'], f['name']]
                 trace['remoteSite'] = rse_settings['rse']
                 trace['protocol'] = rse_settings['protocols'][0]['scheme']
                 trace['filesize'] = f['bytes']
                 trace['transferStart'] = time.time()
+                logger.debug("Uploading source file to RSE")
                 f['upstate'] = rsemgr.upload(rse_settings=rse_settings,
-                                             lfns=[{'name': f['name'],
-                                                    'lfn': f['lfn'],
+                                             lfns=[{'filename': f['filename'],
+                                                    'name': f['name'],
                                                     'scope': f['scope'],
                                                     'adler32': f['adler32'],
                                                     'filesize': f['bytes']}],
@@ -1106,7 +1107,7 @@ def upload(args):
                                              force_pfn=args.pfn)
                 trace['transferEnd'] = time.time()
                 trace['clientState'] = 'DONE'
-                logger.info('File {0}:{1} successfully uploaded on the storage'.format(f['scope'], f['lfn']))
+                logger.info('File {0}:{1} successfully uploaded on the storage'.format(f['scope'], f['name']))
                 send_trace(trace, client.host, args.user_agent)
                 summary.append(deepcopy(f))
                 f.pop('upstate', None)
@@ -1140,10 +1141,10 @@ def upload(args):
         for rep in client.list_replicas([make_valid_did(f) for f in chunk_files_to_list]):
             replica_dictionary[rep['scope'], rep['name']] = rep['rses'].keys()
     for file in list_files:
-        if (file['scope'], file['lfn']) not in replica_dictionary:
+        if (file['scope'], file['name']) not in replica_dictionary:
             file['state'] = 'A'
             replicas.append(file)
-        elif args.rse not in replica_dictionary[file['scope'], file['lfn']]:
+        elif args.rse not in replica_dictionary[file['scope'], file['name']]:
             file['state'] = 'A'
             replicas.append(file)
     if args.no_register is False and replicas != []:
@@ -1159,13 +1160,13 @@ def upload(args):
         final_summary = {}
         for file in summary:
             final_summary['%s:%s' % (file['scope'],
-                                     file['lfn'])] = {'scope': file['scope'],
-                                                      'name': file['lfn'],
-                                                      'bytes': file['bytes'],
-                                                      'rse': args.rse,
-                                                      'pfn': file['upstate']['pfn'],
-                                                      'guid': file['meta']['guid'],
-                                                      'adler32': file['adler32']}
+                                     file['name'])] = {'scope': file['scope'],
+                                                       'name': file['name'],
+                                                       'bytes': file['bytes'],
+                                                       'rse': args.rse,
+                                                       'pfn': file['upstate']['pfn'],
+                                                       'guid': file['meta']['guid'],
+                                                       'adler32': file['adler32']}
         with open('rucio_upload.json', 'wb') as summary_file:
             json.dump(final_summary, summary_file, sort_keys=True, indent=1)
     return SUCCESS

--- a/bin/rucio
+++ b/bin/rucio
@@ -50,7 +50,7 @@ from rucio.common.exception import (DataIdentifierAlreadyExists, Duplicate, File
                                     DataIdentifierNotFound, InvalidObject, RSENotFound, InvalidRSEExpression, DuplicateContent, RSEProtocolNotSupported,
                                     RuleNotFound, CannotAuthenticate, MissingDependency, UnsupportedOperation, FileConsistencyMismatch,
                                     RucioException, DuplicateRule, NoFilesDownloaded, NotAllFilesDownloaded)
-from rucio.common.utils import adler32, generate_uuid, execute, chunks, sizefmt, Color, detect_client_location
+from rucio.common.utils import adler32, generate_uuid, execute, chunks, sizefmt, Color, detect_client_location, make_valid_did
 from rucio.rse import rsemanager as rsemgr
 
 SUCCESS = 0
@@ -1013,16 +1013,6 @@ def upload(args):
             logger.warning("The dataset name already exist")
     else:
         logger.debug('Skipping dataset registration')
-
-    def make_valid_did(lfn_dict):
-        """
-        Given a LFN dictionary describing all the local state of an LFN,
-        transform it to a DID that can be registered with Rucio.
-        """
-        lfn_copy = dict(lfn_dict)
-        lfn_copy['name'] = lfn_copy.get('name', lfn_copy['filename'])
-        del lfn_copy['filename']
-        return lfn_copy
 
     # Adding files to the catalog
     for f in list_files:

--- a/bin/rucio
+++ b/bin/rucio
@@ -928,12 +928,26 @@ def upload(args):
     trace['hostname'] = socket.getfqdn()
     trace['scope'] = fscope
     trace['uuid'] = generate_uuid()
+    if len(files) > 1 and args.guid:
+        logger.error("A single GUID was specified on the command line, but there are multiple files to upload.")
+        logger.error("If GUID auto-detection is not used, only one file may be uploaded at a time")
+        return FAILURE
+    if len(files) > 1 and args.lfn:
+        logger.error("A single LFN was specified on the command line, but there are multiple files to upload.")
+        logger.error("If LFN auto-detection is not used, only one file may be uploaded at a time")
+        return FAILURE
     for name in files:
         try:
             size = os.stat(name).st_size
             checksum = adler32(name)
-            logger.debug('Extracting filesize (%s) and checksum (%s) for file %s:%s' % (str(size), checksum, fscope, os.path.basename(name)))
-            files_to_list.append({'scope': fscope, 'name': os.path.basename(name)})
+            base_name = os.path.basename(name)
+            dir_name = os.path.dirname(name)
+            lfn = base_name
+            if args.lfn:
+                lfn = args.lfn
+            logger.debug('Extracting filesize (%s) and checksum (%s) for file %s:%s' % (str(size), checksum, fscope, lfn))
+            files_to_list.append({'scope': fscope, 'lfn': lfn, 'name': base_name})
+            current_file_info = {'scope': fscope, 'name': base_name, 'lfn': lfn, 'bytes': size, 'adler32': checksum, 'state': 'C', 'meta': {}}
             if not args.guid and 'pool.root' in name.lower() and not args.no_register:  # is a root file, getting the GUID
                 status, output, err = execute('pool_extractFileIdentifier {0}'.format(name))
                 if status != 0:
@@ -946,17 +960,18 @@ def upload(args):
                 except Exception:
                     logger.error('Error during GUID extraction. Failing. None of the files will be uploaded.')
                     return FAILURE
-                list_files.append({'scope': fscope, 'name': os.path.basename(name), 'bytes': size, 'adler32': checksum, 'state': 'C', 'meta': {'guid': guid}})
+                current_file_info['meta']['guid'] = guid
             elif args.guid:
                 logger.info('Manually set GUID: %s' % args.guid.replace('-', ''))
-                list_files.append({'scope': fscope, 'name': os.path.basename(name), 'bytes': size, 'adler32': checksum, 'state': 'C', 'meta': {'guid': args.guid.replace('-', '')}})
+                current_file_info['meta']['guid'] = args.guid.replace('-', '')
             else:
                 logger.debug('Automatically setting new GUID')
-                list_files.append({'scope': fscope, 'name': os.path.basename(name), 'bytes': size, 'adler32': checksum, 'state': 'C', 'meta': {'guid': generate_uuid()}})
-            if not os.path.dirname(name) in lfns:
-                lfns[os.path.dirname(name)] = []
-            lfns[os.path.dirname(name)].append({'name': os.path.basename(name), 'scope': fscope, 'adler32': checksum, 'filesize': size})
-            revert_dict[fscope, os.path.basename(name)] = os.path.dirname(name)
+                current_file_info['meta']['guid'] = generate_uuid()
+            list_files.append(current_file_info)
+            directory_worklist = lfns.setdefault(dir_name, [])
+            # TODO: why is this different from current_file_info?
+            directory_worklist.append({'name': base_name, 'lfn': lfn, 'scope': fscope, 'adler32': checksum, 'filesize': size})
+            revert_dict[fscope, lfn] = dir_name
 
         except OSError as error:
             logger.error(error)
@@ -1003,26 +1018,42 @@ def upload(args):
     else:
         logger.debug('Skipping dataset registration')
 
+    def make_valid_did(lfn_dict):
+        """
+        Given a LFN dictionary describing all the local state of an LFN,
+        transform it to a DID that can be registered with Rucio.
+        """
+        lfn_copy = dict(lfn_dict)
+        lfn_copy['name'] = lfn_copy.get('lfn', lfn_copy['name'])
+        del lfn_copy['lfn']
+        return lfn_copy
+
     # Adding files to the catalog
     for f in list_files:
+        logger.debug("Processing file %s:%s for upload" % (f['scope'], f['lfn']))
         try:  # If the did already exist in the catalog, only should be upload if the checksum is the same
-            meta = client.get_metadata(f['scope'], f['name'])
-            replicastate = [rep for rep in client.list_replicas([{'scope': f['scope'], 'name': f['name']}], all_states=True)]
+            meta = client.get_metadata(f['scope'], f['lfn'])
+            replicastate = [rep for rep in client.list_replicas([{'scope': f['scope'], 'name': f['lfn']}], all_states=True)]
             if args.rse not in replicastate[0]['rses']:
-                client.add_replicas(files=[f], rse=args.rse)
-            # logger.warning("The file {0}:{1} already exist in the catalog and will not be added.".format(f['scope'], f['name']))
-            if rsemgr.exists(rse_settings=rse_settings, files={'name': f['name'], 'scope': f['scope']}):
-                logger.warning('File {0}:{1} already exists on RSE. Will not try to reupload'.format(f['scope'], f['name']))
+                try:
+                    client.add_replicas(files=[f], rse=args.rse)
+                except RucioException:
+                    logger.error("A Rucio exception occurred when registering a file replica in Rucio.")
+                    raise
+            # logger.warning("The file {0}:{1} already exist in the catalog and will not be added.".format(f['scope'], f['lfn']))
+            if rsemgr.exists(rse_settings=rse_settings, files={'name': f['lfn'], 'scope': f['scope']}):
+                logger.warning('File {0}:{1} already exists on RSE. Will not try to reupload'.format(f['scope'], f['lfn']))
             else:
                 if meta['adler32'] == f['adler32']:
-                    logger.info('Local files and file %s:%s recorded in Rucio have the same checksum. Will try the upload' % (f['scope'], f['name']))
-                    directory = revert_dict[f['scope'], f['name']]
+                    logger.info('Local files and file %s:%s recorded in Rucio have the same checksum. Will try the upload' % (f['scope'], f['lfn']))
+                    directory = revert_dict[f['scope'], f['lfn']]
                     trace['remoteSite'] = rse_settings['rse']
                     trace['protocol'] = rse_settings['protocols'][0]['scheme']
                     trace['filesize'] = f['bytes']
                     trace['transferStart'] = time.time()
                     f['upstate'] = rsemgr.upload(rse_settings=rse_settings,
                                                  lfns=[{'name': f['name'],
+                                                        'lfn': f['lfn'],
                                                         'scope': f['scope'],
                                                         'adler32': f['adler32'],
                                                         'filesize': f['bytes']}],
@@ -1030,7 +1061,7 @@ def upload(args):
                                                  force_pfn=args.pfn)
                     trace['transferEnd'] = time.time()
                     trace['clientState'] = 'DONE'
-                    logger.info('File %s:%s successfully uploaded on the storage' % (f['scope'], f['name']))
+                    logger.info('File %s:%s successfully uploaded on the storage' % (f['scope'], f['lfn']))
                     send_trace(trace, client.host, args.user_agent)
                     summary.append(deepcopy(f))
                     f.pop('upstate', None)
@@ -1045,21 +1076,29 @@ def upload(args):
         except DataIdentifierNotFound:
             try:
                 if args.no_register is False:
-                    # Skiping registration for pilot
+                    # Skipping registration for pilot
                     logger.info('Adding replicas in Rucio catalog')
-                    client.add_replicas(files=[f], rse=args.rse)
+                    try:
+                        client.add_replicas(files=[make_valid_did(f)], rse=args.rse)
+                    except RucioException:
+                        logger.error("A Rucio exception occurred when adding replicas for %s:%s" % (f['scope'], f['lfn']))
+                        raise
                     logger.info('Replicas successfully added')
                     if not dsscope:
                         # only need to add rules for files if no dataset is given
-                        logger.info('Adding replication rule on RSE {0} for the file {1}:{2}'.format(args.rse, f['scope'], f['name']))
-                        client.add_replication_rule([f], copies=1, rse_expression=args.rse, lifetime=args.lifetime)
-                directory = revert_dict[f['scope'], f['name']]
+                        logger.info('Adding replication rule on RSE {0} for the file {1}:{2}'.format(args.rse, f['scope'], f['lfn']))
+                        try:
+                            client.add_replication_rule([make_valid_did(f)], copies=1, rse_expression=args.rse, lifetime=args.lifetime)
+                        except RucioException:
+                            logger.error("A Rucio exception occurred when adding a replication rule for %s:%s" % (f['scope'], f['lfn']))
+                directory = revert_dict[f['scope'], f['lfn']]
                 trace['remoteSite'] = rse_settings['rse']
                 trace['protocol'] = rse_settings['protocols'][0]['scheme']
                 trace['filesize'] = f['bytes']
                 trace['transferStart'] = time.time()
                 f['upstate'] = rsemgr.upload(rse_settings=rse_settings,
                                              lfns=[{'name': f['name'],
+                                                    'lfn': f['lfn'],
                                                     'scope': f['scope'],
                                                     'adler32': f['adler32'],
                                                     'filesize': f['bytes']}],
@@ -1067,7 +1106,7 @@ def upload(args):
                                              force_pfn=args.pfn)
                 trace['transferEnd'] = time.time()
                 trace['clientState'] = 'DONE'
-                logger.info('File {0}:{1} successfully uploaded on the storage'.format(f['scope'], f['name']))
+                logger.info('File {0}:{1} successfully uploaded on the storage'.format(f['scope'], f['lfn']))
                 send_trace(trace, client.host, args.user_agent)
                 summary.append(deepcopy(f))
                 f.pop('upstate', None)
@@ -1080,11 +1119,16 @@ def upload(args):
         except DataIdentifierAlreadyExists as error:
             logger.debug(error)
             logger.error("Some of the files already exist in the catalog. No one will be added.")
+        except RucioException:
+            logger.error("A Rucio exception occurred when processing a file for upload.")
+            raise
+    logger.debug("Finished uploading files to RSE.")
+
     if dsname:
         # A dataset is provided. Must add the files to the dataset.
         for f in list_files:
             try:
-                client.add_files_to_dataset(scope=dsscope, name=dsname, files=[f])
+                client.add_files_to_dataset(scope=dsscope, name=dsname, files=[make_valid_did(f)])
             except Exception as error:
                 logger.warning('Failed to attach file {0} to the dataset'.format(f))
                 logger.warning(error)
@@ -1093,20 +1137,20 @@ def upload(args):
     replicas = []
     replica_dictionary = {}
     for chunk_files_to_list in chunks(files_to_list, 50):
-        for rep in client.list_replicas(chunk_files_to_list):
+        for rep in client.list_replicas([make_valid_did(f) for f in chunk_files_to_list]):
             replica_dictionary[rep['scope'], rep['name']] = rep['rses'].keys()
     for file in list_files:
-        if (file['scope'], file['name']) not in replica_dictionary:
+        if (file['scope'], file['lfn']) not in replica_dictionary:
             file['state'] = 'A'
             replicas.append(file)
-        elif args.rse not in replica_dictionary[file['scope'], file['name']]:
+        elif args.rse not in replica_dictionary[file['scope'], file['lfn']]:
             file['state'] = 'A'
             replicas.append(file)
     if args.no_register is False and replicas != []:
         logger.info('Will update the file replicas states')
         for chunk_replicas in chunks(replicas, 20):
             try:
-                client.update_replicas_states(rse=args.rse, files=chunk_replicas)
+                client.update_replicas_states(rse=args.rse, files=[make_valid_did(f) for f in chunk_replicas])
             except AccessDenied as error:
                 logger.error(error)
                 return FAILURE
@@ -1115,13 +1159,13 @@ def upload(args):
         final_summary = {}
         for file in summary:
             final_summary['%s:%s' % (file['scope'],
-                                     file['name'])] = {'scope': file['scope'],
-                                                       'name': file['name'],
-                                                       'bytes': file['bytes'],
-                                                       'rse': args.rse,
-                                                       'pfn': file['upstate']['pfn'],
-                                                       'guid': file['meta']['guid'],
-                                                       'adler32': file['adler32']}
+                                     file['lfn'])] = {'scope': file['scope'],
+                                                      'name': file['lfn'],
+                                                      'bytes': file['bytes'],
+                                                      'rse': args.rse,
+                                                      'pfn': file['upstate']['pfn'],
+                                                      'guid': file['meta']['guid'],
+                                                      'adler32': file['adler32']}
         with open('rucio_upload.json', 'wb') as summary_file:
             json.dump(final_summary, summary_file, sort_keys=True, indent=1)
     return SUCCESS
@@ -2623,6 +2667,7 @@ Commands:
     upload_parser.add_argument('--guid', dest='guid', action='store', help='Manually specify the GUID for the file.')
     upload_parser.add_argument('--protocol', action='store', help='Force the protocol to use')
     upload_parser.add_argument('--pfn', dest='pfn', action='store', help='Specify the exact PFN for the upload.')
+    upload_parser.add_argument('--lfn', dest='lfn', action='store', help='Specify the exact LFN for the upload.')
     upload_parser.add_argument(dest='args', action='store', nargs='+', help='files and datasets.')
 
     # The download subparser

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -581,3 +581,20 @@ def ssh_sign(private_key, message):
     signature_stream = priv_k.sign_ssh_data(message)
     signature_stream.rewind()
     return base64.b64encode(signature_stream.get_remainder())
+
+
+def make_valid_did(lfn_dict):
+    """
+    When managing information about a LFN (such as in `rucio upload` or
+    the RSE manager's upload), we add the `filename` attribute to record
+    the name of the file on the local disk in addition to the remainder
+    of the DID information.
+
+    This function will take that python dictionary, and strip out the
+    additional `filename` key.  If this is not done, then the dictionary
+    will not pass the DID JSON schema validation.
+    """
+    lfn_copy = dict(lfn_dict)
+    lfn_copy['name'] = lfn_copy.get('name', lfn_copy['filename'])
+    del lfn_copy['filename']
+    return lfn_copy

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -728,7 +728,7 @@ def get_rse_protocols(rse, schemes=None, session=None):
     if not _rse:
         raise exception.RSENotFound('RSE \'%s\' not found')
 
-    lfn2pfn_algorithms = get_rse_attribute('lfn2pfn_algorithm', rse_id=_rse.id)
+    lfn2pfn_algorithms = get_rse_attribute('lfn2pfn_algorithm', rse_id=_rse.id, session=session)
     lfn2pfn_algorithm = 'default'
     if lfn2pfn_algorithms:
         lfn2pfn_algorithm = lfn2pfn_algorithms[0]

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -728,6 +728,11 @@ def get_rse_protocols(rse, schemes=None, session=None):
     if not _rse:
         raise exception.RSENotFound('RSE \'%s\' not found')
 
+    lfn2pfn_algorithms = get_rse_attribute('lfn2pfn_algorithm', rse_id=_rse.id)
+    lfn2pfn_algorithm = 'default'
+    if lfn2pfn_algorithms:
+        lfn2pfn_algorithm = lfn2pfn_algorithms[0]
+
     read = True if _rse.availability & 4 else False
     write = True if _rse.availability & 2 else False
     delete = True if _rse.availability & 1 else False
@@ -740,6 +745,7 @@ def get_rse_protocols(rse, schemes=None, session=None):
             'domain': utils.rse_supported_protocol_domains(),
             'protocols': list(),
             'deterministic': _rse.deterministic,
+            'lfn2pfn_algorithm': lfn2pfn_algorithm,
             'rse_type': str(_rse.rse_type),
             'credentials': None,
             'volatile': _rse.volatile,

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -65,7 +65,7 @@ class RSEProtocol(object):
 
         lfns = [lfns] if type(lfns) == dict else lfns
         for lfn in lfns:
-            scope, name = lfn['scope'], lfn.get('lfn', lfn['name'])
+            scope, name = lfn['scope'], lfn['name']
             if 'path' in lfn and lfn['path'] is not None:
                 pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'],
                                                          '://',
@@ -99,7 +99,7 @@ class RSEProtocol(object):
         lfns = [lfns] if type(lfns) == dict else lfns
         for lfn in lfns:
             scope = lfn['scope']
-            name = lfn.get('lfn', lfn['name'])
+            name = lfn['name']
             replicas = [r for r in client.list_replicas([{'scope': scope, 'name': name}, ], schemes=[self.attributes['scheme'], ])]  # schemes is used to narrow down the response message.
             if len(replicas) > 1:
                 pfns['%s:%s' % (scope, name)] = exception.RSEOperationNotSupported('This operation can only be performed for files.')

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -45,7 +45,7 @@ class RSEProtocol(object):
             if getattr(rsemanager, 'SERVER_MODE', None):
                 setattr(self, '_get_path', self._get_path_nondeterministic_server)
         else:
-            self.attributes['determinism_type'] = self.rse.get('determinism_type', 'default')
+            self.attributes['lfn2pfn_algorithm'] = self.rse.get('lfn2pfn_algorithm', None)
 
     def lfns2pfns(self, lfns):
         """
@@ -120,7 +120,7 @@ class RSEProtocol(object):
         hstr = hashlib.md5('%s:%s' % (scope, name)).hexdigest()
         if scope.startswith('user') or scope.startswith('group'):
             scope = scope.replace('.', '/')
-        if self.attributes.get('determinism_type', 'default') == 'identity':
+        if self.attributes.get('lfn2pfn_algorithm', 'default') == 'identity':
             return '%s/%s' % (scope, name)
         else:
             return '%s/%s/%s/%s' % (scope, hstr[0:2], hstr[2:4], name)

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -324,7 +324,7 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None):
 
         :param lfns:        a single dict or a list with dicts containing 'scope' and 'name'. E.g. [{'name': '1_rse_local_put.raw', 'scope': 'user.jdoe', 'filesize': 42, 'adler32': '87HS3J968JSNWID'},
                                                                                                     {'name': '2_rse_local_put.raw', 'scope': 'user.jdoe', 'filesize': 4711, 'adler32': 'RSSMICETHMISBA837464F'}]
-                            If the 'lfn' key is present, it will be used for the LFN in Rucio over the actual name on disk (in the 'name' key).
+                            If the 'filename' key is present, it will be used by Rucio as the actual name of the file on disk (separate from the Rucio 'name').
         :param source_dir:  path to the local directory including the source files
         :param force_pfn: use the given PFN -- can lead to dark data, use sparingly
 
@@ -349,14 +349,14 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None):
         transform it to a DID that can be registered with Rucio.
         """
         lfn_copy = dict(lfn_dict)
-        lfn_copy['name'] = lfn_copy.get('lfn', lfn_copy['name'])
-        del lfn_copy['lfn']
+        lfn_copy['name'] = lfn_copy.get('name', lfn_copy['filename'])
+        del lfn_copy['filename']
         return lfn_copy
 
     lfns = [lfns] if not type(lfns) is list else lfns
     for lfn in lfns:
-        base_name = lfn['name']
-        name = lfn.get('lfn', base_name)
+        base_name = lfn.get('filename', lfn['name'])
+        name = lfn.get('name', base_name)
         scope = lfn['scope']
         if 'adler32' not in lfn:
             gs = False

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -22,6 +22,7 @@ import os
 from urlparse import urlparse
 
 from rucio.common import exception, utils, constants
+from rucio.common.utils import make_valid_did
 
 DEFAULT_PROTOCOL = 1
 
@@ -342,16 +343,6 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None):
     protocol.connect()
     protocol_delete = create_protocol(rse_settings, 'delete')
     protocol_delete.connect()
-
-    def make_valid_did(lfn_dict):
-        """
-        Given a LFN dictionary describing all the local state of an LFN,
-        transform it to a DID that can be registered with Rucio.
-        """
-        lfn_copy = dict(lfn_dict)
-        lfn_copy['name'] = lfn_copy.get('name', lfn_copy['filename'])
-        del lfn_copy['filename']
-        return lfn_copy
 
     lfns = [lfns] if not type(lfns) is list else lfns
     for lfn in lfns:

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -324,6 +324,7 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None):
 
         :param lfns:        a single dict or a list with dicts containing 'scope' and 'name'. E.g. [{'name': '1_rse_local_put.raw', 'scope': 'user.jdoe', 'filesize': 42, 'adler32': '87HS3J968JSNWID'},
                                                                                                     {'name': '2_rse_local_put.raw', 'scope': 'user.jdoe', 'filesize': 4711, 'adler32': 'RSSMICETHMISBA837464F'}]
+                            If the 'lfn' key is present, it will be used for the LFN in Rucio over the actual name on disk (in the 'name' key).
         :param source_dir:  path to the local directory including the source files
         :param force_pfn: use the given PFN -- can lead to dark data, use sparingly
 
@@ -342,39 +343,50 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None):
     protocol_delete = create_protocol(rse_settings, 'delete')
     protocol_delete.connect()
 
+    def make_valid_did(lfn_dict):
+        """
+        Given a LFN dictionary describing all the local state of an LFN,
+        transform it to a DID that can be registered with Rucio.
+        """
+        lfn_copy = dict(lfn_dict)
+        lfn_copy['name'] = lfn_copy.get('lfn', lfn_copy['name'])
+        del lfn_copy['lfn']
+        return lfn_copy
+
     lfns = [lfns] if not type(lfns) is list else lfns
     for lfn in lfns:
-        name = lfn['name']
+        base_name = lfn['name']
+        name = lfn.get('lfn', base_name)
         scope = lfn['scope']
         if 'adler32' not in lfn:
             gs = False
-            ret['%s:%s' % (scope, name)] = exception.RucioException('Missing checksum for file %s:%s' % (lfn['scope'], lfn['name']))
+            ret['%s:%s' % (scope, name)] = exception.RucioException('Missing checksum for file %s:%s' % (lfn['scope'], name))
             continue
         if 'filesize' not in lfn:
             gs = False
-            ret['%s:%s' % (scope, name)] = exception.RucioException('Missing filesize for file %s:%s' % (lfn['scope'], lfn['name']))
+            ret['%s:%s' % (scope, name)] = exception.RucioException('Missing filesize for file %s:%s' % (lfn['scope'], name))
             continue
 
         if force_pfn:
             pfn = force_pfn
         else:
-            pfn = protocol.lfns2pfns(lfn).values()[0]
+            pfn = protocol.lfns2pfns(make_valid_did(lfn)).values()[0]
 
         # First check if renaming operation is supported
         if protocol.renaming:
 
             # Check if file replica is already on the storage system
             if protocol.overwrite is False and protocol.exists(pfn):
-                ret['%s:%s' % (scope, name)] = exception.FileReplicaAlreadyExists('File %s in scope %s already exists on storage' % (name, scope))
+                ret['%s:%s' % (scope, name)] = exception.FileReplicaAlreadyExists('File %s in scope %s already exists on storage as PFN %s' % (name, scope, pfn))
                 gs = False
             else:
                 if protocol.exists('%s.rucio.upload' % pfn):  # Check for left over of previous unsuccessful attempts
                     try:
-                        protocol_delete.delete('%s.rucio.upload', protocol_delete.lfns2pfns(lfn).values()[0])
+                        protocol_delete.delete('%s.rucio.upload', protocol_delete.lfns2pfns(make_valid_did(lfn)).values()[0])
                     except Exception as e:
                         ret['%s:%s' % (scope, name)] = exception.RSEOperationNotSupported('Unable to remove temporary file %s.rucio.upload: %s' % (pfn, str(e)))
                 try:  # Try uploading file
-                    protocol.put(name, '%s.rucio.upload' % pfn, source_dir)
+                    protocol.put(base_name, '%s.rucio.upload' % pfn, source_dir)
                 except Exception as e:
                     gs = False
                     ret['%s:%s' % (scope, name)] = e
@@ -408,11 +420,11 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None):
 
             # Check if file replica is already on the storage system
             if protocol.overwrite is False and protocol.exists(pfn):
-                ret['%s:%s' % (scope, name)] = exception.FileReplicaAlreadyExists('File %s in scope %s already exists on storage' % (name, scope))
+                ret['%s:%s' % (scope, name)] = exception.FileReplicaAlreadyExists('File %s in scope %s already exists on storage as PFN %s' % (name, scope, pfn))
                 gs = False
             else:
                 try:  # Try uploading file
-                    protocol.put(name, pfn, source_dir)
+                    protocol.put(base_name, pfn, source_dir)
                 except Exception as e:
                     gs = False
                     ret['%s:%s' % (scope, name)] = e


### PR DESCRIPTION
This allows the upload path to track the "file name" (on local disk) and the LFN separately, allowing the `rucio upload` client to expose the option of explicitly providing a LFN that differs from the file
name.

Additionally, to help upload files with '/' in them that are effectively pre-hashed, this allows the RSE to be marked as having the 'identity' determinism type, meaning to skipping the hashing step of generating a PFN.