### PR TITLE
Use atlas policy when no permission section exists.  Fixes #407

### DIFF
--- a/lib/rucio/common/policy.py
+++ b/lib/rucio/common/policy.py
@@ -38,7 +38,7 @@ def get_policy():
     if isinstance(policy, NoValue):
         try:
             policy = config_get('permission', 'policy')
-        except NoOptionError:
+        except (NoOptionError, NoSectionError):
             policy = 'atlas'
         REGION.set('policy', policy)
     return policy


### PR DESCRIPTION
Catch uncaught exception