### PR TITLE
client: Recreate session after authorization failure. Fix #433

### DIFF
--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -277,6 +277,7 @@ class BaseClient(object):
                 continue
 
             if result is not None and result.status_code == codes.unauthorized:  # pylint: disable-msg=E1101
+                self.session = session()
                 self.__get_token()
                 hds['X-Rucio-Auth-Token'] = self.auth_token
             else:
@@ -363,8 +364,10 @@ class BaseClient(object):
                 if retry > self.request_retries:
                     raise
 
-        if not result:
-            LOG.error('cannot get auth_token')
+        # Note a response object for a failed request evaluates to false, so we cannot
+        # use "not result" here
+        if result is None:
+            LOG.error('Internal error: Request for authentication token returned no result!')
             return False
 
         if result.status_code != codes.ok:   # pylint: disable-msg=E1101


### PR DESCRIPTION
I've encountered sporadic cases where session reuse against the token endpoint causes failures because the session was not established using the client certificate (meaning issuing a new token will fail).

With this patch, failures are properly detected and - if it's an auth failure - will trigger the creation of a fresh session.
