### PR TITLE
client: Recreate session after authorization failure (next). Fix #433

### DIFF
--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -277,6 +277,7 @@ class BaseClient(object):
                 continue
 
             if result is not None and result.status_code == codes.unauthorized:  # pylint: disable-msg=E1101
+                self.session = session()
                 self.__get_token()
                 hds['X-Rucio-Auth-Token'] = self.auth_token
             else:
@@ -363,8 +364,10 @@ class BaseClient(object):
                 if retry > self.request_retries:
                     raise
 
-        if not result:
-            LOG.error('cannot get auth_token')
+        # Note a response object for a failed request evaluates to false, so we cannot
+        # use "not result" here
+        if result is None:
+            LOG.error('Internal error: Request for authentication token returned no result!')
             return False
 
         if result.status_code != codes.ok:   # pylint: disable-msg=E1101

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -11,6 +11,7 @@
 # - Martin Barisits, <martin.barisits@cern.ch>, 2017
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2017
 # - Frank Berghaus, <frank.berghaus@cern.ch>, 2017
+# - Martin Barisits, <martin.barisits@cern.ch>, 2017-2018
 
 import base64
 import datetime
@@ -265,7 +266,7 @@ def execute(cmd):
 
 def rse_supported_protocol_operations():
     """ Returns a list with operations supported by all RSE protocols."""
-    return ['read', 'write', 'delete']
+    return ['read', 'write', 'delete', 'third_party_copy']
 
 
 def rse_supported_protocol_domains():

--- a/lib/rucio/core/permission/atlas.py
+++ b/lib/rucio/core/permission/atlas.py
@@ -11,7 +11,7 @@
 # - Yun-Pin Sun, <yun-pin.sun@cern.ch>, 2012-2013
 # - Ralph Vigne, <ralph.vigne@cern.ch>, 2013
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2013-2015, 2017
-# - Martin Barisits, <martin.barisits@cern.ch>, 2013-2016
+# - Martin Barisits, <martin.barisits@cern.ch>, 2013-2018
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2013-2017
 # - Joaquin Bogado, <joaquin.bogado@cern.ch>, 2015
 
@@ -60,6 +60,7 @@ def has_permission(issuer, action, kwargs):
             'approve_rule': perm_approve_rule,
             'update_subscription': perm_update_subscription,
             'reduce_rule': perm_reduce_rule,
+            'move_rule': perm_move_rule,
             'get_auth_token_user_pass': perm_get_auth_token_user_pass,
             'get_auth_token_gss': perm_get_auth_token_gss,
             'get_auth_token_x509': perm_get_auth_token_x509,

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -9,7 +9,7 @@
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2012-2016
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2012-2013, 2017
 # - Ralph Vigne, <ralph.vigne@cern.ch>, 2013-2015
-# - Martin Barisits, <martin.barisits@cern.ch>, 2013-2016
+# - Martin Barisits, <martin.barisits@cern.ch>, 2013-2018
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2013-2016
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2014, 2017
 # - Wen Guan, <wen.guan@cern.ch>, 2015-2016
@@ -949,14 +949,15 @@ def del_protocols(rse, scheme, hostname=None, port=None, session=None):
     for domain in utils.rse_supported_protocol_domains():
         for op in utils.rse_supported_protocol_operations():
             op_name = ''.join([op, '_', domain])
-            prots = session.query(models.RSEProtocols).\
-                filter(sqlalchemy.and_(models.RSEProtocols.rse_id == rid,
-                                       getattr(models.RSEProtocols, op_name) > 0)).\
-                order_by(getattr(models.RSEProtocols, op_name).asc())
-            i = 1
-            for p in prots:
-                p.update({op_name: i})
-                i += 1
+            if getattr(models.RSEProtocols, op_name, None):
+                prots = session.query(models.RSEProtocols).\
+                    filter(sqlalchemy.and_(models.RSEProtocols.rse_id == rid,
+                                           getattr(models.RSEProtocols, op_name) > 0)).\
+                    order_by(getattr(models.RSEProtocols, op_name).asc())
+                i = 1
+                for p in prots:
+                    p.update({op_name: i})
+                    i += 1
 
 
 @transactional_session


### PR DESCRIPTION
I've encountered sporadic cases where session reuse against the token endpoint causes failures because the session was not established using the client certificate (meaning issuing a new token will fail).

With this patch, failures are properly detected and - if it's an auth failure - will trigger the creation of a fresh session.

This is a duplicate of #434 against the `next` branch.