### PR TITLE
client: Escape DIDs and scope embedded in URLs.  Fix #436

### DIFF
--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -13,8 +13,10 @@
   - Cedric Serfon, <cedric.serfon@cern.ch>, 2014-2015
   - Ralph Vigne, <ralph.vigne@cern.ch>, 2015
   - Martin Barisits, <martin.barisits@cern.ch>, 2014-2015
+  - Brian Bockelman, <bbockelm@cse.unl.edu>, 2018
 '''
 
+from urllib import quote_plus
 from json import dumps
 from requests.status_codes import codes
 
@@ -44,7 +46,7 @@ class DIDClient(BaseClient):
         :param type: The type of the did: 'all'(container, dataset or file)|'collection'(dataset or container)|'dataset'|'container'|'file'
         :param long: Long format option to display more information for each DID.
         """
-        path = '/'.join([self.DIDS_BASEURL, scope, 'dids', 'search'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), 'dids', 'search'])
         payload = {}
         if long:
             payload['long'] = 1
@@ -80,7 +82,7 @@ class DIDClient(BaseClient):
         :param dids: The content.
         :param rse: The RSE name when registering replicas.
         """
-        path = '/'.join([self.DIDS_BASEURL, scope, name])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name)])
         url = build_url(choice(self.list_hosts), path=path)
         # Build json
         data = {'type': type}
@@ -171,7 +173,7 @@ class DIDClient(BaseClient):
         :param dids: The content.
         :param rse: The RSE name when registering replicas.
         """
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'dids'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'dids'])
         url = build_url(choice(self.list_hosts), path=path)
         data = {'dids': dids}
         if rse:
@@ -192,7 +194,7 @@ class DIDClient(BaseClient):
         :param dids: The content.
         """
 
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'dids'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'dids'])
         url = build_url(choice(self.list_hosts), path=path)
         data = {'dids': dids}
         r = self._send_request(url, type='DEL', data=render_json(**data))
@@ -305,7 +307,7 @@ class DIDClient(BaseClient):
         :param name: The data identifier name.
         """
 
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'dids'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'dids'])
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, type='GET')
         if r.status_code == codes.ok:
@@ -321,7 +323,7 @@ class DIDClient(BaseClient):
         :param name: The data identifier name.
         """
 
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'dids', 'history'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'dids', 'history'])
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, type='GET')
         if r.status_code == codes.ok:
@@ -339,7 +341,7 @@ class DIDClient(BaseClient):
         """
 
         payload = {}
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'files'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'files'])
         if long:
             payload['long'] = True
         url = build_url(choice(self.list_hosts), path=path, params=payload)
@@ -359,7 +361,7 @@ class DIDClient(BaseClient):
         :param name: The data identifier name.
         """
 
-        path = '/'.join([self.DIDS_BASEURL, scope, name])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name)])
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, type='GET')
         if r.status_code == codes.ok:
@@ -375,7 +377,7 @@ class DIDClient(BaseClient):
         :param scope: The scope name.
         :param name: The data identifier name.
         """
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'meta'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'meta'])
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, type='GET')
         if r.status_code == codes.ok:
@@ -395,7 +397,7 @@ class DIDClient(BaseClient):
         :param value: the value.
         :param recursive: Option to propagate the metadata change to content.
         """
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'meta', key])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'meta', key])
         url = build_url(choice(self.list_hosts), path=path)
         data = dumps({'value': value, 'recursive': recursive})
         r = self._send_request(url, type='POST', data=data)
@@ -413,7 +415,7 @@ class DIDClient(BaseClient):
         :param name: The data identifier name.
         :param kwargs:  Keyword arguments of the form status_name=value.
         """
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'status'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'status'])
         url = build_url(choice(self.list_hosts), path=path)
         data = dumps(kwargs)
         r = self._send_request(url, type='PUT', data=data)
@@ -440,7 +442,7 @@ class DIDClient(BaseClient):
         :param name: The data identifier.
         :param key: the key.
         """
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'meta', key])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'meta', key])
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, type='DEL')
 
@@ -458,7 +460,7 @@ class DIDClient(BaseClient):
         :param name: The data identifier name.
         """
 
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'rules'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'rules'])
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, type='GET')
         if r.status_code == codes.ok:
@@ -475,7 +477,7 @@ class DIDClient(BaseClient):
         :param name:  The file name.
         """
 
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'associated_rules'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'associated_rules'])
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, type='GET')
         if r.status_code == codes.ok:
@@ -510,7 +512,7 @@ class DIDClient(BaseClient):
         """
 
         payload = {}
-        path = '/'.join([self.DIDS_BASEURL, scope, ''])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), ''])
         if name:
             payload['name'] = name
         if recursive:
@@ -532,7 +534,7 @@ class DIDClient(BaseClient):
         :param name:  The name.
         """
 
-        path = '/'.join([self.DIDS_BASEURL, scope, name, 'parents'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'parents'])
         url = build_url(choice(self.list_hosts), path=path)
 
         r = self._send_request(url, type='GET')
@@ -553,7 +555,7 @@ class DIDClient(BaseClient):
         :param account: The account.
         :param nbfiles: The number of files to register in the output dataset.
         """
-        path = '/'.join([self.DIDS_BASEURL, input_scope, input_name, output_scope, output_name, str(nbfiles), 'sample'])
+        path = '/'.join([self.DIDS_BASEURL, quote_plus(input_scope), quote_plus(input_name), quote_plus(output_scope), quote_plus(output_name), str(nbfiles), 'sample'])
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, type='POST', data=dumps({}))
         if r.status_code == codes.created:
@@ -597,7 +599,7 @@ class DIDClient(BaseClient):
         :param scope: The scope name.
         :param name: The data identifier name.
         """
-        path = '/'.join([self.ARCHIVES_BASEURL, scope, name, 'files'])
+        path = '/'.join([self.ARCHIVES_BASEURL, quote_plus(scope), quote_plus(name), 'files'])
         url = build_url(choice(self.list_hosts), path=path)
 
         r = self._send_request(url, type='GET')

--- a/lib/rucio/client/fileclient.py
+++ b/lib/rucio/client/fileclient.py
@@ -8,7 +8,9 @@
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2012-2015
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2014
 # - Ralph Vigne, <ralph.vigne@cern.ch>, 2015
+# - Brian Bockelman, <bbockelm@cse.unl.edu>, 2018
 
+from urllib import quote_plus
 from json import loads
 from requests.status_codes import codes
 
@@ -35,7 +37,7 @@ class FileClient(BaseClient):
 
         :return: List of replicas.
         """
-        path = '/'.join([self.BASEURL, scope, lfn, 'rses'])
+        path = '/'.join([self.BASEURL, quote_plus(scope), quote_plus(lfn), 'rses'])
         url = build_url(choice(self.list_hosts), path=path)
 
         r = self._send_request(url, type='GET')

--- a/lib/rucio/client/lockclient.py
+++ b/lib/rucio/client/lockclient.py
@@ -8,7 +8,10 @@
   - Martin Barisits, <martin.barisits@cern.ch>, 2014
   - Ralph Vigne, <ralph.vigne@cern.ch>, 2015
   - Vincent Garonne, <vincent.garonne@cern.ch>, 2015
+  - Brian Bockelman, <bbockelm@cse.unl.edu>, 2018
 '''
+
+from urllib import quote_plus
 
 from requests.status_codes import codes
 
@@ -36,7 +39,7 @@ class LockClient(BaseClient):
         :param name: the name of the did of the locks to list.
         """
 
-        path = '/'.join([self.LOCKS_BASEURL, scope, name])
+        path = '/'.join([self.LOCKS_BASEURL, quote_plus(scope), quote_plus(name)])
         url = build_url(choice(self.list_hosts), path=path, params={'did_type': 'dataset'})
 
         result = self._send_request(url)

--- a/lib/rucio/client/metaclient.py
+++ b/lib/rucio/client/metaclient.py
@@ -8,7 +8,9 @@
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2012-2015
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2014
 # - Ralph Vigne, <ralph.vigne@cern.ch>, 2015
+# - Brian Bockelman, <bbockelm@cse.unl.edu>, 2018
 
+from urllib import quote_plus
 from json import dumps, loads
 from requests.status_codes import codes
 
@@ -39,7 +41,7 @@ class MetaClient(BaseClient):
         :raises Duplicate: if key already exists.
         """
 
-        path = '/'.join([self.META_BASEURL, key])
+        path = '/'.join([self.META_BASEURL, quote_plus(key)])
         url = build_url(choice(self.list_hosts), path=path)
         data = dumps({'value_type': value_type and str(value_type),
                       'value_regexp': value_regexp,
@@ -75,7 +77,7 @@ class MetaClient(BaseClient):
 
         :return: a list containing the names of all values for a key.
         """
-        path = self.META_BASEURL + '/' + key + '/'
+        path = '/'.join([self.META_BASEURL, quote_plus(key)]) + '/'
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url)
         if r.status_code == codes.ok:
@@ -96,7 +98,7 @@ class MetaClient(BaseClient):
         :raises Duplicate: if valid already exists.
         """
 
-        path = self.META_BASEURL + '/' + key + '/'
+        path = '/'.join([self.META_BASEURL, quote_plus(key)]) + '/'
         data = dumps({'value': value})
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, type='POST', data=data)

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -10,7 +10,10 @@
   - Cedric Serfon, <cedric.serfon@cern.ch>, 2014-2015
   - Ralph Vigne, <ralph.vigne@cern.ch>, 2015
   - Mario Lassnig, <mario.lassnig@cern.ch>, 2017
+  - Brian Bockelman, <bbockelm@cse.unl.edu>, 2018
 '''
+
+from urllib import quote_plus
 
 from json import dumps, loads
 from requests.status_codes import codes
@@ -220,7 +223,7 @@ class ReplicaClient(BaseClient):
             payload = {'deep': True}
 
         url = build_url(self.host,
-                        path='/'.join([self.REPLICAS_BASEURL, scope, name, 'datasets']),
+                        path='/'.join([self.REPLICAS_BASEURL, quote_plus(scope), quote_plus(name), 'datasets']),
                         params=payload)
         r = self._send_request(url, type='GET')
         if r.status_code == codes.ok:

--- a/lib/rucio/client/scopeclient.py
+++ b/lib/rucio/client/scopeclient.py
@@ -9,7 +9,9 @@
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2012-2015
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2014
 # - Ralph Vigne, <ralph.vigne@cern.ch>, 2015
+# - Brian Bockelman, <bbockelm@cse.unl.edu>, 2018
 
+from urllib import quote_plus
 from json import loads
 from requests.status_codes import codes
 
@@ -38,7 +40,7 @@ class ScopeClient(BaseClient):
         :raises AccountNotFound: if account doesn't exist.
         """
 
-        path = '/'.join([self.SCOPE_BASEURL, account, 'scopes', scope])
+        path = '/'.join([self.SCOPE_BASEURL, account, 'scopes', quote_plus(scope)])
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, type='POST')
         if r.status_code == codes.created:


### PR DESCRIPTION
This prevents URLs from being generated with unescaped URL meta-characters stemming from a DID.  Issue encountered by CMS.