### PR TITLE
Clients: Add unix auth for xrd (needed by EOS in addition to gsi) #467

### DIFF
--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -12,6 +12,7 @@
  - Vincent Garonne, <vincent.garonne@cern.ch>, 2016
  - Mario Lassnig, <mario.lassnig@cern.ch>, 2016-2017
  - Tobias Wegner, <tobias.wegner@cern.ch>, 2017
+ - Nicolo Magini, <nicolo.magini@cern.ch>, 2018
 '''
 
 import errno
@@ -166,7 +167,7 @@ class Default(protocol.RSEProtocol):
         # self.__ctx.set_opt_string("X509", "CERT", proxy)
         # self.__ctx.set_opt_string("X509", "KEY", proxy)
         self.__ctx.set_opt_string_list("SRM PLUGIN", "TURL_PROTOCOLS", ["gsiftp", "rfio", "gsidcap", "dcap", "kdcap"])
-        self.__ctx.set_opt_string("XROOTD PLUGIN", "XRD.WANTPROT", "gsi")
+        self.__ctx.set_opt_string("XROOTD PLUGIN", "XRD.WANTPROT", "gsi,unix")
 
     def get(self, path, dest):
         """


### PR DESCRIPTION
Clients: Add unix auth for xrd (needed by EOS in addition to gsi) #467