### PR TITLE
Client: Generate error message on unparseable response.  Fix 576

### DIFF
--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -208,7 +208,10 @@ class BaseClient(object):
 
         :return: A rucio exception class and an error string.
         """
-        data = parse_response(data)
+        try:
+            data = parse_response(data)
+        except ValueError:
+            data = {}
         if 'ExceptionClass' not in data:
             if 'ExceptionMessage' not in data:
                 human_http_code = _codes.get(status_code, None)  # NOQA, pylint: disable-msg=W0612


### PR DESCRIPTION
This causes the base client to generate a readable error message
if the server responds with a non-JSON response.

Before:

```
$ rucio whoami
2018-02-01 19:52:07,284 ERROR   No JSON object could be decoded
2018-02-01 19:52:07,284 ERROR   Rucio exited with an unexpected/unknown error. Please rerun the last command with the '-v' option and submit a ticket with all the available information to reproduce t
his error at https://its.cern.ch/jira/browse/RUCIO
```

After:

```
$ rucio -v whoami
2018-02-01 19:58:04,581 ERROR   An unknown exception occurred.
Details: no error information passed (http status code: 403 ('forbidden',))
```