### PR TITLE
Conveyor: Handle empty spacetokens correctly. Fix #574

### DIFF
--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -162,7 +162,7 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, fts_source_str
                 file['checksum'] = 'ADLER32:%s' % str(file['metadata']['adler32'])
 
         job_params = {'verify_checksum': True if file['checksum'] and file['metadata'].get('verify_checksum', True) else False,
-                      'spacetoken': transfer['dest_spacetoken'] if transfer['dest_spacetoken'] else 'null',
+                      'spacetoken': transfer['dest_spacetoken'] if transfer['dest_spacetoken'] else None,
                       'copy_pin_lifetime': transfer['copy_pin_lifetime'] if transfer['copy_pin_lifetime'] else -1,
                       'bring_online': transfer['bring_online'] if transfer['bring_online'] else None,
                       'job_metadata': {'issuer': 'rucio'},  # finaly job_meta will like this. currently job_meta will equal file_meta to include request_id and etc.

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -168,7 +168,7 @@ def submit_transfers(transfers, job_metadata):
                                   'activity': str(transfer['activity']),
                                   'selection_strategy': transfer.get('selection_strategy', 'auto')}],
                        'params': {'verify_checksum': True if transfer['checksum'] else False,
-                                  'spacetoken': transfer['dest_spacetoken'] if transfer['dest_spacetoken'] else 'null',
+                                  'spacetoken': transfer['dest_spacetoken'] if transfer['dest_spacetoken'] else None,
                                   'copy_pin_lifetime': transfer['copy_pin_lifetime'] if transfer['copy_pin_lifetime'] else -1,
                                   'bring_online': transfer['bring_online'] if transfer['bring_online'] else None,
                                   'job_metadata': job_metadata,


### PR DESCRIPTION
When an empty spacetoken is specified for a RSE, the conveyor and FTS3 transfer tool should not pass any spacetoken information to FTS3.

Previously, we passed a space token named 'null' (the string).  Now, the `null` object is given to FTS3.

Note the FTS3 logic for bulk submit is embedded in the conveyor code - that's likely not the intent.