### PR TITLE
Transfers: Implement pluggable LFN2PFN algorithms. Fixes #570

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -18,6 +18,7 @@
  - Evangelia Liotiri <evangelia.liotiri@cern.ch>, 2015
  - Tobias Wegner <tobias.wegner@cern.ch>, 2017
  - Nicolo Magini <nicolo.magini@cern.ch>, 2018
+ - Brian Bockelman <bbockelm@cse.unl.edu>, 2018
 """
 
 import argparse
@@ -1111,7 +1112,10 @@ def upload(args):
             logger.debug(error)
             logger.error("Some of the files already exist in the catalog. No one will be added.")
         except RucioException:
-            logger.error("A Rucio exception occurred when processing a file for upload.")
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.exception("A Rucio exception occurred when processing a file for upload.")
+            else:
+                logger.error("A Rucio exception occurred when processing a file for upload.")
             raise
     logger.debug("Finished uploading files to RSE.")
 

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -520,8 +520,10 @@ def add_protocol_rse(args):
     proto.setdefault('extended_attributes', {})
     if args.ext_attr_json:
         proto['extended_attributes'] = args.ext_attr_json
-    if proto['scheme'] == 'srm' and (not args.space_token or not args.web_service_path):
-        print 'Error: space-token and web-service-path must be provided for SRM endpoints.'
+    # Originally, both web-service-path and space-token were required.  However,
+    # many CMS sites don't use space tokens, so we relax this for now.
+    if proto['scheme'] == 'srm' and not args.web_service_path:
+        print 'Error: web-service-path must be provided for SRM endpoints.'
         return FAILURE
     if args.space_token:
         proto['extended_attributes']['space_token'] = args.space_token

--- a/etc/rucio.cfg.template
+++ b/etc/rucio.cfg.template
@@ -188,6 +188,7 @@ scope = user.vzavrtan
 [policy]
 permission=atlas
 schema=atlas
+lfn2pfn_algorithm_default=hash
 
 [webui]
 usercert = /opt/rucio/etc/usercert_with_key.pem

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -277,6 +277,7 @@ class RSEClient(BaseClient):
         The PFNs are generated for the RSE *regardless* of whether a replica exists for the LFN.
 
         :param rse: the RSE name
+        :param lfns: A list of LFN strings to translate to PFNs.
         :param protocol_domain: The scope of the protocol. Supported are 'LAN', 'WAN', and 'ALL' (as default).
         :param operation: The name of the requested operation (read, write, or delete).
                           If None, all operations are queried.

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -273,7 +273,20 @@ class RSEClient(BaseClient):
 
     def lfns2pfns(self, rse, lfns, protocol_domain='ALL', operation=None, scheme=None):
         """
-        TODO: document
+        Returns PFNs that should be used at a RSE, corresponding to requested LFNs.
+        The PFNs are generated for the RSE *regardless* of whether a replica exists for the LFN.
+
+        :param rse: the RSE name
+        :param protocol_domain: The scope of the protocol. Supported are 'LAN', 'WAN', and 'ALL' (as default).
+        :param operation: The name of the requested operation (read, write, or delete).
+                          If None, all operations are queried.
+        :param scheme: The identifier of the requested protocol (gsiftp, https, davs, etc).
+
+        :returns: A dictionary of LFN / PFN pairs.
+        :raises RSENotFound: if the RSE doesn't exist.
+        :raises RSEProtocolNotSupported: if no matching protocol entry could be found.
+        :raises RSEOperationNotSupported: if no matching protocol entry for the requested
+                                          operation could be found.
         """
         path = '/'.join([self.RSE_BASEURL, rse, 'lfns2pfns'])
         params = []

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -271,6 +271,31 @@ class RSEClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
+    def lfns2pfns(self, rse, lfns, protocol_domain='ALL', operation=None, scheme=None):
+        """
+        TODO: document
+        """
+        path = '/'.join([self.RSE_BASEURL, rse, 'lfns2pfns'])
+        params = []
+        if scheme:
+            params.append(('scheme', scheme))
+        if protocol_domain != 'ALL':
+            params.append(('domain', protocol_domain))
+        if operation:
+            params.append(('operation', operation))
+        for lfn in lfns:
+            params.append(('lfn', lfn))
+
+        url = build_url(choice(self.list_hosts), path=path, params=params, doseq=True)
+
+        r = self._send_request(url, type='GET')
+        if r.status_code == codes.ok:
+            pfns = loads(r.text)
+            return pfns
+        else:
+            exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+            raise exc_cls(exc_msg)
+
     def delete_protocols(self, rse, scheme, hostname=None, port=None):
         """
         Deletes matching protocols from RSE. Protocols using the same identifier can be

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -33,12 +33,22 @@ def config_get(section, option):
 
 
 def config_has_section(section):
-    """Indicates whether the named section is present in the configuration. The DEFAULT section is not acknowledged.)"""
+    """
+    Indicates whether the named section is present in the configuration. The DEFAULT section is not acknowledged.)
+
+    :param section: Name of section in the Rucio config to verify.
+    :returns: True if the section exists in the configuration; False otherwise
+    """
     return __CONFIG.has_section(section)
 
 
 def config_add_section(section):
-    """Add a new section to the configuration object.  Throws DuplicateSectionError if it already exists."""
+    """
+    Add a new section to the configuration object.  Throws DuplicateSectionError if it already exists.
+
+    :param section: Name of section in the Rucio config to add.
+    :returns: None
+    """
     return __CONFIG.add_section(section)
 
 
@@ -68,19 +78,27 @@ def config_get_items(section):
 
 
 def config_remove_option(section, option):
-    """Remove the specified option from a given section.
+    """
+    Remove the specified option from a given section.
 
-       If the option existed in the configuration, return True.
+    :param section: Name of section in the Rucio config.
+    :param option: Name of option to remove from Rucio configuration.
+    :returns: True if the option existed in the configuration, False otherwise.
 
-       If the section does not exist, throws NoSectionError.
+    :raises NoSectionError: If the section does not exist.
     """
     return __CONFIG.remove_option(section, option)
 
 
 def config_set(section, option, value):
-    """Set a configuration option in a given section.
+    """
+    Set a configuration option in a given section.
 
-       If the section does not exist, throws a NoSectionError.
+    :param section: Name of section in the Rucio config.
+    :param option: Name of option to set in the Rucio configuration.
+    :param value: New value for the option.
+
+    :raises NoSectionError: If the section does not exist.
     """
     return __CONFIG.set(section, option, value)
 

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -35,9 +35,11 @@ def config_has_section(section):
     """Indicates whether the named section is present in the configuration. The DEFAULT section is not acknowledged.)"""
     return __CONFIG.has_section(section)
 
+
 def config_add_section(section):
     """Add a new section to the configuration object.  Throws DuplicateSectionError if it already exists."""
     return __CONFIG.add_section(section)
+
 
 def config_get_int(section, option):
     """Return the integer value for a given option in a section"""

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -61,6 +61,24 @@ def config_get_items(section):
     return __CONFIG.items(section)
 
 
+def config_remove_option(section, option):
+    """Remove the specified option from a given section.
+
+       If the option existed in the configuration, return True.
+
+       If the section does not exist, throws NoSectionError.
+    """
+    return __CONFIG.remove_option(section, option)
+
+
+def config_set(section, option, value):
+    """Set a configuration option in a given section.
+
+       If the section does not exist, throws a NoSectionError.
+    """
+    return __CONFIG.set(section, option, value)
+
+
 def get_config_dir():
     """Return the rucio configuration directory"""
     configdirs = ['/opt/rucio/etc/', ]

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -9,6 +9,7 @@
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2012
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2013-2018
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2013
+# - Brian Bockelman, <bbockelm@cse.unl.edu>, 2018
 
 """
 Get the configuration file from /opt/rucio/etc/rucio.cfg
@@ -97,6 +98,16 @@ def get_config_dir():
     for configdir in configdirs:
         if os.path.exists(configdir):
             return configdir
+
+
+def get_lfn2pfn_algorithm_default():
+    """Returns the default algorithm name for LFN2PFN translation for this server."""
+    default_lfn2pfn = "hash"
+    try:
+        default_lfn2pfn = config_get('policy', 'lfn2pfn_algorithm_default')
+    except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+        pass
+    return default_lfn2pfn
 
 
 def get_schema_dir():

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -35,6 +35,9 @@ def config_has_section(section):
     """Indicates whether the named section is present in the configuration. The DEFAULT section is not acknowledged.)"""
     return __CONFIG.has_section(section)
 
+def config_add_section(section):
+    """Add a new section to the configuration object.  Throws DuplicateSectionError if it already exists."""
+    return __CONFIG.add_section(section)
 
 def config_get_int(section, option):
     """Return the integer value for a given option in a section"""

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -13,6 +13,7 @@
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2013-2016
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2014, 2017
 # - Wen Guan, <wen.guan@cern.ch>, 2015-2016
+# - Brian Bockelman, <bbockelm@cse.unl.edu>, 2018
 
 from re import match
 from StringIO import StringIO
@@ -34,6 +35,7 @@ import rucio.core.account_counter
 from rucio.core.rse_counter import add_counter
 
 from rucio.common import exception, utils
+from rucio.common.config import get_lfn2pfn_algorithm_default
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import RSEType
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
@@ -688,7 +690,7 @@ def add_protocol(rse, parameter, session=None):
             pass  # String is not JSON
 
     if parameter['scheme'] == 'srm':
-        if ('space_token' not in parameter['extended_attributes']) or ('web_service_path' not in parameter['extended_attributes']):
+        if 'web_service_path' not in parameter['extended_attributes']:
             raise exception.InvalidObject('Missing values! For SRM, extended_attributes and web_service_path must be specified')
 
     try:
@@ -729,7 +731,9 @@ def get_rse_protocols(rse, schemes=None, session=None):
         raise exception.RSENotFound('RSE \'%s\' not found')
 
     lfn2pfn_algorithms = get_rse_attribute('lfn2pfn_algorithm', rse_id=_rse.id, session=session)
-    lfn2pfn_algorithm = 'default'
+    # Resolve LFN2PFN default algorithm as soon as possible.  This way, we can send back the actual
+    # algorithm name in response to REST queries.
+    lfn2pfn_algorithm = get_lfn2pfn_algorithm_default()
     if lfn2pfn_algorithms:
         lfn2pfn_algorithm = lfn2pfn_algorithms[0]
 

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -28,7 +28,6 @@ from rucio.common import config, exception
 from rucio.rse import rsemanager
 
 if getattr(rsemanager, 'CLIENT_MODE', None):
-    from rucio.client.replicaclient import ReplicaClient
     from rucio.client.rseclient import RSEClient
 
 if getattr(rsemanager, 'SERVER_MODE', None):
@@ -211,7 +210,6 @@ class RSEProtocol(object):
             :returns: dict with scope:name as keys and PFN as value (in case of errors the Rucio exception si assigned to the key)
         """
         client = RSEClient()
-        pfns = {}
 
         lfns = [lfns] if isinstance(lfns, dict) else lfns
         lfn_query = ["%s:%s" % (lfn['scope'], lfn['name']) for lfn in lfns]

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -46,6 +46,10 @@ class RSEDeterministicTranslation(object):
         """
         Initialize a translator object from the RSE, its attributes, and the protocol-specific
         attributes.
+
+        :param rse: Name of RSE for this translation.
+        :param rse_attributes: A dictionary of RSE-specific attributes for use in the translation.
+        :param protocol_attributes: A dictionary of RSE/protocol-specific attributes.
         """
         self.rse = rse
         self.rse_attributes = rse_attributes if rse_attributes else {}
@@ -53,8 +57,11 @@ class RSEDeterministicTranslation(object):
 
     @classmethod
     def supports(cls, name):
-        """Returns True if `name` is an algorithm supported by the translator
-           class, False otherwise.
+        """
+        Check to see if a specific algorithm is supported.
+
+        :param name: Name of the deterministic algorithm.
+        :returns: True if `name` is an algorithm supported by the translator class, False otherwise.
         """
         return name in cls._LFN2PFN_ALGORITHMS
 
@@ -71,6 +78,9 @@ class RSEDeterministicTranslation(object):
          - protocol_attributes: Attributes of the RSE's protocol
         The return value should be the last part of the PFN - it will be appended to the
         rest of the URL.
+
+        :param lfn2pfn_callable: Callable function to use for generating paths.
+        :param name: Algorithm name used for registration.  If None, then `lfn2pfn_callable.__name__` is used.
         """
         if name is None:
             name = lfn2pfn_callable.__name__
@@ -80,6 +90,16 @@ class RSEDeterministicTranslation(object):
     def __hash(scope, name, rse, rse_attrs, protocol_attrs):
         """
         Given a LFN, turn it into a sub-directory structure using a hash function.
+
+        This takes the MD5 of the LFN and uses the first four characters as a subdirectory
+        name.
+
+        :param scope: Scope of the LFN.
+        :param name: File name of the LFN.
+        :param rse: RSE for PFN (ignored)
+        :param rse_attrs: RSE attributes for PFN (ignored)
+        :param protocol_attrs: RSE protocol attributes for PFN (ignored)
+        :returns: Path for use in the PFN generation.
         """
         del rse
         del rse_attrs
@@ -96,6 +116,12 @@ class RSEDeterministicTranslation(object):
 
             scope:path -> scope/path
 
+        :param scope: Scope of the LFN.
+        :param name: File name of the LFN.
+        :param rse: RSE for PFN (ignored)
+        :param rse_attrs: RSE attributes for PFN (ignored)
+        :param protocol_attrs: RSE protocol attributes for PFN (ignored)
+        :returns: Path for use in the PFN generation.
         """
         del rse
         del rse_attrs
@@ -220,8 +246,8 @@ class RSEProtocol(object):
             Suitable for sites implementing the RUCIO naming convention.
             This implementation is only invoked if the RSE is deterministic.
 
-            :param lfn: filename
             :param scope: scope
+            :param name: filename
 
             :returns: RSE specific URI of the physical file
         """

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -13,9 +13,11 @@
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2017
 
 import hashlib
+import importlib
 
 from exceptions import NotImplementedError
 from urlparse import urlparse
+from ConfigParser import NoOptionError, NoSectionError
 
 from rucio.common import config, exception
 from rucio.rse import rsemanager
@@ -26,58 +28,101 @@ if getattr(rsemanager, 'CLIENT_MODE', None):
 if getattr(rsemanager, 'SERVER_MODE', None):
     from rucio.core import replica
 
-# Provide the ability to register custom lfn2pfn algorithms for this server isntance
-# Algorithms take in three inputs:
-# - scope
-# - name
-# - RSE
-# And should return part of a PFN that will be appended to the rest of the URL plus
-# the prefix.
-__LFN2PFN_ALGORITHMS = {}
-def register_lfn2pfn(lfn2pfn_callable, name=None):
+
+class RSEDeterministicTranslation(object):
     """
-    Provided a callable function, register it as one of the valid LFN2PFN algorithms.
+    Execute the logic for translating a LFN to a path.
     """
-    global __LFN2PFN_ALGORITHMS
-    if name is None:
-        name = lfn2pfn_callable.__name__
-    __LFN2PFN_ALGORITHMS[name] = lfn2pfn_callable
+
+    _LFN2PFN_ALGORITHMS = {}
+    _DEFAULT_LFN2PFN = "hash"
+
+    def __init__(self, rse=None, rse_attributes=None, protocol_attributes=None):
+        """
+        Initialize a translator object from the RSE, its attributes, and the protocol-specific
+        attributes.
+        """
+        self.rse = rse
+        self.rse_attributes = rse_attributes if rse_attributes else {}
+        self.protocol_attributes = protocol_attributes if protocol_attributes else {}
+
+    @staticmethod
+    def register(lfn2pfn_callable, name=None):
+        """
+        Provided a callable function, register it as one of the valid LFN2PFN algorithms.
+
+        The callable will receive five arguments:
+         - scope: Scope of the LFN.
+         - name: LFN's path name
+         - rse: RSE name the translation is being done for.
+         - rse_attributes: Attributes of the RSE.
+         - protocol_attributes: Attributes of the RSE's protocol
+        The return value should be the last part of the PFN - it will be appended to the
+        rest of the URL.
+        """
+        if name is None:
+            name = lfn2pfn_callable.__name__
+        RSEDeterministicTranslation._LFN2PFN_ALGORITHMS[name] = lfn2pfn_callable
+
+    @staticmethod
+    def __hash(scope, name, rse, _, __):
+        """
+        Given a LFN, turn it into a sub-directory structure using a hash function.
+        """
+        hstr = hashlib.md5('%s:%s' % (scope, name)).hexdigest()
+        if scope.startswith('user') or scope.startswith('group'):
+            scope = scope.replace('.', '/')
+        return '%s/%s/%s/%s' % (scope, hstr[0:2], hstr[2:4], name)
+
+    @staticmethod
+    def __identity(scope, name, rse, _, __):
+        """
+        Given a LFN, convert it directly to a path using the mapping:
+
+            scope:path -> scope/path
+
+        """
+        if scope.startswith('user') or scope.startswith('group'):
+            scope = scope.replace('.', '/')
+        return '%s/%s' % (scope, name)
+
+    @classmethod
+    def _module_init_(cls):
+        """
+        Initialize the class object on first module load.
+        """
+        cls.register(cls.__hash, "hash")
+        cls.register(cls.__identity, "identity")
+        if config.config_has_section('policy'):
+            policy_module = None
+        try:
+            policy_module = config.config_get('policy', 'lfn2pfn_module')
+        except (NoOptionError, NoSectionError):
+            pass
+        if policy_module:
+            importlib.import_module(policy_module)
+        cls._DEFAULT_LFN2PFN = "hash"
+        try:
+            cls._DEFAULT_LFN2PFN = config.config_get('policy', 'lfn2pfn_algorithm_default')
+        except (NoOptionError, NoSectionError):
+            pass
+
+    def path(self, scope, name):
+        """ Transforms the logical file name into a PFN's path.
+
+            :param lfn: filename
+            :param scope: scope
+
+            :returns: RSE specific URI of the physical file
+        """
+        algorithm = self.rse_attributes.get('lfn2pfn_algorithm', 'default')
+        if algorithm == 'default':
+            algorithm = RSEDeterministicTranslation._DEFAULT_LFN2PFN
+        algorithm_callable = RSEDeterministicTranslation._LFN2PFN_ALGORITHMS[algorithm]
+        return algorithm_callable(scope, name, self.rse, self.rse_attributes, self.protocol_attributes)
 
 
-def lfn2pfn_hash(scope, name, rse):
-    """
-    Given a LFN, turn it into a sub-directory structure using a hash function.
-    """
-    hstr = hashlib.md5('%s:%s' % (scope, name)).hexdigest()
-    if scope.startswith('user') or scope.startswith('group'):
-        scope = scope.replace('.', '/')
-    return '%s/%s/%s/%s' % (scope, hstr[0:2], hstr[2:4], name)
-
-
-def lfn2pfn_identity(scope, name, rse):
-    """
-    Given a LFN, use it as a subdirectory.
-    """
-    if scope.startswith('user') or scope.startswith('group'):
-        scope = scope.replace('.', '/')
-    return '%s/%s' % (scope, name)
-
-
-__LFN2PFN_ALGORITHMS['hash'] = lfn2pfn_hash
-__LFN2PFN_ALGORITHMS['identity'] = lfn2pfn_identity
-if config.config_has_section('policy'):
-    POLICY_MODULE = None
-    try:
-        POLICY_MODULE = config.config_get('policy', 'lfn2pfn_module')
-    except (NoOptionError, NoSectionError) as error:
-        pass
-    if POLICY_MODULE:
-        importlib.import_module(POLICY_MODULE)
-    DEFAULT_LFN2PFN = "hash"
-    try:
-        DEFAULT_LFN2PFN = config.config_get('policy', 'lfn2pfn_algorithm_default')
-    except (NoOptionError, NoSectionError) as error:
-        pass
+RSEDeterministicTranslation._module_init_()
 
 
 class RSEProtocol(object):
@@ -89,16 +134,17 @@ class RSEProtocol(object):
             :param props: Properties of the reuested protocol
         """
         self.attributes = protocol_attr
+        self.translator = None
         self.renaming = True
         self.overwrite = False
         self.rse = rse_settings
-        if not self.rse['deterministic']:
+        if self.rse['deterministic']:
+            self.translator = RSEDeterministicTranslation(self.rse['rse'], self.rse_settings, self.attributes)
+        else:
             if getattr(rsemanager, 'CLIENT_MODE', None):
                 setattr(self, 'lfns2pfns', self.__lfns2pfns_client)
             if getattr(rsemanager, 'SERVER_MODE', None):
                 setattr(self, '_get_path', self._get_path_nondeterministic_server)
-        else:
-            self.attributes['lfn2pfn_algorithm'] = self.rse.get('lfn2pfn_algorithm', None)
 
     def lfns2pfns(self, lfns):
         """
@@ -164,18 +210,14 @@ class RSEProtocol(object):
     def _get_path(self, scope, name):
         """ Transforms the logical file name into a PFN.
             Suitable for sites implementing the RUCIO naming convention.
+            This implementation is only invoked if the RSE is deterministic.
 
             :param lfn: filename
             :param scope: scope
 
             :returns: RSE specific URI of the physical file
         """
-        algorithm = self.attributes.get('lfn2pfn_algorithm', 'default')
-        if algorithm == 'default':
-            algorithm = DEFAULT_LFN2PFN
-        algorithm_callable = __LFN2PFN_ALGORITHMS[algorithm]
-        # TODO: include RSE.
-        return algorithm_callable(scope, name, None)
+        return self.translator.path(scope, name)
 
     def _get_path_nondeterministic_server(self, scope, name):
         """ Provides the path of a replica for non-deterministic sites. Will be assigned to get path by the __init__ method if neccessary. """

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -104,8 +104,7 @@ class RSEDeterministicTranslation(object):
         """
         cls.register(cls.__hash, "hash")
         cls.register(cls.__identity, "identity")
-        if config.config_has_section('policy'):
-            policy_module = None
+        policy_module = None
         try:
             policy_module = config.config_get('policy', 'lfn2pfn_module')
         except (NoOptionError, NoSectionError):

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -133,7 +133,7 @@ class RSEDeterministicTranslation(object):
         return algorithm_callable(scope, name, self.rse, self.rse_attributes, self.protocol_attributes)
 
 
-RSEDeterministicTranslation._module_init_()  #pylint: disable=protected-access
+RSEDeterministicTranslation._module_init_()  # pylint: disable=protected-access
 
 
 class RSEProtocol(object):
@@ -184,7 +184,7 @@ class RSEProtocol(object):
                                                          str(self.attributes['port']),
                                                          prefix,
                                                          lfn['path'] if not lfn['path'].startswith('/') else lfn['path'][1:]
-                                                        ])
+                                                         ])
             else:
                 pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'],
                                                          '://',
@@ -193,7 +193,7 @@ class RSEProtocol(object):
                                                          str(self.attributes['port']),
                                                          prefix,
                                                          self._get_path(scope=scope, name=name)
-                                                        ])
+                                                         ])
         return pfns
 
     def __lfns2pfns_client(self, lfns):
@@ -230,7 +230,7 @@ class RSEProtocol(object):
         """
         return self.translator.path(scope, name)
 
-    def _get_path_nondeterministic_server(self, scope, name): #pylint: disable=invalid-name
+    def _get_path_nondeterministic_server(self, scope, name):  # pylint: disable=invalid-name
         """ Provides the path of a replica for non-deterministic sites. Will be assigned to get path by the __init__ method if neccessary. """
         rep = replica.get_replica(rse=self.rse['rse'], scope=scope, name=name, rse_id=self.rse['id'])
         if 'path' in rep and rep['path'] is not None:

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -298,6 +298,9 @@ def exists(rse_settings, files):
             exists = protocol.exists(f)
             ret[f] = exists
         elif 'scope' in f:  # a LFN is provided
+            pfn = protocol.lfns2pfns(f).values()[0]
+            if isinstance(pfn, exception.RucioException):
+                raise pfn
             exists = protocol.exists(protocol.lfns2pfns(f).values()[0])
             ret[f['scope'] + ':' + f['name']] = exists
         else:
@@ -357,6 +360,8 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None):
             pfn = force_pfn
         else:
             pfn = protocol.lfns2pfns(make_valid_did(lfn)).values()[0]
+            if isinstance(pfn, exception.RucioException):
+                raise pfn
 
         # First check if renaming operation is supported
         if protocol.renaming:

--- a/lib/rucio/tests/lfn2pfn_module_test.py
+++ b/lib/rucio/tests/lfn2pfn_module_test.py
@@ -1,0 +1,16 @@
+''' Copyright European Organization for Nuclear Research (CERN)
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Authors:
+ - Brian Bockelman, <bbockelm@cse.unl.edu>, 2019
+'''
+
+from rucio.rse.protocols.protocol import RSEDeterministicTranslation
+
+def lfn2pfn_module_algorithm(scope, name, rse, rse_attributes, protcol_attributes):
+    return "lfn2pfn_module_algorithm_value"
+
+RSEDeterministicTranslation.register(lfn2pfn_module_algorithm)

--- a/lib/rucio/tests/lfn2pfn_module_test.py
+++ b/lib/rucio/tests/lfn2pfn_module_test.py
@@ -10,7 +10,9 @@
 
 from rucio.rse.protocols.protocol import RSEDeterministicTranslation
 
+
 def lfn2pfn_module_algorithm(scope, name, rse, rse_attributes, protcol_attributes):
     return "lfn2pfn_module_algorithm_value"
+
 
 RSEDeterministicTranslation.register(lfn2pfn_module_algorithm)

--- a/lib/rucio/tests/lfn2pfn_module_test.py
+++ b/lib/rucio/tests/lfn2pfn_module_test.py
@@ -11,7 +11,13 @@
 from rucio.rse.protocols.protocol import RSEDeterministicTranslation
 
 
-def lfn2pfn_module_algorithm(scope, name, rse, rse_attributes, protcol_attributes):
+def lfn2pfn_module_algorithm(scope, name, rse, rse_attributes, protocol_attributes):
+    """Dummy LFN2PFN algorithm for unit tests."""
+    del scope
+    del name
+    del rse
+    del rse_attributes
+    del protocol_attributes
     return "lfn2pfn_module_algorithm_value"
 
 

--- a/lib/rucio/tests/test_rse_lfn2path.py
+++ b/lib/rucio/tests/test_rse_lfn2path.py
@@ -15,6 +15,7 @@ from nose.tools import assert_equal
 from rucio.rse.protocols.protocol import RSEDeterministicTranslation
 from rucio.common import config
 
+
 class TestDeterministicTranslation(object):
     """
     Verify the deterministic translator.
@@ -55,8 +56,10 @@ class TestDeterministicTranslation(object):
         """LFN2PFN: Verify we can register a custom function (Success)"""
         def static_register_test1(scope, name, rse, rse_attrs, proto_attrs):
             return "static_register_value1"
+
         def static_register_test2(scope, name, rse, rse_attrs, proto_attrs):
             return "static_register_value2"
+
         RSEDeterministicTranslation.register(static_register_test1)
         RSEDeterministicTranslation.register(static_register_test2, name="static_register_custom_name")
         self.rse_attributes['lfn2pfn_algorithm'] = 'static_register_test1'
@@ -66,7 +69,7 @@ class TestDeterministicTranslation(object):
         self.create_translator()
         assert_equal(self.translator.path("foo", "bar"), "static_register_value2")
 
-    def test_register_func(self):
+    def test_attr_mapping(self):
         """LFN2PFN: Verify we can map using rse and attrs (Successs)"""
         def rse_algorithm(scope, name, rse, rse_attrs, proto_attrs):
             tier = rse_attrs.get("tier", "T1")
@@ -100,8 +103,10 @@ class TestDeterministicTranslation(object):
             orig_value = config.config_get('policy', 'lfn2pfn_algorithm_default')
         except NoOptionError:
             orig_value = None
+
         def static_test(scope, name, rse, rse_attrs, proto_attrs):
             return "static_test_value"
+
         RSEDeterministicTranslation.register(static_test)
         try:
             config.config_set('policy', 'lfn2pfn_algorithm_default', 'static_test')

--- a/lib/rucio/tests/test_rse_lfn2path.py
+++ b/lib/rucio/tests/test_rse_lfn2path.py
@@ -112,7 +112,7 @@ class TestDeterministicTranslation(object):
     def test_module_load(self):
         """LFN2PFN: Test ability to provide LFN2PFN functions via module (Success)"""
         config.config_set('policy', 'lfn2pfn_module', 'rucio.tests.lfn2pfn_module_test')
-        RSEDeterministicTranslation._module_init_() #pylint: disable=protected-access
+        RSEDeterministicTranslation._module_init_()  # pylint: disable=protected-access
         self.rse_attributes['lfn2pfn_algorithm'] = 'lfn2pfn_module_algorithm'
         self.create_translator()
         assert_equal(self.translator.path("foo", "bar"), "lfn2pfn_module_algorithm_value")
@@ -136,11 +136,11 @@ class TestDeterministicTranslation(object):
         RSEDeterministicTranslation.register(static_test)
         try:
             config.config_set('policy', 'lfn2pfn_algorithm_default', 'static_test')
-            RSEDeterministicTranslation._module_init_() #pylint: disable=protected-access
+            RSEDeterministicTranslation._module_init_()  # pylint: disable=protected-access
             assert_equal(self.translator.path("foo", "bar"), "static_test_value")
         finally:
             if orig_value is None:
                 config.config_remove_option('policy', 'lfn2pfn_algorithm_default')
             else:
                 config.config_set('policy', 'lfn2pfn_algorithm_default', orig_value)
-            RSEDeterministicTranslation._module_init_() #pylint: disable=protected-access
+            RSEDeterministicTranslation._module_init_()  # pylint: disable=protected-access

--- a/lib/rucio/tests/test_rse_lfn2path.py
+++ b/lib/rucio/tests/test_rse_lfn2path.py
@@ -121,6 +121,8 @@ class TestDeterministicTranslation(object):
 
     def test_config_default_override(self):
         """LFN2PFN: Test override of default LFN2PFN algorithm via config (Success)"""
+        if not config.config_has_section('policy'):
+            config.config_add_section('policy')
         try:
             orig_value = config.config_get('policy', 'lfn2pfn_algorithm_default')
         except (NoOptionError, NoSectionError):

--- a/lib/rucio/tests/test_rse_lfn2path.py
+++ b/lib/rucio/tests/test_rse_lfn2path.py
@@ -1,0 +1,115 @@
+''' Copyright European Organization for Nuclear Research (CERN)
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Authors:
+ - Brian Bockelman, <bbockelm@cse.unl.edu>, 2019
+'''
+
+from ConfigParser import NoOptionError
+
+from nose.tools import assert_equal
+
+from rucio.rse.protocols.protocol import RSEDeterministicTranslation
+from rucio.common import config
+
+class TestDeterministicTranslation(object):
+    """
+    Verify the deterministic translator.
+    """
+
+    def setup(self):
+        """LFN2PFN: Creating RSEDeterministicTranslation instance"""
+        self.rse = 'Mock'
+        self.rse_attributes = {"rse": "Mock"}
+        self.protocol_attributes = {"protocol": "test"}
+        self.create_translator()
+
+    def create_translator(self):
+        """Create a new RSEDeterministicTranslation for use with tests."""
+        self.translator = RSEDeterministicTranslation(self.rse, self.rse_attributes, self.protocol_attributes)
+
+    def test_hash(self):
+        """LFN2PFN: Translate to path using a hash (Success)"""
+        self.rse_attributes['lfn2pfn_algorithm'] = 'hash'
+        self.create_translator()
+        assert_equal(self.translator.path("foo", "bar"), "foo/4e/99/bar")
+
+    def test_default_hash(self):
+        """LFN2PFN: Translate to path using default algorithm (Success)"""
+        assert_equal(self.translator.path("foo", "bar"), "foo/4e/99/bar")
+
+    def test_identity(self):
+        """LFN2PFN: Translate to path using identity (Success)"""
+        self.rse_attributes['lfn2pfn_algorithm'] = 'identity'
+        self.create_translator()
+        assert_equal(self.translator.path("foo", "bar"), "foo/bar")
+
+    def test_user_scope(self):
+        """LFN2PFN: Test special user scope rules (Success)"""
+        assert_equal(self.translator.path("user.foo", "bar"), "user/foo/13/7f/bar")
+
+    def test_register_func(self):
+        """LFN2PFN: Verify we can register a custom function (Success)"""
+        def static_register_test1(scope, name, rse, rse_attrs, proto_attrs):
+            return "static_register_value1"
+        def static_register_test2(scope, name, rse, rse_attrs, proto_attrs):
+            return "static_register_value2"
+        RSEDeterministicTranslation.register(static_register_test1)
+        RSEDeterministicTranslation.register(static_register_test2, name="static_register_custom_name")
+        self.rse_attributes['lfn2pfn_algorithm'] = 'static_register_test1'
+        self.create_translator()
+        assert_equal(self.translator.path("foo", "bar"), "static_register_value1")
+        self.rse_attributes['lfn2pfn_algorithm'] = 'static_register_custom_name'
+        self.create_translator()
+        assert_equal(self.translator.path("foo", "bar"), "static_register_value2")
+
+    def test_register_func(self):
+        """LFN2PFN: Verify we can map using rse and attrs (Successs)"""
+        def rse_algorithm(scope, name, rse, rse_attrs, proto_attrs):
+            tier = rse_attrs.get("tier", "T1")
+            scheme = proto_attrs.get("scheme", "http")
+            return "%s://%s_%s/%s/%s" % (scheme, tier, rse, scope, name)
+        RSEDeterministicTranslation.register(rse_algorithm)
+        self.rse_attributes['lfn2pfn_algorithm'] = 'rse_algorithm'
+        self.create_translator()
+        assert_equal(self.translator.path("foo", "bar"), "http://T1_Mock/foo/bar")
+        self.rse_attributes['tier'] = 'T2'
+        self.create_translator()
+        assert_equal(self.translator.path("foo", "bar"), "http://T2_Mock/foo/bar")
+        self.protocol_attributes['scheme'] = 'https'
+        self.create_translator()
+        assert_equal(self.translator.path("foo", "bar"), "https://T2_Mock/foo/bar")
+        self.protocol_attributes['scheme'] = 'srm'
+        self.create_translator()
+        assert_equal(self.translator.path("foo", "bar"), "srm://T2_Mock/foo/bar")
+
+    def test_module_load(self):
+        """LFN2PFN: Test ability to provide LFN2PFN functions via module (Success)"""
+        config.config_set('policy', 'lfn2pfn_module', 'rucio.tests.lfn2pfn_module_test')
+        RSEDeterministicTranslation._module_init_()
+        self.rse_attributes['lfn2pfn_algorithm'] = 'lfn2pfn_module_algorithm'
+        self.create_translator()
+        assert_equal(self.translator.path("foo", "bar"), "lfn2pfn_module_algorithm_value")
+
+    def test_config_default_override(self):
+        """LFN2PFN: Test override of default LFN2PFN algorithm via config (Success)"""
+        try:
+            orig_value = config.config_get('policy', 'lfn2pfn_algorithm_default')
+        except NoOptionError:
+            orig_value = None
+        def static_test(scope, name, rse, rse_attrs, proto_attrs):
+            return "static_test_value"
+        RSEDeterministicTranslation.register(static_test)
+        try:
+            config.config_set('policy', 'lfn2pfn_algorithm_default', 'static_test')
+            RSEDeterministicTranslation._module_init_()
+            assert_equal(self.translator.path("foo", "bar"), "static_test_value")
+        finally:
+            if orig_value is None:
+                config.config_remove_option('policy', 'lfn2pfn_algorithm_default')
+            else:
+                config.config_set('policy', 'lfn2pfn_algorithm_default', orig_value)
+            RSEDeterministicTranslation._module_init_()

--- a/lib/rucio/tests/test_rse_lfn2path.py
+++ b/lib/rucio/tests/test_rse_lfn2path.py
@@ -8,7 +8,7 @@
  - Brian Bockelman, <bbockelm@cse.unl.edu>, 2018
 '''
 
-from ConfigParser import NoOptionError
+from ConfigParser import NoOptionError, NoSectionError
 
 from nose.tools import assert_equal
 
@@ -111,6 +111,8 @@ class TestDeterministicTranslation(object):
 
     def test_module_load(self):
         """LFN2PFN: Test ability to provide LFN2PFN functions via module (Success)"""
+        if not config.config_has_section('policy'):
+            config.config_add_section('policy')
         config.config_set('policy', 'lfn2pfn_module', 'rucio.tests.lfn2pfn_module_test')
         RSEDeterministicTranslation._module_init_()  # pylint: disable=protected-access
         self.rse_attributes['lfn2pfn_algorithm'] = 'lfn2pfn_module_algorithm'
@@ -121,7 +123,7 @@ class TestDeterministicTranslation(object):
         """LFN2PFN: Test override of default LFN2PFN algorithm via config (Success)"""
         try:
             orig_value = config.config_get('policy', 'lfn2pfn_algorithm_default')
-        except NoOptionError:
+        except (NoOptionError, NoSectionError):
             orig_value = None
 
         def static_test(scope, name, rse, rse_attrs, proto_attrs):

--- a/lib/rucio/tests/test_rse_lfn2path.py
+++ b/lib/rucio/tests/test_rse_lfn2path.py
@@ -5,7 +5,7 @@
  http://www.apache.org/licenses/LICENSE-2.0
 
  Authors:
- - Brian Bockelman, <bbockelm@cse.unl.edu>, 2019
+ - Brian Bockelman, <bbockelm@cse.unl.edu>, 2018
 '''
 
 from ConfigParser import NoOptionError

--- a/lib/rucio/tests/test_rse_lfn2path.py
+++ b/lib/rucio/tests/test_rse_lfn2path.py
@@ -148,3 +148,19 @@ class TestDeterministicTranslation(object):
             else:
                 config.config_set('policy', 'lfn2pfn_algorithm_default', orig_value)
             RSEDeterministicTranslation._module_init_()  # pylint: disable=protected-access
+
+    def test_supports(self):  # pylint: disable=no-self-use
+        """LFN2PFN: See if the static `supports` method works"""
+
+        def static_test(scope, name, rse, rse_attrs, proto_attrs):
+            """Static test function for testing supports."""
+            del scope
+            del name
+            del rse
+            del rse_attrs
+            del proto_attrs
+            return "static_test_value"
+
+        assert not RSEDeterministicTranslation.supports("static_supports")
+        RSEDeterministicTranslation.register(static_test, "static_supports")
+        assert RSEDeterministicTranslation.supports("static_supports")

--- a/lib/rucio/web/rest/rse.py
+++ b/lib/rucio/web/rest/rse.py
@@ -338,7 +338,18 @@ class LFNS2PFNS(RucioController):
     """ Translate one-or-more LFNs to corresponding PFNs. """
 
     def GET(self, rse, scheme=None):
-        """ Return PFNs for a set of LFNs.
+        """
+        Return PFNs for a set of LFNs.  Formatted as a JSON object where the key is a LFN and the
+        value is the corresponding PFN.
+
+        - One or more LFN should be passed as the LFN arguments.
+        - A URL scheme (e.g., http / gsiftp / srm) can be passed to help with protocol selection using the
+          `scheme` query argument.
+        - The `domain` query argument is used to select protocol for wan or lan use cases.
+        - The `operation` query argument is used to select the protocol for read-vs-writes.
+
+        The `scheme`, `domain`, and `operation` options help with the selection of the protocol, in case
+        if that affects the possible PFN generation.
 
         HTTP Success:
             200 OK

--- a/lib/rucio/web/rest/rse.py
+++ b/lib/rucio/web/rest/rse.py
@@ -15,7 +15,7 @@
 
 from json import dumps, loads
 from traceback import format_exc
-from urlparse import parse_qs
+from urlparse import parse_qs, parse_qsl
 from web import (application, ctx, data, header, Created, InternalError, OK,
                  input, loadhook)
 
@@ -33,6 +33,7 @@ from rucio.common.exception import (Duplicate, AccessDenied, RSENotFound, RucioE
                                     RSEProtocolPriorityError, InvalidRSEExpression)
 from rucio.common.utils import generate_http_error, render_json, APIEncoder
 from rucio.web.rest.common import rucio_loadhook, RucioController
+from rucio.rse import rsemanager
 
 URLS = (
     '/(.+)/attr/(.+)', 'Attributes',
@@ -43,6 +44,7 @@ URLS = (
     '/(.+)/protocols/(.+)/(.+)', 'Protocol',  # delete (DELETE) all protocols with the same identifier and the same hostname
     '/(.+)/protocols/(.+)', 'Protocol',  # List (GET), create (POST), update (PUT), or delete (DELETE) a all protocols with the same identifier
     '/(.+)/protocols', 'Protocols',  # List all supported protocols (GET)
+    '/(.+)/lfns2pfns', 'LFNS2PFNS',  # Translate a list of LFNs to PFNs (GET)
     '/(.+)/accounts/usage', 'RSEAccountUsageLimit',
     '/(.+)/usage', 'Usage',  # Update RSE usage information
     '/(.+)/usage/history', 'UsageHistory',  # Get RSE usage history information
@@ -330,6 +332,62 @@ class Protocols(RucioController):
             return dumps(p_list['protocols'])
         else:
             raise generate_http_error(404, 'RSEProtocolNotSupported', 'No prptocols found for this RSE')
+
+
+class LFNS2PFNS(RucioController):
+    """ Translate one-or-more LFNs to corresponding PFNs. """
+
+    def GET(self, rse, scheme=None):
+        """ Return PFNs for a set of LFNs.
+
+        HTTP Success:
+            200 OK
+
+        HTTP Error:
+            400 LFN parameter(s) malformed
+            404 Resource not Found
+            500 InternalError
+
+        :returns: A list with detailed PFN information.
+        """
+        header('Content-Type', 'application/json')
+
+        lfns = []
+        scheme = None
+        domain = 'wan'
+        operation = 'write'
+        if ctx.query:
+            params = parse_qsl(ctx.query[1:])
+            for key, val in params:
+                if key == 'lfn':
+                    info = val.split(":", 1)
+                    if len(info) != 2:
+                        raise generate_http_error(400, 'InvalidPath', 'LFN in invalid format')
+                    lfn_dict = {'scope': info[0], 'name': info[1]}
+                    lfns.append(lfn_dict)
+                elif key == 'scheme':
+                    scheme = val
+                elif key == 'domain':
+                    domain = val
+                elif key == 'operation':
+                    operation = val
+
+        rse_settings = None
+        try:
+            rse_settings = get_rse_protocols(rse, issuer=ctx.env.get('issuer'))
+        except RSENotFound, error:
+            raise generate_http_error(404, 'RSENotFound', error[0][0])
+        except RSEProtocolNotSupported, error:
+            raise generate_http_error(404, 'RSEProtocolNotSupported', error[0][0])
+        except RSEProtocolDomainNotSupported, error:
+            raise generate_http_error(404, 'RSEProtocolDomainNotSupported', error[0][0])
+        except Exception, error:
+            print error
+            print format_exc()
+            raise InternalError(error)
+
+        pfns = rsemanager.lfns2pfns(rse_settings, lfns, operation=operation, scheme=scheme, domain=domain)
+        return dumps(pfns)
 
 
 class Protocol(RucioController):


### PR DESCRIPTION
This adds the ability for a Rucio server configuration to specify a module that can register additional lfn2pfn algorithm implementations.  The configuration file may also specify the default LFN2PFN algorithm (for example, replacing `hash` with `identity` or a VO-specific algorithm).

The callout algorithms receive a scope, LFN name, RSE name, RSE attributes, and protocol attributes.  It should return the path portion of a PFN (not the full PFN).

The server instance's default can still be overridden by setting the `lfn2pfn_algorithm` attribute on the RSE.

This is the `next` version of #584.