### PR TITLE
Clients: Clients: disable certification verification on s3 boto protocol

### DIFF
--- a/lib/rucio/rse/protocols/s3boto.py
+++ b/lib/rucio/rse/protocols/s3boto.py
@@ -176,6 +176,9 @@ class Default(protocol.RSEProtocol):
                                      aws_secret_access_key=secret_key,
                                      is_secure=is_secure,
                                      calling_format=OrdinaryCallingFormat())
+            if '_https_verify_certificates' in dir(ssl):
+                # pylint: disable=no-member
+                ssl._https_verify_certificates(enable=True)
             self._reset_http_proxy()
         except Exception as e:
             self._reset_http_proxy()

--- a/lib/rucio/rse/protocols/s3boto.py
+++ b/lib/rucio/rse/protocols/s3boto.py
@@ -176,9 +176,6 @@ class Default(protocol.RSEProtocol):
                                      aws_secret_access_key=secret_key,
                                      is_secure=is_secure,
                                      calling_format=OrdinaryCallingFormat())
-            if '_https_verify_certificates' in dir(ssl):
-                # pylint: disable=no-member
-                ssl._https_verify_certificates(enable=True)
             self._reset_http_proxy()
         except Exception as e:
             self._reset_http_proxy()
@@ -186,7 +183,9 @@ class Default(protocol.RSEProtocol):
 
     def close(self):
         """ Closes the connection to RSE."""
-        pass
+        if '_https_verify_certificates' in dir(ssl):
+            # pylint: disable=no-member
+            ssl._https_verify_certificates(enable=True)
 
     def get(self, pfn, dest):
         """

--- a/lib/rucio/rse/protocols/s3boto.py
+++ b/lib/rucio/rse/protocols/s3boto.py
@@ -10,6 +10,7 @@
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2016-2017
 
 import os
+import ssl
 import urlparse
 import logging
 
@@ -166,6 +167,9 @@ class Default(protocol.RSEProtocol):
                         get(service_url, False)
 
             self._disable_http_proxy()
+            if '_https_verify_certificates' in dir(ssl):
+                # pylint: disable=no-member
+                ssl._https_verify_certificates(enable=False)
             self.__conn = connect_s3(host=self.attributes['hostname'],
                                      port=int(port),
                                      aws_access_key_id=access_key,


### PR DESCRIPTION
To fix the ssl verification problem on centos7 machines