### PR TITLE
clients: Make space tokens optional. Fix #575

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -572,7 +572,7 @@ def add_protocol_rse(args):
     proto.setdefault('extended_attributes', {})
     if args.ext_attr_json:
         proto['extended_attributes'] = args.ext_attr_json
-    if proto['scheme'] == 'srm' and (not args.space_token or not args.web_service_path):
+    if proto['scheme'] == 'srm' and not args.web_service_path:
         print 'Error: space-token and web-service-path must be provided for SRM endpoints.'
         return FAILURE
     if args.space_token:

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -688,7 +688,7 @@ def add_protocol(rse, parameter, session=None):
             pass  # String is not JSON
 
     if parameter['scheme'] == 'srm':
-        if ('space_token' not in parameter['extended_attributes']) or ('web_service_path' not in parameter['extended_attributes']):
+        if ('extended_attributes' not in parameter) or ('web_service_path' not in parameter['extended_attributes']):
             raise exception.InvalidObject('Missing values! For SRM, extended_attributes and web_service_path must be specified')
 
     try:


### PR DESCRIPTION
Outside ATLAS (particularly, for CMS), space tokens are optional at some SRM endpoints.  Previously, for #574, we fixed the conveyor to handle empty space tokens.  Additionally, the fix for the client-side of #575 got mistakenly wrapped up in #570 (pluggable LFN2PFN) and put into `next`.

This is the missing piece for `master`.