### PR TITLE
Transfers: Shuffle Equal-Weight protocols.  Fix #697

### DIFF
--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -19,6 +19,7 @@
 
 import copy
 import os
+import random
 
 from urlparse import urlparse
 
@@ -125,6 +126,8 @@ def select_protocol(rse_settings, operation, scheme=None, domain='wan'):
         raise exception.RSEProtocolDomainNotSupported('Domain %s not supported' % domain)
 
     candidates = _get_possible_protocols(rse_settings, operation, scheme, domain)
+    # Shuffle candidates to load-balance over equal sources
+    random.shuffle(candidates)
     return min(candidates, key=lambda k: k['domains'][domain][operation])
 
 
@@ -633,6 +636,10 @@ def find_matching_scheme(rse_settings_dest, rse_settings_src, operation_src, ope
 
     if not len(src_candidates) or not len(dest_candidates):
         raise exception.RSEProtocolNotSupported('No protocol for provided settings found : %s.' % str(rse_settings_dest))
+
+    # Shuffle the candidates to load-balance across equal weights.
+    random.shuffle(dest_candidates)
+    random.shuffle(src_candidates)
 
     # Select the one with the highest priority
     dest_candidates = sorted(dest_candidates, key=lambda k: k['domains'][domain][operation_dest])


### PR DESCRIPTION
Given equal-weight protocols eligible for transfer, shuffle the candidates in order to balance across several endpoints.

Fixes #697.  Duplicate of #698 for `next`.