### PR TITLE
Fix client options according to naming conventions

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -938,7 +938,7 @@ def get_parser():
     oparser.add_argument('--version', action='version', version='%(prog)s ' + version.version_string())
     oparser.add_argument('--verbose', '-v', default=False, action='store_true', help="Print more verbose output")
     oparser.add_argument('-H', '--host', dest="host", metavar="ADDRESS", help="The Rucio API host")
-    oparser.add_argument('--auth_host', dest="auth_host", metavar="ADDRESS", help="The Rucio Authentication host")
+    oparser.add_argument('--auth-host', dest="auth_host", metavar="ADDRESS", help="The Rucio Authentication host")
     oparser.add_argument('-a', '--account', dest="issuer", metavar="ACCOUNT", help="Rucio account to use")
     oparser.add_argument('-S', '--auth-strategy', dest="auth_strategy", default=None, help="Authentication strategy (userpass, x509, ssh ...)")
     oparser.add_argument('-T', '--timeout', dest="timeout", type=float, default=None, help="Set all timeout values to SECONDS")

--- a/bin/rucio-cache-client
+++ b/bin/rucio-cache-client
@@ -116,7 +116,7 @@ def get_parser():
     oparser.add_argument('-b', '--broker', dest='broker', default=config_get('messaging-cache', 'brokers').split(',')[0], help='Message broker name')
     oparser.add_argument('-p', '--port', dest='port', default=config_get_int('messaging-cache', 'port'), help='Message broker port')
     oparser.add_argument('-c', '--certificate', dest='ssl_cert_file', default=config_get('messaging-cache', 'ssl_cert_file'), help='Certificate file')
-    oparser.add_argument('-k', '--certificate_key', dest='ssl_key_file', default=config_get('messaging-cache', 'ssl_key_file'), help='Certificate key file')
+    oparser.add_argument('-k', '--certificate-key', dest='ssl_key_file', default=config_get('messaging-cache', 'ssl_key_file'), help='Certificate key file')
     oparser.add_argument('-d', '--destination', dest='destination', default=config_get('messaging-cache', 'destination'), help="Message broker topic")
     oparser.add_argument('-m', '--message', dest='message', default=None, help=message_help)
 


### PR DESCRIPTION
This helps to find options with  underscores, which should be replaced by the dashes: 

[root@5a295a254cfc bin]# grep oparser.add_argument rucio* | cut -d\( -f2  | tr "," "\n" | egrep '\-\-.*_.*'
'--auth_host'
 '--certificate_key'
 