### PR TITLE
Documentation : fix in multiple files Fix #910

### DIFF
--- a/doc/source/overview_Replica_management.rst
+++ b/doc/source/overview_Replica_management.rst
@@ -19,7 +19,7 @@ The rule engine is triggered when a new rule is defined on an existing data iden
 
 Notifications can be provided for rules and their underlying transfer requests. All transfer requests are transient.
 
-The deletion serivce supports two different modes: greedy and non-greedy. Greedy means that the service trys to immediately delete all replicas which are not protected by a replication rule.
+The deletion service supports two different modes: greedy and non-greedy. Greedy means that the service tries to immediately delete all replicas which are not protected by a replication rule.
 Non-greedy deletion is triggered when storage policy dictates that space must be freed. The deletion service will look for replicas on that RSE which can be deleted without violating any replication rule. The deletion service will use a Least Recently Used (LRU) algorithm to select replicas for deletion. The deletion service will also immediately delete all replicas of any file which is declared obsolete.
 
 Some examples for replication rules are listed `here`_.
@@ -28,4 +28,4 @@ Some examples for replication rules are listed `here`_.
 
 .. _RSE Expression: rse_expressions.html
 .. _here: replication_rules_examples.html
-.. [#f1] The system may reject rules if these violate other policies, e.g., only specific accounts are allowed to request replication rules for tape systems. 
+.. [#f1] The system may reject rules if these violate other policies, e.g., only specific accounts are allowed to request replication rules for tape systems.

--- a/doc/source/overview_Replica_management.rst
+++ b/doc/source/overview_Replica_management.rst
@@ -19,13 +19,13 @@ The rule engine is triggered when a new rule is defined on an existing data iden
 
 Notifications can be provided for rules and their underlying transfer requests. All transfer requests are transient.
 
-The deletion service supports two different modes: greedy and non-greedy. Greedy means that the service tries to immediately delete all replicas which are not protected by a replication rule.
+The deletion serivce supports two different modes: greedy and non-greedy. Greedy means that the service trys to immediately delete all replicas which are not protected by a replication rule.
 Non-greedy deletion is triggered when storage policy dictates that space must be freed. The deletion service will look for replicas on that RSE which can be deleted without violating any replication rule. The deletion service will use a Least Recently Used (LRU) algorithm to select replicas for deletion. The deletion service will also immediately delete all replicas of any file which is declared obsolete.
 
 Some examples for replication rules are listed `here`_.
 
 .. rubric:: Footnotes
 
-.. _RSE Expression: RSE_Expressions.html
+.. _RSE Expression: rse_expressions.html
 .. _here: replication_rules_examples.html
-.. [#f1] The system may reject rules if these violate other policies, e.g., only specific accounts are allowed to request replication rules for tape systems.
+.. [#f1] The system may reject rules if these violate other policies, e.g., only specific accounts are allowed to request replication rules for tape systems. 

--- a/doc/source/replication_rules_examples.rst
+++ b/doc/source/replication_rules_examples.rst
@@ -15,8 +15,8 @@ possible destination RSEs for the number of replicas the user wants to create.
 
 Is possible to find detailed information and examples about how to write RSE Expressions `here`_.
 
-.. _RSE Expression: RSE_Expressions.html
-.. _here: RSE_Expressions.html
+.. _RSE Expression: rse_expressions.html
+.. _here: rse_expressions.html
 
 ^^^^^^^^^
 Example 1


### PR DESCRIPTION
RSE_Expressions link fix 
------------------

The files 'overview_Replica_management.rst' and 'replication_rules_examples.rst' also had a similar error for RSE_expressions link as mentioned in issue #910   
