### PR TITLE
Release: setup_client classifiers need to be list, not tuples; Fix #949

### DIFF
--- a/setup_rucio_client.py
+++ b/setup_rucio_client.py
@@ -190,7 +190,7 @@ setup(
     license="Apache License, Version 2.0",
     url="http://rucio.cern.ch/",
     python_requires=">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    classifiers=(
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: Apache Software License',
         'Intended Audience :: Information Technology',
@@ -207,7 +207,7 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Environment :: No Input/Output (Daemon)'
-    ),
+    ],
     install_requires=REQUIRES,
     extras_require=EXTRAS_REQUIRES,
     dependency_links=DEPEND_LINKS,


### PR DESCRIPTION
Release: setup_client classifiers need to be list, not tuples; Fix #949