### PR TITLE
Use docker-compose from pip to ensure that it runs

### DIFF
--- a/etc/docker/dev/README.rst
+++ b/etc/docker/dev/README.rst
@@ -8,6 +8,15 @@ Prerequisites
 Setting up a Rucio development environment requires to have Docker installed. Docker is an
 application that makes it simple and easy to run application processes. To install Docker for
 your platform, please refer to the `Docker installation guide <https://docs.docker.com/install/>`_.
+After installation of docker, you can set up a virtual environment for developing Rucio : ::
+
+    virtualenv dev
+    source dev/bin/activate
+    (dev) pip install -r requirements.readthedocs.txt
+
+This will ensure that you have a tested, supported development environment. *Please note that the package from 
+the docker repository for your operating system may have an older version of docker-compose which can result in conflicts*. 
+If you run into such problems, please `open an issue on GitHub <https://github.com/rucio/rucio/issues/new>`_.
 
 Container for Development
 -------------------------

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -91,3 +91,4 @@ pytz==2017.3                # World timezone definitions, modern and historical
 Babel==2.5.1                # Internationalization utilities
 git-review==1.26.0          # Command-line tool for Git / Gerrit
 subprocess32==3.2.7         # A backport of the subprocess module from Python 3.2/3.3 for use on 2.x.
+docker-compose>=1.20.1      # Docker-compose module is necessary for running the dev environment


### PR DESCRIPTION
Documentation: use pip for docker-compose #999 
------------------

This just tells potential contributors that if they use Docker-Compose from their OS repos they might have a bad time. It adds docker-compose to requirements and shows devs how to create a virtualenv and install the pips into it.
I tested this on my laptop, the test script works. 