### PR TITLE
Clients: list-rules should give a warning if parent/content dids are searched; Fix #1077

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -2266,9 +2266,13 @@ def list_rules(args):
             if meta['did_type'] == u'CONTAINER':
                 for dsn in client.list_content(scope, name):
                     rules.extend(client.list_did_rules(scope=dsn['scope'], name=dsn['name']))
+                if rules:
+                    print('No rules found, listing rules for content')
             if meta['did_type'] == u'DATASET':
                 for container in client.list_parent_dids(scope, name):
                     rules.extend(client.list_did_rules(scope=container['scope'], name=container['name']))
+                if rules:
+                    print('No rules found, listing rules for parents')
     elif args.rule_account:
         rules = client.list_account_rules(account=args.rule_account)
     elif args.subscription:


### PR DESCRIPTION
Clients: list-rules should give a warning if parent/content dids are searched; Fix #1077