### PR TITLE
Consistency: Add support for HTTPS links to Auditor #367

### DIFF
--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -158,6 +158,10 @@ protocol_funcs = {
         'links': http_links,
         'download': http_download_to_file,
     },
+    'https': {
+        'links': http_links,
+        'download': http_download_to_file,
+    },
 }
 
 


### PR DESCRIPTION
Both `http_links()` and `http_download_to_file()` seem to have support for HTTPS. All that is needed is the proper mapping.

Unfortunately, I have not been able to test this because none of the sites currently provide a working HTTPS link.