### PR TITLE
Consistency: Add support for WebDAV,  GridFTP and XRootD to Auditor #429

### DIFF
--- a/lib/rucio/common/dumper/__init__.py
+++ b/lib/rucio/common/dumper/__init__.py
@@ -16,6 +16,7 @@
 # - Fernando Lopez <felopez@cern.ch>, 2015
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2016
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2017-2018
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 
 from rucio.common import config
 

--- a/lib/rucio/common/dumper/__init__.py
+++ b/lib/rucio/common/dumper/__init__.py
@@ -315,7 +315,7 @@ def http_download(url, filename):
         http_download_to_file(url, f)
 
 
-def srm_download_to_file(url, file_):
+def gfal_download_to_file(url, file_):
     '''
     Download the file in `url` storing it in the `file_` file-like
     object.
@@ -340,9 +340,9 @@ def srm_download_to_file(url, file_):
         chunk = infile.read(CHUNK_SIZE)
 
 
-def srm_download(url, filename):
+def gfal_download(url, filename):
     '''
     Download the file in `url` storing it in the path given by `filename`.
     '''
     with open(filename, 'w') as f:
-        srm_download_to_file(url, f)
+        gfal_download_to_file(url, f)

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -18,7 +18,7 @@
 
 from rucio.common.config import __CONFIGFILES as __RUCIOCONFIGFILES
 from rucio.common.dumper import DUMPS_CACHE_DIR
-from rucio.common.dumper import http_download_to_file, srm_download_to_file, ddmendpoint_url, temp_file
+from rucio.common.dumper import http_download_to_file, gfal_download_to_file, ddmendpoint_url, temp_file
 
 import ConfigParser
 import HTMLParser
@@ -152,7 +152,7 @@ def http_links(base_url):
 protocol_funcs = {
     'srm': {
         'links': gfal_links,
-        'download': srm_download_to_file,
+        'download': gfal_download_to_file,
     },
     'http': {
         'links': http_links,

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -15,6 +15,7 @@
 # Authors:
 # - Fernando Lopez <felopez@cern.ch>, 2015
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2017-2018
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 
 from rucio.common.config import __CONFIGFILES as __RUCIOCONFIGFILES
 from rucio.common.dumper import DUMPS_CACHE_DIR

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -112,7 +112,7 @@ def get_newest(base_url, url_pattern, links):
     return max(times, key=operator.itemgetter(1))
 
 
-def srm_links(base_url):
+def gfal_links(base_url):
     '''
     Returns a list of the urls contained in `base_url`.
     '''
@@ -151,7 +151,7 @@ def http_links(base_url):
 
 protocol_funcs = {
     'srm': {
-        'links': srm_links,
+        'links': gfal_links,
         'download': srm_download_to_file,
     },
     'http': {

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -150,6 +150,18 @@ def http_links(base_url):
 
 
 protocol_funcs = {
+    'davs': {
+        'links': gfal_links,
+        'download': gfal_download_to_file,
+    },
+    'gsiftp': {
+        'links': gfal_links,
+        'download': gfal_download_to_file,
+    },
+    'root': {
+        'links': gfal_links,
+        'download': gfal_download_to_file,
+    },
     'srm': {
         'links': gfal_links,
         'download': gfal_download_to_file,

--- a/lib/rucio/tests/test_auditor.py
+++ b/lib/rucio/tests/test_auditor.py
@@ -7,6 +7,7 @@
 
  Authors:
  - Vincent Garonne,  <vincent.garonne@cern.ch> , 2017
+ - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 '''
 
 from datetime import datetime

--- a/lib/rucio/tests/test_auditor.py
+++ b/lib/rucio/tests/test_auditor.py
@@ -44,12 +44,12 @@ def test_auditor_download_dumps_with_expected_dates():
 
     date = datetime.strptime('01-01-2015', '%d-%m-%Y')
 
-    fake_srm_download, fake_srm_download_calls = mock_fn_wrapper(('', date))
+    fake_gfal_download, fake_gfal_download_calls = mock_fn_wrapper(('', date))
     fake_rrd_download, fake_rrd_download_calls = mock_fn_wrapper('')
     fake_consistency_dump, fake_consistency_dump_calls = mock_fn_wrapper('')
     tmp_dir = tempfile.mkdtemp()
 
-    with stubbed(srmdumps.download_rse_dump, fake_srm_download):
+    with stubbed(srmdumps.download_rse_dump, fake_gfal_download):
         with stubbed(hdfs.ReplicaFromHDFS.download, fake_rrd_download):
             with stubbed(consistency.Consistency.dump, fake_consistency_dump):
                 auditor.consistency('RSENAME', timedelta(days=3), None, cache_dir=tmp_dir, results_dir=tmp_dir)

--- a/lib/rucio/tests/test_auditor_srmdumps.py
+++ b/lib/rucio/tests/test_auditor_srmdumps.py
@@ -16,6 +16,7 @@
 # - Fernando Lopez <fernando.e.lopez@gmail.com>, 2015
 # - Martin Barisits <martin.barisits@cern.ch>, 2017
 # - Vincent Garonne <vgaronne@gmail.com>, 2018
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 
 from ConfigParser import ConfigParser
 from datetime import datetime

--- a/lib/rucio/tests/test_auditor_srmdumps.py
+++ b/lib/rucio/tests/test_auditor_srmdumps.py
@@ -89,9 +89,13 @@ def test_returns_a_list_of_links():
     eq_(collector.links, ['x', 'y'])
 
 
-def test_identifies_http_and_srm():
-    """ test_protocol_identifies_http_and_srm """
+def test_identifies_known_protocols():
+    """ test_protocol_identifies_known_protocols """
+    eq_(srmdumps.protocol('davs://some/example'), 'davs')
+    eq_(srmdumps.protocol('gsiftp://some/example'), 'gsiftp')
     eq_(srmdumps.protocol('http://some/example'), 'http')
+    eq_(srmdumps.protocol('https://some/example'), 'https')
+    eq_(srmdumps.protocol('root://some/example'), 'root')
     eq_(srmdumps.protocol('srm://some/example'), 'srm')
 
 

--- a/lib/rucio/tests/test_dumper.py
+++ b/lib/rucio/tests/test_dumper.py
@@ -200,28 +200,28 @@ def test_http_download_creates_file_with_content():
     eq_(stringio.read(), 'abc')
 
 
-def test_srm_download_to_file():
-    srm_file = StringIO()
+def test_gfal_download_to_file():
+    gfal_file = StringIO()
     local_file = StringIO()
-    srm_file.write('content')
-    srm_file.seek(0)
+    gfal_file.write('content')
+    gfal_file.seek(0)
 
-    with gfal2.mocked_gfal2(dumper, files={'srm://example.com/file': srm_file}):
-        dumper.srm_download_to_file('srm://example.com/file', local_file)
+    with gfal2.mocked_gfal2(dumper, files={'srm://example.com/file': gfal_file}):
+        dumper.gfal_download_to_file('srm://example.com/file', local_file)
 
     local_file.seek(0)
     eq_(local_file.read(), 'content')
 
 
-def test_srm_download_creates_file_with_content():
-    srm_file = StringIO()
+def test_gfal_download_creates_file_with_content():
+    gfal_file = StringIO()
     local_file = StringIO()
-    srm_file.write('content')
-    srm_file.seek(0)
+    gfal_file.write('content')
+    gfal_file.seek(0)
 
-    with gfal2.mocked_gfal2(dumper, files={'srm://example.com/file': srm_file}):
+    with gfal2.mocked_gfal2(dumper, files={'srm://example.com/file': gfal_file}):
         with mock_open(dumper, local_file):
-            dumper.srm_download('srm://example.com/file', 'filename')
+            dumper.gfal_download('srm://example.com/file', 'filename')
 
     local_file.seek(0)
     eq_(local_file.read(), 'content')

--- a/lib/rucio/tests/test_dumper.py
+++ b/lib/rucio/tests/test_dumper.py
@@ -8,6 +8,7 @@
 # Authors:
 # - Fernando Lopez, <felopez@cern.ch>, 2015
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2017
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 
 
 import __builtin__


### PR DESCRIPTION
The support was essentially already there. What was missing was the necessary plumbing. Successfully tested WebDAV with `BNL-OSG2`.