### PR TITLE
Consistency: Add support for WebDAV,  GridFTP and XRootD to Auditor #429

### DIFF
--- a/etc/docker/daemons/Dockerfile
+++ b/etc/docker/daemons/Dockerfile
@@ -21,7 +21,8 @@ RUN rpm -i /tmp/oic.rpm; \
     echo "/usr/lib/oracle/12.2/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
     ldconfig
 RUN pip install --upgrade pip setuptools
-RUN pip install rucio[oracle,mysql,postgresql]==1.16.0.post1 j2cli
+RUN rm -rf /usr/lib/python2.7/site-packages/ipaddress*
+RUN pip install rucio[oracle,mysql,postgresql] j2cli psycopg2-binary
 
 # Install dependecies
 RUN yum install -y \

--- a/etc/docker/server/Dockerfile
+++ b/etc/docker/server/Dockerfile
@@ -21,7 +21,8 @@ RUN rpm -i /tmp/oic.rpm; \
     echo "/usr/lib/oracle/12.2/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
     ldconfig
 RUN pip install --upgrade pip setuptools
-RUN pip install rucio[oracle,mysql,postgresql] j2cli
+RUN rm -rf /usr/lib/python2.7/site-packages/ipaddress*
+RUN pip install rucio[oracle,mysql,postgresql] j2cli psycopg2-binary
 
 ADD rucio.conf.j2 /tmp/
 ADD httpd.conf /etc/httpd/conf/

--- a/etc/rucio.cfg.template
+++ b/etc/rucio.cfg.template
@@ -204,3 +204,4 @@ usercert = /opt/rucio/etc/usercert_with_key.pem
 
 [credentials]
 gcs = /opt/rucio/etc/google-cloud-storage-test.json
+signature_lifetime = 3600

--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -89,7 +89,7 @@ def get_did_from_pfns(pfns, rse):
 
 def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
                   ignore_availability=True, all_states=False, rse_expression=None,
-                  client_location=None, domain=None, lifetime=None, issuer=None):
+                  client_location=None, domain=None, signature_lifetime=None, issuer=None):
     """
     List file replicas for a list of data identifiers.
 
@@ -101,7 +101,7 @@ def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
     :param rse_expression: The RSE expression to restrict replicas on a set of RSEs.
     :param client_location: Client location dictionary for PFN modification {'ip', 'fqdn', 'site'}
     :param domain: The network domain for the call, either None, 'wan' or 'lan'. Compatibility fallback: None falls back to 'wan'.
-    :param lifetime: If supported, in seconds, restrict the lifetime of the replica PFN.
+    :param signature_lifetime: If supported, in seconds, restrict the lifetime of the signed PFN.
     :param issuer: The issuer account.
     """
     validate_schema(name='r_dids', obj=dids)
@@ -109,7 +109,7 @@ def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
     # Allow selected authenticated users to retrieve signed URLs.
     # Unauthenticated users, or permission-less users will get the raw URL without the signature.
     sign_urls = False
-    if permission.has_permission(issuer=issuer, action='get_signed_urls', kwargs={}):
+    if permission.has_permission(issuer=issuer, action='get_signed_url', kwargs={}):
         sign_urls = True
 
     return replica.list_replicas(dids=dids, schemes=schemes, unavailable=unavailable,
@@ -117,7 +117,7 @@ def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
                                  ignore_availability=ignore_availability,
                                  all_states=all_states, rse_expression=rse_expression,
                                  client_location=client_location, domain=domain,
-                                 sign_urls=sign_urls, lifetime=lifetime)
+                                 sign_urls=sign_urls, signature_lifetime=signature_lifetime)
 
 
 def add_replicas(rse, files, issuer, ignore_availability=False):

--- a/lib/rucio/common/constraints.py
+++ b/lib/rucio/common/constraints.py
@@ -14,6 +14,7 @@
 #
 # Authors:
 # - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
+# - Frank Berghaus <frank.berghaus@cern.ch>, 2018
 
 
 # List of authorized value types for key
@@ -21,3 +22,9 @@ try:
     AUTHORIZED_VALUE_TYPES = (float, int, unicode)
 except NameError:
     AUTHORIZED_VALUE_TYPES = (float, int, str)
+
+# unicode no longer exists in python3, hence this workaround
+try:
+    STRING_TYPES = (str, unicode,)
+except NameError:
+    STRING_TYPES = (str,)

--- a/lib/rucio/common/dumper/__init__.py
+++ b/lib/rucio/common/dumper/__init__.py
@@ -16,6 +16,7 @@
 # - Fernando Lopez <felopez@cern.ch>, 2015
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2016
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2017-2018
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 
 from rucio.common import config
 

--- a/lib/rucio/common/dumper/__init__.py
+++ b/lib/rucio/common/dumper/__init__.py
@@ -315,7 +315,7 @@ def http_download(url, filename):
         http_download_to_file(url, f)
 
 
-def srm_download_to_file(url, file_):
+def gfal_download_to_file(url, file_):
     '''
     Download the file in `url` storing it in the `file_` file-like
     object.
@@ -340,9 +340,9 @@ def srm_download_to_file(url, file_):
         chunk = infile.read(CHUNK_SIZE)
 
 
-def srm_download(url, filename):
+def gfal_download(url, filename):
     '''
     Download the file in `url` storing it in the path given by `filename`.
     '''
     with open(filename, 'w') as f:
-        srm_download_to_file(url, f)
+        gfal_download_to_file(url, f)

--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -849,3 +849,13 @@ class NotAllFilesUploaded(RucioException):
         super(NotAllFilesUploaded, self).__init__(args, kwargs)
         self._message = "Not all of the given files have been uploaded."
         self.error_code = 80
+
+
+class RSEChecksumUnavailable(RucioException):
+    """
+    Cannot retrieve checksum from RSE
+    """
+    def __init__(self, *args, **kwargs):
+        super(RSEChecksumUnavailable, self).__init__(*args, **kwargs)
+        self._message = "RSE checksum unavailable."
+        self.error_code = 81

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -26,15 +26,14 @@ from rucio.common.exception import UnsupportedOperation
 
 from oauth2client.service_account import ServiceAccountCredentials
 
-
-CREDS_GCS = ServiceAccountCredentials.from_json_keyfile_name(config_get('credentials', 'gcs'))
+CREDS_GCS = None
 
 
 def get_signed_url(service, operation, url, lifetime=600):
     """
     Get a signed URL for a particular service and operation.
 
-    The signed URL will be valid for 1 hour.
+    The signed URL will be valid for 1 hour but can be overriden.
 
     :param service: The service to authorise, currently only 'gsc'.
     :param operation: The operation to sign, either 'read', 'write', or 'delete'.
@@ -42,6 +41,13 @@ def get_signed_url(service, operation, url, lifetime=600):
     :param lifetime: Lifetime of the signed URL in seconds.
     :returns: Signed URL as a variable-length string.
     """
+
+    global CREDS_GCS
+
+    if not CREDS_GCS:
+        CREDS_GCS = ServiceAccountCredentials.from_json_keyfile_name(config_get('credentials', 'gcs',
+                                                                                raise_exception=False,
+                                                                                default='/opt/rucio/etc/google-cloud-storage-test.json'))
 
     if service not in ['gcs']:
         raise UnsupportedOperation('Service must be "gcs"')

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -726,7 +726,7 @@ def _list_replicas_for_files(file_clause, state_clause, files, rse_clause, sessi
         #    raise exception.DataIdentifierNotFound("Files not found %s", str(files))
 
 
-def _list_replicas(dataset_clause, file_clause, state_clause, show_pfns, schemes, files, rse_clause, client_location, domain, sign_urls, lifetime, session):
+def _list_replicas(dataset_clause, file_clause, state_clause, show_pfns, schemes, files, rse_clause, client_location, domain, sign_urls, signature_lifetime, session):
 
     files = [dataset_clause and _list_replicas_for_datasets(dataset_clause, state_clause, rse_clause, session),
              file_clause and _list_replicas_for_files(file_clause, state_clause, files, rse_clause, session)]
@@ -843,7 +843,7 @@ def _list_replicas(dataset_clause, file_clause, state_clause, show_pfns, schemes
                                                      value='gcs',
                                                      session=session)
                             if sign and isinstance(sign, list) and sign[0]:
-                                pfn = get_signed_url(service='gcs', operation='read', url=pfn, lifetime=lifetime)
+                                pfn = get_signed_url(service='gcs', operation='read', url=pfn, lifetime=signature_lifetime)
 
                         # TODO: this is not nice, but since pfns don't have the concept of 'domain'
                         #       we can work around by encapsulating it in a tuple. a proper refactor requires
@@ -894,7 +894,7 @@ def _list_replicas(dataset_clause, file_clause, state_clause, show_pfns, schemes
 def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
                   ignore_availability=True, all_states=False, pfns=True,
                   rse_expression=None, client_location=None, domain=None,
-                  sign_urls=False, lifetime=None, session=None):
+                  sign_urls=False, signature_lifetime=None, session=None):
     """
     List file replicas for a list of data identifiers (DIDs).
 
@@ -908,7 +908,7 @@ def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
     :param client_location: Client location dictionary for PFN modification {'ip', 'fqdn', 'site'}
     :param domain: The network domain for the call, either None, 'wan' or 'lan'. None is automatic mode, 'all' is both ['lan','wan']
     :param sign_urls: If set, will sign the PFNs if necessary.
-    :param lifetime: If supported, in seconds, restrict the lifetime of the replica PFN.
+    :param signature_lifetime: If supported, in seconds, restrict the lifetime of the signed PFN.
     :param session: The database session in use.
     """
 
@@ -920,7 +920,7 @@ def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
         for rse in parse_expression(expression=rse_expression, session=session):
             rse_clause.append(models.RSEFileAssociation.rse_id == rse['id'])
 
-    for file in _list_replicas(dataset_clause, file_clause, state_clause, pfns, schemes, files, rse_clause, client_location, domain, sign_urls, lifetime, session):
+    for file in _list_replicas(dataset_clause, file_clause, state_clause, pfns, schemes, files, rse_clause, client_location, domain, sign_urls, signature_lifetime, session):
         yield file
 
 

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -158,6 +158,10 @@ protocol_funcs = {
         'links': http_links,
         'download': http_download_to_file,
     },
+    'https': {
+        'links': http_links,
+        'download': http_download_to_file,
+    },
 }
 
 

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -18,7 +18,7 @@
 
 from rucio.common.config import __CONFIGFILES as __RUCIOCONFIGFILES
 from rucio.common.dumper import DUMPS_CACHE_DIR
-from rucio.common.dumper import http_download_to_file, srm_download_to_file, ddmendpoint_url, temp_file
+from rucio.common.dumper import http_download_to_file, gfal_download_to_file, ddmendpoint_url, temp_file
 
 import ConfigParser
 import HTMLParser
@@ -152,7 +152,7 @@ def http_links(base_url):
 protocol_funcs = {
     'srm': {
         'links': gfal_links,
-        'download': srm_download_to_file,
+        'download': gfal_download_to_file,
     },
     'http': {
         'links': http_links,

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -15,6 +15,7 @@
 # Authors:
 # - Fernando Lopez <felopez@cern.ch>, 2015
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2017-2018
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 
 from rucio.common.config import __CONFIGFILES as __RUCIOCONFIGFILES
 from rucio.common.dumper import DUMPS_CACHE_DIR

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -112,7 +112,7 @@ def get_newest(base_url, url_pattern, links):
     return max(times, key=operator.itemgetter(1))
 
 
-def srm_links(base_url):
+def gfal_links(base_url):
     '''
     Returns a list of the urls contained in `base_url`.
     '''
@@ -151,7 +151,7 @@ def http_links(base_url):
 
 protocol_funcs = {
     'srm': {
-        'links': srm_links,
+        'links': gfal_links,
         'download': srm_download_to_file,
     },
     'http': {

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -150,6 +150,18 @@ def http_links(base_url):
 
 
 protocol_funcs = {
+    'davs': {
+        'links': gfal_links,
+        'download': gfal_download_to_file,
+    },
+    'gsiftp': {
+        'links': gfal_links,
+        'download': gfal_download_to_file,
+    },
+    'root': {
+        'links': gfal_links,
+        'download': gfal_download_to_file,
+    },
     'srm': {
         'links': gfal_links,
         'download': gfal_download_to_file,

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -20,6 +20,7 @@
 # - Tobias Wegner <twegner@cern.ch>, 2017
 # - Nicolo Magini <Nicolo.Magini@cern.ch>, 2018
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
+# - Frank Berghaus <frank.berghaus@cern.ch>, 2018
 
 import errno
 import json
@@ -28,6 +29,7 @@ import re
 import urlparse
 
 from rucio.common import exception, config
+from rucio.common.constraints import STRING_TYPES
 from rucio.rse.protocols import protocol
 
 try:
@@ -96,7 +98,7 @@ class Default(protocol.RSEProtocol):
         """
 
         ret = dict()
-        pfns = [pfns] if ((type(pfns) == str) or (type(pfns) == unicode)) else pfns
+        pfns = [pfns] if isinstance(pfns, STRING_TYPES) else pfns
         for pfn in pfns:
             parsed = urlparse.urlparse(pfn)
             if parsed.path.startswith('/srm/managerv2') or parsed.path.startswith('/srm/managerv1') or parsed.path.startswith('/srm/v2/server'):
@@ -250,7 +252,7 @@ class Default(protocol.RSEProtocol):
         :raises SourceNotFound: if the source file was not found on the referred storage.
         """
 
-        pfns = [path] if ((type(path) == str) or (type(path) == unicode)) else path
+        pfns = [path] if isinstance(path, STRING_TYPES) else path
 
         try:
             status = self.__gfal2_rm(pfns)
@@ -343,7 +345,7 @@ class Default(protocol.RSEProtocol):
             ret['adler32'] = ctx.checksum(str(path), str('ADLER32'))
         except Exception as error:
             msg = 'Error while processing gfal checksum call. Error: %s'
-            raise exception.ServiceUnavailable(msg % str(error))
+            raise exception.RSEChecksumUnavailable(msg % str(error))
 
         return ret
 

--- a/lib/rucio/tests/test_auditor.py
+++ b/lib/rucio/tests/test_auditor.py
@@ -7,6 +7,7 @@
 
  Authors:
  - Vincent Garonne,  <vincent.garonne@cern.ch> , 2017
+ - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 '''
 
 from datetime import datetime

--- a/lib/rucio/tests/test_auditor.py
+++ b/lib/rucio/tests/test_auditor.py
@@ -44,12 +44,12 @@ def test_auditor_download_dumps_with_expected_dates():
 
     date = datetime.strptime('01-01-2015', '%d-%m-%Y')
 
-    fake_srm_download, fake_srm_download_calls = mock_fn_wrapper(('', date))
+    fake_gfal_download, fake_gfal_download_calls = mock_fn_wrapper(('', date))
     fake_rrd_download, fake_rrd_download_calls = mock_fn_wrapper('')
     fake_consistency_dump, fake_consistency_dump_calls = mock_fn_wrapper('')
     tmp_dir = tempfile.mkdtemp()
 
-    with stubbed(srmdumps.download_rse_dump, fake_srm_download):
+    with stubbed(srmdumps.download_rse_dump, fake_gfal_download):
         with stubbed(hdfs.ReplicaFromHDFS.download, fake_rrd_download):
             with stubbed(consistency.Consistency.dump, fake_consistency_dump):
                 auditor.consistency('RSENAME', timedelta(days=3), None, cache_dir=tmp_dir, results_dir=tmp_dir)

--- a/lib/rucio/tests/test_auditor_srmdumps.py
+++ b/lib/rucio/tests/test_auditor_srmdumps.py
@@ -16,6 +16,7 @@
 # - Fernando Lopez <fernando.e.lopez@gmail.com>, 2015
 # - Martin Barisits <martin.barisits@cern.ch>, 2017
 # - Vincent Garonne <vgaronne@gmail.com>, 2018
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 
 from ConfigParser import ConfigParser
 from datetime import datetime

--- a/lib/rucio/tests/test_auditor_srmdumps.py
+++ b/lib/rucio/tests/test_auditor_srmdumps.py
@@ -89,9 +89,13 @@ def test_returns_a_list_of_links():
     eq_(collector.links, ['x', 'y'])
 
 
-def test_identifies_http_and_srm():
-    """ test_protocol_identifies_http_and_srm """
+def test_identifies_known_protocols():
+    """ test_protocol_identifies_known_protocols """
+    eq_(srmdumps.protocol('davs://some/example'), 'davs')
+    eq_(srmdumps.protocol('gsiftp://some/example'), 'gsiftp')
     eq_(srmdumps.protocol('http://some/example'), 'http')
+    eq_(srmdumps.protocol('https://some/example'), 'https')
+    eq_(srmdumps.protocol('root://some/example'), 'root')
     eq_(srmdumps.protocol('srm://some/example'), 'srm')
 
 

--- a/lib/rucio/tests/test_dumper.py
+++ b/lib/rucio/tests/test_dumper.py
@@ -200,28 +200,28 @@ def test_http_download_creates_file_with_content():
     eq_(stringio.read(), 'abc')
 
 
-def test_srm_download_to_file():
-    srm_file = StringIO()
+def test_gfal_download_to_file():
+    gfal_file = StringIO()
     local_file = StringIO()
-    srm_file.write('content')
-    srm_file.seek(0)
+    gfal_file.write('content')
+    gfal_file.seek(0)
 
-    with gfal2.mocked_gfal2(dumper, files={'srm://example.com/file': srm_file}):
-        dumper.srm_download_to_file('srm://example.com/file', local_file)
+    with gfal2.mocked_gfal2(dumper, files={'srm://example.com/file': gfal_file}):
+        dumper.gfal_download_to_file('srm://example.com/file', local_file)
 
     local_file.seek(0)
     eq_(local_file.read(), 'content')
 
 
-def test_srm_download_creates_file_with_content():
-    srm_file = StringIO()
+def test_gfal_download_creates_file_with_content():
+    gfal_file = StringIO()
     local_file = StringIO()
-    srm_file.write('content')
-    srm_file.seek(0)
+    gfal_file.write('content')
+    gfal_file.seek(0)
 
-    with gfal2.mocked_gfal2(dumper, files={'srm://example.com/file': srm_file}):
+    with gfal2.mocked_gfal2(dumper, files={'srm://example.com/file': gfal_file}):
         with mock_open(dumper, local_file):
-            dumper.srm_download('srm://example.com/file', 'filename')
+            dumper.gfal_download('srm://example.com/file', 'filename')
 
     local_file.seek(0)
     eq_(local_file.read(), 'content')

--- a/lib/rucio/tests/test_dumper.py
+++ b/lib/rucio/tests/test_dumper.py
@@ -8,6 +8,7 @@
 # Authors:
 # - Fernando Lopez, <felopez@cern.ch>, 2015
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2017
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 
 
 import __builtin__

--- a/lib/rucio/web/rest/webpy/v1/replica.py
+++ b/lib/rucio/web/rest/webpy/v1/replica.py
@@ -36,6 +36,7 @@ from rucio.api.replica import (add_replicas, list_replicas, list_dataset_replica
                                declare_suspicious_file_replicas, list_bad_replicas_status,
                                get_bad_replicas_summary, list_datasets_per_rse)
 from rucio.db.sqla.constants import BadFilesStatus
+from rucio.common.config import config_get
 from rucio.common.exception import (AccessDenied, DataIdentifierAlreadyExists,
                                     DataIdentifierNotFound, Duplicate, InvalidPath,
                                     ResourceTemporaryUnavailable, RucioException,
@@ -271,8 +272,7 @@ class ListReplicas(RucioController):
             401 Unauthorized
             500 InternalError
 
-        :returns: A dictionary containing all replicas information.
-        :returns: A metalink description of replicas if metalink(4)+xml is specified in Accept:
+        :returns: A dictionary containing all replicas information, either as JSON stream or metalink4.
         """
 
         metalink = False
@@ -287,6 +287,7 @@ class ListReplicas(RucioController):
 
         dids, schemes, select, unavailable, limit = [], None, None, False, None
         ignore_availability, rse_expression, all_states, domain = False, None, False, None
+        signature_lifetime = None
         client_location = {}
 
         json_data = data()
@@ -310,6 +311,13 @@ class ListReplicas(RucioController):
                 select = params['sort']
             if 'domain' in params:
                 domain = params['domain']
+
+            if 'signature_lifetime' in params:
+                signature_lifetime = params['signature_lifetime']
+            else:
+                # hardcoded default of 1h if config is not parseable
+                signature_lifetime = config_get('credentials', 'signature_lifetime', raise_exception=False, default=600)
+
         except ValueError:
             raise generate_http_error(400, 'ValueError', 'Cannot decode json parameter list')
 
@@ -338,7 +346,8 @@ class ListReplicas(RucioController):
                                        all_states=all_states,
                                        rse_expression=rse_expression,
                                        client_location=client_location,
-                                       domain=domain, issuer=ctx.env.get('issuer')):
+                                       domain=domain, signature_lifetime=signature_lifetime,
+                                       issuer=ctx.env.get('issuer')):
                 replicas = []
                 dictreplica = {}
                 for rse in rfile['rses']:


### PR DESCRIPTION
The support was essentially already there. What was missing was the necessary plumbing. Successfully tested WebDAV with `BNL-OSG2`.