### PR TITLE
Consistency: Adapt to new AGIS scheme #1268

### DIFF
--- a/lib/rucio/common/dumper/__init__.py
+++ b/lib/rucio/common/dumper/__init__.py
@@ -273,7 +273,9 @@ def agis_endpoints_data(cache=True):
 def ddmendpoint_url(ddmendpoint):
     agisdata = agis_endpoints_data()
     endpointdata = next(entry for entry in agisdata if entry['name'] == ddmendpoint)
-    return str(''.join((endpointdata['se'], endpointdata['endpoint'])))
+    protocoldata = endpointdata['arprotocols']['read_wan'][0]
+    return str(''.join([protocoldata['endpoint'],
+                       re.sub(r'rucio/$', '', protocoldata['path'])]))
 
 # Using AGIS is better to avoid the use of ATLAS credentials, but using
 # rucio.client for the same task is also possible:

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -244,6 +244,7 @@ def download_rse_dump(rse, configuration, date='latest', destdir=DUMPS_CACHE_DIR
     logger = logging.getLogger('auditor.srmdumps')
     base_url, url_pattern = generate_url(rse, configuration)
     if date == 'latest':
+        logger.debug('Looking for site dumps in: "%s"', base_url)
         links = get_links(base_url)
         url, date = get_newest(base_url, url_pattern, links)
     else:

--- a/lib/rucio/tests/test_dumper.py
+++ b/lib/rucio/tests/test_dumper.py
@@ -132,9 +132,15 @@ def test_agis_endpoints_data_parses_proper_json():
 
 def test_ddmendpoint_url_builds_url_from_agis_records():
     agisdata = [{
+        'arprotocols': {
+            'read_wan': [
+                {
+                    'endpoint': 'srm://example.com',
+                    'path': '/atlasdatadisk/rucio/'
+                }
+            ]
+        },
         'name': 'SOMEENDPOINT',
-        'se': 'srm://example.com/',
-        'endpoint': 'atlasdatadisk/',
     }]
     with stubbed(dumper.agis_endpoints_data, lambda: agisdata):
         eq_(dumper.ddmendpoint_url('SOMEENDPOINT'), 'srm://example.com/atlasdatadisk/')


### PR DESCRIPTION
As a side effect, the Auditor will choose the preferred protocol as defined by the site, which might not be SRM. The site dump search location is added to the log to improve debugging.