### PR TITLE
webui: fix wrong link to DDM dashboard in certain cases #1410

### DIFF
--- a/lib/rucio/web/ui/static/rule.js
+++ b/lib/rucio/web/ui/static/rule.js
@@ -6,7 +6,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Authors:
- * - Thomas Beermann, <thomas.beermann@cern.ch>, 2014-2016, 2018
+ * - Thomas Beermann, <thomas.beermann@cern.ch>, 2014-2018
  * - Mario Lassnig, <mario.lassnig@cern.ch>, 2014
  */
 
@@ -203,8 +203,9 @@ function link_to_fts(e) {
 };
 
 function link_to_dashboard(file, scope, rse) {
-    var site = rse.split("_")[0];
-    var token = rse.split("_")[1];
+    var items = rse.split("_");
+    var site = items.slice(0,-1).join('_');
+    var token = items.slice(-1)[0];
     var link = "http://dashb-atlas-ddm.cern.ch/ddm2/#d.dst.site=";
     link += site;
     link += "&d.dst.token=";


### PR DESCRIPTION
webui: fix wrong link to DDM dashboard in certain cases #1410