### PR TITLE
Documentation: Added mock class to mock pycurls for readthedocs build; Fix #1390

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -17,9 +17,24 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-# import sys
+import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+from mock import Mock as MagicMock
+
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return Mock()
+
+    @classmethod
+    def __getitem__(cls, name):
+        return Mock()
+
+
+MOCK_MODULES = ['pycurl']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # -- General configuration ------------------------------------------------
 

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -82,3 +82,4 @@ pytz==2017.3                # World timezone definitions, modern and historical
 Babel==2.5.1                # Internationalization utilities - Dependency of sphinx
 subprocess32==3.2.7; python_version <= '3.0' # A backport of the subprocess module from Python 3.2/3.3 for use on 2.x.
 pycodestyle==2.3.1          # New package replacing pep8
+mock==2.0.0                 # Mock package needed for readthedocs build for mocking pycurls

--- a/tools/pip-requires-test
+++ b/tools/pip-requires-test
@@ -23,3 +23,4 @@ pytz==2017.3                # World timezone definitions, modern and historical
 Babel==2.5.1                # Internationalization utilities - Dependency of sphinx
 subprocess32==3.2.7; python_version <= '3.0' # A backport of the subprocess module from Python 3.2/3.3 for use on 2.x.
 pycodestyle==2.3.1          # New package replacing pep8
+mock==2.0.0                 # Mock package needed for readthedocs build for mocking pycurls


### PR DESCRIPTION
Documentation: Added mock class to mock pycurls for readthedocs build; Fix #1390