### PR TITLE
Release: Futures package should only be installed for py<3; Fix #1486

### DIFF
--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -55,7 +55,7 @@ tabulate>=0.8.2                                   # Pretty-print tabular data
 progressbar2>=3.37.1                              # Text progress bar
 bz2file>=0.98                                     # Read and write bzip2-compressed files.
 python-magic>=0.4.15                              # File type identification using libmagic
-futures>=3.2.0                                    # Clean single-source support for Python 3 and 2
+futures>=3.2.0; python_version < '3.0'            # Clean single-source support for Python 3 and 2
 six>=1.11.0                                       # Python 2 and 3 compatibility utilities
 # All dependencies needed to develop/test rucio should be defined here
 

--- a/tools/pip-requires-client
+++ b/tools/pip-requires-client
@@ -11,5 +11,5 @@ tabulate>=0.8.2                                   # Pretty-print tabular data
 progressbar2>=3.37.1                              # Text progress bar
 bz2file>=0.98                                     # Read and write bzip2-compressed files.
 python-magic>=0.4.15                              # File type identification using libmagic
-futures>=3.2.0                                    # Clean single-source support for Python 3 and 2
+futures>=3.2.0; python_version < '3.0'            # Clean single-source support for Python 3 and 2
 six>=1.11.0                                       # Python 2 and 3 compatibility utilities


### PR DESCRIPTION
Release: Futures package should only be installed for py<3; Fix #1486