### PR TITLE
Release: Force urllib3 version to 1.23 to unblock tests; Fix #1682

### DIFF
--- a/tools/pip-requires-client
+++ b/tools/pip-requires-client
@@ -3,7 +3,7 @@ setuptools>=36.8.0                                # Python packaging utilities (
 argparse>=1.4.0; python_version == '2.6'          # Command-line parsing library
 argcomplete>=1.9.4                                # Bash tab completion for argparse
 requests>=2.6.0                                   # Python HTTP for Humans.
-urllib3>=1.23                                     # HTTP library with thread-safe connection pooling, file post, etc.
+urllib3==1.23                                     # HTTP library with thread-safe connection pooling, file post, etc.
 dogpile.cache>=0.6.5                              # Caching API plugins
 nose>=1.3.7                                       # For rucio test-server
 boto>=2.48.0; python_version >= '2.7'             # S3 boto protocol


### PR DESCRIPTION
Release: Force urllib3 version to 1.23 to unblock tests; Fix #1682