### PR TITLE
Release: Requests 2.20 not python 2.6 compatible; Fix #1698

### DIFF
--- a/tools/pip-requires-client
+++ b/tools/pip-requires-client
@@ -2,8 +2,8 @@
 setuptools>=36.8.0                                # Python packaging utilities (36.8.0 last py2.6 compatible version)
 argparse>=1.4.0; python_version == '2.6'          # Command-line parsing library
 argcomplete>=1.9.4                                # Bash tab completion for argparse
-requests>=2.6.0                                   # Python HTTP for Humans.
-urllib3==1.23                                     # HTTP library with thread-safe connection pooling, file post, etc.
+requests>=2.6.0,<2.20.0                           # Python HTTP for Humans.
+urllib3>=1.23,<1.24                               # HTTP library with thread-safe connection pooling, file post, etc.
 dogpile.cache>=0.6.5                              # Caching API plugins
 nose>=1.3.7                                       # For rucio test-server
 boto>=2.48.0; python_version >= '2.7'             # S3 boto protocol


### PR DESCRIPTION
Release: Requests 2.20 not python 2.6 compatible; Fix #1698