### PR TITLE
Core & Internals: set and get account properties; Fix #1685

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -249,6 +249,20 @@ def delete_account(args):
 
 
 @exception_handler
+def update_account(args):
+    """
+    %(prog)s update [options] <field1=value1 field2=value2 ...>
+
+    Update an account.
+
+    """
+    client = get_client(args)
+    client.update_account(account=args.account, key=args.key, value=args.value)
+    print('%s of account %s changed to %s' % (args.key, args.account, args.value))
+    return SUCCESS
+
+
+@exception_handler
 def ban_account(args):
     """
     %(prog)s ban [options] <field1=value1 field2=value2 ...>
@@ -257,7 +271,7 @@ def ban_account(args):
 
     """
     client = get_client(args)
-    client.set_account_status(account=args.account, status='SUSPENDED')
+    client.update_account(account=args.account, key='status', value='SUSPENDED')
     print('Account %s banned' % args.account)
     return SUCCESS
 
@@ -271,7 +285,7 @@ def unban_account(args):
 
     """
     client = get_client(args)
-    client.set_account_status(account=args.account, status='ACTIVE')
+    client.update_account(account=args.account, key='status', value='ACTIVE')
     print('Account %s unbanned' % args.account)
     return SUCCESS
 
@@ -1196,6 +1210,22 @@ def get_parser():
     unban_account_limits_parser.set_defaults(which='unban_account')
     unban_account_limits_parser.add_argument('--account', dest='account', action='store', help='Account name', required=True)
 
+    # Update account subparser
+    update_account_parser = account_subparser.add_parser('update',
+                                                         help='Update an account.',
+                                                         formatter_class=argparse.RawDescriptionHelpFormatter,
+                                                         epilog='Usage example\n'
+                                                                '"""""""""""""\n'
+                                                                '::\n'
+                                                                '\n'
+                                                                '    $ rucio-admin account update --account jdoe --key email --value test\n'
+                                                                '    Account jdoe updated\n'
+                                                                '\n')
+    update_account_parser.set_defaults(which='update_account')
+    update_account_parser.add_argument('--account', dest='account', action='store', help='Account name', required=True)
+    update_account_parser.add_argument('--key', dest='key', action='store', help='Account parameter', required=True)
+    update_account_parser.add_argument('--value', dest='value', action='store', help='Account parameter value', required=True)
+
     # The identity subparser
     identity_parser = subparsers.add_parser('identity', help='Identity methods')
     identity_subparser = identity_parser.add_subparsers()
@@ -1779,6 +1809,7 @@ if __name__ == '__main__':
                 'info_account': info_account,
                 'ban_account': ban_account,
                 'unban_account': unban_account,
+                'update_account': update_account,
                 'get_limits': get_limits,
                 'set_limits': set_limits,
                 'delete_limits': delete_limits,

--- a/lib/rucio/api/account.py
+++ b/lib/rucio/api/account.py
@@ -12,6 +12,7 @@
 # - Martin Barisits, <martin.barisits@cern.ch>, 2014
 # - Joaquin Bogado, <joaquin.bogado@cern.ch>, 2015
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2015
+# - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018
 #
 # PY3K COMPATIBLE
 
@@ -70,26 +71,18 @@ def get_account_info(account):
     return account_core.get_account(account)
 
 
-def get_account_status(account):
-    """
-    Returns the state of the account_core.
+def update_account(account, key, value, issuer='root'):
+    """ Update a property of an account_core.
 
     :param account: Name of the account_core.
-    """
-    return account_core.get_account_status(account)
-
-
-def set_account_status(account, status, issuer='root'):
-    """ Set the status of an account_core.
-
-    :param account: Name of the account_core.
-    :param status: The status for the account_core.
+    :param key: Account property like status.
+    :param value: Property value.
     """
     validate_schema(name='account', obj=account)
     kwargs = {}
-    if not rucio.api.permission.has_permission(issuer=issuer, action='set_account_status', kwargs=kwargs):
-        raise rucio.common.exception.AccessDenied('Account %s can not change the status of the account' % (issuer))
-    return account_core.set_account_status(account, status)
+    if not rucio.api.permission.has_permission(issuer=issuer, action='update_account', kwargs=kwargs):
+        raise rucio.common.exception.AccessDenied('Account %s can not change %s  of the account' % (issuer, key))
+    return account_core.update_account(account, key, value)
 
 
 def list_accounts(filter={}):

--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -22,6 +22,7 @@
 # - Cheng-Hsi Chao <cheng-hsi.chao@cern.ch>, 2014
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2015
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 #
 # PY3K COMPATIBLE
 
@@ -102,13 +103,14 @@ class AccountClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=res.headers, status_code=res.status_code, data=res.content)
         raise exc_cls(exc_msg)
 
-    def set_account_status(self, account, status):
-        """ Set the status of an account.
+    def update_account(self, account, key, value):
+        """ Update a property of an account.
 
         :param account: Name of the account.
-        :param status: The status for the account.
+        :param key: Account property like status.
+        :param value: Property value.
         """
-        data = dumps({'status': status})
+        data = dumps({key: value})
         path = '/'.join([self.ACCOUNTS_BASEURL, account])
         url = build_url(choice(self.list_hosts), path=path)
 

--- a/lib/rucio/core/permission/atlas.py
+++ b/lib/rucio/core/permission/atlas.py
@@ -17,6 +17,7 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2016-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2016-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 
 import rucio.core.authentication
 import rucio.core.did
@@ -40,7 +41,7 @@ def has_permission(issuer, action, kwargs):
     """
     perm = {'add_account': perm_add_account,
             'del_account': perm_del_account,
-            'set_account_status': perm_set_account_status,
+            'update_account': perm_update_account,
             'add_rule': perm_add_rule,
             'add_subscription': perm_add_subscription,
             'add_scope': perm_add_scope,
@@ -247,9 +248,9 @@ def perm_del_account(issuer, kwargs):
     return issuer == 'root'
 
 
-def perm_set_account_status(issuer, kwargs):
+def perm_update_account(issuer, kwargs):
     """
-    Checks if an account can ban/unban an account.
+    Checks if an account can update an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/core/permission/cms.py
+++ b/lib/rucio/core/permission/cms.py
@@ -11,6 +11,7 @@
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2017-2018
 # - Martin Barisits, <martin.barisits@cern.ch>, 2017
 # - Eric Vaandering, <ewv@fnal.gov>, 2018
+# - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018
 
 import rucio.core.authentication
 import rucio.core.scope
@@ -32,7 +33,7 @@ def has_permission(issuer, action, kwargs):
     """
     perm = {'add_account': perm_add_account,
             'del_account': perm_del_account,
-            'set_account_status': perm_set_account_status,
+            'update_account': perm_update_account,
             'add_rule': perm_add_rule,
             'add_subscription': perm_add_subscription,
             'add_scope': perm_add_scope,
@@ -219,9 +220,9 @@ def perm_del_account(issuer, kwargs):
     return issuer == 'root'
 
 
-def perm_set_account_status(issuer, kwargs):
+def perm_update_account(issuer, kwargs):
     """
-    Checks if an account can ban/unban an account.
+    Checks if an account can update an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -17,6 +17,7 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2016-2017
 # - Martin Barisits <martin.barisits@cern.ch>, 2017
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 
 import rucio.core.authentication
 import rucio.core.scope
@@ -37,7 +38,7 @@ def has_permission(issuer, action, kwargs):
     """
     perm = {'add_account': perm_add_account,
             'del_account': perm_del_account,
-            'set_account_status': perm_set_account_status,
+            'update_account': perm_update_account,
             'add_rule': perm_add_rule,
             'add_subscription': perm_add_subscription,
             'add_scope': perm_add_scope,
@@ -224,9 +225,9 @@ def perm_del_account(issuer, kwargs):
     return issuer == 'root'
 
 
-def perm_set_account_status(issuer, kwargs):
+def perm_update_account(issuer, kwargs):
     """
-    Checks if an account can ban/unban an account.
+    Checks if an account can update an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/web/rest/flaskapi/v1/account.py
+++ b/lib/rucio/web/rest/flaskapi/v1/account.py
@@ -21,7 +21,11 @@
 # - Cheng-Hsi Chao <cheng-hsi.chao@cern.ch>, 2014
 # - Joaquin Bogado <joaquin.bogado@cern.ch>, 2015
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+#
+# PY3K COMPATIBLE
 
+from __future__ import print_function
 from datetime import datetime
 from json import dumps, loads
 from logging import getLogger, StreamHandler, DEBUG
@@ -29,7 +33,7 @@ from traceback import format_exc
 from flask import Flask, Blueprint, Response, request, redirect
 from flask.views import MethodView
 
-from rucio.api.account import add_account, del_account, get_account_info, list_accounts, list_identities, list_account_attributes, add_account_attribute, del_account_attribute, set_account_status
+from rucio.api.account import add_account, del_account, get_account_info, list_accounts, list_identities, list_account_attributes, add_account_attribute, del_account_attribute, update_account
 from rucio.api.identity import add_account_identity, del_account_identity
 from rucio.api.account_limit import get_account_limits, get_account_limit, get_account_usage
 from rucio.api.rule import list_replication_rules
@@ -67,7 +71,7 @@ class Attributes(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             return error, 500
         return Response(dumps(attribs), content_type="application/json")
 
@@ -110,7 +114,7 @@ class Attributes(MethodView):
         except AccountNotFound as error:
             return generate_http_error_flask(404, 'AccountNotFound', error.args[0])
         except Exception as error:
-            print str(format_exc())
+            print(str(format_exc()))
             return error, 500
 
         return "Created", 201
@@ -161,7 +165,7 @@ class Scopes(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             return error, 500
 
         if not len(scopes):
@@ -193,7 +197,7 @@ class Scopes(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             return error, 500
 
         return "Created", 201
@@ -231,7 +235,7 @@ class AccountParameter(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             return error, 500
 
         dict = acc.to_dict()
@@ -245,7 +249,7 @@ class AccountParameter(MethodView):
         return Response(render_json(**dict), content_type="application/json")
 
     def put(self, account):
-        """ update the status for a given account name
+        """ update a parameter for a given account name
 
         .. :quickref: AccountParameter; Update account information.
 
@@ -261,17 +265,17 @@ class AccountParameter(MethodView):
             parameter = loads(json_data)
         except ValueError:
             return generate_http_error_flask(400, 'ValueError', 'cannot decode json parameter dictionary')
-        status = parameter.get('status', 'ACTIVE')
-        try:
-            set_account_status(account, status=status, issuer=request.environ.get('issuer'))
-        except ValueError:
-            return generate_http_error_flask(400, 'ValueError', 'Unknown status %s' % status)
-        except AccessDenied as error:
-            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
-        except AccountNotFound as error:
-            return generate_http_error_flask(404, 'AccountNotFound', error.args[0])
-        except Exception as error:
-            return error, 500
+        for key, value in parameter.items():
+            try:
+                update_account(account, key=key, value=value, issuer=request.environ.get('issuer'))
+            except ValueError:
+                return generate_http_error_flask(400, 'ValueError', 'Unknown value %s' % value)
+            except AccessDenied as error:
+                return generate_http_error_flask(401, 'AccessDenied', error.args[0])
+            except AccountNotFound as error:
+                return generate_http_error_flask(404, 'AccountNotFound', error.args[0])
+            except Exception as error:
+                return error, 500
 
         return "OK", 200
 
@@ -319,7 +323,7 @@ class AccountParameter(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             return error, 500
 
         return "Created", 201
@@ -440,7 +444,7 @@ class Identities(MethodView):
         except AccountNotFound as error:
             return generate_http_error_flask(404, 'AccountNotFound', error.args[0])
         except Exception as error:
-            print str(format_exc())
+            print(str(format_exc()))
             return error, 500
 
         return "Created", 201
@@ -468,7 +472,7 @@ class Identities(MethodView):
         except AccountNotFound as error:
             return generate_http_error_flask(404, 'AccountNotFound', error.args[0])
         except Exception as error:
-            print str(format_exc())
+            print(str(format_exc()))
             return error, 500
 
     def delete(self, account):
@@ -508,7 +512,7 @@ class Identities(MethodView):
         except IdentityError as error:
             return generate_http_error_flask(404, 'IdentityError', error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             return error, 500
 
         return "OK", 200
@@ -543,7 +547,7 @@ class Rules(MethodView):
         except RuleNotFound as error:
             return generate_http_error_flask(404, 'RuleNotFound', error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             return error, 500
 
 
@@ -574,7 +578,7 @@ class Usage1(MethodView):
         except AccessDenied as error:
             return generate_http_error_flask(401, 'AccessDenied', error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             return error, 500
 
 
@@ -608,7 +612,7 @@ class Usage2(MethodView):
         except AccessDenied as error:
             return generate_http_error_flask(401, 'AccessDenied', error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             return error, 500
 
 

--- a/lib/rucio/web/rest/webpy/v1/account.py
+++ b/lib/rucio/web/rest/webpy/v1/account.py
@@ -21,15 +21,22 @@
 # - Cheng-Hsi Chao <cheng-hsi.chao@cern.ch>, 2014
 # - Joaquin Bogado <joaquin.bogado@cern.ch>, 2015
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+#
+# PY3K COMPATIBLE
 
+from __future__ import print_function
 from datetime import datetime
 from json import dumps, loads
 from logging import getLogger, StreamHandler, DEBUG
 from traceback import format_exc
-from urlparse import parse_qsl
+try:
+    from urlparse import parse_qsl
+except ImportError:
+    from urllib.parse import parse_qsl
 from web import application, ctx, data, header, BadRequest, Created, InternalError, OK, loadhook, redirect, seeother
 
-from rucio.api.account import add_account, del_account, get_account_info, list_accounts, list_identities, list_account_attributes, add_account_attribute, del_account_attribute, set_account_status
+from rucio.api.account import add_account, del_account, get_account_info, list_accounts, list_identities, list_account_attributes, add_account_attribute, del_account_attribute, update_account
 from rucio.api.identity import add_account_identity, del_account_identity
 from rucio.api.account_limit import get_account_limits, get_account_limit, get_account_usage
 from rucio.api.rule import list_replication_rules
@@ -85,7 +92,7 @@ class Attributes(RucioController):
         except RucioException as error:
             raise generate_http_error(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             raise InternalError(error)
         return dumps(attribs)
 
@@ -127,7 +134,7 @@ class Attributes(RucioController):
         except AccountNotFound as error:
             raise generate_http_error(404, 'AccountNotFound', error.args[0])
         except Exception as error:
-            print str(format_exc())
+            print(str(format_exc()))
             raise InternalError(error)
 
         raise Created()
@@ -182,7 +189,7 @@ class Scopes(RucioController):
         except RucioException as error:
             raise generate_http_error(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             raise InternalError(error)
 
         if not len(scopes):
@@ -218,7 +225,7 @@ class Scopes(RucioController):
         except RucioException as error:
             raise generate_http_error(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             raise InternalError(error)
 
         raise Created()
@@ -261,7 +268,7 @@ class AccountParameter(RucioController):
         except RucioException as error:
             raise generate_http_error(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             raise InternalError(error)
 
         dict = acc.to_dict()
@@ -275,7 +282,7 @@ class AccountParameter(RucioController):
         return render_json(**dict)
 
     def PUT(self, account):
-        """ update the status for a given account name
+        """ update a parameter for a given account name
         HTTP Success:
             200 OK
 
@@ -290,17 +297,17 @@ class AccountParameter(RucioController):
             parameter = loads(json_data)
         except ValueError:
             raise generate_http_error(400, 'ValueError', 'cannot decode json parameter dictionary')
-        status = parameter.get('status', 'ACTIVE')
-        try:
-            set_account_status(account, status=status, issuer=ctx.env.get('issuer'))
-        except ValueError:
-            raise generate_http_error(400, 'ValueError', 'Unknown status %s' % status)
-        except AccessDenied as error:
-            raise generate_http_error(401, 'AccessDenied', error.args[0])
-        except AccountNotFound as error:
-            raise generate_http_error(404, 'AccountNotFound', error.args[0])
-        except Exception as error:
-            raise InternalError(error)
+        for key, value in parameter.items():
+            try:
+                update_account(account, key=key, value=value, issuer=ctx.env.get('issuer'))
+            except ValueError:
+                raise generate_http_error(400, 'ValueError', 'Unknown value %s' % value)
+            except AccessDenied as error:
+                raise generate_http_error(401, 'AccessDenied', error.args[0])
+            except AccountNotFound as error:
+                raise generate_http_error(404, 'AccountNotFound', error.args[0])
+            except Exception as error:
+                raise InternalError(error)
 
         raise OK()
 
@@ -351,7 +358,7 @@ class AccountParameter(RucioController):
         except RucioException as error:
             raise generate_http_error(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             raise InternalError(error)
 
         raise Created()
@@ -489,7 +496,7 @@ class Identities(RucioController):
         except AccountNotFound as error:
             raise generate_http_error(404, 'AccountNotFound', error.args[0])
         except Exception as error:
-            print str(format_exc())
+            print(str(format_exc()))
             raise InternalError(error)
 
         raise Created()
@@ -502,7 +509,7 @@ class Identities(RucioController):
         except AccountNotFound as error:
             raise generate_http_error(404, 'AccountNotFound', error.args[0])
         except Exception as error:
-            print str(format_exc())
+            print(str(format_exc()))
             raise InternalError(error)
 
     def PUT(self):
@@ -545,7 +552,7 @@ class Identities(RucioController):
         except IdentityError as error:
             raise generate_http_error(404, 'IdentityError', error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             raise InternalError(error)
 
         raise OK()
@@ -578,7 +585,7 @@ class Rules(RucioController):
         except RuleNotFound as error:
             raise generate_http_error(404, 'RuleNotFound', error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             raise InternalError(error)
 
     def PUT(self):
@@ -615,7 +622,7 @@ class Usage1(RucioController):
         except AccessDenied as error:
             raise generate_http_error(401, 'AccessDenied', error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             raise InternalError(error)
 
     def PUT(self):
@@ -655,7 +662,7 @@ class Usage2(RucioController):
         except AccessDenied as error:
             raise generate_http_error(401, 'AccessDenied', error.args[0])
         except Exception as error:
-            print format_exc()
+            print(format_exc())
             raise InternalError(error)
 
     def PUT(self):


### PR DESCRIPTION
Core & Internals: set and get account properties; Fix #1685 

Summary of changes:
- replaced `set_account_status` with `update_account`
- replaced `get_account_status` with `get_account_info` as it is only used in the tests
- added rucio-admin command to update account properties
- updated tests
- python3 compatibility