### PR TITLE
Clients: Use SCOPE_NAME_REGEXP for "request by DID" REST call. Fix #1791

### DIFF
--- a/lib/rucio/web/rest/webpy/v1/request.py
+++ b/lib/rucio/web/rest/webpy/v1/request.py
@@ -26,6 +26,7 @@ from logging import getLogger, StreamHandler, DEBUG
 from web import application, ctx, loadhook, header
 
 from rucio.api import request
+from rucio.common.schema import SCOPE_NAME_REGEXP
 from rucio.common.utils import generate_http_error, APIEncoder
 from rucio.web.rest.common import rucio_loadhook, RucioController, exception_wrapper
 
@@ -35,7 +36,7 @@ SH = StreamHandler()
 SH.setLevel(DEBUG)
 LOGGER.addHandler(SH)
 
-URLS = ('/(.+)/(.+)/(.+)', 'RequestGet',)
+URLS = ('%s/(.+)' % SCOPE_NAME_REGEXP, 'RequestGet',)
 
 
 class RequestGet(RucioController):


### PR DESCRIPTION
Clients: Use SCOPE_NAME_REGEXP for "request by DID" REST call. Fix #1791