### PR TITLE
Core & Internals: added import/export of RSEs to API, client, CLI; Fix #716

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -57,7 +57,7 @@ from rucio.common.config import config_get
 from rucio.common.exception import (AccountNotFound, DataIdentifierAlreadyExists, AccessDenied, DataIdentifierNotFound, InvalidObject, ReplicaNotFound,
                                     RSENotFound, RSEOperationNotSupported, InvalidRSEExpression, DuplicateContent, RuleNotFound, CannotAuthenticate,
                                     Duplicate)
-from rucio.common.utils import chunks, construct_surl, sizefmt, get_bytes_value_from_string
+from rucio.common.utils import chunks, construct_surl, sizefmt, get_bytes_value_from_string, render_json, parse_response
 from rucio import version
 from rucio.rse import rsemanager as rsemgr
 
@@ -970,6 +970,64 @@ def list_pfns(args):
     return SUCCESS
 
 
+@exception_handler
+def import_data(args):
+    """
+    %(prog)s list [options] <field1=value1 field2=value2 ...>
+
+    Import data from JSON file to Rucio.
+
+    """
+    client = get_client(args)
+    import_file_path = args.file_path
+    data = None
+    print('Start reading file.')
+    try:
+        with open(import_file_path) as import_file:
+            data_string = import_file.read()
+            data = parse_response(data_string)
+    except ValueError as error:
+        print('There was problem with decoding your file.')
+        print(error)
+        return FAILURE
+    except IOError as error:
+        print('There was a problem with reading your file.')
+        print(error)
+        return FAILURE
+
+    if data:
+        client.import_data(data)
+        print('Data successfully imported.')
+        return SUCCESS
+    else:
+        print('Nothing to import.')
+        return FAILURE
+
+
+@exception_handler
+def export_data(args):
+    """
+    %(prog)s list [options] <field1=value1 field2=value2 ...>
+
+    Export data from Rucio to JSON file.
+
+    """
+    client = get_client(args)
+    destination_file_path = args.file_path
+    print('Start querying data.')
+    data = client.export_data()
+    try:
+        with open(destination_file_path, 'w+') as destination_file:
+            destination_file.write(render_json(**data))
+            print('File successfully written.')
+        print('Data successfully exported to %s' % args.file_path)
+        return SUCCESS
+    except IOError as error:
+        print('There was a problem with reading your file.')
+        print(error)
+        return FAILURE
+
+
 def get_parser():
     """
     Returns the argparse parser.
@@ -993,6 +1051,36 @@ def get_parser():
     # Options for the x509  auth_strategy
     oparser.add_argument('--certificate', dest='certificate', default=None, help='Client certificate file')
     oparser.add_argument('--ca-certificate', dest='ca_certificate', default=None, help='CA certificate to verify peer against (SSL)')
+
+    # The import export subparser
+    data_parser = subparsers.add_parser('data', help='Import and export data')
+    data_subparsers = data_parser.add_subparsers()
+
+    # The import command
+    import_parser = data_subparsers.add_parser('import',
+                                               help='Import data to Rucio from JSON file.',
+                                               formatter_class=argparse.RawDescriptionHelpFormatter,
+                                               epilog='Usage example\n'
+                                                      '"""""""""""""\n'
+                                                      'Import data from the file file.json::\n'
+                                                      '\n'
+                                                      '    $ rucio-admin data import file.json\n'
+                                                      '\n')
+    import_parser.add_argument('file_path', action='store', help='File path.')
+    import_parser.set_defaults(which='import')
+
+    # The export command
+    export_parser = data_subparsers.add_parser('export',
+                                               help='Export data from  Rucio to JSON file.',
+                                               formatter_class=argparse.RawDescriptionHelpFormatter,
+                                               epilog='Usage example\n'
+                                                      '"""""""""""""\n'
+                                                      'Export data to the file file.json::\n'
+                                                      '\n'
+                                                      '    $ rucio-admin data export file.json\n'
+                                                      '\n')
+    export_parser.add_argument('file_path', action='store', help='File path.')
+    export_parser.set_defaults(which='export')
 
     # The account subparser
     account_parser = subparsers.add_parser('account', help='Account methods')
@@ -1843,7 +1931,9 @@ if __name__ == '__main__':
                 'update_subscription': update_subscription,
                 'reevaluate_did_for_subscription': reevaluate_did_for_subscription,
                 'declare_bad_file_replicas': declare_bad_file_replicas,
-                'list_pfns': list_pfns}
+                'list_pfns': list_pfns,
+                'import': import_data,
+                'export': export_data}
 
     try:
         if args.verbose:

--- a/etc/docker/demo/aliases-py27.conf
+++ b/etc/docker/demo/aliases-py27.conf
@@ -22,3 +22,5 @@ WSGIScriptAlias /subscriptions           /usr/lib/python2.7/site-packages/rucio/
 WSGIScriptAlias /traces                  /usr/lib/python2.7/site-packages/rucio/web/rest/trace.py
 WSGIScriptAlias /objectstores            /usr/lib/python2.7/site-packages/rucio/web/rest/objectstore.py
 WSGIScriptAlias /lifetime_exceptions     /usr/lib/python2.7/site-packages/rucio/web/rest/lifetime_exception.py
+WSGIScriptAlias /import                  /opt/rucio/lib/rucio/web/rest/importer.py
+WSGIScriptAlias /export                  /opt/rucio/lib/rucio/web/rest/exporter.py

--- a/etc/docker/dev/aliases-py27.conf
+++ b/etc/docker/dev/aliases-py27.conf
@@ -23,3 +23,5 @@ WSGIScriptAlias /subscriptions           /opt/rucio/lib/rucio/web/rest/subscript
 WSGIScriptAlias /traces                  /opt/rucio/lib/rucio/web/rest/trace.py
 WSGIScriptAlias /objectstores            /opt/rucio/lib/rucio/web/rest/objectstore.py
 WSGIScriptAlias /lifetime_exceptions     /opt/rucio/lib/rucio/web/rest/lifetime_exception.py
+WSGIScriptAlias /import                  /opt/rucio/lib/rucio/web/rest/importer.py
+WSGIScriptAlias /export                  /opt/rucio/lib/rucio/web/rest/exporter.py

--- a/etc/docker/travis/aliases-py27.conf
+++ b/etc/docker/travis/aliases-py27.conf
@@ -23,3 +23,5 @@ WSGIScriptAlias /subscriptions           /opt/rucio/lib/rucio/web/rest/subscript
 WSGIScriptAlias /traces                  /opt/rucio/lib/rucio/web/rest/trace.py
 WSGIScriptAlias /objectstores            /opt/rucio/lib/rucio/web/rest/objectstore.py
 WSGIScriptAlias /lifetime_exceptions     /opt/rucio/lib/rucio/web/rest/lifetime_exception.py
+WSGIScriptAlias /import                  /opt/rucio/lib/rucio/web/rest/importer.py
+WSGIScriptAlias /export                  /opt/rucio/lib/rucio/web/rest/exporter.py

--- a/lib/rucio/api/exporter.py
+++ b/lib/rucio/api/exporter.py
@@ -1,0 +1,29 @@
+'''
+  Copyright European Organization for Nuclear Research (CERN)
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Authors:
+  - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018
+
+  PY3K COMPATIBLE
+'''
+
+from rucio.api import permission
+from rucio.common import exception
+from rucio.core import exporter
+
+
+def export_data(issuer):
+    """
+    Export data from Rucio.
+
+    :param issuer: the issuer.
+    """
+    kwargs = {'issuer': issuer}
+    if not permission.has_permission(issuer=issuer, action='export', kwargs=kwargs):
+        raise exception.AccessDenied('Account %s can not export data' % issuer)
+
+    return exporter.export_data()

--- a/lib/rucio/api/importer.py
+++ b/lib/rucio/api/importer.py
@@ -1,0 +1,32 @@
+'''
+  Copyright European Organization for Nuclear Research (CERN)
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Authors:
+  - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018
+
+  PY3K COMPATIBLE
+'''
+
+from rucio.api import permission
+from rucio.common import exception
+from rucio.common.schema import validate_schema
+from rucio.core import importer
+
+
+def import_data(data, issuer):
+    """
+    Import data to add/update/delete records in Rucio.
+
+    :param data: data to be imported.
+    :param issuer: the issuer.
+    """
+    kwargs = {'issuer': issuer}
+    validate_schema(name='import', obj=data)
+    if not permission.has_permission(issuer=issuer, action='import', kwargs=kwargs):
+        raise exception.AccessDenied('Account %s can not import data' % issuer)
+
+    return importer.import_data(data)

--- a/lib/rucio/client/client.py
+++ b/lib/rucio/client/client.py
@@ -29,6 +29,8 @@ Client class for callers of the Rucio system
 from rucio.client.accountclient import AccountClient
 from rucio.client.accountlimitclient import AccountLimitClient
 from rucio.client.didclient import DIDClient
+from rucio.client.exportclient import ExportClient
+from rucio.client.importclient import ImportClient
 from rucio.client.lockclient import LockClient
 from rucio.client.metaclient import MetaClient
 from rucio.client.pingclient import PingClient
@@ -42,7 +44,7 @@ from rucio.client.configclient import ConfigClient
 from rucio.client.touchclient import TouchClient
 
 
-class Client(AccountClient, AccountLimitClient, MetaClient, PingClient, ReplicaClient, RequestClient, RSEClient, ScopeClient, DIDClient, RuleClient, SubscriptionClient, LockClient, ConfigClient, TouchClient):
+class Client(AccountClient, AccountLimitClient, MetaClient, PingClient, ReplicaClient, RequestClient, RSEClient, ScopeClient, DIDClient, RuleClient, SubscriptionClient, LockClient, ConfigClient, TouchClient, ImportClient, ExportClient):
 
     """Main client class for accessing Rucio resources. Handles the authentication."""
 

--- a/lib/rucio/client/exportclient.py
+++ b/lib/rucio/client/exportclient.py
@@ -1,0 +1,51 @@
+# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+#
+# PY3K COMPATIBLE
+
+from requests.status_codes import codes
+
+from rucio.client.baseclient import BaseClient
+from rucio.client.baseclient import choice
+from rucio.common.utils import build_url, parse_response
+
+
+class ExportClient(BaseClient):
+    """RSE client class for exporting data from Rucio"""
+
+    EXPORT_BASEURL = 'export'
+
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None,
+                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients'):
+        super(ExportClient, self).__init__(rucio_host, auth_host, account, ca_cert,
+                                           auth_type, creds, timeout, user_agent)
+
+    def export_data(self):
+        """
+        Export data.
+
+        :returns: A dict containing data
+        """
+        path = '/'.join([self.EXPORT_BASEURL])
+        url = build_url(choice(self.list_hosts), path=path)
+
+        r = self._send_request(url, type='GET')
+        if r.status_code == codes.ok:
+            return parse_response(r.text)
+        else:
+            exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+            raise exc_cls(exc_msg)

--- a/lib/rucio/client/importclient.py
+++ b/lib/rucio/client/importclient.py
@@ -1,0 +1,52 @@
+# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+#
+# PY3K COMPATIBLE
+
+from json import dumps
+from requests.status_codes import codes
+
+from rucio.client.baseclient import BaseClient
+from rucio.client.baseclient import choice
+from rucio.common.utils import build_url
+
+
+class ImportClient(BaseClient):
+    """RSE client class for importing data into Rucio"""
+
+    IMPORT_BASEURL = 'import'
+
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None,
+                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients'):
+        super(ImportClient, self).__init__(rucio_host, auth_host, account, ca_cert,
+                                           auth_type, creds, timeout, user_agent)
+
+    def import_data(self, data):
+        """
+        Imports data into Rucio.
+
+        :param data: a dict containing data to be imported into Rucio.
+        """
+        path = '/'.join([self.IMPORT_BASEURL])
+        url = build_url(choice(self.list_hosts), path=path)
+
+        r = self._send_request(url, type='POST', data=dumps(data))
+        if r.status_code == codes.created:
+            return r.text
+        else:
+            exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+            raise exc_cls(exc_msg)

--- a/lib/rucio/common/schema/atlas.py
+++ b/lib/rucio/common/schema/atlas.py
@@ -346,6 +346,35 @@ ACCOUNT_ATTRIBUTE = {"description": "Account attribute",
 
 SCOPE_NAME_REGEXP = '/(.*)/(.*)'
 
+RSES = {"description": "list of RSEs",
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "rse": RSE
+            },
+            "required": ["rse"],
+            "additionalProperties": True}}
+
+DISTANCE = {"description": "RSE distance",
+            "type": "object",
+            "properties": {
+                "src_rse_id": {"type": "string"},
+                "dest_rse_id": {"type": "string"},
+                "ranking": {"type": "integer"}
+            },
+            "required": ["src_rse_id", "dest_rse_id", "ranking"],
+            "additionalProperties": True}
+
+IMPORT = {"description": "import data into rucio.",
+          "type": "object",
+          "properties": {
+              "rses": RSES,
+              "distances": {
+                  "type": "object"
+              }
+          }}
+
 SCHEMAS = {'account': ACCOUNT,
            'account_type': ACCOUNT_TYPE,
            'activity': ACTIVITY,
@@ -368,7 +397,8 @@ SCHEMAS = {'account': ACCOUNT,
            'subscription_filter': SUBSCRIPTION_FILTER,
            'cache_add_replicas': CACHE_ADD_REPLICAS,
            'cache_delete_replicas': CACHE_DELETE_REPLICAS,
-           'account_attribute': ACCOUNT_ATTRIBUTE}
+           'account_attribute': ACCOUNT_ATTRIBUTE,
+           'import': IMPORT}
 
 
 def validate_schema(name, obj):

--- a/lib/rucio/common/schema/cms.py
+++ b/lib/rucio/common/schema/cms.py
@@ -344,6 +344,36 @@ ACCOUNT_ATTRIBUTE = {"description": "Account attribute",
 
 SCOPE_NAME_REGEXP = '/([^/]*)(?=/)(.*)'
 
+RSES = {"description": "list of RSEs",
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "rse": RSE
+            },
+            "required": ["rse"],
+            "additionalProperties": True
+        }}
+
+DISTANCE = {"description": "RSE distance",
+            "type": "object",
+            "properties": {
+                "src_rse_id": {"type": "string"},
+                "dest_rse_id": {"type": "string"},
+                "ranking": {"type": "integer"}
+            },
+            "required": ["src_rse_id", "dest_rse_id", "ranking"],
+            "additionalProperties": True}
+
+IMPORT = {"description": "import data into rucio.",
+          "type": "object",
+          "properties": {
+              "rses": RSES,
+              "distances": {
+                  "type": "object"
+              }
+          }}
+
 SCHEMAS = {'account': ACCOUNT,
            'account_type': ACCOUNT_TYPE,
            'activity': ACTIVITY,
@@ -366,7 +396,8 @@ SCHEMAS = {'account': ACCOUNT,
            'subscription_filter': SUBSCRIPTION_FILTER,
            'cache_add_replicas': CACHE_ADD_REPLICAS,
            'cache_delete_replicas': CACHE_DELETE_REPLICAS,
-           'account_attribute': ACCOUNT_ATTRIBUTE}
+           'account_attribute': ACCOUNT_ATTRIBUTE,
+           'import': IMPORT}
 
 
 def validate_schema(name, obj):

--- a/lib/rucio/common/schema/generic.py
+++ b/lib/rucio/common/schema/generic.py
@@ -341,9 +341,37 @@ ACCOUNT_ATTRIBUTE = {"description": "Account attribute",
                      "type": "string",
                      "pattern": r'^[a-z0-9-_]{1,30}$'}
 
-
 SCOPE_NAME_REGEXP = '/(.*)/(.*)'
 
+RSES = {"description": "list of RSEs",
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "rse": RSE
+            },
+            "required": ["rse"],
+            "additionalProperties": True
+        }}
+
+DISTANCE = {"description": "RSE distance",
+            "type": "object",
+            "properties": {
+                "src_rse_id": {"type": "string"},
+                "dest_rse_id": {"type": "string"},
+                "ranking": {"type": "integer"}
+            },
+            "required": ["src_rse_id", "dest_rse_id", "ranking"],
+            "additionalProperties": True}
+
+IMPORT = {"description": "import data into rucio.",
+          "type": "object",
+          "properties": {
+              "rses": RSES,
+              "distances": {
+                  "type": "object"
+              }
+          }}
 
 SCHEMAS = {'account': ACCOUNT,
            'account_type': ACCOUNT_TYPE,
@@ -367,7 +395,8 @@ SCHEMAS = {'account': ACCOUNT,
            'subscription_filter': SUBSCRIPTION_FILTER,
            'cache_add_replicas': CACHE_ADD_REPLICAS,
            'cache_delete_replicas': CACHE_DELETE_REPLICAS,
-           'account_attribute': ACCOUNT_ATTRIBUTE}
+           'account_attribute': ACCOUNT_ATTRIBUTE,
+           'import': IMPORT}
 
 
 def validate_schema(name, obj):

--- a/lib/rucio/core/exporter.py
+++ b/lib/rucio/core/exporter.py
@@ -1,0 +1,35 @@
+# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+#
+# PY3K COMPATIBLE
+
+from rucio.core import rse as rse_module, distance as distance_module
+from rucio.db.sqla.session import transactional_session
+
+
+@transactional_session
+def export_data(session=None):
+    """
+    Export data.
+
+    :param session: database session in use.
+    """
+    data = {
+        'rses': [rse_module.export_rse(rse['rse'], session=session) for rse in rse_module.list_rses(session=session)],
+        'distances': distance_module.export_distances(session=session)
+    }
+    return data

--- a/lib/rucio/core/importer.py
+++ b/lib/rucio/core/importer.py
@@ -1,0 +1,116 @@
+# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+#
+# PY3K COMPATIBLE
+
+from rucio.core import rse as rse_module, distance as distance_module
+from rucio.db.sqla.session import transactional_session
+
+
+@transactional_session
+def import_data(data, session=None):
+    """
+    Import data to add and update records in Rucio.
+
+    :param data: data to be imported as dictionary.
+    :param session: database session in use.
+    """
+    # RSEs
+    rses = data.get('rses')
+    if rses:
+        for rse in rses:
+            protocols = rse.get('protocols')
+            if protocols:
+                protocols = protocols.get('protocols')
+                del rse['protocols']
+            rse_name = rse['rse']
+            del rse['rse']
+            if not rse_module.rse_exists(rse_name, session=session):
+                rse_module.add_rse(rse_name, deterministic=rse.get('deterministic'), volatile=rse.get('volatile'),
+                                   city=rse.get('city'), region_code=rse.get('region_code'), country_name=rse.get('country_name'),
+                                   staging_area=rse.get('staging_area'), continent=rse.get('continent'), time_zone=rse.get('time_zone'),
+                                   ISP=rse.get('ISP'), rse_type=rse.get('rse_type'), latitude=rse.get('latitude'),
+                                   longitude=rse.get('longitude'), ASN=rse.get('ASN'), availability=rse.get('availability'),
+                                   session=session)
+            else:
+                rse_module.update_rse(rse_name, rse, session=session)
+
+            # Protocols
+            if protocols:
+                old_protocols = rse_module.get_rse_protocols(rse=rse_name, session=session)
+                for protocol in protocols:
+                    scheme = protocol.get('scheme')
+                    hostname = protocol.get('hostname')
+                    port = protocol.get('port')
+                    intersection = [old_protocol for old_protocol in old_protocols['protocols'] if old_protocol['scheme'] == scheme and old_protocol['hostname'] == hostname and
+                                    old_protocol['port'] == port]
+                    if intersection:
+                        del protocol['scheme']
+                        del protocol['hostname']
+                        del protocol['port']
+                        rse_module.update_protocols(rse=rse_name, scheme=scheme, data=protocol, hostname=hostname, port=port, session=session)
+                    else:
+                        rse_module.add_protocol(rse=rse_name, parameter=protocol, session=session)
+
+            # Limits
+            limits = rse.get('limits')
+            if limits:
+                old_limits = rse_module.get_rse_limits(rse=rse_name, session=session)
+                for limit in limits:
+                    if limit in old_limits:
+                        rse_module.delete_rse_limit(rse=rse_name, name=limit, session=session)
+                    rse_module.set_rse_limits(rse=rse_name, name=limit, value=limits[limit], session=session)
+
+            # Transfer limits
+            transfer_limits = rse.get('transfer_limits')
+            if transfer_limits:
+                for limit in transfer_limits:
+                    old_transfer_limits = rse_module.get_rse_transfer_limits(rse=rse_name, activity=limit, session=session)
+                    if limit in old_transfer_limits:
+                        rse_module.delete_rse_transfer_limits(rse=rse_name, activity=limit, session=session)
+                    max_transfers = transfer_limits[limit].items()[0][1]['max_transfers']
+                    rse_module.set_rse_transfer_limits(rse=rse_name, activity=limit, max_transfers=max_transfers, session=session)
+
+            # Attributes
+            attributes = rse.get('attributes')
+            if attributes:
+                old_attributes = rse_module.list_rse_attributes(rse=rse_name, session=session)
+                for attr in attributes:
+                    if attr in old_attributes:
+                        rse_module.del_rse_attribute(rse=rse_name, key=attr, session=session)
+                    rse_module.add_rse_attribute(rse=rse_name, key=attr, value=attributes[attr], session=session)
+
+    # Distances
+    distances = data.get('distances')
+    if distances:
+        for src_rse_name in distances:
+            src = rse_module.get_rse_id(src_rse_name, session=session)
+            for dest_rse_name in distances[src_rse_name]:
+                dest = rse_module.get_rse_id(dest_rse_name, session=session)
+                distance = distances[src_rse_name][dest_rse_name]
+                del distance['src_rse_id']
+                del distance['dest_rse_id']
+
+                old_distance = distance_module.get_distances(src_rse_id=src, dest_rse_id=dest, session=session)
+                if old_distance:
+                    distance_module.update_distances(src_rse_id=src, dest_rse_id=dest, parameters=distance, session=session)
+                else:
+                    distance_module.add_distance(src_rse_id=src, dest_rse_id=dest, ranking=distance.get('ranking'),
+                                                 agis_distance=distance.get('agis_distance'), geoip_distance=distance.get('geoip_distance'),
+                                                 active=distance.get('active'), submitted=distance.get('submitted'),
+                                                 transfer_speed=distance.get('transfer_speed'), finished=distance.get('finished'),
+                                                 failed=distance.get('failed'), session=session)

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -40,6 +40,8 @@ import sqlalchemy.orm
 from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 
+from six import string_types
+
 from sqlalchemy.exc import DatabaseError, IntegrityError, OperationalError
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.exc import FlushError
@@ -86,7 +88,7 @@ def add_rse(rse, deterministic=True, volatile=False, city=None, region_code=None
     :param availability: Availability.
     :param session: The database session in use.
     """
-    if isinstance(rse_type, str) or isinstance(rse_type, unicode):
+    if isinstance(rse_type, string_types):
         rse_type = RSEType.from_string(str(rse_type))
 
     new_rse = models.RSE(rse=rse, deterministic=deterministic, volatile=volatile, city=city,
@@ -615,6 +617,23 @@ def get_rse_limits(rse, name=None, rse_id=None, session=None):
 
 
 @transactional_session
+def delete_rse_limit(rse, name=None, rse_id=None, session=None):
+    """
+    Delete RSE limit.
+
+    :param rse: The RSE name.
+    :param name: The name of the limit.
+    :param rse_id: The RSE id.
+    """
+    try:
+        if not rse_id:
+            rse_id = get_rse_id(rse=rse, session=session)
+        session.query(models.RSELimit).filter_by(rse_id=rse_id, name=name).delete()
+    except IntegrityError as error:
+        raise exception.RucioException(error.args)
+
+
+@transactional_session
 def set_rse_transfer_limits(rse, activity, rse_id=None, rse_expression=None, max_transfers=0, transfers=0, waitings=0, session=None):
     """
     Set RSE transfer limits.
@@ -1105,7 +1124,7 @@ def export_rse(rse, rse_id=None, session=None):
     if not rse_id:
         rse_id = get_rse_id(rse=rse, session=session)
 
-    query = session.query(models.RSE).filter_by(rse_id=rse_id)
+    query = session.query(models.RSE).filter_by(id=rse_id)
 
     rse_data = {}
     for _rse in query:

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -29,6 +29,7 @@ from __future__ import print_function
 
 from os import remove, unlink, listdir, rmdir, stat, path
 
+import json
 import nose.tools
 import re
 
@@ -1065,3 +1066,23 @@ class TestBinRucio():
         cmd = 'rucio list-content {0}'.format(container)
         exitcode, out, err = execute(cmd)
         nose.tools.assert_not_equal(re.search("{0}:{1}".format(self.user, new_dataset['name']), out), None)
+
+    def test_import_data(self):
+        """ CLIENT(ADMIN): Import data into rucio"""
+        file_path = 'data_import.json'
+        data = {'rses': [{'rse': rse_name_generator()}]}
+        with open(file_path, 'w+') as file:
+            file.write(json.dumps(data))
+        cmd = 'rucio-admin data import {0}'.format(file_path)
+        exitcode, out, err = execute(cmd)
+        nose.tools.assert_not_equal(re.search('Data successfully imported', out), None)
+        remove(file_path)
+
+    def test_export_data(self):
+        """ CLIENT(ADMIN): Export data from rucio"""
+        file_path = 'data_export.json'
+        cmd = 'rucio-admin data export {0}'.format(file_path)
+        exitcode, out, err = execute(cmd)
+        print(re.search('Data successfully exported', out))
+        nose.tools.assert_not_equal(re.search('Data successfully exported', out), None)
+        remove(file_path)

--- a/lib/rucio/tests/test_import_export.py
+++ b/lib/rucio/tests/test_import_export.py
@@ -1,0 +1,358 @@
+# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+#
+# PY3K COMPATIBLE
+
+from __future__ import print_function
+
+from nose.tools import assert_equal, assert_true
+from paste.fixture import TestApp
+
+from rucio.db.sqla.constants import RSEType
+from rucio.client.importclient import ImportClient
+from rucio.client.exportclient import ExportClient
+from rucio.common.utils import render_json, parse_response
+from rucio.core.distance import add_distance, get_distances, export_distances
+from rucio.core.exporter import export_data
+from rucio.core.importer import import_data
+from rucio.core.rse import get_rse_id, add_rse, get_rse, add_protocol, get_rse_protocols, list_rse_attributes, get_rse_transfer_limits, get_rse_limits, set_rse_limits, set_rse_transfer_limits, add_rse_attribute, list_rses, export_rse
+from rucio.tests.common import rse_name_generator
+from rucio.web.rest.importer import APP as import_app
+from rucio.web.rest.exporter import APP as export_app
+from rucio.web.rest.authentication import APP as auth_app
+
+
+class TestImporter(object):
+
+    def setup(self):
+        # New RSE
+        self.new_rse = rse_name_generator()
+
+        # RSE 1 that already exists
+        self.old_rse_1 = rse_name_generator()
+        add_rse(self.old_rse_1, availability=1)
+        add_protocol(self.old_rse_1, {'scheme': 'scheme1', 'hostname': 'hostname1', 'port': 1000, 'impl': 'impl'})
+        self.old_rse_id_1 = get_rse_id(self.old_rse_1)
+        set_rse_limits(rse=self.old_rse_1, name='limit1', value='10')
+        set_rse_transfer_limits(rse=self.old_rse_1, activity='activity1', max_transfers=10)
+        add_rse_attribute(rse=self.old_rse_1, key='attr1', value='test10')
+
+        # RSE 2 that already exists
+        self.old_rse_2 = rse_name_generator()
+        add_rse(self.old_rse_2)
+        self.old_rse_id_2 = get_rse_id(self.old_rse_2)
+
+        # RSE 3 that already exists
+        self.old_rse_3 = rse_name_generator()
+        add_rse(self.old_rse_3)
+        self.old_rse_id_3 = get_rse_id(self.old_rse_3)
+
+        # Distance that already exists
+        add_distance(self.old_rse_id_1, self.old_rse_id_2)
+
+        self.data1 = {
+            'rses': [{
+                'rse': self.new_rse,
+                'rse_type': 'TAPE',
+                'availability': 5,
+                'city': 'NewCity',
+                'protocols': {
+                    'protocols': [{
+                        'scheme': 'scheme',
+                        'hostname': 'hostname',
+                        'port': 1000,
+                        'impl': 'impl'
+                    }]
+                },
+                'limits': {
+                    'limit1': 0
+                },
+                'transfer_limits': {
+                    'activity1': {
+                        'unknown_rse_id': {
+                            'max_transfers': 1
+                        }
+                    }
+                },
+                'attributes': {
+                    'attr1': 'test'
+                }
+            }, {
+                'rse': self.old_rse_1,
+                'protocols': {
+                    'protocols': [{
+                        'scheme': 'scheme1',
+                        'hostname': 'hostname1',
+                        'port': 1000,
+                        'prefix': 'prefix',
+                        'impl': 'impl1'
+                    }, {
+                        'scheme': 'scheme2',
+                        'hostname': 'hostname2',
+                        'port': 1001,
+                        'impl': 'impl'
+                    }]
+                },
+                'limits': {
+                    'limit1': 0,
+                    'limit2': 2
+                },
+                'transfer_limits': {
+                    'activity1': {
+                        self.old_rse_id_1: {
+                            'max_transfers': 1
+                        }
+                    },
+                    'activity2': {
+                        self.old_rse_id_1: {
+                            'max_transfers': 2
+                        }
+                    }
+                },
+                'attributes': {
+                    'attr1': 'test1',
+                    'attr2': 'test2'
+                }
+            }],
+            'distances': {
+                self.old_rse_1: {
+                    self.old_rse_2: {'src_rse_id': self.old_rse_id_1, 'dest_rse_id': self.old_rse_id_2, 'ranking': 10},
+                    self.old_rse_3: {'src_rse_id': self.old_rse_id_1, 'dest_rse_id': self.old_rse_id_3, 'ranking': 4}
+                }
+            }
+        }
+        self.data2 = {'rses': [{'rse': self.new_rse}]}
+        self.data3 = {'distances': {}}
+
+    def test_importer_core(self):
+        """ IMPORTER (CORE): test import. """
+        import_data(data=self.data1)
+
+        # RSE that had not existed before
+        rse = get_rse(self.new_rse)
+        assert_equal(rse['availability'], 5)
+        assert_equal(rse['city'], 'NewCity')
+        assert_equal(rse['rse_type'], RSEType.TAPE)
+
+        protocols = [{'hostname': protocol['hostname'], 'scheme': protocol['scheme'], 'port': protocol['port']} for protocol in get_rse_protocols(self.new_rse)['protocols']]
+        assert_true({'scheme': 'scheme', 'hostname': 'hostname', 'port': 1000} in protocols)
+
+        attributes = list_rse_attributes(rse=self.new_rse)
+        assert_equal(attributes['attr1'], 'test')
+
+        limits = get_rse_limits(rse=self.new_rse)
+        assert_equal(limits['limit1'], 0)
+
+        transfer_limits = get_rse_transfer_limits(rse=self.new_rse)
+        assert_equal(transfer_limits['activity1'][get_rse_id(self.new_rse)]['max_transfers'], 1)
+
+        # RSE 1 that already exists
+        rse = get_rse(self.old_rse_1)
+        assert_equal(rse['rse'], self.old_rse_1)
+
+        protocols = [{'hostname': protocol['hostname'], 'scheme': protocol['scheme'], 'port': protocol['port'], 'impl': protocol['impl'], 'prefix': protocol['prefix']} for protocol in get_rse_protocols(self.old_rse_1)['protocols']]
+        assert_true({'scheme': 'scheme1', 'hostname': 'hostname1', 'port': 1000, 'prefix': 'prefix', 'impl': 'impl1'} in protocols)
+        assert_true({'scheme': 'scheme2', 'hostname': 'hostname2', 'port': 1001, 'impl': 'impl', 'prefix': ''} in protocols)
+
+        attributes = list_rse_attributes(rse=self.old_rse_1)
+        assert_equal(attributes['attr1'], 'test1')
+        assert_equal(attributes['attr2'], 'test2')
+
+        limits = get_rse_limits(rse=self.old_rse_1)
+        assert_equal(limits['limit1'], 0)
+        assert_equal(limits['limit2'], 2)
+
+        transfer_limits = get_rse_transfer_limits(rse=self.old_rse_1)
+        assert_equal(transfer_limits['activity1'][get_rse_id(self.old_rse_1)]['max_transfers'], 1)
+        assert_equal(transfer_limits['activity2'][get_rse_id(self.old_rse_1)]['max_transfers'], 2)
+
+        # Distances
+        distance = get_distances(self.old_rse_id_1, self.old_rse_id_2)[0]
+        assert_equal(distance['ranking'], 10)
+
+        distance = get_distances(self.old_rse_id_1, self.old_rse_id_3)[0]
+        assert_equal(distance['ranking'], 4)
+
+        import_data(data=self.data2)
+        import_data(data=self.data3)
+
+    def test_importer_client(self):
+        """ IMPORTER (CLIENT): test import. """
+        import_client = ImportClient()
+        import_client.import_data(data=self.data1)
+
+        # RSE that had not existed before
+        rse = get_rse(self.new_rse)
+        assert_equal(rse['availability'], 5)
+        assert_equal(rse['city'], 'NewCity')
+        assert_equal(rse['rse_type'], RSEType.TAPE)
+        protocols = [{'hostname': protocol['hostname'], 'scheme': protocol['scheme'], 'port': protocol['port']} for protocol in get_rse_protocols(self.new_rse)['protocols']]
+        assert_true({'scheme': 'scheme', 'hostname': 'hostname', 'port': 1000} in protocols)
+
+        attributes = list_rse_attributes(rse=self.new_rse)
+        assert_equal(attributes['attr1'], 'test')
+
+        limits = get_rse_limits(rse=self.new_rse)
+        assert_equal(limits['limit1'], 0)
+
+        transfer_limits = get_rse_transfer_limits(rse=self.new_rse)
+        assert_equal(transfer_limits['activity1'][get_rse_id(self.new_rse)]['max_transfers'], 1)
+
+        # RSE 1 that already exists
+        rse = get_rse(self.old_rse_1)
+        assert_equal(rse['rse'], self.old_rse_1)
+
+        protocols = [{'hostname': protocol['hostname'], 'scheme': protocol['scheme'], 'port': protocol['port'], 'impl': protocol['impl'], 'prefix': protocol['prefix']} for protocol in get_rse_protocols(self.old_rse_1)['protocols']]
+        assert_true({'scheme': 'scheme1', 'hostname': 'hostname1', 'port': 1000, 'prefix': 'prefix', 'impl': 'impl1'} in protocols)
+        assert_true({'scheme': 'scheme2', 'hostname': 'hostname2', 'port': 1001, 'impl': 'impl', 'prefix': ''} in protocols)
+
+        attributes = list_rse_attributes(rse=self.old_rse_1)
+        assert_equal(attributes['attr1'], 'test1')
+        assert_equal(attributes['attr2'], 'test2')
+
+        limits = get_rse_limits(rse=self.old_rse_1)
+        assert_equal(limits['limit1'], 0)
+        assert_equal(limits['limit2'], 2)
+
+        transfer_limits = get_rse_transfer_limits(rse=self.old_rse_1)
+        assert_equal(transfer_limits['activity1'][get_rse_id(self.old_rse_1)]['max_transfers'], 1)
+        assert_equal(transfer_limits['activity2'][get_rse_id(self.old_rse_1)]['max_transfers'], 2)
+
+        # Distances
+        distance = get_distances(self.old_rse_id_1, self.old_rse_id_2)[0]
+        assert_equal(distance['ranking'], 10)
+
+        distance = get_distances(self.old_rse_id_1, self.old_rse_id_3)[0]
+        assert_equal(distance['ranking'], 4)
+
+        import_client.import_data(data=self.data2)
+        import_client.import_data(data=self.data3)
+
+    def test_importer_rest(self):
+        """ IMPORTER (REST): test import. """
+        mw = []
+        headers1 = {'X-Rucio-Account': 'root', 'X-Rucio-Username': 'ddmlab', 'X-Rucio-Password': 'secret'}
+        r1 = TestApp(auth_app.wsgifunc(*mw)).get('/userpass', headers=headers1, expect_errors=True)
+        token = str(r1.header('X-Rucio-Auth-Token'))
+        headers2 = {'X-Rucio-Type': 'user', 'X-Rucio-Account': 'root', 'X-Rucio-Auth-Token': str(token)}
+
+        r2 = TestApp(import_app.wsgifunc(*mw)).post('/', headers=headers2, expect_errors=True, params=render_json(**self.data1))
+        assert_equal(r2.status, 201)
+
+        # RSE that not existed before
+        rse = get_rse(self.new_rse)
+        assert_equal(rse['availability'], 5)
+        assert_equal(rse['city'], 'NewCity')
+        assert_equal(rse['rse_type'], RSEType.TAPE)
+
+        protocols = [{'hostname': protocol['hostname'], 'scheme': protocol['scheme'], 'port': protocol['port']} for protocol in get_rse_protocols(self.new_rse)['protocols']]
+        assert_true({'scheme': 'scheme', 'hostname': 'hostname', 'port': 1000} in protocols)
+
+        attributes = list_rse_attributes(rse=self.new_rse)
+        assert_equal(attributes['attr1'], 'test')
+
+        limits = get_rse_limits(rse=self.new_rse)
+        assert_equal(limits['limit1'], 0)
+
+        transfer_limits = get_rse_transfer_limits(rse=self.new_rse)
+        assert_equal(transfer_limits['activity1'][get_rse_id(self.new_rse)]['max_transfers'], 1)
+
+        # RSE 1 that already existed before
+        rse = get_rse(self.old_rse_1)
+        assert_equal(rse['rse'], self.old_rse_1)
+
+        protocols = [{'hostname': protocol['hostname'], 'scheme': protocol['scheme'], 'port': protocol['port'], 'impl': protocol['impl'], 'prefix': protocol['prefix']} for protocol in get_rse_protocols(self.old_rse_1)['protocols']]
+        assert_true({'scheme': 'scheme1', 'hostname': 'hostname1', 'port': 1000, 'prefix': 'prefix', 'impl': 'impl1'} in protocols)
+        assert_true({'scheme': 'scheme2', 'hostname': 'hostname2', 'port': 1001, 'impl': 'impl', 'prefix': ''} in protocols)
+
+        attributes = list_rse_attributes(rse=self.old_rse_1)
+        assert_equal(attributes['attr1'], 'test1')
+        assert_equal(attributes['attr2'], 'test2')
+
+        limits = get_rse_limits(rse=self.old_rse_1)
+        assert_equal(limits['limit1'], 0)
+        assert_equal(limits['limit2'], 2)
+
+        transfer_limits = get_rse_transfer_limits(rse=self.old_rse_1)
+        assert_equal(transfer_limits['activity1'][get_rse_id(self.old_rse_1)]['max_transfers'], 1)
+        assert_equal(transfer_limits['activity2'][get_rse_id(self.old_rse_1)]['max_transfers'], 2)
+
+        # Distances
+        distance = get_distances(self.old_rse_id_1, self.old_rse_id_2)[0]
+        assert_equal(distance['ranking'], 10)
+
+        distance = get_distances(self.old_rse_id_1, self.old_rse_id_3)[0]
+        assert_equal(distance['ranking'], 4)
+
+        r2 = TestApp(import_app.wsgifunc(*mw)).post('/', headers=headers2, expect_errors=True, params=render_json(**self.data2))
+        assert_equal(r2.status, 201)
+
+        r2 = TestApp(import_app.wsgifunc(*mw)).post('/', headers=headers2, expect_errors=True, params=render_json(**self.data3))
+        assert_equal(r2.status, 201)
+
+
+class TestExporter(object):
+
+    def test_export_core(self):
+        """ EXPORT (CORE): Test the export of data."""
+        data = export_data()
+        assert_equal(data['rses'], [export_rse(rse['rse']) for rse in list_rses()])
+        assert_equal(data['distances'], export_distances())
+
+    def test_export_client(self):
+        """ EXPORT (CLIENT): Test the export of data."""
+        export_client = ExportClient()
+        data = render_json(**export_client.export_data())
+        assert_true('rses' in data)
+        assert_true('distances' in data)
+
+    def test_export_rest(self):
+        """ EXPORT (REST): Test the export of data."""
+        mw = []
+        headers1 = {'X-Rucio-Account': 'root', 'X-Rucio-Username': 'ddmlab', 'X-Rucio-Password': 'secret'}
+        r1 = TestApp(auth_app.wsgifunc(*mw)).get('/userpass', headers=headers1, expect_errors=True)
+        token = str(r1.header('X-Rucio-Auth-Token'))
+        headers2 = {'X-Rucio-Type': 'user', 'X-Rucio-Account': 'root', 'X-Rucio-Auth-Token': str(token)}
+
+        r2 = TestApp(export_app.wsgifunc(*mw)).get('/', headers=headers2, expect_errors=True)
+        rses = [export_rse(rse['rse']) for rse in list_rses()]
+        assert_equal(r2.status, 200)
+        assert_equal(r2.body, render_json(**{'rses': rses, 'distances': export_distances()}))
+
+
+class TestExportImport(object):
+
+    def test_export_import(self):
+        """ IMPORT/EXPORT (REST): Test the export and import of data together to check same syntax."""
+        # Setup new RSE, distance, attribute, limits
+        new_rse = rse_name_generator()
+        add_rse(new_rse)
+
+        # Get token
+        mw = []
+        headers1 = {'X-Rucio-Account': 'root', 'X-Rucio-Username': 'ddmlab', 'X-Rucio-Password': 'secret'}
+        r1 = TestApp(auth_app.wsgifunc(*mw)).get('/userpass', headers=headers1, expect_errors=True)
+        token = str(r1.header('X-Rucio-Auth-Token'))
+        headers2 = {'X-Rucio-Type': 'user', 'X-Rucio-Account': 'root', 'X-Rucio-Auth-Token': str(token)}
+
+        # Export data
+        r2 = TestApp(export_app.wsgifunc(*mw)).get('/', headers=headers2, expect_errors=True)
+        exported_data = parse_response(r2.body)
+
+        # Import data
+        r3 = TestApp(import_app.wsgifunc(*mw)).post('/', headers=headers2, expect_errors=True, params=render_json(**exported_data))
+        assert_equal(r3.status, 201)

--- a/lib/rucio/web/rest/exporter.py
+++ b/lib/rucio/web/rest/exporter.py
@@ -1,0 +1,1 @@
+webpy/v1/exporter.py

--- a/lib/rucio/web/rest/flaskapi/v1/exporter.py
+++ b/lib/rucio/web/rest/flaskapi/v1/exporter.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+#
+# PY3K COMPATIBLE
+
+
+from flask import Flask, Blueprint, request
+from flask.views import MethodView
+
+from rucio.api.exporter import export_data
+from rucio.common.exception import RucioException
+from rucio.common.utils import generate_http_error_flask, render_json
+from rucio.web.rest.flaskapi.v1.common import before_request, after_request
+
+
+class Export(MethodView):
+    """ Export data. """
+
+    def get(self):
+        """ Export data from Rucio.
+
+        .. :quickref: Export data
+
+        **Example request**:
+
+        .. sourcecode:: http
+
+            GET /export HTTP/1.1
+            Host: rucio.cern.ch
+
+        **Example response**:
+
+        .. sourcecode:: http
+
+            HTTP/1.1 200 OK
+            Vary: Accept
+            Content-Type: application/json
+
+            {"rses": [{"rse": "MOCK", "rse_type": "TAPE"}], "distances": {}}
+        :resheader Content-Type: application/json
+        :status 200: DIDs found
+        :status 401: Invalid Auth Token
+        :returns: dictionary with rucio data
+        """
+
+        try:
+            return render_json(**export_data(issuer=request.environ.get('issuer')))
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
+
+
+bp = Blueprint('export', __name__)
+
+export_view = Export.as_view('scope')
+bp.add_url_rule('', view_func=export_view, methods=['get', ])
+
+application = Flask(__name__)
+application.register_blueprint(bp)
+application.before_request(before_request)
+application.after_request(after_request)
+
+
+def make_doc():
+    """ Only used for sphinx documentation to add the prefix """
+    doc_app = Flask(__name__)
+    doc_app.register_blueprint(bp, url_prefix='/export')
+    return doc_app
+
+
+if __name__ == "__main__":
+    application.run()

--- a/lib/rucio/web/rest/flaskapi/v1/importer.py
+++ b/lib/rucio/web/rest/flaskapi/v1/importer.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+#
+# PY3K COMPATIBLE
+
+from flask import Flask, Blueprint, request
+from flask.views import MethodView
+
+from rucio.api.importer import import_data
+from rucio.common.exception import RucioException
+from rucio.common.utils import generate_http_error_flask, parse_response
+from rucio.web.rest.flaskapi.v1.common import before_request, after_request
+
+
+class Import(MethodView):
+    """ Import data. """
+
+    def post(self):
+        """ Import data into Rucio.
+
+        .. :quickref: Import data into Rucio.
+
+        **Example request**:
+
+        .. sourcecode:: http
+
+            POST /import HTTP/1.1
+            Host: rucio.cern.ch
+
+            {
+                "rses": [{"rse": "MOCK", "rse_type": "TAPE"}]
+            }
+
+        **Example response**:
+
+        .. sourcecode:: http
+
+            HTTP/1.1 201 OK
+            Vary: Accept
+            Content-Type: application/x-json-stream
+
+            Created
+        :resheader Content-Type: application/json
+        :status 200: DIDs found
+        :status 401: Invalid Auth Token
+        :returns: dictionary with rucio data
+        """
+        json_data = request.data
+        try:
+            data_to_import = json_data and parse_response(json_data)
+        except ValueError:
+            return generate_http_error_flask(400, 'ValueError', 'Cannot decode json parameter dictionary')
+
+        try:
+            import_data(data=data_to_import, issuer=request.environ.get('issuer'))
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
+
+        return 'Created', 201
+
+
+bp = Blueprint('import', __name__)
+
+import_view = Import.as_view('scope')
+bp.add_url_rule('', view_func=import_view, methods=['post', ])
+
+application = Flask(__name__)
+application.register_blueprint(bp)
+application.before_request(before_request)
+application.after_request(after_request)
+
+
+def make_doc():
+    """ Only used for sphinx documentation to add the prefix """
+    doc_app = Flask(__name__)
+    doc_app.register_blueprint(bp, url_prefix='/import')
+    return doc_app
+
+
+if __name__ == "__main__":
+    application.run()

--- a/lib/rucio/web/rest/importer.py
+++ b/lib/rucio/web/rest/importer.py
@@ -1,0 +1,1 @@
+webpy/v1/importer.py

--- a/lib/rucio/web/rest/webpy/v1/exporter.py
+++ b/lib/rucio/web/rest/webpy/v1/exporter.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+#
+# PY3K COMPATIBLE
+
+from web import (application, header, loadhook, ctx)
+
+from rucio.common.exception import RucioException
+from rucio.common.utils import generate_http_error, render_json
+from rucio.api.exporter import export_data
+from rucio.web.rest.common import rucio_loadhook, RucioController
+
+URLS = (
+    '/', 'Export',
+    '', 'Export'
+)
+
+
+class Export(RucioController):
+    """ Export data from Rucio. """
+
+    def GET(self):
+        """ Export data from Rucio.
+
+        HTTP Success:
+            200 OK
+
+        HTTP Error:
+            400 Bad request
+            401 Unauthorized
+            404 Resource not Found
+            500 InternalError
+        """
+        header('Content-Type', 'application/json')
+        try:
+            return render_json(**export_data(issuer=ctx.env.get('issuer')))
+        except RucioException as error:
+            raise generate_http_error(500, error.__class__.__name__, error.args[0])
+
+
+"""----------------------
+   Web service startup
+----------------------"""
+
+APP = application(URLS, globals())
+APP.add_processor(loadhook(rucio_loadhook))
+application = APP.wsgifunc()

--- a/lib/rucio/web/rest/webpy/v1/importer.py
+++ b/lib/rucio/web/rest/webpy/v1/importer.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+#
+# PY3K COMPATIBLE
+
+from web import (application, data, header, loadhook, ctx, Created)
+
+from rucio.common.exception import RucioException
+from rucio.common.utils import generate_http_error, parse_response
+from rucio.api.importer import import_data
+from rucio.web.rest.common import rucio_loadhook, RucioController
+
+URLS = (
+    '/', 'Import',
+    '', 'Import'
+)
+
+
+class Import(RucioController):
+    """ Import data into Rucio """
+
+    def POST(self):
+        """ Import data into Rucio.
+
+        HTTP Success:
+            200 OK
+
+        HTTP Error:
+            400 Bad request
+            401 Unauthorized
+            404 Resource not Found
+            500 InternalError
+        """
+        header('Content-Type', 'application/x-json-stream')
+        json_data = data()
+        try:
+            data_to_import = json_data and parse_response(json_data)
+        except ValueError:
+            raise generate_http_error(400, 'ValueError', 'Cannot decode json parameter dictionary')
+
+        try:
+            import_data(data=data_to_import, issuer=ctx.env.get('issuer'))
+        except RucioException as error:
+            raise generate_http_error(500, error.__class__.__name__, error.args[0])
+
+        raise Created()
+
+
+"""----------------------
+   Web service startup
+----------------------"""
+
+APP = application(URLS, globals())
+APP.add_processor(loadhook(rucio_loadhook))
+application = APP.wsgifunc()


### PR DESCRIPTION
1. A few words to the workflow:
The import process creates new RSEs, limits, attributes and distances if they are not found, otherwise it overrides them or deletes/creates them new. For example if there is no RSE with the given name, it wil be created, otherwise the properties that can be changed, will be updated.
Same for distances and protocols. Limits and attributes will be deleted if already there and will be new created.

2. For the distances, I created two new functions export_distances and list_distances. list_distances is there because there is also list_rse. The export_distances function is needed because the RSE ids can not be used for importing because if the RSE has to be created, it will get a new id. Therefor the RSE names are needed.

3. I tried to add some schema validation for the json data, for example to check the outer structure and the RSE names but couldn't add validation for the distances matrix as the keys can change.