### PR TITLE
bug: Fix CMS RSE Name pattern for ATTACHMENTS Fix #1901

### DIFF
--- a/lib/rucio/common/schema/cms.py
+++ b/lib/rucio/common/schema/cms.py
@@ -269,7 +269,7 @@ ATTACHMENT = {"description": "Attachement",
                              "name": NAME,
                              "rse": {"description": "RSE name",
                                      "type": ["string", "null"],
-                                     "pattern": "^([A-Z0-9]+([_-][A-Z0-9]+)*)$"},
+                                     "pattern": "^T[0-3]_[A-Z]{2}((_[A-Za-z0-9]+)+)$"},
                              "dids": DIDS},
               "required": ["dids"],
               "additionalProperties": False}


### PR DESCRIPTION
Pull request title
------------------

The format of the Pull request title must be:

    <component>: <short_change_message> #<issue number>

If you add a [github-recognised keyword](https://help.github.com/articles/closing-issues-using-keywords/) then
the associated issue can be closed automatically once the pull request is merged, e.g.::

    <component>: <short_change_message> Fix #<issue number>

Valid component names are listed in the `label list <https://github.com/rucio/rucio/labels>`_.
