### PR TITLE
Core: Definition of Replicas Table PK (in models.py) is wrong; Fix #1749

### DIFF
--- a/lib/rucio/db/sqla/migrate_repo/versions/3345511706b8_replicas_table_pk_definition_is_in_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3345511706b8_replicas_table_pk_definition_is_in_.py
@@ -27,7 +27,7 @@ from alembic import context
 
 # revision identifiers used by alembic
 revision = '3345511706b8'       # pylint: disable=invalid-name
-down_revision = '9eb936a81eb1'  # pylint: disable=invalid-name
+down_revision = 'bf3baa1c1474'  # pylint: disable=invalid-name
 
 
 def upgrade():

--- a/lib/rucio/db/sqla/migrate_repo/versions/3345511706b8_replicas_table_pk_definition_is_in_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3345511706b8_replicas_table_pk_definition_is_in_.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2019 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Martin Barisits <martin.barisits@cern.ch>, 2019
+#
+# Topic: Replicas table PK definition is in wrong order
+# Revision ID: 3345511706b8
+# Revises: 9eb936a81eb1
+# Creation Date: 2019-01-30 14:20:35.058889
+
+from alembic.op import (create_primary_key, drop_constraint)
+
+from alembic import context
+
+
+# revision identifiers used by alembic
+revision = '3345511706b8'       # pylint: disable=invalid-name
+down_revision = '9eb936a81eb1'  # pylint: disable=invalid-name
+
+
+def upgrade():
+    '''
+    Upgrade the database to this revision
+    '''
+    if context.get_context().dialect.name != 'sqlite':
+        drop_constraint('REPLICAS_PK', 'replicas')
+        create_primary_key('REPLICAS_PK', 'replicas', ['scope', 'name', 'rse_id'])
+
+
+def downgrade():
+    '''
+    Downgrade the database to the previous revision
+    '''
+    if context.get_context().dialect.name != 'sqlite':
+        drop_constraint('REPLICAS_PK', 'replicas')
+        create_primary_key('REPLICAS_PK', 'replicas', ['rse_id', 'scope', 'name'])

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -751,7 +751,7 @@ class RSEFileAssociation(BASE, ModelBase):
     accessed_at = Column(DateTime)
     tombstone = Column(DateTime)
     rse = relationship("RSE", backref=backref('replicas', order_by="RSE.id"))
-    _table_args = (PrimaryKeyConstraint('rse_id', 'scope', 'name', name='REPLICAS_PK'),
+    _table_args = (PrimaryKeyConstraint('scope', 'name', 'rse_id', name='REPLICAS_PK'),
                    ForeignKeyConstraint(['scope', 'name'], ['dids.scope', 'dids.name'], name='REPLICAS_LFN_FK'),
                    ForeignKeyConstraint(['rse_id'], ['rses.id'], name='REPLICAS_RSE_ID_FK'),
                    CheckConstraint('STATE IS NOT NULL', name='REPLICAS_STATE_NN'),


### PR DESCRIPTION
Core: Definition of Replicas Table PK (in models.py) is wrong; Fix #1749