### PR TITLE
Documentation: Fix grammatical errors and typos in documentation Fix #2194

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -4,7 +4,7 @@ The Client API Reference
 Rucio includes a client class to remove some of the complexities of dealing with raw
 HTTP requests against the RESTful API.
 
-All client methods are accesible through the high level class Client. Below is one
+All client methods are accessible through the high-level class Client. Below is one
 example of using Rucio Client class::
 
    >>> from rucio.client import Client

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -50,7 +50,7 @@ You can also list all the accounts matching a certain attribute using the filter
 Creating scope
 ==============
 
-One needs then to create some scopes associated to the accounts::
+One needs then to create some scopes associated with the accounts::
 
   $ rucio-admin scope add --account jdoe --scope user.jdoe
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -25,7 +25,7 @@ General Information
 
 This section contains the general information related to Rucio which is common to
 all developers, users and operators.
-For documentation specific to the any of these three, please see the subsequent sections.
+For documentation specific to any of these three, please see the subsequent sections.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
Documentation: Fix grammatical errors and typos in documentation Fix #2194

