### PR TITLE
Core & Internals: Implement URL signing for Swift object stores #1787

### DIFF
--- a/lib/rucio/client/credentialclient.py
+++ b/lib/rucio/client/credentialclient.py
@@ -38,7 +38,7 @@ class CredentialClient(BaseClient):
         """
         Return a signed version of the given URL for the given operation.
 
-        :param service: The service the URL points to (gcs, s3)
+        :param service: The service the URL points to (gcs, s3, swift)
         :param operation: The desired operation (read, write, delete)
         :param url: The URL to sign
         :param lifetime: The desired lifetime of the URL in seconds

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -367,7 +367,7 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None, force_scheme=Non
         :param force_pfn: use the given PFN -- can lead to dark data, use sparingly
         :param force_scheme: use the given protocol scheme, overriding the protocol priority in the RSE description
         :param transfer_timeout: set this timeout (in seconds) for the transfers, for protocols that support it
-        :param sign_service: use the given service (e.g. gcs, s3) to sign the URL
+        :param sign_service: use the given service (e.g. gcs, s3, swift) to sign the URL
 
         :returns: True/False for a single file or a dict object with 'scope:name' as keys and True or the exception as value for each file in bulk mode
 

--- a/lib/rucio/web/rest/flaskapi/v1/credential.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credential.py
@@ -120,8 +120,8 @@ class SignURL(MethodView):
         except ValueError:
             return generate_http_error_flask(400, 'ValueError', 'Cannot decode json parameter list')
 
-        if service not in ['gcs', 's3']:
-            return generate_http_error_flask(400, 'ValueError', 'Parameter "svc" must be either empty(=gcs), gcs or s3')
+        if service not in ['gcs', 's3', 'swift']:
+            return generate_http_error_flask(400, 'ValueError', 'Parameter "svc" must be either empty(=gcs), gcs, s3 or swift')
 
         if url is None:
             return generate_http_error_flask(400, 'ValueError', 'Parameter "url" not found')

--- a/lib/rucio/web/rest/webpy/v1/credential.py
+++ b/lib/rucio/web/rest/webpy/v1/credential.py
@@ -102,8 +102,8 @@ class SignURL(RucioController):
         except ValueError:
             raise generate_http_error(400, 'ValueError', 'Cannot decode json parameter list')
 
-        if service not in ['gcs', 's3']:
-            raise generate_http_error(400, 'ValueError', 'Parameter "svc" must be either empty(=gcs), gcs or s3')
+        if service not in ['gcs', 's3', 'swift']:
+            raise generate_http_error(400, 'ValueError', 'Parameter "svc" must be either empty(=gcs), gcs, s3 or swift')
 
         if url is None:
             raise generate_http_error(400, 'ValueError', 'Parameter "url" not found')


### PR DESCRIPTION
This adds support for Swift tempurls to the core Rucio code. I have tested this against our OpenStack object store at Edinburgh. It works very similarly to the S3 support in my previous pull request.
