### PR TITLE
Clients: fix config_get to not raise if default is given; Fix #1485

### DIFF
--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -55,7 +55,7 @@ def config_get(section, option, raise_exception=True, default=None):
     try:
         return __CONFIG.get(section, option)
     except (ConfigParser.NoOptionError, ConfigParser.NoSectionError) as err:
-        if raise_exception:
+        if raise_exception and default is None:
             raise err
         return default
 


### PR DESCRIPTION
Clients: fix config_get to not raise if default is given; Fix #1485