### PR TITLE
Clients: Fix installation issues with Py2->Py3 and hash sum #2480

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/../admix/admix/config/host_config_osg_restapi.config" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding">
-    <file url="file://$PROJECT_DIR$/../admix/admix/config/host_config_osg_restapi.config" charset="UTF-8" />
-  </component>
-</project>

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -36,6 +36,7 @@ Individual contributors to the source code
 - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 - Vivek Nigam <viveknigam.nigam3@gmail.com>, 2019
 - Kaustubh Hiware <hiwarekaustubh@gmail.com>, 2019
+- Boris Bauermeister <Boris.Bauermeister@gmail.com> 2019
 
 Organisations employing contributors
 ------------------------------------
@@ -54,3 +55,4 @@ Organisations employing contributors
 - Academia Sinica (Taiwan)
 - Birla Institute of Technology, Mesra (India)
 - Indian Institute of Technology, Kharagpur (India)
+- Stockholm University, Stockholm (Sweden)

--- a/bin/rucio
+++ b/bin/rucio
@@ -875,10 +875,8 @@ def upload(args):
 
     client = get_client(args)
     upload_client = UploadClient(client, logger)
-
     summary_file_path = 'rucio_upload.json' if args.summary else None
     upload_client.upload(items, summary_file_path)
-
     return SUCCESS
 
 

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -68,10 +68,8 @@ class UploadClient:
         self.trace['eventType'] = 'upload'
         self.trace['eventVersion'] = version.RUCIO_VERSION[0]
 
-
     def upload(self, items, summary_file_path=None):
         """
-
         :param items: List of dictionaries. Each dictionary describing a file to upload. Keys:
             path                  - path of the file that will be uploaded
             rse                   - rse name (e.g. 'CERN-PROD_DATADISK') where to upload the file

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -43,7 +43,7 @@ from rucio import version
 
 class UploadClient:
 
-    def __init__(self, _client: object = None, logger: object = None, tracing: object = True) -> object:
+    def __init__(self, _client=None, logger=None, tracing=True):
         """
         Initialises the basic settings for an UploadClient object
 
@@ -317,7 +317,6 @@ class UploadClient:
             logger.debug('local checksum: %s, remote checksum: %s' % (file['adler32'], meta['adler32']))
 
             if meta['adler32'] != file['adler32']:
-                logger.info("Here")
                 logger.error('Local checksum %s does not match remote checksum %s' % (file['adler32'], meta['adler32']))
 
                 raise DataIdentifierAlreadyExists

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -43,7 +43,7 @@ from rucio import version
 
 class UploadClient:
 
-    def __init__(self, _client=None, logger=None, tracing=True):
+    def __init__(self, _client: object = None, logger: object = None, tracing: object = True) -> object:
         """
         Initialises the basic settings for an UploadClient object
 
@@ -67,6 +67,7 @@ class UploadClient:
         self.trace['account'] = self.client.account
         self.trace['eventType'] = 'upload'
         self.trace['eventVersion'] = version.RUCIO_VERSION[0]
+
 
     def upload(self, items, summary_file_path=None):
         """
@@ -105,6 +106,7 @@ class UploadClient:
         # and cache rse settings
         registered_dataset_dids = set()
         registered_file_dids = set()
+
         for file in files:
             rse = file['rse']
             if not self.rses.get(rse):
@@ -129,6 +131,7 @@ class UploadClient:
         registered_dataset_dids = set()
         num_succeeded = 0
         summary = []
+
         for file in files:
             basename = file['basename']
             logger.info('Preparing upload for file %s' % basename)
@@ -312,8 +315,11 @@ class UploadClient:
             meta = self.client.get_metadata(file_scope, file_name)
             logger.info('File DID already exists')
             logger.debug('local checksum: %s, remote checksum: %s' % (file['adler32'], meta['adler32']))
+
             if meta['adler32'] != file['adler32']:
+                logger.info("Here")
                 logger.error('Local checksum %s does not match remote checksum %s' % (file['adler32'], meta['adler32']))
+
                 raise DataIdentifierAlreadyExists
 
             # add file to rse if it is not registered yet

--- a/lib/rucio/common/pcache.py
+++ b/lib/rucio/common/pcache.py
@@ -874,19 +874,12 @@ class Pcache:
             except:
                 maxfd = MAXFD  # use default value
 
-        #try to be backwards compatible with Python2 (?)
-        try:
-            for fd in xrange(0, maxfd + 1):
-                try:
-                    os.close(fd)
-                except:
-                    pass
-        except NameError:
-            for fd in range(0, maxfd + 1):
-                try:
-                    os.close(fd)
-                except:
-                    pass
+        for fd in range(0, maxfd + 1):
+            try:
+                os.close(fd)
+            except:
+                pass
+
 
     # Panda server callback functions
     def do_http_post(self, url, data):

--- a/lib/rucio/common/pcache.py
+++ b/lib/rucio/common/pcache.py
@@ -880,7 +880,6 @@ class Pcache:
             except:
                 pass
 
-
     # Panda server callback functions
     def do_http_post(self, url, data):
         # see http://www.faqs.org/faqs/unix-faq/faq/part3/section-13.html
@@ -1138,7 +1137,6 @@ class Pcache:
                 pass
             else:
                 # Don't use log here, log dir may not exist
-                #print >> sys.stderr, e
                 print(sys.stderr.write(), e)
                 return e.errno
 

--- a/lib/rucio/common/pcache.py
+++ b/lib/rucio/common/pcache.py
@@ -197,7 +197,7 @@ class Pcache:
 
             # XXXX cache, stats, reset, clean, delete, inventory
             # TODO: move checksum/size validation from lsm to pcache
-        except getopt.GetoptError, err:
+        except getopt.GetoptError as err:
             sys.stderr.write("%s\n" % err)
             self.Usage()
             self.fail(100)
@@ -239,7 +239,7 @@ class Pcache:
             elif opt in ("-r", "--retry"):
                 self.max_retries = int(arg)
             elif opt in ("-V", "--version"):
-                print self.version
+                print(self.version)
                 sys.exit(0)
             elif opt in ("-l", "--log"):
                 self.log_file = arg
@@ -428,7 +428,7 @@ class Pcache:
             f = open(fname, 'w')
             f.write(self.src + '\n')
             f.close()
-            self.chmod(fname, 0666)
+            self.chmod(fname, 0o666)
         except:
             pass
 
@@ -439,7 +439,7 @@ class Pcache:
                 f = open(fname, 'w')
                 f.write(self.guid + '\n')
                 f.close()
-                self.chmod(fname, 0666)
+                self.chmod(fname, 0o666)
             except:
                 pass
 
@@ -543,7 +543,7 @@ class Pcache:
             try:
                 d = os.readlink(l)
 
-            except OSError, e:
+            except OSError as e:
                 self.log(ERROR, "readlink: %s", e)
                 continue
 
@@ -563,7 +563,7 @@ class Pcache:
             try:
                 os.unlink(l)
 
-            except OSError, e:
+            except OSError as e:
                 if e.errno != errno.ENOENT:
                     self.log(ERROR, "unlink: %s", e)
 
@@ -602,7 +602,7 @@ class Pcache:
             try:
                 os.rename(d, d + ts)
                 os.system("rm -rf %s &" % (d + ts))
-            except OSError, e:
+            except OSError as e:
                 if e.errno != errno.ENOENT:
                     self.log(ERROR, "%s: %s", d, e)
 
@@ -615,7 +615,7 @@ class Pcache:
         # Remove any transfer file with the same name
         try:
             os.unlink(xfer_file)
-        except OSError, e:
+        except OSError as e:
             if e.errno != errno.ENOENT:
                 self.log(ERROR, "unlink: %s", e)
 
@@ -641,7 +641,7 @@ class Pcache:
 
         # Display any output from the copy
         if (copy_output):
-            print '%s' % copy_output
+            print('%s' % copy_output)
 
         # Did the copy succeed (good status and an existing file)
         if ((copy_status > 0) or (not os.path.exists(xfer_file))):
@@ -654,7 +654,7 @@ class Pcache:
         try:
             os.rename(xfer_file, cache_file)
             # self.log(INFO, "rename %s %s", xfer_file, cache_file)
-        except OSError, e:  # Fatal error if we can't do this
+        except OSError as e:  # Fatal error if we can't do this
             self.log(ERROR, "rename %s %s", xfer_file, cache_file)
             try:
                 os.unlink(xfer_file)
@@ -663,7 +663,7 @@ class Pcache:
             self.fail(104)
 
         # Make the file readable to all
-        self.chmod(cache_file, 0666)
+        self.chmod(cache_file, 0o666)
 
         # Transfer completed, return the transfer command status
         return (0, None)
@@ -698,7 +698,7 @@ class Pcache:
             if os.path.exists(dst):
                 os.unlink(dst)
             os.link(src, dst)
-        except OSError, e:
+        except OSError as e:
             self.log(ERROR, "make_hard_link: %s", e)
             ret = e.errno
             if ret == errno.ENOENT:
@@ -739,9 +739,9 @@ class Pcache:
         return data
 
     def print_stats(self):
-        print "Cache size:", unitize(self.get_stat("CACHE", "size"))
-        print "Cache hits:", self.get_stat("stats", "cache_hits")
-        print "Cache misses:", self.get_stat("stats", "cache_misses")
+        print("Cache size:", unitize(self.get_stat("CACHE", "size")))
+        print("Cache hits:", self.get_stat("stats", "cache_hits"))
+        print("Cache misses:", self.get_stat("stats", "cache_misses"))
 
     def reset_stats(self):
         stats_dir = os.path.join(self.pcache_dir, "stats")
@@ -774,7 +774,7 @@ class Pcache:
             f = open(stats_file, 'w')
             f.write("%s\n" % value)
             f.close()
-            self.chmod(stats_file, 0666)
+            self.chmod(stats_file, 0o666)
         except:
             pass
             # XXX
@@ -825,7 +825,7 @@ class Pcache:
                     fullname = os.path.join(root, f)
                     try:
                         size += os.stat(fullname).st_size
-                    except OSError, e:
+                    except OSError as e:
                         self.log(ERROR, "stat(%s): %s", fullname, e)
 
         filename = os.path.join(self.pcache_dir, "CACHE", "size")
@@ -834,7 +834,7 @@ class Pcache:
             f = open(filename, 'w')
             f.write("%s\n" % size)
             f.close()
-            self.chmod(filename, 0666)
+            self.chmod(filename, 0o666)
         except:
             pass  # XXXX
 
@@ -873,11 +873,20 @@ class Pcache:
                 maxfd = os.sysconf("SC_OPEN_MAX")
             except:
                 maxfd = MAXFD  # use default value
-        for fd in xrange(0, maxfd + 1):
-            try:
-                os.close(fd)
-            except:
-                pass
+
+        #try to be backwards compatible with Python2 (?)
+        try:
+            for fd in xrange(0, maxfd + 1):
+                try:
+                    os.close(fd)
+                except:
+                    pass
+        except NameError:
+            for fd in range(0, maxfd + 1):
+                try:
+                    os.close(fd)
+                except:
+                    pass
 
     # Panda server callback functions
     def do_http_post(self, url, data):
@@ -952,7 +961,7 @@ class Pcache:
             return
         try:
             f = open(name, 'w')
-        except IOError, e:
+        except IOError as e:
             self.log(ERROR, "open: %s", e)
             return e.errno
 
@@ -964,7 +973,7 @@ class Pcache:
             try:
                 status = fcntl.lockf(f, flag)
                 break
-            except IOError, e:
+            except IOError as e:
                 if e.errno in (errno.EAGAIN, errno.EACCES) and not blocking:
                     f.close()
                     del self.locks[name]
@@ -1004,7 +1013,7 @@ class Pcache:
     def delete_file_and_parents(self, name):
         try:
             os.unlink(name)
-        except OSError, e:
+        except OSError as e:
             if e.errno != errno.ENOENT:
                 self.log(ERROR, "unlink: %s", e)
                 self.fail(107)
@@ -1016,7 +1025,7 @@ class Pcache:
             if not os.listdir(dirname):
                 os.rmdir(dirname)
                 self.delete_parents_recursive(dirname)
-        except OSError, e:
+        except OSError as e:
             self.log(DEBUG, "delete_parents_recursive: %s", e)
 
     def update_mru(self):
@@ -1028,7 +1037,7 @@ class Pcache:
 
         try:
             os.unlink(link_to_mru)
-        except OSError, e:
+        except OSError as e:
             if e.errno != errno.ENOENT:
                 self.log(ERROR, "unlink: %s", e)
                 self.fail(108)
@@ -1050,7 +1059,7 @@ class Pcache:
             try:
                 os.symlink(self.pcache_dst_dir, link_from_mru)
                 break
-            except OSError, e:
+            except OSError as e:
                 if e.errno == errno.EEXIST:
                     ext += 1  # add an extension & retry if file exists
                     continue
@@ -1062,11 +1071,11 @@ class Pcache:
             try:
                 os.symlink(link_from_mru, link_to_mru)
                 break
-            except OSError, e:
+            except OSError as e:
                 if e.errno == errno.EEXIST:
                     try:
                         os.unlink(link_to_mru)
-                    except OSError, e:
+                    except OSError as e:
                         if e.errno != errno.ENOENT:
                             self.log(ERROR, "unlink: %s %s", e, link_to_mru)
                             self.fail(109)
@@ -1089,7 +1098,7 @@ class Pcache:
             if name == "data":
                 try:
                     size = os.stat(fullname).st_size
-                except OSError, e:
+                except OSError as e:
                     if e.errno != errno.ENOENT:
                         self.log(WARN, "stat: %s", e)
             elif name == "guid":
@@ -1103,15 +1112,15 @@ class Pcache:
                     mru_file = os.readlink(fullname)
                     os.unlink(fullname)
                     self.delete_file_and_parents(mru_file)
-                except OSError, e:
+                except OSError as e:
                     if e.errno != errno.ENOENT:
                         self.log(WARN, "empty_dir: %s", e)
             try:
                 if self.debug:
-                    print "UNLINK", fullname
+                    print("UNLINK", fullname)
                 os.unlink(fullname)
                 bytes_deleted += size
-            except OSError, e:
+            except OSError as e:
                 if e.errno != errno.ENOENT:
                     self.log(WARN, "empty_dir2: %s", e)
                 # self.fail()
@@ -1122,21 +1131,22 @@ class Pcache:
     def chmod(self, path, mode):
         try:
             os.chmod(path, mode)
-        except OSError, e:
+        except OSError as e:
             if e.errno != errno.EPERM:  # Cannot chmod files we don't own!
                 self.log(ERROR, "chmod %s %s", path, e)
 
-    def mkdir_p(self, d, mode=0777):
+    def mkdir_p(self, d, mode=0o777):
         # Thread-safe
         try:
             os.makedirs(d, mode)
             return 0
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.EEXIST:
                 pass
             else:
                 # Don't use log here, log dir may not exist
-                print >> sys.stderr, e
+                #print >> sys.stderr, e
+                print(sys.stderr.write(), e)
                 return e.errno
 
     def log(self, level, msg, *args):
@@ -1155,11 +1165,11 @@ class Pcache:
                                     str(msg) % args)
 
         try:
-            f = open(self.log_file, "a+", 0666)
+            f = open(self.log_file, "a+", 0o666)
             f.write(msg)
             f.close()
 
-        except Exception, e:
+        except Exception as e:
             sys.stderr.write("%s\n" % e)
             sys.stderr.write(msg)
             sys.stderr.flush()

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -115,7 +115,7 @@ class RSEDeterministicTranslation(object):
         del rse
         del rse_attrs
         del protocol_attrs
-        hstr = hashlib.md5('%s:%s' % (scope, name)).hexdigest()
+        hstr = hashlib.md5(('%s:%s' % (scope, name)).encode('utf-8')).hexdigest()
         if scope.startswith('user') or scope.startswith('group'):
             scope = scope.replace('.', '/')
         return '%s/%s/%s/%s' % (scope, hstr[0:2], hstr[2:4], name)

--- a/lib/rucio/rse/protocols/storm.py
+++ b/lib/rucio/rse/protocols/storm.py
@@ -104,7 +104,7 @@ class Default(protocol.RSEProtocol):
         cmd = 'davix-http --capath /cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/etc/grid-security-emi/certificates --cert $X509_USER_PROXY -X PROPFIND %s' % pfn
         try:
             rcode, output = run_cmd_process(cmd, timeout=10)
-        except Exception, e:
+        except Exception as e:
             raise exception.ServiceUnavailable('Could not retrieve STORM WebDAV ETag: %s' % str(e))
         p_output = minidom.parseString(output)
 
@@ -118,7 +118,7 @@ class Default(protocol.RSEProtocol):
         # make the symlink
         try:
             os.symlink(target, dest)
-        except Exception, e:
+        except Exception as e:
             exception.ServiceUnavailable('Could not create symlink: %s for target %s' % (str(e), str(target)))
 
     def put(self, source, target, source_dir=None, transfer_timeout=None):


### PR DESCRIPTION
There are two issues observed in: 
  - Installation in Python 3.6.8 failed because of bad translated Py2->Py3 code in rucio/lib/rucio/rse/protocols/storm.py when it comes to evaluate the exceptions.
  - The hash sum calculation failed due to an encoding error when the hash sum is calculated for the final path definition. (protocols.py)

Both are addressed in this pull request.