### PR TITLE
Deletion: Sign URL for deletion in reaper when required #2411

### DIFF
--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -49,6 +49,7 @@ from rucio.common.exception import (SourceNotFound, ServiceUnavailable, RSEAcces
 from rucio.common.utils import chunks
 from rucio.core import monitor
 from rucio.core import rse as rse_core
+from rucio.core.credential import get_signed_url
 from rucio.core.heartbeat import live, die, sanity_check
 from rucio.core.message import add_message
 from rucio.core.replica import (list_unlocked_replicas, update_replicas_states,
@@ -247,7 +248,11 @@ def reaper(rses, worker_number=1, child_number=1, total_children=1, chunk_size=1
                                                             worker_number, child_number, replica['scope'], replica['name'], replica['pfn'], rse['rse'])
                                         else:
                                             if replica['pfn']:
-                                                prot.delete(replica['pfn'])
+                                                pfn = replica['pfn']
+                                                # sign the URL if necessary
+                                                if prot.attributes['scheme'] == 'https' and rse_info['sign_url'] is not None:
+                                                    pfn = get_signed_url(rse_info['sign_url'], 'delete', pfn)
+                                                prot.delete(pfn)
                                             else:
                                                 logging.warning('Reaper %s-%s: Deletion UNAVAILABLE of %s:%s as %s on %s', worker_number, child_number, replica['scope'], replica['name'], replica['pfn'], rse['rse'])
                                         monitor.record_timer('daemons.reaper.delete.%s.%s' % (prot.attributes['scheme'], rse['rse']), (time.time() - start) * 1000)


### PR DESCRIPTION
This only works correctly with GFAL2 2.16.2 or later (earlier versions caused Davix to perform a stat operation before the actual delete, which fails for signed URLs). See https://its.cern.ch/jira/browse/DMC-1155 for details.
