### PR TITLE
Core & Internals: Add support for per RSE checksum support setting; Fix #2498

### DIFF
--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -22,7 +22,6 @@
 from rucio.api import permission
 from rucio.common import exception
 from rucio.common.schema import validate_schema
-from rucio.common.utils import api_update_return_dict, CHECKSUM_KEY
 from rucio.core import distance as distance_module
 from rucio.core import rse as rse_module
 from rucio.core.rse_expression_parser import parse_expression
@@ -125,17 +124,6 @@ def del_rse_attribute(rse, key, issuer):
 
     return rse_module.del_rse_attribute(rse_id=rse_id, key=key)
 
-def reset_rse_checksum_support(rse, issuer):
-    """
-    Delete a RSE attribute.
-
-    :param rse: the name of the rse_module.
-
-    :return: True if RSE attribute was deleted successfully, False otherwise.
-    """
-
-    return del_rse_attribute(rse=rse, key=CHECKSUM_KEY, issuer=issuer)
-
 
 def add_rse_attribute(rse, key, value, issuer):
     """ Adds a RSE attribute.
@@ -154,27 +142,6 @@ def add_rse_attribute(rse, key, value, issuer):
         raise exception.AccessDenied('Account %s can not add RSE attributes' % (issuer))
 
     return rse_module.add_rse_attribute(rse_id=rse_id, key=key, value=value)
-
-
-def set_rse_checksum_support(rse, checksum_names, issuer):
-    """ Adds a RSE attribute.
-
-    :param rse: the rse name.
-    :param checksum_names: the checksum name[s] as a single item or a list.
-    :param issuer: The issuer account.
-
-    returns: True if successful, False otherwise.
-    """
-
-    if type(checksum_names) is not list:
-        checksum_names = [checksum_names]
-    supported_checksums = filter(lambda x: is_checksum_valid(x), checksum_names)
-    supported_checksums = map(lambda x: ''.join(x.split()), supported_checksums)
-    if any(supported_checksums):
-        supported_checksums_csv = ','.join(map(str, supported_checksums))
-        return add_rse_attribute(rse=rse, key=CHECKSUM_KEY, value=supported_checksums_csv, issuer=issuer)
-    else:
-        return False
 
 
 def list_rse_attributes(rse):

--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -125,6 +125,7 @@ def del_rse_attribute(rse, key, issuer):
 
     return rse_module.del_rse_attribute(rse_id=rse_id, key=key)
 
+
 def del_rse_checksum(rse, checksum_name, issuer):
     """
     Delete a RSE attribute.
@@ -155,6 +156,7 @@ def add_rse_attribute(rse, key, value, issuer):
         raise exception.AccessDenied('Account %s can not add RSE attributes' % (issuer))
 
     return rse_module.add_rse_attribute(rse_id=rse_id, key=key, value=value)
+
 
 def add_rse_checksum(rse, checksum_name, issuer):
     """ Adds a RSE attribute.

--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -166,7 +166,8 @@ def set_rse_checksum_support(rse, checksum_names, issuer):
     returns: True if successful, False otherwise.
     """
 
-    if type(checksum_names) is not list: checksum_names = [checksum_names]
+    if type(checksum_names) is not list:
+        checksum_names = [checksum_names]
     supported_checksums = filter(lambda x: is_checksum_valid(x), checksum_names)
     supported_checksums = map(lambda x: ''.join(x.split()), supported_checksums)
     if any(supported_checksums):

--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -31,7 +31,7 @@ from rucio.core.rse_expression_parser import parse_expression
 def add_rse(rse, issuer, deterministic=True, volatile=False, city=None, region_code=None,
             country_name=None, continent=None, time_zone=None, ISP=None,
             staging_area=False, rse_type=None, latitude=None, longitude=None, ASN=None,
-            availability=None, supported_checksums=None):
+            availability=None):
     """
     Creates a new Rucio Storage Element(RSE).
 
@@ -51,7 +51,6 @@ def add_rse(rse, issuer, deterministic=True, volatile=False, city=None, region_c
     :param longitude: Longitude coordinate of RSE.
     :param ASN: Access service network.
     :param availability: Availability.
-    :param supported_checksums: The checksums supported by the RSE.
     """
     validate_schema(name='rse', obj=rse)
     kwargs = {'rse': rse}
@@ -61,7 +60,7 @@ def add_rse(rse, issuer, deterministic=True, volatile=False, city=None, region_c
     return rse_module.add_rse(rse, deterministic=deterministic, volatile=volatile, city=city,
                               region_code=region_code, country_name=country_name, staging_area=staging_area,
                               continent=continent, time_zone=time_zone, ISP=ISP, rse_type=rse_type, latitude=latitude,
-                              longitude=longitude, ASN=ASN, availability=availability, supported_checksums=supported_checksums)
+                              longitude=longitude, ASN=ASN, availability=availability)
 
 
 def get_rse(rse):

--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -22,6 +22,7 @@
 from rucio.api import permission
 from rucio.common import exception
 from rucio.common.schema import validate_schema
+from rucio.common.utils import api_update_return_dict
 from rucio.core import distance as distance_module
 from rucio.core import rse as rse_module
 from rucio.core.rse_expression_parser import parse_expression

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -42,7 +42,7 @@ from threading import Thread
 from rucio.client.client import Client
 from rucio.common.exception import (InputValidationError, NoFilesDownloaded, NotAllFilesDownloaded, RucioException)
 from rucio.common.pcache import Pcache
-from rucio.common.utils import adler32, md5, detect_client_location, generate_uuid, parse_replicas_from_string, \
+from rucio.common.utils import adler32, detect_client_location, generate_uuid, parse_replicas_from_string, \
     send_trace, sizefmt, execute, parse_replicas_from_file
 from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS, CHECKSUM_ALGO_DICT, PREFERRED_CHECKSUM
 from rucio.rse import rsemanager as rsemgr

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -42,7 +42,9 @@ from threading import Thread
 from rucio.client.client import Client
 from rucio.common.exception import (InputValidationError, NoFilesDownloaded, NotAllFilesDownloaded, RucioException)
 from rucio.common.pcache import Pcache
-from rucio.common.utils import adler32, md5, detect_client_location, generate_uuid, parse_replicas_from_string, send_trace, sizefmt, execute, parse_replicas_from_file
+from rucio.common.utils import adler32, md5, detect_client_location, generate_uuid, parse_replicas_from_string, \
+    send_trace, sizefmt, execute, parse_replicas_from_file
+from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS, CHECKSUM_ALGO_DICT, PREFERRED_CHECKSUM
 from rucio.rse import rsemanager as rsemgr
 from rucio import version
 
@@ -571,16 +573,16 @@ class DownloadClient:
                 end_time = time.time()
 
                 if success and not item.get('merged_options', {}).get('ignore_checksum', False):
-                    rucio_checksum = item.get('adler32')
-                    local_checksum = None
-                    if rucio_checksum is None:
-                        rucio_checksum = item.get('md5')
-                        if rucio_checksum is None:
-                            logger.warning('%sNo remote checksum available. Skipping validation.' % log_prefix)
-                        else:
-                            local_checksum = md5(temp_file_path)
-                    else:
-                        local_checksum = adler32(temp_file_path)
+                    rucio_checksum = 'rucio_checksum'
+                    local_checksum = 'local_checksum'
+
+                    for checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS:
+                        rucio_checksum = item.get(checksum_name)
+                        if checksum_name is not None:
+                            if checksum_name in CHECKSUM_ALGO_DICT:
+                                local_checksum = CHECKSUM_ALGO_DICT[checksum_name](temp_file_path)
+                                if checksum_name == PREFERRED_CHECKSUM:
+                                    break
 
                     if rucio_checksum != local_checksum:
                         success = False

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1462,4 +1462,4 @@ def _verify_checksum(item, path):
             local_checksum = checksum_algo(path)
             return rucio_checksum == local_checksum, rucio_checksum, local_checksum
 
-    return False
+    return False, None, None

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -577,8 +577,9 @@ class DownloadClient:
                     local_checksum = 'local_checksum'
 
                     for checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS:
-                        rucio_checksum = item.get(checksum_name)
-                        if rucio_checksum is not None:
+                        rucio_checksum_temp = item.get(checksum_name)
+                        if rucio_checksum_temp is not None:
+                            rucio_checksum = rucio_checksum_temp
                             if checksum_name in CHECKSUM_ALGO_DICT:
                                 local_checksum = CHECKSUM_ALGO_DICT[checksum_name](temp_file_path)
                                 if checksum_name == PREFERRED_CHECKSUM:

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1463,4 +1463,3 @@ def _verify_checksum(item, path):
                 break
 
     return rucio_checksum == local_checksum, rucio_checksum, local_checksum
-

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -578,7 +578,7 @@ class DownloadClient:
 
                     for checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS:
                         rucio_checksum = item.get(checksum_name)
-                        if checksum_name is not None:
+                        if rucio_checksum is not None:
                             if checksum_name in CHECKSUM_ALGO_DICT:
                                 local_checksum = CHECKSUM_ALGO_DICT[checksum_name](temp_file_path)
                                 if checksum_name == PREFERRED_CHECKSUM:

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1454,12 +1454,12 @@ def _verify_checksum(item, path):
     if rucio_checksum and checksum_algo:
         local_checksum = checksum_algo(path)
         return rucio_checksum == local_checksum, rucio_checksum, local_checksum
-    else:
-        for checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS:
-            rucio_checksum = item.get(checksum_name)
-            checksum_algo = CHECKSUM_ALGO_DICT.get(checksum_name)
-            if rucio_checksum and checksum_algo:
-                local_checksum = checksum_algo(path)
-                break
 
-    return rucio_checksum == local_checksum, rucio_checksum, local_checksum
+    for checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS:
+        rucio_checksum = item.get(checksum_name)
+        checksum_algo = CHECKSUM_ALGO_DICT.get(checksum_name)
+        if rucio_checksum and checksum_algo:
+            local_checksum = checksum_algo(path)
+            return rucio_checksum == local_checksum, rucio_checksum, local_checksum
+
+    return False

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -21,7 +21,6 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014
 # - Wen Guan <wguan.icedew@gmail.com>, 2014
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
-# - Gabriele Fronze' <gfronze@cern.ch>, 2019
 #
 # PY3K COMPATIBLE
 

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -33,7 +33,7 @@ except ImportError:
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice
-from rucio.common.utils import build_url, is_checksum_valid, CHECKSUM_KEY
+from rucio.common.utils import build_url
 
 
 class RSEClient(BaseClient):
@@ -171,7 +171,6 @@ class RSEClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-
     def delete_rse_attribute(self, rse, key):
         """
         Sends the request to delete a RSE attribute.
@@ -190,7 +189,6 @@ class RSEClient(BaseClient):
         else:
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
-
 
     def list_rse_attributes(self, rse):
         """

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -33,7 +33,7 @@ except ImportError:
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice
-from rucio.common.utils import build_url, is_checksum_valid, get_checksum_attr_key
+from rucio.common.utils import build_url, is_checksum_valid, CHECKSUM_KEY
 
 
 class RSEClient(BaseClient):
@@ -183,7 +183,7 @@ class RSEClient(BaseClient):
         """
 
         if is_checksum_valid(checksum_name):
-            return self.add_rse_attribute(rse=rse, key=get_checksum_attr_key(checksum_name), value=True)
+            return self.add_rse_attribute(rse=rse, key=CHECKSUM_KEY, value=True)
         else:
             return False
 
@@ -215,7 +215,7 @@ class RSEClient(BaseClient):
 
         :return: True if RSE attribute was deleted successfully else False.
         """
-        return self.delete_rse_attribute(rse=rse, key=get_checksum_attr_key(checksum_name))
+        return self.delete_rse_attribute(rse=rse, key=CHECKSUM_KEY)
 
     def list_rse_attributes(self, rse):
         """

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -171,21 +171,6 @@ class RSEClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def add_rse_checksum(self, rse, checksum_name):
-        """
-        Sends the request to add a RSE checksum.
-
-        :param rse: the name of the rse.
-        :param checksum_name: the checksum name.
-
-        :return: True if RSE attribute was created successfully else False.
-        :raises Duplicate: if RSE attribute already exists.
-        """
-
-        if is_checksum_valid(checksum_name):
-            return self.add_rse_attribute(rse=rse, key=CHECKSUM_KEY, value=True)
-        else:
-            return False
 
     def delete_rse_attribute(self, rse, key):
         """
@@ -206,16 +191,6 @@ class RSEClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def delete_rse_checksum(self, rse, checksum_name):
-        """
-        Sends the request to delete a RSE attribute.
-
-        :param rse: the RSE name.
-        :param checksum_name: the checksum name.
-
-        :return: True if RSE attribute was deleted successfully else False.
-        """
-        return self.delete_rse_attribute(rse=rse, key=CHECKSUM_KEY)
 
     def list_rse_attributes(self, rse):
         """

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -21,6 +21,7 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014
 # - Wen Guan <wguan.icedew@gmail.com>, 2014
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Gabriele Fronze' <gfronze@cern.ch>, 2019
 #
 # PY3K COMPATIBLE
 
@@ -33,7 +34,7 @@ except ImportError:
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice
-from rucio.common.utils import build_url
+from rucio.common.utils import build_url, is_checksum_valid, get_checksum_attr_key
 
 
 class RSEClient(BaseClient):
@@ -86,6 +87,7 @@ class RSEClient(BaseClient):
         :param longitude: Longitude coordinate of RSE.
         :param ASN: Access service network.
         :param availability: Availability.
+        :param supported_checksums: The checksums supported by the RSE.
 
         :return: True if location was created successfully else False.
         :raises Duplicate: if rse already exists.
@@ -171,6 +173,22 @@ class RSEClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
+    def add_rse_checksum(self, rse, checksum_name):
+        """
+        Sends the request to add a RSE checksum.
+
+        :param rse: the name of the rse.
+        :param checksum_name: the checksum name.
+
+        :return: True if RSE attribute was created successfully else False.
+        :raises Duplicate: if RSE attribute already exists.
+        """
+
+        if is_checksum_valid(checksum_name):
+            return self.add_rse_attribute(rse=rse, key=get_checksum_attr_key(checksum_name), value=True)
+        else:
+            return False
+
     def delete_rse_attribute(self, rse, key):
         """
         Sends the request to delete a RSE attribute.
@@ -189,6 +207,17 @@ class RSEClient(BaseClient):
         else:
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
+
+    def delete_rse_checksum(self, rse, checksum_name):
+        """
+        Sends the request to delete a RSE attribute.
+
+        :param rse: the RSE name.
+        :param checksum_name: the checksum name.
+
+        :return: True if RSE attribute was deleted successfully else False.
+        """
+        return self.delete_rse_attribute(rse=rse, key=get_checksum_attr_key(checksum_name))
 
     def list_rse_attributes(self, rse):
         """

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -87,7 +87,6 @@ class RSEClient(BaseClient):
         :param longitude: Longitude coordinate of RSE.
         :param ASN: Access service network.
         :param availability: Availability.
-        :param supported_checksums: The checksums supported by the RSE.
 
         :return: True if location was created successfully else False.
         :raises Duplicate: if rse already exists.

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -20,6 +20,7 @@
 # - Tobias Wegner <twegner@cern.ch>, 2018
 # - Nicolo Magini <nicolo.magini@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Gabriele Fronze' <gfronze@cern.ch>, 2019
 #
 # PY3K COMPATIBLE
 

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -208,6 +208,7 @@ class UploadClient:
                 lfn['scope'] = file['did_scope']
                 lfn['name'] = file['did_name']
                 lfn['adler32'] = file['adler32']
+                lfn['md5'] = file['md5']
                 lfn['filesize'] = file['bytes']
 
                 sign_service = None

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -25,6 +25,7 @@
 # - Tobias Wegner <twegner@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Gabriele Fronze' <gfronze@cern.ch>, 2019
 #
 # PY3K COMPATIBLE
 

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -179,6 +179,30 @@ def clean_headers(msg):
         msg = str(msg).replace(c, ' ')
     return msg
 
+GLOBALLY_SUPPORTED_CHECKSUMS = ["md5", "adler32"]
+CHECKSUM_PATTERN_PREFIX = "is_"
+CHECKSUM_PATTERN_SUFFIX = "_supported"
+
+def is_checksum_valid(checksum_name):
+    """
+    A simple function to check wether a checksum algorithm is supported.
+    Relies on GLOBALLY_SUPPORTED_CHECKSUMS to allow for expandability.
+
+    :param checksum_name: The name of the checksum to be verified.
+    :returns: True if checksum_name is in GLOBALLY_SUPPORTED_CHECKSUMS list, False otherwise.
+    """
+    
+    return checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS
+
+def get_checksum_attr_key(checksum_name):
+    """
+    A function to generate the attribute name based on the privided checksum name.
+
+    :param checksum_name: The name of the checksum the attribute key should nbe generated for.
+    :returns: The checksum name packed inside the attribute pattern.
+    """
+
+    return CHECKSUM_PATTERN_PREFIX+checksum_name+CHECKSUM_PATTERN_SUFFIX
 
 def adler32(file):
     """

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -199,6 +199,14 @@ def is_checksum_valid(checksum_name):
     return checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS
 
 
+def set_checksum_value(file, checksum_names_list):
+    for checksum_name in checksum_names_list:
+        if checksum_name in file['metadata'].keys() and file['metadata'][checksum_name]:
+            file['checksum'] = '%s:%s' % (checksum_name.upper(), str(file['metadata'][checksum_name]))
+            if checksum_name == PREFERRED_CHECKSUM:
+                break
+
+
 def adler32(file):
     """
     An Adler-32 checksum is obtained by calculating two 16-bit checksums A and B and concatenating their bits into a 32-bit integer. A is the sum of all bytes in the stream plus one, and B is the sum of the individual values of A from each step.

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -182,6 +182,7 @@ def clean_headers(msg):
 
 
 GLOBALLY_SUPPORTED_CHECKSUMS = ['adler32', 'md5']
+CHECKSUM_ALGO_DICT = {}
 PREFERRED_CHECKSUM = GLOBALLY_SUPPORTED_CHECKSUMS[0]
 CHECKSUM_KEY = 'supported_checksums'
 
@@ -222,6 +223,9 @@ def adler32(file):
     return str('%08x' % adler)
 
 
+CHECKSUM_ALGO_DICT['adler32'] = adler32
+
+
 def md5(file):
     """
     Runs the MD5 algorithm (RFC-1321) on the binary content of the file named file and returns the hexadecimal digest
@@ -237,6 +241,9 @@ def md5(file):
         raise Exception('FATAL - could not get MD5 checksum of file %s - %s' % (file, e))
 
     return hash_md5.hexdigest()
+
+
+CHECKSUM_ALGO_DICT['md5'] = md5
 
 
 def str_to_date(string):

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -180,10 +180,12 @@ def clean_headers(msg):
         msg = str(msg).replace(c, ' ')
     return msg
 
+
 GLOBALLY_SUPPORTED_CHECKSUMS = ['adler32', 'md5']
 PREFERRED_CHECKSUM = GLOBALLY_SUPPORTED_CHECKSUMS[0]
 CHECKSUM_PATTERN_PREFIX = "is_"
 CHECKSUM_PATTERN_SUFFIX = "_supported"
+
 
 def is_checksum_valid(checksum_name):
     """
@@ -193,8 +195,9 @@ def is_checksum_valid(checksum_name):
     :param checksum_name: The name of the checksum to be verified.
     :returns: True if checksum_name is in GLOBALLY_SUPPORTED_CHECKSUMS list, False otherwise.
     """
-    
+
     return checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS
+
 
 def get_checksum_attr_key(checksum_name):
     """
@@ -204,7 +207,8 @@ def get_checksum_attr_key(checksum_name):
     :returns: The checksum name packed inside the attribute pattern.
     """
 
-    return CHECKSUM_PATTERN_PREFIX+checksum_name+CHECKSUM_PATTERN_SUFFIX
+    return CHECKSUM_PATTERN_PREFIX + checksum_name + CHECKSUM_PATTERN_SUFFIX
+
 
 def adler32(file):
     """

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -181,7 +181,7 @@ def clean_headers(msg):
     return msg
 
 
-GLOBALLY_SUPPORTED_CHECKSUMS = ['adler32', 'md5']
+GLOBALLY_SUPPORTED_CHECKSUMS = ['adler32', 'md5', 'sha256', 'crc32']
 CHECKSUM_ALGO_DICT = {}
 PREFERRED_CHECKSUM = GLOBALLY_SUPPORTED_CHECKSUMS[0]
 CHECKSUM_KEY = 'supported_checksums'
@@ -211,6 +211,7 @@ def adler32(file):
     """
     An Adler-32 checksum is obtained by calculating two 16-bit checksums A and B and concatenating their bits into a 32-bit integer. A is the sum of all bytes in the stream plus one, and B is the sum of the individual values of A from each step.
 
+    :param file: file name
     :returns: Hexified string, padded to 8 values.
     """
 
@@ -238,7 +239,7 @@ def md5(file):
     """
     Runs the MD5 algorithm (RFC-1321) on the binary content of the file named file and returns the hexadecimal digest
 
-    :param string: file name
+    :param file: file name
     :returns: string of 32 hexadecimal digits
     """
     hash_md5 = hashlib.md5()
@@ -252,6 +253,39 @@ def md5(file):
 
 
 CHECKSUM_ALGO_DICT['md5'] = md5
+
+
+def sha256(file):
+    """
+    Runs the SHA256 algorithm on the binary content of the file named file and returns the hexadecimal digest
+
+    :param file: file name
+    :returns: string of 32 hexadecimal digits
+    """
+    with open(file, "rb") as f:
+        bytes = f.read()  # read entire file as bytes
+        readable_hash = hashlib.sha256(bytes).hexdigest()
+        print(readable_hash)
+        return readable_hash
+
+
+CHECKSUM_ALGO_DICT['sha256'] = sha256
+
+
+def crc32(file):
+    """
+    Runs the CRC32 algorithm on the binary content of the file named file and returns the hexadecimal digest
+
+    :param file: file name
+    :returns: string of 32 hexadecimal digits
+    """
+    prev = 0
+    for eachLine in open(file,"rb"):
+        prev = zlib.crc32(eachLine, prev)
+    return "%X"%(prev & 0xFFFFFFFF)
+
+
+CHECKSUM_ALGO_DICT['crc32'] = crc32
 
 
 def str_to_date(string):

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -181,7 +181,8 @@ def clean_headers(msg):
     return msg
 
 
-GLOBALLY_SUPPORTED_CHECKSUMS = ['adler32', 'md5', 'sha256', 'crc32']
+# GLOBALLY_SUPPORTED_CHECKSUMS = ['adler32', 'md5', 'sha256', 'crc32']
+GLOBALLY_SUPPORTED_CHECKSUMS = ['adler32', 'md5']
 CHECKSUM_ALGO_DICT = {}
 PREFERRED_CHECKSUM = GLOBALLY_SUPPORTED_CHECKSUMS[0]
 CHECKSUM_KEY = 'supported_checksums'

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -280,9 +280,9 @@ def crc32(file):
     :returns: string of 32 hexadecimal digits
     """
     prev = 0
-    for eachLine in open(file,"rb"):
+    for eachLine in open(file, "rb"):
         prev = zlib.crc32(eachLine, prev)
-    return "%X"%(prev & 0xFFFFFFFF)
+    return "%X" % (prev & 0xFFFFFFFF)
 
 
 CHECKSUM_ALGO_DICT['crc32'] = crc32

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -183,8 +183,7 @@ def clean_headers(msg):
 
 GLOBALLY_SUPPORTED_CHECKSUMS = ['adler32', 'md5']
 PREFERRED_CHECKSUM = GLOBALLY_SUPPORTED_CHECKSUMS[0]
-CHECKSUM_PATTERN_PREFIX = "is_"
-CHECKSUM_PATTERN_SUFFIX = "_supported"
+CHECKSUM_KEY = 'supported_checksums'
 
 
 def is_checksum_valid(checksum_name):
@@ -197,17 +196,6 @@ def is_checksum_valid(checksum_name):
     """
 
     return checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS
-
-
-def get_checksum_attr_key(checksum_name):
-    """
-    A function to generate the attribute name based on the privided checksum name.
-
-    :param checksum_name: The name of the checksum the attribute key should nbe generated for.
-    :returns: The checksum name packed inside the attribute pattern.
-    """
-
-    return CHECKSUM_PATTERN_PREFIX + checksum_name + CHECKSUM_PATTERN_SUFFIX
 
 
 def adler32(file):

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -179,7 +179,8 @@ def clean_headers(msg):
         msg = str(msg).replace(c, ' ')
     return msg
 
-GLOBALLY_SUPPORTED_CHECKSUMS = ["md5", "adler32"]
+GLOBALLY_SUPPORTED_CHECKSUMS = ['adler32', 'md5']
+PREFERRED_CHECKSUM = GLOBALLY_SUPPORTED_CHECKSUMS[0]
 CHECKSUM_PATTERN_PREFIX = "is_"
 CHECKSUM_PATTERN_SUFFIX = "_supported"
 

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -56,7 +56,7 @@ import rucio.core.account_counter
 
 from rucio.core.rse_counter import add_counter, get_counter
 from rucio.common import exception, utils
-from rucio.common.config import get_lfn2pfn_algorithm_default
+from rucio.common.config import get_lfn2pfn_algorithm_default, config_get
 from rucio.common.utils import CHECKSUM_KEY, is_checksum_valid, GLOBALLY_SUPPORTED_CHECKSUMS
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import RSEType
@@ -380,7 +380,7 @@ def add_rse_attribute(rse_id, key, value, session=None):
 
 
 @transactional_session
-def del_rse_attribute(rse, key, session=None):
+def del_rse_attribute(rse_id, key, session=None):
     """
     Delete a RSE attribute.
 
@@ -560,6 +560,7 @@ def get_rse_supported_checksums(rse_id=None, session=None):
         return GLOBALLY_SUPPORTED_CHECKSUMS
     else:
         return supported_checksum_list
+
 
 @read_session
 def get_rse_is_checksum_supported(checksum_name, rse_id=None, session=None):

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -57,7 +57,7 @@ import rucio.core.account_counter
 from rucio.core.rse_counter import add_counter, get_counter
 from rucio.common import exception, utils
 from rucio.common.config import get_lfn2pfn_algorithm_default
-from rucio.common.utils import CHECKSUM_KEY, GLOBALLY_SUPPORTED_CHECKSUMS, is_checksum_valid
+from rucio.common.utils import CHECKSUM_KEY, is_checksum_valid
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import RSEType
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
@@ -389,7 +389,8 @@ def set_rse_checksum_support(rse, checksum_names, session=None):
 
     :returns: True is successful
     """
-    if type(checksum_names) is not list: checksum_names = [checksum_names]
+    if type(checksum_names) is not list:
+        checksum_names = [checksum_names]
     supported_checksums = filter(lambda x: is_checksum_valid(x), checksum_names)
     supported_checksums = map(lambda x: ''.join(x.split()), supported_checksums)
     if any(supported_checksums):

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -547,8 +547,11 @@ def get_rse_supported_checksums(rse_id=None, session=None):
 
     :returns: The list of checksums supported by the selected RSE.
     """
-
-    return str(get_rse_attribute(CHECKSUM_KEY, rse_id=rse_id, session=session)).split(',')
+    # each checksum is formatted as: ["[u'adler32']"]
+    return str(get_rse_attribute(CHECKSUM_KEY, rse_id=rse_id, session=session))\
+        .replace('[u\'', '')\
+        .replace('\']', '')\
+        .split(',')
 
 
 @read_session

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -57,7 +57,7 @@ import rucio.core.account_counter
 from rucio.core.rse_counter import add_counter, get_counter
 from rucio.common import exception, utils
 from rucio.common.config import get_lfn2pfn_algorithm_default
-from rucio.common.utils import CHECKSUM_KEY, is_checksum_valid
+from rucio.common.utils import CHECKSUM_KEY, is_checksum_valid, GLOBALLY_SUPPORTED_CHECKSUMS
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import RSEType
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
@@ -546,14 +546,20 @@ def get_rse_supported_checksums(rse_id=None, session=None):
     :param session: The database session in use.
 
     :returns: The list of checksums supported by the selected RSE.
+              If the list is empty (aka attribute is not set) it returns all the default checksums.
+              Use 'none' to explicitly tell the RSE does not support any checksum algorithm.
     """
+
     # each checksum is formatted as: ["[u'adler32']"]
     supported_checksum_list = str(get_rse_attribute(CHECKSUM_KEY, rse_id=rse_id, session=session)) \
         .replace('[u\'', '') \
         .replace('\']', '') \
         .split(',')
 
-    return supported_checksum_list
+    if not supported_checksum_list:
+        return GLOBALLY_SUPPORTED_CHECKSUMS
+    else:
+        return supported_checksum_list
 
 @read_session
 def get_rse_is_checksum_supported(checksum_name, rse_id=None, session=None):

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -548,11 +548,12 @@ def get_rse_supported_checksums(rse_id=None, session=None):
     :returns: The list of checksums supported by the selected RSE.
     """
     # each checksum is formatted as: ["[u'adler32']"]
-    return str(get_rse_attribute(CHECKSUM_KEY, rse_id=rse_id, session=session))\
-        .replace('[u\'', '')\
-        .replace('\']', '')\
+    supported_checksum_list = str(get_rse_attribute(CHECKSUM_KEY, rse_id=rse_id, session=session)) \
+        .replace('[u\'', '') \
+        .replace('\']', '') \
         .split(',')
 
+    return supported_checksum_list
 
 @read_session
 def get_rse_is_checksum_supported(checksum_name, rse_id=None, session=None):
@@ -566,7 +567,7 @@ def get_rse_is_checksum_supported(checksum_name, rse_id=None, session=None):
     :returns: True if required checksum is supported, False otherwise.
     """
     if is_checksum_valid(checksum_name):
-        return (checksum_name in get_rse_supported_checksums(rse_id=rse_id, session=session))
+        return checksum_name in get_rse_supported_checksums(rse_id=rse_id, session=session)
     else:
         return False
 

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -380,28 +380,7 @@ def add_rse_attribute(rse_id, key, value, session=None):
 
 
 @transactional_session
-def set_rse_checksum_support(rse, checksum_names, session=None):
-    """ Adds a RSE attribute.
-
-    :param rse: the rse name.
-    :param checksum_names: the checksum name[s] as a single item or a list.
-    :param session: The database session in use.
-
-    :returns: True is successful
-    """
-    if type(checksum_names) is not list:
-        checksum_names = [checksum_names]
-    supported_checksums = filter(lambda x: is_checksum_valid(x), checksum_names)
-    supported_checksums = map(lambda x: ''.join(x.split()), supported_checksums)
-    if any(supported_checksums):
-        supported_checksums_csv = ','.join(map(str, supported_checksums))
-        return add_rse_attribute(rse=rse, key=CHECKSUM_KEY, value=supported_checksums_csv, session=session)
-    else:
-        return False
-
-
-@transactional_session
-def del_rse_attribute(rse_id, key, session=None):
+def del_rse_attribute(rse, key, session=None):
     """
     Delete a RSE attribute.
 
@@ -419,20 +398,6 @@ def del_rse_attribute(rse_id, key, session=None):
         raise exception.RSEAttributeNotFound('RSE attribute \'%s\' cannot be found' % key)
     rse_attr.delete(session=session)
     return True
-
-
-@transactional_session
-def reset_rse_checksum_support(rse, session=None):
-    """
-    Delete a RSE attribute.
-
-    :param rse: the name of the rse.
-    :param session: The database session in use.
-
-    :return: True if RSE attribute was deleted.
-    """
-
-    return del_rse_attribute(rse=rse, key=CHECKSUM_KEY, session=session)
 
 
 @read_session

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -378,6 +378,7 @@ def add_rse_attribute(rse_id, key, value, session=None):
         raise exception.Duplicate("RSE attribute '%(key)s-%(value)s\' for RSE '%(rse)s' already exists!" % locals())
     return True
 
+
 @transactional_session
 def add_rse_checksum(rse, checksum_name, session=None):
     """ Adds a RSE attribute.
@@ -414,6 +415,7 @@ def del_rse_attribute(rse_id, key, session=None):
     rse_attr.delete(session=session)
     return True
 
+
 @transactional_session
 def del_rse_checksum(rse, checksum_name, session=None):
     """
@@ -426,6 +428,7 @@ def del_rse_checksum(rse, checksum_name, session=None):
     :return: True if RSE attribute was deleted.
     """
     return del_rse_attribute(rse=rse, key=get_checksum_attr_key(checksum_name), session=session)
+
 
 @read_session
 def list_rse_attributes(rse_id, session=None):
@@ -585,6 +588,7 @@ def get_rse_supported_checksums(rse_id=None, session=None):
     else:
         return list(filter(lambda x: (get_rse_attribute(get_checksum_attr_key(x), rse_id=rse_id, value=True, session=session) is not None), GLOBALLY_SUPPORTED_CHECKSUMS))
 
+
 @read_session
 def get_rse_is_checksum_supported(checksum_name, rse_id=None, session=None):
     """
@@ -597,9 +601,10 @@ def get_rse_is_checksum_supported(checksum_name, rse_id=None, session=None):
     :returns: True if required checksum is supported, False otherwise.
     """
     if is_checksum_valid(checksum_name):
-        return (checksum_name in  get_rse_supported_checksums(rse_id=rse_id, session=session))
+        return (checksum_name in get_rse_supported_checksums(rse_id=rse_id, session=session))
     else:
         return False
+
 
 @transactional_session
 def set_rse_usage(rse_id, source, used, free, session=None):

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -109,15 +109,6 @@ def add_rse(rse, deterministic=True, volatile=False, city=None, region_code=None
     # Add rse name as a RSE-Tag
     add_rse_attribute(rse_id=new_rse.id, key=rse, value=True, session=session)
 
-    # # Add supported checksums in rse_attr_map if specified
-    # if supported_checksums:
-    #     for checksum in GLOBALLY_SUPPORTED_CHECKSUMS:
-    #         if checksum in supported_checksums:
-    #             add_rse_checksum(rse=rse, checksum_name=checksum, session=session)
-    # else:
-    #     for checksum in GLOBALLY_SUPPORTED_CHECKSUMS:
-    #         add_rse_checksum(rse=rse, checksum_name=checksum, session=session)
-
     # Add counter to monitor the space usage
     add_counter(rse_id=new_rse.id, session=session)
 

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -44,7 +44,7 @@ from rucio.core import did, message as message_core, request as request_core
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core.replica import add_replicas
 from rucio.core.request import queue_requests, set_requests_state
-from rucio.core.rse import get_rse_name, list_rses
+from rucio.core.rse import get_rse_name, list_rses, get_rse_supported_checksums
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import DIDType, RequestState, FTSState, RSEType, RequestType, ReplicaState
@@ -780,9 +780,14 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                     else:
                         verify_checksum = 'both'
 
-                logging.info('source RSE checksum compatibility: {}'.format(rse_attrs[source_rse_id][CHECKSUM_KEY]))
-                logging.info('destination RSE checksum compatibility: {}'.format(rse_attrs[dest_rse_id][CHECKSUM_KEY]))
-                common_checksum_names = set(rse_attrs[dest_rse_id][CHECKSUM_KEY]).intersection(rse_attrs[source_rse_id][CHECKSUM_KEY])
+                source_rse_checksums = get_rse_supported_checksums(source_rse_id, session)
+                dest_rse_checksums = get_rse_supported_checksums(dest_rse_id, session)
+
+                logging.info('source RSE checksum compatibility: {}'.format(source_rse_checksums))
+                logging.info('destination RSE checksum compatibility: {}'.format(dest_rse_checksums))
+
+                common_checksum_names = set(source_rse_checksums).intersection(dest_rse_checksums)
+
                 if len(common_checksum_names) == 0:
                     logging.info('No common checksum method. Verifying destination only.')
                     verify_checksum = 'destination'

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -38,7 +38,7 @@ from rucio.common.exception import (RucioException, UnsupportedOperation,
                                     RequestNotFound, NoDistance)
 from rucio.common.rse_attributes import get_rse_attributes
 from rucio.common.types import InternalAccount
-from rucio.common.utils import construct_surl, CHECKSUM_KEY
+from rucio.common.utils import construct_surl
 from rucio.common.constants import SUPPORTED_PROTOCOLS
 from rucio.core import did, message as message_core, request as request_core
 from rucio.core.monitor import record_counter, record_timer

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -38,7 +38,7 @@ from rucio.common.exception import (RucioException, UnsupportedOperation,
                                     RequestNotFound, NoDistance)
 from rucio.common.rse_attributes import get_rse_attributes
 from rucio.common.types import InternalAccount
-from rucio.common.utils import construct_surl
+from rucio.common.utils import construct_surl, CHECKSUM_KEY
 from rucio.common.constants import SUPPORTED_PROTOCOLS
 from rucio.core import did, message as message_core, request as request_core
 from rucio.core.monitor import record_counter, record_timer
@@ -779,6 +779,10 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                         verify_checksum = 'destination'
                     else:
                         verify_checksum = 'both'
+
+                common_checksum_names = set(rse_attrs[dest_rse_id][CHECKSUM_KEY]).intersection(rse_attrs[source_rse_id][CHECKSUM_KEY])
+                if len(common_checksum_names) == 0:
+                    verify_checksum = 'destination'
 
                 # VI - Fill the transfer dictionary including file_metadata
                 file_metadata = {'request_id': req_id,

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -780,8 +780,11 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                     else:
                         verify_checksum = 'both'
 
+                logging.info('source RSE checksum compatibility: {}'.format(rse_attrs[source_rse_id][CHECKSUM_KEY]))
+                logging.info('destination RSE checksum compatibility: {}'.format(rse_attrs[dest_rse_id][CHECKSUM_KEY]))
                 common_checksum_names = set(rse_attrs[dest_rse_id][CHECKSUM_KEY]).intersection(rse_attrs[source_rse_id][CHECKSUM_KEY])
                 if len(common_checksum_names) == 0:
+                    logging.info('No common checksum method. Verifying destination only.')
                     verify_checksum = 'destination'
 
                 # VI - Fill the transfer dictionary including file_metadata

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -269,17 +269,21 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                   'activity': str(transfer['file_metadata']['activity'])}
 
         if verify_checksum != 'none':
-            rse_id = transfer['file_metadata']['dest_rse_id']
-            supported_checksums = get_rse_supported_checksums(rse_id=rse_id, session=session)
-            logging.info('Checksums supported by rse_id={}: {}'.format(rse_id, supported_checksums))
-            for checksum_name in supported_checksums:
-                checksum_name = checksum_name.replace('\']', '').replace('[u\'', '')
-                logging.info('Trying with {}'.format(checksum_name))
-                if checksum_name in list(t_file['metadata'].keys()) and t_file['metadata'][checksum_name]:
-                    logging.info('{} is supported!'.format(checksum_name))
-                    t_file['checksum'] = '%s:%s' % (checksum_name.capitalize(), str(t_file['metadata'][checksum_name]))
-                    if checksum_name == PREFERRED_CHECKSUM:
-                        break
+            try:
+                rse_id = transfer['file_metadata']['dest_rse_id']
+                supported_checksums = get_rse_supported_checksums(rse_id=rse_id, session=session)
+                logging.info('Checksums supported by rse_id={}: {}'.format(rse_id, supported_checksums))
+                for checksum_name in supported_checksums:
+                    checksum_name = checksum_name.replace('\']', '').replace('[u\'', '')
+                    logging.info('Trying with {}'.format(checksum_name))
+                    if checksum_name in t_file['metadata'].keys() and t_file['metadata'][checksum_name]:
+                        logging.info('{} is supported. Adding {}'.format(checksum_name, str(t_file['metadata'][checksum_name])))
+                        t_file['checksum'] = '%s:%s' % (checksum_name.upper(), str(t_file['metadata'][checksum_name]))
+                        logging.info('{}'.format(t_file['checksum']))
+                        if checksum_name == PREFERRED_CHECKSUM:
+                            break
+            except:
+                return
 
         multihop = transfer.get('multihop', False)
 

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -42,11 +42,11 @@ import traceback
 
 from rucio.common.config import config_get
 from rucio.common.exception import InvalidRSEExpression, TransferToolTimeout, TransferToolWrongAnswer, RequestNotFound, ConfigNotFound, DuplicateFileTransferSubmission
-from rucio.common.utils import chunks, PREFERRED_CHECKSUM, set_checksum_value
+from rucio.common.utils import chunks, set_checksum_value
 from rucio.core import request, transfer as transfer_core
 from rucio.core.config import get
 from rucio.core.monitor import record_counter, record_timer
-from rucio.core.rse import list_rses, get_rse_supported_checksums, get_rse_id
+from rucio.core.rse import list_rses, get_rse_supported_checksums
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla.session import read_session
 from rucio.db.sqla.constants import RequestState

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -269,7 +269,7 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                   'activity': str(transfer['file_metadata']['activity'])}
 
         if verify_checksum != 'none':
-            rse_id = get_rse_id(transfer['rse'], session=session)
+            rse_id = get_rse_id(transfer['dest_rse'], session=session)
             supported_checksums = get_rse_supported_checksums(rse_id=rse_id, session=session)
             for checksum_name in supported_checksums:
                 if checksum_name in list(t_file['metadata'].keys()) and t_file['metadata'][checksum_name]:

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -269,7 +269,7 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                   'activity': str(transfer['file_metadata']['activity'])}
 
         if verify_checksum != 'none':
-            rse_id = get_rse_id(transfer['dest_rse'], session=session)
+            rse_id = transfer['file_metadata']['dest_rse_id']
             supported_checksums = get_rse_supported_checksums(rse_id=rse_id, session=session)
             for checksum_name in supported_checksums:
                 if checksum_name in list(t_file['metadata'].keys()) and t_file['metadata'][checksum_name]:

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -269,47 +269,43 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                   'activity': str(transfer['file_metadata']['activity'])}
 
         if verify_checksum != 'none':
-            try:
-                dest_rse_id = transfer['file_metadata']['dest_rse_id']
-                source_rse_id = transfer['file_metadata']['src_rse_id']
-                dest_supported_checksums = get_rse_supported_checksums(rse_id=dest_rse_id, session=session)
-                source_supported_checksums = get_rse_supported_checksums(rse_id=source_rse_id, session=session)
+            dest_rse_id = transfer['file_metadata']['dest_rse_id']
+            source_rse_id = transfer['file_metadata']['src_rse_id']
+            dest_supported_checksums = get_rse_supported_checksums(rse_id=dest_rse_id, session=session)
+            source_supported_checksums = get_rse_supported_checksums(rse_id=source_rse_id, session=session)
 
-                logging.info('source RSE checksum compatibility: {}'.format(source_supported_checksums))
-                logging.info('destination RSE checksum compatibility: {}'.format(dest_supported_checksums))
-                common_checksum_names = set(source_supported_checksums).intersection(dest_supported_checksums)
+            logging.info('source RSE checksum compatibility: {}'.format(source_supported_checksums))
+            logging.info('destination RSE checksum compatibility: {}'.format(dest_supported_checksums))
+            common_checksum_names = set(source_supported_checksums).intersection(dest_supported_checksums)
 
-                if len(common_checksum_names) == 0:
-                    logging.info('No common checksum method. Verifying destination only.')
-                    verify_checksum = 'destination'
-                    t_file['verify_checksum'] = 'destination'
+            if len(common_checksum_names) == 0:
+                logging.info('No common checksum method. Verifying destination only.')
+                verify_checksum = 'destination'
+                t_file['verify_checksum'] = 'destination'
 
-                    for checksum_name in dest_supported_checksums:
-                        logging.info('Trying with {}'.format(checksum_name))
+                for checksum_name in dest_supported_checksums:
+                    logging.info('Trying with {}'.format(checksum_name))
 
-                        if checksum_name in t_file['metadata'].keys() and t_file['metadata'][checksum_name]:
-                            logging.info('{} is supported. Adding {}'.format(checksum_name,str(t_file['metadata'][checksum_name])))
-                            t_file['checksum'] = '%s:%s' % (checksum_name.upper(), str(t_file['metadata'][checksum_name]))
-                            logging.info('{}'.format(t_file['checksum']))
+                    if checksum_name in t_file['metadata'].keys() and t_file['metadata'][checksum_name]:
+                        logging.info('{} is supported. Adding {}'.format(checksum_name,str(t_file['metadata'][checksum_name])))
+                        t_file['checksum'] = '%s:%s' % (checksum_name.upper(), str(t_file['metadata'][checksum_name]))
+                        logging.info('{}'.format(t_file['checksum']))
 
-                            if checksum_name == PREFERRED_CHECKSUM:
-                                logging.info('{} is the preferred algorithm. Moving on.'.format(checksum_name))
-                                break
-                else:
-                    for checksum_name in common_checksum_names:
-                        logging.info('Trying with {}'.format(checksum_name))
+                        if checksum_name == PREFERRED_CHECKSUM:
+                            logging.info('{} is the preferred algorithm. Moving on.'.format(checksum_name))
+                            break
+            else:
+                for checksum_name in common_checksum_names:
+                    logging.info('Trying with {}'.format(checksum_name))
 
-                        if checksum_name in t_file['metadata'].keys() and t_file['metadata'][checksum_name]:
-                            logging.info('{} is supported. Adding {}'.format(checksum_name,str(t_file['metadata'][checksum_name])))
-                            t_file['checksum'] = '%s:%s' % (checksum_name.upper(), str(t_file['metadata'][checksum_name]))
-                            logging.info('{}'.format(t_file['checksum']))
+                    if checksum_name in t_file['metadata'].keys() and t_file['metadata'][checksum_name]:
+                        logging.info('{} is supported. Adding {}'.format(checksum_name,str(t_file['metadata'][checksum_name])))
+                        t_file['checksum'] = '%s:%s' % (checksum_name.upper(), str(t_file['metadata'][checksum_name]))
+                        logging.info('{}'.format(t_file['checksum']))
 
-                            if checksum_name == PREFERRED_CHECKSUM:
-                                logging.info('{} is the preferred algorithm. Moving on.'.format(checksum_name))
-                                break
-
-            except:
-                return
+                        if checksum_name == PREFERRED_CHECKSUM:
+                            logging.info('{} is the preferred algorithm. Moving on.'.format(checksum_name))
+                            break
 
         multihop = transfer.get('multihop', False)
 

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -223,6 +223,7 @@ def submit_transfer(external_host, job, submitter='submitter', logging_prepend_s
     except Exception as error:
         logging.error('%s Failed to submit a job with error %s: %s', prepend_str, str(error), traceback.format_exc())
 
+
 @read_session
 def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strategy=None, max_time_in_queue=None, session=None):
     """
@@ -266,7 +267,7 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                   'selection_strategy': source_strategy if source_strategy else activity_source_strategy.get(str(transfer['file_metadata']['activity']), default_source_strategy),
                   'request_type': transfer['file_metadata'].get('request_type', None),
                   'activity': str(transfer['file_metadata']['activity'])}
-        
+
         if verify_checksum != 'none':
             rse_id = get_rse_id(transfer['rse'], session=session)
             supported_checksums = get_rse_supported_checksums(rse_id=rse_id, session=session)

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -278,21 +278,38 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                 logging.info('source RSE checksum compatibility: {}'.format(source_supported_checksums))
                 logging.info('destination RSE checksum compatibility: {}'.format(dest_supported_checksums))
                 common_checksum_names = set(source_supported_checksums).intersection(dest_supported_checksums)
+
                 if len(common_checksum_names) == 0:
                     logging.info('No common checksum method. Verifying destination only.')
                     verify_checksum = 'destination'
                     t_file['verify_checksum'] = 'destination'
 
-                logging.info('Checksums supported by rse_id={}: {}'.format(dest_rse_id, dest_supported_checksums))
-                for checksum_name in dest_supported_checksums:
-                    logging.info('Trying with {}'.format(checksum_name))
-                    if checksum_name in t_file['metadata'].keys() and t_file['metadata'][checksum_name]:
-                        logging.info(
-                            '{} is supported. Adding {}'.format(checksum_name, str(t_file['metadata'][checksum_name])))
-                        t_file['checksum'] = '%s:%s' % (checksum_name.upper(), str(t_file['metadata'][checksum_name]))
-                        logging.info('{}'.format(t_file['checksum']))
-                        if checksum_name == PREFERRED_CHECKSUM:
-                            break
+                    for checksum_name in dest_supported_checksums:
+                        logging.info('Trying with {}'.format(checksum_name))
+
+                        if checksum_name in t_file['metadata'].keys() and t_file['metadata'][checksum_name]:
+                            logging.info('{} is supported. Adding {}'.format(checksum_name,str(t_file['metadata'][checksum_name])))
+                            t_file['checksum'] = '%s:%s' % (checksum_name.upper(), str(t_file['metadata'][checksum_name]))
+                            logging.info('{}'.format(t_file['checksum']))
+
+                            if checksum_name == PREFERRED_CHECKSUM:
+                                logging.info('{} is the preferred algorithm. Moving on.'.format(checksum_name))
+                                break
+                else:
+                    for checksum_name in common_checksum_names:
+                        logging.info('Trying with {}'.format(checksum_name))
+
+                        if checksum_name in t_file['metadata'].keys() and t_file['metadata'][checksum_name]:
+                            logging.info('{} is supported. Adding {}'.format(checksum_name,str(t_file['metadata'][checksum_name])))
+                            t_file['checksum'] = '%s:%s' % (checksum_name.upper(), str(t_file['metadata'][checksum_name]))
+                            logging.info('{}'.format(t_file['checksum']))
+
+                            if checksum_name == PREFERRED_CHECKSUM:
+                                logging.info('{} is the preferred algorithm. Moving on.'.format(checksum_name))
+                                break
+
+                logging.info('Checksums supported by dest_rse_id={}: {}'.format(dest_rse_id, dest_supported_checksums))
+
             except:
                 return
 

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -271,8 +271,12 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
         if verify_checksum != 'none':
             rse_id = transfer['file_metadata']['dest_rse_id']
             supported_checksums = get_rse_supported_checksums(rse_id=rse_id, session=session)
+            logging.info('Checksums supported by rse_id={}: {}'.format(rse_id, supported_checksums))
             for checksum_name in supported_checksums:
+                checksum_name = checksum_name.replace('\']', '').replace('[u\'', '')
+                logging.info('Trying with {}'.format(checksum_name))
                 if checksum_name in list(t_file['metadata'].keys()) and t_file['metadata'][checksum_name]:
+                    logging.info('{} is supported!'.format(checksum_name))
                     t_file['checksum'] = '%s:%s' % (checksum_name.capitalize(), str(t_file['metadata'][checksum_name]))
                     if checksum_name == PREFERRED_CHECKSUM:
                         break

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -281,6 +281,7 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                 if len(common_checksum_names) == 0:
                     logging.info('No common checksum method. Verifying destination only.')
                     verify_checksum = 'destination'
+                    t_file['verify_checksum'] = 'destination'
 
                 logging.info('Checksums supported by rse_id={}: {}'.format(dest_rse_id, dest_supported_checksums))
                 for checksum_name in dest_supported_checksums:

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -308,8 +308,6 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                                 logging.info('{} is the preferred algorithm. Moving on.'.format(checksum_name))
                                 break
 
-                logging.info('Checksums supported by dest_rse_id={}: {}'.format(dest_rse_id, dest_supported_checksums))
-
             except:
                 return
 

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -22,6 +22,7 @@
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Frank Berghaus <frank.berghaus@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Gabriele Fronze' <gfronze@cern.ch>, 2019
 #
 # PY3K COMPATIBLE
 

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -41,7 +41,7 @@ from threading import Timer
 
 from rucio.common import exception, config
 from rucio.common.constraints import STRING_TYPES
-from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS, PREFERRED_CHECKSUM
+from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS
 from rucio.rse.protocols import protocol
 
 try:

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -359,8 +359,6 @@ class Default(protocol.RSEProtocol):
             try:
                 ret[checksum_name] = ctx.checksum(str(path), str(checksum_name.capitalize()))
                 verified = True
-                if checksum_name == PREFERRED_CHECKSUM:
-                    break
             except Exception as error:
                 message += 'Error while processing gfal checksum call (%s). Error: %s \n' % checksum_name, str(error)
 

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -26,6 +26,7 @@
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Nicolo Magini <nicolo.magini@cern.ch>, 2018
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2019
+# - Gabriele Fronze' <gfronze@cern.ch>, 2019
 #
 # PY3K COMPATIBLE
 

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -405,10 +405,12 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None, force_scheme=Non
                 valid = None
                 try:  # Get metadata of file to verify if upload was successful
                     try:
-                        stats = _retry_protocol_stat(protocol, readpfn)
-                        if ('adler32' in stats) and ('adler32' in lfn):
-                            valid = stats['adler32'] == lfn['adler32']
-                        if (valid is None) and ('filesize' in stats) and ('filesize' in lfn):
+                        stats = _retry_protocol_stat(protocol, '%s.rucio.upload' % pfn)
+                        # Verify all supported checksums and keep rack of the verified ones
+                        verified_checksums = map(lambda x: stats[x] == lfn[x], GLOBALLY_SUPPORTED_CHECKSUMS)
+                        # Upload is successful if at least one checksum was found
+                        valid = any(verified_checksums)
+                        if not valid and ('filesize' in stats) and ('filesize' in lfn):
                             valid = stats['filesize'] == lfn['filesize']
                     except exception.RSEChecksumUnavailable as e:
                         if rse_settings['verify_checksum'] is False:

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -363,7 +363,7 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None, force_scheme=Non
                     try:
                         stats = _retry_protocol_stat(protocol, '%s.rucio.upload' % pfn)
                         # Verify all supported checksums and keep rack of the verified ones
-                        verified_checksums  = map(lambda x: stats[x] == lfn[x], GLOBALLY_SUPPORTED_CHECKSUMS)
+                        verified_checksums = map(lambda x: stats[x] == lfn[x], GLOBALLY_SUPPORTED_CHECKSUMS)
                         # Upload is successful if at least one checksum was found
                         valid = any(verified_checksums)
                         if not valid and ('filesize' in stats) and ('filesize' in lfn):

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -362,8 +362,13 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None, force_scheme=Non
                 try:  # Get metadata of file to verify if upload was successful
                     try:
                         stats = _retry_protocol_stat(protocol, '%s.rucio.upload' % pfn)
+
                         # Verify all supported checksums and keep rack of the verified ones
-                        verified_checksums = map(lambda x: stats[x] == lfn[x], GLOBALLY_SUPPORTED_CHECKSUMS)
+                        verified_checksums = []
+                        for checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS:
+                            if (checksum_name in stats) and (checksum_name in lfn):
+                                verified_checksums.append(stats[checksum_name] == lfn[checksum_name])
+
                         # Upload is successful if at least one checksum was found
                         valid = any(verified_checksums)
                         if not valid and ('filesize' in stats) and ('filesize' in lfn):
@@ -406,8 +411,13 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None, force_scheme=Non
                 try:  # Get metadata of file to verify if upload was successful
                     try:
                         stats = _retry_protocol_stat(protocol, '%s.rucio.upload' % pfn)
+
                         # Verify all supported checksums and keep rack of the verified ones
-                        verified_checksums = map(lambda x: stats[x] == lfn[x], GLOBALLY_SUPPORTED_CHECKSUMS)
+                        verified_checksums = []
+                        for checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS:
+                            if (checksum_name in stats) and (checksum_name in lfn):
+                                verified_checksums.append(stats[checksum_name] == lfn[checksum_name])
+
                         # Upload is successful if at least one checksum was found
                         valid = any(verified_checksums)
                         if not valid and ('filesize' in stats) and ('filesize' in lfn):

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -44,7 +44,9 @@ except ImportError:
 from rucio.common import exception, utils, constants
 from rucio.common.config import config_get_int
 from rucio.common.constraints import STRING_TYPES
-from rucio.common.utils import make_valid_did, GLOBALLY_SUPPORTED_CHECKSUMS
+from rucio.common.utils import make_valid_did, GLOBALLY_SUPPORTED_CHECKSUMS, CHECKSUM_ALGO_DICT, PREFERRED_CHECKSUM
+from rucio.core.rse import get_rse_is_checksum_supported, get_rse_id
+from rucio.db.sqla.session import get_session
 
 
 def get_rse_info(rse, session=None):

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -43,7 +43,7 @@ except ImportError:
 from rucio.common import exception, utils, constants
 from rucio.common.config import config_get_int
 from rucio.common.constraints import STRING_TYPES
-from rucio.common.utils import make_valid_did
+from rucio.common.utils import make_valid_did, GLOBALLY_SUPPORTED_CHECKSUMS
 
 
 def get_rse_info(rse, session=None):
@@ -357,12 +357,15 @@ def upload(rse_settings, lfns, source_dir=None, force_pfn=None, force_scheme=Non
                     continue
 
                 valid = None
+
                 try:  # Get metadata of file to verify if upload was successful
                     try:
                         stats = _retry_protocol_stat(protocol, '%s.rucio.upload' % pfn)
-                        if ('adler32' in stats) and ('adler32' in lfn):
-                            valid = stats['adler32'] == lfn['adler32']
-                        if (valid is None) and ('filesize' in stats) and ('filesize' in lfn):
+                        # Verify all supported checksums and keep rack of the verified ones
+                        verified_checksums  = map(lambda x: stats[x] == lfn[x], GLOBALLY_SUPPORTED_CHECKSUMS)
+                        # Upload is successful if at least one checksum was found
+                        valid = any(verified_checksums)
+                        if not valid and ('filesize' in stats) and ('filesize' in lfn):
                             valid = stats['filesize'] == lfn['filesize']
                     except exception.RSEChecksumUnavailable as e:
                         if rse_settings['verify_checksum'] is False:

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -44,9 +44,7 @@ except ImportError:
 from rucio.common import exception, utils, constants
 from rucio.common.config import config_get_int
 from rucio.common.constraints import STRING_TYPES
-from rucio.common.utils import make_valid_did, GLOBALLY_SUPPORTED_CHECKSUMS, CHECKSUM_ALGO_DICT, PREFERRED_CHECKSUM
-from rucio.core.rse import get_rse_is_checksum_supported, get_rse_id
-from rucio.db.sqla.session import get_session
+from rucio.common.utils import make_valid_did, GLOBALLY_SUPPORTED_CHECKSUMS
 
 
 def get_rse_info(rse, session=None):


### PR DESCRIPTION
Following issue available at https://github.com/rucio/rucio/issues/2498 I have modified Rucio to allow for the specification of per-RSE checksum compatibility.

This required:
- Implementation of utilities and cosnstants in `common.utils`
- Addition of specific methods to set the RSE attributes related to checksums compatibility in `core.rse`
- Rework of the checksum verification procedure to enable RSE compatibility-aware third party copies in `conveyor.common`
- Rework of the checksum verification procedure in the`upload` method in `rse.rsemanager`
- Extension of `rse.protocols.gfal` protocol to return all the available checksums in the `stats` object

All the modifications were implemented keeping the standard Rucio behaviour, hence compatibility with previous setups should be complete.

PLEASE NOTE: some testing is still undergoing and merging is not yet safe nor recommended.
