### PR TITLE
Core & Internals: Declare strings passed to SQLAlchemy as text explicitly. Fix #2732

### DIFF
--- a/lib/rucio/core/account_counter.py
+++ b/lib/rucio/core/account_counter.py
@@ -128,9 +128,9 @@ def get_updated_account_counters(total_workers, worker_number, session=None):
                           bindparam('total_workers', total_workers)]
             query = query.filter(text('ORA_HASH(CONCAT(account, rse_id), :total_workers) = :worker_number', bindparams=bindparams))
         elif session.bind.dialect.name == 'mysql':
-            query = query.filter('mod(md5(concat(account, rse_id)), %s) = %s' % (total_workers + 1, worker_number))
+            query = query.filter(text('mod(md5(concat(account, rse_id)), %s) = %s' % (total_workers + 1, worker_number)))
         elif session.bind.dialect.name == 'postgresql':
-            query = query.filter('mod(abs((\'x\'||md5(concat(account, rse_id)))::bit(32)::int), %s) = %s' % (total_workers + 1, worker_number))
+            query = query.filter(text('mod(abs((\'x\'||md5(concat(account, rse_id)))::bit(32)::int), %s) = %s' % (total_workers + 1, worker_number)))
 
     return query.all()
 

--- a/lib/rucio/core/message.py
+++ b/lib/rucio/core/message.py
@@ -81,9 +81,9 @@ def retrieve_messages(bulk=1000, thread=None, total_threads=None, event_type=Non
                 bindparams = [bindparam('thread_number', thread), bindparam('total_threads', total_threads - 1)]
                 subquery = subquery.filter(text('ORA_HASH(id, :total_threads) = :thread_number', bindparams=bindparams))
             elif session.bind.dialect.name == 'mysql':
-                subquery = subquery.filter('mod(md5(id), %s) = %s' % (total_threads - 1, thread))
+                subquery = subquery.filter(text('mod(md5(id), %s) = %s' % (total_threads - 1, thread)))
             elif session.bind.dialect.name == 'postgresql':
-                subquery = subquery.filter('mod(abs((\'x\'||md5(id::text))::bit(32)::int), %s) = %s' % (total_threads - 1, thread))
+                subquery = subquery.filter(text('mod(abs((\'x\'||md5(id::text))::bit(32)::int), %s) = %s' % (total_threads - 1, thread)))
 
         if event_type:
             subquery = subquery.filter_by(event_type=event_type)

--- a/lib/rucio/core/rse_counter.py
+++ b/lib/rucio/core/rse_counter.py
@@ -112,9 +112,9 @@ def get_updated_rse_counters(total_workers, worker_number, session=None):
                           bindparam('total_workers', total_workers)]
             query = query.filter(text('ORA_HASH(rse_id, :total_workers) = :worker_number', bindparams=bindparams))
         elif session.bind.dialect.name == 'mysql':
-            query = query.filter('mod(md5(rse_id), %s) = %s' % (total_workers + 1, worker_number))
+            query = query.filter(text('mod(md5(rse_id), %s) = %s' % (total_workers + 1, worker_number)))
         elif session.bind.dialect.name == 'postgresql':
-            query = query.filter('mod(abs((\'x\'||md5(rse_id::text))::bit(32)::int), %s) = %s' % (total_workers + 1, worker_number))
+            query = query.filter(text('mod(abs((\'x\'||md5(rse_id::text))::bit(32)::int), %s) = %s' % (total_workers + 1, worker_number)))
 
     results = query.all()
     return [result.rse_id for result in results]


### PR DESCRIPTION
Core & Internals: Declare strings passed to SQLAlchemy as text explicitly. Fix #2732