### PR TITLE
Core & Internals: Adds internal types for account and scope, to be used as unique refs in core methods; Fix #2553

### DIFF
--- a/lib/rucio/api/account_limit.py
+++ b/lib/rucio/api/account_limit.py
@@ -15,6 +15,7 @@ import rucio.api.permission
 import rucio.common.exception
 
 from rucio.common.utils import api_update_return_dict
+from rucio.common.types import InternalAccount
 
 from rucio.core import account_limit as account_limit_core
 from rucio.core.account import account_exists
@@ -44,6 +45,8 @@ def get_account_limits(account):
     :returns: The account limits.
     """
 
+    account = InternalAccount(account)
+
     rse_instead_id = {}
     for elem in account_limit_core.get_account_limits(account=account).items():
         rse_instead_id[get_rse_name(rse_id=elem[0])] = elem[1]
@@ -61,6 +64,8 @@ def get_account_limit(account, rse):
 
     :returns: The account limit.
     """
+
+    account = InternalAccount(account)
 
     rse_id = get_rse_id(rse=rse)
     return {rse: account_limit_core.get_account_limit(account=account, rse_id=rse_id)}
@@ -80,6 +85,8 @@ def set_account_limit(account, rse, bytes, issuer):
     kwargs = {'account': account, 'rse': rse, 'rse_id': rse_id, 'bytes': bytes}
     if not rucio.api.permission.has_permission(issuer=issuer, action='set_account_limit', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not set account limits.' % (issuer))
+
+    account = InternalAccount(account)
 
     if not account_exists(account=account):
         raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (account))
@@ -102,6 +109,8 @@ def delete_account_limit(account, rse, issuer):
     kwargs = {'account': account, 'rse': rse, 'rse_id': rse_id}
     if not rucio.api.permission.has_permission(issuer=issuer, action='delete_account_limit', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not delete account limits.' % (issuer))
+
+    account = InternalAccount(account)
 
     if not account_exists(account=account):
         raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (account))
@@ -128,7 +137,9 @@ def get_account_usage(account, rse, issuer):
     if not rucio.api.permission.has_permission(issuer=issuer, action='get_account_usage', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not list account usage.' % (issuer))
 
+    account = InternalAccount(account)
+
     if not account_exists(account=account):
         raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (account))
 
-    return account_limit_core.get_account_usage(account=account, rse_id=rse_id)
+    return [api_update_return_dict(d) for d in account_limit_core.get_account_usage(account=account, rse_id=rse_id)]

--- a/lib/rucio/api/did.py
+++ b/lib/rucio/api/did.py
@@ -20,12 +20,16 @@
 
 from __future__ import print_function
 
+from copy import deepcopy
+
 import rucio.api.permission
 
 from rucio.core import did, naming_convention, meta as meta_core
 from rucio.core.rse import get_rse_id
 from rucio.common.constants import RESERVED_KEYS
 from rucio.common.schema import validate_schema
+from rucio.common.types import InternalAccount, InternalScope
+from rucio.common.utils import api_update_return_dict
 from rucio.db.sqla.constants import DIDType
 
 
@@ -43,8 +47,19 @@ def list_dids(scope, filters, type='collection', ignore_case=False, limit=None, 
     :param recursive: Recursively list DIDs content.
     """
     validate_schema(name='did_filters', obj=filters)
-    return did.list_dids(scope=scope, filters=filters, type=type, ignore_case=ignore_case,
-                         limit=limit, offset=offset, long=long, recursive=recursive)
+
+    scope = InternalScope(scope)
+
+    if 'account' in filters:
+        filters['account'] = InternalAccount(filters['account'])
+    if 'scope' in filters:
+        filters['scope'] = InternalScope(filters['scope'])
+
+    result = did.list_dids(scope=scope, filters=filters, type=type, ignore_case=ignore_case,
+                           limit=limit, offset=offset, long=long, recursive=recursive)
+
+    for d in result:
+        yield api_update_return_dict(d)
 
 
 def add_did(scope, name, type, issuer, account=None, statuses={}, meta={}, rules=[], lifetime=None, dids=[], rse=None):
@@ -71,6 +86,19 @@ def add_did(scope, name, type, issuer, account=None, statuses={}, meta={}, rules
     if not rucio.api.permission.has_permission(issuer=issuer, action='add_did', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not add data identifier to scope %s' % (issuer, scope))
 
+    if account is not None:
+        account = InternalAccount(account)
+    issuer = InternalAccount(issuer)
+    scope = InternalScope(scope)
+    for d in dids:
+        d['scope'] = InternalScope(d['scope'])
+    for r in rules:
+        r['account'] = InternalAccount(r['account'])
+
+    rse_id = None
+    if rse is not None:
+        rse_id = get_rse_id(rse=rse)
+
     if type == 'DATASET':
         # naming_convention validation
         extra_meta = naming_convention.validate_name(scope=scope, name=name, did_type='D')
@@ -85,10 +113,6 @@ def add_did(scope, name, type, issuer, account=None, statuses={}, meta={}, rules
 
         # Validate metadata
         meta_core.validate_meta(meta=meta, did_type=DIDType.from_sym(type))
-
-    rse_id = None
-    if rse is not None:
-        rse_id = get_rse_id(rse=rse)
 
     return did.add_did(scope=scope, name=name, type=DIDType.from_sym(type), account=account or issuer,
                        statuses=statuses, meta=meta, rules=rules, lifetime=lifetime,
@@ -113,6 +137,12 @@ def add_dids(dids, issuer):
     if not rucio.api.permission.has_permission(issuer=issuer, action='add_dids', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not bulk add data identifier' % (issuer))
 
+    issuer = InternalAccount(issuer)
+    for d in dids:
+        d['scope'] = InternalScope(d['scope'])
+        if 'dids' in d.keys():
+            for child in d['dids']:
+                child['scope'] = InternalScope(child['scope'])
     return did.add_dids(dids, account=issuer)
 
 
@@ -134,6 +164,13 @@ def attach_dids(scope, name, attachment, issuer):
     kwargs = {'scope': scope, 'name': name, 'attachment': attachment}
     if not rucio.api.permission.has_permission(issuer=issuer, action='attach_dids', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not add data identifiers to %s:%s' % (issuer, scope, name))
+
+    scope = InternalScope(scope)
+    issuer = InternalAccount(issuer)
+    if 'account' in attachment.keys():
+        attachment['account'] = InternalAccount(attachment['account'])
+    for d in attachment['dids']:
+        d['scope'] = InternalScope(d['scope'])
 
     if rse_id is not None:
         dids = did.attach_dids(scope=scope, name=name, dids=attachment['dids'],
@@ -165,6 +202,12 @@ def attach_dids_to_dids(attachments, issuer, ignore_duplicate=False):
     if not rucio.api.permission.has_permission(issuer=issuer, action='attach_dids_to_dids', kwargs={'attachments': attachments}):
         raise rucio.common.exception.AccessDenied('Account %s can not add data identifiers' % (issuer))
 
+    issuer = InternalAccount(issuer)
+    for attachment in attachments:
+        attachment['scope'] = InternalScope(attachment['scope'])
+        for d in attachment['dids']:
+            d['scope'] = InternalScope(d['scope'])
+
     return did.attach_dids_to_dids(attachments=attachments, account=issuer,
                                    ignore_duplicate=ignore_duplicate)
 
@@ -181,6 +224,11 @@ def detach_dids(scope, name, dids, issuer):
     kwargs = {'scope': scope, 'name': name, 'dids': dids, 'issuer': issuer}
     if not rucio.api.permission.has_permission(issuer=issuer, action='detach_dids', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not detach data identifiers from %s:%s' % (issuer, scope, name))
+
+    scope = InternalScope(scope)
+    for d in dids:
+        d['scope'] = InternalScope(d['scope'])
+
     return did.detach_dids(scope=scope, name=name, dids=dids)
 
 
@@ -190,7 +238,9 @@ def list_new_dids(type=None, thread=None, total_threads=None, chunk_size=1000):
 
     :param type : The DID type.
     """
-    return did.list_new_dids(did_type=type and DIDType.from_sym(type), thread=thread, total_threads=total_threads, chunk_size=chunk_size)
+    dids = did.list_new_dids(did_type=type and DIDType.from_sym(type), thread=thread, total_threads=total_threads, chunk_size=chunk_size)
+    for d in dids:
+        yield api_update_return_dict(d)
 
 
 def set_new_dids(dids, new_flag=True):
@@ -201,6 +251,9 @@ def set_new_dids(dids, new_flag=True):
     :param name: The data identifier name.
     :param new_flag: A boolean to flag new DIDs.
     """
+    for d in dids:
+        d['scope'] = InternalScope(d['scope'])
+
     return did.set_new_dids(dids, new_flag)
 
 
@@ -211,7 +264,12 @@ def list_content(scope, name):
     :param scope: The scope name.
     :param name: The data identifier name.
     """
-    return did.list_content(scope=scope, name=name)
+
+    scope = InternalScope(scope)
+
+    dids = did.list_content(scope=scope, name=name)
+    for d in dids:
+        yield api_update_return_dict(d)
 
 
 def list_content_history(scope, name):
@@ -221,7 +279,13 @@ def list_content_history(scope, name):
     :param scope: The scope name.
     :param name: The data identifier name.
     """
-    return did.list_content_history(scope=scope, name=name)
+
+    scope = InternalScope(scope)
+
+    dids = did.list_content_history(scope=scope, name=name)
+
+    for d in dids:
+        yield api_update_return_dict(d)
 
 
 def list_files(scope, name, long):
@@ -233,7 +297,12 @@ def list_files(scope, name, long):
     :param long:       A boolean to choose if GUID is returned or not.
     """
 
-    return did.list_files(scope=scope, name=name, long=long)
+    scope = InternalScope(scope)
+
+    dids = did.list_files(scope=scope, name=name, long=long)
+
+    for d in dids:
+        yield api_update_return_dict(d)
 
 
 def scope_list(scope, name=None, recursive=False):
@@ -245,7 +314,16 @@ def scope_list(scope, name=None, recursive=False):
     :param recursive: boolean, True or False.
     """
 
-    return did.scope_list(scope, name=name, recursive=recursive)
+    scope = InternalScope(scope)
+
+    dids = did.scope_list(scope, name=name, recursive=recursive)
+
+    for d in dids:
+        ret_did = deepcopy(d)
+        ret_did['scope'] = ret_did['scope'].external
+        if ret_did['parent'] is not None:
+            ret_did['parent']['scope'] = ret_did['parent']['scope'].external
+        yield ret_did
 
 
 def get_did(scope, name, dynamic=False):
@@ -257,7 +335,10 @@ def get_did(scope, name, dynamic=False):
     :return did: Dictionary containing {'name', 'scope', 'type'}, Exception otherwise
     """
 
-    return did.get_did(scope=scope, name=name, dynamic=dynamic)
+    scope = InternalScope(scope)
+
+    d = did.get_did(scope=scope, name=name, dynamic=dynamic)
+    return api_update_return_dict(d)
 
 
 def set_metadata(scope, name, key, value, issuer, recursive=False):
@@ -278,6 +359,8 @@ def set_metadata(scope, name, key, value, issuer, recursive=False):
 
     if not rucio.api.permission.has_permission(issuer=issuer, action='set_metadata', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not add metadata to data identifier %s:%s' % (issuer, scope, name))
+
+    scope = InternalScope(scope)
     return did.set_metadata(scope=scope, name=name, key=key, value=value, recursive=recursive)
 
 
@@ -288,7 +371,11 @@ def get_metadata(scope, name):
     :param scope: The scope name.
     :param name: The data identifier name.
     """
-    return did.get_metadata(scope=scope, name=name)
+
+    scope = InternalScope(scope)
+
+    d = did.get_metadata(scope=scope, name=name)
+    return api_update_return_dict(d)
 
 
 def get_did_meta(scope, name):
@@ -298,6 +385,8 @@ def get_did_meta(scope, name):
     :param scope: the scope of did
     :param name: the name of the did
     """
+
+    scope = InternalScope(scope)
     return did.get_did_meta(scope=scope, name=name)
 
 
@@ -309,6 +398,8 @@ def add_did_meta(scope, name, meta):
     :param name: the name of the did
     :param meta: the metadata to be added or updated
     """
+
+    scope = InternalScope(scope)
     return did.add_did_meta(scope=scope, name=name, meta=meta)
 
 
@@ -320,6 +411,8 @@ def delete_did_meta(scope, name, key):
     :param name: the name of the did
     :param key: the key to be deleted
     """
+
+    scope = InternalScope(scope)
     return did.delete_did_meta(scope=scope, name=name, key=key)
 
 
@@ -330,7 +423,9 @@ def list_dids_by_meta(scope, select):
     :param scope: the scope to search in(optional)
     :param select: the list of key value pairs to filter on
     """
-    return did.list_dids_by_meta(scope=scope, select=select)
+
+    scope = InternalScope(scope)
+    return [api_update_return_dict(d) for d in did.list_dids_by_meta(scope=scope, select=select)]
 
 
 def set_status(scope, name, issuer, **kwargs):
@@ -345,6 +440,9 @@ def set_status(scope, name, issuer, **kwargs):
 
     if not rucio.api.permission.has_permission(issuer=issuer, action='set_status', kwargs={'scope': scope, 'name': name, 'issuer': issuer}):
         raise rucio.common.exception.AccessDenied('Account %s can not set status on data identifier %s:%s' % (issuer, scope, name))
+
+    scope = InternalScope(scope)
+
     return did.set_status(scope=scope, name=name, **kwargs)
 
 
@@ -355,7 +453,10 @@ def get_dataset_by_guid(guid):
 
     :returns: A did
     """
-    return did.get_dataset_by_guid(guid=guid)
+    dids = did.get_dataset_by_guid(guid=guid)
+
+    for d in dids:
+        yield api_update_return_dict(d)
 
 
 def list_parent_dids(scope, name):
@@ -366,7 +467,12 @@ def list_parent_dids(scope, name):
     :param name:    The name.
     """
 
-    return did.list_parent_dids(scope=scope, name=name)
+    scope = InternalScope(scope)
+
+    dids = did.list_parent_dids(scope=scope, name=name)
+
+    for d in dids:
+        yield api_update_return_dict(d)
 
 
 def create_did_sample(input_scope, input_name, output_scope, output_name, issuer, nbfiles):
@@ -384,6 +490,12 @@ def create_did_sample(input_scope, input_name, output_scope, output_name, issuer
     kwargs = {'issuer': issuer, 'scope': output_scope}
     if not rucio.api.permission.has_permission(issuer=issuer, action='create_did_sample', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not bulk add data identifier' % (issuer))
+
+    input_scope = InternalScope(input_scope)
+    output_scope = InternalScope(output_scope)
+
+    issuer = InternalAccount(issuer)
+
     return did.create_did_sample(input_scope=input_scope, input_name=input_name, output_scope=output_scope, output_name=output_name, account=issuer, nbfiles=nbfiles)
 
 
@@ -398,6 +510,10 @@ def resurrect(dids, issuer):
     if not rucio.api.permission.has_permission(issuer=issuer, action='resurrect', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not resurrect data identifiers' % (issuer))
     validate_schema(name='dids', obj=dids)
+
+    for d in dids:
+        d['scope'] = InternalScope(d['scope'])
+
     return did.resurrect(dids=dids)
 
 
@@ -408,4 +524,9 @@ def list_archive_content(scope, name):
     :param scope: The archive scope name.
     :param name: The archive data identifier name.
     """
-    return did.list_archive_content(scope=scope, name=name)
+
+    scope = InternalScope(scope)
+
+    dids = did.list_archive_content(scope=scope, name=name)
+    for d in dids:
+        yield api_update_return_dict(d)

--- a/lib/rucio/api/lifetime_exception.py
+++ b/lib/rucio/api/lifetime_exception.py
@@ -8,6 +8,7 @@
 
   Authors:
   - Cedric Serfon, <cedric.serfon@cern.ch>, 2016-2017
+  - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 
   PY3K COMPATIBLE
 '''
@@ -15,6 +16,8 @@
 from rucio.api import permission
 from rucio.core import lifetime_exception
 from rucio.common import exception
+from rucio.common.types import InternalAccount, InternalScope
+from rucio.common.utils import api_update_return_dict
 
 
 def list_exceptions(exception_id=None, states=None):
@@ -25,7 +28,9 @@ def list_exceptions(exception_id=None, states=None):
     :param states:     The states to filter
     """
 
-    return lifetime_exception.list_exceptions(exception_id=exception_id, states=states)
+    exceptions = lifetime_exception.list_exceptions(exception_id=exception_id, states=states)
+    for e in exceptions:
+        yield api_update_return_dict(e)
 
 
 def add_exception(dids, account, pattern, comments, expires_at):
@@ -40,6 +45,10 @@ def add_exception(dids, account, pattern, comments, expires_at):
 
     returns:            The id of the exception.
     """
+
+    account = InternalAccount(account)
+    for d in dids:
+        d['scope'] = InternalScope(d['scope'])
     return lifetime_exception.add_exception(dids=dids, account=account, pattern=pattern, comments=comments, expires_at=expires_at)
 
 

--- a/lib/rucio/api/lock.py
+++ b/lib/rucio/api/lock.py
@@ -6,9 +6,12 @@
 #
 # Authors:
 # - Martin Barisits, <martin.barisits@cern.ch>, 2014
+# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 #
 # PY3K COMPATIBLE
 
+from rucio.common.types import InternalScope
+from rucio.common.utils import api_update_return_dict
 from rucio.core import lock
 from rucio.core.rse import get_rse_id
 
@@ -22,7 +25,12 @@ def get_dataset_locks(scope, name):
     :return:               List of dicts {'rse_id': ..., 'state': ...}
     """
 
-    return lock.get_dataset_locks(scope=scope, name=name)
+    scope = InternalScope(scope)
+
+    locks = lock.get_dataset_locks(scope=scope, name=name)
+
+    for l in locks:
+        yield api_update_return_dict(l)
 
 
 def get_dataset_locks_by_rse(rse):
@@ -34,7 +42,10 @@ def get_dataset_locks_by_rse(rse):
     """
 
     rse_id = get_rse_id(rse=rse)
-    return lock.get_dataset_locks_by_rse_id(rse_id=rse_id)
+    locks = lock.get_dataset_locks_by_rse_id(rse_id=rse_id)
+
+    for l in locks:
+        yield api_update_return_dict(l)
 
 
 def get_replica_locks_for_rule_id(rule_id):
@@ -45,4 +56,7 @@ def get_replica_locks_for_rule_id(rule_id):
     :return:            List of dicts.
     """
 
-    return lock.get_replica_locks_for_rule_id(rule_id=rule_id)
+    locks = lock.get_replica_locks_for_rule_id(rule_id=rule_id)
+
+    for l in locks:
+        yield api_update_return_dict(l)

--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -280,6 +280,10 @@ def get_rse_usage(rse, issuer, source=None, per_account=False):
     rse_id = rse_module.get_rse_id(rse=rse)
     usages = rse_module.get_rse_usage(rse_id=rse_id, source=source, per_account=per_account)
 
+    for u in usages:
+        if 'account_usages' in u:
+            for account_usage in u['account_usages']:
+                account_usage['account'] = account_usage['account'].external
     return [api_update_return_dict(u) for u in usages]
 
 

--- a/lib/rucio/api/scope.py
+++ b/lib/rucio/api/scope.py
@@ -8,6 +8,7 @@
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2012-2013
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2012
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2012
+# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 #
 # PY3K COMPATIBLE
 
@@ -15,6 +16,7 @@ import rucio.api.permission
 import rucio.common.exception
 
 from rucio.core import scope as core_scope
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.schema import validate_schema
 
 
@@ -24,7 +26,7 @@ def list_scopes():
 
     :returns: A list containing all scopes.
     """
-    return core_scope.list_scopes()
+    return [scope.external for scope in core_scope.list_scopes()]
 
 
 def add_scope(scope, account, issuer):
@@ -42,6 +44,9 @@ def add_scope(scope, account, issuer):
     if not rucio.api.permission.has_permission(issuer=issuer, action='add_scope', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not add scope' % (issuer))
 
+    scope = InternalScope(scope)
+    account = InternalAccount(account)
+
     core_scope.add_scope(scope, account)
 
 
@@ -53,4 +58,7 @@ def get_scopes(account):
 
     :returns: A list containing the names of all scopes for this account.
     """
-    return core_scope.get_scopes(account)
+
+    account = InternalAccount(account)
+
+    return [scope.external for scope in core_scope.get_scopes(account)]

--- a/lib/rucio/api/temporary_did.py
+++ b/lib/rucio/api/temporary_did.py
@@ -13,6 +13,7 @@
   PY3K COMPATIBLE
 '''
 
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.core import temporary_did
 from rucio.core.rse import get_rse_id
 
@@ -30,5 +31,10 @@ def add_temporary_dids(dids, issuer):
             if did['rse'] is not None:
                 rse_id = get_rse_id(rse=did['rse'])
             did['rse_id'] = rse_id
+        if 'scope' in did:
+            did['scope'] = InternalScope(did['scope'])
+        if 'parent_scope' in did:
+            did['parent_scope'] = InternalScope(did['parent_scope'])
 
+    issuer = InternalAccount(issuer)
     return temporary_did.add_temporary_dids(dids=dids, account=issuer)

--- a/lib/rucio/common/types.py
+++ b/lib/rucio/common/types.py
@@ -1,0 +1,83 @@
+# Copyright 2012-2019 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+#
+# PY3K COMPATIBLE
+
+from six import string_types
+
+
+class InternalType(object):
+    '''
+    Base for Internal representations of string types
+    '''
+    def __init__(self, value, fromExternal=True):
+        if value is None:
+            self.external = None
+            self.internal = None
+        elif not isinstance(value, string_types):
+            raise TypeError('Expected string type, got %s' % type(value))
+        elif fromExternal:
+            self.external = value
+            self.internal = self._calc_internal()
+        else:
+            self.internal = value
+            external = self._calc_external()
+            self.external = external
+
+    def __repr__(self):
+        return self.internal
+
+    def __str__(self):
+        return self.external
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.internal == other.internal
+        return NotImplemented
+
+    def __ne__(self, other):
+        val = self == other
+        if val is NotImplemented:
+            return NotImplemented
+        return not val
+
+    def __hash__(self):
+        return hash(self.internal)
+
+    def _calc_external(self):
+        ''' Utility to convert between internal and external representations'''
+        return self.internal
+
+    def _calc_internal(self):
+        ''' Utility to convert between internal and external representations'''
+        return self.external
+
+
+class InternalAccount(InternalType):
+    '''
+    Internal representation of an account
+    '''
+    def __init__(self, value, fromExternal=True):
+        super(InternalAccount, self).__init__(value=value, fromExternal=fromExternal)
+
+
+class InternalScope(InternalType):
+    '''
+    Internal representation of a scope
+    '''
+    def __init__(self, value, fromExternal=True):
+        super(InternalScope, self).__init__(value=value, fromExternal=fromExternal)

--- a/lib/rucio/core/lifetime_exception.py
+++ b/lib/rucio/core/lifetime_exception.py
@@ -184,11 +184,11 @@ def define_eol(scope, name, rses, session=None):
         return None
     policy_dict = rucio.common.policy.get_lifetime_policy()
     did_type = 'other'
-    if scope.startswith('mc'):
+    if scope.external.startswith('mc'):
         did_type = 'mc'
-    elif scope.startswith('data'):
+    elif scope.external.startswith('data'):
         did_type = 'data'
-    elif scope.startswith('valid'):
+    elif scope.external.startswith('valid'):
         did_type = 'valid'
     else:
         did_type = 'other'

--- a/lib/rucio/core/naming_convention.py
+++ b/lib/rucio/core/naming_convention.py
@@ -89,7 +89,7 @@ def delete_naming_convention(scope, regexp, convention_type, session=None):
     :param convention_type: the did_type on which the regexp should apply.
     :param session: The database session in use.
     """
-    REGION.delete(str(scope))
+    REGION.delete(scope.internal)
     return session.query(models.NamingConvention.regexp).\
         filter(models.NamingConvention.scope == scope).\
         filter(models.NamingConvention.convention_type == convention_type).\
@@ -123,18 +123,18 @@ def validate_name(scope, name, did_type, session=None):
 
     :returns: a dictionary with metadata.
     """
-    if scope.startswith('user'):
+    if scope.external.startswith('user'):
         return {'project': 'user'}
-    elif scope.startswith('group'):
+    elif scope.external.startswith('group'):
         return {'project': 'group'}
 
     # Check if naming convention can be found in cache region
-    regexp = REGION.get(str(scope))
+    regexp = REGION.get(scope.internal)
     if regexp is NO_VALUE:  # no cached entry found
         regexp = get_naming_convention(scope=scope,
                                        convention_type=KeyType.DATASET,
                                        session=session)
-        regexp and REGION.set(str(scope), regexp)
+        regexp and REGION.set(scope.internal, regexp)
 
     if not regexp:
         return

--- a/lib/rucio/core/permission/atlas.py
+++ b/lib/rucio/core/permission/atlas.py
@@ -114,6 +114,10 @@ def has_permission(issuer, action, kwargs):
     return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs)
 
 
+def _is_root(issuer):
+    return issuer.external == 'root'
+
+
 def perm_default(issuer, kwargs):
     """
     Default permission.
@@ -122,7 +126,7 @@ def perm_default(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_add_rse(issuer, kwargs):
@@ -133,7 +137,7 @@ def perm_add_rse(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_update_rse(issuer, kwargs):
@@ -144,7 +148,7 @@ def perm_update_rse(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_add_rule(issuer, kwargs):
@@ -157,7 +161,7 @@ def perm_add_rule(issuer, kwargs):
     """
     if kwargs['account'] == issuer and not kwargs['locked']:
         return True
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
 
     return False
@@ -171,7 +175,7 @@ def perm_add_subscription(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
 
     return False
@@ -185,7 +189,7 @@ def perm_add_rse_attribute(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     if kwargs['key'] in ['rule_deleters', 'auto_approve_bytes', 'auto_approve_files', 'rule_approvers', 'default_account_limit_bytes', 'default_limit_files', 'block_manual_approve']:
         # Check if user is a country admin
@@ -207,7 +211,7 @@ def perm_del_rse_attribute(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     if kwargs['key'] in ['rule_deleters', 'auto_approve_bytes', 'auto_approve_files', 'rule_approvers', 'default_account_limit_bytes', 'default_limit_files', 'block_manual_approve']:
         # Check if user is a country admin
@@ -229,7 +233,7 @@ def perm_del_rse(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_add_account(issuer, kwargs):
@@ -240,7 +244,7 @@ def perm_add_account(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_del_account(issuer, kwargs):
@@ -251,7 +255,7 @@ def perm_del_account(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_update_account(issuer, kwargs):
@@ -262,7 +266,7 @@ def perm_update_account(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_add_scope(issuer, kwargs):
@@ -273,7 +277,7 @@ def perm_add_scope(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or issuer == kwargs.get('account')
+    return _is_root(issuer) or issuer == kwargs.get('account')
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs):
@@ -324,7 +328,7 @@ def perm_add_account_identity(issuer, kwargs):
     :returns: True if account is allowed, otherwise False
     """
 
-    return issuer == 'root' or issuer == kwargs.get('account')
+    return _is_root(issuer) or issuer == kwargs.get('account')
 
 
 def perm_del_account_identity(issuer, kwargs):
@@ -336,7 +340,7 @@ def perm_del_account_identity(issuer, kwargs):
     :returns: True if account is allowed, otherwise False
     """
 
-    return issuer == 'root' or issuer == kwargs.get('account')
+    return _is_root(issuer) or issuer == kwargs.get('account')
 
 
 def perm_del_identity(issuer, kwargs):
@@ -348,7 +352,7 @@ def perm_del_identity(issuer, kwargs):
     :returns: True if account is allowed, otherwise False
     """
 
-    return issuer == 'root' or issuer in kwargs.get('accounts')
+    return _is_root(issuer) or issuer in kwargs.get('accounts')
 
 
 def perm_add_did(issuer, kwargs):
@@ -365,7 +369,7 @@ def perm_add_did(issuer, kwargs):
             if rule['account'] != issuer:
                 return False
 
-    return issuer == 'root'\
+    return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin')\
         or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
         or kwargs['scope'] == u'mock'
@@ -386,7 +390,7 @@ def perm_add_dids(issuer, kwargs):
                 if rule['account'] != issuer:
                     return False
 
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_attach_dids(issuer, kwargs):
@@ -397,7 +401,7 @@ def perm_attach_dids(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'\
+    return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin')\
         or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
         or kwargs['scope'] == 'mock'
@@ -411,7 +415,7 @@ def perm_attach_dids_to_dids(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     attachments = kwargs['attachments']
     scopes = [did['scope'] for did in attachments]
@@ -430,7 +434,7 @@ def perm_create_did_sample(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'\
+    return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin')\
         or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
         or kwargs['scope'] == 'mock'
@@ -444,7 +448,7 @@ def perm_del_rule(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or issuer == 'ddmadmin':
+    if _is_root(issuer) or issuer == 'ddmadmin':
         return True
     if get_rule(kwargs['rule_id'])['account'] == issuer:
         return True
@@ -481,7 +485,7 @@ def perm_update_rule(issuer, kwargs):
     :returns: True if account is allowed to call the API call, otherwise False
     """
     # Admin accounts can do everything
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
 
     # Only admin accounts can change account, state, priority of a rule
@@ -525,7 +529,7 @@ def perm_move_rule(issuer, kwargs):
     :returns:        True if account is allowed to call the API call, otherwise False
     """
     # Admin accounts can do everything
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
 
     # Country admins are allowed to change the but need to be admin for the original, as well as future rule
@@ -566,7 +570,7 @@ def perm_approve_rule(issuer, kwargs):
     :returns: True if account is allowed to call the API call, otherwise False
     """
     # Admin accounts can do everything
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
 
     rule = get_rule(rule_id=kwargs['rule_id'])
@@ -614,7 +618,7 @@ def perm_reduce_rule(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -627,7 +631,7 @@ def perm_update_subscription(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
 
     return False
@@ -652,7 +656,7 @@ def perm_set_metadata(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    cond = issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    cond = _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
     if kwargs['scope'] != 'archive':
         return cond or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
     meta = rucio.core.did.get_metadata(scope=kwargs['scope'], name=kwargs['name'])
@@ -670,7 +674,7 @@ def perm_set_status(issuer, kwargs):
     if kwargs.get('open', False):
         if issuer != 'root' and not has_account_attribute(account=issuer, key='admin'):
             return False
-    cond = (issuer == 'root' or has_account_attribute(account=issuer, key='admin'))
+    cond = (_is_root(issuer) or has_account_attribute(account=issuer, key='admin'))
     if kwargs['scope'] != 'archive':
         return cond or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
     meta = rucio.core.did.get_metadata(scope=kwargs['scope'], name=kwargs['name'])
@@ -685,7 +689,7 @@ def perm_add_protocol(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_del_protocol(issuer, kwargs):
@@ -696,7 +700,7 @@ def perm_del_protocol(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_update_protocol(issuer, kwargs):
@@ -707,7 +711,7 @@ def perm_update_protocol(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_declare_bad_file_replicas(issuer, kwargs):
@@ -719,7 +723,7 @@ def perm_declare_bad_file_replicas(issuer, kwargs):
     :returns: True if account is allowed, otherwise False
     """
     is_cloud_admin = bool([acc_attr for acc_attr in list_account_attributes(account=issuer) if (acc_attr['key'].startswith('cloud-')) and (acc_attr['value'] == 'admin')])
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin') or is_cloud_admin
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or is_cloud_admin
 
 
 def perm_declare_suspicious_file_replicas(issuer, kwargs):
@@ -757,7 +761,7 @@ def perm_add_replicas(issuer, kwargs):
                 return True
 
     return rse_attr.get('type', '') in ['SCRATCHDISK', 'MOCK', 'TEST']\
-        or issuer == 'root'\
+        or _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin')
 
 
@@ -769,7 +773,7 @@ def perm_skip_availability_check(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_delete_replicas(issuer, kwargs):
@@ -807,7 +811,7 @@ def perm_update_replicas_states(issuer, kwargs):
                 return True
 
     return rse_attr.get('type', '') in ['SCRATCHDISK', 'MOCK', 'TEST']\
-        or issuer == 'root'\
+        or _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin')
 
 
@@ -819,7 +823,7 @@ def perm_queue_requests(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_query_request(issuer, kwargs):
@@ -830,7 +834,7 @@ def perm_query_request(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_get_request_by_did(issuer, kwargs):
@@ -852,7 +856,7 @@ def perm_cancel_request(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_get_next(issuer, kwargs):
@@ -863,7 +867,7 @@ def perm_get_next(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_set_rse_usage(issuer, kwargs):
@@ -874,7 +878,7 @@ def perm_set_rse_usage(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_set_rse_limits(issuer, kwargs):
@@ -885,7 +889,7 @@ def perm_set_rse_limits(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_set_account_limit(issuer, kwargs):
@@ -896,7 +900,7 @@ def perm_set_account_limit(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     # Check if user is a country admin
     admin_in_country = []
@@ -916,7 +920,7 @@ def perm_delete_account_limit(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     # Check if user is a country admin
     admin_in_country = []
@@ -936,7 +940,7 @@ def perm_config(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_get_account_usage(issuer, kwargs):
@@ -958,7 +962,7 @@ def perm_add_account_attribute(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_del_account_attribute(issuer, kwargs):
@@ -980,7 +984,7 @@ def perm_list_heartbeats(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_resurrect(issuer, kwargs):
@@ -991,7 +995,7 @@ def perm_resurrect(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_update_lifetime_exceptions(issuer, kwargs):
@@ -1001,7 +1005,7 @@ def perm_update_lifetime_exceptions(issuer, kwargs):
     :param issuer: Account identifier which issues the command.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_get_ssh_challenge_token(issuer, kwargs):
@@ -1021,7 +1025,7 @@ def perm_get_signed_url(issuer, kwargs):
     :param issuer: Account identifier which issues the command.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='sign-gcs')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='sign-gcs')
 
 
 def perm_add_bad_pfns(issuer, kwargs):
@@ -1034,7 +1038,7 @@ def perm_add_bad_pfns(issuer, kwargs):
     """
     if kwargs['state'] in [str(BadPFNStatus.BAD), str(BadPFNStatus.TEMPORARY_UNAVAILABLE)]:
         is_cloud_admin = bool([acc_attr for acc_attr in list_account_attributes(account=issuer) if (acc_attr['key'].startswith('cloud-')) and (acc_attr['value'] == 'admin')])
-        return issuer == 'root' or has_account_attribute(account=issuer, key='admin') or is_cloud_admin
+        return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or is_cloud_admin
     elif kwargs['state'] == str(BadPFNStatus.SUSPICIOUS):
         return True
-    return issuer == 'root'
+    return _is_root(issuer)

--- a/lib/rucio/core/permission/cms.py
+++ b/lib/rucio/core/permission/cms.py
@@ -105,6 +105,10 @@ def has_permission(issuer, action, kwargs):
     return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs)
 
 
+def _is_root(issuer):
+    return issuer.external == 'root'
+
+
 def perm_default(issuer, kwargs):
     """
     Default permission.
@@ -113,7 +117,7 @@ def perm_default(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_add_rse(issuer, kwargs):
@@ -124,7 +128,7 @@ def perm_add_rse(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_update_rse(issuer, kwargs):
@@ -135,7 +139,7 @@ def perm_update_rse(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_add_rule(issuer, kwargs):
@@ -148,7 +152,7 @@ def perm_add_rule(issuer, kwargs):
     """
     if kwargs['account'] == issuer and not kwargs['locked']:
         return True
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -161,7 +165,7 @@ def perm_add_subscription(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -174,7 +178,7 @@ def perm_add_rse_attribute(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -187,7 +191,7 @@ def perm_del_rse_attribute(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -200,7 +204,7 @@ def perm_del_rse(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_add_account(issuer, kwargs):
@@ -211,7 +215,7 @@ def perm_add_account(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_del_account(issuer, kwargs):
@@ -222,7 +226,7 @@ def perm_del_account(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_update_account(issuer, kwargs):
@@ -233,7 +237,7 @@ def perm_update_account(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_add_scope(issuer, kwargs):
@@ -244,7 +248,7 @@ def perm_add_scope(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or issuer == kwargs.get('account')
+    return _is_root(issuer) or issuer == kwargs.get('account')
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs):
@@ -298,7 +302,7 @@ def perm_add_account_identity(issuer, kwargs):
     :returns: True if account is allowed, otherwise False
     """
 
-    return issuer == 'root' or issuer == kwargs.get('account')
+    return _is_root(issuer) or issuer == kwargs.get('account')
 
 
 def perm_del_account_identity(issuer, kwargs):
@@ -310,7 +314,7 @@ def perm_del_account_identity(issuer, kwargs):
     :returns: True if account is allowed, otherwise False
     """
 
-    return issuer == 'root' or issuer == kwargs.get('account')
+    return _is_root(issuer) or issuer == kwargs.get('account')
 
 
 def perm_del_identity(issuer, kwargs):
@@ -322,7 +326,7 @@ def perm_del_identity(issuer, kwargs):
     :returns: True if account is allowed, otherwise False
     """
 
-    return issuer == 'root' or issuer in kwargs.get('accounts')
+    return _is_root(issuer) or issuer in kwargs.get('accounts')
 
 
 def perm_add_did(issuer, kwargs):
@@ -339,7 +343,7 @@ def perm_add_did(issuer, kwargs):
             if rule['account'] != issuer:
                 return False
 
-    return (issuer == 'root' or
+    return (_is_root(issuer) or
             has_account_attribute(account=issuer, key='admin') or
             rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer) or
             kwargs['scope'] == u'mock')
@@ -360,7 +364,7 @@ def perm_add_dids(issuer, kwargs):
                 if rule['account'] != issuer:
                     return False
 
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_attach_dids(issuer, kwargs):
@@ -371,7 +375,7 @@ def perm_attach_dids(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return (issuer == 'root' or
+    return (_is_root(issuer) or
             has_account_attribute(account=issuer, key='admin') or
             rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer) or
             kwargs['scope'] == 'mock')
@@ -385,7 +389,7 @@ def perm_attach_dids_to_dids(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     else:
         attachments = kwargs['attachments']
@@ -419,7 +423,7 @@ def perm_del_rule(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     if get_rule(kwargs['rule_id'])['account'] == issuer:
         return True
@@ -435,7 +439,7 @@ def perm_update_rule(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -448,7 +452,7 @@ def perm_approve_rule(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -461,7 +465,7 @@ def perm_reduce_rule(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -474,7 +478,7 @@ def perm_move_rule(issuer, kwargs):
     :param kwargs:   List of arguments for the action.
     :returns:        True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -487,7 +491,7 @@ def perm_update_subscription(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
 
     return False
@@ -512,7 +516,7 @@ def perm_set_metadata(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return (issuer == 'root' or has_account_attribute(account=issuer, key='admin') or
+    return (_is_root(issuer) or has_account_attribute(account=issuer, key='admin') or
             rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer))
 
 
@@ -528,7 +532,7 @@ def perm_set_status(issuer, kwargs):
         if issuer != 'root' and not has_account_attribute(account=issuer, key='admin'):
             return False
 
-    return (issuer == 'root' or has_account_attribute(account=issuer, key='admin') or
+    return (_is_root(issuer) or has_account_attribute(account=issuer, key='admin') or
             rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer))
 
 
@@ -540,7 +544,7 @@ def perm_add_protocol(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_del_protocol(issuer, kwargs):
@@ -551,7 +555,7 @@ def perm_del_protocol(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_update_protocol(issuer, kwargs):
@@ -562,7 +566,7 @@ def perm_update_protocol(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_declare_bad_file_replicas(issuer, kwargs):
@@ -575,7 +579,7 @@ def perm_declare_bad_file_replicas(issuer, kwargs):
     """
     is_cloud_admin = bool(list(filter(lambda x: (x['key'].startswith('cloud-')) and (x['value'] == 'admin'),
                                       list_account_attributes(account=issuer))))
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin') or is_cloud_admin
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or is_cloud_admin
 
 
 def perm_declare_suspicious_file_replicas(issuer, kwargs):
@@ -597,7 +601,7 @@ def perm_add_replicas(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return (issuer == 'root' or
+    return (_is_root(issuer) or
             str(kwargs.get('rse', '')).endswith('SCRATCHDISK') or
             str(kwargs.get('rse', '')).endswith('USERDISK') or
             str(kwargs.get('rse', '')).endswith('MOCK') or
@@ -613,7 +617,7 @@ def perm_skip_availability_check(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_delete_replicas(issuer, kwargs):
@@ -627,7 +631,7 @@ def perm_delete_replicas(issuer, kwargs):
 
     # FIXME: Remove after the transition is over?
 
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_update_replicas_states(issuer, kwargs):
@@ -638,7 +642,7 @@ def perm_update_replicas_states(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_queue_requests(issuer, kwargs):
@@ -649,7 +653,7 @@ def perm_queue_requests(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_query_request(issuer, kwargs):
@@ -660,7 +664,7 @@ def perm_query_request(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_get_request_by_did(issuer, kwargs):
@@ -682,7 +686,7 @@ def perm_cancel_request(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_get_next(issuer, kwargs):
@@ -693,7 +697,7 @@ def perm_get_next(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_set_rse_usage(issuer, kwargs):
@@ -704,7 +708,7 @@ def perm_set_rse_usage(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_set_rse_limits(issuer, kwargs):
@@ -715,7 +719,7 @@ def perm_set_rse_limits(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_set_account_limit(issuer, kwargs):
@@ -726,7 +730,7 @@ def perm_set_account_limit(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     # Check if user is a country admin
     admin_in_country = []
@@ -746,7 +750,7 @@ def perm_delete_account_limit(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     # Check if user is a country admin
     admin_in_country = []
@@ -766,7 +770,7 @@ def perm_config(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_get_account_usage(issuer, kwargs):
@@ -777,7 +781,7 @@ def perm_get_account_usage(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
         return True
     # Check if user is a country admin
     for kv in list_account_attributes(account=issuer):
@@ -794,7 +798,7 @@ def perm_add_account_attribute(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_del_account_attribute(issuer, kwargs):
@@ -816,7 +820,7 @@ def perm_list_heartbeats(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_resurrect(issuer, kwargs):
@@ -827,7 +831,7 @@ def perm_resurrect(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_update_lifetime_exceptions(issuer, kwargs):
@@ -838,7 +842,7 @@ def perm_update_lifetime_exceptions(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_get_ssh_challenge_token(issuer, kwargs):
@@ -859,7 +863,7 @@ def perm_get_signed_url(issuer, kwargs):
     :param issuer: Account identifier which issues the command.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_add_bad_pfns(issuer, kwargs):
@@ -870,4 +874,4 @@ def perm_add_bad_pfns(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -111,6 +111,10 @@ def has_permission(issuer, action, kwargs):
     return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs)
 
 
+def _is_root(issuer):
+    return issuer.external == 'root'
+
+
 def perm_default(issuer, kwargs):
     """
     Default permission.
@@ -119,7 +123,7 @@ def perm_default(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_add_rse(issuer, kwargs):
@@ -130,7 +134,7 @@ def perm_add_rse(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_update_rse(issuer, kwargs):
@@ -141,7 +145,7 @@ def perm_update_rse(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_add_rule(issuer, kwargs):
@@ -154,7 +158,7 @@ def perm_add_rule(issuer, kwargs):
     """
     if kwargs['account'] == issuer and not kwargs['locked']:
         return True
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -167,7 +171,7 @@ def perm_add_subscription(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -180,7 +184,7 @@ def perm_add_rse_attribute(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -193,7 +197,7 @@ def perm_del_rse_attribute(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -206,7 +210,7 @@ def perm_del_rse(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_add_account(issuer, kwargs):
@@ -217,7 +221,7 @@ def perm_add_account(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_del_account(issuer, kwargs):
@@ -228,7 +232,7 @@ def perm_del_account(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_update_account(issuer, kwargs):
@@ -239,7 +243,7 @@ def perm_update_account(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_add_scope(issuer, kwargs):
@@ -250,7 +254,7 @@ def perm_add_scope(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or issuer == kwargs.get('account')
+    return _is_root(issuer) or issuer == kwargs.get('account')
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs):
@@ -301,7 +305,7 @@ def perm_add_account_identity(issuer, kwargs):
     :returns: True if account is allowed, otherwise False
     """
 
-    return issuer == 'root' or issuer == kwargs.get('account')
+    return _is_root(issuer) or issuer == kwargs.get('account')
 
 
 def perm_del_account_identity(issuer, kwargs):
@@ -313,7 +317,7 @@ def perm_del_account_identity(issuer, kwargs):
     :returns: True if account is allowed, otherwise False
     """
 
-    return issuer == 'root' or issuer == kwargs.get('account')
+    return _is_root(issuer) or issuer == kwargs.get('account')
 
 
 def perm_del_identity(issuer, kwargs):
@@ -325,7 +329,7 @@ def perm_del_identity(issuer, kwargs):
     :returns: True if account is allowed, otherwise False
     """
 
-    return issuer == 'root' or issuer in kwargs.get('accounts')
+    return _is_root(issuer) or issuer in kwargs.get('accounts')
 
 
 def perm_add_did(issuer, kwargs):
@@ -342,7 +346,7 @@ def perm_add_did(issuer, kwargs):
             if rule['account'] != issuer:
                 return False
 
-    return issuer == 'root'\
+    return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin')\
         or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
         or kwargs['scope'] == u'mock'
@@ -363,7 +367,7 @@ def perm_add_dids(issuer, kwargs):
                 if rule['account'] != issuer:
                     return False
 
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_attach_dids(issuer, kwargs):
@@ -374,7 +378,7 @@ def perm_attach_dids(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'\
+    return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin')\
         or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
         or kwargs['scope'] == 'mock'
@@ -388,7 +392,7 @@ def perm_attach_dids_to_dids(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     else:
         attachments = kwargs['attachments']
@@ -408,7 +412,7 @@ def perm_create_did_sample(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'\
+    return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin')\
         or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
         or kwargs['scope'] == 'mock'
@@ -422,7 +426,7 @@ def perm_del_rule(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -435,7 +439,7 @@ def perm_update_rule(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -448,7 +452,7 @@ def perm_approve_rule(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -461,7 +465,7 @@ def perm_reduce_rule(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -474,7 +478,7 @@ def perm_move_rule(issuer, kwargs):
     :param kwargs:   List of arguments for the action.
     :returns:        True if account is allowed to call the API call, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     return False
 
@@ -487,7 +491,7 @@ def perm_update_subscription(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
 
     return False
@@ -512,7 +516,7 @@ def perm_set_metadata(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
 
 
 def perm_set_status(issuer, kwargs):
@@ -527,7 +531,7 @@ def perm_set_status(issuer, kwargs):
         if issuer != 'root' and not has_account_attribute(account=issuer, key='admin'):
             return False
 
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
 
 
 def perm_add_protocol(issuer, kwargs):
@@ -538,7 +542,7 @@ def perm_add_protocol(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_del_protocol(issuer, kwargs):
@@ -549,7 +553,7 @@ def perm_del_protocol(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_update_protocol(issuer, kwargs):
@@ -560,7 +564,7 @@ def perm_update_protocol(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_declare_bad_file_replicas(issuer, kwargs):
@@ -571,7 +575,7 @@ def perm_declare_bad_file_replicas(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_declare_suspicious_file_replicas(issuer, kwargs):
@@ -597,7 +601,7 @@ def perm_add_replicas(issuer, kwargs):
         or str(kwargs.get('rse', '')).endswith('USERDISK')\
         or str(kwargs.get('rse', '')).endswith('MOCK')\
         or str(kwargs.get('rse', '')).endswith('LOCALGROUPDISK')\
-        or issuer == 'root'\
+        or _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin')
 
 
@@ -609,7 +613,7 @@ def perm_skip_availability_check(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_delete_replicas(issuer, kwargs):
@@ -631,7 +635,7 @@ def perm_update_replicas_states(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_queue_requests(issuer, kwargs):
@@ -642,7 +646,7 @@ def perm_queue_requests(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_query_request(issuer, kwargs):
@@ -653,7 +657,7 @@ def perm_query_request(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_get_request_by_did(issuer, kwargs):
@@ -675,7 +679,7 @@ def perm_cancel_request(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_get_next(issuer, kwargs):
@@ -686,7 +690,7 @@ def perm_get_next(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_set_rse_usage(issuer, kwargs):
@@ -697,7 +701,7 @@ def perm_set_rse_usage(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_set_rse_limits(issuer, kwargs):
@@ -708,7 +712,7 @@ def perm_set_rse_limits(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_set_account_limit(issuer, kwargs):
@@ -719,7 +723,7 @@ def perm_set_account_limit(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     # Check if user is a country admin
     admin_in_country = []
@@ -739,7 +743,7 @@ def perm_delete_account_limit(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
         return True
     # Check if user is a country admin
     admin_in_country = []
@@ -759,7 +763,7 @@ def perm_config(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_get_account_usage(issuer, kwargs):
@@ -770,7 +774,7 @@ def perm_get_account_usage(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    if issuer == 'root' or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
         return True
     # Check if user is a country admin
     for kv in list_account_attributes(account=issuer):
@@ -787,7 +791,7 @@ def perm_add_account_attribute(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_del_account_attribute(issuer, kwargs):
@@ -809,7 +813,7 @@ def perm_list_heartbeats(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_resurrect(issuer, kwargs):
@@ -820,7 +824,7 @@ def perm_resurrect(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_update_lifetime_exceptions(issuer, kwargs):
@@ -830,7 +834,7 @@ def perm_update_lifetime_exceptions(issuer, kwargs):
     :param issuer: Account identifier which issues the command.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root' or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_get_ssh_challenge_token(issuer, kwargs):
@@ -850,7 +854,7 @@ def perm_get_signed_url(issuer, kwargs):
     :param issuer: Account identifier which issues the command.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)
 
 
 def perm_add_bad_pfns(issuer, kwargs):
@@ -861,4 +865,4 @@ def perm_add_bad_pfns(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed, otherwise False
     """
-    return issuer == 'root'
+    return _is_root(issuer)

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -62,6 +62,7 @@ from rucio.common.exception import (InvalidRSEExpression, InvalidReplicationRule
                                     InvalidObject, RSEBlacklisted, RuleReplaceFailed, RequestNotFound,
                                     ManualRuleApprovalBlocked, UnsupportedOperation, UndefinedPolicy)
 from rucio.common.schema import validate_schema
+from rucio.common.types import InternalScope
 from rucio.common.utils import str_to_date, sizefmt
 from rucio.core import account_counter, rse_counter, request as request_core
 from rucio.core.account import get_account
@@ -1776,10 +1777,10 @@ def update_rules_for_lost_replica(scope, name, rse_id, nowait=False, session=Non
     for dts in datasets:
         logging.info('File %s:%s bad at site %s is completely lost from dataset %s:%s. Will be marked as LOST and detached', scope, name, rse, dts['scope'], dts['name'])
         rucio.core.did.detach_dids(scope=dts['scope'], name=dts['name'], dids=[{'scope': scope, 'name': name}], session=session)
-        add_message('LOST', {'scope': scope,
+        add_message('LOST', {'scope': scope.external,
                              'name': name,
                              'dataset_name': dts['name'],
-                             'dataset_scope': dts['scope']},
+                             'dataset_scope': dts['scope'].external},
                     session=session)
 
 
@@ -1875,7 +1876,7 @@ def generate_rule_notifications(rule, replicating_locks_before=None, session=Non
         # RULE_OK RULE_PROGRESS NOTIFICATIONS:
         if rule.notification == RuleNotification.YES:
             add_message(event_type='RULE_OK',
-                        payload={'scope': rule.scope,
+                        payload={'scope': rule.scope.external,
                                  'name': rule.name,
                                  'rule_id': rule.id},
                         session=session)
@@ -1884,13 +1885,13 @@ def generate_rule_notifications(rule, replicating_locks_before=None, session=Non
                 did = rucio.core.did.get_did(scope=rule.scope, name=rule.name, session=session)
                 if not did['open']:
                     add_message(event_type='RULE_OK',
-                                payload={'scope': rule.scope,
+                                payload={'scope': rule.scope.external,
                                          'name': rule.name,
                                          'rule_id': rule.id},
                                 session=session)
                     if rule.notification == RuleNotification.PROGRESS:
                         add_message(event_type='RULE_PROGRESS',
-                                    payload={'scope': rule.scope,
+                                    payload={'scope': rule.scope.external,
                                              'name': rule.name,
                                              'rule_id': rule.id,
                                              'progress': __progress_class(rule.locks_replicating_cnt, total_locks)},
@@ -1906,7 +1907,7 @@ def generate_rule_notifications(rule, replicating_locks_before=None, session=Non
                 dataset_locks = session.query(models.DatasetLock).filter_by(rule_id=rule.id).all()
                 for dataset_lock in dataset_locks:
                     add_message(event_type='DATASETLOCK_OK',
-                                payload={'scope': dataset_lock.scope,
+                                payload={'scope': dataset_lock.scope.external,
                                          'name': dataset_lock.name,
                                          'rse': get_rse_name(rse_id=dataset_lock.rse_id, session=session),
                                          'rse_id': dataset_lock.rse_id,
@@ -1922,7 +1923,7 @@ def generate_rule_notifications(rule, replicating_locks_before=None, session=Non
                                 return
                             if did['length'] * rule.copies == rule.locks_ok_cnt:
                                 add_message(event_type='DATASETLOCK_OK',
-                                            payload={'scope': dataset_lock.scope,
+                                            payload={'scope': dataset_lock.scope.external,
                                                      'name': dataset_lock.name,
                                                      'rse': get_rse_name(rse_id=dataset_lock.rse_id, session=session),
                                                      'rse_id': dataset_lock.rse_id,
@@ -1938,7 +1939,7 @@ def generate_rule_notifications(rule, replicating_locks_before=None, session=Non
                 did = rucio.core.did.get_did(scope=rule.scope, name=rule.name, session=session)
                 if not did['open']:
                     add_message(event_type='RULE_PROGRESS',
-                                payload={'scope': rule.scope,
+                                payload={'scope': rule.scope.external,
                                          'name': rule.name,
                                          'rule_id': rule.id,
                                          'progress': __progress_class(rule.locks_replicating_cnt, total_locks)},
@@ -1969,7 +1970,7 @@ def generate_email_for_rule_ok_notification(rule, session=None):
                                                  'expires_at': str(rule.expires_at),
                                                  'rse_expression': rule.rse_expression,
                                                  'comment': rule.comments,
-                                                 'scope': rule.scope,
+                                                 'scope': rule.scope.external,
                                                  'name': rule.name,
                                                  'did_type': rule.did_type})
                 add_message(event_type='email',
@@ -2042,7 +2043,7 @@ def approve_rule(rule_id, approver=None, notify_approvers=True, session=None):
                                                      'expires_at': str(rule.expires_at),
                                                      'rse_expression': rule.rse_expression,
                                                      'comment': rule.comments,
-                                                     'scope': rule.scope,
+                                                     'scope': rule.scope.external,
                                                      'name': rule.name,
                                                      'did_type': rule.did_type,
                                                      'approver': approver})
@@ -2098,7 +2099,7 @@ def deny_rule(rule_id, approver=None, reason=None, session=None):
                 text = template.safe_substitute({'rule_id': str(rule.id),
                                                  'rse_expression': rule.rse_expression,
                                                  'comment': rule.comments,
-                                                 'scope': rule.scope,
+                                                 'scope': rule.scope.external,
                                                  'name': rule.name,
                                                  'did_type': rule.did_type,
                                                  'approver': approver,
@@ -2961,11 +2962,11 @@ def __create_rule_approval_email(rule, session=None):
         text = template.safe_substitute({'rule_id': str(rule.id),
                                          'created_at': str(rule.created_at),
                                          'expires_at': str(rule.expires_at),
-                                         'account': rule.account,
+                                         'account': rule.account.external,
                                          'email': get_account(account=rule.account, session=session).email,
                                          'rse_expression': rule.rse_expression,
                                          'comment': rule.comments,
-                                         'scope': rule.scope,
+                                         'scope': rule.scope.external,
                                          'name': rule.name,
                                          'did_type': rule.did_type,
                                          'length': '0' if did['length'] is None else str(did['length']),
@@ -3073,9 +3074,10 @@ def archive_localgroupdisk_datasets(scope, name, session=None):
 
     rses_to_rebalance = []
 
+    archive = InternalScope('archive')
     # Check if the archival dataset already exists
     try:
-        rucio.core.did.get_did(scope='archive', name=name, session=session)
+        rucio.core.did.get_did(scope=archive, name=name, session=session)
         return
     except DataIdentifierNotFound:
         pass
@@ -3095,7 +3097,7 @@ def archive_localgroupdisk_datasets(scope, name, session=None):
             did = rucio.core.did.get_did(scope=scope, name=name, session=session)
             meta = rucio.core.did.get_metadata(scope=scope, name=name, session=session)
             new_meta = {k: v for k, v in meta.items() if k in ['project', 'datatype', 'run_number', 'stream_name', 'prod_step', 'version', 'campaign', 'task_id', 'panda_id'] and v is not None}
-            rucio.core.did.add_did(scope='archive',
+            rucio.core.did.add_did(scope=archive,
                                    name=name,
                                    type=DIDType.DATASET,
                                    account=did['account'],
@@ -3106,12 +3108,12 @@ def archive_localgroupdisk_datasets(scope, name, session=None):
                                    dids=[],
                                    rse_id=None,
                                    session=session)
-            rucio.core.did.attach_dids(scope='archive', name=name, dids=content, account=did['account'], session=session)
+            rucio.core.did.attach_dids(scope=archive, name=name, dids=content, account=did['account'], session=session)
             if not did['open']:
                 rucio.core.did.set_status(scope='archive', name=name, open=False, session=session)
 
             for rse in rses_to_rebalance:
-                add_rule(dids=[{'scope': 'archive', 'name': name}],
+                add_rule(dids=[{'scope': archive, 'name': name}],
                          account=rse['account'],
                          copies=1,
                          rse_expression=rse['rse'],

--- a/lib/rucio/core/subscription.py
+++ b/lib/rucio/core/subscription.py
@@ -19,6 +19,7 @@
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2013-2019
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2014
 # - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018
+# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 #
 # PY3K COMPATIBLE
 
@@ -238,7 +239,8 @@ def list_subscription_rule_states(name=None, account=None, session=None):
     """
     subscription = aliased(models.Subscription)
     rule = aliased(models.ReplicationRule)
-    query = session.query(subscription.account, subscription.name, rule.state, func.count()).join(rule, subscription.id == rule.subscription_id)
+    # count needs a label to allow conversion to dict (label name can be changed)
+    query = session.query(subscription.account, subscription.name, rule.state, func.count().label('count')).join(rule, subscription.id == rule.subscription_id)
 
     try:
         if name:

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -169,7 +169,7 @@ def set_transfers_state(transfers, submitted_at, session=None):
             request_type = transfers[request_id].get('request_type', None)
             msg = {'request-id': request_id,
                    'request-type': str(request_type).lower() if request_type else request_type,
-                   'scope': transfers[request_id]['scope'],
+                   'scope': transfers[request_id]['scope'].external,
                    'name': transfers[request_id]['name'],
                    'src-rse-id': transfers[request_id]['metadata'].get('src_rse_id', None),
                    'src-rse': transfers[request_id]['metadata'].get('src_rse', None),

--- a/lib/rucio/daemons/auditor/__init__.py
+++ b/lib/rucio/daemons/auditor/__init__.py
@@ -43,6 +43,7 @@ from rucio.common.dumper import LogPipeHandler
 from rucio.common.dumper import mkdir
 from rucio.common.dumper import temp_file
 from rucio.common.dumper.consistency import Consistency
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.quarantined_replica import add_quarantined_replicas
 from rucio.core.replica import declare_bad_file_replicas, list_replicas
 from rucio.core.rse import get_rse_usage, get_rse_id
@@ -152,10 +153,10 @@ def process_output(output, sanity_check=True, compress=True):
                 scope, name = guess_replica_info(path)
                 if label == 'DARK':
                     dark_replicas.append({'path': path,
-                                          'scope': scope,
+                                          'scope': InternalScope(scope),
                                           'name': name})
                 elif label == 'LOST':
-                    lost_replicas.append({'scope': scope,
+                    lost_replicas.append({'scope': InternalScope(scope),
                                           'name': name})
                 else:
                     raise ValueError('unexpected label')
@@ -194,7 +195,7 @@ def process_output(output, sanity_check=True, compress=True):
     logger.debug('Processed %d DARK files from "%s"', len(dark_replicas),
                  output)
     declare_bad_file_replicas(lost_pfns, reason='Reported by Auditor',
-                              issuer='root', status=BadFilesStatus.SUSPICIOUS)
+                              issuer=InternalAccount('root'), status=BadFilesStatus.SUSPICIOUS)
     logger.debug('Processed %d LOST files from "%s"', len(lost_replicas),
                  output)
 

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space.py
@@ -58,8 +58,8 @@ class PlacementAlgorithm:
 
     def place(self, did):
         self.__update_penalties()
-        decision = {'did': ':'.join(did)}
-        if (not did[0].startswith('data')) and (not did[0].startswith('mc')):
+        decision = {'did': '{}:{}'.format(did[0].internal, did[1])}
+        if (not did[0].external.startswith('data')) and (not did[0].external.startswith('mc')):
             decision['error_reason'] = 'not a data or mc dataset'
             return decision
 

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop.py
@@ -58,12 +58,12 @@ class PlacementAlgorithm:
 
     def place(self, did):
         self.__update_penalties()
-        decision = {'did': ':'.join(did)}
-        if (self._added_cache.check_dataset(':'.join(did))):
+        decision = {'did': '{}:{}'.format(did[0].internal, did[1])}
+        if (self._added_cache.check_dataset(decision['did'])):
             decision['error_reason'] = 'already added replica for this did in the last 24h'
             return decision
 
-        if (not did[0].startswith('data')) and (not did[0].startswith('mc')):
+        if (not did[0].external.startswith('data')) and (not did[0].external.startswith('mc')):
             decision['error_reason'] = 'not a data or mc dataset'
             return decision
 
@@ -123,6 +123,6 @@ class PlacementAlgorithm:
         decision['rse_ratios'] = sorted_rses
         self._penalties[sorted_rses[0][0]] = 10.0
 
-        self._added_cache.add_dataset(':'.join(did))
+        self._added_cache.add_dataset(decision['did'])
 
         return decision

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
@@ -88,12 +88,12 @@ class PlacementAlgorithm:
                 self._src_penalties[rse_id] += 10.0
 
     def check_did(self, did):
-        decision = {'did': ':'.join(did)}
-        if (self._added_cache.check_dataset(':'.join(did))):
+        decision = {'did': '{}:{}'.format(did[0].internal, did[1])}
+        if (self._added_cache.check_dataset(decision['did'])):
             decision['error_reason'] = 'already added replica for this did in the last 24h'
             return decision
 
-        if (not did[0].startswith('data')) and (not did[0].startswith('mc')):
+        if (not did[0].external.startswith('data')) and (not did[0].external.startswith('mc')):
             decision['error_reason'] = 'not a data or mc dataset'
             return decision
 
@@ -165,8 +165,8 @@ class PlacementAlgorithm:
         space_info = self._fsc.get_rse_space()
         max_mbps = 0.0
         for rep in reps:
-            rse_attr = list_rse_attributes(rep['id'])
-            src_rse_id = rep['id']
+            rse_attr = list_rse_attributes(rep['rse_id'])
+            src_rse_id = rep['rse_id']
             if 'site' not in rse_attr:
                 continue
 
@@ -269,7 +269,7 @@ class PlacementAlgorithm:
         self._dst_penalties[destination_rse] = 10.0
         self._src_penalties[source_rse] = 10.0
 
-        self._added_cache.add_dataset(':'.join(did))
+        self._added_cache.add_dataset(decision['did'])
 
         self._added_bytes.add_point(destination_rse, meta['bytes'])
         self._added_files.add_point(destination_rse, meta['length'])

--- a/lib/rucio/daemons/c3po/utils/dataset_cache.py
+++ b/lib/rucio/daemons/c3po/utils/dataset_cache.py
@@ -7,6 +7,7 @@
 #
 # Authors:
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2016
+# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 #
 # PY3K COMPATIBLE
 
@@ -27,11 +28,11 @@ class DatasetCache(object):
             self._tms.delete_keys()
 
     def add_did(self, did):
-        self._tms.add_point('_'.join(did), 1)
+        self._tms.add_point('{}_{}'.format(did[0].internal, did[1]), 1)
 
     def get_did(self, did):
         self._tms.trim()
 
-        series = self._tms.get_series('_'.join(did))
+        series = self._tms.get_series('{}_{}'.format(did[0].internal, did[1]))
 
         return len(series)

--- a/lib/rucio/daemons/c3po/utils/popularity.py
+++ b/lib/rucio/daemons/c3po/utils/popularity.py
@@ -8,6 +8,7 @@
 # Authors:
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2016-2017
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2017
+# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 #
 # PY3K COMPATIBLE
 
@@ -58,7 +59,7 @@ def get_popularity(did):
         "size": 0
     }
 
-    query['query']['bool']['must'].append({"term": {"scope": did[0]}})
+    query['query']['bool']['must'].append({"term": {"scope": did[0].external}})
     query['query']['bool']['must'].append({"term": {"name": did[1]}})
 
     logging.debug(query)

--- a/lib/rucio/daemons/cache/consumer.py
+++ b/lib/rucio/daemons/cache/consumer.py
@@ -38,6 +38,7 @@ import json
 import stomp
 
 from rucio.common.config import config_get, config_get_int
+from rucio.common.types import InternalScope
 from rucio.core.monitor import record_counter
 from rucio.core.volatile_replica import add_volatile_replicas, delete_volatile_replicas
 from rucio.core.rse import get_rse_id
@@ -83,6 +84,8 @@ class Consumer(object):
         try:
             msg = json.loads(message)
             if isinstance(msg, dict) and 'operation' in msg.keys():
+                for f in msg['files']:
+                    f['scope'] = InternalScope(f['scope'])
                 if 'rse_id' in msg:
                     rse_id = msg['rse_id']
                 else:

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -23,6 +23,7 @@
 # - Brian Bockelman <bbockelm@cse.unl.edu>, 2018
 # - Eric Vaandering <ericvaandering@gmail.com>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 #
 # PY3K COMPATIBLE
 
@@ -270,6 +271,7 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
 
         external_host = transfer['external_host']
         scope = t_file['metadata']['scope']
+        scope_str = scope.internal
         activity = t_file['activity']
 
         if external_host not in grouped_transfers:
@@ -278,9 +280,9 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                 grouped_jobs[external_host] = []
             elif activity in USER_ACTIVITY:
                 grouped_jobs[external_host] = {}
-                if scope not in grouped_transfers[external_host]:
-                    grouped_transfers[external_host][scope] = {}
-                    grouped_jobs[external_host][scope] = []
+                if scope_str not in grouped_transfers[external_host]:
+                    grouped_transfers[external_host][scope_str] = {}
+                    grouped_jobs[external_host][scope_str] = []
 
         job_params = {'verify_checksum': verify_checksum,
                       'copy_pin_lifetime': transfer['copy_pin_lifetime'] if transfer['copy_pin_lifetime'] else -1,
@@ -308,7 +310,7 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
             if USER_TRANSFERS not in ['cms'] or activity not in USER_ACTIVITY:
                 grouped_jobs[external_host].append({'files': [t_file], 'job_params': job_params})
             elif activity in USER_ACTIVITY:
-                grouped_jobs[external_host][scope].append({'files': [t_file], 'job_params': job_params})
+                grouped_jobs[external_host][scope_str].append({'files': [t_file], 'job_params': job_params})
         else:
             job_params['job_metadata']['multi_sources'] = False
             job_key = '%s,%s,%s,%s,%s,%s,%s,%s' % (job_params['verify_checksum'], job_params.get('spacetoken', None),
@@ -323,7 +325,7 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                 if USER_TRANSFERS not in ['cms'] or activity not in USER_ACTIVITY:
                     grouped_transfers[external_host][job_key] = {}
                 elif activity in USER_ACTIVITY:
-                    grouped_transfers[external_host][scope][job_key] = {}
+                    grouped_transfers[external_host][scope_str][job_key] = {}
 
             if policy == 'rule':
                 policy_key = '%s' % (transfer['rule_id'])
@@ -347,10 +349,10 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                 else:
                     grouped_transfers[external_host][job_key][policy_key]['files'].append(t_file)
             elif activity in USER_ACTIVITY:
-                if policy_key not in grouped_transfers[external_host][scope][job_key]:
-                    grouped_transfers[external_host][scope][job_key][policy_key] = {'files': [t_file], 'job_params': job_params}
+                if policy_key not in grouped_transfers[external_host][scope_str][job_key]:
+                    grouped_transfers[external_host][scope_str][job_key][policy_key] = {'files': [t_file], 'job_params': job_params}
                 else:
-                    grouped_transfers[external_host][scope][job_key][policy_key]['files'].append(t_file)
+                    grouped_transfers[external_host][scope_str][job_key][policy_key]['files'].append(t_file)
 
     # for jobs with different job_key, we cannot put in one job.
     for external_host in grouped_transfers:

--- a/lib/rucio/daemons/mock/conveyorinjector.py
+++ b/lib/rucio/daemons/mock/conveyorinjector.py
@@ -37,6 +37,7 @@ import traceback
 import requests
 
 from rucio.common.config import config_get, config_get_int
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core import account_limit, did, rse, replica, rule
 from rucio.db.sqla.constants import DIDType
@@ -84,7 +85,7 @@ def generate_rse(endpoint, token):
     rse.add_protocol(rse_id=rse_id, parameter=tmp_proto)
     rse.add_rse_attribute(rse_id=rse_id, key='fts', value='https://fts3-pilot.cern.ch:8446')
 
-    account_limit.set_account_limit(account='root', rse_id=rsemanager.get_rse_info(rse_name)['id'], bytes=-1)
+    account_limit.set_account_limit(account=InternalAccount('root'), rse_id=rsemanager.get_rse_info(rse_name)['id'], bytes=-1)
 
     return rsemanager.get_rse_info(rse_name)
 
@@ -120,11 +121,13 @@ def request_transfer(loop=1, src=None, dst=None,
             tmp_name = generate_uuid()
 
             # add a new dataset
-            did.add_did(scope='mock', name='dataset-%s' % tmp_name,
-                        type=DIDType.DATASET, account='root', session=session)
+            scope = InternalScope('mock')
+            account = InternalAccount('root')
+            did.add_did(scope=scope, name='dataset-%s' % tmp_name,
+                        type=DIDType.DATASET, account=account, session=session)
 
             # construct PFN
-            pfn = rsemanager.lfns2pfns(src_rse, lfns=[{'scope': 'mock', 'name': 'file-%s' % tmp_name}])['mock:file-%s' % tmp_name]
+            pfn = rsemanager.lfns2pfns(src_rse, lfns=[{'scope': scope.external, 'name': 'file-%s' % tmp_name}])['%s:file-%s' % (scope.external, tmp_name)]
 
             if upload:
                 # create the directories if needed
@@ -142,26 +145,26 @@ def request_transfer(loop=1, src=None, dst=None,
                     p.put(fn, pfn, source_dir=fp)
                 except:
                     logging.critical('Could not upload, removing temporary DID: %s' % str(sys.exc_info()))
-                    did.delete_dids([{'scope': 'mock', 'name': 'dataset-%s' % tmp_name}], account='root', session=session)
+                    did.delete_dids([{'scope': scope, 'name': 'dataset-%s' % tmp_name}], account=account, session=session)
                     break
 
             # add the replica
-            replica.add_replica(rse_id=src_rse['id'], scope='mock', name='file-%s' % tmp_name,
+            replica.add_replica(rse_id=src_rse['id'], scope=scope, name='file-%s' % tmp_name,
                                 bytes=config_get_int('injector', 'bytes'),
                                 adler32=config_get('injector', 'adler32'),
                                 md5=config_get('injector', 'md5'),
-                                account='root', session=session)
+                                account=account, session=session)
             logging.info('added replica on %s for DID mock:%s' % (src_rse['rse'], tmp_name))
 
             # to the dataset
-            did.attach_dids(scope='mock', name='dataset-%s' % tmp_name, dids=[{'scope': 'mock',
-                                                                               'name': 'file-%s' % tmp_name,
-                                                                               'bytes': config_get('injector', 'bytes')}],
-                            account='root', session=session)
+            did.attach_dids(scope=scope, name='dataset-%s' % tmp_name, dids=[{'scope': scope,
+                                                                              'name': 'file-%s' % tmp_name,
+                                                                              'bytes': config_get('injector', 'bytes')}],
+                            account=account, session=session)
 
             # add rule for the dataset
-            rule.add_rule(dids=[{'scope': 'mock', 'name': 'dataset-%s' % tmp_name}],
-                          account='root',
+            rule.add_rule(dids=[{'scope': scope, 'name': 'dataset-%s' % tmp_name}],
+                          account=account,
                           copies=1,
                           rse_expression=dst_rse['rse'],
                           grouping='ALL',
@@ -171,7 +174,7 @@ def request_transfer(loop=1, src=None, dst=None,
                           subscription_id=None,
                           activity='mock-injector',
                           session=session)
-            logging.info('added rule for %s for DID mock:%s' % (dst_rse['rse'], tmp_name))
+            logging.info('added rule for %s for DID %s:%s' % (dst_rse['rse'], scope, tmp_name))
 
             session.commit()
         except:

--- a/lib/rucio/daemons/mock/os_injector.py
+++ b/lib/rucio/daemons/mock/os_injector.py
@@ -31,6 +31,7 @@ import time
 import traceback
 
 from rucio.common.config import config_get
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.core import rse as rse_core
 from rucio.core.heartbeat import live, die, sanity_check
 from rucio.core.temporary_did import (add_temporary_dids, get_count_of_expired_temporary_dids)
@@ -68,7 +69,7 @@ def inject(rse, older_than):
                 for key in prot.list():
                     d = dateutil.parser.parse(key.last_modified)
                     if d < older_than_time:
-                        did = {'scope': 'transient',
+                        did = {'scope': InternalScope('transient'),
                                'name': key.name.encode('utf-8'),
                                'rse': rse,
                                'rse_id': rse_id,
@@ -76,7 +77,7 @@ def inject(rse, older_than):
                                'created_at': d}
                         dids.append(did)
                         if len(dids) == 1000:
-                            add_temporary_dids(dids=dids, account='root')
+                            add_temporary_dids(dids=dids, account=InternalAccount('root'))
                             logging.info('Adding 1000 dids to temp dids.')
                             dids = []
                     else:

--- a/lib/rucio/daemons/reaper/dark_reaper.py
+++ b/lib/rucio/daemons/reaper/dark_reaper.py
@@ -103,14 +103,14 @@ def reaper(rses=[], worker_number=1, total_workers=1, chunk_size=100, once=False
                         nothing_to_do = False
                         try:
                             pfn = str(rsemgr.lfns2pfns(rse_settings=rse_info,
-                                                       lfns=[{'scope': replica['scope'], 'name': replica['name'], 'path': replica['path']}],
+                                                       lfns=[{'scope': replica['scope'].external, 'name': replica['name'], 'path': replica['path']}],
                                                        operation='delete', scheme=scheme).values()[0])
                             logging.info('Dark Reaper %s-%s: Deletion ATTEMPT of %s:%s as %s on %s', worker_number, total_workers, replica['scope'], replica['name'], pfn, rse)
                             start = time.time()
                             prot.delete(pfn)
                             duration = time.time() - start
                             logging.info('Dark Reaper %s-%s: Deletion SUCCESS of %s:%s as %s on %s in %s seconds', worker_number, total_workers, replica['scope'], replica['name'], pfn, rse, duration)
-                            add_message('deletion-done', {'scope': replica['scope'],
+                            add_message('deletion-done', {'scope': replica['scope'].external,
                                                           'name': replica['name'],
                                                           'rse': rse,
                                                           'rse_id': rse_id,
@@ -127,7 +127,7 @@ def reaper(rses=[], worker_number=1, total_workers=1, chunk_size=100, once=False
                         except (ServiceUnavailable, RSEAccessDenied, ResourceTemporaryUnavailable) as error:
                             err_msg = 'Dark Reaper %s-%s: Deletion NOACCESS of %s:%s as %s on %s: %s' % (worker_number, total_workers, replica['scope'], replica['name'], pfn, rse, str(error))
                             logging.warning(err_msg)
-                            add_message('deletion-failed', {'scope': replica['scope'],
+                            add_message('deletion-failed', {'scope': replica['scope'].external,
                                                             'name': replica['name'],
                                                             'rse': rse,
                                                             'rse_id': rse_id,

--- a/lib/rucio/daemons/reaper/light_reaper.py
+++ b/lib/rucio/daemons/reaper/light_reaper.py
@@ -100,7 +100,7 @@ def reaper(rses=[], worker_number=1, total_workers=1, chunk_size=100, once=False
                         nothing_to_do = False
                         try:
                             # pfn = str(rsemgr.lfns2pfns(rse_settings=rse_info,
-                            #                            lfns=[{'scope': replica['scope'], 'name': replica['name'], 'path': replica['path']}],
+                            #                            lfns=[{'scope': replica['scope'].external, 'name': replica['name'], 'path': replica['path']}],
                             #                            operation='delete', scheme=scheme).values()[0])
                             pfn = 's3://%s%s%s' % (prot.attributes['hostname'], prot.attributes['prefix'], replica['name'])
                             # logging.debug('Light Reaper %s-%s: Deletion ATTEMPT of %s:%s as %s on %s', worker_number, total_workers, replica['scope'], replica['name'], pfn, rse)
@@ -108,7 +108,7 @@ def reaper(rses=[], worker_number=1, total_workers=1, chunk_size=100, once=False
                             prot.delete(pfn)
                             duration = time.time() - start
                             logging.info('Light Reaper %s-%s: Deletion SUCCESS of %s:%s as %s on %s in %s seconds', worker_number, total_workers, replica['scope'], replica['name'], pfn, rse, duration)
-                            add_message('deletion-done', {'scope': replica['scope'],
+                            add_message('deletion-done', {'scope': replica['scope'].external,
                                                           'name': replica['name'],
                                                           'rse': rse,
                                                           'rse_id': rse_id,
@@ -125,7 +125,7 @@ def reaper(rses=[], worker_number=1, total_workers=1, chunk_size=100, once=False
                         except (ServiceUnavailable, RSEAccessDenied, ResourceTemporaryUnavailable) as error:
                             err_msg = 'Light Reaper %s-%s: Deletion NOACCESS of %s:%s as %s on %s: %s' % (worker_number, total_workers, replica['scope'], replica['name'], pfn, rse, str(error))
                             logging.warning(err_msg)
-                            add_message('deletion-failed', {'scope': replica['scope'],
+                            add_message('deletion-failed', {'scope': replica['scope'].external,
                                                             'name': replica['name'],
                                                             'rse': rse,
                                                             'rse_id': rse_id,

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -228,7 +228,7 @@ def reaper(rses, worker_number=1, child_number=1, total_children=1, chunk_size=1
                             for replica in files:
                                 try:
                                     replica['pfn'] = str(rsemgr.lfns2pfns(rse_settings=rse_info,
-                                                                          lfns=[{'scope': replica['scope'], 'name': replica['name'], 'path': replica['path']}],
+                                                                          lfns=[{'scope': replica['scope'].external, 'name': replica['name'], 'path': replica['path']}],
                                                                           operation='delete', scheme=scheme).values()[0])
                                 except (ReplicaUnAvailable, ReplicaNotFound) as error:
                                     err_msg = 'Failed to get pfn UNAVAILABLE replica %s:%s on %s with error %s' % (replica['scope'], replica['name'], rse['rse'], str(error))
@@ -261,7 +261,7 @@ def reaper(rses, worker_number=1, child_number=1, total_children=1, chunk_size=1
 
                                         deleted_files.append({'scope': replica['scope'], 'name': replica['name']})
 
-                                        add_message('deletion-done', {'scope': replica['scope'],
+                                        add_message('deletion-done', {'scope': replica['scope'].external,
                                                                       'name': replica['name'],
                                                                       'rse': rse_info['rse'],
                                                                       'rse_id': rse_info['id'],
@@ -276,7 +276,7 @@ def reaper(rses, worker_number=1, child_number=1, total_children=1, chunk_size=1
                                         logging.warning(err_msg)
                                         deleted_files.append({'scope': replica['scope'], 'name': replica['name']})
                                         if replica['state'] == ReplicaState.AVAILABLE:
-                                            add_message('deletion-failed', {'scope': replica['scope'],
+                                            add_message('deletion-failed', {'scope': replica['scope'].external,
                                                                             'name': replica['name'],
                                                                             'rse': rse_info['rse'],
                                                                             'rse_id': rse_info['id'],
@@ -287,7 +287,7 @@ def reaper(rses, worker_number=1, child_number=1, total_children=1, chunk_size=1
                                                                             'protocol': prot.attributes['scheme']})
                                     except (ServiceUnavailable, RSEAccessDenied, ResourceTemporaryUnavailable) as error:
                                         logging.warning('Reaper %s-%s: Deletion NOACCESS of %s:%s as %s on %s: %s', worker_number, child_number, replica['scope'], replica['name'], replica['pfn'], rse['rse'], str(error))
-                                        add_message('deletion-failed', {'scope': replica['scope'],
+                                        add_message('deletion-failed', {'scope': replica['scope'].external,
                                                                         'name': replica['name'],
                                                                         'rse': rse_info['rse'],
                                                                         'rse_id': rse_info['id'],
@@ -298,7 +298,7 @@ def reaper(rses, worker_number=1, child_number=1, total_children=1, chunk_size=1
                                                                         'protocol': prot.attributes['scheme']})
                                     except Exception as error:
                                         logging.critical('Reaper %s-%s: Deletion CRITICAL of %s:%s as %s on %s: %s', worker_number, child_number, replica['scope'], replica['name'], replica['pfn'], rse['rse'], str(traceback.format_exc()))
-                                        add_message('deletion-failed', {'scope': replica['scope'],
+                                        add_message('deletion-failed', {'scope': replica['scope'].external,
                                                                         'name': replica['name'],
                                                                         'rse': rse_info['rse'],
                                                                         'rse_id': rse_info['id'],
@@ -312,7 +312,7 @@ def reaper(rses, worker_number=1, child_number=1, total_children=1, chunk_size=1
                             except (ServiceUnavailable, RSEAccessDenied, ResourceTemporaryUnavailable) as error:
                                 for replica in files:
                                     logging.warning('Reaper %s-%s: Deletion NOACCESS of %s:%s as %s on %s: %s', worker_number, child_number, replica['scope'], replica['name'], replica['pfn'], rse['rse'], str(error))
-                                    add_message('deletion-failed', {'scope': replica['scope'],
+                                    add_message('deletion-failed', {'scope': replica['scope'].external,
                                                                     'name': replica['name'],
                                                                     'rse': rse_info['rse'],
                                                                     'rse_id': rse_info['id'],

--- a/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
+++ b/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
@@ -16,6 +16,7 @@
 # Authors:
 #  - Cedric Serfon, <cedric.serfon@cern.ch>, 2018
 #  - Jaroslav Guenther, <jaroslav.guenther@cern.ch>, 2019
+#  - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 # PY3K COMPATIBLE
 
 """
@@ -46,6 +47,7 @@ from rucio.db.sqla.constants import BadFilesStatus
 from rucio.db.sqla.util import get_db_time
 from rucio.common.config import config_get
 from rucio.common.exception import DatabaseException
+from rucio.common.types import InternalAccount
 
 
 logging.basicConfig(stream=stdout,
@@ -166,7 +168,7 @@ def declare_suspicious_replicas_bad(once=False, younger_than=3, nattempts=10, rs
                     if len(surls_to_recover[rse_id]) > max_replicas_per_rse:
                         logging.warning('replica_recoverer[%i/%i]: encountered more than %i suspicious replicas (%s) on %s. Please investigate.', worker_number, total_workers, max_replicas_per_rse, str(len(surls_to_recover[rse_id])), rse)
                     else:
-                        declare_bad_file_replicas(pfns=surls_to_recover[rse_id], reason='Suspicious. Automatic recovery.', issuer='root', status=BadFilesStatus.BAD, session=None)
+                        declare_bad_file_replicas(pfns=surls_to_recover[rse_id], reason='Suspicious. Automatic recovery.', issuer=InternalAccount('root'), status=BadFilesStatus.BAD, session=None)
                         logging.info('replica_recoverer[%i/%i]: finished declaring bad replicas on %s.', worker_number, total_workers, rse)
 
         except (DatabaseException, DatabaseError) as err:

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -38,8 +38,6 @@ from sys import exc_info, stdout, argv
 from traceback import format_exception
 
 
-from rucio.api.did import list_new_dids, set_new_dids, get_metadata
-from rucio.api.subscription import list_subscriptions, update_subscription
 from rucio.db.sqla.constants import DIDType, SubscriptionState
 from rucio.common.exception import (DatabaseException, DataIdentifierNotFound, InvalidReplicationRule, DuplicateRule, RSEBlacklisted,
                                     InvalidRSEExpression, InsufficientTargetRSEs, InsufficientAccountLimit, InputValidationError, RSEOverQuota,
@@ -48,10 +46,12 @@ from rucio.common.config import config_get
 from rucio.common.schema import validate_schema
 from rucio.common.utils import chunks
 from rucio.core import monitor, heartbeat
+from rucio.core.did import list_new_dids, set_new_dids, get_metadata
 from rucio.core.rse import list_rses
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.rse_selector import RSESelector
 from rucio.core.rule import add_rule, list_rules
+from rucio.core.subscription import list_subscriptions, update_subscription
 
 
 logging.basicConfig(stream=stdout,
@@ -121,7 +121,7 @@ def is_matching_subscription(subscription, did, metadata):
         elif key == 'scope':
             match_scope = False
             for scope in values:
-                if re.match(scope, did['scope']):
+                if re.match(scope, did['scope'].external):
                     match_scope = True
                     break
             if not match_scope:
@@ -173,7 +173,7 @@ def transmogrifier(bulk=5, once=False, sleep_time=60):
 
         try:
             #  Get the new DIDs based on the is_new flag
-            for did in list_new_dids(thread=heart_beat['assign_thread'], total_threads=heart_beat['nr_threads'], chunk_size=bulk):
+            for did in list_new_dids(thread=heart_beat['assign_thread'], total_threads=heart_beat['nr_threads'], chunk_size=bulk, did_type=None):
                 dids.append({'scope': did['scope'], 'did_type': str(did['did_type']), 'name': did['name']})
 
             sub_dict = {3: []}
@@ -181,7 +181,7 @@ def transmogrifier(bulk=5, once=False, sleep_time=60):
             #  The priority is defined as 'policyid'
             for sub in list_subscriptions(None, None):
                 if sub['state'] != SubscriptionState.INACTIVE and sub['lifetime'] and (datetime.now() > sub['lifetime']):
-                    update_subscription(name=sub['name'], account=sub['account'], metadata={'state': SubscriptionState.INACTIVE}, issuer='root')
+                    update_subscription(name=sub['name'], account=sub['account'], metadata={'state': SubscriptionState.INACTIVE})
 
                 elif sub['state'] in [SubscriptionState.ACTIVE, SubscriptionState.UPDATED]:
                     priority = 3
@@ -212,7 +212,8 @@ def transmogrifier(bulk=5, once=False, sleep_time=60):
             for did in dids:
                 did_success = True
                 if did['did_type'] == str(DIDType.DATASET) or did['did_type'] == str(DIDType.CONTAINER):
-                    results['%s:%s' % (did['scope'], did['name'])] = []
+                    did_tag = '%s:%s' % (did['scope'].internal, did['name'])
+                    results[did_tag] = []
                     try:
                         metadata = get_metadata(did['scope'], did['name'])
                         # Loop over all the subscriptions
@@ -226,7 +227,7 @@ def transmogrifier(bulk=5, once=False, sleep_time=60):
                                 elif split_rule == 'false':
                                     split_rule = False
                                 stime = time.time()
-                                results['%s:%s' % (did['scope'], did['name'])].append(subscription['id'])
+                                results[did_tag].append(subscription['id'])
                                 logging.info(prepend_str + '%s:%s matches subscription %s' % (did['scope'], did['name'], subscription['name']))
                                 for rule_string in loads(subscription['replication_rules']):
                                     # Get all the rule and subscription parameters
@@ -371,7 +372,7 @@ def transmogrifier(bulk=5, once=False, sleep_time=60):
             logging.info(prepend_str + 'Time to set the new flag : %f' % (time.time() - time1))
             tottime = time.time() - start_time
             for sub in subscriptions:
-                update_subscription(name=sub['name'], account=sub['account'], metadata={'last_processed': datetime.now()}, issuer='root')
+                update_subscription(name=sub['name'], account=sub['account'], metadata={'last_processed': datetime.now()})
             logging.info(prepend_str + 'It took %f seconds to process %i DIDs' % (tottime, len(dids)))
             logging.debug(prepend_str + 'DIDs processed : %s' % (str(dids)))
             monitor.record_counter(counters='transmogrifier.job.done', delta=1)

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -46,7 +46,7 @@ from rucio.db.sqla.constants import (AccountStatus, AccountType, DIDAvailability
                                      BadPFNStatus)
 from rucio.db.sqla.history import Versioned
 from rucio.db.sqla.session import BASE
-from rucio.db.sqla.types import GUID, BooleanString, JSON
+from rucio.db.sqla.types import GUID, BooleanString, JSON, InternalAccountString, InternalScopeString
 
 
 # Recipe to force str instead if unicode
@@ -265,7 +265,7 @@ class SoftModelBase(ModelBase):
 class Account(BASE, ModelBase):
     """Represents an account"""
     __tablename__ = 'accounts'
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     account_type = Column(AccountType.db_type(name='ACCOUNTS_TYPE_CHK'))
     status = Column(AccountStatus.db_type(default=AccountStatus.ACTIVE, name='ACCOUNTS_STATUS_CHK'))
     email = Column(String(255))
@@ -279,7 +279,7 @@ class Account(BASE, ModelBase):
 class AccountAttrAssociation(BASE, ModelBase):
     """Represents an account"""
     __tablename__ = 'account_attr_map'
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     key = Column(String(255))
     value = Column(BooleanString(255))
     _table_args = (PrimaryKeyConstraint('account', 'key', name='ACCOUNT_ATTR_MAP_PK'),
@@ -306,7 +306,7 @@ class IdentityAccountAssociation(BASE, ModelBase):
     __tablename__ = 'account_map'
     identity = Column(String(2048))
     identity_type = Column(IdentityType.db_type(name='ACCOUNT_MAP_ID_TYPE_CHK'))
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     is_default = Column(Boolean(name='ACCOUNT_MAP_DEFAULT_CHK'), default=False)
     _table_args = (PrimaryKeyConstraint('identity', 'identity_type', 'account', name='ACCOUNT_MAP_PK'),
                    ForeignKeyConstraint(['account'], ['accounts.account'], name='ACCOUNT_MAP_ACCOUNT_FK'),
@@ -318,8 +318,8 @@ class IdentityAccountAssociation(BASE, ModelBase):
 class Scope(BASE, ModelBase):
     """Represents a scope"""
     __tablename__ = 'scopes'
-    scope = Column(String(SCOPE_LENGTH))
-    account = Column(String(25))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
+    account = Column(InternalAccountString(25))
     is_default = Column(Boolean(name='SCOPES_DEFAULT_CHK'), default=False)
     status = Column(ScopeStatus.db_type(name='SCOPE_STATUS_CHK', default=ScopeStatus.OPEN))
     closed_at = Column(DateTime)
@@ -334,9 +334,9 @@ class Scope(BASE, ModelBase):
 class DataIdentifier(BASE, ModelBase):
     """Represents a dataset"""
     __tablename__ = 'dids'
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     did_type = Column(DIDType.db_type(name='DIDS_TYPE_CHK'))
     is_open = Column(Boolean(name='DIDS_IS_OPEN_CHK'))
     monotonic = Column(Boolean(name='DIDS_MONOTONIC_CHK'), server_default='0')
@@ -391,7 +391,7 @@ class DataIdentifier(BASE, ModelBase):
 
 class DidMeta(BASE, ModelBase):
     __tablename__ = 'did_meta'
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     meta = Column(JSON())
     _table_args = (PrimaryKeyConstraint('scope', 'name', name='DID_META_PK'),
@@ -401,9 +401,9 @@ class DidMeta(BASE, ModelBase):
 class DeletedDataIdentifier(BASE, ModelBase):
     """Represents a dataset"""
     __tablename__ = 'deleted_dids'
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     did_type = Column(DIDType.db_type(name='DEL_DIDS_TYPE_CHK'))
     is_open = Column(Boolean(name='DEL_DIDS_IS_OPEN_CHK'))
     monotonic = Column(Boolean(name='DEL_DIDS_MONO_CHK'), server_default='0')
@@ -449,7 +449,7 @@ class UpdatedDID(BASE, ModelBase):
     """Represents the recently updated dids"""
     __tablename__ = 'updated_dids'
     id = Column(GUID(), default=utils.generate_uuid)
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     rule_evaluation_action = Column(DIDReEvaluation.db_type(name='UPDATED_DIDS_RULE_EVAL_ACT_CHK'))
     _table_args = (PrimaryKeyConstraint('id', name='UPDATED_DIDS_PK'),
@@ -461,12 +461,12 @@ class UpdatedDID(BASE, ModelBase):
 class BadReplicas(BASE, ModelBase):
     """Represents the suspicious or bad replicas"""
     __tablename__ = 'bad_replicas'
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     rse_id = Column(GUID())
     reason = Column(String(255))
     state = Column(BadFilesStatus.db_type(name='BAD_REPLICAS_STATE_CHK'), default=BadFilesStatus.SUSPICIOUS)
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     bytes = Column(BigInteger)
     expires_at = Column(DateTime)
     _table_args = (PrimaryKeyConstraint('scope', 'name', 'rse_id', 'state', 'created_at', name='BAD_REPLICAS_STATE_PK'),
@@ -484,7 +484,7 @@ class BadPFNs(BASE, ModelBase):
     path = Column(String(2048))  # PREFIX + PFN
     state = Column(BadPFNStatus.db_type(name='BAD_PFNS_STATE_CHK'), default=BadPFNStatus.SUSPICIOUS)
     reason = Column(String(255))
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     expires_at = Column(DateTime)
     _table_args = (PrimaryKeyConstraint('path', 'state', name='BAD_PFNS_PK'),
                    ForeignKeyConstraint(['account'], ['accounts.account'], name='BAD_PFNS_ACCOUNT_FK'))
@@ -498,7 +498,7 @@ class QuarantinedReplica(BASE, ModelBase, Versioned):
     bytes = Column(BigInteger)
     md5 = Column(String(32))
     adler32 = Column(String(8))
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     _table_args = (PrimaryKeyConstraint('rse_id', 'path', name='QURD_REPLICAS_STATE_PK'),
                    ForeignKeyConstraint(['rse_id'], ['rses.id'], name='QURD_REPLICAS_RSE_ID_FK'),
@@ -530,9 +530,9 @@ class DIDKeyValueAssociation(BASE, ModelBase):
 class DataIdentifierAssociation(BASE, ModelBase):
     """Represents the map between containers/datasets and files"""
     __tablename__ = 'contents'
-    scope = Column(String(SCOPE_LENGTH))  # dataset scope
+    scope = Column(InternalScopeString(SCOPE_LENGTH))  # dataset scope
     name = Column(String(NAME_LENGTH))    # dataset name
-    child_scope = Column(String(SCOPE_LENGTH))  # Provenance scope
+    child_scope = Column(InternalScopeString(SCOPE_LENGTH))  # Provenance scope
     child_name = Column(String(NAME_LENGTH))    # Provenance name
     did_type = Column(DIDType.db_type(name='CONTENTS_DID_TYPE_CHK'))
     child_type = Column(DIDType.db_type(name='CONTENTS_CHILD_TYPE_CHK'))
@@ -553,9 +553,9 @@ class DataIdentifierAssociation(BASE, ModelBase):
 class ConstituentAssociation(BASE, ModelBase):
     """Represents the map between archives and constituents"""
     __tablename__ = 'archive_contents'
-    child_scope = Column(String(SCOPE_LENGTH))    # Constituent file scope
+    child_scope = Column(InternalScopeString(SCOPE_LENGTH))    # Constituent file scope
     child_name = Column(String(NAME_LENGTH))    # Constituent file name
-    scope = Column(String(SCOPE_LENGTH))          # Archive file scope
+    scope = Column(InternalScopeString(SCOPE_LENGTH))          # Archive file scope
     name = Column(String(NAME_LENGTH))          # Archive file name
     bytes = Column(BigInteger)
     adler32 = Column(String(8))
@@ -576,9 +576,9 @@ class ConstituentAssociation(BASE, ModelBase):
 class ConstituentAssociationHistory(BASE, ModelBase):
     """Represents the map between archives and constituents"""
     __tablename__ = 'archive_contents_history'
-    child_scope = Column(String(SCOPE_LENGTH))    # Constituent file scope
+    child_scope = Column(InternalScopeString(SCOPE_LENGTH))    # Constituent file scope
     child_name = Column(String(NAME_LENGTH))    # Constituent file name
-    scope = Column(String(SCOPE_LENGTH))          # Archive file scope
+    scope = Column(InternalScopeString(SCOPE_LENGTH))          # Archive file scope
     name = Column(String(NAME_LENGTH))  # Archive file name
     bytes = Column(BigInteger)
     adler32 = Column(String(8))
@@ -596,9 +596,9 @@ class ConstituentAssociationHistory(BASE, ModelBase):
 class DataIdentifierAssociationHistory(BASE, ModelBase):
     """Represents the map history between containers/datasets and files"""
     __tablename__ = 'contents_history'
-    scope = Column(String(SCOPE_LENGTH))          # dataset scope
+    scope = Column(InternalScopeString(SCOPE_LENGTH))          # dataset scope
     name = Column(String(NAME_LENGTH))  # dataset name
-    child_scope = Column(String(SCOPE_LENGTH))          # Provenance scope
+    child_scope = Column(InternalScopeString(SCOPE_LENGTH))          # Provenance scope
     child_name = Column(String(NAME_LENGTH))  # Provenance name
     did_type = Column(DIDType.db_type(name='CONTENTS_HIST_DID_TYPE_CHK'))
     child_type = Column(DIDType.db_type(name='CONTENTS_HIST_CHILD_TYPE_CHK'))
@@ -733,7 +733,7 @@ class RSEProtocols(BASE, ModelBase):
 class AccountLimit(BASE, ModelBase):
     """Represents account limits"""
     __tablename__ = 'account_limits'
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     rse_id = Column(GUID())
     bytes = Column(BigInteger)
     _table_args = (PrimaryKeyConstraint('account', 'rse_id', name='ACCOUNT_LIMITS_PK'),
@@ -744,7 +744,7 @@ class AccountLimit(BASE, ModelBase):
 class AccountUsage(BASE, ModelBase, Versioned):
     """Represents account usage"""
     __tablename__ = 'account_usage'
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     rse_id = Column(GUID())
     files = Column(BigInteger)
     bytes = Column(BigInteger)
@@ -757,7 +757,7 @@ class RSEFileAssociation(BASE, ModelBase):
     """Represents the map between locations and files"""
     __tablename__ = 'replicas'
     rse_id = Column(GUID())
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     bytes = Column(BigInteger)
     md5 = Column(String(32))
@@ -781,7 +781,7 @@ class RSEFileAssociation(BASE, ModelBase):
 class CollectionReplica(BASE, ModelBase):
     """Represents replicas for datasets/collections"""
     __tablename__ = 'collection_replicas'
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     did_type = Column(DIDType.db_type(name='COLLECTION_REPLICAS_TYPE_CHK'))
     rse_id = Column(GUID())
@@ -803,7 +803,7 @@ class UpdatedCollectionReplica(BASE, ModelBase):
     """Represents updates to replicas for datasets/collections"""
     __tablename__ = 'updated_col_rep'
     id = Column(GUID(), default=utils.generate_uuid)
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     did_type = Column(DIDType.db_type(name='UPDATED_COL_REP_TYPE_CHK'))
     rse_id = Column(GUID())
@@ -817,7 +817,7 @@ class RSEFileAssociationHistory(BASE, ModelBase):
     """Represents a short history of the deleted replicas"""
     __tablename__ = 'replicas_history'
     rse_id = Column(GUID())
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     bytes = Column(BigInteger)
     _table_args = (PrimaryKeyConstraint('rse_id', 'scope', 'name', name='REPLICAS_HIST_PK'),
@@ -831,8 +831,8 @@ class ReplicationRule(BASE, ModelBase):
     __tablename__ = 'rules'
     id = Column(GUID(), default=utils.generate_uuid)
     subscription_id = Column(GUID())
-    account = Column(String(25))
-    scope = Column(String(SCOPE_LENGTH))
+    account = Column(InternalAccountString(25))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     did_type = Column(DIDType.db_type(name='RULES_DID_TYPE_CHK'))
     state = Column(RuleState.db_type(name='RULES_STATE_CHK'), default=RuleState.REPLICATING)
@@ -888,8 +888,8 @@ class ReplicationRuleHistoryRecent(BASE, ModelBase):
     __tablename__ = 'rules_hist_recent'
     id = Column(GUID())
     subscription_id = Column(GUID())
-    account = Column(String(25))
-    scope = Column(String(SCOPE_LENGTH))
+    account = Column(InternalAccountString(25))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     did_type = Column(DIDType.db_type(name='RULES_HIST_RECENT_DIDTYPE_CHK'))
     state = Column(RuleState.db_type(name='RULES_HIST_RECENT_STATE_CHK'))
@@ -928,8 +928,8 @@ class ReplicationRuleHistory(BASE, ModelBase):
     __tablename__ = 'rules_history'
     id = Column(GUID())
     subscription_id = Column(GUID())
-    account = Column(String(25))
-    scope = Column(String(SCOPE_LENGTH))
+    account = Column(InternalAccountString(25))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     did_type = Column(DIDType.db_type(name='RULES_HISTORY_DIDTYPE_CHK'))
     state = Column(RuleState.db_type(name='RULES_HISTORY_STATE_CHK'))
@@ -965,11 +965,11 @@ class ReplicationRuleHistory(BASE, ModelBase):
 class ReplicaLock(BASE, ModelBase):
     """Represents replica locks"""
     __tablename__ = 'locks'
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     rule_id = Column(GUID())
     rse_id = Column(GUID())
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     bytes = Column(BigInteger)
     state = Column(LockState.db_type(name='LOCKS_STATE_CHK'), default=LockState.REPLICATING)
     repair_cnt = Column(BigInteger)
@@ -985,11 +985,11 @@ class ReplicaLock(BASE, ModelBase):
 class DatasetLock(BASE, ModelBase):
     """Represents dataset locks"""
     __tablename__ = 'dataset_locks'
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     rule_id = Column(GUID())
     rse_id = Column(GUID())
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     state = Column(LockState.db_type(name='DATASET_LOCKS_STATE_CHK'), default=LockState.REPLICATING)
     length = Column(BigInteger)
     bytes = Column(BigInteger)
@@ -1008,7 +1008,7 @@ class UpdatedAccountCounter(BASE, ModelBase):
     """Represents the recently updated Account counters"""
     __tablename__ = 'updated_account_counters'
     id = Column(GUID(), default=utils.generate_uuid)
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     rse_id = Column(GUID())
     files = Column(BigInteger)
     bytes = Column(BigInteger)
@@ -1023,7 +1023,7 @@ class Request(BASE, ModelBase, Versioned):
     __tablename__ = 'requests'
     id = Column(GUID(), default=utils.generate_uuid)
     request_type = Column(RequestType.db_type(name='REQUESTS_TYPE_CHK'), default=RequestType.TRANSFER)
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     did_type = Column(DIDType.db_type(name='REQUESTS_DIDTYPE_CHK'), default=DIDType.FILE)
     dest_rse_id = Column(GUID())
@@ -1048,7 +1048,7 @@ class Request(BASE, ModelBase, Versioned):
     submitter_id = Column(Integer)
     estimated_started_at = Column(DateTime)
     estimated_transferred_at = Column(DateTime)
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     requested_at = Column(DateTime)
     priority = Column(Integer)
     _table_args = (PrimaryKeyConstraint('id', name='REQUESTS_PK'),
@@ -1067,7 +1067,7 @@ class Source(BASE, ModelBase, Versioned):
     """Represents source files for transfers"""
     __tablename__ = 'sources'
     request_id = Column(GUID())
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     rse_id = Column(GUID())
     dest_rse_id = Column(GUID())
@@ -1121,7 +1121,7 @@ class Subscription(BASE, ModelBase, Versioned):
     policyid = Column(SmallInteger, server_default='0')
     state = Column(SubscriptionState.db_type(name='SUBSCRIPTIONS_STATE_CHK', default=SubscriptionState.ACTIVE))
     last_processed = Column(DateTime, default=datetime.datetime.utcnow())
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     lifetime = Column(DateTime)
     comments = Column(String(4000))
     retroactive = Column(Boolean(name='SUBSCRIPTIONS_RETROACTIVE_CHK'), default=False)
@@ -1137,7 +1137,7 @@ class Token(BASE, ModelBase):
     """Represents the authentication tokens and their lifetime"""
     __tablename__ = 'tokens'
     token = Column(String(352))  # account-identity-appid-uuid -> max length: (+ 30 1 255 1 32 1 32)
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     identity = Column(String(2048))
     expired_at = Column(DateTime, default=lambda: datetime.datetime.utcnow() + datetime.timedelta(seconds=3600))  # one hour lifetime by default
     ip = Column(String(39), nullable=True)
@@ -1203,7 +1203,7 @@ class Heartbeats(BASE, ModelBase):
 class NamingConvention(BASE, ModelBase):
     """Represents naming conventions for name within a scope"""
     __tablename__ = 'naming_conventions'
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     regexp = Column(String(255))
     convention_type = Column(KeyType.db_type(name='CVT_TYPE_CHK'))
     _table_args = (PrimaryKeyConstraint('scope', name='NAMING_CONVENTIONS_PK'),
@@ -1213,7 +1213,7 @@ class NamingConvention(BASE, ModelBase):
 class TemporaryDataIdentifier(BASE, ModelBase):
     """Represents a temporary DID (pre-merged files, etc.)"""
     __tablename__ = 'tmp_dids'
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     rse_id = Column(GUID())
     path = Column(String(1024))
@@ -1225,7 +1225,7 @@ class TemporaryDataIdentifier(BASE, ModelBase):
     events = Column(BigInteger)
     task_id = Column(Integer())
     panda_id = Column(Integer())
-    parent_scope = Column(String(SCOPE_LENGTH))
+    parent_scope = Column(InternalScopeString(SCOPE_LENGTH))
     parent_name = Column(String(NAME_LENGTH))
     offset = Column(BigInteger)
     _table_args = (PrimaryKeyConstraint('scope', 'name', name='TMP_DIDS_PK'),
@@ -1236,10 +1236,10 @@ class LifetimeExceptions(BASE, ModelBase):
     """Represents the exceptions to the lifetime model"""
     __tablename__ = 'lifetime_except'
     id = Column(GUID(), default=utils.generate_uuid)
-    scope = Column(String(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(SCOPE_LENGTH))
     name = Column(String(NAME_LENGTH))
     did_type = Column(DIDType.db_type(name='LIFETIME_EXCEPT_TYPE_CHK'))
-    account = Column(String(25))
+    account = Column(InternalAccountString(25))
     pattern = Column(String(255))
     comments = Column(String(4000))
     state = Column(LifetimeExceptionsState.db_type(name='LIFETIME_EXCEPT_STATE_CHK'))

--- a/lib/rucio/db/sqla/util.py
+++ b/lib/rucio/db/sqla/util.py
@@ -9,6 +9,7 @@
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2013-2014, 2017-2018
 # - Martin Barisits, <martin.barisits@cern.ch>, 2014
 # - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2019
+# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 #
 # PY3K COMPATIBLE
 
@@ -25,6 +26,7 @@ from sqlalchemy.schema import MetaData, Table, DropTable, ForeignKeyConstraint, 
 from sqlalchemy.sql.expression import select, text
 
 from rucio.common.config import config_get
+from rucio.common.types import InternalAccount
 from rucio.core.account_counter import create_counters_for_new_account
 from rucio.db.sqla import session, models
 from rucio.db.sqla.constants import AccountStatus, AccountType, IdentityType
@@ -134,7 +136,7 @@ def create_root_account():
 
     s = session.get_session()
 
-    account = models.Account(account='root', account_type=AccountType.SERVICE, status=AccountStatus.ACTIVE)
+    account = models.Account(account=InternalAccount('root'), account_type=AccountType.SERVICE, status=AccountStatus.ACTIVE)
 
     identity1 = models.Identity(identity=up_id, identity_type=IdentityType.USERPASS, password=up_pwd, salt='0', email=up_email)
     iaa1 = models.IdentityAccountAssociation(identity=identity1.identity, identity_type=identity1.identity_type, account=account.account, is_default=True)
@@ -152,7 +154,7 @@ def create_root_account():
     iaa4 = models.IdentityAccountAssociation(identity=identity4.identity, identity_type=identity4.identity_type, account=account.account, is_default=True)
 
     # Account counters
-    create_counters_for_new_account(account='root', session=s)
+    create_counters_for_new_account(account=account.account, session=s)
 
     # Apply
     s.add_all([account, identity1, identity2, identity3, identity4])

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -80,14 +80,14 @@ class Default(protocol.RSEProtocol):
         lfns = [lfns] if type(lfns) == dict else lfns
         if self.attributes['port'] == 0:
             for lfn in lfns:
-                scope, name = lfn['scope'], lfn['name']
+                scope, name = str(lfn['scope']), lfn['name']
                 path = lfn['path'] if 'path' in lfn and lfn['path'] else self._get_path(scope=scope, name=name)
                 if self.attributes['scheme'] != 'root' and path.startswith('/'):  # do not modify path if it is root
                     path = path[1:]
                 pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'], '://', hostname, web_service_path, prefix, path])
         else:
             for lfn in lfns:
-                scope, name = lfn['scope'], lfn['name']
+                scope, name = str(lfn['scope']), lfn['name']
                 path = lfn['path'] if 'path' in lfn and lfn['path'] else self._get_path(scope=scope, name=name)
                 if self.attributes['scheme'] != 'root' and path.startswith('/'):  # do not modify path if it is root
                     path = path[1:]

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -25,7 +25,7 @@
 # - Nicolo Magini <Nicolo.Magini@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
 # - James Clark <james.clark@physics.gatech.edu>, 2019
-# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 #
 # PY3K COMPATIBLE
 
@@ -53,6 +53,7 @@ if getattr(rsemanager, 'CLIENT_MODE', None):
     from rucio.client.rseclient import RSEClient
 
 if getattr(rsemanager, 'SERVER_MODE', None):
+    from rucio.common.types import InternalScope
     from rucio.core import replica
 
 
@@ -255,7 +256,7 @@ class RSEProtocol(object):
 
         lfns = [lfns] if isinstance(lfns, dict) else lfns
         for lfn in lfns:
-            scope, name = lfn['scope'], lfn['name']
+            scope, name = str(lfn['scope']), lfn['name']
             if 'path' in lfn and lfn['path'] is not None:
                 pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'],
                                                          '://',
@@ -303,6 +304,7 @@ class RSEProtocol(object):
 
     def _get_path_nondeterministic_server(self, scope, name):  # pylint: disable=invalid-name
         """ Provides the path of a replica for non-deterministic sites. Will be assigned to get path by the __init__ method if neccessary. """
+        scope = InternalScope(scope)
         rep = replica.get_replica(scope=scope, name=name, rse_id=self.rse['id'])
         if 'path' in rep and rep['path'] is not None:
             path = rep['path']

--- a/lib/rucio/rse/protocols/s3.py
+++ b/lib/rucio/rse/protocols/s3.py
@@ -68,7 +68,7 @@ class Default(protocol.RSEProtocol):
         pfns = {}
         lfns = [lfns] if type(lfns) == dict else lfns
         for lfn in lfns:
-            scope, name = lfn['scope'], lfn['name']
+            scope, name = str(lfn['scope']), lfn['name']
             pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'], '://', self._get_path(scope=scope, name=name)])
         return pfns
 

--- a/lib/rucio/rse/protocols/srm.py
+++ b/lib/rucio/rse/protocols/srm.py
@@ -68,7 +68,7 @@ class Default(protocol.RSEProtocol):
         lfns = [lfns] if type(lfns) == dict else lfns
         if not self.attributes['port']:
             for lfn in lfns:
-                scope, name, path = lfn['scope'], lfn['name'], lfn.get('path')
+                scope, name, path = str(lfn['scope']), lfn['name'], lfn.get('path')
                 if not path:
                     path = self._get_path(scope=scope, name=name)
                 if path.startswith('/'):
@@ -77,7 +77,7 @@ class Default(protocol.RSEProtocol):
                                                          hostname, web_service_path, prefix, path])
         else:
             for lfn in lfns:
-                scope, name, path = lfn['scope'], lfn['name'], lfn.get('path')
+                scope, name, path = str(lfn['scope']), lfn['name'], lfn.get('path')
                 if not path:
                     path = self._get_path(scope=scope, name=name)
                 if path.startswith('/'):

--- a/lib/rucio/rse/protocols/xrootd.py
+++ b/lib/rucio/rse/protocols/xrootd.py
@@ -95,7 +95,7 @@ class Default(protocol.RSEProtocol):
 
         lfns = [lfns] if type(lfns) == dict else lfns
         for lfn in lfns:
-            scope, name = lfn['scope'], lfn['name']
+            scope, name = str(lfn['scope']), lfn['name']
             if 'path' in lfn and lfn['path'] is not None:
                 pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'], '://', self.attributes['hostname'], ':', str(self.attributes['port']), prefix, lfn['path']])
             else:

--- a/lib/rucio/tests/test_abacus_collection_replica.py
+++ b/lib/rucio/tests/test_abacus_collection_replica.py
@@ -27,6 +27,7 @@ from rucio.client.didclient import DIDClient
 from rucio.client.replicaclient import ReplicaClient
 from rucio.client.ruleclient import RuleClient
 from rucio.client.uploadclient import UploadClient
+from rucio.common.types import InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.replica import delete_replicas
 from rucio.core.rse import get_rse_id
@@ -86,7 +87,7 @@ class TestAbacusCollectionReplica():
 
         # Delete one file -> collection replica should be unavailable
         cleaner.run(once=True)
-        delete_replicas(rse_id=self.rse_id, files=[{'name': self.files[0]['did_name'], 'scope': self.files[0]['did_scope']}])
+        delete_replicas(rse_id=self.rse_id, files=[{'name': self.files[0]['did_name'], 'scope': InternalScope(self.files[0]['did_scope'])}])
         self.rule_client.add_replication_rule([{'scope': self.scope, 'name': self.dataset}], 1, self.rse, lifetime=-1)
         collection_replica.run(once=True)
         dataset_replica = [replica for replica in self.replica_client.list_dataset_replicas(self.scope, self.dataset)][0]

--- a/lib/rucio/tests/test_account.py
+++ b/lib/rucio/tests/test_account.py
@@ -13,6 +13,7 @@
 # - Joaquin Bogado, <joaquin.bogado@cern.ch>, 2015
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2015, 2017
 # - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 #
 # PY3K COMPATIBLE
 
@@ -25,6 +26,7 @@ from rucio.api.account import add_account, account_exists, del_account, update_a
 from rucio.client.accountclient import AccountClient
 from rucio.common.config import config_get
 from rucio.common.exception import AccountNotFound, Duplicate, InvalidObject
+from rucio.common.types import InternalAccount
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account import list_identities
 from rucio.core.identity import add_account_identity, add_identity
@@ -64,7 +66,7 @@ class TestAccountCoreApi():
         email = 'email'
         identity = uuid()
         identity_type = IdentityType.USERPASS
-        account = 'root'
+        account = InternalAccount('root')
         add_account_identity(identity, identity_type, account, email, password='secret')
         identities = list_identities(account)
         assert_in({'type': identity_type, 'identity': identity, 'email': email}, identities)
@@ -302,7 +304,7 @@ class TestAccountRestApi():
         password = 'secret'
         add_account(account, 'USER', 'rucio@email.com', 'root')
         add_identity(identity, IdentityType.USERPASS, 'email@email.com', password)
-        add_account_identity(identity, IdentityType.USERPASS, account, 'email@email.com')
+        add_account_identity(identity, IdentityType.USERPASS, InternalAccount(account), 'email@email.com')
         headers1 = {'X-Rucio-Account': account, 'X-Rucio-Username': identity, 'X-Rucio-Password': password}
         res1 = TestApp(auth_app.wsgifunc(*mw)).get('/userpass', headers=headers1, expect_errors=True)
         token = str(res1.header('X-Rucio-Auth-Token'))

--- a/lib/rucio/tests/test_account_limits.py
+++ b/lib/rucio/tests/test_account_limits.py
@@ -17,6 +17,7 @@ from nose.tools import assert_equal, assert_in
 
 from rucio.client.accountclient import AccountClient
 from rucio.client.accountlimitclient import AccountLimitClient
+from rucio.common.types import InternalAccount
 from rucio.core import account_limit
 from rucio.core.account import add_account
 from rucio.core.rse import get_rse_id
@@ -28,7 +29,7 @@ class TestCoreAccountLimits():
     @classmethod
     def setUpClass(cls):
         # Add test account
-        cls.account = ''.join(random.choice(string.ascii_uppercase) for x in range(10))
+        cls.account = InternalAccount(''.join(random.choice(string.ascii_uppercase) for x in range(10)))
         add_account(account=cls.account, type=AccountType.USER, email='rucio@email.com')
 
         # Add test RSE
@@ -51,7 +52,7 @@ class TestAccountClient():
     @classmethod
     def setUpClass(cls):
         # Add test account
-        cls.account = ''.join(random.choice(string.ascii_uppercase) for x in range(10))
+        cls.account = InternalAccount(''.join(random.choice(string.ascii_uppercase) for x in range(10)))
         add_account(account=cls.account, type=AccountType.USER, email='rucio@email.com')
 
         # Add test RSE
@@ -70,7 +71,7 @@ class TestAccountClient():
         account_limit.set_account_limit(account=self.account, rse_id=self.rse1_id, bytes=12345)
         account_limit.set_account_limit(account=self.account, rse_id=self.rse2_id, bytes=12345)
 
-        limits = self.client.get_account_limits(account=self.account)
+        limits = self.client.get_account_limits(account=self.account.external)
 
         assert_in((self.rse1, 12345), limits.items())
         assert_in((self.rse2, 12345), limits.items())
@@ -83,28 +84,28 @@ class TestAccountClient():
         account_limit.delete_account_limit(account=self.account, rse_id=self.rse1_id)
         account_limit.set_account_limit(account=self.account, rse_id=self.rse1_id, bytes=333)
 
-        limit = self.client.get_account_limit(account=self.account, rse=self.rse1)
+        limit = self.client.get_account_limit(account=self.account.external, rse=self.rse1)
 
         assert_equal(limit, {self.rse1: 333})
         account_limit.delete_account_limit(account=self.account, rse_id=self.rse1_id)
 
     def test_setting_account_limit(self):
         """ ACCOUNTLIMIT (CLIENTS): Test setting account limit """
-        self.alclient.set_account_limit(account=self.account, rse=self.rse1, bytes=987)
+        self.alclient.set_account_limit(account=self.account.external, rse=self.rse1, bytes=987)
 
-        limit = self.client.get_account_limit(account=self.account, rse=self.rse1)
+        limit = self.client.get_account_limit(account=self.account.external, rse=self.rse1)
 
         assert_equal(limit[self.rse1], 987)
         account_limit.delete_account_limit(account=self.account, rse_id=self.rse1_id)
 
     def test_deleting_account_limit(self):
         """ ACCOUNTLIMIT (CLIENTS): Test deleting account limit """
-        self.alclient.set_account_limit(account=self.account, rse=self.rse1, bytes=786)
+        self.alclient.set_account_limit(account=self.account.external, rse=self.rse1, bytes=786)
 
-        limit = self.client.get_account_limit(account=self.account, rse=self.rse1)
+        limit = self.client.get_account_limit(account=self.account.external, rse=self.rse1)
         assert_equal(limit, {self.rse1: 786})
 
-        self.alclient.delete_account_limit(account=self.account, rse=self.rse1)
-        limit = self.client.get_account_limit(account=self.account, rse=self.rse1)
+        self.alclient.delete_account_limit(account=self.account.external, rse=self.rse1)
+        limit = self.client.get_account_limit(account=self.account.external, rse=self.rse1)
         assert_equal(limit[self.rse1], None)
         account_limit.delete_account_limit(account=self.account, rse_id=self.rse1_id)

--- a/lib/rucio/tests/test_archive.py
+++ b/lib/rucio/tests/test_archive.py
@@ -26,6 +26,7 @@ from nose.tools import assert_equal, assert_in, assert_not_in
 
 from rucio.client.didclient import DIDClient
 from rucio.client.replicaclient import ReplicaClient
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.replica import add_replicas
 from rucio.core.rse import add_rse, add_protocol
@@ -65,9 +66,10 @@ class TestArchive(object):
     def test_list_archive_contents_transparently(self):
         """ ARCHIVE (CORE): Transparent archive listing """
 
-        scope = 'mock'
+        scope = InternalScope('mock')
         rse = 'APERTURE_%s' % rse_name_generator()
         rse_id = add_rse(rse)
+        root = InternalAccount('root')
 
         add_protocol(rse_id, {'scheme': 'root',
                               'hostname': 'root.aperture.com',
@@ -81,15 +83,24 @@ class TestArchive(object):
         # register archive
         archive = {'scope': scope, 'name': 'weighted.storage.cube.zip', 'type': 'FILE',
                    'bytes': 2596, 'adler32': 'beefdead'}
-        add_replicas(rse_id=rse_id, files=[archive], account='root')
+        archive_client = archive.copy()
+        archive_client['scope'] = archive_client['scope'].external
+
+        add_replicas(rse_id=rse_id, files=[archive], account=root)
 
         # archived files with replicas
         files_with_replicas = [{'scope': scope, 'name': 'witrep-%i-%s' % (i, str(generate_uuid())), 'type': 'FILE',
                                 'bytes': 1234, 'adler32': 'deadbeef'} for i in range(2)]
-        add_replicas(rse_id=rse_id, files=files_with_replicas, account='root')
-        self.dc.add_files_to_archive(scope=scope, name=archive['name'], files=files_with_replicas)
+        files_with_replicas_client = []
+        for f in files_with_replicas:
+            new_file = f.copy()
+            new_file['scope'] = new_file['scope'].external
+            files_with_replicas_client.append(new_file)
 
-        res = [r['pfns'] for r in self.rc.list_replicas(dids=[{'scope': scope, 'name': f['name']} for f in files_with_replicas],
+        add_replicas(rse_id=rse_id, files=files_with_replicas, account=root)
+        self.dc.add_files_to_archive(scope=scope.external, name=archive_client['name'], files=files_with_replicas_client)
+
+        res = [r['pfns'] for r in self.rc.list_replicas(dids=[{'scope': scope.external, 'name': f['name']} for f in files_with_replicas_client],
                                                         resolve_archives=True)]
         assert_equal(len(res), 2)
         assert_equal(len(res[0]), 2)
@@ -102,10 +113,10 @@ class TestArchive(object):
                     assert_not_in('weighted.storage.cube.zip?xrdcl.unzip=witrep-', p)
 
         # archived files without replicas
-        files = [{'scope': scope, 'name': 'norep-%i-%s' % (i, str(generate_uuid())), 'type': 'FILE',
+        files = [{'scope': scope.external, 'name': 'norep-%i-%s' % (i, str(generate_uuid())), 'type': 'FILE',
                   'bytes': 1234, 'adler32': 'deadbeef'} for i in range(2)]
-        self.dc.add_files_to_archive(scope=scope, name=archive['name'], files=files)
-        res = [r['pfns'] for r in self.rc.list_replicas(dids=[{'scope': scope, 'name': f['name']} for f in files],
+        self.dc.add_files_to_archive(scope=scope.external, name=archive_client['name'], files=files)
+        res = [r['pfns'] for r in self.rc.list_replicas(dids=[{'scope': scope.external, 'name': f['name']} for f in files],
                                                         resolve_archives=True)]
         assert_equal(len(res), 2)
         for r in res:
@@ -114,7 +125,8 @@ class TestArchive(object):
     def test_list_archive_contents_at_rse(self):
         """ ARCHIVE (CORE): Transparent archive listing at RSE """
 
-        scope = 'mock'
+        scope = InternalScope('mock')
+        root = InternalAccount('root')
 
         rse1 = 'APERTURE_%s' % rse_name_generator()
         rse1_id = add_rse(rse1)
@@ -141,23 +153,23 @@ class TestArchive(object):
         # register archive
         archive1 = {'scope': scope, 'name': 'cube.1.zip', 'type': 'FILE', 'bytes': 2596, 'adler32': 'beefdead'}
         archive2 = {'scope': scope, 'name': 'cube.2.zip', 'type': 'FILE', 'bytes': 5432, 'adler32': 'deadbeef'}
-        add_replicas(rse_id=rse1_id, files=[archive1], account='root')
-        add_replicas(rse_id=rse2_id, files=[archive2], account='root')
+        add_replicas(rse_id=rse1_id, files=[archive1], account=root)
+        add_replicas(rse_id=rse2_id, files=[archive2], account=root)
 
         # archived files with replicas
-        archived_file = [{'scope': scope, 'name': 'zippedfile-%i-%s' % (i, str(generate_uuid())), 'type': 'FILE',
+        archived_file = [{'scope': scope.external, 'name': 'zippedfile-%i-%s' % (i, str(generate_uuid())), 'type': 'FILE',
                           'bytes': 4322, 'adler32': 'beefbeef'} for i in range(2)]
-        self.dc.add_files_to_archive(scope=scope, name=archive1['name'], files=archived_file)
-        self.dc.add_files_to_archive(scope=scope, name=archive2['name'], files=archived_file)
+        self.dc.add_files_to_archive(scope=scope.external, name=archive1['name'], files=archived_file)
+        self.dc.add_files_to_archive(scope=scope.external, name=archive2['name'], files=archived_file)
 
-        res = [r['pfns'] for r in self.rc.list_replicas(dids=[{'scope': scope, 'name': f['name']} for f in archived_file],
+        res = [r['pfns'] for r in self.rc.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file],
                                                         rse_expression=rse1,
                                                         resolve_archives=True)]
 
-        res = self.rc.list_replicas(dids=[{'scope': scope, 'name': f['name']} for f in archived_file], metalink=True, rse_expression=rse1, resolve_archives=True)
+        res = self.rc.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file], metalink=True, rse_expression=rse1, resolve_archives=True)
         assert_in('APERTURE', res)
         assert_not_in('BLACKMESA', res)
 
-        res = self.rc.list_replicas(dids=[{'scope': scope, 'name': f['name']} for f in archived_file], metalink=True, rse_expression=rse2, resolve_archives=True)
+        res = self.rc.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file], metalink=True, rse_expression=rse2, resolve_archives=True)
         assert_in('BLACKMESA', res)
         assert_not_in('APERTURE', res)

--- a/lib/rucio/tests/test_authentication.py
+++ b/lib/rucio/tests/test_authentication.py
@@ -8,6 +8,7 @@
  Authors:
  - Mario Lassnig, <mario.lassnig@cern.ch>, 2012, 2017
  - Vincent Garonne,  <vincent.garonne@cern.ch> , 2011-2017
+ - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 '''
 
 import base64
@@ -17,6 +18,7 @@ from paste.fixture import TestApp
 
 from rucio.api.authentication import get_auth_token_user_pass, get_auth_token_ssh, get_ssh_challenge_token
 from rucio.common.exception import Duplicate
+from rucio.common.types import InternalAccount
 from rucio.common.utils import ssh_sign
 from rucio.core.identity import add_account_identity, del_account_identity
 from rucio.db.sqla.constants import IdentityType
@@ -78,8 +80,9 @@ class TestAuthCoreApi(object):
     def test_get_auth_token_ssh_success(self):
         """AUTHENTICATION (CORE): SSH RSA public key exchange (good signature)."""
 
+        root = InternalAccount('root')
         try:
-            add_account_identity(PUBLIC_KEY, IdentityType.SSH, 'root', email='ph-adp-ddm-lab@cern.ch')
+            add_account_identity(PUBLIC_KEY, IdentityType.SSH, root, email='ph-adp-ddm-lab@cern.ch')
         except Duplicate:
             pass  # might already exist, can skip
 
@@ -91,13 +94,14 @@ class TestAuthCoreApi(object):
 
         assert_is_not_none(result)
 
-        del_account_identity(PUBLIC_KEY, IdentityType.SSH, 'root')
+        del_account_identity(PUBLIC_KEY, IdentityType.SSH, root)
 
     def test_get_auth_token_ssh_fail(self):
         """AUTHENTICATION (CORE): SSH RSA public key exchange (wrong signature)."""
 
+        root = InternalAccount('root')
         try:
-            add_account_identity(PUBLIC_KEY, IdentityType.SSH, 'root', email='ph-adp-ddm-lab@cern.ch')
+            add_account_identity(PUBLIC_KEY, IdentityType.SSH, root, email='ph-adp-ddm-lab@cern.ch')
         except Duplicate:
             pass  # might already exist, can skip
 
@@ -107,7 +111,7 @@ class TestAuthCoreApi(object):
 
         assert_is_none(result)
 
-        del_account_identity(PUBLIC_KEY, IdentityType.SSH, 'root')
+        del_account_identity(PUBLIC_KEY, IdentityType.SSH, root)
 
 
 class TestAuthRestApi(object):
@@ -132,8 +136,9 @@ class TestAuthRestApi(object):
     def test_ssh_success(self):
         """AUTHENTICATION (REST): SSH RSA public key exchange (correct credentials)."""
 
+        root = InternalAccount('root')
         try:
-            add_account_identity(PUBLIC_KEY, IdentityType.SSH, 'root', email='ph-adp-ddm-lab@cern.ch')
+            add_account_identity(PUBLIC_KEY, IdentityType.SSH, root, email='ph-adp-ddm-lab@cern.ch')
         except Duplicate:
             pass  # might already exist, can skip
 
@@ -150,13 +155,14 @@ class TestAuthRestApi(object):
         assert_equal(result.status, 200)
         assert_greater(len(result.header('X-Rucio-Auth-Token')), 32)
 
-        del_account_identity(PUBLIC_KEY, IdentityType.SSH, 'root')
+        del_account_identity(PUBLIC_KEY, IdentityType.SSH, root)
 
     def test_ssh_fail(self):
         """AUTHENTICATION (REST): SSH RSA public key exchange (wrong credentials)."""
 
+        root = InternalAccount('root')
         try:
-            add_account_identity(PUBLIC_KEY, IdentityType.SSH, 'root', email='ph-adp-ddm-lab@cern.ch')
+            add_account_identity(PUBLIC_KEY, IdentityType.SSH, root, email='ph-adp-ddm-lab@cern.ch')
         except Duplicate:
             pass  # might already exist, can skip
 
@@ -167,4 +173,4 @@ class TestAuthRestApi(object):
         result = TestApp(APP.wsgifunc(*options)).get('/ssh', headers=headers, expect_errors=True)
         assert_equal(result.status, 401)
 
-        del_account_identity(PUBLIC_KEY, IdentityType.SSH, 'root')
+        del_account_identity(PUBLIC_KEY, IdentityType.SSH, root)

--- a/lib/rucio/tests/test_bb8.py
+++ b/lib/rucio/tests/test_bb8.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from nose.tools import assert_raises
 
 from rucio.common.utils import generate_uuid as uuid
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.account_limit import set_account_limit
 from rucio.core.did import add_did, attach_dids
 from rucio.core.rse import add_rse_attribute, get_rse_id
@@ -56,25 +57,27 @@ class TestJudgeCleaner():
         add_rse_attribute(cls.rse5_id, "fakeweight", 0)
 
         # Add quota
-        set_account_limit('jdoe', cls.rse1_id, -1)
-        set_account_limit('jdoe', cls.rse3_id, -1)
-        set_account_limit('jdoe', cls.rse4_id, -1)
-        set_account_limit('jdoe', cls.rse5_id, -1)
+        cls.jdoe = InternalAccount('jdoe')
+        cls.root = InternalAccount('root')
+        set_account_limit(cls.jdoe, cls.rse1_id, -1)
+        set_account_limit(cls.jdoe, cls.rse3_id, -1)
+        set_account_limit(cls.jdoe, cls.rse4_id, -1)
+        set_account_limit(cls.jdoe, cls.rse5_id, -1)
 
-        set_account_limit('root', cls.rse1_id, -1)
-        set_account_limit('root', cls.rse3_id, -1)
-        set_account_limit('root', cls.rse4_id, -1)
-        set_account_limit('root', cls.rse5_id, -1)
+        set_account_limit(cls.root, cls.rse1_id, -1)
+        set_account_limit(cls.root, cls.rse3_id, -1)
+        set_account_limit(cls.root, cls.rse4_id, -1)
+        set_account_limit(cls.root, cls.rse5_id, -1)
 
     def test_bb8_rebalance_rule(self):
         """ BB8: Test the rebalance rule method"""
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
-        attach_dids(scope, dataset, files, 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
 
-        rule_id = add_rule(dids=[{'scope': scope, 'name': dataset}], account='jdoe', copies=1, rse_expression=self.rse1, grouping='NONE', weight='fakeweight', lifetime=None, locked=False, subscription_id=None)[0]
+        rule_id = add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=1, rse_expression=self.rse1, grouping='NONE', weight='fakeweight', lifetime=None, locked=False, subscription_id=None)[0]
 
         rule = {}
         try:

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -42,6 +42,7 @@ from rucio.client.didclient import DIDClient
 from rucio.client.replicaclient import ReplicaClient
 from rucio.client.ruleclient import RuleClient
 from rucio.common.config import config_get
+from rucio.common.types import InternalScope
 from rucio.common.utils import generate_uuid, md5
 from rucio.core.rse import add_rse_attribute, get_rse_id
 from rucio.tests.common import execute, account_name_generator, rse_name_generator, file_generator, scope_name_generator
@@ -260,10 +261,10 @@ class TestBinRucio():
         # removing replica -> file on RSE should be overwritten
         # (simulating an upload error, where a part of the file is uploaded but the replica is not registered)
         db_session = session.get_session()
-        db_session.query(models.RSEFileAssociation).filter_by(name=tmp_file1_name, scope=self.user).delete()
+        db_session.query(models.RSEFileAssociation).filter_by(name=tmp_file1_name, scope=InternalScope(self.user)).delete()
         db_session.query(models.ReplicaLock).delete()
-        db_session.query(models.ReplicationRule).filter_by(name=tmp_file1_name, scope=self.user).delete()
-        db_session.query(models.DataIdentifier).filter_by(name=tmp_file1_name, scope=self.user).delete()
+        db_session.query(models.ReplicationRule).filter_by(name=tmp_file1_name, scope=InternalScope(self.user)).delete()
+        db_session.query(models.DataIdentifier).filter_by(name=tmp_file1_name, scope=InternalScope(self.user)).delete()
         db_session.commit()
         tmp_file4 = file_generator()
         checksum_tmp_file4 = md5(tmp_file4)
@@ -581,7 +582,7 @@ class TestBinRucio():
         print(out, err)
         remove(tmp_file1)
         db_session = session.get_session()
-        db_session.query(models.DataIdentifier).filter_by(scope=self.user, name=dataset_name).one().length = 15
+        db_session.query(models.DataIdentifier).filter_by(scope=InternalScope(self.user), name=dataset_name).one().length = 15
         db_session.commit()
         cmd = 'rucio download --dir /tmp --scope {0} --filter length=100'.format(self.user)
         exitcode, out, err = execute(cmd)
@@ -609,7 +610,7 @@ class TestBinRucio():
         print(out, err)
         remove(tmp_file1)
         db_session = session.get_session()
-        db_session.query(models.DataIdentifier).filter_by(scope=self.user, name=dataset_name).one().length = 1
+        db_session.query(models.DataIdentifier).filter_by(scope=InternalScope(self.user), name=dataset_name).one().length = 1
         db_session.commit()
         cmd = 'rucio download --dir /tmp {0}:{1} --filter length=10'.format(self.user, dataset_name[0:-1] + '*')
         exitcode, out, err = execute(cmd)

--- a/lib/rucio/tests/test_common_types.py
+++ b/lib/rucio/tests/test_common_types.py
@@ -1,0 +1,68 @@
+# Copyright 2019 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+
+from rucio.common.types import InternalScope, InternalAccount, InternalType
+import nose.tools
+
+
+class TestInternalType(object):
+    ''' Test the base InternalType class '''
+
+    def setup(self):
+        ''' INTERNAL TYPES: Setup the tests '''
+        self.base = InternalType('test')
+        self.same = InternalType('test')
+        self.diff = InternalType('different')
+
+        self.base_account = InternalAccount('test')
+        self.base_scope = InternalScope('test')
+
+    def test_equality(self):
+        ''' INTERNAL TYPES: Equality '''
+        equal = self.base == self.same
+        nose.tools.assert_true(equal)
+
+        identical = self.base is self.same
+        nose.tools.assert_true(not identical)
+
+        different = self.base != self.diff
+        nose.tools.assert_true(different)
+
+        equal = (self.base.internal == self.same.internal) \
+            & (self.base.external == self.same.external)
+        nose.tools.assert_true(equal)
+
+        different = (self.base.internal != self.diff.internal) \
+            & (self.base.external != self.diff.external)
+        nose.tools.assert_true(different)
+
+        different = self.base_account != self.base_scope
+        nose.tools.assert_true(different)
+
+    def test_conversion(self):
+        ''' INTERNAL TYPES: Conversion '''
+        internal = self.base.internal
+        from_internal = InternalType(internal, fromExternal=False)
+
+        equal = self.base == from_internal
+        nose.tools.assert_true(equal)
+
+    def test_str_rep(self):
+        ''' INTERNAL TYPES: Representation '''
+        base_str = '%s' % self.base
+        equal = base_str == self.base.external
+        nose.tools.assert_true(equal)

--- a/lib/rucio/tests/test_counter.py
+++ b/lib/rucio/tests/test_counter.py
@@ -15,6 +15,7 @@
 from nose.tools import assert_equal, assert_in
 
 from rucio.db.sqla import session, models
+from rucio.common.types import InternalAccount
 from rucio.core import account_counter, rse_counter
 from rucio.core.account import get_usage
 from rucio.core.rse import get_rse_id
@@ -89,7 +90,7 @@ class TestCoreAccountCounter():
         """ACCOUNT COUNTER (CORE): Increase, decrease and get counter """
         account_update(once=True)
         rse_id = get_rse_id(rse='MOCK')
-        account = 'jdoe'
+        account = InternalAccount('jdoe')
         account_counter.del_counter(rse_id=rse_id, account=account)
         account_counter.add_counter(rse_id=rse_id, account=account)
         cnt = get_usage(rse_id=rse_id, account=account)

--- a/lib/rucio/tests/test_credential.py
+++ b/lib/rucio/tests/test_credential.py
@@ -20,6 +20,7 @@ from nose.tools import assert_equal, assert_raises, assert_in, assert_greater
 
 from rucio.client import client
 from rucio.common.exception import UnsupportedOperation
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.credential import get_signed_url
 from rucio.core.replica import add_replicas, delete_replicas
 from rucio.core.rse import add_rse, del_rse, add_protocol, add_rse_attribute
@@ -55,18 +56,19 @@ class TestCredential(object):
                                         'wan': {'read': 1, 'write': 1, 'delete': 1, 'third_party_copy': 1}}})
 
         # register some files there
-        self.files = [{'scope': 'mock',
+        self.files = [{'scope': InternalScope('mock'),
                        'name': 'file-on-gcs_%s' % i,
                        'bytes': 1234,
                        'adler32': 'deadbeef',
                        'meta': {'events': 666}} for i in range(0, 3)]
+        root = InternalAccount('root')
         add_replicas(rse_id=self.rse1_id,
                      files=self.files,
-                     account='root',
+                     account=root,
                      ignore_availability=True)
         add_replicas(rse_id=self.rse2_id,
                      files=self.files,
-                     account='root',
+                     account=root,
                      ignore_availability=True)
 
         def tearDown(self):

--- a/lib/rucio/tests/test_did.py
+++ b/lib/rucio/tests/test_did.py
@@ -41,6 +41,7 @@ from rucio.client.scopeclient import ScopeClient
 from rucio.common.exception import (DataIdentifierNotFound, DataIdentifierAlreadyExists,
                                     InvalidPath, KeyNotFound, UnsupportedOperation,
                                     UnsupportedStatus, ScopeNotFound, FileAlreadyExists, FileConsistencyMismatch)
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.account_limit import set_account_limit
 from rucio.core.did import (list_dids, add_did, delete_dids, get_did_atime, touch_dids, attach_dids, detach_dids,
@@ -56,28 +57,30 @@ class TestDIDCore:
 
     def test_list_dids(self):
         """ DATA IDENTIFIERS (CORE): List dids """
-        for d in list_dids(scope='data13_hip', filters={'name': '*'}, type='collection'):
+        for d in list_dids(scope=InternalScope('data13_hip'), filters={'name': '*'}, type='collection'):
             print(d)
 
     def test_delete_dids(self):
         """ DATA IDENTIFIERS (CORE): Delete dids """
-        tmp_scope = 'mock'
+        tmp_scope = InternalScope('mock')
+        root = InternalAccount('root')
         dsns = [{'name': 'dsn_%s' % generate_uuid(),
                  'scope': tmp_scope,
                  'purge_replicas': False,
                  'did_type': DIDType.DATASET} for i in range(5)]
         for dsn in dsns:
-            add_did(scope=tmp_scope, name=dsn['name'], type='DATASET', account='root')
-        delete_dids(dids=dsns, account='root')
+            add_did(scope=tmp_scope, name=dsn['name'], type='DATASET', account=root)
+        delete_dids(dids=dsns, account=root)
 
     def test_touch_dids_atime(self):
         """ DATA IDENTIFIERS (CORE): Touch dids accessed_at timestamp"""
-        tmp_scope = 'mock'
+        tmp_scope = InternalScope('mock')
+        root = InternalAccount('root')
         tmp_dsn1 = 'dsn_%s' % generate_uuid()
         tmp_dsn2 = 'dsn_%s' % generate_uuid()
 
-        add_did(scope=tmp_scope, name=tmp_dsn1, type=DIDType.DATASET, account='root')
-        add_did(scope=tmp_scope, name=tmp_dsn2, type=DIDType.DATASET, account='root')
+        add_did(scope=tmp_scope, name=tmp_dsn1, type=DIDType.DATASET, account=root)
+        add_did(scope=tmp_scope, name=tmp_dsn2, type=DIDType.DATASET, account=root)
         now = datetime.utcnow()
 
         now -= timedelta(microseconds=now.microsecond)
@@ -90,12 +93,13 @@ class TestDIDCore:
 
     def test_touch_dids_access_cnt(self):
         """ DATA IDENTIFIERS (CORE): Increase dids access_cnt"""
-        tmp_scope = 'mock'
+        tmp_scope = InternalScope('mock')
+        root = InternalAccount('root')
         tmp_dsn1 = 'dsn_%s' % generate_uuid()
         tmp_dsn2 = 'dsn_%s' % generate_uuid()
 
-        add_did(scope=tmp_scope, name=tmp_dsn1, type=DIDType.DATASET, account='root')
-        add_did(scope=tmp_scope, name=tmp_dsn2, type=DIDType.DATASET, account='root')
+        add_did(scope=tmp_scope, name=tmp_dsn1, type=DIDType.DATASET, account=root)
+        add_did(scope=tmp_scope, name=tmp_dsn2, type=DIDType.DATASET, account=root)
 
         assert_equal(None, get_did_access_cnt(scope=tmp_scope, name=tmp_dsn1))
         assert_equal(None, get_did_access_cnt(scope=tmp_scope, name=tmp_dsn2))
@@ -107,15 +111,16 @@ class TestDIDCore:
 
     def test_update_dids(self):
         """ DATA IDENTIFIERS (CORE): Update file size and checksum"""
-        tmp_scope = 'mock'
+        tmp_scope = InternalScope('mock')
+        root = InternalAccount('root')
         dsn = 'dsn_%s' % generate_uuid()
         lfn = 'lfn.%s' % str(generate_uuid())
-        add_did(scope=tmp_scope, name=dsn, type=DIDType.DATASET, account='root')
+        add_did(scope=tmp_scope, name=dsn, type=DIDType.DATASET, account=root)
 
         files = [{'scope': tmp_scope, 'name': lfn,
                   'bytes': 724963570, 'adler32': '0cc737eb',
                   'meta': {'guid': str(generate_uuid()), 'events': 100}}]
-        attach_dids(scope=tmp_scope, name=dsn, rse_id=get_rse_id(rse='MOCK'), dids=files, account='root')
+        attach_dids(scope=tmp_scope, name=dsn, rse_id=get_rse_id(rse='MOCK'), dids=files, account=root)
 
         set_metadata(scope=tmp_scope, name=lfn, key='adler32', value='0cc737ee')
         assert_equal(get_metadata(scope=tmp_scope, name=lfn)['adler32'], '0cc737ee')
@@ -128,7 +133,8 @@ class TestDIDCore:
 
     def test_get_did_with_dynamic(self):
         """ DATA IDENTIFIERS (CORE): Get did with dynamic resolve of size"""
-        tmp_scope = 'mock'
+        tmp_scope = InternalScope('mock')
+        root = InternalAccount('root')
         tmp_dsn1 = 'dsn_%s' % generate_uuid()
         tmp_dsn2 = 'dsn_%s' % generate_uuid()
         tmp_dsn3 = 'dsn_%s' % generate_uuid()
@@ -136,33 +142,34 @@ class TestDIDCore:
 
         rse_id = get_rse_id(rse='MOCK')
 
-        add_did(scope=tmp_scope, name=tmp_dsn1, type=DIDType.DATASET, account='root')
-        add_replica(rse_id=rse_id, scope=tmp_scope, name=tmp_dsn2, bytes=10, account='root')
-        add_replica(rse_id=rse_id, scope=tmp_scope, name=tmp_dsn3, bytes=10, account='root')
-        attach_dids(scope=tmp_scope, name=tmp_dsn1, dids=[{'scope': tmp_scope, 'name': tmp_dsn2}, {'scope': tmp_scope, 'name': tmp_dsn3}], account='root')
+        add_did(scope=tmp_scope, name=tmp_dsn1, type=DIDType.DATASET, account=root)
+        add_replica(rse_id=rse_id, scope=tmp_scope, name=tmp_dsn2, bytes=10, account=root)
+        add_replica(rse_id=rse_id, scope=tmp_scope, name=tmp_dsn3, bytes=10, account=root)
+        attach_dids(scope=tmp_scope, name=tmp_dsn1, dids=[{'scope': tmp_scope, 'name': tmp_dsn2}, {'scope': tmp_scope, 'name': tmp_dsn3}], account=root)
 
-        add_did(scope=tmp_scope, name=tmp_dsn4, type=DIDType.CONTAINER, account='root')
-        attach_dids(scope=tmp_scope, name=tmp_dsn4, dids=[{'scope': tmp_scope, 'name': tmp_dsn1}], account='root')
+        add_did(scope=tmp_scope, name=tmp_dsn4, type=DIDType.CONTAINER, account=root)
+        attach_dids(scope=tmp_scope, name=tmp_dsn4, dids=[{'scope': tmp_scope, 'name': tmp_dsn1}], account=root)
 
         assert_equal(get_did(scope=tmp_scope, name=tmp_dsn1, dynamic=True)['bytes'], 20)
         assert_equal(get_did(scope=tmp_scope, name=tmp_dsn4, dynamic=True)['bytes'], 20)
 
     def test_reattach_dids(self):
         """ DATA IDENTIFIERS (CORE): Repeatedly attach and detach DIDs """
-        tmp_scope = 'mock'
+        tmp_scope = InternalScope('mock')
+        root = InternalAccount('root')
         parent_name = 'parent_%s' % generate_uuid()
-        add_did(scope=tmp_scope, name=parent_name, type=DIDType.DATASET, account='root')
+        add_did(scope=tmp_scope, name=parent_name, type=DIDType.DATASET, account=root)
 
         child_name = 'child_%s' % generate_uuid()
         files = [{'scope': tmp_scope, 'name': child_name,
                   'bytes': 12345, 'adler32': '0cc737eb'}]
 
         rse_id = get_rse_id('MOCK')
-        attach_dids(scope=tmp_scope, name=parent_name, rse_id=rse_id, dids=files, account='root')
+        attach_dids(scope=tmp_scope, name=parent_name, rse_id=rse_id, dids=files, account=root)
 
         detach_dids(scope=tmp_scope, name=parent_name, dids=files)
 
-        attach_dids(scope=tmp_scope, name=parent_name, rse_id=rse_id, dids=files, account='root')
+        attach_dids(scope=tmp_scope, name=parent_name, rse_id=rse_id, dids=files, account=root)
 
         detach_dids(scope=tmp_scope, name=parent_name, dids=files)
 
@@ -374,9 +381,9 @@ class TestDIDClients:
         tmp_scope = 'mock'
         tmp_rse = 'MOCK'
         tmp_dsn = 'dsn_%s' % generate_uuid()
-
-        set_account_limit('root', get_rse_id('MOCK'), -1)
-        set_account_limit('root', get_rse_id('CERN-PROD_TZERO'), -1)
+        root = InternalAccount('root')
+        set_account_limit(root, get_rse_id('MOCK'), -1)
+        set_account_limit(root, get_rse_id('CERN-PROD_TZERO'), -1)
 
         # PFN example: rfio://castoratlas.cern.ch/castor/cern.ch/grid/atlas/tzero/xx/xx/xx/filename
         dataset_meta = {'project': 'data13_hip',

--- a/lib/rucio/tests/test_identity.py
+++ b/lib/rucio/tests/test_identity.py
@@ -9,6 +9,7 @@
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2012, 2017
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2013-2015
 # - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2019
+# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 
 """
 Test the Identity abstraction layer
@@ -17,6 +18,7 @@ Test the Identity abstraction layer
 from nose.tools import assert_equal
 from paste.fixture import TestApp
 
+from rucio.common.types import InternalAccount
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account import add_account, del_account
 from rucio.core.identity import add_identity, del_identity, add_account_identity, del_account_identity, list_identities
@@ -33,7 +35,7 @@ class TestIdentity(object):
 
     def setup(self):
         """ Setup the Test Case """
-        self.account = account_name_generator()
+        self.account = InternalAccount(account_name_generator())
         add_account(self.account, AccountType.USER, 'rucio@email.com')
 
     def tearDown(self):
@@ -43,7 +45,7 @@ class TestIdentity(object):
     def test_userpass(self):
         """ IDENTITY (CORE): Test adding and removing username/password authentication """
 
-        add_identity(self.account, IdentityType.USERPASS, email='ph-adp-ddm-lab@cern.ch', password='secret')
+        add_identity(self.account.external, IdentityType.USERPASS, email='ph-adp-ddm-lab@cern.ch', password='secret')
         add_account_identity('ddmlab_%s' % self.account, IdentityType.USERPASS, self.account, email='ph-adp-ddm-lab@cern.ch', password='secret')
 
         add_identity('/ch/cern/rucio/ddmlab_%s' % self.account, IdentityType.X509, email='ph-adp-ddm-lab@cern.ch')
@@ -63,13 +65,13 @@ class TestIdentity(object):
     def test_ssh(self):
         """ IDENTITY (CORE): Test adding and removing SSH public key authentication """
 
-        add_identity(self.account, IdentityType.SSH, email='ph-adp-ddm-lab@cern.ch')
+        add_identity(self.account.external, IdentityType.SSH, email='ph-adp-ddm-lab@cern.ch')
         add_account_identity('my_public_key', IdentityType.SSH, self.account, email='ph-adp-ddm-lab@cern.ch')
 
         list_identities()
 
         del_account_identity('my_public_key', IdentityType.SSH, self.account)
-        del_identity(self.account, IdentityType.SSH)
+        del_identity(self.account.external, IdentityType.SSH)
 
 
 class TestIdentityRest(object):

--- a/lib/rucio/tests/test_judge_cleaner.py
+++ b/lib/rucio/tests/test_judge_cleaner.py
@@ -9,6 +9,7 @@
 # - Martin Barisits, <martin.barisits@cern.ch>, 2014-2018
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account_limit import set_account_limit
 from rucio.core.did import add_did, attach_dids
@@ -50,27 +51,29 @@ class TestJudgeCleaner():
         add_rse_attribute(cls.rse5_id, "fakeweight", 0)
 
         # Add quota
-        set_account_limit('jdoe', cls.rse1_id, -1)
-        set_account_limit('jdoe', cls.rse3_id, -1)
-        set_account_limit('jdoe', cls.rse4_id, -1)
-        set_account_limit('jdoe', cls.rse5_id, -1)
+        cls.jdoe = InternalAccount('jdoe')
+        cls.root = InternalAccount('root')
+        set_account_limit(cls.jdoe, cls.rse1_id, -1)
+        set_account_limit(cls.jdoe, cls.rse3_id, -1)
+        set_account_limit(cls.jdoe, cls.rse4_id, -1)
+        set_account_limit(cls.jdoe, cls.rse5_id, -1)
 
-        set_account_limit('root', cls.rse1_id, -1)
-        set_account_limit('root', cls.rse3_id, -1)
-        set_account_limit('root', cls.rse4_id, -1)
-        set_account_limit('root', cls.rse5_id, -1)
+        set_account_limit(cls.root, cls.rse1_id, -1)
+        set_account_limit(cls.root, cls.rse3_id, -1)
+        set_account_limit(cls.root, cls.rse4_id, -1)
+        set_account_limit(cls.root, cls.rse5_id, -1)
 
     def test_judge_expire_rule(self):
         """ JUDGE CLEANER: Test the judge when deleting expired rules"""
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
-        attach_dids(scope, dataset, files, 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
 
-        add_rule(dids=[{'scope': scope, 'name': dataset}], account='jdoe', copies=1, rse_expression=self.rse1, grouping='NONE', weight='fakeweight', lifetime=-3, locked=False, subscription_id=None)[0]
-        add_rule(dids=[{'scope': scope, 'name': dataset}], account='jdoe', copies=2, rse_expression=self.T1, grouping='NONE', weight='fakeweight', lifetime=None, locked=False, subscription_id=None)[0]
-        add_rule(dids=[{'scope': scope, 'name': dataset}], account='jdoe', copies=3, rse_expression=self.T1, grouping='NONE', weight='fakeweight', lifetime=None, locked=False, subscription_id=None)[0]
+        add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=1, rse_expression=self.rse1, grouping='NONE', weight='fakeweight', lifetime=-3, locked=False, subscription_id=None)[0]
+        add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=2, rse_expression=self.T1, grouping='NONE', weight='fakeweight', lifetime=None, locked=False, subscription_id=None)[0]
+        add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=3, rse_expression=self.T1, grouping='NONE', weight='fakeweight', lifetime=None, locked=False, subscription_id=None)[0]
 
         rule_cleaner(once=True)
 
@@ -80,14 +83,14 @@ class TestJudgeCleaner():
 
     def test_judge_expire_rule_with_child_rule(self):
         """ JUDGE CLEANER: Test the judge when deleting expired rules with child rules"""
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
-        attach_dids(scope, dataset, files, 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
 
-        rule_id = add_rule(dids=[{'scope': scope, 'name': dataset}], account='jdoe', copies=1, rse_expression=self.rse1, grouping='NONE', weight='fakeweight', lifetime=None, locked=False, subscription_id=None)[0]
-        child_rule = add_rule(dids=[{'scope': scope, 'name': dataset}], account='jdoe', copies=1, rse_expression=self.rse3, grouping='NONE', weight='fakeweight', lifetime=-3, locked=False, subscription_id=None)[0]
+        rule_id = add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=1, rse_expression=self.rse1, grouping='NONE', weight='fakeweight', lifetime=None, locked=False, subscription_id=None)[0]
+        child_rule = add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=1, rse_expression=self.rse3, grouping='NONE', weight='fakeweight', lifetime=-3, locked=False, subscription_id=None)[0]
         update_rule(rule_id, {'child_rule_id': child_rule})
 
         rule_cleaner(once=True)

--- a/lib/rucio/tests/test_judge_evaluator.py
+++ b/lib/rucio/tests/test_judge_evaluator.py
@@ -18,6 +18,7 @@
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2019
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account import get_usage
 from rucio.core.account_limit import set_account_limit
@@ -61,31 +62,33 @@ class TestJudgeEvaluator():
         add_rse_attribute(cls.rse5_id, "fakeweight", 0)
 
         # Add quota
-        set_account_limit('jdoe', cls.rse1_id, -1)
-        set_account_limit('jdoe', cls.rse3_id, -1)
-        set_account_limit('jdoe', cls.rse4_id, -1)
-        set_account_limit('jdoe', cls.rse5_id, -1)
+        cls.jdoe = InternalAccount('jdoe')
+        cls.root = InternalAccount('root')
+        set_account_limit(cls.jdoe, cls.rse1_id, -1)
+        set_account_limit(cls.jdoe, cls.rse3_id, -1)
+        set_account_limit(cls.jdoe, cls.rse4_id, -1)
+        set_account_limit(cls.jdoe, cls.rse5_id, -1)
 
-        set_account_limit('root', cls.rse1_id, -1)
-        set_account_limit('root', cls.rse3_id, -1)
-        set_account_limit('root', cls.rse4_id, -1)
-        set_account_limit('root', cls.rse5_id, -1)
+        set_account_limit(cls.root, cls.rse1_id, -1)
+        set_account_limit(cls.root, cls.rse3_id, -1)
+        set_account_limit(cls.root, cls.rse4_id, -1)
+        set_account_limit(cls.root, cls.rse5_id, -1)
 
     def test_judge_add_files_to_dataset(self):
         """ JUDGE EVALUATOR: Test the judge when adding files to dataset"""
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
 
         # Add a first rule to the DS
-        add_rule(dids=[{'scope': scope, 'name': dataset}], account='jdoe', copies=2, rse_expression=self.T1, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
+        add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=2, rse_expression=self.T1, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
 
-        attach_dids(scope, dataset, files, 'jdoe')
+        attach_dids(scope, dataset, files, self.jdoe)
         re_evaluator(once=True)
 
         files = create_files(3, scope, self.rse1_id)
-        attach_dids(scope, dataset, files, 'jdoe')
+        attach_dids(scope, dataset, files, self.jdoe)
 
         # Fake judge
         re_evaluator(once=True)
@@ -96,17 +99,17 @@ class TestJudgeEvaluator():
 
     def test_judge_add_dataset_to_container(self):
         """ JUDGE EVALUATOR: Test the judge when adding dataset to container"""
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
-        attach_dids(scope, dataset, files, 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
 
         parent_container = 'dataset_' + str(uuid())
-        add_did(scope, parent_container, DIDType.from_sym('CONTAINER'), 'jdoe')
+        add_did(scope, parent_container, DIDType.from_sym('CONTAINER'), self.jdoe)
         # Add a first rule to the DS
-        add_rule(dids=[{'scope': scope, 'name': parent_container}], account='jdoe', copies=2, rse_expression=self.T1, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
-        attach_dids(scope, parent_container, [{'scope': scope, 'name': dataset}], 'jdoe')
+        add_rule(dids=[{'scope': scope, 'name': parent_container}], account=self.jdoe, copies=2, rse_expression=self.T1, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
+        attach_dids(scope, parent_container, [{'scope': scope, 'name': dataset}], self.jdoe)
         # Fake judge
         re_evaluator(once=True)
 
@@ -123,22 +126,22 @@ class TestJudgeEvaluator():
         re_evaluator(once=True)
         account_update(once=True)
 
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id, bytes=100)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
 
         # Add a first rule to the DS
-        add_rule(dids=[{'scope': scope, 'name': dataset}], account='jdoe', copies=1, rse_expression=self.rse1, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
+        add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=1, rse_expression=self.rse1, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
 
-        account_counter_before = get_usage(self.rse1_id, 'jdoe')
-        attach_dids(scope, dataset, files, 'jdoe')
+        account_counter_before = get_usage(self.rse1_id, self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
 
         # Fake judge
         re_evaluator(once=True)
         account_update(once=True)
 
-        account_counter_after = get_usage(self.rse1_id, 'jdoe')
+        account_counter_after = get_usage(self.rse1_id, self.jdoe)
         assert(account_counter_before['bytes'] + 3 * 100 == account_counter_after['bytes'])
         assert(account_counter_before['files'] + 3 == account_counter_after['files'])
 
@@ -147,18 +150,18 @@ class TestJudgeEvaluator():
         re_evaluator(once=True)
         account_update(once=True)
 
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id, bytes=100)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
-        attach_dids(scope, dataset, files, 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
 
         # Add a first rule to the DS
-        add_rule(dids=[{'scope': scope, 'name': dataset}], account='jdoe', copies=1, rse_expression=self.rse1, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
+        add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=1, rse_expression=self.rse1, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
 
         account_update(once=True)
 
-        account_counter_before = get_usage(self.rse1_id, 'jdoe')
+        account_counter_before = get_usage(self.rse1_id, self.jdoe)
 
         detach_dids(scope, dataset, [files[0]])
 
@@ -166,7 +169,7 @@ class TestJudgeEvaluator():
         re_evaluator(once=True)
         account_update(once=True)
 
-        account_counter_after = get_usage(self.rse1_id, 'jdoe')
+        account_counter_after = get_usage(self.rse1_id, self.jdoe)
         assert(account_counter_before['bytes'] - 100 == account_counter_after['bytes'])
         assert(account_counter_before['files'] - 1 == account_counter_after['files'])
 
@@ -174,18 +177,18 @@ class TestJudgeEvaluator():
         """ JUDGE EVALUATOR: Test if the a datasetlock is detached correctly when removing a dataset from a container"""
         re_evaluator(once=True)
 
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id, bytes=100)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
-        attach_dids(scope, dataset, files, 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
 
         container = 'container_' + str(uuid())
-        add_did(scope, container, DIDType.from_sym('CONTAINER'), 'jdoe')
-        attach_dids(scope, container, [{'scope': scope, 'name': dataset}], 'jdoe')
+        add_did(scope, container, DIDType.from_sym('CONTAINER'), self.jdoe)
+        attach_dids(scope, container, [{'scope': scope, 'name': dataset}], self.jdoe)
 
         # Add a rule to the Container
-        add_rule(dids=[{'scope': scope, 'name': container}], account='jdoe', copies=1, rse_expression=self.rse1, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
+        add_rule(dids=[{'scope': scope, 'name': container}], account=self.jdoe, copies=1, rse_expression=self.rse1, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
 
         # Check if the datasetlock is there
         locks = [ds_lock for ds_lock in get_dataset_locks(scope=scope, name=dataset)]
@@ -203,33 +206,33 @@ class TestJudgeEvaluator():
         """ JUDGE EVALUATOR: Test if the detach is done correctly"""
         re_evaluator(once=True)
 
-        scope = 'mock'
+        scope = InternalScope('mock')
         container = 'container_' + str(uuid())
-        add_did(scope, container, DIDType.from_sym('CONTAINER'), 'jdoe')
+        add_did(scope, container, DIDType.from_sym('CONTAINER'), self.jdoe)
 
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id, bytes=100)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
-        attach_dids(scope, dataset, files, 'jdoe')
-        attach_dids(scope, container, [{'scope': scope, 'name': dataset}], 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
+        attach_dids(scope, container, [{'scope': scope, 'name': dataset}], self.jdoe)
 
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id, bytes=100)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
-        attach_dids(scope, dataset, files, 'jdoe')
-        attach_dids(scope, container, [{'scope': scope, 'name': dataset}], 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
+        attach_dids(scope, container, [{'scope': scope, 'name': dataset}], self.jdoe)
 
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id, bytes=100)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
-        attach_dids(scope, dataset, files, 'jdoe')
-        attach_dids(scope, container, [{'scope': scope, 'name': dataset}], 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
+        attach_dids(scope, container, [{'scope': scope, 'name': dataset}], self.jdoe)
 
         # Add a first rule to the Container
-        rule_id = add_rule(dids=[{'scope': scope, 'name': container}], account='jdoe', copies=1, rse_expression=self.rse1, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)[0]
+        rule_id = add_rule(dids=[{'scope': scope, 'name': container}], account=self.jdoe, copies=1, rse_expression=self.rse1, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)[0]
 
         # Fake judge
         re_evaluator(once=True)
@@ -245,20 +248,20 @@ class TestJudgeEvaluator():
 
     def test_judge_add_files_to_dataset_with_2_rules(self):
         """ JUDGE EVALUATOR: Test the judge when adding files to dataset with 2 rules"""
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
 
         # Add a first rule to the DS
-        add_rule(dids=[{'scope': scope, 'name': dataset}], account='jdoe', copies=1, rse_expression=self.rse5, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
-        add_rule(dids=[{'scope': scope, 'name': dataset}], account='root', copies=1, rse_expression=self.rse5, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
+        add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=1, rse_expression=self.rse5, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
+        add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.root, copies=1, rse_expression=self.rse5, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
 
-        attach_dids(scope, dataset, files, 'jdoe')
+        attach_dids(scope, dataset, files, self.jdoe)
         re_evaluator(once=True)
 
         files = create_files(3, scope, self.rse1_id)
-        attach_dids(scope, dataset, files, 'jdoe')
+        attach_dids(scope, dataset, files, self.jdoe)
 
         # Fake judge
         re_evaluator(once=True)
@@ -269,22 +272,22 @@ class TestJudgeEvaluator():
 
     def test_judge_add_files_to_dataset_rule_on_container(self):
         """ JUDGE EVALUATOR: Test the judge when attaching file to dataset with rule on two levels of containers"""
-        scope = 'mock'
+        scope = InternalScope('mock')
         files = create_files(3, scope, self.rse1_id)
         dataset = 'dataset_' + str(uuid())
-        add_did(scope, dataset, DIDType.from_sym('DATASET'), 'jdoe')
-        attach_dids(scope, dataset, files, 'jdoe')
+        add_did(scope, dataset, DIDType.from_sym('DATASET'), self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
 
         parent_container = 'dataset_' + str(uuid())
-        add_did(scope, parent_container, DIDType.from_sym('CONTAINER'), 'jdoe')
-        attach_dids(scope, parent_container, [{'scope': scope, 'name': dataset}], 'jdoe')
+        add_did(scope, parent_container, DIDType.from_sym('CONTAINER'), self.jdoe)
+        attach_dids(scope, parent_container, [{'scope': scope, 'name': dataset}], self.jdoe)
 
         parent_parent_container = 'dataset_' + str(uuid())
-        add_did(scope, parent_parent_container, DIDType.from_sym('CONTAINER'), 'jdoe')
-        attach_dids(scope, parent_parent_container, [{'scope': scope, 'name': parent_container}], 'jdoe')
+        add_did(scope, parent_parent_container, DIDType.from_sym('CONTAINER'), self.jdoe)
+        attach_dids(scope, parent_parent_container, [{'scope': scope, 'name': parent_container}], self.jdoe)
 
         # Add a first rule to the DS
-        add_rule(dids=[{'scope': scope, 'name': parent_parent_container}], account='jdoe', copies=2, rse_expression=self.T1, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
+        add_rule(dids=[{'scope': scope, 'name': parent_parent_container}], account=self.jdoe, copies=2, rse_expression=self.T1, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None)
 
         # Fake judge
         re_evaluator(once=True)
@@ -295,7 +298,7 @@ class TestJudgeEvaluator():
 
         # create more files and attach them
         more_files = create_files(3, scope, self.rse1_id)
-        attach_dids(scope, dataset, more_files, 'jdoe')
+        attach_dids(scope, dataset, more_files, self.jdoe)
         re_evaluator(once=True)
         # Check if the Locks are created properly
         for file in more_files:

--- a/lib/rucio/tests/test_naming_convention.py
+++ b/lib/rucio/tests/test_naming_convention.py
@@ -8,6 +8,7 @@
 
   Authors:
   - Vincent Garonne, <vincent.garonne@cern.ch>, 2015
+  - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 """
 
 # pylint: disable=E0611
@@ -15,6 +16,7 @@ from nose.tools import assert_equal, assert_raises
 
 from rucio.client.didclient import DIDClient
 from rucio.common.exception import InvalidObject
+from rucio.common.types import InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.naming_convention import (add_naming_convention,
                                           validate_name,
@@ -38,19 +40,20 @@ class TestNamingConventionCore:
         for convention in list_naming_conventions():
             conventions[convention['scope']] = convention['regexp']
 
-        if 'mock' not in conventions:
-            add_naming_convention(scope='mock',
+        scope = InternalScope('mock')
+        if scope not in conventions:
+            add_naming_convention(scope=scope,
                                   regexp='^(?P<project>mock)\.(?P<datatype>\w+)\.\w+$',
                                   convention_type=KeyType.DATASET)
 
-        meta = validate_name(scope='mck', name='mock.DESD.yipeeee', did_type='D')
+        meta = validate_name(scope=InternalScope('mck'), name='mock.DESD.yipeeee', did_type='D')
         assert_equal(meta, None)
 
-        meta = validate_name(scope='mock', name='mock.DESD.yipeeee', did_type='D')
+        meta = validate_name(scope=scope, name='mock.DESD.yipeeee', did_type='D')
         assert_equal(meta, {u'project': 'mock', u'datatype': 'DESD'})
 
         with assert_raises(InvalidObject):
-            validate_name(scope='mock', name='mockyipeeee', did_type='D')
+            validate_name(scope=scope, name='mockyipeeee', did_type='D')
 
         # Register a dataset
         tmp_dataset = 'mock.AD.' + str(generate_uuid())
@@ -65,6 +68,6 @@ class TestNamingConventionCore:
         observed_datatype = self.did_client.get_metadata(scope='mock', name=tmp_dataset)['datatype']
         assert_equal(observed_datatype, 'AOD')
 
-        delete_naming_convention(scope='mock',
+        delete_naming_convention(scope=scope,
                                  regexp='(?P<project>mock)\.(\w+)$',
                                  convention_type=KeyType.DATASET)

--- a/lib/rucio/tests/test_permission.py
+++ b/lib/rucio/tests/test_permission.py
@@ -8,6 +8,7 @@
 # Authors:
 # - Vincent Garonne,  <vincent.garonne@cern.ch> , 2012
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2013
+# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 
 """
 Test the Permission Core and API
@@ -17,6 +18,7 @@ from nose.tools import assert_true, assert_false
 
 from rucio.api.permission import has_permission
 from rucio.common.config import config_get
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.scope import add_scope
 from rucio.tests.common import scope_name_generator
 
@@ -37,7 +39,7 @@ class TestPermissionCoreApi(object):
     def test_permission_add_did(self):
         """ PERMISSION(CORE): Check permission to add a did"""
         scope = scope_name_generator()
-        add_scope(scope=scope, account='root')
+        add_scope(scope=InternalScope(scope), account=InternalAccount('root'))
         assert_true(has_permission(issuer='panda', action='add_did', kwargs={'scope': scope}))
         assert_false(has_permission(issuer='spock', action='add_did', kwargs={'scope': scope}))
 

--- a/lib/rucio/tests/test_reaper.py
+++ b/lib/rucio/tests/test_reaper.py
@@ -16,11 +16,12 @@
 # - Vincent Garonne <vgaronne@gmail.com>, 2013-2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2016
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
-# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 
 import nose.tools
 
 from rucio.common.utils import execute, generate_uuid
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.core import rse as rse_core
 from rucio.core import replica as replica_core
 
@@ -34,9 +35,9 @@ def test_reaper():
     rse_id = rse_core.get_rse_id(rse='MOCK')
 
     for i in range(nb_files):
-        replica_core.add_replica(rse_id=rse_id, scope='data13_hip',
+        replica_core.add_replica(rse_id=rse_id, scope=InternalScope('data13_hip'),
                                  name='lfn' + generate_uuid(), bytes=file_size,
-                                 account='root', adler32=None, md5=None)
+                                 account=InternalAccount('root'), adler32=None, md5=None)
 
     rse_core.set_rse_usage(rse_id=rse_id, source='srm', used=nb_files * file_size, free=800)
     rse_core.set_rse_limits(rse_id=rse_id, name='MinFreeSpace', value=10737418240)

--- a/lib/rucio/tests/test_replica_sorting.py
+++ b/lib/rucio/tests/test_replica_sorting.py
@@ -20,6 +20,7 @@
 from nose.tools import assert_equal, assert_in, assert_not_in
 
 from rucio.client import ReplicaClient
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.replica import add_replicas, delete_replicas
 from rucio.core.rse import add_rse, del_rse, add_rse_attribute, add_protocol
 from rucio.tests.common import rse_name_generator
@@ -39,10 +40,11 @@ class TestReplicaSorting(object):
         add_rse_attribute(rse_id=self.rse1_id, key='site', value='APERTURE')
         add_rse_attribute(rse_id=self.rse2_id, key='site', value='BLACKMESA')
 
-        self.files = [{'scope': 'mock', 'name': 'element_0',
+        self.files = [{'scope': InternalScope('mock'), 'name': 'element_0',
                        'bytes': 1234, 'adler32': 'deadbeef'}]
-        add_replicas(rse_id=self.rse1_id, files=self.files, account='root')
-        add_replicas(rse_id=self.rse2_id, files=self.files, account='root')
+        root = InternalAccount('root')
+        add_replicas(rse_id=self.rse1_id, files=self.files, account=root)
+        add_replicas(rse_id=self.rse2_id, files=self.files, account=root)
 
         add_protocol(self.rse1_id, {'scheme': 'root',
                                     'hostname': 'root.aperture.com',

--- a/lib/rucio/tests/test_request.py
+++ b/lib/rucio/tests/test_request.py
@@ -20,6 +20,7 @@
 from datetime import datetime
 from nose.tools import assert_equal
 
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.did import attach_dids, add_did
 from rucio.core.replica import add_replica
@@ -38,8 +39,8 @@ class TestRequestCore(object):
         cls.source_rse = 'MOCK4'
         cls.dest_rse_id = get_rse_id(cls.dest_rse)
         cls.source_rse_id = get_rse_id(cls.source_rse)
-        cls.scope = 'mock'
-        cls.account = 'root'
+        cls.scope = InternalScope('mock')
+        cls.account = InternalAccount('root')
         cls.user_activity = 'User Subscription'
         cls.all_activities = 'all_activities'
 
@@ -736,7 +737,7 @@ class TestRequestCore(object):
             'scope': self.scope,
             'rule_id': generate_uuid(),
             'retry_count': 1,
-            'account': 'jdoe',
+            'account': InternalAccount('jdoe'),
             'attributes': {
                 'activity': self.user_activity,
                 'bytes': 1,

--- a/lib/rucio/tests/test_root_proxy.py
+++ b/lib/rucio/tests/test_root_proxy.py
@@ -31,6 +31,7 @@ from nose.tools import assert_equal, assert_in, assert_not_in
 from paste.fixture import TestApp
 
 from rucio.client import ReplicaClient
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.config import set as config_set
 from rucio.core.replica import add_replicas, delete_replicas
 from rucio.core.rse import add_rse, add_rse_attribute, del_rse, add_protocol
@@ -65,7 +66,7 @@ class TestROOTProxy(object):
         # APERTURE1 site has an internal proxy
         config_set('root-proxy-internal', 'APERTURE1', 'proxy.aperture.com:1094')
 
-        self.files = [{'scope': 'mock',
+        self.files = [{'scope': InternalScope('mock'),
                        'name': 'half-life_%s' % i,
                        'bytes': 1234,
                        'adler32': 'deadbeef',
@@ -73,7 +74,7 @@ class TestROOTProxy(object):
         for rse_id in [self.rse_with_proxy_id, self.rse_without_proxy_id]:
             add_replicas(rse_id=rse_id,
                          files=self.files,
-                         account='root',
+                         account=InternalAccount('root'),
                          ignore_availability=True)
 
         add_protocol(self.rse_without_proxy_id, {'scheme': 'root',

--- a/lib/rucio/tests/test_scope.py
+++ b/lib/rucio/tests/test_scope.py
@@ -11,6 +11,7 @@
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2012
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2012-2015
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2017
+# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 
 from json import dumps, loads
 
@@ -20,6 +21,7 @@ from nose.tools import assert_equal, assert_true, assert_in, raises, assert_rais
 from rucio.client.accountclient import AccountClient
 from rucio.client.scopeclient import ScopeClient
 from rucio.common.exception import AccountNotFound, Duplicate, ScopeNotFound, InvalidObject
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.scope import get_scopes, add_scope, is_scope_owner
 from rucio.tests.common import account_name_generator, scope_name_generator
@@ -30,21 +32,22 @@ from rucio.web.rest.authentication import APP as auth_app
 class TestScopeCoreApi():
 
     def __init__(self):
-        self.scopes = [scope_name_generator() for _ in range(5)]
+        self.scopes = [InternalScope(scope_name_generator()) for _ in range(5)]
+        self.jdoe = InternalAccount('jdoe')
 
     def test_list_scopes(self):
         """ SCOPE (CORE): List scopes """
         for scope in self.scopes:
-            add_scope(scope=scope, account='jdoe')
-        scopes = get_scopes(account='jdoe')
+            add_scope(scope=scope, account=self.jdoe)
+        scopes = get_scopes(account=self.jdoe)
         for scope in scopes:
             assert_in(scope, scopes)
 
     def test_is_scope_owner(self):
         """ SCOPE (CORE): Is scope owner """
-        scope = scope_name_generator()
-        add_scope(scope=scope, account='jdoe')
-        anwser = is_scope_owner(scope=scope, account='jdoe')
+        scope = InternalScope(scope_name_generator())
+        add_scope(scope=scope, account=self.jdoe)
+        anwser = is_scope_owner(scope=scope, account=self.jdoe)
         assert_equal(anwser, True)
 
 

--- a/lib/rucio/tests/test_temporary_did.py
+++ b/lib/rucio/tests/test_temporary_did.py
@@ -15,10 +15,11 @@
 # Authors:
 # - Vincent Garonne <vgaronne@gmail.com>, 2016-2018
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
-# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 
 from nose.tools import assert_equal
 
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.temporary_did import (add_temporary_dids, compose, delete_temporary_dids,
                                       list_expired_temporary_dids)
@@ -30,20 +31,22 @@ from rucio.client.didclient import DIDClient
 def test_core_temporary_dids():
     """ TMP DATA IDENTIFIERS (CORE): """
 
+    scope = InternalScope('mock')
+    root = InternalAccount('root')
     temporary_dids = []
     rse = 'MOCK'
     rse_id = get_rse_id(rse=rse)
     for _ in range(10):
-        temporary_dids.append({'scope': 'mock',
+        temporary_dids.append({'scope': scope,
                                'name': 'object_%s' % generate_uuid(),
                                'rse_id': rse_id,
                                'bytes': 1,
                                'path': None})
 
-    add_temporary_dids(dids=temporary_dids, account='root')
+    add_temporary_dids(dids=temporary_dids, account=root)
 
-    compose(scope='mock', name='file_%s' % generate_uuid(), rse_id=rse_id,
-            bytes=10, sources=temporary_dids, account='root',
+    compose(scope=scope, name='file_%s' % generate_uuid(), rse_id=rse_id,
+            bytes=10, sources=temporary_dids, account=root,
             md5=None, adler32=None, pfn=None, meta={}, rules=[],
             parent_scope=None, parent_name=None)
 

--- a/lib/rucio/tests/test_throttler.py
+++ b/lib/rucio/tests/test_throttler.py
@@ -20,6 +20,7 @@
 from datetime import datetime
 from nose.tools import assert_equal
 
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.config import set, remove_option
 from rucio.core.did import attach_dids, add_did
@@ -39,8 +40,8 @@ class TestThrottlerGroupedFIFO(object):
         cls.source_rse = 'MOCK4'
         cls.dest_rse_id = get_rse_id(cls.dest_rse)
         cls.source_rse_id = get_rse_id(cls.source_rse)
-        cls.scope = 'mock'
-        cls.account = 'root'
+        cls.scope = InternalScope('mock')
+        cls.account = InternalAccount('root')
         cls.user_activity = 'User Subscription'
         cls.all_activities = 'all_activities'
         set('throttler_release_strategy', 'dest_%s' % cls.dest_rse_id, 'grouped_fifo')
@@ -374,8 +375,8 @@ class TestThrottlerFIFO(object):
         cls.source_rse = 'MOCK4'
         cls.dest_rse_id = get_rse_id(cls.dest_rse)
         cls.source_rse_id = get_rse_id(cls.source_rse)
-        cls.scope = 'mock'
-        cls.account = 'root'
+        cls.scope = InternalScope('mock')
+        cls.account = InternalAccount('root')
         cls.user_activity = 'User Subscription'
         cls.all_activities = 'all_activities'
         set_rse_transfer_limits(cls.dest_rse_id, cls.user_activity, max_transfers=1, session=cls.db_session)

--- a/lib/rucio/tests/test_undertaker.py
+++ b/lib/rucio/tests/test_undertaker.py
@@ -17,12 +17,13 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2015-2017
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
-# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 
 from datetime import datetime, timedelta
 
 from nose.tools import assert_not_equal
 
+from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.account_limit import set_account_limit
 from rucio.core.did import add_dids, attach_dids, list_expired_dids, get_did
@@ -37,13 +38,16 @@ class TestUndertaker:
 
     def test_undertaker(self):
         """ UNDERTAKER (CORE): Test the undertaker. """
-        tmp_scope = 'mock'
+        tmp_scope = InternalScope('mock')
+        jdoe = InternalAccount('jdoe')
+        root = InternalAccount('root')
+
         nbdatasets = 5
         nbfiles = 5
         rse = 'MOCK'
         rse_id = get_rse_id('MOCK')
 
-        set_account_limit('jdoe', rse_id, -1)
+        set_account_limit(jdoe, rse_id, -1)
 
         dsns1 = [{'name': 'dsn_%s' % generate_uuid(),
                   'scope': tmp_scope,
@@ -54,21 +58,21 @@ class TestUndertaker:
                   'scope': tmp_scope,
                   'type': 'DATASET',
                   'lifetime': -1,
-                  'rules': [{'account': 'jdoe', 'copies': 1,
+                  'rules': [{'account': jdoe, 'copies': 1,
                              'rse_expression': rse,
                              'grouping': 'DATASET'}]} for i in range(nbdatasets)]
 
-        add_dids(dids=dsns1 + dsns2, account='root')
+        add_dids(dids=dsns1 + dsns2, account=root)
 
         replicas = list()
         for dsn in dsns1 + dsns2:
             files = [{'scope': tmp_scope, 'name': 'file_%s' % generate_uuid(),
                       'bytes': 1, 'adler32': '0cc737eb',
                       'tombstone': datetime.utcnow() + timedelta(weeks=2), 'meta': {'events': 10}} for i in range(nbfiles)]
-            attach_dids(scope=tmp_scope, name=dsn['name'], rse_id=rse_id, dids=files, account='root')
+            attach_dids(scope=tmp_scope, name=dsn['name'], rse_id=rse_id, dids=files, account=root)
             replicas += files
 
-        add_rules(dids=dsns1, rules=[{'account': 'jdoe', 'copies': 1, 'rse_expression': rse, 'grouping': 'DATASET'}])
+        add_rules(dids=dsns1, rules=[{'account': jdoe, 'copies': 1, 'rse_expression': rse, 'grouping': 'DATASET'}])
 
         undertaker(worker_number=1, total_workers=1, once=True)
         undertaker(worker_number=1, total_workers=1, once=True)
@@ -78,50 +82,55 @@ class TestUndertaker:
 
     def test_list_expired_dids_with_locked_rules(self):
         """ UNDERTAKER (CORE): Test that the undertaker does not list expired dids with locked rules"""
-        tmp_scope = 'mock'
+        tmp_scope = InternalScope('mock')
+        jdoe = InternalAccount('jdoe')
+        root = InternalAccount('root')
 
         # Add quota
-        set_account_limit('jdoe', get_rse_id('MOCK'), -1)
+        set_account_limit(jdoe, get_rse_id('MOCK'), -1)
 
         dsn = {'name': 'dsn_%s' % generate_uuid(),
                'scope': tmp_scope,
                'type': 'DATASET',
                'lifetime': -1,
-               'rules': [{'account': 'jdoe', 'copies': 1,
+               'rules': [{'account': jdoe, 'copies': 1,
                           'rse_expression': 'MOCK', 'locked': True,
                           'grouping': 'DATASET'}]}
 
-        add_dids(dids=[dsn], account='root')
+        add_dids(dids=[dsn], account=root)
 
         for did in list_expired_dids(limit=1000):
             assert(did['scope'] != dsn['scope'] and did['name'] != dsn['name'])
 
     def test_atlas_archival_policy(self):
         """ UNDERTAKER (CORE): Test the atlas archival policy. """
-        tmp_scope = 'mock'
+        tmp_scope = InternalScope('mock')
+        jdoe = InternalAccount('jdoe')
+        root = InternalAccount('root')
+
         nbdatasets = 5
         nbfiles = 5
 
         rse = 'LOCALGROUPDISK_%s' % rse_name_generator()
         rse_id = add_rse(rse)
 
-        set_account_limit('jdoe', rse_id, -1)
+        set_account_limit(jdoe, rse_id, -1)
 
         dsns2 = [{'name': 'dsn_%s' % generate_uuid(),
                   'scope': tmp_scope,
                   'type': 'DATASET',
                   'lifetime': -1,
-                  'rules': [{'account': 'jdoe', 'copies': 1,
+                  'rules': [{'account': jdoe, 'copies': 1,
                              'rse_expression': rse,
                              'grouping': 'DATASET'}]} for i in range(nbdatasets)]
 
-        add_dids(dids=dsns2, account='root')
+        add_dids(dids=dsns2, account=root)
 
         replicas = list()
         for dsn in dsns2:
             files = [{'scope': tmp_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1,
                       'adler32': '0cc737eb', 'tombstone': datetime.utcnow() + timedelta(weeks=2), 'meta': {'events': 10}} for i in range(nbfiles)]
-            attach_dids(scope=tmp_scope, name=dsn['name'], rse_id=rse_id, dids=files, account='root')
+            attach_dids(scope=tmp_scope, name=dsn['name'], rse_id=rse_id, dids=files, account=root)
             replicas += files
 
         undertaker(worker_number=1, total_workers=1, once=True)
@@ -130,5 +139,5 @@ class TestUndertaker:
             assert(get_replica(scope=replica['scope'], name=replica['name'], rse_id=rse_id)['tombstone'] is None)
 
         for dsn in dsns2:
-            assert(get_did(scope='archive', name=dsn['name'])['name'] == dsn['name'])
-            assert(len([x for x in list_rules(filters={'scope': 'archive', 'name': dsn['name']})]) == 1)
+            assert(get_did(scope=InternalScope('archive'), name=dsn['name'])['name'] == dsn['name'])
+            assert(len([x for x in list_rules(filters={'scope': InternalScope('archive'), 'name': dsn['name']})]) == 1)

--- a/tools/bootstrap_tests.py
+++ b/tools/bootstrap_tests.py
@@ -18,6 +18,7 @@
 from rucio.client import Client
 from rucio.common.exception import Duplicate
 from rucio.core.account import add_account_attribute
+from rucio.common.types import InternalAccount
 
 
 if __name__ == '__main__':
@@ -28,13 +29,13 @@ if __name__ == '__main__':
         print('Account jdoe already added' % locals())
 
     try:
-        add_account_attribute(account='root', key='admin', value=True)
+        add_account_attribute(account=InternalAccount('root'), key='admin', value=True)  # bypass client as schema validation fails at API level
     except Exception as error:
         print(error)
 
     try:
         c.add_account('panda', 'SERVICE', 'panda@email.com')
-        add_account_attribute(account='panda', key='admin', value=True)
+        add_account_attribute(account=InternalAccount('panda'), key='admin', value=True)
     except Duplicate:
         print('Account panda already added' % locals())
 


### PR DESCRIPTION
Core & Internals: Adds internal types for account and scope, to be used as unique refs in core methods; Fix #2553