### PR TITLE
RSE Manager: fix parent directory creation logic for GFAL #2754

### DIFF
--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -394,7 +394,7 @@ class Default(protocol.RSEProtocol):
             params.timeout = int(transfer_timeout)
             watchdog = Timer(params.timeout + 60, self.__gfal2_cancel)
 
-        if not self.renaming and dest[:5] == 'https':
+        if not (self.renaming and dest[:5] == 'https'):
             dir_name = os.path.dirname(dest)
             # This function will be removed soon. gfal2 will create parent dir automatically.
             try:


### PR DESCRIPTION
This should fix the issue caused by an erroneous condition when checking for signed URL case.