### PR TITLE
<Core & Internals>: Change caching endpoint address to be obtained from Rucio config or use localhost. Fix #2812

### DIFF
--- a/lib/rucio/common/objectstore.py
+++ b/lib/rucio/common/objectstore.py
@@ -46,7 +46,7 @@ logging.getLogger("boto.s3.connection").setLevel(logging.WARNING)
 
 REGION = make_region().configure('dogpile.cache.memcached',
                                  expiration_time=3600,
-                                 arguments={'url': "127.0.0.1:11211", 'distributed_lock': True})
+                                 arguments={'url': config.config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
 
 # for local test
 REGION = make_region().configure('dogpile.cache.memory',

--- a/lib/rucio/common/rse_attributes.py
+++ b/lib/rucio/common/rse_attributes.py
@@ -21,10 +21,11 @@ from dogpile.cache import make_region
 from dogpile.cache.api import NoValue
 
 from rucio.core import rse as rse_core
+from rucio.common.config import config_get
 
 REGION = make_region().configure('dogpile.cache.memcached',
                                  expiration_time=3600,
-                                 arguments={'url': "127.0.0.1:11211", 'distributed_lock': True})
+                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
 
 # for local test
 # REGION = make_region().configure('dogpile.cache.memory',

--- a/lib/rucio/core/config.py
+++ b/lib/rucio/core/config.py
@@ -24,13 +24,14 @@ from dogpile.cache import make_region
 from dogpile.cache.api import NoValue
 
 from rucio.common.exception import ConfigNotFound
+from rucio.common.config import config_get
 from rucio.db.sqla import models
 from rucio.db.sqla.session import read_session, transactional_session
 
 
 REGION = make_region().configure('dogpile.cache.memcached',
                                  expiration_time=3600,
-                                 arguments={'url': "127.0.0.1:11211", 'distributed_lock': True})
+                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
 
 
 @read_session

--- a/lib/rucio/core/naming_convention.py
+++ b/lib/rucio/core/naming_convention.py
@@ -23,6 +23,7 @@ from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 
 from rucio.common.exception import Duplicate, RucioException, InvalidObject
+from rucio.common.config import config_get
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import KeyType
 from rucio.db.sqla.session import read_session, transactional_session
@@ -30,7 +31,7 @@ from rucio.db.sqla.session import read_session, transactional_session
 
 REGION = make_region().configure('dogpile.cache.memcached',
                                  expiration_time=3600,
-                                 arguments={'url': "127.0.0.1:11211",
+                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'),
                                             'distributed_lock': True})
 
 

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -54,7 +54,7 @@ import rucio.core.account_counter
 
 from rucio.core.rse_counter import add_counter, get_counter
 from rucio.common import exception, utils
-from rucio.common.config import get_lfn2pfn_algorithm_default
+from rucio.common.config import get_lfn2pfn_algorithm_default, config_get
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import RSEType
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
@@ -62,7 +62,7 @@ from rucio.db.sqla.session import read_session, transactional_session, stream_se
 
 REGION = make_region().configure('dogpile.cache.memcached',
                                  expiration_time=3600,
-                                 arguments={'url': "127.0.0.1:11211",
+                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'),
                                             'distributed_lock': True})
 
 

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -24,6 +24,7 @@ from hashlib import sha256
 from six import add_metaclass
 
 from rucio.common import schema
+from rucio.common.config import config_get
 from rucio.common.exception import InvalidRSEExpression, RSEBlacklisted
 from rucio.core.rse import list_rses, get_rses_with_attribute, get_rse_attribute
 from rucio.db.sqla.session import transactional_session
@@ -41,7 +42,7 @@ PATTERN = r'^%s(%s|%s|%s)*' % (PRIMITIVE, UNION, INTERSECTION, COMPLEMENT)
 
 REGION = make_region().configure('dogpile.cache.memcached',
                                  expiration_time=3600,
-                                 arguments={'url': "127.0.0.1:11211", 'distributed_lock': True})
+                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
 
 
 @transactional_session

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -53,7 +53,7 @@ Requests accessed by request_id  are covered in the core request.py
 
 REGION_SHORT = make_region().configure('dogpile.cache.memcached',
                                        expiration_time=600,
-                                       arguments={'url': "127.0.0.1:11211", 'distributed_lock': True})
+                                       arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
 USER_TRANSFERS = config_get('conveyor', 'user_transfers', False, None)
 
 

--- a/lib/rucio/daemons/reaper/reaper2.py
+++ b/lib/rucio/daemons/reaper/reaper2.py
@@ -75,7 +75,7 @@ GRACEFUL_STOP = threading.Event()
 
 REGION = make_region().configure('dogpile.cache.memcached',
                                  expiration_time=600,
-                                 arguments={'url': "127.0.0.1:11211",
+                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'),
                                             'distributed_lock': True})
 
 

--- a/lib/rucio/rse/__init__.py
+++ b/lib/rucio/rse/__init__.py
@@ -91,5 +91,5 @@ if rsemanager.SERVER_MODE:   # pylint:disable=no-member
     RSE_REGION = make_region(function_key_generator=rse_key_generator).configure(
         'dogpile.cache.memcached',
         expiration_time=3600,
-        arguments={'url': "127.0.0.1:11211", 'distributed_lock': True})
+        arguments={'url': config.config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
     setattr(rsemanager, 'RSE_REGION', RSE_REGION)

--- a/lib/rucio/tests/test_judge_repairer.py
+++ b/lib/rucio/tests/test_judge_repairer.py
@@ -15,6 +15,7 @@ from hashlib import sha256
 
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid
+from rucio.common.config import config_get
 from rucio.core.account_limit import set_account_limit
 from rucio.core.did import add_did, attach_dids
 from rucio.core.lock import successful_transfer, failed_transfer, get_replica_locks
@@ -298,7 +299,7 @@ class TestJudgeRepairer():
 
         region = make_region().configure('dogpile.cache.memcached',
                                          expiration_time=3600,
-                                         arguments={'url': "127.0.0.1:11211", 'distributed_lock': True})
+                                         arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
         region.delete(sha256(rse).hexdigest())
 
         update_rse(rse_id, {'availability_write': True})


### PR DESCRIPTION
<Core & Internals>: Change caching endpoint address to be obtained from Rucio config or use localhost. Fix #2812