### PR TITLE
hotfix: Fixing subquery ambiguity

### DIFF
--- a/lib/rucio/core/message.py
+++ b/lib/rucio/core/message.py
@@ -84,7 +84,7 @@ def retrieve_messages(bulk=1000, thread=None, total_threads=None, event_type=Non
             elif session.bind.dialect.name == 'mysql':
                 subquery = subquery.filter(text('mod(md5(id), %s) = %s' % (total_threads - 1, thread)))
             elif session.bind.dialect.name == 'postgresql':
-                subquery = subquery.filter(text('mod(abs((\'x\'||md5(id::text))::bit(32)::int), %s) = %s' % (total_threads - 1, thread)))
+                subquery = subquery.filter(text('mod(abs((\'x\'||md5(messages.id::text))::bit(32)::int), %s) = %s' % (total_threads - 1, thread)))
 
         if event_type:
             subquery = subquery.filter_by(event_type=event_type)

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -755,7 +755,7 @@ def list_stagein_requests_and_source_replicas(total_workers=0, worker_number=0, 
         elif session.bind.dialect.name == 'mysql':
             sub_requests = sub_requests.filter(text('mod(md5(id), %s) = %s' % (total_workers + 1, worker_number)))
         elif session.bind.dialect.name == 'postgresql':
-            sub_requests = sub_requests.filter(text('mod(abs((\'x\'||md5(id::text))::bit(32)::int), %s) = %s' % (total_workers + 1, worker_number)))
+            sub_requests = sub_requests.filter(text('mod(abs((\'x\'||md5(requests.id::text))::bit(32)::int), %s) = %s' % (total_workers + 1, worker_number)))
 
     if limit:
         sub_requests = sub_requests.limit(limit)


### PR DESCRIPTION
The following SQL ambiguity error was triggered while a `rucio-conveyor-submitter` instance tried to evaluate the pending requests in my test environment.

```yaml
(psycopg2.ProgrammingError) column reference "id" is ambiguous
LINE 4: ...vailability IN (0, 1, 4, 5) AND mod(abs(('x'||md5(id::text))...
                                                             ^
​
[SQL: SELECT anon_1.id AS anon_1_id, anon_1.rule_id AS anon_1_rule_id, anon_1.scope AS anon_1_scope, anon_1.name AS anon_1_name, anon_1.md5 AS anon_1_md5, anon_1.adler32 AS anon_1_adler32, anon_1.bytes AS anon_1_bytes, anon_1.activity AS anon_1_activity, anon_1.attributes AS anon_1_attributes, anon_1.previous_attempt_id AS anon_1_previous_attempt_id, anon_1.dest_rse_id AS anon_1_dest_rse_id, replicas.rse_id AS replicas_rse_id, rses.rse AS rses_rse, rses.deterministic AS rses_deterministic, rses.rse_type AS rses_rse_type, replicas.path AS replicas_path, anon_1.retry_count AS anon_1_retry_count, sources.url AS sources_url, sources.ranking AS sources_ranking, distances.ranking AS distances_ranking
FROM (SELECT requests.id AS id, requests.rule_id AS rule_id, requests.scope AS scope, requests.name AS name, requests.md5 AS md5, requests.adler32 AS adler32, requests.bytes AS bytes, requests.activity AS activity, requests.attributes AS attributes, requests.previous_attempt_id AS previous_attempt_id, requests.dest_rse_id AS dest_rse_id, requests.retry_count AS retry_count
FROM requests JOIN rses ON rses.id = requests.dest_rse_id
WHERE requests.state = %(state_1)s AND requests.request_type = %(request_type_1)s AND rses.deleted = false AND rses.availability IN (%(availability_1)s, %(availability_2)s, %(availability_3)s, %(availability_4)s) AND mod(abs(('x'||md5(id::text))::bit(32)::int), 2) = 1
 LIMIT %(param_1)s) AS anon_1 LEFT OUTER JOIN replicas ON anon_1.scope = replicas.scope AND anon_1.name = replicas.name AND replicas.state = %(state_2)s AND anon_1.dest_rse_id != replicas.rse_id LEFT OUTER JOIN rses ON rses.id = replicas.rse_id AND rses.deleted = false LEFT OUTER JOIN sources ON anon_1.id = sources.request_id AND rses.id = sources.rse_id LEFT OUTER JOIN distances ON anon_1.dest_rse_id = distances.dest_rse_id AND replicas.rse_id = distances.src_rse_id]
[parameters: {'state_2': 'A', 'param_1': 100, 'request_type_1': 'T', 'availability_2': 1, 'state_1': 'Q', 'availability_3': 4, 'availability_1': 0, 'availability_4': 5}]
(Background on this error at: http://sqlalche.me/e/f405)
(psycopg2.ProgrammingError) column reference "id" is ambiguous
LINE 4: ...vailability IN (0, 1, 4, 5) AND mod(abs(('x'||md5(id::text))...
```

It was found to be related to an ambiguity between `uses.id` and `requests.id` columns.

This PR fixes this error by explicitly specifying the correct table, instead of leaving the field `id` alone.
