### PR TITLE
Core & Internals: added exception and default handling to config number functions; Fix #2874

### DIFF
--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -80,14 +80,24 @@ def config_add_section(section):
     return __CONFIG.add_section(section)
 
 
-def config_get_int(section, option):
+def config_get_int(section, option, raise_exception=True, default=None):
     """Return the integer value for a given option in a section"""
-    return __CONFIG.getint(section, option)
+    try:
+        return __CONFIG.getint(section, option)
+    except (ConfigParser.NoOptionError, ConfigParser.NoSectionError) as err:
+        if raise_exception and default is None:
+            raise err
+        return default
 
 
-def config_get_float(section, option):
+def config_get_float(section, option, raise_exception=True, default=None):
     """Return the floating point value for a given option in a section"""
-    return __CONFIG.getfloat(section, option)
+    try:
+        return __CONFIG.getfloat(section, option)
+    except (ConfigParser.NoOptionError, ConfigParser.NoSectionError) as err:
+        if raise_exception and default is None:
+            raise err
+        return default
 
 
 def config_get_bool(section, option, raise_exception=True, default=None):

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -42,7 +42,7 @@ except ImportError:
     from urllib.parse import urlparse
 
 from rucio.common import exception, utils, constants
-from rucio.common.config import config_get
+from rucio.common.config import config_get_int
 from rucio.common.constraints import STRING_TYPES
 from rucio.common.utils import make_valid_did
 
@@ -733,7 +733,7 @@ def _retry_protocol_stat(protocol, pfn):
     :param protocol     The protocol to use to reach this file
     :param pfn          Physical file name of the target for the protocol stat
     """
-    retries = config_get('client', 'protocol_stat_retries', raise_exception=False, default=6)
+    retries = config_get_int('client', 'protocol_stat_retries', raise_exception=False, default=6)
 
     for attempt in range(retries):
         try:


### PR DESCRIPTION
Core & Internals: added exception and default handling to config number functions; Fix #2874