### PR TITLE
bug : add missing columns updated_at created_at on did_meta fixes #2462

### DIFF
--- a/lib/rucio/db/sqla/migrate_repo/versions/53b479c3cb0f_fix_did_meta_table_missing_updated_at_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/53b479c3cb0f_fix_did_meta_table_missing_updated_at_.py
@@ -1,0 +1,50 @@
+# Copyright 2013-2019 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Aristeidis Fkiaras, <aristeidis.fkiaras@cern.ch>, 2019
+
+''' fix did_meta table missing updated_at, created_at columns '''
+
+import sqlalchemy as sa
+
+from alembic import context
+from alembic.op import add_column, drop_column
+
+
+# Alembic revision identifiers
+revision = '53b479c3cb0f'
+down_revision = '2cbee484dcf9'
+
+
+def upgrade():
+    '''
+    Upgrade the database to this revision
+    '''
+
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        schema = context.get_context().version_table_schema if context.get_context().version_table_schema else ''
+        add_column('did_meta', sa.Column('created_at', sa.DateTime), schema=schema)
+        add_column('did_meta', sa.Column('updated_at', sa.DateTime), schema=schema)
+
+
+def downgrade():
+    '''
+    Downgrade the database to the previous revision
+    '''
+
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        schema = context.get_context().version_table_schema if context.get_context().version_table_schema else ''
+        drop_column('did_meta', 'created_at', schema=schema)
+        drop_column('did_meta', 'updated_at', schema=schema)


### PR DESCRIPTION
Fixing a bug that caused the DID_META table not to have the updated_at and created_at columns.
Basically a database migration.

Also enables again the did_meta tests that were set to always succeed in the past. Also fixed some bugs on them that would cause them to fail on concurrent runs. 