### PR TITLE
hermes: Allow 0 to hold MB connection open indefinitely #2861

### DIFF
--- a/lib/rucio/daemons/hermes/hermes.py
+++ b/lib/rucio/daemons/hermes/hermes.py
@@ -173,6 +173,9 @@ def deliver_messages(once=False, brokers_resolved=None, thread=0, bulk=1000, del
         logging.fatal('No brokers resolved.')
         return
 
+    if not broker_timeout:  # Allow zero in config
+        broker_timeout = None
+
     logging.info('[broker] checking authentication method')
     use_ssl = True
     try:


### PR DESCRIPTION
Allow MB connections to stay open indefinitely. In investigating #2861 I see the the message broker connections are closed after "broker_timeout" seconds. And the default for "broker_timeout" is 3 seconds. So we were constantly allowing them to close and reopening them.

I suspect ATLAS does not see this because they provide a long version on the command line. However, looking at the STOMP docs, None is the default timeout value which holds open the connection. 

This patch makes it so that setting 0 as the timeout value from the cli sets None as the Stomp timeout value.

I provided a corresponding helm patch. With both of these, the reconnections go away.