### PR TITLE
Clients: Can now get local/global account limits via rucio-admin. Fix #3324

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -398,7 +398,8 @@ def get_limits(args):
 
     """
     client = get_client(args)
-    limits = client.get_local_account_limit(account=args.account, rse=args.rse)
+    locality = args.locality.lower()
+    limits = client.get_account_limits(account=args.account, rse_expression=args.rse, locality=locality)
     for rse in limits:
         print('Quota on %s for %s : %s' % (rse, args.account, sizefmt(limits[rse], True)))
     return SUCCESS
@@ -1360,7 +1361,7 @@ def get_parser():
     get_account_limits_parser.set_defaults(which='get_limits')
     get_account_limits_parser.add_argument('account', action='store', help='Account name')
     get_account_limits_parser.add_argument('rse', action='store', help='The RSE name')
-    set_account_limits_parser.add_argument('locality', action='store', nargs='?', default='local', choices=['local', 'global'], help='Global or local limit scope. Default: "local"')
+    get_account_limits_parser.add_argument('locality', action='store', nargs='?', default='local', choices=['local', 'global'], help='Global or local limit scope. Default: "local"')
 
     # The delete_quota command
     delete_account_limits_parser = account_subparser.add_parser('delete-limits',

--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -242,6 +242,23 @@ class AccountClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=res.headers, status_code=res.status_code, data=res.content)
             raise exc_cls(exc_msg)
 
+    def get_account_limits(self, account, rse_expression, locality):
+        """
+        Return the correct account limits for the given locality.
+
+        :param account:        The account name.
+        :param rse_expression: Valid RSE expression
+        :param locality:       The scope of the account limit. 'local' or 'global'.
+        """
+
+        if locality == 'local':
+            return self.get_local_account_limit(account, rse_expression)
+        elif locality == 'global':
+            return self.get_global_account_limit(account, rse_expression)
+        else:
+            from rucio.common.exception import UnsupportedOperation
+            raise UnsupportedOperation('The provided locality (%s) for the account limit was invalid' % locality)
+
     def get_global_account_limit(self, account, rse_expression):
         """
         List the account limit for the specific RSE expression.


### PR DESCRIPTION
Clients: Can now get local/global account limits via rucio-admin. Fix #3324