### PR TITLE
Infrastructure: Restore min.io objectstore to dev docker #2855

### DIFF
--- a/etc/docker/dev/docker-compose-storage-localhost.yml
+++ b/etc/docker/dev/docker-compose-storage-localhost.yml
@@ -13,6 +13,7 @@ services:
       - xrd1:xrd1
       - xrd2:xrd2
       - xrd3:xrd3
+      - minio:minio
     volumes:
       - ../../../tools:/opt/rucio/tools
       - ../../../bin:/opt/rucio/bin
@@ -79,3 +80,15 @@ services:
     volumes:
       - ../../certs/hostcert_xrd3.pem:/tmp/xrdcert.pem
       - ../../certs/hostcert_xrd3.key.pem:/tmp/xrdkey.pem
+  minio:
+    image: minio/minio
+    hostname: minio
+    environment:
+      - MINIO_ACCESS_KEY=admin
+      - MINIO_SECRET_KEY=password
+    ports:
+      - "127.0.0.1:9000:9000"
+    volumes:
+      - ../../certs/hostcert_minio.pem:/root/.minio/certs/public.crt
+      - ../../certs/hostcert_minio.key.pem:/root/.minio/certs/private.key
+    command: ["server", "/data"]

--- a/etc/docker/dev/docker-compose-storage-monit.yml
+++ b/etc/docker/dev/docker-compose-storage-monit.yml
@@ -13,6 +13,7 @@ services:
       - xrd1:xrd1
       - xrd2:xrd2
       - xrd3:xrd3
+      - minio:minio
       - activemq:activemq
       - kibana:kibana
       - grafana:grafana
@@ -83,6 +84,18 @@ services:
     volumes:
       - ../../certs/hostcert_xrd3.pem:/tmp/xrdcert.pem
       - ../../certs/hostcert_xrd3.key.pem:/tmp/xrdkey.pem
+  minio:
+    image: minio/minio
+    hostname: minio
+    environment:
+      - MINIO_ACCESS_KEY=admin
+      - MINIO_SECRET_KEY=password
+    ports:
+      - "9000:9000"
+    volumes:
+      - ../../certs/hostcert_minio.pem:/root/.minio/certs/public.crt
+      - ../../certs/hostcert_minio.key.pem:/root/.minio/certs/private.key
+    command: ["server", "/data"]
   activemq:
     image: webcenter/activemq:latest
     hostname: activemq

--- a/etc/docker/dev/docker-compose-storage.yml
+++ b/etc/docker/dev/docker-compose-storage.yml
@@ -13,6 +13,7 @@ services:
       - xrd1:xrd1
       - xrd2:xrd2
       - xrd3:xrd3
+      - minio:minio
     volumes:
       - ../../../tools:/opt/rucio/tools
       - ../../../bin:/opt/rucio/bin
@@ -79,3 +80,15 @@ services:
     volumes:
       - ../../certs/hostcert_xrd3.pem:/tmp/xrdcert.pem
       - ../../certs/hostcert_xrd3.key.pem:/tmp/xrdkey.pem
+  minio:
+    image: minio/minio
+    hostname: minio
+    environment:
+      - MINIO_ACCESS_KEY=admin
+      - MINIO_SECRET_KEY=password
+    ports:
+      - "9000:9000"
+    volumes:
+      - ../../certs/hostcert_minio.pem:/root/.minio/certs/public.crt
+      - ../../certs/hostcert_minio.key.pem:/root/.minio/certs/private.key
+    command: ["server", "/data"]


### PR DESCRIPTION
The min.io objectstore that I added to the development docker-compose in PR #2862 seems to have been lost at some point, probably when the docker-compose files were rearranged. This PR adds it back.