### PR TITLE
Consistency: Implement core consistency function #3437

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -2009,7 +2009,7 @@ You can filter by key/value, e.g.::
 
     # The list_files command
     list_files_parser = subparsers.add_parser('list-files', help='List DID contents', description='List all the files in a Data IDentifier. The DID can be a container, dataset or a file.\
-                                                                  What is returned is a list of files in the DID with : <scope>:<name>\t<filesize>\t<checksum>\t<guid>')
+                                                                  What is returned is a list of files in the DID with : <scope>:<name>\t<guid>\t<checksum>\t<filesize>')
     list_files_parser.set_defaults(function=list_files)
     list_files_parser.add_argument('--csv', dest='csv', action='store_true', default=False, help='Comma Separated Value output. This output format is preferred for easy parsing and scripting.')
     list_files_parser.add_argument('--pfc', dest='LOCALPATH', action='store', default=False, help='Outputs the list of files in the dataset with the LOCALPATH prepended as a PoolFileCatalog')

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -27,7 +27,7 @@
 # - Brian Bockelman, <bbockelm@cse.unl.edu>, 2017-2018
 # - Nicolo Magini, <Nicolo.Magini@cern.ch>, 2018
 # - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Dimitrios Christidis, <dimitrios.christidis@cern.ch>, 2019
+# - Dimitrios Christidis, <dimitrios.christidis@cern.ch>, 2019-2020
 # - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
 # - Jaroslav Guenther <jaroslav.guenther@gmail.com>, 2019
 #
@@ -1000,8 +1000,8 @@ def declare_temporary_unavailable_replicas(args):
     else:
         bad_files = args.listbadfiles
 
-    if args.expiration_date:
-        expiration_date = (datetime.datetime.now() + datetime.timedelta(hours=args.expiration_date)).isoformat()
+    if args.expiration_date is not None:
+        expiration_date = (datetime.datetime.utcnow() + datetime.timedelta(hours=args.expiration_date)).isoformat()
 
     chunk_size = 10000
     tot_files = len(bad_files)

--- a/doc/source/cli_examples.rst
+++ b/doc/source/cli_examples.rst
@@ -170,7 +170,7 @@ If you want to resolve a collection (CONTAINER or DATASET) into the list of its 
 
 You can resolve also the collections (CONTAINER or DATASET) into the list of files::
 
-  $ rucio list-content user.jdoe:user.jdoe.test.container.1234.1
+  $ rucio list-files user.jdoe:user.jdoe.test.container.1234.1
   +-----------------------+--------------------------------------+-------------+------------+----------+
   | SCOPE:NAME            | GUID                                 | ADLER32     | FILESIZE   | EVENTS   |
   |-----------------------+--------------------------------------+-------------+------------+----------|

--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -27,7 +27,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
-# - Goossens Luc <luc.goossens@cern.ch>, 2020
+# - Luc Goossens <luc.goossens@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -975,6 +975,10 @@ def list_child_datasets(scope, name, session=None):
             result.extend(list_child_datasets(scope=child_scope, name=child_name, session=session))
         else:
             result.append({'scope': child_scope, 'name': child_name, 'type': child_type})
+
+    # remove duplicate entries
+    result = {(elem['scope'], elem['name']): elem for elem in result}.values()
+
     return result
 
 

--- a/lib/rucio/core/lock.py
+++ b/lib/rucio/core/lock.py
@@ -11,6 +11,7 @@
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2014-2018
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2014-2018
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2014-2018
+# - Luc Goossens <luc.goossens@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -29,7 +30,7 @@ from rucio.common.config import config_get
 from rucio.common.exception import RSENotFound
 from rucio.core.lifetime_exception import define_eol
 from rucio.core.rse import get_rse_name, get_rse_id
-from rucio.db.sqla import models
+from rucio.db.sqla import models, filter_thread_work
 from rucio.db.sqla.constants import LockState, RuleState, RuleGrouping, DIDType, RuleNotification
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
 
@@ -182,7 +183,9 @@ def get_replica_locks_for_rule_id_per_rse(rule_id, session=None):
 
 
 @read_session
-def get_files_and_replica_locks_of_dataset(scope, name, nowait=False, restrict_rses=None, only_stuck=False, session=None):
+def get_files_and_replica_locks_of_dataset(scope, name, nowait=False, restrict_rses=None, only_stuck=False,
+                                           total_threads=None, thread_id=None,
+                                           session=None):
     """
     Get all the files of a dataset and, if existing, all locks of the file.
 
@@ -191,6 +194,8 @@ def get_files_and_replica_locks_of_dataset(scope, name, nowait=False, restrict_r
     :param nowait:         Nowait parameter for the FOR UPDATE statement
     :param restrict_rses:  Possible RSE_ids to filter on.
     :param only_stuck:     If true, only get STUCK locks.
+    :param total_threads:  Total threads
+    :param thread_id:      This thread
     :param session:        The db session.
     :return:               Dictionary with keys: (scope, name)
                            and as value: [LockObject]
@@ -205,6 +210,10 @@ def get_files_and_replica_locks_of_dataset(scope, name, nowait=False, restrict_r
                       'oracle').\
             filter(models.DataIdentifierAssociation.scope == scope,
                    models.DataIdentifierAssociation.name == name)
+
+        if total_threads and total_threads > 1:
+            content_query = filter_thread_work(session=session, query=content_query, total_threads=total_threads,
+                                               thread_id=thread_id, hash_variable='child_name')
 
         for child_scope, child_name in content_query.yield_per(1000):
             locks[(child_scope, child_name)] = []
@@ -262,6 +271,10 @@ def get_files_and_replica_locks_of_dataset(scope, name, nowait=False, restrict_r
 
     if only_stuck:
         query = query.filter(models.ReplicaLock.state == LockState.STUCK)
+
+    if total_threads and total_threads > 1:
+        query = filter_thread_work(session=session, query=query, total_threads=total_threads,
+                                   thread_id=thread_id, hash_variable='child_name')
 
     query = query.with_for_update(nowait=nowait, of=models.ReplicaLock.state)
 

--- a/lib/rucio/daemons/auditor/auditor2.py
+++ b/lib/rucio/daemons/auditor/auditor2.py
@@ -18,6 +18,65 @@
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2020
 
 
+class Result:
+    """Tags used for the results of the consistency check."""
+    DARK = 'DARK'
+    LOST = 'LOST'
+
+
+def consistency(rucio_dump_before, storage_dump, rucio_dump_after, output):
+    """Perform a consistency check.
+
+    All parameters should be ``str``s with the paths to the appropriate
+    files.
+
+    The storage and Rucio dumps must be sorted and not contain any
+    duplicate entries.  Each line must contain solely the local path of
+    a file (i.e. by stripping the common base from the absolute path on
+    the RSE).
+
+    The results are written to the file located at ``output`` in CSV
+    format.  The first field is a tag and the second is the path.
+
+    The table that follows shows all possible outcomes of the
+    comparison.  Only the ones marked with (*) are written to the
+    output file.  'B' and 'A' are the Rucio dumps generated before and
+    after the storage dump 'S'.
+
+            +---------------+------------+
+            |  Set          |  Result    |
+            +===============+============+
+            |  B - (A | S)  |  Deleted   |
+            +---------------+------------+
+            |  (B & S) - A  |  Deleted   |
+            +---------------+------------+
+            |  (B & A) - S  |  LOST (*)  |
+            +---------------+------------+
+            |  B & A & S    |  OK        |
+            +---------------+------------+
+            |  (B | A) - S  |  DARK (*)  |
+            +---------------+------------+
+            |  A - (B | S)  |  New       |
+            +---------------+------------+
+            |  (A & S) - B  |  New       |
+            +---------------+------------+
+    """
+    with open(rucio_dump_before) as fh_rucio_before,\
+            open(storage_dump) as fh_storage,\
+            open(rucio_dump_after) as fh_rucio_after,\
+            open(output, 'w') as fh_output:
+
+        for item in merge((line.rstrip() for line in fh_rucio_before),
+                          (line.rstrip() for line in fh_storage),
+                          (line.rstrip() for line in fh_rucio_after)):
+
+            path, found = item
+            if not found[0] and found[1] and not found[2]:
+                print(Result.DARK, path, sep=',', file=fh_output)
+            if found[0] and not found[1] and found[2]:
+                print(Result.LOST, path, sep=',', file=fh_output)
+
+
 def merge(*args):
     r"""Merge and compare iterables.
 

--- a/lib/rucio/daemons/auditor/auditor2.py
+++ b/lib/rucio/daemons/auditor/auditor2.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2020
+
+
+def merge(*args):
+    r"""Merge and compare iterables.
+
+    Each of the ``args`` must be an iterable object.  Their elements
+    must be sorted, not have duplicates, be of the same type and
+    implement rich comparison methods.  Typically, this function is
+    expected to be called with three iterables whose elements are
+    ``str``s.
+
+    Returns a ``tuple`` whose first element is the merged element from
+    the iterables.  The second element is itself a ``tuple`` of
+    ``bools``s, each signifying whether the merged element was found in
+    the corresponding iterable.
+
+    Conceptually, the algorithm might look similar to a merge sort
+    without divide-and-conquer.  A key distinction is that, when
+    merged, each element appears only once.
+
+    Visually, assuming the following state:
+
+                      C---E---F
+                     /
+                A---B---C---E---F
+                     \
+                      D---F---G
+
+    When the generator resumes, it will transition to:
+
+                      E---F
+                     /
+            A---B---C---E---F
+                     \
+                      D---F---G
+
+    And yield:
+
+            ('C', (True, True, False))
+    """
+    iterators = [iter(s) for s in args]
+    items = [next(s) for s in iterators]
+
+    while any(v is not None for v in items):
+        v_min = min(v for v in items if v is not None)
+        found = tuple(v == v_min for v in items)
+        yield (v_min, found)
+
+        for i in range(len(args)):
+            if items[i] == v_min:
+                items[i] = next(iterators[i], None)


### PR DESCRIPTION
This is a work in progress. Preliminary comparison against the old Reaper implementation shows promise, but some small differences were observed and need to be further investigated.

Run be manually preparing the dumps, then calling the `consistency()` function. For example, given the following three files and their contents:

**rucio_dump_before:**
```
A
AB
ABC
AC
```

**storage_dump:**
```
AB
ABC
B
BC
```

**rucio_dump_after:**
```
ABC
AC
BC
C
```

Calling the function:
```
Python 3.7.6 (default, Jan 30 2020, 09:44:41) 
[GCC 9.2.1 20190827 (Red Hat 9.2.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from rucio.daemons.auditor.auditor2 import consistency
>>> consistency('rucio_dump_before', 'storage_dump', 'rucio_dump_after', 'results')
```

Then, the content of **results** should be:
```
LOST,AC
DARK,B
```