### PR TITLE
Replicas registration: removing adler32 requirement in add_replica methods #3494

### DIFF
--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -184,11 +184,11 @@ class ReplicaClient(BaseClient):
         :return: True if files were created successfully.
 
         """
-        dict = {'scope': scope, 'name': name, 'bytes': bytes, 'meta': meta}
+        dictio = {'scope': scope, 'name': name, 'bytes': bytes, 'meta': meta}
 
-        set_replica_checksums(dict, md5=md5, adler32=adler32, pfn=pfn)
+        set_replica_checksums(dictio, md5=md5, adler32=adler32, pfn=pfn)
 
-        return self.add_replicas(rse=rse, files=[dict])
+        return self.add_replicas(rse=rse, files=[dictio])
 
     def add_replicas(self, rse, files, ignore_availability=True):
         """

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -36,6 +36,7 @@ from requests.status_codes import codes
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice
 from rucio.common.utils import build_url, render_json
+from rucio.common.utils import set_replica_checksums
 
 
 class ReplicaClient(BaseClient):
@@ -167,7 +168,7 @@ class ReplicaClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def add_replica(self, rse, scope, name, bytes, adler32, pfn=None, md5=None, meta={}):
+    def add_replica(self, rse, scope, name, bytes, adler32=None, pfn=None, md5=None, meta={}):
         """
         Add file replicas to a RSE.
 
@@ -183,11 +184,10 @@ class ReplicaClient(BaseClient):
         :return: True if files were created successfully.
 
         """
-        dict = {'scope': scope, 'name': name, 'bytes': bytes, 'meta': meta, 'adler32': adler32}
-        if md5:
-            dict['md5'] = md5
-        if pfn:
-            dict['pfn'] = pfn
+        dict = {'scope': scope, 'name': name, 'bytes': bytes, 'meta': meta}
+
+        set_replica_checksums(dict, md5=md5, adler32=adler32, pfn=pfn)
+
         return self.add_replicas(rse=rse, files=[dict])
 
     def add_replicas(self, rse, files, ignore_availability=True):

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -295,18 +295,18 @@ def set_checksum_value(file, checksum_names_list):
                 break
 
 
-def set_replica_checksums(dict, **checksums):
+def set_replica_checksums(dictio, **checksums):
     """
     Utility to fill a replica dictionary with all the passed checksums, automatically excluding unsupported ones
 
-    :param dict: replica description dictionary.
+    :param dictio: replica description dictionary.
     :param checksums: arbitrary number of checksum values. Passed variables must be named after the checksum algorithm name.
     """
     for checksum_name in checksums:
         if checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS or checksum_name == 'pfn':
             value = checksums[checksum_name]
             if value:
-                dict[checksum_name] = value
+                dictio[checksum_name] = value
 
 
 def adler32(file):

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -295,6 +295,20 @@ def set_checksum_value(file, checksum_names_list):
                 break
 
 
+def set_replica_checksums(dict, **checksums):
+    """
+    Utility to fill a replica dictionary with all the passed checksums, automatically excluding unsupported ones
+
+    :param dict: replica description dictionary.
+    :param checksums: arbitrary number of checksum values. Passed variables must be named after the checksum algorithm name.
+    """
+    for checksum_name in checksums:
+        if checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS or checksum_name == 'pfn':
+            value = checksums[checksum_name]
+            if value:
+                dict[checksum_name] = value
+
+
 def adler32(file):
     """
     An Adler-32 checksum is obtained by calculating two 16-bit checksums A and B and concatenating their bits into a 32-bit integer. A is the sum of all bytes in the stream plus one, and B is the sum of the individual values of A from each step.

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1365,7 +1365,7 @@ def add_replica(rse_id, scope, name, bytes, account, adler32=None, md5=None, dsn
     """
     file = {'scope': scope, 'name': name, 'bytes': bytes, 'meta': meta, 'rules': rules, 'tombstone': tombstone}
 
-    set_replica_checksums(dict, md5=md5, adler32=adler32, pfn=pfn)
+    set_replica_checksums(file, md5=md5, adler32=adler32, pfn=pfn)
 
     return add_replicas(rse_id=rse_id, files=[file, ], account=account, session=session)
 

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -54,6 +54,7 @@ import rucio.core.lock
 from rucio.common import exception
 from rucio.common.utils import chunks, clean_surls, str_to_date, add_url_query
 from rucio.common.types import InternalScope
+from rucio.common.utils import set_replica_checksums
 from rucio.core.config import get as config_get
 from rucio.core.credential import get_signed_url
 from rucio.core.rse import get_rse, get_rse_name, get_rse_attribute
@@ -1362,9 +1363,10 @@ def add_replica(rse_id, scope, name, bytes, account, adler32=None, md5=None, dsn
 
     :returns: True is successful.
     """
-    file = {'scope': scope, 'name': name, 'bytes': bytes, 'adler32': adler32, 'md5': md5, 'meta': meta, 'rules': rules, 'tombstone': tombstone}
-    if pfn:
-        file['pfn'] = pfn
+    file = {'scope': scope, 'name': name, 'bytes': bytes, 'meta': meta, 'rules': rules, 'tombstone': tombstone}
+
+    set_replica_checksums(dict, md5=md5, adler32=adler32, pfn=pfn)
+
     return add_replicas(rse_id=rse_id, files=[file, ], account=account, session=session)
 
 


### PR DESCRIPTION
Replicas registration: removing adler32 requirement in add_replica methods #3494