### PR TITLE
Core & Internals: prepare policy package code for multi-VO #3542

### DIFF
--- a/bin/rucio-cache-client
+++ b/bin/rucio-cache-client
@@ -37,7 +37,7 @@ from rucio.client.didclient import DIDClient
 from rucio.client.rseclient import RSEClient
 from rucio.common.config import config_get, config_get_int
 from rucio.common.exception import DataIdentifierNotFound
-from rucio.common.schema import CACHE_ADD_REPLICAS, CACHE_DELETE_REPLICAS, MESSAGE_OPERATION
+from rucio.common.schema import get_cache_add_replicas, get_cache_delete_replicas, get_message_operation
 
 SUCCESS = 0
 FAILURE = 1
@@ -74,13 +74,13 @@ def validate_rse(rse):
 def cache_operation(args):
     """ cache operation"""
     payload = json.loads(args.message)
-    validate(payload, MESSAGE_OPERATION)
+    validate(payload, get_message_operation())
     validate_rse(payload["rse"])
     if payload["operation"] == "add_replicas":
-        validate(payload, CACHE_ADD_REPLICAS)
+        validate(payload, get_cache_add_replicas())
         validate_files(payload["files"])
     else:
-        validate(payload, CACHE_DELETE_REPLICAS)
+        validate(payload, get_cache_delete_replicas())
     conn = stomp.Connection([(args.broker, args.port)], use_ssl=True, ssl_key_file=args.ssl_key_file, ssl_cert_file=args.ssl_cert_file, ssl_version=ssl.PROTOCOL_TLSv1)
 
     conn.start()

--- a/doc/source/policy_packages.rst
+++ b/doc/source/policy_packages.rst
@@ -52,9 +52,11 @@ event that the policy package interface changes in the future. Example::
 Custom surl construction algorithms can be registered in `__init__.py`::
 
     from rucio.common.utils import register_surl_algorithm
-    register_surl_algorithm(construct_surl_special, 'special')
+    register_surl_algorithm(construct_surl_special, 'voname_special')
 
 So can custom lfn to pfn algorithms::
 
     from rucio.rse.protocols.protocol import RSEDeterministicTranslation
-    RSEDeterministicTranslation.register(lfn2pfn_special, 'special')
+    RSEDeterministicTranslation.register(lfn2pfn_special, 'voname_special')
+
+In both cases the name used to register the function must be prefixed with the name of the virtual organisation that owns the policy package, to avoid naming conflicts on multi-VO Rucio installations.

--- a/doc/source/policy_packages.rst
+++ b/doc/source/policy_packages.rst
@@ -59,4 +59,6 @@ So can custom lfn to pfn algorithms::
     from rucio.rse.protocols.protocol import RSEDeterministicTranslation
     RSEDeterministicTranslation.register(lfn2pfn_special, 'voname_special')
 
-In both cases the name used to register the function must be prefixed with the name of the virtual organisation that owns the policy package, to avoid naming conflicts on multi-VO Rucio installations.
+In both cases the name used to register the function must be prefixed with the
+name of the virtual organisation that owns the policy package, to avoid naming
+conflicts on multi-VO Rucio installations.

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -18,6 +18,9 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2019
 
+# dictionary of schema modules for each VO
+schema_modules = {}
+
 try:
     from ConfigParser import NoOptionError, NoSectionError
 except ImportError:
@@ -27,6 +30,7 @@ from rucio.common import config, exception
 
 import importlib
 
+# TODO: load schema module for each VO in multi-VO installations
 if config.config_has_section('policy'):
     try:
         POLICY = config.config_get('policy', 'package') + ".schema"
@@ -45,6 +49,45 @@ try:
 except (ImportError) as error:
     raise exception.PolicyPackageNotFound('Module ' + POLICY + ' not found')
 
-for i in dir(module):
-    if i[:1] != '_':
-        globals()[i] = getattr(module, i)
+schema_modules["def"] = module
+
+
+# TODO: in all of these functions, verify that named module exists
+def validate_schema(name, obj, vo='def'):
+    schema_modules[vo].validate_schema(name, obj)
+
+
+def get_activity(vo='def'):
+    return schema_modules[vo].ACTIVITY
+
+
+def get_scope_length(vo='def'):
+    return schema_modules[vo].SCOPE_LENGTH
+
+
+def get_name_length(vo='def'):
+    return schema_modules[vo].NAME_LENGTH
+
+
+def get_scope_name_regexp(vo='def'):
+    return schema_modules[vo].SCOPE_NAME_REGEXP
+
+
+def get_default_rse_attribute(vo='def'):
+    return schema_modules[vo].DEFAULT_RSE_ATTRIBUTE
+
+
+def get_rse_attribute(vo='def'):
+    return schema_modules[vo].RSE_ATTRIBUTE
+
+
+def get_cache_add_replicas(vo='def'):
+    return schema_modules[vo].CACHE_ADD_REPLICAS
+
+
+def get_cache_delete_replicas(vo='def'):
+    return schema_modules[vo].CACHE_DELETE_REPLICAS
+
+
+def get_message_operation(vo='def'):
+    return schema_modules[vo].MESSAGE_OPERATION

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -18,9 +18,6 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2019
 
-# dictionary of schema modules for each VO
-schema_modules = {}
-
 try:
     from ConfigParser import NoOptionError, NoSectionError
 except ImportError:
@@ -29,6 +26,9 @@ except ImportError:
 from rucio.common import config, exception
 
 import importlib
+
+# dictionary of schema modules for each VO
+schema_modules = {}
 
 # TODO: load schema module for each VO in multi-VO installations
 if config.config_has_section('policy'):

--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -14,9 +14,6 @@
  PY3K COMPATIBLE
 """
 
-# dictionary of permission modules for each VO
-permission_modules = {}
-
 try:
     from ConfigParser import NoOptionError, NoSectionError
 except ImportError:
@@ -24,6 +21,9 @@ except ImportError:
 from rucio.common import config, exception
 
 import importlib
+
+# dictionary of permission modules for each VO
+permission_modules = {}
 
 # TODO: load permission module for each VO in multi-VO installations
 if config.config_has_section('permission'):

--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -14,6 +14,9 @@
  PY3K COMPATIBLE
 """
 
+# dictionary of permission modules for each VO
+permission_modules = {}
+
 try:
     from ConfigParser import NoOptionError, NoSectionError
 except ImportError:
@@ -22,6 +25,7 @@ from rucio.common import config, exception
 
 import importlib
 
+# TODO: load permission module for each VO in multi-VO installations
 if config.config_has_section('permission'):
     try:
         FALLBACK_POLICY = config.config_get('permission', 'policy')
@@ -49,6 +53,9 @@ try:
 except (ImportError) as error:
     raise exception.PolicyPackageNotFound('Module ' + POLICY + ' not found')
 
-for i in dir(module):
-    if i[:1] != '_' or i == '_is_root':
-        globals()[i] = getattr(module, i)
+permission_modules["def"] = module
+
+
+def has_permission(issuer, action, kwargs):
+    # TODO: determine VO from issuer and call corresponding permission module
+    return permission_modules["def"].has_permission(issuer, action, kwargs)

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -37,8 +37,8 @@ from rucio.core.rse import list_rses, get_rses_with_attribute, get_rse_attribute
 from rucio.db.sqla.session import transactional_session
 
 
-DEFAULT_RSE_ATTRIBUTE = schema.DEFAULT_RSE_ATTRIBUTE['pattern']
-RSE_ATTRIBUTE = schema.RSE_ATTRIBUTE['pattern']
+DEFAULT_RSE_ATTRIBUTE = schema.get_default_rse_attribute()['pattern']
+RSE_ATTRIBUTE = schema.get_rse_attribute()['pattern']
 PRIMITIVE = r'(\(*(%s|%s|%s)\)*)' % (RSE_ATTRIBUTE, DEFAULT_RSE_ATTRIBUTE, r'\*')
 UNION = r'(\|%s)' % (PRIMITIVE)
 INTERSECTION = r'(\&%s)' % (PRIMITIVE)

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -51,7 +51,7 @@ from six import iteritems
 from prometheus_client import Counter
 
 from rucio.common.config import config_get
-from rucio.common.schema import ACTIVITY
+from rucio.common.schema import get_activity
 from rucio.core import heartbeat, request as request_core, transfer as transfer_core
 from rucio.core.monitor import record_counter, record_timer
 from rucio.daemons.conveyor.common import submit_transfer, bulk_group_transfer, get_conveyor_rses, USER_ACTIVITY
@@ -264,7 +264,7 @@ def run(once=False, group_bulk=1, group_policy='rule',
 
     if exclude_activities:
         if not activities:
-            activities = ACTIVITY
+            activities = get_activity()
         for activity in exclude_activities:
             if activity in activities:
                 activities.remove(activity)

--- a/lib/rucio/db/sqla/migrate_repo/versions/1d1215494e95_add_quarantined_replicas_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1d1215494e95_add_quarantined_replicas_table.py
@@ -26,7 +26,7 @@ from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key,
                         create_check_constraint, drop_table)
 
-from rucio.common.schema import SCOPE_LENGTH, NAME_LENGTH
+from rucio.common.schema import get_scope_length, get_name_length
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers
@@ -46,8 +46,8 @@ def upgrade():
                      sa.Column('bytes', sa.BigInteger),
                      sa.Column('md5', sa.String(32)),
                      sa.Column('adler32', sa.String(8)),
-                     sa.Column('scope', sa.String(SCOPE_LENGTH)),
-                     sa.Column('name', sa.String(NAME_LENGTH)),
+                     sa.Column('scope', sa.String(get_scope_length())),
+                     sa.Column('name', sa.String(get_name_length())),
                      sa.Column('created_at', sa.DateTime, default=datetime.datetime.utcnow),
                      sa.Column('updated_at', sa.DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow))
 
@@ -57,8 +57,8 @@ def upgrade():
                      sa.Column('bytes', sa.BigInteger),
                      sa.Column('md5', sa.String(32)),
                      sa.Column('adler32', sa.String(8)),
-                     sa.Column('scope', sa.String(SCOPE_LENGTH)),
-                     sa.Column('name', sa.String(NAME_LENGTH)),
+                     sa.Column('scope', sa.String(get_scope_length())),
+                     sa.Column('name', sa.String(get_name_length())),
                      sa.Column('created_at', sa.DateTime),
                      sa.Column('updated_at', sa.DateTime),
                      sa.Column('deleted_at', sa.DateTime, default=datetime.datetime.utcnow))

--- a/lib/rucio/db/sqla/migrate_repo/versions/3082b8cef557_add_naming_convention_table_and_closed_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3082b8cef557_add_naming_convention_table_and_closed_.py
@@ -26,7 +26,7 @@ from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key, add_column,
                         create_check_constraint, drop_column, drop_table)
 
-from rucio.common.schema import SCOPE_LENGTH
+from rucio.common.schema import get_scope_length
 from rucio.db.sqla.constants import KeyType
 
 
@@ -45,7 +45,7 @@ def upgrade():
         add_column('dids', sa.Column('closed_at', sa.DateTime), schema=schema)
         add_column('contents_history', sa.Column('deleted_at', sa.DateTime), schema=schema)
         create_table('naming_conventions',
-                     sa.Column('scope', sa.String(SCOPE_LENGTH)),
+                     sa.Column('scope', sa.String(get_scope_length())),
                      sa.Column('regexp', sa.String(255)),
                      sa.Column('convention_type', KeyType.db_type()),
                      sa.Column('updated_at', sa.DateTime, default=datetime.datetime.utcnow),

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -42,7 +42,7 @@ from sqlalchemy.sql import Delete
 from sqlalchemy.types import LargeBinary
 
 from rucio.common import utils
-from rucio.common.schema import NAME_LENGTH, SCOPE_LENGTH
+from rucio.common.schema import get_name_length, get_scope_length
 from rucio.db.sqla.constants import (AccountStatus, AccountType, DIDAvailability, DIDType, DIDReEvaluation,
                                      KeyType, IdentityType, LockState, RuleGrouping, BadFilesStatus,
                                      RuleState, ReplicaState, RequestState, RequestType, RSEType,
@@ -339,7 +339,7 @@ class IdentityAccountAssociation(BASE, ModelBase):
 class Scope(BASE, ModelBase):
     """Represents a scope"""
     __tablename__ = 'scopes'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
     account = Column(InternalAccountString(25))
     is_default = Column(Boolean(name='SCOPES_DEFAULT_CHK'), default=False)
     status = Column(ScopeStatus.db_type(name='SCOPE_STATUS_CHK', default=ScopeStatus.OPEN))
@@ -355,8 +355,8 @@ class Scope(BASE, ModelBase):
 class DataIdentifier(BASE, ModelBase):
     """Represents a dataset"""
     __tablename__ = 'dids'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     account = Column(InternalAccountString(25))
     did_type = Column(DIDType.db_type(name='DIDS_TYPE_CHK'))
     is_open = Column(Boolean(name='DIDS_IS_OPEN_CHK'))
@@ -412,8 +412,8 @@ class DataIdentifier(BASE, ModelBase):
 
 class DidMeta(BASE, ModelBase):
     __tablename__ = 'did_meta'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     meta = Column(JSON())
     _table_args = (PrimaryKeyConstraint('scope', 'name', name='DID_META_PK'),
                    ForeignKeyConstraint(['scope', 'name'], ['dids.scope', 'dids.name'], name='DID_META_FK'),)
@@ -422,8 +422,8 @@ class DidMeta(BASE, ModelBase):
 class DeletedDataIdentifier(BASE, ModelBase):
     """Represents a dataset"""
     __tablename__ = 'deleted_dids'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     account = Column(InternalAccountString(25))
     did_type = Column(DIDType.db_type(name='DEL_DIDS_TYPE_CHK'))
     is_open = Column(Boolean(name='DEL_DIDS_IS_OPEN_CHK'))
@@ -470,8 +470,8 @@ class UpdatedDID(BASE, ModelBase):
     """Represents the recently updated dids"""
     __tablename__ = 'updated_dids'
     id = Column(GUID(), default=utils.generate_uuid)
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     rule_evaluation_action = Column(DIDReEvaluation.db_type(name='UPDATED_DIDS_RULE_EVAL_ACT_CHK'))
     _table_args = (PrimaryKeyConstraint('id', name='UPDATED_DIDS_PK'),
                    CheckConstraint('SCOPE IS NOT NULL', name='UPDATED_DIDS_SCOPE_NN'),
@@ -482,8 +482,8 @@ class UpdatedDID(BASE, ModelBase):
 class BadReplicas(BASE, ModelBase):
     """Represents the suspicious or bad replicas"""
     __tablename__ = 'bad_replicas'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     rse_id = Column(GUID())
     reason = Column(String(255))
     state = Column(BadFilesStatus.db_type(name='BAD_REPLICAS_STATE_CHK'), default=BadFilesStatus.SUSPICIOUS)
@@ -519,8 +519,8 @@ class QuarantinedReplica(BASE, ModelBase, Versioned):
     bytes = Column(BigInteger)
     md5 = Column(String(32))
     adler32 = Column(String(8))
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     _table_args = (PrimaryKeyConstraint('rse_id', 'path', name='QURD_REPLICAS_STATE_PK'),
                    ForeignKeyConstraint(['rse_id'], ['rses.id'], name='QURD_REPLICAS_RSE_ID_FK'),
                    Index('QUARANTINED_REPLICAS_PATH_IDX', 'path', 'rse_id', unique=True))
@@ -551,10 +551,10 @@ class DIDKeyValueAssociation(BASE, ModelBase):
 class DataIdentifierAssociation(BASE, ModelBase):
     """Represents the map between containers/datasets and files"""
     __tablename__ = 'contents'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))  # dataset scope
-    name = Column(String(NAME_LENGTH))    # dataset name
-    child_scope = Column(InternalScopeString(SCOPE_LENGTH))  # Provenance scope
-    child_name = Column(String(NAME_LENGTH))    # Provenance name
+    scope = Column(InternalScopeString(get_scope_length()))  # dataset scope
+    name = Column(String(get_name_length()))    # dataset name
+    child_scope = Column(InternalScopeString(get_scope_length()))  # Provenance scope
+    child_name = Column(String(get_name_length()))    # Provenance name
     did_type = Column(DIDType.db_type(name='CONTENTS_DID_TYPE_CHK'))
     child_type = Column(DIDType.db_type(name='CONTENTS_CHILD_TYPE_CHK'))
     bytes = Column(BigInteger)
@@ -574,10 +574,10 @@ class DataIdentifierAssociation(BASE, ModelBase):
 class ConstituentAssociation(BASE, ModelBase):
     """Represents the map between archives and constituents"""
     __tablename__ = 'archive_contents'
-    child_scope = Column(InternalScopeString(SCOPE_LENGTH))    # Constituent file scope
-    child_name = Column(String(NAME_LENGTH))    # Constituent file name
-    scope = Column(InternalScopeString(SCOPE_LENGTH))          # Archive file scope
-    name = Column(String(NAME_LENGTH))          # Archive file name
+    child_scope = Column(InternalScopeString(get_scope_length()))    # Constituent file scope
+    child_name = Column(String(get_name_length()))    # Constituent file name
+    scope = Column(InternalScopeString(get_scope_length()))          # Archive file scope
+    name = Column(String(get_name_length()))          # Archive file name
     bytes = Column(BigInteger)
     adler32 = Column(String(8))
     md5 = Column(String(32))
@@ -597,10 +597,10 @@ class ConstituentAssociation(BASE, ModelBase):
 class ConstituentAssociationHistory(BASE, ModelBase):
     """Represents the map between archives and constituents"""
     __tablename__ = 'archive_contents_history'
-    child_scope = Column(InternalScopeString(SCOPE_LENGTH))    # Constituent file scope
-    child_name = Column(String(NAME_LENGTH))    # Constituent file name
-    scope = Column(InternalScopeString(SCOPE_LENGTH))          # Archive file scope
-    name = Column(String(NAME_LENGTH))  # Archive file name
+    child_scope = Column(InternalScopeString(get_scope_length()))    # Constituent file scope
+    child_name = Column(String(get_name_length()))    # Constituent file name
+    scope = Column(InternalScopeString(get_scope_length()))          # Archive file scope
+    name = Column(String(get_name_length()))  # Archive file name
     bytes = Column(BigInteger)
     adler32 = Column(String(8))
     md5 = Column(String(32))
@@ -617,10 +617,10 @@ class ConstituentAssociationHistory(BASE, ModelBase):
 class DataIdentifierAssociationHistory(BASE, ModelBase):
     """Represents the map history between containers/datasets and files"""
     __tablename__ = 'contents_history'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))          # dataset scope
-    name = Column(String(NAME_LENGTH))  # dataset name
-    child_scope = Column(InternalScopeString(SCOPE_LENGTH))          # Provenance scope
-    child_name = Column(String(NAME_LENGTH))  # Provenance name
+    scope = Column(InternalScopeString(get_scope_length()))          # dataset scope
+    name = Column(String(get_name_length()))  # dataset name
+    child_scope = Column(InternalScopeString(get_scope_length()))          # Provenance scope
+    child_name = Column(String(get_name_length()))  # Provenance name
     did_type = Column(DIDType.db_type(name='CONTENTS_HIST_DID_TYPE_CHK'))
     child_type = Column(DIDType.db_type(name='CONTENTS_HIST_CHILD_TYPE_CHK'))
     bytes = Column(BigInteger)
@@ -795,8 +795,8 @@ class RSEFileAssociation(BASE, ModelBase):
     """Represents the map between locations and files"""
     __tablename__ = 'replicas'
     rse_id = Column(GUID())
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     bytes = Column(BigInteger)
     md5 = Column(String(32))
     adler32 = Column(String(8))
@@ -813,14 +813,14 @@ class RSEFileAssociation(BASE, ModelBase):
                    CheckConstraint('bytes IS NOT NULL', name='REPLICAS_SIZE_NN'),
                    CheckConstraint('lock_cnt IS NOT NULL', name='REPLICAS_LOCK_CNT_NN'),
                    Index('REPLICAS_TOMBSTONE_IDX', 'tombstone'),
-                   Index('REPLICAS_PATH_IDX', 'path', mysql_length=NAME_LENGTH))
+                   Index('REPLICAS_PATH_IDX', 'path', mysql_length=get_name_length()))
 
 
 class CollectionReplica(BASE, ModelBase):
     """Represents replicas for datasets/collections"""
     __tablename__ = 'collection_replicas'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     did_type = Column(DIDType.db_type(name='COLLECTION_REPLICAS_TYPE_CHK'))
     rse_id = Column(GUID())
     bytes = Column(BigInteger)
@@ -841,8 +841,8 @@ class UpdatedCollectionReplica(BASE, ModelBase):
     """Represents updates to replicas for datasets/collections"""
     __tablename__ = 'updated_col_rep'
     id = Column(GUID(), default=utils.generate_uuid)
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     did_type = Column(DIDType.db_type(name='UPDATED_COL_REP_TYPE_CHK'))
     rse_id = Column(GUID())
     _table_args = (PrimaryKeyConstraint('id', name='UPDATED_COL_REP_PK'),
@@ -855,8 +855,8 @@ class RSEFileAssociationHistory(BASE, ModelBase):
     """Represents a short history of the deleted replicas"""
     __tablename__ = 'replicas_history'
     rse_id = Column(GUID())
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     bytes = Column(BigInteger)
     _table_args = (PrimaryKeyConstraint('rse_id', 'scope', 'name', name='REPLICAS_HIST_PK'),
                    ForeignKeyConstraint(['rse_id'], ['rses.id'], name='REPLICAS_HIST_RSE_ID_FK'),
@@ -870,8 +870,8 @@ class ReplicationRule(BASE, ModelBase):
     id = Column(GUID(), default=utils.generate_uuid)
     subscription_id = Column(GUID())
     account = Column(InternalAccountString(25))
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     did_type = Column(DIDType.db_type(name='RULES_DID_TYPE_CHK'))
     state = Column(RuleState.db_type(name='RULES_STATE_CHK'), default=RuleState.REPLICATING)
     error = Column(String(255))
@@ -927,8 +927,8 @@ class ReplicationRuleHistoryRecent(BASE, ModelBase):
     id = Column(GUID())
     subscription_id = Column(GUID())
     account = Column(InternalAccountString(25))
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     did_type = Column(DIDType.db_type(name='RULES_HIST_RECENT_DIDTYPE_CHK'))
     state = Column(RuleState.db_type(name='RULES_HIST_RECENT_STATE_CHK'))
     error = Column(String(255))
@@ -967,8 +967,8 @@ class ReplicationRuleHistory(BASE, ModelBase):
     id = Column(GUID())
     subscription_id = Column(GUID())
     account = Column(InternalAccountString(25))
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     did_type = Column(DIDType.db_type(name='RULES_HISTORY_DIDTYPE_CHK'))
     state = Column(RuleState.db_type(name='RULES_HISTORY_STATE_CHK'))
     error = Column(String(255))
@@ -1003,8 +1003,8 @@ class ReplicationRuleHistory(BASE, ModelBase):
 class ReplicaLock(BASE, ModelBase):
     """Represents replica locks"""
     __tablename__ = 'locks'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     rule_id = Column(GUID())
     rse_id = Column(GUID())
     account = Column(InternalAccountString(25))
@@ -1023,8 +1023,8 @@ class ReplicaLock(BASE, ModelBase):
 class DatasetLock(BASE, ModelBase):
     """Represents dataset locks"""
     __tablename__ = 'dataset_locks'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     rule_id = Column(GUID())
     rse_id = Column(GUID())
     account = Column(InternalAccountString(25))
@@ -1061,8 +1061,8 @@ class Request(BASE, ModelBase, Versioned):
     __tablename__ = 'requests'
     id = Column(GUID(), default=utils.generate_uuid)
     request_type = Column(RequestType.db_type(name='REQUESTS_TYPE_CHK'), default=RequestType.TRANSFER)
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     did_type = Column(DIDType.db_type(name='REQUESTS_DIDTYPE_CHK'), default=DIDType.FILE)
     dest_rse_id = Column(GUID())
     source_rse_id = Column(GUID())
@@ -1107,8 +1107,8 @@ class Source(BASE, ModelBase, Versioned):
     """Represents source files for transfers"""
     __tablename__ = 'sources'
     request_id = Column(GUID())
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     rse_id = Column(GUID())
     dest_rse_id = Column(GUID())
     url = Column(String(2048))
@@ -1267,7 +1267,7 @@ class Heartbeats(BASE, ModelBase):
 class NamingConvention(BASE, ModelBase):
     """Represents naming conventions for name within a scope"""
     __tablename__ = 'naming_conventions'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
     regexp = Column(String(255))
     convention_type = Column(KeyType.db_type(name='CVT_TYPE_CHK'))
     _table_args = (PrimaryKeyConstraint('scope', name='NAMING_CONVENTIONS_PK'),
@@ -1277,8 +1277,8 @@ class NamingConvention(BASE, ModelBase):
 class TemporaryDataIdentifier(BASE, ModelBase):
     """Represents a temporary DID (pre-merged files, etc.)"""
     __tablename__ = 'tmp_dids'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     rse_id = Column(GUID())
     path = Column(String(1024))
     bytes = Column(BigInteger)
@@ -1289,8 +1289,8 @@ class TemporaryDataIdentifier(BASE, ModelBase):
     events = Column(BigInteger)
     task_id = Column(Integer())
     panda_id = Column(Integer())
-    parent_scope = Column(InternalScopeString(SCOPE_LENGTH))
-    parent_name = Column(String(NAME_LENGTH))
+    parent_scope = Column(InternalScopeString(get_scope_length()))
+    parent_name = Column(String(get_name_length()))
     offset = Column(BigInteger)
     _table_args = (PrimaryKeyConstraint('scope', 'name', name='TMP_DIDS_PK'),
                    Index('TMP_DIDS_EXPIRED_AT_IDX', 'expired_at'))
@@ -1300,8 +1300,8 @@ class LifetimeExceptions(BASE, ModelBase):
     """Represents the exceptions to the lifetime model"""
     __tablename__ = 'lifetime_except'
     id = Column(GUID(), default=utils.generate_uuid)
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     did_type = Column(DIDType.db_type(name='LIFETIME_EXCEPT_TYPE_CHK'))
     account = Column(InternalAccountString(25))
     pattern = Column(String(255))
@@ -1327,8 +1327,8 @@ class VO(BASE, ModelBase):
 class DidsFollowed(BASE, ModelBase):
     """Represents the datasets followed by an user"""
     __tablename__ = 'dids_followed'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     account = Column(InternalAccountString(25))
     did_type = Column(DIDType.db_type(name='DIDS_FOLLOWED_TYPE_CHK'))
     _table_args = (PrimaryKeyConstraint('scope', 'name', 'account', name='DIDS_FOLLOWED_PK'),
@@ -1343,8 +1343,8 @@ class DidsFollowed(BASE, ModelBase):
 class FollowEvents(BASE, ModelBase):
     """Represents the events affecting the datasets which are followed"""
     __tablename__ = 'dids_followed_events'
-    scope = Column(InternalScopeString(SCOPE_LENGTH))
-    name = Column(String(NAME_LENGTH))
+    scope = Column(InternalScopeString(get_scope_length()))
+    name = Column(String(get_name_length()))
     account = Column(InternalAccountString(25))
     did_type = Column(DIDType.db_type(name='DIDS_FOLLOWED_EVENTS_TYPE_CHK'))
     event_type = Column(String(1024))

--- a/lib/rucio/web/rest/webpy/v1/archive.py
+++ b/lib/rucio/web/rest/webpy/v1/archive.py
@@ -27,14 +27,14 @@ from traceback import format_exc
 from web import application, loadhook, header, InternalError
 
 from rucio.api.did import list_archive_content
-from rucio.common.schema import SCOPE_NAME_REGEXP
+from rucio.common.schema import get_scope_name_regexp
 from rucio.web.rest.common import rucio_loadhook, RucioController, check_accept_header_wrapper
 
 LOGGER, SH = getLogger("rucio.meta"), StreamHandler()
 SH.setLevel(DEBUG)
 LOGGER.addHandler(SH)
 
-URLS = ('%s/files' % SCOPE_NAME_REGEXP, 'Archive')
+URLS = ('%s/files' % get_scope_name_regexp(), 'Archive')
 
 
 class Archive(RucioController):

--- a/lib/rucio/web/rest/webpy/v1/did.py
+++ b/lib/rucio/web/rest/webpy/v1/did.py
@@ -50,7 +50,7 @@ from rucio.common.exception import (ScopeNotFound, DataIdentifierNotFound,
                                     UnsupportedStatus, UnsupportedOperation,
                                     RSENotFound, RucioException, RuleNotFound,
                                     InvalidMetadata)
-from rucio.common.schema import SCOPE_NAME_REGEXP
+from rucio.common.schema import get_scope_name_regexp
 from rucio.common.utils import generate_http_error, render_json, APIEncoder
 from rucio.web.rest.common import rucio_loadhook, RucioController, check_accept_header_wrapper
 
@@ -58,24 +58,24 @@ URLS = (
     '/(.*)/$', 'Scope',
     '/(.*)/guid', 'GUIDLookup',
     '/(.*)/dids/search', 'Search',
-    '%s/files' % SCOPE_NAME_REGEXP, 'Files',
-    '%s/dids/history' % SCOPE_NAME_REGEXP, 'AttachmentHistory',
-    '%s/dids' % SCOPE_NAME_REGEXP, 'Attachment',
-    '%s/meta/(.*)' % SCOPE_NAME_REGEXP, 'Meta',
-    '%s/meta' % SCOPE_NAME_REGEXP, 'Meta',
-    '%s/status' % SCOPE_NAME_REGEXP, 'DIDs',
-    '%s/rules' % SCOPE_NAME_REGEXP, 'Rules',
-    '%s/parents' % SCOPE_NAME_REGEXP, 'Parents',
-    '%s/associated_rules' % SCOPE_NAME_REGEXP, 'AssociatedRules',
-    '%s/did_meta' % SCOPE_NAME_REGEXP, 'DidMeta',
+    '%s/files' % get_scope_name_regexp(), 'Files',
+    '%s/dids/history' % get_scope_name_regexp(), 'AttachmentHistory',
+    '%s/dids' % get_scope_name_regexp(), 'Attachment',
+    '%s/meta/(.*)' % get_scope_name_regexp(), 'Meta',
+    '%s/meta' % get_scope_name_regexp(), 'Meta',
+    '%s/status' % get_scope_name_regexp(), 'DIDs',
+    '%s/rules' % get_scope_name_regexp(), 'Rules',
+    '%s/parents' % get_scope_name_regexp(), 'Parents',
+    '%s/associated_rules' % get_scope_name_regexp(), 'AssociatedRules',
+    '%s/did_meta' % get_scope_name_regexp(), 'DidMeta',
     '/(.*)/(.*)/(.*)/(.*)/(.*)/sample', 'Sample',
-    '%s' % SCOPE_NAME_REGEXP, 'DIDs',
+    '%s' % get_scope_name_regexp(), 'DIDs',
     '', 'BulkDIDS',
     '/attachments', 'Attachments',
     '/new', 'NewDIDs',
     '/resurrect', 'Resurrect',
     '/list_dids_by_meta', 'ListByMeta',
-    '%s/follow' % SCOPE_NAME_REGEXP, 'Follow',
+    '%s/follow' % get_scope_name_regexp(), 'Follow',
 )
 
 

--- a/lib/rucio/web/rest/webpy/v1/lock.py
+++ b/lib/rucio/web/rest/webpy/v1/lock.py
@@ -30,7 +30,7 @@ from web import application, ctx, header, InternalError, loadhook
 
 from rucio.api.lock import get_dataset_locks_by_rse, get_dataset_locks
 from rucio.common.exception import RucioException, RSENotFound
-from rucio.common.schema import SCOPE_NAME_REGEXP
+from rucio.common.schema import get_scope_name_regexp
 from rucio.common.utils import generate_http_error, render_json
 from rucio.web.rest.common import rucio_loadhook, check_accept_header_wrapper
 
@@ -39,7 +39,7 @@ SH = StreamHandler()
 SH.setLevel(DEBUG)
 LOGGER.addHandler(SH)
 
-URLS = ('%s' % SCOPE_NAME_REGEXP, 'LockByScopeName',
+URLS = ('%s' % get_scope_name_regexp(), 'LockByScopeName',
         '/(.*)', 'LockByRSE')
 
 

--- a/lib/rucio/web/rest/webpy/v1/redirect.py
+++ b/lib/rucio/web/rest/webpy/v1/redirect.py
@@ -34,7 +34,7 @@ from logging import getLogger, StreamHandler, DEBUG
 from rucio.api.replica import list_replicas
 from rucio.common.exception import RucioException, DataIdentifierNotFound, ReplicaNotFound
 from rucio.common.replica_sorter import sort_random, sort_geoip, sort_closeness, sort_ranking, sort_dynamic, site_selector
-from rucio.common.schema import SCOPE_NAME_REGEXP
+from rucio.common.schema import get_scope_name_regexp
 from rucio.common.utils import generate_http_error
 from rucio.web.rest.common import RucioController, check_accept_header_wrapper
 
@@ -44,8 +44,8 @@ SH = StreamHandler()
 SH.setLevel(DEBUG)
 LOGGER.addHandler(SH)
 
-URLS = ('%s/metalink?$' % SCOPE_NAME_REGEXP, 'MetaLinkRedirector',
-        '%s/?$' % SCOPE_NAME_REGEXP, 'HeaderRedirector')
+URLS = ('%s/metalink?$' % get_scope_name_regexp(), 'MetaLinkRedirector',
+        '%s/?$' % get_scope_name_regexp(), 'HeaderRedirector')
 
 
 class MetaLinkRedirector(RucioController):

--- a/lib/rucio/web/rest/webpy/v1/replica.py
+++ b/lib/rucio/web/rest/webpy/v1/replica.py
@@ -55,7 +55,7 @@ from rucio.common.exception import (AccessDenied, DataIdentifierAlreadyExists, I
                                     ResourceTemporaryUnavailable, RucioException,
                                     RSENotFound, UnsupportedOperation, ReplicaNotFound)
 from rucio.common.replica_sorter import sort_random, sort_geoip, sort_closeness, sort_dynamic, sort_ranking
-from rucio.common.schema import SCOPE_NAME_REGEXP
+from rucio.common.schema import get_scope_name_regexp
 from rucio.common.utils import generate_http_error, parse_response, APIEncoder, render_json_list
 from rucio.common.constants import SUPPORTED_PROTOCOLS
 from rucio.web.rest.common import rucio_loadhook, rucio_unloadhook, RucioController, check_accept_header_wrapper
@@ -69,9 +69,9 @@ URLS = ('/list/?$', 'ListReplicas',
         '/rse/(.*)/?$', 'ReplicasRSE',
         '/bad/?$', 'BadReplicas',
         '/dids/?$', 'ReplicasDIDs',
-        '%s/datasets$' % SCOPE_NAME_REGEXP, 'DatasetReplicas',
-        '%s/datasets_vp$' % SCOPE_NAME_REGEXP, 'DatasetReplicasVP',
-        '%s/?$' % SCOPE_NAME_REGEXP, 'Replicas',
+        '%s/datasets$' % get_scope_name_regexp(), 'DatasetReplicas',
+        '%s/datasets_vp$' % get_scope_name_regexp(), 'DatasetReplicasVP',
+        '%s/?$' % get_scope_name_regexp(), 'Replicas',
         '/tombstone/?$', 'Tombstone')
 
 

--- a/lib/rucio/web/rest/webpy/v1/request.py
+++ b/lib/rucio/web/rest/webpy/v1/request.py
@@ -31,7 +31,7 @@ from web import application, ctx, loadhook, header
 from rucio.api import request
 from rucio.db.sqla.constants import RequestState
 from rucio.core.rse import get_rses_with_attribute_value, get_rse_name
-from rucio.common.schema import SCOPE_NAME_REGEXP
+from rucio.common.schema import get_scope_name_regexp
 from rucio.common.utils import generate_http_error, render_json
 from rucio.web.rest.common import rucio_loadhook, RucioController, exception_wrapper, check_accept_header_wrapper
 
@@ -41,7 +41,7 @@ SH = StreamHandler()
 SH.setLevel(DEBUG)
 LOGGER.addHandler(SH)
 
-URLS = ('%s/(.+)' % SCOPE_NAME_REGEXP, 'RequestGet',
+URLS = ('%s/(.+)' % get_scope_name_regexp(), 'RequestGet',
         '/list', 'RequestsGet')
 
 

--- a/lib/rucio/web/rest/webpy/v1/rule.py
+++ b/lib/rucio/web/rest/webpy/v1/rule.py
@@ -43,7 +43,7 @@ from rucio.common.exception import (InsufficientAccountLimit, RuleNotFound, Acce
                                     ReplicationRuleCreationTemporaryFailed, InvalidRuleWeight, StagingAreaRuleRequiresLifetime,
                                     DuplicateRule, InvalidObject, AccountNotFound, RuleReplaceFailed, ScratchDiskLifetimeConflict,
                                     ManualRuleApprovalBlocked, UnsupportedOperation)
-from rucio.common.schema import SCOPE_NAME_REGEXP
+from rucio.common.schema import get_scope_name_regexp
 from rucio.common.utils import generate_http_error, render_json, APIEncoder
 from rucio.web.rest.common import rucio_loadhook, check_accept_header_wrapper
 
@@ -55,7 +55,7 @@ LOGGER.addHandler(SH)
 URLS = ('/(.+)/locks', 'ReplicaLocks',
         '/(.+)/reduce', 'ReduceRule',
         '/(.+)/move', 'MoveRule',
-        '%s/history' % SCOPE_NAME_REGEXP, 'RuleHistoryFull',
+        '%s/history' % get_scope_name_regexp(), 'RuleHistoryFull',
         '/(.+)/history', 'RuleHistory',
         '/(.+)/analysis', 'RuleAnalysis',
         '/', 'AllRule',


### PR DESCRIPTION
This PR prepares the groundwork for making policy packages work with multi-VO Rucio. Instead of loading the schema and permission modules from the policy packages directly into the relevant namespaces, it instead stores them in dictionaries so that we can later load a separate module per VO. All access to them now goes through centralised functions that pass through to the correct policy package. Getter functions have been added for schema data since it is no longer possible to access it directly from outside the module in this model.

Please leave the issue open as there is still more work to be done before this is fully functional.