### PR TITLE
Core: rucio-admin wrongly removes default RSE tag; Fix #3608

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -15,7 +15,7 @@
 #
 # Authors:
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2012-2018
-# - Martin Barisits, <martin.barisits@cern.ch>, 2012-2017
+# - Martin Barisits, <martin.barisits@cern.ch>, 2012-2020
 # - Vincent Garonne, <vgaronne@gmail.com>, 2012-2018
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2012-2013
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2013-2020
@@ -526,7 +526,7 @@ def update_rse(args):
         args.value = True
     if args.value in ['false', 'False', 'FALSE', '0']:
         args.value = False
-    params = {'name': args.rse, args.param: args.value}
+    params = {args.param: args.value}
     client.update_rse(args.rse, parameters=params)
     print('Updated RSE %s settings %s to %s' % (args.rse, args.param, args.value))
     return SUCCESS
@@ -1568,7 +1568,7 @@ def get_parser():
                                                         '\n')
     update_rse_parser.set_defaults(which='update_rse')
     update_rse_parser.add_argument('--rse', dest='rse', action='store', help='RSE name')
-    update_rse_parser.add_argument('--setting', dest='param', action='store', help="One of availability_read, availability_write, availability_delete, latitude, longitude, time_zone, region_code, country_name, or city")
+    update_rse_parser.add_argument('--setting', dest='param', action='store', help="One of availability_read, availability_write, availability_delete, name, latitude, longitude, time_zone, region_code, country_name, or city")
     update_rse_parser.add_argument('--value', dest='value', action='store', help='Value for the new setting configuration.')
 
     # The info_rse command

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -16,7 +16,7 @@
 # - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2012-2015
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2019
-# - Martin Barisits <martin.barisits@cern.ch>, 2013-2018
+# - Martin Barisits <martin.barisits@cern.ch>, 2013-2020
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2018
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2014-2017
 # - Wen Guan <wguan.icedew@gmail.com>, 2015-2016
@@ -1191,7 +1191,7 @@ def update_rse(rse_id, parameters, session=None):
     param = {}
     availability_mapping = {'availability_read': 4, 'availability_write': 2, 'availability_delete': 1}
     for key in parameters:
-        if key == 'name':
+        if key == 'name' and parameters['name'] != rse:  # Needed due to wrongly setting name in pre1.22.7 clients
             param['rse'] = parameters['name']
         elif key in ['availability_read', 'availability_write', 'availability_delete']:
             if parameters[key] is True:
@@ -1202,8 +1202,8 @@ def update_rse(rse_id, parameters, session=None):
             param[key] = parameters[key]
     param['availability'] = availability
     query.update(param)
-    if 'name' in parameters:
-        add_rse_attribute(rse_id=rse_id, key=parameters['name'], value=1, session=session)
+    if 'rse' in param:
+        add_rse_attribute(rse_id=rse_id, key=parameters['name'], value=True, session=session)
         query = session.query(models.RSEAttrAssociation).filter_by(rse_id=rse_id).filter(models.RSEAttrAssociation.key == rse)
         rse_attr = query.one()
         rse_attr.delete(session=session)

--- a/lib/rucio/tests/test_rse.py
+++ b/lib/rucio/tests/test_rse.py
@@ -429,6 +429,13 @@ class TestRSEClient(object):
 
     def test_update_rse(self):
         """ RSE (CLIENTS): update rse."""
+        # Check if updating RSE does not remove RSE tag
+        rse = rse_name_generator()
+        ret = self.client.add_rse(rse)
+        assert_equal(get_rse_attribute(key=rse, rse_id=get_rse_id(rse)), [True])
+        self.client.update_rse(rse, {'availability_write': False, 'availability_delete': False})
+        assert_equal(get_rse_attribute(key=rse, rse_id=get_rse_id(rse)), [True])
+
         rse = rse_name_generator()
         renamed_rse = 'renamed_rse%s' % rse
         ret = self.client.add_rse(rse)

--- a/lib/rucio/web/rest/webpy/v1/rse.py
+++ b/lib/rucio/web/rest/webpy/v1/rse.py
@@ -18,7 +18,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2012, 2014
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2013-2014
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2018
-# - Martin Barisits <martin.barisits@cern.ch>, 2017
+# - Martin Barisits <martin.barisits@cern.ch>, 2017-2020
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 #


### PR DESCRIPTION
Core: rucio-admin wrongly removes default RSE tag; Fix #3608