### PR TITLE
Patch 3726 make reaper tests assert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2017-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 # - Vincent Garonne <vgaronne@gmail.com>, 2017-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018-2019
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Martin Barisits <martin.barisits@cern.ch>, 2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2019-2020
 
 sudo:
   - required
@@ -92,8 +92,6 @@ matrix:
   - python: 3.7
     env: SUITE=syntax
   - python: 3.7
-    env:  SUITE=all RDBMS=oracle
-  - python: 3.7
     env:  SUITE=all RDBMS=mysql5
   - python: 3.7
     env:  SUITE=all RDBMS=mysql8
@@ -110,8 +108,6 @@ matrix:
   - python: 3.8
     env: SUITE=syntax
   - python: 3.8
-    env:  SUITE=all RDBMS=oracle
-  - python: 3.8
     env:  SUITE=all RDBMS=mysql5
   - python: 3.8
     env:  SUITE=all RDBMS=mysql8
@@ -123,6 +119,10 @@ matrix:
     env:  SUITE=all RDBMS=sqlite
   allow_failures:
   - python: 3.6
+    env:  SUITE=all RDBMS=oracle
+  - python: 3.7
+    env:  SUITE=all RDBMS=oracle
+  - python: 3.8
     env:  SUITE=all RDBMS=oracle
 
 notifications:

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2012-2013
 # - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
 # - Yun-Pin Sun <winter0128@gmail.com>, 2013
-# - Mario Lassnig <mario.lassnig@cern.ch>, 2013-2019
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2013-2020
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2015
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2015
@@ -350,7 +350,6 @@ class BaseClient(object):
                     return
             except ConnectionError as error:
                 LOG.warning('ConnectionError: ' + str(error))
-                self.ca_cert = False
                 if retry > self.request_retries:
                     raise
                 continue

--- a/lib/rucio/common/constraints.py
+++ b/lib/rucio/common/constraints.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 # - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
 # - Frank Berghaus <frank.berghaus@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 from six import string_types
 
 # List of authorized value types for key
-AUTHORIZED_VALUE_TYPES = (float, int, string_types)
+AUTHORIZED_VALUE_TYPES = (float, int) + string_types
 STRING_TYPES = string_types

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -28,6 +28,7 @@
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 # - Brandon White, <bjwhite@fnal.gov>, 2019
 # - Luc Goossens <luc.goossens@cern.ch>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -1635,9 +1636,9 @@ def list_unlocked_replicas(rse_id, limit, bytes=None, worker_number=None, total_
     for (scope, name, path, bytes, tombstone, state) in query.yield_per(1000):
         if state != ReplicaState.UNAVAILABLE:
 
-            total_bytes += bytes
             if tombstone != OBSOLETE and needed_space is not None and total_bytes > needed_space:
                 break
+            total_bytes += bytes
 
             total_files += 1
             if total_files > limit:

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -185,7 +185,7 @@ def receiver(id, total_threads=1, full_mode=False):
 
     logging.info('receiver starting in full mode: %s' % full_mode)
 
-    executable = ' '.join(sys.argv)
+    executable = 'conveyor-receiver'
     hostname = socket.getfqdn()
     pid = os.getpid()
     hb_thread = threading.current_thread()

--- a/lib/rucio/rse/protocols/xrootd.py
+++ b/lib/rucio/rse/protocols/xrootd.py
@@ -16,6 +16,7 @@
 '''
 
 import os
+import logging
 
 from rucio.common import exception
 from rucio.rse.protocols import protocol
@@ -31,9 +32,15 @@ class Default(protocol.RSEProtocol):
             :param props Properties derived from the RSE Repository
         """
         super(Default, self).__init__(protocol_attr, rse_settings, logger=logger)
+
+        if not logger:
+            logger = logging.getLogger('%s.null' % __name__)
+            logger.disabled = True
+
         self.scheme = self.attributes['scheme']
         self.hostname = self.attributes['hostname']
         self.port = str(self.attributes['port'])
+        self.logger = logger
 
     def path2pfn(self, path):
         """
@@ -44,6 +51,7 @@ class Default(protocol.RSEProtocol):
             :returns: Fully qualified PFN.
 
         """
+        self.logger.debug('xrootd.path2pfn: path: {}'.format(path))
         if not path.startswith('xroot') and not path.startswith('root'):
             if path.startswith('/'):
                 return '%s://%s:%s/%s' % (self.scheme, self.hostname, self.port, path)
@@ -61,9 +69,11 @@ class Default(protocol.RSEProtocol):
 
             :raise  ServiceUnavailable
         """
+        self.logger.debug('xrootd.exists: pfn: {}'.format(pfn))
         try:
             path = self.pfn2path(pfn)
             cmd = 'xrdfs %s:%s stat %s' % (self.hostname, self.port, path)
+            self.logger.info('xrootd.exists: cmd: {}'.format(cmd))
             status, out, err = execute(cmd)
             if not status == 0:
                 return False
@@ -82,6 +92,7 @@ class Default(protocol.RSEProtocol):
 
         :returns: a dict with two keys, filesize and an element of GLOBALLY_SUPPORTED_CHECKSUMS.
         """
+        self.logger.debug('xrootd.stat: path: {}'.format(path))
         ret = {}
         chsum = None
         if path.startswith('root:'):
@@ -90,12 +101,14 @@ class Default(protocol.RSEProtocol):
         try:
             # xrdfs stat for getting filesize
             cmd = 'xrdfs %s:%s stat %s' % (self.hostname, self.port, path)
+            self.logger.info('xrootd.stat: filesize cmd: {}'.format(cmd))
             status_stat, out, err = execute(cmd)
             if status_stat == 0:
                 ret['filesize'] = out.split('\n')[2].split()[-1]
 
             # xrdfs query checksum for getting checksum
             cmd = 'xrdfs %s:%s query checksum %s' % (self.hostname, self.port, path)
+            self.logger.info('xrootd.stat: checksum cmd: {}'.format(cmd))
             status_query, out, err = execute(cmd)
             if status_query == 0:
                 chsum, value = out.strip('\n').split()
@@ -120,6 +133,7 @@ class Default(protocol.RSEProtocol):
 
         :returns: path.
         """
+        self.logger.debug('xrootd.pfn2path: pfn: {}'.format(pfn))
         if pfn.startswith('//'):
             return pfn
         elif pfn.startswith('/'):
@@ -138,6 +152,7 @@ class Default(protocol.RSEProtocol):
 
         :returns: Fully qualified PFN.
         """
+        self.logger.debug('xrootd.lfns2pfns: lfns: {}'.format(lfns))
         pfns = {}
         prefix = self.attributes['prefix']
 
@@ -165,10 +180,12 @@ class Default(protocol.RSEProtocol):
 
             :raises RSEAccessDenied
         """
+        self.logger.debug('xrootd.connect: port: {}, hostname {}'.format(self.port, self.hostname))
         try:
             # The query stats call is not implemented on some xroot doors.
             # Workaround: fail, if server does not reply within 10 seconds for static config query
             cmd = 'XrdSecPROTOCOL=gsi XRD_REQUESTTIMEOUT=10 xrdfs %s:%s query config %s:%s' % (self.hostname, self.port, self.hostname, self.port)
+            self.logger.info('xrootd.connect: cmd: {}'.format(cmd))
             status, out, err = execute(cmd)
             if not status == 0:
                 raise exception.RSEAccessDenied(err)
@@ -188,9 +205,10 @@ class Default(protocol.RSEProtocol):
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound
         """
-
+        self.logger.debug('xrootd.get: pfn: {}'.format(pfn))
         try:
             cmd = 'XrdSecPROTOCOL=gsi xrdcp -f %s %s' % (pfn, dest)
+            self.logger.info('xrootd.get: cmd: {}'.format(cmd))
             status, out, err = execute(cmd)
             if status == 54:
                 raise exception.SourceNotFound()
@@ -212,12 +230,16 @@ class Default(protocol.RSEProtocol):
             :raises ServiceUnavailable: if some generic error occured in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
+        self.logger.debug('xrootd.put: filename: {} target: {}'.format(filename, target))
+        source_dir = source_dir or '.'
         source_url = '%s/%s' % (source_dir, filename)
+        self.logger.debug('xrootd put: source url: {}'.format(source_url))
         path = self.path2pfn(target)
         if not os.path.exists(source_url):
             raise exception.SourceNotFound()
         try:
             cmd = 'XrdSecPROTOCOL=gsi xrdcp -f %s %s' % (source_url, path)
+            self.logger.info('xrootd.put: cmd: {}'.format(cmd))
             status, out, err = execute(cmd)
             if not status == 0:
                 raise exception.RucioException(err)
@@ -233,11 +255,13 @@ class Default(protocol.RSEProtocol):
             :raises ServiceUnavailable: if some generic error occured in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
+        self.logger.debug('xrootd.delete: pfn: {}'.format(pfn))
         if not self.exists(pfn):
             raise exception.SourceNotFound()
         try:
             path = self.pfn2path(pfn)
             cmd = 'XrdSecPROTOCOL=gsi xrdfs %s:%s rm %s' % (self.hostname, self.port, path)
+            self.logger.info('xrootd.delete: cmd: {}'.format(cmd))
             status, out, err = execute(cmd)
             if not status == 0:
                 raise exception.RucioException(err)
@@ -253,6 +277,7 @@ class Default(protocol.RSEProtocol):
             :raises ServiceUnavailable: if some generic error occured in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
+        self.logger.debug('xrootd.rename: pfn: {}'.format(pfn))
         if not self.exists(pfn):
             raise exception.SourceNotFound()
         try:
@@ -260,8 +285,10 @@ class Default(protocol.RSEProtocol):
             new_path = self.pfn2path(new_pfn)
             new_dir = new_path[:new_path.rindex('/') + 1]
             cmd = 'XrdSecPROTOCOL=gsi xrdfs %s:%s mkdir -p %s' % (self.hostname, self.port, new_dir)
+            self.logger.info('xrootd.stat: mkdir cmd: {}'.format(cmd))
             status, out, err = execute(cmd)
             cmd = 'XrdSecPROTOCOL=gsi xrdfs %s:%s mv %s %s' % (self.hostname, self.port, path, new_path)
+            self.logger.info('xrootd.stat: rename cmd: {}'.format(cmd))
             status, out, err = execute(cmd)
             if not status == 0:
                 raise exception.RucioException(err)

--- a/lib/rucio/tests/test_reaper.py
+++ b/lib/rucio/tests/test_reaper.py
@@ -21,7 +21,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from nose.tools import assert_equal
 
 from rucio.common.types import InternalAccount, InternalScope
@@ -59,7 +59,8 @@ def test_reaper():
         file_name = 'lfn' + generate_uuid()
         file_names.append(file_name)
         replica_core.add_replica(rse_id=rse_id, scope=InternalScope('data13_hip'),
-                                 name=file_name, bytes=file_size, tombstone=datetime.utcnow(),
+                                 name=file_name, bytes=file_size,
+                                 tombstone=datetime.utcnow() - timedelta(days=1),
                                  account=InternalAccount('root'), adler32=None, md5=None)
 
     rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=800)

--- a/lib/rucio/tests/test_reaper.py
+++ b/lib/rucio/tests/test_reaper.py
@@ -18,29 +18,55 @@
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2019
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+
+from datetime import datetime
+from nose.tools import assert_equal
 
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core import rse as rse_core
 from rucio.core import replica as replica_core
 from rucio.daemons.reaper.reaper import reaper
+from rucio.tests.common import rse_name_generator
 
 
 def test_reaper():
     """ REAPER (DAEMON): Test the reaper daemon."""
+    rse_name = rse_name_generator()
+    rse_id = rse_core.add_rse(rse_name)
+
+    mock_protocol = {'scheme': 'MOCK',
+                     'hostname': 'localhost',
+                     'port': 123,
+                     'prefix': '/test/reaper',
+                     'impl': 'rucio.rse.protocols.mock.Default',
+                     'domains': {
+                         'lan': {'read': 1,
+                                 'write': 1,
+                                 'delete': 1},
+                         'wan': {'read': 1,
+                                 'write': 1,
+                                 'delete': 1}}}
+    rse_core.add_protocol(rse_id=rse_id, parameter=mock_protocol)
+
     nb_files = 30
     file_size = 2147483648  # 2G
-    rse_id = rse_core.get_rse_id(rse='MOCK')
 
+    file_names = []
     for i in range(nb_files):
+        file_name = 'lfn' + generate_uuid()
+        file_names.append(file_name)
         replica_core.add_replica(rse_id=rse_id, scope=InternalScope('data13_hip'),
-                                 name='lfn' + generate_uuid(), bytes=file_size,
+                                 name=file_name, bytes=file_size, tombstone=datetime.utcnow(),
                                  account=InternalAccount('root'), adler32=None, md5=None)
 
-    rse_core.set_rse_usage(rse_id=rse_id, source='srm', used=nb_files * file_size, free=800)
+    rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=800)
     rse_core.set_rse_limits(rse_id=rse_id, name='MinFreeSpace', value=10737418240)
     rse_core.set_rse_limits(rse_id=rse_id, name='MaxBeingDeletedFiles', value=10)
 
-    rses = [rse_core.get_rse(rse_core.get_rse_id('MOCK')), ]
+    rses = [rse_core.get_rse(rse_id), ]
     reaper(once=True, rses=rses)
     reaper(once=True, rses=rses)
+    assert_equal(len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip'), 'name': n} for n in file_names], rse_expression=rse_name))), nb_files - 10)

--- a/lib/rucio/tests/test_reaper2.py
+++ b/lib/rucio/tests/test_reaper2.py
@@ -16,7 +16,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from nose.tools import assert_equal
 
 from rucio.common.types import InternalAccount, InternalScope
@@ -54,7 +54,8 @@ def test_reaper():
         file_name = 'lfn' + generate_uuid()
         file_names.append(file_name)
         replica_core.add_replica(rse_id=rse_id, scope=InternalScope('data13_hip'),
-                                 name=file_name, bytes=file_size, tombstone=datetime.utcnow(),
+                                 name=file_name, bytes=file_size,
+                                 tombstone=datetime.utcnow() - timedelta(days=1),
                                  account=InternalAccount('root'), adler32=None, md5=None)
 
     rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=800)


### PR DESCRIPTION
Add asserts to reaper tests
------------------

Modified the reaper and reaper2 tests to allow replicas to be deleted, and assert that they are. Also changed the RSE used from `MOCK` to a randomly generated RSE, and fixed a bug with how the original reaper decides how many files to delete.