### PR TITLE
Core: Add bulk method for list dataset replicas; Fix #2459

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -322,24 +322,49 @@ def list_dataset_replicas(args):
     List dataset replicas
     """
     client = get_client(args)
-    datasets, result = {}, {}
-    scope, name = extract_scope(args.did)
-    meta = client.get_metadata(scope, name)
-    if meta['did_type'] != 'DATASET':
-        dids = client.scope_list(scope=scope, name=name, recursive=True)
-        for did in dids:
-            if did['type'] == 'FILE':
-                dsn = '%s:%s' % (did['parent']['scope'], did['parent']['name'])
-                if dsn not in datasets:
-                    datasets[dsn] = 0
-                datasets[dsn] += 1
+    result = {}
+    datasets = []
+
+    def _append_to_datasets(scope, name):
+        filedid = {'scope': scope, 'name': name}
+        if filedid not in datasets:
+            datasets.append(filedid)
+
+    def _fetch_datasets_for_meta(meta):
+        """Internal function to fetch datasets and recurse into files."""
+        if meta['did_type'] != 'DATASET':
+            dids = client.scope_list(scope=meta['scope'], name=meta['name'], recursive=True)
+            for did in dids:
+                if did['type'] == 'FILE':
+                    _append_to_datasets(did['parent']['scope'], did['parent']['name'])
+        else:
+            _append_to_datasets(meta['scope'], meta['name'])
+
+    def _append_result(dsn, replica):
+        if dsn not in result:
+            result[dsn] = {}
+        result[dsn][replica['rse']] = [replica['rse'], replica['available_length'], replica['length']]
+
+    if len(args.dids) == 1:
+        scope, name = extract_scope(args.dids[0])
+        dmeta = client.get_metadata(scope, name)
+        _fetch_datasets_for_meta(meta=dmeta)
     else:
-        datasets['%s:%s' % (scope, name)] = 0
-    for dsn in datasets:
-        scope, name = extract_scope(dsn)
-        result[dsn] = {}
-        for rep in client.list_dataset_replicas(scope, name, args.deep):
-            result[dsn][rep['rse']] = [rep['rse'], rep['available_length'], rep['length']]
+        extractdids = (extract_scope(did) for did in args.dids)
+        splitdids = [{'scope': scope, 'name': name} for scope, name in extractdids]
+        for dmeta in client.get_metadata_bulk(dids=splitdids):
+            _fetch_datasets_for_meta(meta=dmeta)
+
+    if args.deep or len(datasets) < 2:
+        for did in datasets:
+            dsn = "%s:%s" % (did['scope'], did['name'])
+            for rep in client.list_dataset_replicas(scope=did['scope'], name=did['name'], deep=args.deep):
+                _append_result(dsn=dsn, replica=rep)
+    else:
+        for rep in client.list_dataset_replicas_bulk(dids=datasets):
+            dsn = "%s:%s" % (rep['scope'], rep['name'])
+            _append_result(dsn=dsn, replica=rep)
+
     if args.csv:
         for dsn in result:
             for rse in list(result[dsn].values()):
@@ -1781,7 +1806,7 @@ To list the missing replica of a dataset of a given RSE::
     +------------+---------+---------+
     ''')
     list_dataset_replicas_parser.set_defaults(function=list_dataset_replicas)
-    list_dataset_replicas_parser.add_argument(dest='did', action='store', help='The name of the DID to search.')
+    list_dataset_replicas_parser.add_argument(dest='dids', action='store', nargs='+', help='The name of the DID to search.')
     list_dataset_replicas_parser.add_argument('--deep', action='store_true', help='Make a deep check.')
     list_dataset_replicas_parser.add_argument('--csv', dest='csv', action='store_true', default=False, help='Comma Separated Value output.',)
 

--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
 # - Luc Goossens <luc.goossens@cern.ch>, 2020
 # - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -302,6 +303,34 @@ def list_dataset_replicas(scope, name, deep=False, vo='def'):
     scope = InternalScope(scope, vo=vo)
 
     replicas = replica.list_dataset_replicas(scope=scope, name=name, deep=deep)
+
+    for r in replicas:
+        r['scope'] = r['scope'].external
+        yield r
+
+
+def list_dataset_replicas_bulk(dids, vo='def'):
+    """
+    :param dids: The list of did dictionaries with scope and name.
+    :param vo: The VO to act on.
+
+    :returns: A list of dict dataset replicas
+    """
+
+    validate_schema(name='dids', obj=dids)
+    names_by_scope = dict()
+    for d in dids:
+        if d['scope'] in names_by_scope:
+            names_by_scope[d['scope']].append(d['name'])
+        else:
+            names_by_scope[d['scope']] = [d['name'], ]
+
+    names_by_intscope = dict()
+    for scope in names_by_scope:
+        internal_scope = InternalScope(scope, vo=vo)
+        names_by_intscope[internal_scope] = names_by_scope[scope]
+
+    replicas = replica.list_dataset_replicas_bulk(names_by_intscope)
 
     for r in replicas:
         yield api_update_return_dict(r)

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Luc Goossens <luc.goossens@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -276,6 +277,22 @@ class ReplicaClient(BaseClient):
                         path='/'.join([self.REPLICAS_BASEURL, quote_plus(scope), quote_plus(name), 'datasets']),
                         params=payload)
         r = self._send_request(url, type='GET')
+        if r.status_code == codes.ok:
+            return self._load_json_data(r)
+        exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+        raise exc_cls(exc_msg)
+
+    def list_dataset_replicas_bulk(self, dids):
+        """
+        List dataset replicas for a did (scope:name).
+
+        :param dids: The list of DIDs of the datasets.
+
+        :returns: A list of dict dataset replicas.
+        """
+        payload = {'dids': list(dids)}
+        url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, 'datasets_bulk']))
+        r = self._send_request(url, type='POST', data=dumps(payload))
         if r.status_code == codes.ok:
             return self._load_json_data(r)
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)

--- a/lib/rucio/web/rest/webpy/v1/replica.py
+++ b/lib/rucio/web/rest/webpy/v1/replica.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Luc Goossens <luc.goossens@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -31,6 +32,7 @@ from datetime import datetime
 from json import dumps, loads
 from six import string_types
 from traceback import format_exc
+
 try:
     from urllib import unquote
     from urlparse import parse_qs
@@ -42,7 +44,7 @@ from xml.sax.saxutils import escape
 
 from geoip2.errors import AddressNotFoundError
 
-from rucio.api.replica import (add_replicas, list_replicas, list_dataset_replicas,
+from rucio.api.replica import (add_replicas, list_replicas, list_dataset_replicas, list_dataset_replicas_bulk,
                                delete_replicas, list_dataset_replicas_vp,
                                get_did_from_pfns, update_replicas_states,
                                declare_bad_file_replicas, add_bad_pfns, get_suspicious_files,
@@ -54,7 +56,7 @@ from rucio.common.config import config_get
 from rucio.common.exception import (AccessDenied, DataIdentifierAlreadyExists, InvalidType,
                                     DataIdentifierNotFound, Duplicate, InvalidPath,
                                     ResourceTemporaryUnavailable, RucioException,
-                                    RSENotFound, UnsupportedOperation, ReplicaNotFound)
+                                    RSENotFound, UnsupportedOperation, ReplicaNotFound, InvalidObject)
 from rucio.common.replica_sorter import sort_random, sort_geoip, sort_closeness, sort_dynamic, sort_ranking
 from rucio.common.schema import SCOPE_NAME_REGEXP
 from rucio.common.utils import generate_http_error, parse_response, APIEncoder, render_json_list
@@ -71,6 +73,7 @@ URLS = ('/list/?$', 'ListReplicas',
         '/bad/?$', 'BadReplicas',
         '/dids/?$', 'ReplicasDIDs',
         '%s/datasets$' % SCOPE_NAME_REGEXP, 'DatasetReplicas',
+        '/datasets_bulk/?$', 'DatasetReplicasBulk',
         '%s/datasets_vp$' % SCOPE_NAME_REGEXP, 'DatasetReplicasVP',
         '%s/?$' % SCOPE_NAME_REGEXP, 'Replicas',
         '/tombstone/?$', 'Tombstone')
@@ -754,7 +757,7 @@ class DatasetReplicas(RucioController):
     @check_accept_header_wrapper(['application/x-json-stream'])
     def GET(self, scope, name):
         """
-        List dataset replicas replicas.
+        List dataset replicas.
 
         HTTP Success:
             200 OK
@@ -778,6 +781,53 @@ class DatasetReplicas(RucioController):
         try:
             for row in list_dataset_replicas(scope=scope, name=name, deep=deep, vo=ctx.env.get('vo')):
                 yield dumps(row, cls=APIEncoder) + '\n'
+        except RucioException as error:
+            raise generate_http_error(500, error.__class__.__name__, error.args[0])
+        except Exception as error:
+            print(format_exc())
+            raise InternalError(error)
+
+
+class DatasetReplicasBulk(RucioController):
+
+    @check_accept_header_wrapper(['application/x-json-stream'])
+    def POST(self):
+        """
+        List dataset replicas for multiple DIDs.
+
+        HTTP Success:
+            200 OK
+
+        HTTP Error:
+            400 Bad Request
+            401 Unauthorized
+            406 Not Acceptable
+            500 InternalError
+
+        :returns: A dictionary containing all replicas information.
+        """
+        header('Content-Type', 'application/x-json-stream')
+        json_data = data()
+        try:
+            params = parse_response(json_data)
+            dids = params['dids']
+            didslength = len(dids)
+        except KeyError as error:
+            raise generate_http_error(400, 'KeyError', 'Cannot find mandatory parameter : %s' % str(error))
+        except ValueError:
+            raise generate_http_error(400, 'ValueError', 'Cannot decode json parameter list')
+        except RucioException as error:
+            raise generate_http_error(500, error.__class__.__name__, error.args[0])
+        except Exception as error:
+            print(format_exc())
+            raise InternalError(error)
+        if didslength == 0:
+            raise generate_http_error(400, 'ValueError', 'List of DIDs is empty')
+        try:
+            for row in list_dataset_replicas_bulk(dids=dids, vo=ctx.env.get('vo')):
+                yield dumps(row, cls=APIEncoder) + '\n'
+        except InvalidObject as error:
+            raise generate_http_error(400, 'InvalidObject', 'Cannot validate DIDs: %s' % (str(error)))
         except RucioException as error:
             raise generate_http_error(500, error.__class__.__name__, error.args[0])
         except Exception as error:


### PR DESCRIPTION
Core: Add bulk method for list dataset replicas; Fix #2459

- [x] add API access to bulk method
- [x] add ReplicaClient method
- [x] add `test_list_dataset_replicas_bulk` in `test_dataset_replicas.py`
- [ ] ~add list-dataset-replicas tests in `test_bin_rucio.py`~ (I wasn't able to mock/run the replication process)