### PR TITLE
Client: Add dynamic to get_did #3760

### DIFF
--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -373,15 +373,18 @@ class DIDClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def get_did(self, scope, name):
+    def get_did(self, scope, name, dynamic=False):
         """
         Retrieve a single data identifier.
 
         :param scope: The scope name.
         :param name: The data identifier name.
+        :param dynamic: Calculate sizes dynamically when True
         """
 
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name)])
+        if dynamic:
+            path += '?dynamic=True'
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, type='GET')
         if r.status_code == codes.ok:


### PR DESCRIPTION
Add a dynamic parameter to get_did which totals up sizes.


```
cl.get_did(scope="cms", name="/SMS-TChiHZ_HToWWZZTauTau_2LFilter_TuneCP2_13TeV-madgraphMLM-pythia8/RunIIAutumn18NanoAODv7-PUFall18Fast_Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM", dynamic=True) 

{u'account': u'sync_t2_us_purdue', u'name': u'/SMS-TChiHZ_HToWWZZTauTau_2LFilter_TuneCP2_13TeV-madgraphMLM-pythia8/RunIIAutumn18NanoAODv7-PUFall18Fast_Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM', u'type': u'CONTAINER', u'bytes': 7295751658, u'monotonic': False, u'length': 29, u'scope': u'cms', u'open': True, u'expired_at': None}

```