### PR TITLE
bug, Core & Internals: Convert update rule options to internal #3794

### DIFF
--- a/lib/rucio/api/did.py
+++ b/lib/rucio/api/did.py
@@ -16,6 +16,7 @@
   - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
   - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
   - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
+  - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 
   PY3K COMPATIBLE
 '''
@@ -174,6 +175,8 @@ def add_dids(dids, issuer, vo='def'):
     issuer = InternalAccount(issuer, vo=vo)
     for d in dids:
         d['scope'] = InternalScope(d['scope'], vo=vo)
+        if 'account' in d.keys():
+            d['account'] = InternalAccount(d['account'], vo=vo)
         if 'dids' in d.keys():
             for child in d['dids']:
                 child['scope'] = InternalScope(child['scope'], vo=vo)
@@ -206,6 +209,8 @@ def attach_dids(scope, name, attachment, issuer, vo='def'):
         attachment['account'] = InternalAccount(attachment['account'], vo=vo)
     for d in attachment['dids']:
         d['scope'] = InternalScope(d['scope'], vo=vo)
+        if 'account' in d.keys():
+            d['account'] = InternalAccount(d['account'], vo=vo)
 
     if rse_id is not None:
         dids = did.attach_dids(scope=scope, name=name, dids=attachment['dids'],
@@ -243,6 +248,8 @@ def attach_dids_to_dids(attachments, issuer, ignore_duplicate=False, vo='def'):
         attachment['scope'] = InternalScope(attachment['scope'], vo=vo)
         for d in attachment['dids']:
             d['scope'] = InternalScope(d['scope'], vo=vo)
+            if 'account' in d.keys():
+                d['account'] = InternalAccount(d['account'], vo=vo)
 
     return did.attach_dids_to_dids(attachments=attachments, account=issuer,
                                    ignore_duplicate=ignore_duplicate)

--- a/lib/rucio/api/rule.py
+++ b/lib/rucio/api/rule.py
@@ -228,6 +228,8 @@ def update_replication_rule(rule_id, options, issuer, vo='def'):
     else:
         if not has_permission(issuer=issuer, vo=vo, action='update_rule', kwargs=kwargs):
             raise AccessDenied('Account %s can not update this replication rule.' % (issuer))
+        if 'account' in options:
+            options['account'] = InternalAccount(options['account'], vo=vo)
         rule.update_rule(rule_id=rule_id, options=options)
 
 

--- a/lib/rucio/tests/test_did.py
+++ b/lib/rucio/tests/test_did.py
@@ -641,7 +641,7 @@ class TestDIDClients:
         tmp_scope = 'mock'
         dsns = list()
         for i in range(500):
-            tmp_dsn = {'name': 'dsn_%s' % generate_uuid(), 'scope': tmp_scope, 'meta': {'project': 'data13_hip'}}
+            tmp_dsn = {'name': 'dsn_%s' % generate_uuid(), 'scope': tmp_scope, 'meta': {'project': 'data13_hip'}, 'account': 'root'}
             dsns.append(tmp_dsn)
         self.did_client.add_datasets(dsns)
 

--- a/lib/rucio/tests/test_rule.py
+++ b/lib/rucio/tests/test_rule.py
@@ -566,7 +566,7 @@ class TestReplicationRuleCore():
         account_counter_before_1 = get_usage(self.rse1_id, self.jdoe)
         account_counter_before_2 = get_usage(self.rse1_id, self.root)
 
-        update_rule(rule_id, {'account': self.root})
+        rucio.api.rule.update_replication_rule(rule_id, {'account': 'root'}, issuer='root', **self.vo)
         account_update(once=True)
 
         # Check if the counter has been updated correctly


### PR DESCRIPTION
Convert update rule options to internal
------------------

Checks if the dictionary of options we pass when updating a rule contains the account, and if it does, convert it to an internal representation.