### PR TITLE
Authentication & Authorisation: Added authentication options for m-VO, Closes #3855

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -35,6 +35,7 @@
 # - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
 # - Jaroslav Guenther <jaroslav.guenther@gmail.com>, 2019-2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -275,7 +276,7 @@ def get_client(args):
                         account=args.account,
                         auth_type=auth_type, creds=creds,
                         ca_cert=args.ca_certificate, timeout=args.timeout,
-                        user_agent=args.user_agent)
+                        user_agent=args.user_agent, vo=args.vo)
     except CannotAuthenticate as error:
         logger.error(error)
         if 'alert certificate expired' in str(error):
@@ -1712,6 +1713,7 @@ def get_parser():
     oparser.add_argument('-T', '--timeout', dest="timeout", type=float, default=None, help="Set all timeout values to seconds.")
     oparser.add_argument('--robot', '-R', dest="human", default=True, action='store_false', help="All output in bytes and without the units. This output format is preferred by parsers and scripts.")
     oparser.add_argument('--user-agent', '-U', dest="user_agent", default='rucio-clients', action='store', help="Rucio User Agent")
+    oparser.add_argument('--vo', dest="vo", metavar="VO", default=None, help="VO to authenticate at. Only used in multi-VO mode.")
 
     # Options for the userpass or OIDC auth_strategy
     oparser.add_argument('-u', '--user', dest='username', default=None, help='username')

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -30,6 +30,7 @@
 # - Dimitrios Christidis, <dimitrios.christidis@cern.ch>, 2019-2020
 # - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
 # - Jaroslav Guenther <jaroslav.guenther@gmail.com>, 2019-2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -233,7 +234,7 @@ def get_client(args):
         client = Client(rucio_host=args.host, auth_host=args.auth_host,
                         account=args.issuer,
                         auth_type=auth_type, creds=creds,
-                        ca_cert=args.ca_certificate, timeout=args.timeout)
+                        ca_cert=args.ca_certificate, timeout=args.timeout, vo=args.vo)
     except CannotAuthenticate as error:
         logger.error(error)
         if 'alert certificate expired' in str(error):
@@ -1210,6 +1211,7 @@ def get_parser():
     oparser.add_argument('-a', '--account', dest="issuer", metavar="ACCOUNT", help="Rucio account to use")
     oparser.add_argument('-S', '--auth-strategy', dest="auth_strategy", default=None, help="Authentication strategy (userpass, x509, ssh ...)")
     oparser.add_argument('-T', '--timeout', dest="timeout", type=float, default=None, help="Set all timeout values to SECONDS")
+    oparser.add_argument('--vo', dest="vo", metavar="VO", default=None, help="VO to authenticate at. Only used in multi-VO mode.")
 
     # Options for the userpass auth_strategy
     oparser.add_argument('-u', '--user', dest='username', default=None, help='username')

--- a/doc/source/cli_examples.rst
+++ b/doc/source/cli_examples.rst
@@ -14,6 +14,7 @@
      Authors:
    - Cedric Serfon <cedric.serfon@cern.ch>, 2018
    - Vincent Garonne <vgaronne@gmail.com>, 2018
+   - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 
 ===================
 Rucio CLI: Examples
@@ -58,6 +59,27 @@ If you try to authenticate with an account that is not mapped with your credenti
    2018-01-30 16:50:08,554 ERROR   Cannot authenticate.
    Details: x509 authentication failed
    2018-01-30 16:50:08,554 ERROR   Please verify that your proxy is still valid and renew it if needed.
+
+If you're running a multi-VO instance of Rucio, then the VO to authenticate against is set in the configuration file. However you can specify a different VO as a CLI argument if your credentials map to an account there too::
+
+  $ rucio whoami
+  status     : ACTIVE
+  account    : jdoe
+  account_type : SERVICE
+  created_at : 2014-01-17T07:52:18
+  updated_at : 2014-01-17T07:52:18
+  suspended_at : None
+  deleted_at : None
+  email      : jdoe@normalvo.com
+  $ rucio --vo abc --account root whoami
+  status     : ACTIVE
+  account    : root
+  account_type : SERVICE
+  created_at : 2014-01-17T07:51:59
+  updated_at : 2014-01-17T07:51:59
+  suspended_at : None
+  deleted_at : None
+  email      : root@abc.com
 
 
 

--- a/lib/rucio/api/authentication.py
+++ b/lib/rucio/api/authentication.py
@@ -20,6 +20,7 @@
 # - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -31,7 +32,7 @@ from rucio.core import authentication, identity, oidc
 from rucio.db.sqla.constants import IdentityType
 
 
-def refresh_cli_auth_token(token_string, account):
+def refresh_cli_auth_token(token_string, account, vo='def'):
     """
     Checks if there is active refresh token and if so returns
     either active token with expiration timestamp or requests a new
@@ -41,7 +42,7 @@ def refresh_cli_auth_token(token_string, account):
 
     :return: tuple of (access token, expiration epoch), None otherswise
     """
-    account = InternalAccount(account)
+    account = InternalAccount(account, vo=vo)
     return oidc.refresh_cli_auth_token(token_string, account)
 
 

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -450,7 +450,8 @@ class BaseClient(object):
         else:
             return False
 
-        headers = {'X-Rucio-Account': self.account,
+        headers = {'X-Rucio-VO': self.vo,
+                   'X-Rucio-Account': self.account,
                    'X-Rucio-Auth-Token': self.auth_token}
 
         for retry in range(self.AUTH_RETRIES + 1):
@@ -503,7 +504,8 @@ class BaseClient(object):
         :returns: True if the token was successfully received. False otherwise.
         """
         oidc_scope = str(self.creds['oidc_scope'])
-        headers = {'X-Rucio-Account': self.account,
+        headers = {'X-Rucio-VO': self.vo,
+                   'X-Rucio-Account': self.account,
                    'X-Rucio-Client-Authorize-Auto': str(self.creds['oidc_auto']),
                    'X-Rucio-Client-Authorize-Polling': str(self.creds['oidc_polling']),
                    'X-Rucio-Client-Authorize-Scope': str(self.creds['oidc_scope']),

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -14,6 +14,7 @@
 #
 # Authors:
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -37,7 +38,6 @@ from oic.utils import time_util
 from rucio.common.config import config_get, config_get_int
 from rucio.common.exception import (CannotAuthenticate, CannotAuthorize,
                                     RucioException)
-from rucio.common.types import InternalAccount
 from rucio.common.utils import (all_oidc_req_claims_present, build_url, oidc_identity_string,
                                 query_bunches, sqlalchemy_obj_to_dict, val_to_space_sep_str)
 from rucio.core.account import account_exists
@@ -262,7 +262,7 @@ def get_auth_oidc(account, session=None, **kwargs):
     webhome = kwargs.get('webhome', None)
     # For webui a mock account will be used here and default account
     # will be assigned to the identity during get_token_oidc
-    if account == InternalAccount('webui'):
+    if account.external == 'webui':
         pass
     else:
         # Make sure the account exists
@@ -376,7 +376,7 @@ def get_token_oidc(auth_query_string, ip=None, session=None):
                                                         oidc_tokens['id_token']['iss'])
         jwt_row_dict['account'] = oauth_req_params.account
 
-        if jwt_row_dict['account'] == InternalAccount('webui'):
+        if jwt_row_dict['account'].external == 'webui':
             try:
                 jwt_row_dict['account'] = get_default_account(jwt_row_dict['identity'], IdentityType.OIDC, True, session=session)
             except Exception:

--- a/lib/rucio/web/rest/webpy/v1/authentication.py
+++ b/lib/rucio/web/rest/webpy/v1/authentication.py
@@ -26,6 +26,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -206,6 +207,7 @@ class OIDC(RucioController):
         header('Cache-Control', 'post-check=0, pre-check=0', False)
         header('Pragma', 'no-cache')
 
+        vo = ctx.env.get('HTTP_X_RUCIO_VO', 'def')
         account = ctx.env.get('HTTP_X_RUCIO_ACCOUNT', 'webui')
         auth_scope = ctx.env.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_SCOPE', "")
         audience = ctx.env.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_AUDIENCE', "")
@@ -228,7 +230,7 @@ class OIDC(RucioController):
                       'polling': polling,
                       'refresh_lifetime': refresh_lifetime,
                       'ip': ip}
-            result = get_auth_oidc(account, **kwargs)
+            result = get_auth_oidc(account, vo=vo, **kwargs)
         except AccessDenied:
             raise generate_http_error(401, 'CannotAuthenticate', 'Cannot get authentication URL from Rucio Authentication Server for account %(account)s' % locals())
         except RucioException as error:
@@ -327,7 +329,7 @@ class RedirectOIDC(RucioController):
 
 class CodeOIDC(RucioController):
     """
-    IdP redirects to this endpoing with the AuthZ code
+    IdP redirects to this endpoint with the AuthZ code
     Rucio Auth server will request new token. This endpoint should be reached
     only if the request/ IdP login has been made through web browser. Then the response
     content will be in html (including the potential errors displayed).
@@ -541,11 +543,12 @@ class RefreshOIDC(RucioController):
         header('Cache-Control', 'post-check=0, pre-check=0', False)
         header('Pragma', 'no-cache')
 
+        vo = ctx.env.get('HTTP_X_RUCIO_VO', 'def')
         account = ctx.env.get('HTTP_X_RUCIO_ACCOUNT')
         token = ctx.env.get('HTTP_X_RUCIO_AUTH_TOKEN')
 
         try:
-            result = refresh_cli_auth_token(token, account)
+            result = refresh_cli_auth_token(token, account, vo=vo)
 
         except AccessDenied:
             raise generate_http_error(401, 'CannotAuthorize', 'Cannot authorize token request.')


### PR DESCRIPTION
Added authentication options for m-VO
------------------

Have added option specify VO on the CLI, if used then the clients created will have the VO passed to their constructor, otherwise the VO from the config file is used as before.

Have made some minor changes to the OIDC code to ensure VO is passed through all layers.

Added tests to check for interference between 2 VOs for both of the above features, as well as modifying the existing OIDC tests to use the VO from the config file when multi-VO tests are run. 