### PR TITLE
Testing: Changed m-VO tests to use postgres, Closes #3865

### DIFF
--- a/etc/docker/test/extra/rucio_multi_vo_ts2_postgres12.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_ts2_postgres12.cfg
@@ -19,10 +19,13 @@ request_retries = 3
 vo = ts2
 
 [database]
-default = sqlite:////tmp/rucio.db
+default = postgresql://postgres:secret@postgres12/postgres
+schema = dev
 pool_recycle=3600
 echo=0
 pool_reset_on_return=rollback
+pool_size = 20
+max_overflow = 20
 
 [bootstrap]
 # Hardcoded salt = 0, String = secret, Python: hashlib.sha256("0secret").hexdigest()

--- a/etc/docker/test/extra/rucio_multi_vo_tst_postgres12.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_tst_postgres12.cfg
@@ -19,10 +19,13 @@ request_retries = 3
 vo = tst
 
 [database]
-default = sqlite:////tmp/rucio.db
+default = postgresql://postgres:secret@postgres12/postgres
+schema = dev
 pool_recycle=3600
 echo=0
 pool_reset_on_return=rollback
+pool_size = 20
+max_overflow = 20
 
 [bootstrap]
 # Hardcoded salt = 0, String = secret, Python: hashlib.sha256("0secret").hexdigest()

--- a/etc/docker/test/matrix.yml
+++ b/etc/docker/test/matrix.yml
@@ -22,4 +22,4 @@ suites:
   - id: client
     RDBMS: sqlite
   - id: multi_vo
-    RDBMS: sqlite
+    RDBMS: postgres12

--- a/lib/rucio/web/rest/webpy/v1/did.py
+++ b/lib/rucio/web/rest/webpy/v1/did.py
@@ -732,7 +732,7 @@ class Meta(RucioController):
                 raise generate_http_error(404, 'KeyNotFound', 'No key provided to remove')
 
         try:
-            delete_metadata(scope=scope, name=name, key=key)
+            delete_metadata(scope=scope, name=name, key=key, vo=ctx.env.get('vo'))
         except KeyNotFound as error:
             raise generate_http_error(404, 'KeyNotFound', error.args[0])
         except DataIdentifierNotFound as error:

--- a/tools/run_multi_vo_tests_docker.sh
+++ b/tools/run_multi_vo_tests_docker.sh
@@ -40,8 +40,7 @@ do
     r) activate_rse="true";;
   esac
 done
-
-cp /opt/rucio/etc/rucio_multi_vo_tst.cfg /opt/rucio/etc/rucio.cfg
+export RUCIO_HOME=/opt/rucio/etc/multi_vo/tst
 
 echo 'Clearing memcache'
 echo flush_all > /dev/tcp/127.0.0.1/11211
@@ -130,7 +129,7 @@ if [ $? != 0 ]; then
 fi
 
 echo 'Tests on first VO successful, preparing second VO'
-cp /opt/rucio/etc/rucio_multi_vo_ts2.cfg /opt/rucio/etc/rucio.cfg
+export RUCIO_HOME=/opt/rucio/etc/multi_vo/ts2
 
 echo 'Clearing memcache'
 echo flush_all > /dev/tcp/127.0.0.1/11211

--- a/tools/test/before_script.sh
+++ b/tools/test/before_script.sh
@@ -134,17 +134,18 @@ elif [[ $RDBMS == "postgres12" ]]; then
         echo Could not connect to Postgres in time.
         exit 1
     fi
+    if [[ $SUITE == "multi_vo" ]]; then
+        docker exec rucio mkdir -p /opt/rucio/etc/multi_vo/tst/etc
+        docker exec rucio mkdir -p /opt/rucio/etc/multi_vo/ts2/etc
+        docker exec rucio cp /usr/local/src/rucio/etc/docker/test/extra/rucio_multi_vo_tst_postgres12.cfg /opt/rucio/etc/multi_vo/tst/etc/rucio.cfg
+        docker exec rucio cp /usr/local/src/rucio/etc/docker/test/extra/rucio_multi_vo_ts2_postgres12.cfg /opt/rucio/etc/multi_vo/ts2/etc/rucio.cfg
+    fi
     docker exec rucio cp /usr/local/src/rucio/etc/docker/test/extra/rucio_postgres12.cfg /opt/rucio/etc/rucio.cfg
     docker exec rucio cp /usr/local/src/rucio/etc/docker/test/extra/alembic_postgres12.ini /opt/rucio/etc/alembic.ini
     docker exec rucio httpd -k restart
 
 elif [[ $RDBMS == "sqlite" ]]; then
-    if [[ $SUITE == "multi_vo" ]]; then
-        docker exec rucio cp /usr/local/src/rucio/etc/docker/test/extra/rucio_multi_vo_tst_sqlite.cfg /opt/rucio/etc/rucio_multi_vo_tst.cfg
-        docker exec rucio cp /usr/local/src/rucio/etc/docker/test/extra/rucio_multi_vo_ts2_sqlite.cfg /opt/rucio/etc/rucio_multi_vo_ts2.cfg
-    else
-        docker exec rucio cp /usr/local/src/rucio/etc/docker/test/extra/rucio_sqlite.cfg /opt/rucio/etc/rucio.cfg
-    fi
+    docker exec rucio cp /usr/local/src/rucio/etc/docker/test/extra/rucio_sqlite.cfg /opt/rucio/etc/rucio.cfg
     docker exec rucio cp /usr/local/src/rucio/etc/docker/test/extra/alembic_sqlite.ini /opt/rucio/etc/alembic.ini
     docker exec rucio httpd -k restart
 fi


### PR DESCRIPTION
Changed m-VO tests to use postgres
------------------

- Modified and renamed the files for m-VO tests to run against PostgreSQL instead of SQLite.
- Added a line to the normal `run_tests_docker.sh` that allows single-VO tests to be run after multi-VO tests in dev containers, without manually modifying the config files . Currently `run_multi_vo_tests_docker.sh` overwrites `rucio.cfg` when setting `multi_vo = True`, so any future actions, including `run_tests_docker.sh` would be in multi-VO mode.
- Fixed the VO not being passed through the REST layer by `delete_metadata`