### PR TITLE
WebUI: Make m-VO compatible with WebUI, Closes #3885

### DIFF
--- a/lib/rucio/web/ui/common/utils.py
+++ b/lib/rucio/web/ui/common/utils.py
@@ -11,6 +11,7 @@
 # - Jaroslav Guenther, <jaroslav.guenther@cern.ch>, 2019-2020
 # - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 #
@@ -27,9 +28,10 @@ from web import cookies, ctx, input, setcookie, template, seeother
 
 from rucio import version
 from rucio.api import authentication as auth, identity
-from rucio.api.account import get_account_info, list_account_attributes
-from rucio.common.config import config_get
-from rucio.db.sqla.constants import AccountType
+from rucio.api.account import account_exists, get_account_info, list_account_attributes
+from rucio.common.config import config_get, config_get_bool
+from rucio.core import identity as identity_core, vo as vo_core
+from rucio.db.sqla.constants import AccountType, IdentityType
 
 
 if sys.version_info > (3, 0):
@@ -73,6 +75,7 @@ if not AUTH_TYPE:
     except:
         AUTH_ISSUERS = []
 
+MULTI_VO = config_get_bool('common', 'multi_vo', raise_exception=False, default=False)
 
 # excluded characters for injected JavaScript variables
 VARIABLE_VALUE_REGEX = re.compile(r"^[\w\- /=,.+*#()\[\]]*$", re.UNICODE)
@@ -139,17 +142,32 @@ def __to_js(var, value):
     return '<script type="text/javascript">var %s = "%s";</script>' % (var, value)
 
 
-def select_account_name(identitystr, identity_type):
+def select_account_name(identitystr, identity_type, vo=None):
     """
-    Looks for account corresponding to the provided identity.
+    Looks for account (and VO if not known) corresponding to the provided identity.
     :param identitystr: identity string
     :param identity_type: identity_type e.g. x509, saml, oidc, userpass
-    :returns: None or account string
+    :returns: Tuple of None or account string, None or VO string or list of VO strings
     """
-    accounts = identity.list_accounts_for_identity(identitystr, identity_type)
     ui_account = None
+    if not MULTI_VO:
+        vo = 'def'
+    if vo is not None:
+        accounts = identity.list_accounts_for_identity(identitystr, identity_type)
+    else:
+        internal_accounts = identity_core.list_accounts_for_identity(identitystr, IdentityType.from_sym(identity_type))
+        accounts = [account.external for account in internal_accounts]
+        vos = [account.vo for account in internal_accounts]
+        if vos:
+            vos = list(set(vos))
+            # If we only have 1 VO that matches the identity use that, otherwise return all possible VOs so the user can choose
+            if len(vos) == 1:
+                vo = vos[0]
+            else:
+                return None, vos
+
     if len(accounts) == 0:
-        return None
+        return None, vo
     # check if ui_account param is set
     if 'ui_account' in input():
         ui_account = input()['ui_account']
@@ -158,14 +176,14 @@ def select_account_name(identitystr, identity_type):
         ui_account = input()['account']
     if ui_account:
         if ui_account not in accounts:
-            return None
+            return None, vo
         else:
-            return ui_account
+            return ui_account, vo
     else:
         # try to set the default account to the user account, if not available take the first account.
         def_account = accounts[0]
         for account in accounts:
-            account_info = get_account_info(account)
+            account_info = get_account_info(account, vo=vo)
             if account_info.account_type == AccountType.USER:
                 def_account = account
                 break
@@ -173,7 +191,7 @@ def select_account_name(identitystr, identity_type):
         if (selected_account):
             def_account = selected_account
         ui_account = def_account
-    return ui_account
+    return ui_account, vo
 
 
 def get_token(token_method, acc=None, vo=None, idt=None, pwd=None):
@@ -230,10 +248,11 @@ def access_granted(valid_token_dict, rendered_tpl=None):
     :returns: rendered base temmplate with rendered_tpl content
     """
     js_account = __to_js('account', valid_token_dict['account'])
+    js_vo = __to_js('vo', valid_token_dict['vo'])
     js_token = __to_js('token', valid_token_dict['token'])
     rucio_ui_version = version.version_string()
     policy = config_get('policy', 'permission')
-    return RENDERER.base(js_token, js_account, rucio_ui_version, policy, rendered_tpl)
+    return RENDERER.base(js_token, js_account, js_vo, MULTI_VO, rucio_ui_version, policy, rendered_tpl)
 
 
 def finalize_auth(token, identity_type, cookie_dict_extra=None):
@@ -249,7 +268,7 @@ def finalize_auth(token, identity_type, cookie_dict_extra=None):
     if not valid_token_dict:
         return RENDERER.problem("It was not possible to validate and finalize your login with the provided token.")
     try:
-        attribs = list_account_attributes(valid_token_dict['account'])
+        attribs = list_account_attributes(valid_token_dict['account'], valid_token_dict['vo'])
         accounts = identity.list_accounts_for_identity(valid_token_dict['identity'], identity_type)
         accvalues = ""
         for acc in accounts:
@@ -261,13 +280,28 @@ def finalize_auth(token, identity_type, cookie_dict_extra=None):
                        'rucio-auth-token-created-at': long(time()),
                        'rucio-available-accounts': accounts,
                        'rucio-account-attr': dumps(attribs),
-                       'rucio-selected-account': valid_token_dict['account']}
+                       'rucio-selected-account': valid_token_dict['account'],
+                       'rucio-selected-vo': valid_token_dict['vo']}
         if cookie_dict_extra and isinstance(cookie_dict_extra, dict):
             cookie_dict.update(cookie_dict_extra)
         set_cookies(cookie_dict)
         return redirect_to_last_known_url()
     except:
         return RENDERER.problem("It was not possible to validate and finalize your login with the provided token.")
+
+
+def get_vo_descriptions(vos):
+    """
+    Gets the description for each VO in the list.
+    :param vos: List of 3 character VO strings
+    :returns: List of tuples containing VO string, VO description
+    """
+    all_vos = vo_core.list_vos()
+    vos_with_desc = []
+    for vo in all_vos:
+        if vo['vo'] in vos:
+            vos_with_desc.append((vo['vo'], vo['description']))
+    return vos_with_desc
 
 
 # AUTH_TYPE SPECIFIC METHODS FOLLOW:
@@ -285,16 +319,51 @@ def x509token_auth(data=None):
     dn = ctx.env.get('SSL_CLIENT_S_DN')
     if not dn.startswith('/'):
         dn = '/%s' % '/'.join(dn.split(',')[::-1])
+    if not MULTI_VO:
+        ui_vo = 'def'
+    elif hasattr(data, 'vo') and data.vo:
+        ui_vo = data.vo
+    else:
+        ui_vo = None
     if hasattr(data, 'account') and data.account:
         ui_account = data.account
     else:
-        ui_account = select_account_name(dn, 'x509')
-    msg = "<br><br>Your certificate (%s) is not mapped to (possibly any) rucio account: %s." % (html_escape(dn), html_escape(ui_account))
+        ui_account = None
+
+    if ui_account is None and ui_vo is None:
+        ui_account, ui_vo = select_account_name(dn, 'x509', ui_vo)
+    elif ui_account is None:
+        ui_account, _ = select_account_name(dn, 'x509', ui_vo)
+    elif ui_vo is None:
+        _, ui_vo = select_account_name(dn, 'x509', ui_vo)
+
+    # Try to eliminate VOs based on the account name (if we have one), if we still have multiple options let the user select one
+    if type(ui_vo) is list:
+        if ui_account:
+            valid_vos = []
+            for vo in ui_vo:
+                if account_exists(ui_account, vo):
+                    valid_vos.append(vo)
+            if len(valid_vos) == 0:
+                return RENDERER.problem(('<br><br>Your certificate (%s) is not mapped to (possibly any) rucio account: %s at any VO.' % (html_escape(dn), html_escape(ui_account))))
+            elif len(valid_vos) == 1:
+                ui_vo = valid_vos[0]
+            else:
+                vos_with_desc = get_vo_descriptions(valid_vos)
+                return RENDERER.select_login_method(AUTH_ISSUERS, SAML_SUPPORT, vos_with_desc)
+        else:
+            vos_with_desc = get_vo_descriptions(ui_vo)
+            return RENDERER.select_login_method(AUTH_ISSUERS, SAML_SUPPORT, vos_with_desc)
+
+    if MULTI_VO:
+        msg = "<br><br>Your certificate (%s) is not mapped to (possibly any) rucio account: %s at VO: %s." % (html_escape(dn), html_escape(ui_account), html_escape(ui_vo))
+    else:
+        msg = "<br><br>Your certificate (%s) is not mapped to (possibly any) rucio account: %s." % (html_escape(dn), html_escape(ui_account))
     msg += "<br><br><font color=\"red\">First, please make sure it is correctly registered in <a href=\"https://voms2.cern.ch:8443/voms/atlas\">VOMS</a> and be patient until it has been fully propagated through the system.</font>"
     msg += "<br><br>Then, if it is still not working please contact <a href=\"mailto:atlas-adc-ddm-support@cern.ch\">DDM Support</a>."
     if not ui_account:
         return RENDERER.problem(msg)
-    token = get_token(auth.get_auth_token_x509, acc=ui_account, idt=dn)
+    token = get_token(auth.get_auth_token_x509, acc=ui_account, vo=ui_vo, idt=dn)
     if not token:
         return RENDERER.problem(msg)
     return finalize_auth(token, 'x509')
@@ -303,7 +372,7 @@ def x509token_auth(data=None):
 def userpass_auth(data, rendered_tpl):
     """
     Manages login via Rucio USERPASS method.
-    :param data: data object containing account, username and password string
+    :param data: data object containing account, VO (if multi_vo), username and password string
     :param rendered_tpl: rendered page template
     :returns: final page or a page with an error message
     """
@@ -313,15 +382,55 @@ def userpass_auth(data, rendered_tpl):
         # if user tries to access a page through URL without logging in, then redirect to login page.
         if rendered_tpl:
             return RENDERER.login(None)
+        if not MULTI_VO:
+            ui_vo = 'def'
+        elif hasattr(data, 'vo') and data.vo:
+            ui_vo = data.vo
+        else:
+            ui_vo = None
         if hasattr(data, 'account') and data.account:
             ui_account = data.account
         else:
-            ui_account = select_account_name(data.username, 'userpass')
+            ui_account = None
+
+        if ui_account is None and ui_vo is None:
+            ui_account, ui_vo = select_account_name(data.username, 'userpass', ui_vo)
+        elif ui_account is None:
+            ui_account, _ = select_account_name(data.username, 'userpass', ui_vo)
+        elif ui_vo is None:
+            _, ui_vo = select_account_name(data.username, 'userpass', ui_vo)
+
+        # Try to eliminate VOs based on the account name (if we have one), if we still have multiple options let the user select one
+        if type(ui_vo) is list:
+            if ui_account:
+                valid_vos = []
+                for vo in ui_vo:
+                    if account_exists(ui_account, vo):
+                        valid_vos.append(vo)
+
+                if len(valid_vos) == 0:
+                    return RENDERER.problem(('Cannot find any Rucio account %s associated with identity %s at any VO.' % (html_escape(ui_account), html_escape(data.username))))
+                elif len(valid_vos) == 1:
+                    ui_vo = valid_vos[0]
+                else:
+                    vos_with_desc = get_vo_descriptions(valid_vos)
+                    return RENDERER.login(ui_account, None, vos_with_desc)
+            else:
+                vos_with_desc = get_vo_descriptions(ui_vo)
+                return RENDERER.login(None, None, vos_with_desc)
+
         if not ui_account:
-            return RENDERER.problem(('Cannot get find any account associated with %s identity.' % (html_escape(data.username))))
-        token = get_token(auth.get_auth_token_user_pass, acc=ui_account, idt=data.username, pwd=data.password.encode("ascii"))
+            if MULTI_VO:
+                return RENDERER.problem(('Cannot get find any account associated with %s identity at VO %s.' % (html_escape(data.username), html_escape(ui_vo))))
+            else:
+                return RENDERER.problem(('Cannot get find any account associated with %s identity.' % (html_escape(data.username))))
+        token = get_token(auth.get_auth_token_user_pass, acc=ui_account, vo=ui_vo, idt=data.username, pwd=data.password.encode("ascii"))
         if not token:
-            return RENDERER.problem(('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s.') % (html_escape(data.username), html_escape(ui_account)))
+            if MULTI_VO:
+                return RENDERER.problem(('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s at VO %s.') % (html_escape(data.username), html_escape(ui_account), html_escape(ui_vo)))
+            else:
+                return RENDERER.problem(('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s.') % (html_escape(data.username), html_escape(ui_account)))
+
     return finalize_auth(token, 'userpass')
 
 
@@ -337,22 +446,59 @@ def saml_auth(method, data=None):
     req = prepare_webpy_request(ctx.env, dict(input()))
     samlauth = OneLogin_Saml2_Auth(req, custom_base_path=SAML_PATH)
     saml_user_data = cookies().get('saml-user-data')
-    ui_account = None
+    if not MULTI_VO:
+        ui_vo = 'def'
+    elif hasattr(data, 'vo') and data.vo:
+        ui_vo = data.vo
+    else:
+        ui_vo = None
     if hasattr(data, 'account') and data.account:
         ui_account = data.account
+    else:
+        ui_account = None
+
     if method == "GET":
         # If user data is not present, redirect to IdP for authentication
         if not saml_user_data:
             return seeother(samlauth.login())
         # If user data is present but token is not valid, create a new one
         saml_nameid = cookies().get('saml-nameid')
+        if ui_account is None and ui_vo is None:
+            ui_account, ui_vo = select_account_name(saml_nameid, 'saml', ui_vo)
+        elif ui_account is None:
+            ui_account, _ = select_account_name(saml_nameid, 'saml', ui_vo)
+        elif ui_vo is None:
+            _, ui_vo = select_account_name(saml_nameid, 'saml', ui_vo)
+
+        # Try to eliminate VOs based on the account name (if we have one), if we still have multiple options let the user select one
+        if type(ui_vo) is list:
+            if ui_account:
+                valid_vos = []
+                for vo in ui_vo:
+                    if account_exists(ui_account, vo):
+                        valid_vos.append(vo)
+                if len(valid_vos) == 0:
+                    return RENDERER.problem(('Cannot find any Rucio account %s associated with identity %s at any VO.' % (html_escape(ui_account), html_escape(saml_nameid))))
+                elif len(valid_vos) == 1:
+                    ui_vo = valid_vos[0]
+                else:
+                    vos_with_desc = get_vo_descriptions(valid_vos)
+                    return RENDERER.select_login_method(AUTH_ISSUERS, SAML_SUPPORT, vos_with_desc)
+            else:
+                vos_with_desc = get_vo_descriptions(ui_vo)
+                return RENDERER.select_login_method(AUTH_ISSUERS, SAML_SUPPORT, vos_with_desc)
+
         if not ui_account:
-            ui_account = select_account_name(saml_nameid, 'saml')
-        if not ui_account:
-            return RENDERER.problem('Cannot get find any account associated with %s identity.' % (html_escape(saml_nameid)))
-        token = get_token(auth.get_auth_token_saml, acc=ui_account, idt=saml_nameid)
+            if MULTI_VO:
+                return RENDERER.problem('Cannot get find any account associated with %s identity at VO %s.' % (html_escape(saml_nameid), html_escape(ui_vo)))
+            else:
+                return RENDERER.problem('Cannot get find any account associated with %s identity.' % (html_escape(saml_nameid)))
+        token = get_token(auth.get_auth_token_saml, acc=ui_account, vo=ui_vo, idt=saml_nameid)
         if not token:
-            return RENDERER.problem(('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s.') % (html_escape(saml_nameid), html_escape(ui_account)))
+            if MULTI_VO:
+                return RENDERER.problem(('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s at VO %s.') % (html_escape(saml_nameid), html_escape(ui_account), html_escape(ui_vo)))
+            else:
+                return RENDERER.problem(('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s.') % (html_escape(saml_nameid), html_escape(ui_account)))
         return finalize_auth(token, 'saml')
 
     # If method is POST, check the received SAML response and redirect to home if valid
@@ -366,13 +512,42 @@ def saml_auth(method, data=None):
             cookie_extra['saml-session-index'] = samlauth.get_session_index()
             # WHY THIS ATTEMPTS TO GET A NEW TOKEN ?
             # WE SHOULD HAVE IT/GET IT FROM COOKIE OR DB AND JUST REDIRECT, NO ?
+            if ui_account is None and ui_vo is None:
+                ui_account, ui_vo = select_account_name(saml_nameid, 'saml', ui_vo)
+            elif ui_account is None:
+                ui_account, _ = select_account_name(saml_nameid, 'saml', ui_vo)
+            elif ui_vo is None:
+                _, ui_vo = select_account_name(saml_nameid, 'saml', ui_vo)
+
+            # Try to eliminate VOs based on the account name (if we have one), if we still have multiple options let the user select one
+            if type(ui_vo) is list:
+                if ui_account:
+                    valid_vos = []
+                    for vo in ui_vo:
+                        if account_exists(ui_account, vo):
+                            valid_vos.append(vo)
+                    if len(valid_vos) == 0:
+                        return RENDERER.problem(('Cannot find any Rucio account %s associated with identity %s at any VO.' % (html_escape(ui_account), html_escape(saml_nameid))))
+                    elif len(valid_vos) == 1:
+                        ui_vo = valid_vos[0]
+                    else:
+                        vos_with_desc = get_vo_descriptions(valid_vos)
+                        return RENDERER.select_login_method(AUTH_ISSUERS, SAML_SUPPORT, vos_with_desc)
+                else:
+                    vos_with_desc = get_vo_descriptions(ui_vo)
+                    return RENDERER.select_login_method(AUTH_ISSUERS, SAML_SUPPORT, vos_with_desc)
+
             if not ui_account:
-                ui_account = select_account_name(saml_nameid, 'saml')
-            if not ui_account:
-                return RENDERER.problem('Cannot get find any account associated with %s identity.' % (html_escape(saml_nameid)))
-            token = get_token(auth.get_auth_token_saml, acc=ui_account, idt=saml_nameid)
+                if MULTI_VO:
+                    return RENDERER.problem('Cannot get find any account associated with %s identity at VO %s.' % (html_escape(saml_nameid), html_escape(ui_vo)))
+                else:
+                    return RENDERER.problem('Cannot get find any account associated with %s identity.' % (html_escape(saml_nameid)))
+            token = get_token(auth.get_auth_token_saml, acc=ui_account, vo=ui_vo, idt=saml_nameid)
             if not token:
-                return RENDERER.problem(('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s.') % (html_escape(saml_nameid), html_escape(ui_account)))
+                if MULTI_VO:
+                    return RENDERER.problem(('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s at VO %s.') % (html_escape(saml_nameid), html_escape(ui_account), html_escape(ui_vo)))
+                else:
+                    return RENDERER.problem(('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s.') % (html_escape(saml_nameid), html_escape(ui_account)))
             return finalize_auth(token, 'saml', cookie_extra)
 
         return RENDERER.problem("Not authenticated")
@@ -380,16 +555,30 @@ def saml_auth(method, data=None):
     return RENDERER.problem("Error while processing SAML")
 
 
-def oidc_auth(account, issuer):
+def oidc_auth(account, issuer, ui_vo=None):
     """
     Open ID Connect Login
     :param account: Rucio account string
     :param issuer: issuer key (e.g. xdc, wlcg) as in the idpsecrets.json file
+    :param ui_vo: 3 character string to identify the VO, if None will attempt to deduce it from `account`
     :returns: rendered final page or a page with error message
     """
-
     if not account:
         account = 'webui'
+    if ui_vo is None:
+        all_vos = [vo['vo'] for vo in vo_core.list_vos()]
+        valid_vos = []
+        for vo in all_vos:
+            if account_exists(account, vo):
+                valid_vos.append(vo)
+        if len(valid_vos) == 0:
+            return RENDERER.problem(('Cannot find any Rucio account %s at any VO.' % html_escape(account)))
+        elif len(valid_vos) == 1:
+            ui_vo = valid_vos[0]
+        else:
+            vos_with_desc = get_vo_descriptions(valid_vos)
+            return RENDERER.select_login_method(AUTH_ISSUERS, SAML_SUPPORT, vos_with_desc)
+
     if not issuer:
         return RENDERER.problem("Please provide IdP issuer.")
     kwargs = {'audience': None,
@@ -400,7 +589,7 @@ def oidc_auth(account, issuer):
               'refresh_lifetime': None,
               'ip': None,
               'webhome': ctx.realhome + '/oidc_final'}
-    auth_url = auth.get_auth_oidc(account, **kwargs)
+    auth_url = auth.get_auth_oidc(account, vo=ui_vo, **kwargs)
     if not auth_url:
         return RENDERER.problem("It was not possible to get the OIDC authentication url from the Rucio auth server. "
                                 + "In case you provided your account name, make sure it is known to Rucio.")   # NOQA: W503
@@ -423,7 +612,7 @@ def authenticate(rendered_tpl):
 
     # login without any known server config
     if not AUTH_TYPE:
-        return RENDERER.select_login_method(AUTH_ISSUERS, SAML_SUPPORT)
+        return RENDERER.select_login_method(AUTH_ISSUERS, SAML_SUPPORT, None)
     # for AUTH_TYPE predefined by the server continue
     else:
         if AUTH_TYPE == 'userpass':

--- a/lib/rucio/web/ui/static/base.js
+++ b/lib/rucio/web/ui/static/base.js
@@ -19,6 +19,11 @@ if ('rucio-selected-account' in $.cookie()) {
 } else {
     $.cookie('rucio-selected-account', account, { path: '/' });
 }
+if ('rucio-selected-vo' in $.cookie()) {
+    vo = $.cookie('rucio-selected-vo');
+} else {
+    $.cookie('rucio-selected-vo', vo, { path: '/' });
+}
 
 var available_accounts = $.cookie('rucio-available-accounts').split(' ');
 
@@ -175,7 +180,7 @@ function fix_links() {
 }
 
 /* engage */
-var r = new RucioClient(token, account);
+var r = new RucioClient(token, account, vo);
 $(document).ready(function() {
     $('#rucio_webui_version').html(get_version());
     r.ping({
@@ -187,6 +192,7 @@ $(document).ready(function() {
     });
 
     $('#current_account').text(account);
+    $('#current_vo').text(vo);
     available_accounts.forEach(function(acct) {
         $('#accountselecter').append("<li><a onClick=\"set_account('" + acct + "')\">" + acct + "</a></li>")
     });

--- a/lib/rucio/web/ui/static/rucio.js
+++ b/lib/rucio/web/ui/static/rucio.js
@@ -15,12 +15,14 @@
 
 /* --- base Rucio client class definition --- */
 
-function RucioClient(token, account) {
+function RucioClient(token, account, vo) {
     this.token = token;
     this.account = account;
+    this.vo = vo;
     this.script = 'webui::' + window.location.pathname.replace(/\//g, '-');
     this.headers = {'X-Rucio-Auth-Token': this.token,
                     'X-Rucio-Account': this.account,
+                    'X-Rucio-VO': this.vo,
                     'X-Rucio-Script': this.script}
     host = window.location.host;
     this.url = 'https://' + host + ':443/proxy';
@@ -64,6 +66,7 @@ check_token = function() {
         } else {
             r.get_auth_token_x509({
                 account: this.account,
+                vo: this.vo,
                 async: false,
                 success: function(data, textStatus, jqXHR) {
                     r.token = jqXHR.getResponseHeader('X-Rucio-Auth-Token');
@@ -100,6 +103,7 @@ RucioClient.prototype.get_auth_token_x509 = function(options) {
     jQuery.ajax({url: this.authurl,
                  crossDomain: true,
                  headers: {'X-Rucio-Account': options.account,
+                           'X-Rucio-VO': this.vo,
                            'X-Rucio-Script': this.script},
                  async: options.async,
                  success: function(data, textStatus, jqXHR)
@@ -1653,7 +1657,8 @@ RucioClient.prototype.send_trace = function(options) {
         dataType: 'text',
         data: JSON.stringify({
             "eventVersion": options.eventVersion,
-            "account": account,
+            "account": this.account,
+            "vo": this.vo,
             "protocol": options.protocol,
             "uuid": options.uuid,
             "datasetScope": options.datasetScope,

--- a/lib/rucio/web/ui/templates/base.html
+++ b/lib/rucio/web/ui/templates/base.html
@@ -1,4 +1,4 @@
-$def with (token, account, rucio_ui_version, policy, content)
+$def with (token, account, vo, multi_vo, rucio_ui_version, policy, content)
 <!--
  Copyright European Organization for Nuclear Research (CERN)
 
@@ -20,6 +20,7 @@ $def with (token, account, rucio_ui_version, policy, content)
   <head>
     $:token
     $:account
+    $:vo
     <title>Rucio UI - $:content.title</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
@@ -136,7 +137,11 @@ $def with (token, account, rucio_ui_version, policy, content)
 
           <ul class="right">
             <li id="accountlist" class="has-dropdown">
-              <a>Using account: <span id="current_account">[loading]</span></a>
+              <a>Using account: <span id="current_account">[loading]</span>
+              $if multi_vo:
+                 on VO: <span id="current_vo">[loading]</span></a>
+              $else:
+                </a>
               <ul id="accountselecter" class="dropdown">
               </ul>
             </li>

--- a/lib/rucio/web/ui/templates/login.html
+++ b/lib/rucio/web/ui/templates/login.html
@@ -1,4 +1,4 @@
-$def with (account)
+$def with (account, vo, possible_vos)
 <!DOCTYPE html>
 <!--
  Copyright European Organization for Nuclear Research (CERN)
@@ -16,6 +16,7 @@ $def with (account)
  - Vincent Garonne, <vincent.garonne@cern.ch>, 2015
  - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
  - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+ - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 -->
 
 <html>
@@ -70,7 +71,7 @@ $def with (account)
           <div class="row">
             <div class="large-6 columns center">
               <label>Password
-                <input type="password" name="password" placeholder="Enter password here..." id="password" />
+                <input type="password" name="password" placeholder="Enter password here..." id="password"/>
               </label>
             </div>
           </div>
@@ -78,10 +79,30 @@ $def with (account)
               <div class="row">
                 <div class="large-6 columns center">
                   <label>Rucio account name (optional)
-                    <input type="text" name="account" placeholder="account name ..." id="account" />
+                    <input type="text" name="account" placeholder="account name ..." id="account"/>
                   </label>
                 </div>
               </div>
+          $else:
+              <div class="row">
+                <div class="large-6 columns center">
+                  <label>Rucio account name: $account</label>
+                  <input type="hidden" name="account" value=$account id="account"/>
+                </div>
+              </div>
+          $if possible_vos:
+              <div class="row">
+                <div class="large-6 columns center">
+                  <label style="color:red">Unable to login, multiple VOs found for given identity. Please select a VO and try again:</label>
+                    <select name="vo" id="vo">
+                      <option selected></option>
+                      $for possible_vo in possible_vos:
+                          <option value=$possible_vo[0]>$possible_vo[1] - $possible_vo[0]</option>
+                    </select>
+                </div>
+              </div>
+          $else:
+              <input type="hidden" name="vo" id="vo"/>
           <br>
           <div class="row">
             <div class="large-6 columns center">

--- a/lib/rucio/web/ui/templates/select_login_method.html
+++ b/lib/rucio/web/ui/templates/select_login_method.html
@@ -1,4 +1,4 @@
-$def with (oidc_issuers, saml_support, buttons = ["btn btn-block btn-outline-warning btn-lg", "btn btn-block btn-outline-info btn-lg", "btn btn-block btn-outline-danger btn-lg"], original_buttons = ["btn btn-block btn-outline-warning btn-lg", "btn btn-block btn-outline-info btn-lg", "btn btn-block btn-outline-danger btn-lg"])
+$def with (oidc_issuers, saml_support, possible_vos, buttons = ["btn btn-block btn-outline-warning btn-lg", "btn btn-block btn-outline-info btn-lg", "btn btn-block btn-outline-danger btn-lg"], original_buttons = ["btn btn-block btn-outline-warning btn-lg", "btn btn-block btn-outline-info btn-lg", "btn btn-block btn-outline-danger btn-lg"])
 <!--
  Copyright European Organization for Nuclear Research (CERN)
 
@@ -9,6 +9,7 @@ $def with (oidc_issuers, saml_support, buttons = ["btn btn-block btn-outline-war
 
  Authors:
  - Jaroslav Guenther, <jaroslav.guenther@gmail.com>, 2019-2020
+ - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 -->
 
 
@@ -35,15 +36,15 @@ $def with (oidc_issuers, saml_support, buttons = ["btn btn-block btn-outline-war
   <hr>
   <p class="text-success text-center">Choose Login Method</p>
   <p>
-    <a href="" class="btn btn-block btn-outline-primary btn-lg" role="button" onclick="this.href='/x509?account='+document.getElementById('accountname').value" height="auto"><i class="fab fa-2x icon-certificate vertical-align-middle"></i><span class="inline-block padding-bottom-2">   X509 Certificate</span></a>
-    <a href="" class="btn btn-block btn-outline-rucio btn-lg" role="button" onclick="this.href='/login?account='+document.getElementById('accountname').value" height="auto"> <i class="fab fa-2x icon-rucio vertical-align-middle"></i><span class="inline-block padding-bottom-2">   Rucio Userpass</span></a>
+    <a href="" class="btn btn-block btn-outline-primary btn-lg" role="button" onclick="this.href='/x509?account='+document.getElementById('accountname').value+'&vo='+document.getElementById('voname').value" height="auto"><i class="fab fa-2x icon-certificate vertical-align-middle"></i><span class="inline-block padding-bottom-2">   X509 Certificate</span></a>
+    <a href="" class="btn btn-block btn-outline-rucio btn-lg" role="button" onclick="this.href='/login?account='+document.getElementById('accountname').value+'&vo='+document.getElementById('voname').value" height="auto"> <i class="fab fa-2x icon-rucio vertical-align-middle"></i><span class="inline-block padding-bottom-2">   Rucio Userpass</span></a>
     $if saml_support == True:
-        <a href="" class="btn btn-block btn-outline-cern btn-lg" role="button" onclick="this.href='/saml?account='+document.getElementById('accountname').value" height="auto"> <i class="fab fa-2x icon-cern vertical-align-middle"></i><span class="inline-block padding-bottom-2">   CERN SSO Log-In</span></a>
+        <a href="" class="btn btn-block btn-outline-cern btn-lg" role="button" onclick="this.href='/saml?account='+document.getElementById('accountname').value+'&vo='+document.getElementById('voname').value" height="auto"> <i class="fab fa-2x icon-cern vertical-align-middle"></i><span class="inline-block padding-bottom-2">   CERN SSO Log-In</span></a>
     $if len(oidc_issuers) == 1:
-        <a href="" class="btn btn-block btn-outline-warning btn-lg" role="button" onclick="this.href='/oidc?account='+document.getElementById('accountname').value+'&issuer='+&quot;$oidc_issuers[0]&quot;" height="auto"> <i class="fa-2x icon-openid vertical-align-middle"></i><span class="inline-block padding-bottom-2"> $oidc_issuers[0]</span></a>
+        <a href="" class="btn btn-block btn-outline-warning btn-lg" role="button" onclick="this.href='/oidc?account='+document.getElementById('accountname').value+'&vo='+document.getElementById('voname').value+'&issuer='+&quot;$oidc_issuers[0]&quot;" height="auto"> <i class="fa-2x icon-openid vertical-align-middle"></i><span class="inline-block padding-bottom-2"> $oidc_issuers[0]</span></a>
     $if len(oidc_issuers) > 1:
         $for idp in oidc_issuers:
-            <a href="" class="$buttons[0]" role="button" onclick="this.href='/oidc?account='+document.getElementById('accountname').value+'&issuer='+&quot;$idp&quot;" height="auto"> <i class="fa-2x icon-openid vertical-align-middle"></i><span class="inline-block padding-bottom-2"> $idp</span></a>
+            <a href="" class="$buttons[0]" role="button" onclick="this.href='/oidc?account='+document.getElementById('accountname').value+'&vo='+document.getElementById('voname').value+'&issuer='+&quot;$idp&quot;" height="auto"> <i class="fa-2x icon-openid vertical-align-middle"></i><span class="inline-block padding-bottom-2"> $idp</span></a>
             $buttons.append(buttons[0])
             $buttons.remove(buttons[0])
         $for i in range(len(buttons)):
@@ -56,12 +57,25 @@ $def with (oidc_issuers, saml_support, buttons = ["btn btn-block btn-outline-war
   </p>
   <form>
   <div class="form-group">
-  <div class="input-group">
-    <div class="input-group-prepend">
-        <span class="input-group-text"> <i class="fa fa-user"></i> </span>
-     </div>
-    <input name="accountname" class="form-control" placeholder="Optionally specify Rucio account name ..." type="accountname" id="accountname" value="">
-  </div> <!-- input-group.// -->
+    <div class="input-group">
+      <div class="input-group-prepend">
+        <span class="input-group-text" style="width: 2.75em"> <i class="fa fa-user"></i> </span>
+      </div>
+      <input name="accountname" class="form-control" placeholder="Optionally specify Rucio account name ..." type="accountname" id="accountname" value="">
+    </div> <!-- input-group.// -->
+    $if possible_vos:
+        <div class="input-group">
+          <label style="color:red; line-height:21pt; text-align: center;">Unable to login, multiple VOs found for given identity. Please select a VO and try again:</label>
+          <div class="input-group-prepend">
+            <span class="input-group-text" style="width: 2.75em"> <i class="fa fa-desktop"></i> </span>
+          </div>
+          <select name="voname" class="form-control" type="voname" id="voname">
+          <option selected></option>
+          $for possible_vo in possible_vos:
+              <option value=$possible_vo[0]>$possible_vo[1] - $possible_vo[0]</option>
+        </div> <!-- input-group.// -->
+    $else:
+        <input type="hidden" name="voname" id="voname"/>
   </div> <!-- form-group// -->
   </form>
 </article>
@@ -72,4 +86,3 @@ $def with (oidc_issuers, saml_support, buttons = ["btn btn-block btn-outline-war
 
 </body>
 </html>
-


### PR DESCRIPTION
Make m-VO compatible with WebUI
------------------

VO is now either determined based on identity (with account name narrowing the options if provided) at login. If multiple VOs are possible for the identity given, then the user stays on the login screen and has to manually choose their VO from a drop down list.

This VO is then set as a cookie and used in the headers so information displayed only applies to the user's VO.

Should be no change for single-VO operation.