### PR TITLE
Deletion: VO handling for daemons, Closes #3887

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -1082,7 +1082,7 @@ def list_pfns(args):
             print(replicas[0]['rses'][rse][0])
         else:
             logger.warning('The file has no replica on the specified RSE')
-            rse_info = rsemgr.get_rse_info(rse)
+            rse_info = rsemgr.get_rse_info(rse, vo=client.vo)
             proto = rsemgr.create_protocol(rse_info, 'read', scheme=protocol)
             try:
                 pfn = proto.lfns2pfns(lfns={'scope': scope, 'name': name})

--- a/bin/rucio-conveyor-stager
+++ b/bin/rucio-conveyor-stager
@@ -18,6 +18,7 @@
 # - Vincent Garonne, <vgaronne@gmail.com>, 2015-2018
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2018-2019
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -55,7 +56,9 @@ def get_parser():
     parser.add_argument('--include-rses', action="store", default=None, type=str,
                         help='RSE expression to include')
     parser.add_argument('--rses', nargs='+', type=str,
-                        help='Explicit list of RSEs to include (Single-VO only)')
+                        help='Explicit list of RSEs to include')
+    parser.add_argument('--vos', nargs='+', type=str,
+                        help='Optional list of VOs to consider. Only used in multi-VO mode.')
     parser.add_argument('--activities', nargs='+', type=str,
                         help='Explicit list of activities to include')
     parser.add_argument('--sleep-time', action="store", default=600, type=int,
@@ -79,6 +82,7 @@ if __name__ == "__main__":
             include_rses=args.include_rses,
             exclude_rses=args.exclude_rses,
             rses=args.rses,
+            vos=args.vos,
             source_strategy=args.source_strategy,
             activities=args.activities,
             sleep_time=args.sleep_time,

--- a/bin/rucio-conveyor-submitter
+++ b/bin/rucio-conveyor-submitter
@@ -20,6 +20,7 @@
 # - Vincent Garonne, <vgaronne@gmail.com>, 2016-2018
 # - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -67,6 +68,26 @@ Check again the transfer requests for the DID::
     # {'request_type': TRANSFER, 'state': SUBMITTED', ...}
 
 A tranfer request got created by executing the transfer. Depending on the transfer submission, the request state can be different. In this example the transfer got submitted successfully.
+
+When run in multi-VO mode, by default the daemon will run on RSEs from all VOs::
+
+  $ rucio-conveyor-submitter --run-once
+  2020-07-29 13:51:09,436 5784    INFO    This instance will work on VOs: def, abc, xyz, 123
+  2020-07-29 13:51:13,315 5784    INFO    RSE selection: automatic for relevant VOs
+  2020-07-29 13:51:13,316 5784    INFO    starting submitter threads
+
+By using the ``--vos`` argument only the VO or VOs specified will be affected::
+
+  $ rucio-conveyor-submitter --run-once --vos abc xyz
+  2020-07-29 13:51:09,436 5784    INFO    This instance will work on VOs: abc, xyz
+  2020-07-29 13:51:13,315 5784    INFO    RSE selection: automatic for relevant VOs
+  2020-07-29 13:51:13,316 5784    INFO    starting submitter threads
+
+Note that attempting the use the ``--vos`` argument when in single-VO mode will have no affect::
+
+  $ rucio-conveyor-submitter --run-once --vos abc xyz
+  2020-07-29 13:39:37,263 5752    INFO    RSE selection: automatic
+  2020-07-29 13:39:37,264 5752    INFO    starting submitter threads
     ''')
     parser.add_argument("--run-once", action="store_true", default=False,
                         help='One iteration only')
@@ -87,7 +108,9 @@ A tranfer request got created by executing the transfer. Depending on the transf
     parser.add_argument('--include-rses', action="store", default=None, type=str,
                         help='RSE expression to include')
     parser.add_argument('--rses', nargs='+', type=str,
-                        help='Explicit list of RSEs to include (Single-VO only)')
+                        help='Explicit list of RSEs to include')
+    parser.add_argument('--vos', nargs='+', type=str,
+                        help='Optional list of VOs to consider. Only used in multi-VO mode.')
     parser.add_argument('--activities', nargs='+', type=str,
                         help='Explicit list of activities to include')
     parser.add_argument('--exclude-activities', nargs='+', type=str,
@@ -115,6 +138,7 @@ if __name__ == "__main__":
             include_rses=args.include_rses,
             exclude_rses=args.exclude_rses,
             rses=args.rses,
+            vos=args.vos,
             source_strategy=args.source_strategy,
             activities=args.activities,
             exclude_activities=args.exclude_activities,

--- a/bin/rucio-dark-reaper
+++ b/bin/rucio-dark-reaper
@@ -16,6 +16,7 @@
 # Authors:
 # - Vincent Garonne <vgaronne@gmail.com>, 2016-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2019
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 
 """
 Reaper is a daemon to manage file on disk but not in Rucio(dark data) deletion
@@ -38,6 +39,9 @@ def get_parser():
     parser.add_argument("--chunk-size", action="store", default=10, type=int, help='Chunk size')
     parser.add_argument("--scheme", action="store", default=None, type=str, help='Force the reaper to use a particular protocol, e.g., mock.')
     parser.add_argument('--rses', nargs='+', type=str, help='List of RSEs')
+    parser.add_argument('--exclude-rses', action="store", default=None, type=str, help='RSEs expression to exclude RSEs')
+    parser.add_argument('--include-rses', action="store", default=None, type=str, help='RSEs expression to include RSEs')
+    parser.add_argument('--vos', nargs='+', type=str, help='Optional list of VOs to consider. Only used in multi-VO mode.')
     return parser
 
 
@@ -47,7 +51,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     try:
         run(total_workers=args.total_workers, chunk_size=args.chunk_size,
-            once=args.run_once, scheme=args.scheme, rses=args.rses,
-            all_rses=args.all_rses)
+            once=args.run_once, scheme=args.scheme, rses=args.rses, all_rses=args.all_rses,
+            exclude_rses=args.exclude_rses, include_rses=args.include_rses, vos=args.vos)
     except KeyboardInterrupt:
         stop()

--- a/bin/rucio-light-reaper
+++ b/bin/rucio-light-reaper
@@ -16,6 +16,7 @@
 # Authors:
 # - Vincent Garonne <vgaronne@gmail.com>, 2016-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2019
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 
 """
 Reaper is a daemon to manage sub-file deletion
@@ -38,6 +39,9 @@ def get_parser():
     parser.add_argument("--chunk-size", action="store", default=10, type=int, help='Chunk size')
     parser.add_argument("--scheme", action="store", default=None, type=str, help='Force the reaper to use a particular protocol, e.g., mock.')
     parser.add_argument('--rses', nargs='+', type=str, help='List of RSEs')
+    parser.add_argument('--exclude-rses', action="store", default=None, type=str, help='RSEs expression to exclude RSEs')
+    parser.add_argument('--include-rses', action="store", default=None, type=str, help='RSEs expression to include RSEs')
+    parser.add_argument('--vos', nargs='+', type=str, help='Optional list of VOs to consider. Only used in multi-VO mode.')
     return parser
 
 
@@ -47,7 +51,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     try:
         run(total_workers=args.total_workers, chunk_size=args.chunk_size,
-            once=args.run_once, scheme=args.scheme, rses=args.rses,
-            all_rses=args.all_rses)
+            once=args.run_once, scheme=args.scheme, rses=args.rses, all_rses=args.all_rses,
+            exclude_rses=args.exclude_rses, include_rses=args.include_rses, vos=args.vos)
     except KeyboardInterrupt:
         stop()

--- a/bin/rucio-reaper
+++ b/bin/rucio-reaper
@@ -17,6 +17,7 @@
 # - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
 # - Wen Guan <wguan.icedew@gmail.com>, 2014
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2019
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 
 """
 Reaper is a daemon to manage file deletion
@@ -59,6 +60,24 @@ Check if the replica exists::
   | SCOPE   | NAME   | FILESIZE   | ADLER32   | RSE: REPLICA                                            |
   |---------+--------+------------+-----------+---------------------------------------------------------|
   +---------+--------+------------+-----------+---------------------------------------------------------+
+
+When run in multi-VO mode, by default the Reaper will run on RSEs from all VOs::
+
+  $ rucio-reaper --run-once
+  2020-07-28 15:15:14,110 5461    INFO    main: starting processes
+  2020-07-28 15:15:14,151 5461    INFO    Reaper: This instance will work on VOs: def, abc, xyz, 123
+
+By using the ``--vos`` argument only the VO or VOs specified will be affected by the Reaper::
+
+  $ rucio-reaper --run-once --vos abc xyz
+  2020-07-28 15:16:36,022 5474    INFO    main: starting processes
+  2020-07-28 15:16:36,066 5474    INFO    Reaper: This instance will work on VOs: abc, xyz
+
+Note that attempting the use the ``--vos`` argument when in single-VO mode will have no affect::
+
+  $ rucio-reaper --run-once --vos abc xyz
+  2020-07-28 15:21:33,348 5488    INFO    main: starting processes
+  2020-07-28 15:21:33,349 5488    WARNING Ignoring argument vos, this is only applicable in a multi-VO setup.
  ''')
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
     parser.add_argument("--total-workers", action="store", default=1, type=int, help='Total number of workers per process')
@@ -69,6 +88,7 @@ Check if the replica exists::
     parser.add_argument('--exclude-rses', action="store", default=None, type=str, help='RSEs expression to exclude RSEs')
     parser.add_argument('--include-rses', action="store", default=None, type=str, help='RSEs expression to include RSEs')
     parser.add_argument('--rses', nargs='+', type=str, help='List of RSEs')
+    parser.add_argument('--vos', nargs='+', type=str, help='Optional list of VOs to consider. Only used in multi-VO mode.')
     parser.add_argument('--delay-seconds', action="store", default=3600, type=int, help='Delay to retry failed deletion')
     return parser
 
@@ -80,6 +100,6 @@ if __name__ == '__main__':
     try:
         run(total_workers=args.total_workers, chunk_size=args.chunk_size, greedy=args.greedy,
             once=args.run_once, scheme=args.scheme, rses=args.rses, threads_per_worker=args.threads_per_worker,
-            exclude_rses=args.exclude_rses, include_rses=args.include_rses, delay_seconds=args.delay_seconds)
+            exclude_rses=args.exclude_rses, include_rses=args.include_rses, vos=args.vos, delay_seconds=args.delay_seconds)
     except KeyboardInterrupt:
         stop()

--- a/bin/rucio-reaper2
+++ b/bin/rucio-reaper2
@@ -15,6 +15,7 @@
 #
 # Authors:
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2019
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -48,6 +49,8 @@ def get_parser():
                         help='RSE expression to include')
     parser.add_argument('--rses', nargs='+', type=str,
                         help='Explicit list of RSEs to include. If empty, it considers all RSEs')
+    parser.add_argument('--vos', nargs='+', type=str,
+                        help='Optional list of VOs to consider. Only used in multi-VO mode.')
     parser.add_argument("--delay-seconds", action="store", default=600, type=int,
                         help='The delay (seconds) to query replicas in BEING_DELETED state.')
     parser.add_argument('--scheme', action="store", default=None, type=str,
@@ -69,6 +72,7 @@ if __name__ == "__main__":
             include_rses=args.include_rses,
             exclude_rses=args.exclude_rses,
             rses=args.rses,
+            vos=args.vos,
             once=args.run_once,
             greedy=args.greedy,
             scheme=args.scheme,

--- a/bin/rucio-replica-recoverer
+++ b/bin/rucio-replica-recoverer
@@ -16,6 +16,7 @@
 # Authors:
 #  - Cedric Serfon, <cedric.serfon@cern.ch>, 2018
 #  - Jaroslav Guenther, <jaroslav.guenther@cern.ch>, 2019
+#  - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # PY3K COMPATIBLE
 
 """
@@ -217,10 +218,25 @@ $$ list_bad_replicas_status(rse='MOCK_SUSPICIOUS', younger_than=from_date)
 
 $$ exit()
 
+When run in multi-VO mode, by default the daemon will run on RSEs from all VOs::
+
+  $ rucio-replica-recoverer --run-once
+  2020-07-28 15:15:14,151 5461    INFO    replica_recoverer: This instance will work on VOs: def, abc, xyz, 123
+
+By using the ``--vos`` argument only the VO or VOs specified will be affected::
+
+  $ rucio-replica-recoverer --run-once --vos abc xyz
+  2020-07-28 15:16:36,066 5474    INFO    replica_recoverer: This instance will work on VOs: abc, xyz
+
+Note that attempting the use the ``--vos`` argument when in single-VO mode will have no affect::
+
+  $ rucio-replica-recoverer --run-once --vos abc xyz
+  2020-07-28 15:21:33,349 5488    WARNING Ignoring argument vos, this is only applicable in a multi-VO setup.
 ''')  # NOQA: E501
     parser.add_argument("--nattempts", action="store", default=10, help='Minimum count of suspicious file replica appearance in bad_replicas table.Default value is 10.')
     parser.add_argument("--younger-than", action="store", default=3, help='Consider all file replicas logged in bad_replicas table since speicified number of younger-than. Default value is 3.')
     parser.add_argument("--rse-expression", action="store", default='MOCK', help='The RSE on which the recovery should be happening.')
+    parser.add_argument('--vos', nargs='+', type=str, help='Optional list of VOs to consider. Only used in multi-VO mode.')
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only.')
     parser.add_argument("--max-replicas-per-rse", action="store", default=100, help='The maximum number of suspicious replicas found on an RSE which may be declared bad. If a higher count is found, no action is be taken.')
     return parser
@@ -231,6 +247,6 @@ if __name__ == "__main__":
     PARSER = get_parser()
     ARGS = PARSER.parse_args()
     try:
-        run(once=ARGS.run_once, younger_than=ARGS.younger_than, nattempts=ARGS.nattempts, rse_expression=ARGS.rse_expression, max_replicas_per_rse=ARGS.max_replicas_per_rse)
+        run(once=ARGS.run_once, younger_than=ARGS.younger_than, nattempts=ARGS.nattempts, rse_expression=ARGS.rse_expression, vos=ARGS.vos, max_replicas_per_rse=ARGS.max_replicas_per_rse)
     except KeyboardInterrupt:
         stop()

--- a/lib/rucio/core/quarantined_replica.py
+++ b/lib/rucio/core/quarantined_replica.py
@@ -145,10 +145,11 @@ def list_quarantined_replicas(rse_id, limit, worker_number=None, total_workers=N
 
 
 @read_session
-def list_rses(session=None):
+def list_rses(filters=None, session=None):
     """
     List RSEs in the Quarantined Queues.
 
+    :param filters: dictionary of attributes by which the results should be filtered.
     :param session: The database session in use.
 
     :returns: a list of RSEs.
@@ -156,4 +157,8 @@ def list_rses(session=None):
     query = session.query(models.RSE.id).distinct(models.RSE.id).\
         filter(models.QuarantinedReplica.rse_id == models.RSE.id).\
         filter(models.RSE.deleted == false())
+
+    if filters and filters.get('vo'):
+        query = query.filter(getattr(models.RSE, 'vo') == filters.get('vo'))
+
     return [rse for (rse,) in query]

--- a/lib/rucio/daemons/reaper/dark_reaper.py
+++ b/lib/rucio/daemons/reaper/dark_reaper.py
@@ -19,7 +19,8 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2020
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -39,8 +40,8 @@ import traceback
 
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import (SourceNotFound, DatabaseException, ServiceUnavailable,
-                                    RSEAccessDenied, ResourceTemporaryUnavailable)
-from rucio.core import rse as rse_core
+                                    RSEAccessDenied, ResourceTemporaryUnavailable,
+                                    RSENotFound, VONotFound)
 from rucio.core.heartbeat import live, die, sanity_check
 from rucio.core.message import add_message
 from rucio.core.quarantined_replica import (list_quarantined_replicas,
@@ -48,6 +49,7 @@ from rucio.core.quarantined_replica import (list_quarantined_replicas,
                                             list_rses)
 from rucio.rse import rsemanager as rsemgr
 from rucio.core.rse_expression_parser import parse_expression
+from rucio.core.vo import list_vos
 
 
 logging.getLogger("requests").setLevel(logging.CRITICAL)
@@ -73,13 +75,13 @@ def reaper(rses=[], worker_number=0, total_workers=1, chunk_size=100, once=False
     :param once: If True, only runs one iteration of the main loop.
     :param scheme: Force the reaper to use a particular protocol, e.g., mock.
     """
-    logging.info('Starting Dark Reaper %s-%s: Will work on RSEs: %s', worker_number, total_workers, str(rses))
+    logging.info('Starting Dark Reaper %s-%s: Will work on RSEs: %s', worker_number, total_workers, ', '.join([rse['rse'] for rse in rses]))
 
     pid = os.getpid()
     thread = threading.current_thread()
     hostname = socket.gethostname()
     executable = ' '.join(sys.argv)
-    hash_executable = hashlib.sha256(sys.argv[0] + ''.join(rses)).hexdigest()
+    hash_executable = hashlib.sha256(sys.argv[0] + ''.join([rse['rse'] for rse in rses])).hexdigest()
     sanity_check(executable=None, hostname=hostname)
 
     while not GRACEFUL_STOP.is_set():
@@ -90,8 +92,9 @@ def reaper(rses=[], worker_number=0, total_workers=1, chunk_size=100, once=False
             nothing_to_do = True
 
             random.shuffle(rses)
-            for rse_id in rses:
-                rse = rse_core.get_rse_name(rse_id=rse_id)
+            for rse in rses:
+                rse_id = rse['id']
+                rse = rse['rse']
                 replicas = list_quarantined_replicas(rse_id=rse_id,
                                                      limit=chunk_size, worker_number=worker_number,
                                                      total_workers=total_workers)
@@ -177,43 +180,63 @@ def stop(signum=None, frame=None):
     GRACEFUL_STOP.set()
 
 
-def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None,
-        exclude_rses=None, include_rses=None, delay_seconds=0, all_rses=False):
+def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None, all_rses=False,
+        exclude_rses=None, include_rses=None, vos=None, delay_seconds=0):
     """
     Starts up the reaper threads.
 
     :param total_workers: The total number of workers.
     :param chunk_size: the size of chunk for deletion.
-    :param threads_per_worker: Total number of threads created by each worker.
     :param once: If True, only runs one iteration of the main loop.
-    :param greedy: If True, delete right away replicas with tombstone.
     :param rses: List of RSEs the reaper should work against. If empty, it considers all RSEs (Single-VO only).
     :param scheme: Force the reaper to use a particular protocol/scheme, e.g., mock.
     :param exclude_rses: RSE expression to exclude RSEs from the Reaper.
     :param include_rses: RSE expression to include RSEs.
+    :param vos: VOs on which to look for RSEs. Only used in multi-VO mode.
+                If None, we either use all VOs if run from "def", or the current VO otherwise.
     """
     logging.info('main: starting processes')
 
-    all_rses = list_rses()
-    if all_rses:
-        rses = all_rses
+    multi_vo = config_get_bool('common', 'multi_vo', raise_exception=False, default=False)
+    if not multi_vo:
+        if vos:
+            logging.warning('Ignoring argument vos, this is only applicable in a multi-VO setup.')
+        vos = ['def']
+
+        # Preserve the old behaviour until a feature release
+        all_rses = list_rses()
+        if all_rses:
+            rses = all_rses
     else:
+        if vos:
+            invalid = set(vos) - set([v['vo'] for v in list_vos()])
+            if invalid:
+                msg = 'VO{} {} cannot be found'.format('s' if len(invalid) > 1 else '', ', '.join([repr(v) for v in invalid]))
+                raise VONotFound(msg)
+        else:
+            vos = [v['vo'] for v in list_vos()]
+        logging.info('Dark Reaper: This instance will work on VO%s: %s' % ('s' if len(vos) > 1 else '', ', '.join([v for v in vos])))
+
+        all_rses = []
+        for vo in vos:
+            all_rses.extend(list_rses(filters={'vo': vo}))
+
         if rses:
-            if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-                logging.warning('Ignoring argument rses, this is only available in a single-vo setup. Please try an RSE Expression with include_rses if it is required.')
-                rses = []
-            else:
-                rses = [rse_core.get_rse_id(rse=rse) for rse in rses]
-                rses = [rse for rse in rses if rse in all_rses]
+            invalid = set(rses) - set([rse['rse'] for rse in all_rses])
+            if invalid:
+                msg = 'RSE{} {} cannot be found'.format('s' if len(invalid) > 1 else '',
+                                                        ', '.join([repr(rse) for rse in invalid]))
+                raise RSENotFound(msg)
+            rses = [rse for rse in all_rses if rse['rse'] in rses]
         else:
             rses = all_rses
 
         if exclude_rses:
-            excluded_rses = [rse['id'] for rse in parse_expression(exclude_rses)]
+            excluded_rses = parse_expression(exclude_rses)
             rses = [rse for rse in rses if rse not in excluded_rses]
 
         if include_rses:
-            included_rses = [rse['id'] for rse in parse_expression(include_rses)]
+            included_rses = parse_expression(include_rses)
             rses = [rse for rse in rses if rse in included_rses]
 
         if not rses:

--- a/lib/rucio/tests/test_multi_vo.py
+++ b/lib/rucio/tests/test_multi_vo.py
@@ -19,6 +19,7 @@
 
 import sys
 import unittest
+from datetime import datetime
 from json import dumps
 from logging import getLogger
 from os import remove
@@ -38,7 +39,7 @@ from rucio.api.did import add_did, list_dids
 from rucio.api.identity import add_account_identity, list_accounts_for_identity
 from rucio.api.lock import get_replica_locks_for_rule_id
 from rucio.api.replica import list_replicas
-from rucio.api.rse import add_protocol, add_rse, add_rse_attribute, list_rses
+from rucio.api.rse import add_protocol, add_rse, add_rse_attribute, list_rses, set_rse_limits, set_rse_usage
 from rucio.api.rule import delete_replication_rule, get_replication_rule
 from rucio.api.scope import add_scope, list_scopes
 from rucio.api.subscription import add_subscription, list_subscriptions
@@ -62,6 +63,7 @@ from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.rule import add_rule
 from rucio.core.vo import add_vo, vo_exists
 from rucio.daemons.automatix.automatix import automatix
+from rucio.daemons.reaper.reaper import run as run_reaper
 from rucio.db.sqla import models, session as db_session
 from rucio.tests.common import execute
 from rucio.tests.test_authentication import PRIVATE_KEY, PUBLIC_KEY
@@ -1203,3 +1205,66 @@ class TestMultiVODaemons(unittest.TestCase):
         replicas_new = list(list_replicas(did_dicts, rse_expression=shr_rse, **self.new_vo))
         assert len(replicas_tst) != 0
         assert len(replicas_new) == 0
+
+    def test_reaper(self):
+        """ MULTI VO (DAEMON): Test that reaper runs on the specified VO(s) """
+        rse_str = ''.join(choice(ascii_uppercase) for x in range(10))
+        rse_name = 'SHR_%s' % rse_str
+        rse_id_tst = add_rse(rse_name, 'root', **self.vo)
+        rse_id_new = add_rse(rse_name, 'root', **self.new_vo)
+
+        mock_protocol = {'scheme': 'MOCK',
+                         'hostname': 'localhost',
+                         'port': 123,
+                         'prefix': '/test/reaper',
+                         'impl': 'rucio.rse.protocols.mock.Default',
+                         'domains': {
+                             'lan': {'read': 1,
+                                     'write': 1,
+                                     'delete': 1},
+                             'wan': {'read': 1,
+                                     'write': 1,
+                                     'delete': 1}}}
+        add_protocol(rse=rse_name, data=mock_protocol, issuer='root', **self.vo)
+        add_protocol(rse=rse_name, data=mock_protocol, issuer='root', **self.new_vo)
+
+        scope_uuid = str(generate_uuid()).lower()[:16]
+        scope_name = 'shr_%s' % scope_uuid
+        scope_tst = InternalScope(scope_name, **self.vo)
+        scope_new = InternalScope(scope_name, **self.new_vo)
+        add_scope(scope_name, 'root', 'root', **self.vo)
+        add_scope(scope_name, 'root', 'root', **self.new_vo)
+
+        nb_files = 30
+        file_size = 2147483648  # 2G
+
+        names = []
+        for i in range(nb_files):
+            name = 'lfn%s' % generate_uuid()
+            names.append(name)
+            add_replica(rse_id=rse_id_tst, scope=scope_tst, name=name, bytes=file_size, account=InternalAccount('root', **self.vo),
+                        adler32=None, md5=None, tombstone=datetime.utcnow())
+            add_replica(rse_id=rse_id_new, scope=scope_new, name=name, bytes=file_size, account=InternalAccount('root', **self.new_vo),
+                        adler32=None, md5=None, tombstone=datetime.utcnow())
+
+        set_rse_usage(rse=rse_name, source='storage', used=nb_files * file_size, free=800, issuer='root', **self.vo)
+        set_rse_limits(rse=rse_name, name='MinFreeSpace', value=10737418240, issuer='root', **self.vo)
+        set_rse_limits(rse=rse_name, name='MaxBeingDeletedFiles', value=10, issuer='root', **self.vo)
+
+        set_rse_usage(rse=rse_name, source='storage', used=nb_files * file_size, free=800, issuer='root', **self.new_vo)
+        set_rse_limits(rse=rse_name, name='MinFreeSpace', value=10737418240, issuer='root', **self.new_vo)
+        set_rse_limits(rse=rse_name, name='MaxBeingDeletedFiles', value=10, issuer='root', **self.new_vo)
+
+        # Check we start of with the expected number of replicas
+        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.vo))) == nb_files
+        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.new_vo))) == nb_files
+
+        # Check we reap all VOs by default
+        run_reaper(once=True, rses=[rse_name])
+        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.vo))) == nb_files - 5
+        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.new_vo))) == nb_files - 5
+
+        # Check we don't affect a second VO that isn't specified
+        run_reaper(once=True, rses=[rse_name], vos=['new'])
+        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.vo))) == nb_files - 5
+        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.new_vo))) == nb_files - 10

--- a/lib/rucio/tests/test_reaper2.py
+++ b/lib/rucio/tests/test_reaper2.py
@@ -26,6 +26,8 @@ from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core import replica as replica_core
 from rucio.core import rse as rse_core
+from rucio.core import scope as scope_core
+from rucio.core import vo as vo_core
 from rucio.daemons.reaper.reaper2 import reaper
 from rucio.tests.common import rse_name_generator
 
@@ -34,11 +36,16 @@ def test_reaper():
     """ REAPER2 (DAEMON): Test the reaper2 daemon."""
     if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
         vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+        new_vo = {'vo': 'new'}
+        if not vo_core.vo_exists(**new_vo):
+            vo_core.add_vo(description='Test', email='rucio@email.com', **new_vo)
+        if not scope_core.check_scope(InternalScope('data13_hip', **new_vo)):
+            scope_core.add_scope(InternalScope('data13_hip', **new_vo), InternalAccount('root', **new_vo))
+        nb_rses = 2
     else:
         vo = {}
-
-    rse_name = rse_name_generator()
-    rse_id = rse_core.add_rse(rse_name, **vo)
+        new_vo = {}
+        nb_rses = 1
 
     mock_protocol = {'scheme': 'MOCK',
                      'hostname': 'localhost',
@@ -52,29 +59,61 @@ def test_reaper():
                          'wan': {'read': 1,
                                  'write': 1,
                                  'delete': 1}}}
-    rse_core.add_protocol(rse_id=rse_id, parameter=mock_protocol)
 
     nb_files = 30
     file_size = 2147483648  # 2G
 
-    file_names = []
-    for i in range(nb_files):
-        file_name = 'lfn' + generate_uuid()
-        file_names.append(file_name)
-        replica_core.add_replica(rse_id=rse_id, scope=InternalScope('data13_hip', **vo),
-                                 name=file_name, bytes=file_size,
-                                 tombstone=datetime.utcnow() - timedelta(days=1),
-                                 account=InternalAccount('root', **vo), adler32=None, md5=None)
+    rse_names = []
+    all_file_names = []
+    for j in range(nb_rses):
+        rse_name = rse_name_generator()
+        rse_names.append(rse_name)
+        rse_id = rse_core.add_rse(rse_name, **vo)
+        rse_core.add_protocol(rse_id=rse_id, parameter=mock_protocol)
+        if new_vo:
+            rse_id_new = rse_core.add_rse(rse_name, **new_vo)
+            rse_core.add_protocol(rse_id=rse_id_new, parameter=mock_protocol)
 
-    rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=800)
-    rse_core.set_rse_limits(rse_id=rse_id, name='MinFreeSpace', value=10737418240)
-    rse_core.set_rse_limits(rse_id=rse_id, name='MaxBeingDeletedFiles', value=10)
+        file_names = []
+        for i in range(nb_files):
+            file_name = 'lfn' + generate_uuid()
+            file_names.append(file_name)
+            replica_core.add_replica(rse_id=rse_id, scope=InternalScope('data13_hip', **vo),
+                                     name=file_name, bytes=file_size,
+                                     tombstone=datetime.utcnow() - timedelta(days=1),
+                                     account=InternalAccount('root', **vo), adler32=None, md5=None)
+            if new_vo:
+                replica_core.add_replica(rse_id=rse_id_new, scope=InternalScope('data13_hip', **new_vo),
+                                         name=file_name, bytes=file_size,
+                                         tombstone=datetime.utcnow() - timedelta(days=1),
+                                         account=InternalAccount('root', **new_vo), adler32=None, md5=None)
 
-    if vo:
-        reaper(once=True, rses=[], include_rses='vo=%s&(%s)' % (vo['vo'], rse_name), exclude_rses=[])
-        reaper(once=True, rses=[], include_rses='vo=%s&(%s)' % (vo['vo'], rse_name), exclude_rses=[])
+        all_file_names.append(file_names)
+        rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=800)
+        rse_core.set_rse_limits(rse_id=rse_id, name='MinFreeSpace', value=10737418240)
+        rse_core.set_rse_limits(rse_id=rse_id, name='MaxBeingDeletedFiles', value=10)
+        if new_vo:
+            rse_core.set_rse_usage(rse_id=rse_id_new, source='storage', used=nb_files * file_size, free=800)
+            rse_core.set_rse_limits(rse_id=rse_id_new, name='MinFreeSpace', value=10737418240)
+            rse_core.set_rse_limits(rse_id=rse_id_new, name='MaxBeingDeletedFiles', value=10)
+
+    if not vo:
+        reaper(once=True, rses=[], include_rses=rse_names[0], exclude_rses=[])
+        reaper(once=True, rses=[], include_rses=rse_names[0], exclude_rses=[])
+        assert len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip', **vo), 'name': n} for n in all_file_names[0]],
+                                                   rse_expression=rse_name))) == nb_files - 5
     else:
-        reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=[])
-        reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=[])
-
-    assert len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip', **vo), 'name': n} for n in file_names], rse_expression=rse_name))) == nb_files - 5
+        # Check we reap all VOs by default
+        reaper(once=True, rses=[], include_rses=rse_names[0], exclude_rses=[])
+        reaper(once=True, rses=[], include_rses=rse_names[0], exclude_rses=[])
+        assert len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip', **vo), 'name': n} for n in all_file_names[0]],
+                                                   rse_expression=rse_names[0]))) == nb_files - 5
+        assert len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip', **new_vo), 'name': n} for n in all_file_names[0]],
+                                                   rse_expression=rse_names[0]))) == nb_files - 5
+        # Check we don't affect a second VO that isn't specified
+        reaper(once=True, rses=[], include_rses=rse_names[1], exclude_rses=[], vos=['new'])
+        reaper(once=True, rses=[], include_rses=rse_names[1], exclude_rses=[], vos=['new'])
+        assert len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip', **vo), 'name': n} for n in all_file_names[1]],
+                                                   rse_expression=rse_names[1]))), nb_files
+        assert len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip', **new_vo), 'name': n} for n in all_file_names[1]],
+                                                   rse_expression=rse_names[1]))), nb_files - 5


### PR DESCRIPTION
VO handling for daemons
------------------

Added VO as an argument for reaper(s), conveyor-submitter/stager and replica recover. This is mainly used when determining which RSEs to act on. If the VO is specified in `rucio.cfg` then this is also taken into account, e.g. can only run on multiple VOs if the VO isn't specified or the VO in the config is `def`.

Also added some explicit tests of running m-VO reaper to the m-VO test suite.