### PR TITLE
download: setting defaults to trace - Closes #3835

### DIFF
--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -453,6 +453,8 @@ class DownloadClient:
         trace.setdefault('datasetScope', item.get('dataset_scope', ''))
         trace.setdefault('dataset', item.get('dataset_name', ''))
         trace.setdefault('filesize', item.get('bytes'))
+        trace.setdefault('clientState', 'PROCESSING')
+        trace.setdefault('stateReason', 'UNKNOWN')
 
         dest_file_paths = item['dest_file_paths']
 


### PR DESCRIPTION
Adding just two lines in order to set default for the traces. These fields are checked in the pilot and if missing, the trace validation fails. But it can happen due to a timeout, that given Rucio process is aborted. In such case, we still might need the trace to be populated.