### PR TITLE
Core & Internals: Fix Python 3 syntax; #3420

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -14,27 +14,32 @@
 # limitations under the License.
 #
 # Authors:
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2012-2019
-# - Vincent Garonne, <vgaronne@gmail.com>, 2012-2018
-# - Martin Barisits, <martin.barisits@cern.ch>, 2012-2019
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2012-2017
-# - Yun-Pin Sun, <winter0128@gmail.com>, 2012-2013
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2013-2020
-# - Ralph Vigne, <ralph.vigne@cern.ch>, 2013
-# - David Cameron, <d.g.cameron@gmail.com>, 2014
-# - Tomas Kouba, <tomas.kouba@cern.ch>, 2014
-# - Wen Guan, <wguan.icedew@gmail.com>, 2014
-# - Joaquin Bogado, <jbogado@linti.unlp.edu.ar>, 2014-2018
-# - Evangelia Liotiri, <evangelia.liotiri@cern.ch>, 2015
-# - Tobias Wegner, <twegner@cern.ch>, 2017-2019
-# - Brian Bockelman, <bbockelm@cse.unl.edu>, 2017-2018
-# - Nicolo Magini, <Nicolo.Magini@cern.ch>, 2018
-# - Frank Berghaus, <frank.berghaus@cern.ch>, 2018
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2019
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
+# - Martin Barisits <martin.barisits@cern.ch>, 2012-2020
+# - Thomas Beermann <thomas.beermann@cern.ch>, 2012-2017
+# - Yun-Pin Sun <winter0128@gmail.com>, 2012-2013
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2020
+# - Ralph Vigne <ralph.vigne@cern.ch>, 2013
+# - David Cameron <david.cameron@cern.ch>, 2014-2020
+# - Tomas Kouba <tomas.kouba@cern.ch>, 2014
+# - Wen Guan <wen.guan@cern.ch>, 2014
+# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2014-2018
+# - Evangelia Liotiri <evangelia.liotiri@cern.ch>, 2015
+# - Tobias Wegner <twegner@cern.ch>, 2017-2019
+# - Brian Bockelman <bbockelm@cse.unl.edu>, 2017-2018
+# - Frank Berghaus <frank.berghaus@cern.ch>, 2017-2018
+# - Nicolo Magini <nicolo.magini@cern.ch>, 2018
+# - Tomas Javurek <tomas.javurek@cern.ch>, 2018-2019
+# - asket <asket.agarwal96@gmail.com>, 2018
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018-2020
-# - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
-# - Jaroslav Guenther <jaroslav.guenther@gmail.com>, 2019-2020
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Boris Bauermeister <boris.bauermeister@fysik.su.se>, 2019
+# - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Jason Nielsen <jnielsen@ucsc.edu>, 2020
+# - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
@@ -51,25 +56,26 @@ import sys
 import time
 import traceback
 import uuid
+from functools import wraps
 
 import argcomplete
 import tabulate
 
-try:
-    from ConfigParser import NoOptionError, NoSectionError
-except ImportError:
-    from configparser import NoOptionError, NoSectionError
-
-from functools import wraps
-
-from rucio.client import Client
+# rucio module has the same name as this executable module, so this rule fails. pylint: disable=no-name-in-module
 from rucio import version
+from rucio.client import Client
 from rucio.common.config import config_get
 from rucio.common.exception import (DataIdentifierAlreadyExists, AccessDenied, DataIdentifierNotFound, InvalidObject,
                                     RSENotFound, InvalidRSEExpression, InputValidationError, DuplicateContent,
                                     RuleNotFound, CannotAuthenticate, MissingDependency, UnsupportedOperation,
                                     RucioException, DuplicateRule, InvalidType)
-from rucio.common.utils import sizefmt, Color, detect_client_location, chunks, parse_did_filter_from_string, extract_scope
+from rucio.common.utils import sizefmt, Color, detect_client_location, chunks, parse_did_filter_from_string, \
+    extract_scope
+
+try:
+    from ConfigParser import NoOptionError, NoSectionError
+except ImportError:
+    from configparser import NoOptionError, NoSectionError
 
 SUCCESS = 0
 FAILURE = 1
@@ -1237,7 +1243,7 @@ def add_rule(args):
                                                           ask_approval=args.ask_approval,
                                                           asynchronous=args.asynchronous)
                     rule_ids.extend(rule_id)
-                except DuplicateRule as error:
+                except DuplicateRule:
                     print('Duplicate rule for %s:%s found; Skipping.' % (did['scope'], did['name']))
         else:
             raise error

--- a/bin/rucio-auditor
+++ b/bin/rucio-auditor
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,26 +14,31 @@
 # limitations under the License.
 #
 # Authors:
-# - Fernando Lopez, <fernando.e.lopez@gmail.com>, 2015
-# - Vincent Garonne, <vgaronne@gmail.com>, 2018
+# - Fernando Lopez <fernando.e.lopez@gmail.com>, 2015
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
-from datetime import datetime
-from functools import partial
-from multiprocessing import Queue, Process, Event, Pipe
 import argparse
 import logging
 import logging.handlers
 import os
-import rucio.client
-import rucio.common.config as config
-import rucio.common.dumper as dumper
-import rucio.daemons.auditor
 import signal
 import sys
 import textwrap
 import time
+from datetime import datetime
+from functools import partial
+from multiprocessing import Queue, Process, Event, Pipe
+
+import rucio.common.config as config
+import rucio.common.dumper as dumper
+import rucio.daemons.auditor
+from rucio.client.rseclient import RSEClient
 
 
 def setup_pipe_logger(pipe, loglevel):
@@ -55,9 +60,9 @@ def main(args):
     nprocs = args.nprocs
     assert nprocs >= 1
     if args.rses is None:
-        rses_gen = rucio.client.RSEClient().list_rses()
+        rses_gen = RSEClient().list_rses()
     else:
-        rses_gen = rucio.client.RSEClient().list_rses(args.rses)
+        rses_gen = RSEClient().list_rses(args.rses)
 
     rses = [entry['rse'] for entry in rses_gen]
     assert len(rses) > 0

--- a/bin/rucio-automatix
+++ b/bin/rucio-automatix
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,11 @@
 # limitations under the License.
 #
 # Authors:
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2014
-# - Vincent Garonne, <vgaronne@gmail.com>, 2018
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2014
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2018
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2018
+# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 '''
 Automatix (Dataset injector) Daemon
@@ -45,7 +48,7 @@ if __name__ == "__main__":
 
     parser = get_parser()
     args = parser.parse_args()
-    print 'Start Automatix'
+    print('Start Automatix')
     try:
         run(total_workers=args.threads_per_process, once=args.run_once, inputfile=args.input_file)
     except KeyboardInterrupt:

--- a/bin/rucio-cache-client
+++ b/bin/rucio-cache-client
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,23 +14,29 @@
 # limitations under the License.
 #
 # Authors:
-# - Wen Guan <wguan.icedew@gmail.com>, 2014
+# - Wen Guan <wen.guan@cern.ch>, 2014
 # - Martin Barisits <martin.barisits@cern.ch>, 2017
-# - Vincent Garonne <vgaronne@gmail.com>, 2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
+# - nataliaratnikova <natasha@fnal.gov>, 2018
+# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2019
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
     Rucio Cache client.
 """
+
+from __future__ import print_function
 
 import argparse
 import json
 import os
 import random
 import ssl
-import stomp
 import sys
 
+import stomp
 from jsonschema import validate
 
 from rucio.client.didclient import DIDClient
@@ -63,8 +69,8 @@ def validate_rse(rse):
     client = RSEClient()
     try:
         rse_attributes = client.get_rse(rse)
-    except Exception, e:
-        raise Exception(e)
+    except Exception as error:
+        raise Exception(error)
 
     if not rse_attributes["volatile"]:
         err = "%s volatile is not True, Rucio Cache should not update it." % (rse)
@@ -135,6 +141,6 @@ if __name__ == '__main__':
     try:
         result = cache_operation(args)
         sys.exit(result)
-    except (RuntimeError, NotImplementedError), e:
-        print >> sys.stderr, "ERROR: ", e
+    except (RuntimeError, NotImplementedError) as e:
+        print("ERROR: ", e, file=sys.stderr)
         sys.exit(FAILURE)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,20 +19,24 @@
 
 import os
 import sys
-from mock import Mock as MagicMock
+
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
 
 
 sys.path.insert(len(sys.path), os.path.abspath('../../lib'))
 
 
-class Mock(MagicMock):
+class RecursiveMock(mock.Mock):
     @classmethod
     def __getattr__(cls, name):
-        return Mock()
+        return RecursiveMock()
 
     @classmethod
     def __getitem__(cls, name):
-        return Mock()
+        return RecursiveMock()
 
     @classmethod
     def __setitem__(cls, name, value):
@@ -47,8 +51,8 @@ MOCK_MODULES = ['oic', 'oic.oic', 'oic.oauth2', 'oic.oauth2.message', 'oic.utils
                 'oic.utils.authn', 'oic.utils.authn.client', 'oic.oic.message',
                 'jkwest.jwe', 'jwkest.jws', 'jwkest.jwt', 'pycurl', 'M2Crypto',
                 'fts3', 'fts3.rest', 'fts3.rest.client', 'fts3.rest.client.easy',
-                'fts3.rest.client.exceptions', 'builtins']
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+                'fts3.rest.client.exceptions']
+sys.modules.update((mod_name, RecursiveMock()) for mod_name in MOCK_MODULES)
 
 # -- General configuration ------------------------------------------------
 

--- a/etc/docker/test/centos7.Dockerfile
+++ b/etc/docker/test/centos7.Dockerfile
@@ -2,7 +2,7 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at 
+# You may obtain a copy of the License at
 #
 #    http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -44,14 +44,11 @@ RUN curl https://www.sqlite.org/2019/sqlite-autoconf-3290000.tar.gz | tar xzv &&
   make install && \
   cd .. && rm -rf ./sqlite-autoconf-3290000
 
-RUN if [ "$PYTHON" == "2.7" ] ; then ln -sf python2.7 /usr/bin/python ; ln -sf pip2.7 /usr/bin/pip ; fi
-RUN if [ "$PYTHON" == "3.6" ] ; then ln -sf python3.6 /usr/bin/python ; ln -sf pip3.6 /usr/bin/pip ; fi
-# Get the latest setuptools version
-# to fix the setup.py error:
-# install fails with: `install_requires` must be a string or list of strings
-RUN if [ "$PYTHON" == "2.7" ] ; then pip install --no-cache-dir --upgrade pip 'setuptools<45' ; \
-    else pip install --no-cache-dir --upgrade pip setuptools ; fi && \
-    pip install --no-cache-dir -U wheel
+RUN if [ "$PYTHON" == "2.7" ] ; then ln -sf python2.7 /usr/bin/python ; ln -sf pip2.7 /usr/bin/pip ; \
+    elif [ "$PYTHON" == "3.6" ] ; then ln -sf python3.6 /usr/bin/python ; ln -sf pip3.6 /usr/bin/pip ; fi
+
+RUN python -m pip --no-cache-dir install --upgrade pip && \
+    python -m pip --no-cache-dir install --upgrade setuptools wheel
 
 RUN mkdir -p /var/log/rucio/trace && \
   chmod -R 777 /var/log/rucio
@@ -75,14 +72,14 @@ RUN rpm -i etc/docker/test/extra/oic.rpm; \
     ldconfig
 
 # pre-install requirements
-RUN pip install --no-cache-dir -r etc/pip-requires -r etc/pip-requires-client -r etc/pip-requires-test \
+RUN python -m pip --no-cache-dir install --upgrade -r etc/pip-requires -r etc/pip-requires-client -r etc/pip-requires-test \
     'cx_oracle==6.3.1' 'psycopg2-binary>=2.4.2,<2.8' 'PyMySQL' 'kerberos>=1.3.0' 'pykerberos>=1.2.1' 'requests-kerberos>=0.12.0' 'python3-saml>=1.6.0'
 
 # copy everything else (anything above is cache-friendly)
 COPY . .
 
 # Install Rucio + dependencies
-RUN pip install --no-cache-dir .[oracle,postgresql,mysql,kerberos,dev,saml]
+RUN python -m pip --no-cache-dir install --upgrade .[oracle,postgresql,mysql,kerberos,dev,saml]
 
 WORKDIR /opt/rucio
 RUN cp -r /usr/local/src/rucio/{lib,bin,tools,etc} ./

--- a/etc/pip-requires-test
+++ b/etc/pip-requires-test
@@ -9,7 +9,8 @@ Pygments==2.5.2                               # Python Syntax highlighter (2.5.2
 docutils==0.16                                # Needed for sphinx
 pyflakes==2.1.1                               # Passive checker of Python programs
 flake8==3.7.8                                 # Wrapper around PyFlakes&pep8
-pylint==1.9.4; python_version >= '2.7'        # static code analysis. 1.9.5 last 2.7 compatible release
+pylint==1.9.4                                 # static code analysis. 1.9.5 last 2.7 compatible release
+isort>=4.2.5,<5                               # pylint up to now (2.5.3) does not support isort 5
 virtualenv==20.0.12                           # Virtual Python Environment builder
 xmltodict==0.12.0                             # Makes working with XML feel like you are working with JSON
 pytz==2019.3                                  # World timezone definitions, modern and historical

--- a/lib/rucio/__init__.py
+++ b/lib/rucio/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,13 +13,15 @@
 # limitations under the License.
 #
 # Authors:
-# - Mario Lassnig <mario@lassnig.net>, 2012-2013
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2013
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2012
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import gettext
+import sys
 
-try:
-    gettext.install('rucio', unicode=1)
-except TypeError:
-    gettext.install(u'rucio')
+if sys.version_info < (3,):
+    gettext.install('rucio', unicode=1)  # pylint: disable=unexpected-keyword-arg
+else:
+    gettext.install('rucio')

--- a/lib/rucio/client/__init__.py
+++ b/lib/rucio/client/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 #
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2013
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
-from rucio.client.client import *  # NOQA pylint: disable=wildcard-import
+from .client import Client  # noqa: F401

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -14,20 +14,26 @@
 #
 # Authors:
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2012-2013
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
 # - Yun-Pin Sun <winter0128@gmail.com>, 2013
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2013-2020
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2015
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
-# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2015
+# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2015-2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2016-2019
 # - Tobias Wegner <twegner@cern.ch>, 2017
 # - Brian Bockelman <bbockelm@cse.unl.edu>, 2017-2018
+# - Robert Illingworth <illingwo@fnal.gov>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Tomas Javurek <tomas.javurek@cern.ch>, 2019
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
-# - Jaroslav Guenther <jaroslav.guenther@gmail.com>, 2019-2020
+# - Eric Vaandering <ericvaandering@gmail.com>, 2019
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -213,7 +219,7 @@ class BaseClient(object):
                 elif self.auth_type == 'x509_proxy':
                     try:
                         self.creds['client_proxy'] = path.abspath(path.expanduser(path.expandvars(config_get('client', 'client_x509_proxy'))))
-                    except NoOptionError as error:
+                    except NoOptionError:
                         # Recreate the classic GSI logic for locating the proxy:
                         # - $X509_USER_PROXY, if it is set.
                         # - /tmp/x509up_u`id -u` otherwise.
@@ -557,7 +563,7 @@ class BaseClient(object):
                             get_input = input
                             # if Python version <= 2.7 use raw_input
                             if sys.version_info[:2] <= (2, 7):
-                                get_input = raw_input
+                                get_input = raw_input  # noqa: F821 pylint: disable=undefined-variable
                             fetchcode = get_input()
                             fetch_url = build_url(self.auth_host, path='auth/oidc_redirect', params=fetchcode)
                             result = self.session.get(fetch_url, headers=headers, verify=self.ca_cert)

--- a/lib/rucio/client/dq2client.py
+++ b/lib/rucio/client/dq2client.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,13 +13,14 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne <vgaronne@gmail.com>, 2013-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2013-2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2013-2019
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2015
 # - WeiJen Chang <e4523744@gmail.com>, 2014
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2014
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 '''
 Compatibility Wrapper for DQ2 and Rucio.
@@ -31,7 +32,6 @@ from __future__ import print_function
 import copy
 import hashlib
 import re
-import string
 
 from datetime import datetime, timedelta
 from rucio.client.client import Client
@@ -874,7 +874,7 @@ class DQ2Client:
         result = []
         pattern = None
         if name:
-            pattern = string.replace(name, '*', '.*')
+            pattern = str.replace(name, '*', '.*')
         for did in self.client.get_dataset_locks_by_rse(site):
             scope = did['scope']
             dsn = did['name']

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,14 +15,24 @@
 # Authors:
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2012-2015
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2012
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
-# - Martin Barisits <martin.barisits@cern.ch>, 2017
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
+# - Martin Barisits <martin.barisits@cern.ch>, 2017-2020
 # - Tobias Wegner <twegner@cern.ch>, 2018
+# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Nicolo Magini <nicolo.magini@cern.ch>, 2018
+# - Tomas Javurek <tomas.javurek@cern.ch>, 2018-2020
+# - Ale Di Girolamo <alessandro.di.girolamo@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019-2020
+# - Boris Bauermeister <boris.bauermeister@fysik.su.se>, 2019
+# - David Cameron <david.cameron@cern.ch>, 2019
 # - Gabriele Fronze' <gfronze@cern.ch>, 2019
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -622,7 +632,7 @@ class UploadClient:
             if protocol_write.renaming:
                 logger.debug('Renaming file %s to %s' % (pfn_tmp, pfn))
                 protocol_write.rename(pfn_tmp, pfn)
-        except Exception as e:
+        except Exception:
             raise RucioException('Unable to rename the tmp file %s.' % pfn_tmp)
 
         protocol_write.close()
@@ -644,7 +654,7 @@ class UploadClient:
             except RSEChecksumUnavailable as error:
                 # The stat succeeded here, but the checksum failed
                 raise error
-            except Exception as error:
+            except Exception:
                 time.sleep(2**attempt)
         return protocol.stat(pfn)
 

--- a/lib/rucio/common/pcache.py
+++ b/lib/rucio/common/pcache.py
@@ -1,4 +1,25 @@
 #!/usr/bin/env python
+# Copyright 2019-2020 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Tomas Javurek <tomas.javurek@cern.ch>, 2019
+# - Boris Bauermeister <boris.bauermeister@fysik.su.se>, 2019
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+
 import sys
 import os
 import errno
@@ -820,7 +841,7 @@ class Pcache:
         try:
             os.rename(xfer_file, cache_file)
             # self.log(INFO, "rename %s %s", xfer_file, cache_file)
-        except OSError as e:  # Fatal error if we can't do this
+        except OSError:  # Fatal error if we can't do this
             self.log(ERROR, "rename %s %s", xfer_file, cache_file)
             try:
                 os.unlink(xfer_file)

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2017-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +13,12 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne <vgaronne@gmail.com>, 2017-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2017-2018
 # - Edgar Fajardo <emfajard@ucsd.edu>, 2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
-# - James Perry <j.perry@epcc.ed.ac.uk>, 2019
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019-2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 try:
     from ConfigParser import NoOptionError, NoSectionError
@@ -38,17 +39,17 @@ try:
         GENERIC_FALLBACK = 'generic_multi_vo'
     else:
         GENERIC_FALLBACK = 'generic'
-except (NoOptionError, NoSectionError) as error:
+except (NoOptionError, NoSectionError):
     GENERIC_FALLBACK = 'generic'
 
 if config.config_has_section('policy'):
     try:
         POLICY = config.config_get('policy', 'package') + ".schema"
-    except (NoOptionError, NoSectionError) as error:
+    except (NoOptionError, NoSectionError):
         # fall back to old system for now
         try:
             POLICY = config.config_get('policy', 'schema')
-        except (NoOptionError, NoSectionError) as error:
+        except (NoOptionError, NoSectionError):
             POLICY = GENERIC_FALLBACK
         POLICY = 'rucio.common.schema.' + POLICY.lower()
 else:
@@ -56,7 +57,7 @@ else:
 
 try:
     module = importlib.import_module(POLICY)
-except (ImportError) as error:
+except ImportError:
     raise exception.PolicyPackageNotFound('Module ' + POLICY + ' not found')
 
 schema_modules["def"] = module

--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,8 @@
 # limitations under the License.
 #
 # Authors:
-# - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2019 - 2020
+# - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -23,7 +24,6 @@ from rucio.common import config
 from rucio.common.exception import PolicyPackageNotFound
 from rucio.db.sqla.session import read_session
 
-# from . import hardcoded as hardcoded_handler
 
 try:
     from ConfigParser import NoOptionError, NoSectionError
@@ -36,7 +36,7 @@ FALLBACK_METADATA_HANDLER_MODULE = "rucio.core.did_meta_plugins.json_meta.JSONDi
 if config.config_has_section('metadata'):
     try:
         METADATA_HANDLER_MODULES = config.config_get('metadata', 'plugins')
-    except (NoOptionError, NoSectionError) as error:
+    except (NoOptionError, NoSectionError):
         METADATA_HANDLER_MODULES = FALLBACK_METADATA_HANDLER_MODULE
 else:
     METADATA_HANDLER_MODULES = FALLBACK_METADATA_HANDLER_MODULE
@@ -50,7 +50,7 @@ for meta_module_path in META_MODULE_PATHS:
         base_class = meta_module_path.split(".")[-1]
         meta_handler_module = getattr(importlib.import_module(base_module), base_class)()
         METADATA_HANDLERS.append(meta_handler_module)
-    except (ImportError) as error:
+    except ImportError:
         raise PolicyPackageNotFound('Module ' + meta_module_path + ' not found')
 
 

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
 # - Brandon White, <bjwhite@fnal.gov>, 2019
-# - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2019 - 2020
+# - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -196,7 +197,7 @@ class DidColumnMeta(DidMetaPlugin):
                     update({key: value}, synchronize_session='fetch')
             except CompileError as error:
                 raise exception.InvalidMetadata(error)
-            except InvalidRequestError as error:
+            except InvalidRequestError:
                 raise exception.InvalidMetadata("Key %s is not accepted" % key)
 
             # propagate metadata updates to child content
@@ -215,7 +216,7 @@ class DidColumnMeta(DidMetaPlugin):
                             update({key: value}, synchronize_session='fetch')
                     except CompileError as error:
                         raise exception.InvalidMetadata(error)
-                    except InvalidRequestError as error:
+                    except InvalidRequestError:
                         raise exception.InvalidMetadata("Key %s is not accepted" % key)
 
         if not rowcount:

--- a/lib/rucio/core/message.py
+++ b/lib/rucio/core/message.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
 #
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2014-2019
-# - Vincent Garonne <vgaronne@gmail.com>, 2014-2017
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2017
 # - Martin Barisits <martin.barisits@cern.ch>, 2014-2019
 # - Robert Illingworth <illingwo@fnal.gov>, 2018
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -68,7 +69,7 @@ def add_message(event_type, payload, session=None):
 
     try:
         payload = json.dumps(payload, cls=APIEncoder)
-    except TypeError as e:
+    except TypeError as e:  # noqa: F841
         raise InvalidObject('Invalid JSON for payload: %(e)s' % locals())
 
     if len(payload) > 4000:

--- a/lib/rucio/core/meta.py
+++ b/lib/rucio/core/meta.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2012-2015
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2013
-# - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2015
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2013
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Martin Barisits <martin.barisits@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -63,7 +64,7 @@ def add_key(key, key_type, value_type=None, value_regexp=None, session=None):
 
     try:
         key_type = KeyType.from_string(key_type)
-    except ValueError as error:
+    except ValueError:
         raise UnsupportedKeyType('The type \'%s\' is not supported for keys!' % str(key_type))
 
     new_key = models.DIDKey(key=key, value_type=value_type and str(value_type), value_regexp=value_regexp, key_type=key_type)

--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -1,19 +1,26 @@
-"""
- Copyright European Organization for Nuclear Research (CERN)
-
- Licensed under the Apache License, Version 2.0 (the "License");
- You may not use this file except in compliance with the License.
- You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-
- Authors:
- - Vincent Garonne, <vincent.garonne@cern.ch>, 2016-2017
- - Thomas Beermann, <thomas.beermann@cern.ch>, 2017
- - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018
- - James Perry, <j.perry@epcc.ed.ac.uk>, 2019
- - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
-
- PY3K COMPATIBLE
-"""
+# Copyright 2016-2020 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2016-2017
+# - Thomas Beermann <thomas.beermann@cern.ch>, 2017
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019-2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+#
+# PY3K COMPATIBLE
 
 try:
     from ConfigParser import NoOptionError, NoSectionError
@@ -33,18 +40,18 @@ try:
         GENERIC_FALLBACK = 'generic_multi_vo'
     else:
         GENERIC_FALLBACK = 'generic'
-except (NoOptionError, NoSectionError) as error:
+except (NoOptionError, NoSectionError):
     GENERIC_FALLBACK = 'generic'
 
 if config.config_has_section('permission'):
     try:
         FALLBACK_POLICY = config.config_get('permission', 'policy')
-    except (NoOptionError, NoSectionError) as error:
+    except (NoOptionError, NoSectionError):
         FALLBACK_POLICY = GENERIC_FALLBACK
 elif config.config_has_section('policy'):
     try:
         FALLBACK_POLICY = config.config_get('policy', 'permission')
-    except (NoOptionError, NoSectionError) as error:
+    except (NoOptionError, NoSectionError):
         FALLBACK_POLICY = GENERIC_FALLBACK
 else:
     FALLBACK_POLICY = GENERIC_FALLBACK
@@ -52,7 +59,7 @@ else:
 if config.config_has_section('policy'):
     try:
         POLICY = config.config_get('policy', 'package') + ".permission"
-    except (NoOptionError, NoSectionError) as error:
+    except (NoOptionError, NoSectionError):
         # fall back to old system for now
         POLICY = 'rucio.core.permission.' + FALLBACK_POLICY.lower()
 else:
@@ -61,7 +68,7 @@ else:
 
 try:
     module = importlib.import_module(POLICY)
-except (ImportError) as error:
+except ImportError:
     raise exception.PolicyPackageNotFound('Module ' + POLICY + ' not found')
 
 permission_modules["def"] = module

--- a/lib/rucio/core/trace.py
+++ b/lib/rucio/core/trace.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2013
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2014-2017
-# - Vincent Garonne <vgaronne@gmail.com>, 2015-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2015-2018
 # - Robert Illingworth <illingwo@fnal.gov>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -111,12 +112,12 @@ def trace(payload):
                     logging.info('reconnect to ' + conn.transport._Transport__host_and_ports[0][0])
                     conn.start()
                     conn.connect(USERNAME, PASSWORD)
-            except stomp.exception.NotConnectedException as error:
+            except stomp.exception.NotConnectedException:
                 logging.warn('Could not connect to broker %s, try another one' %
                              conn.transport._Transport__host_and_ports[0][0])
                 t_conns.remove(conn)
                 continue
-            except stomp.exception.ConnectFailedException as error:
+            except stomp.exception.ConnectFailedException:
                 logging.warn('Could not connect to broker %s, try another one' %
                              conn.transport._Transport__host_and_ports[0][0])
                 t_conns.remove(conn)

--- a/lib/rucio/daemons/badreplicas/minos.py
+++ b/lib/rucio/daemons/badreplicas/minos.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,13 @@
 #
 # Authors:
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2018-2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
-# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -238,7 +241,7 @@ def minos(bulk=1000, once=False, sleep_time=60):
                                     elif expires_at < datetime.now():
                                         logging.info('%s PFN %s expiration time (%s) is older than now and is not in unavailable state. Removing the PFNs from bad_pfns', prepend_str, str(rep['pfn']), expires_at)
                                         bulk_delete_bad_pfns(pfns=[rep['pfn']], session=None)
-                                except (DataIdentifierNotFound, ReplicaNotFound) as error:
+                                except (DataIdentifierNotFound, ReplicaNotFound):
                                     logging.error(prepend_str + 'Will remove %s from the list of bad PFNs' % str(rep['pfn']))
                                     bulk_delete_bad_pfns(pfns=[rep['pfn']], session=None)
                             session = get_session()

--- a/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
+++ b/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
 # Authors:
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2018-2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2018-2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -126,12 +128,12 @@ def minos_tu_expiration(bulk=1000, once=False, sleep_time=60):
                             update_replicas_states([replicas[idx], ], nowait=True, session=session)
                             bulk_delete_bad_replicas([bad_replicas[idx], ], session=session)
                             session.commit()  # pylint: disable=no-member
-                        except DataIdentifierNotFound as error:
+                        except DataIdentifierNotFound:
                             session.rollback()  # pylint: disable=no-member
                             logging.warning(prepend_str + 'DID %s:%s does not exist anymore. ' % (bad_replicas[idx]['scope'], bad_replicas[idx]['name']))
                             bulk_delete_bad_replicas([bad_replicas[idx], ], session=session)
                             session.commit()  # pylint: disable=no-member
-                        except ReplicaNotFound as error:
+                        except ReplicaNotFound:
                             session.rollback()  # pylint: disable=no-member
                             logging.warning(prepend_str + '%s:%s on RSEID %s does not exist anymore. ' % (replicas[idx]['scope'], replicas[idx]['name'], replicas[idx]['rse_id']))
                             bulk_delete_bad_replicas([bad_replicas[idx], ], session=session)
@@ -142,7 +144,7 @@ def minos_tu_expiration(bulk=1000, once=False, sleep_time=60):
                     logging.critical(traceback.format_exc())
                     session = get_session()
 
-        except Exception as error:
+        except Exception:
             logging.critical(traceback.format_exc())
 
         tottime = time.time() - start_time

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,18 +14,21 @@
 #
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2014-2018
-# - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2019
-# - Vincent Garonne <vgaronne@gmail.com>, 2014-2016
-# - Martin Barisits <martin.barisits@cern.ch>, 2014-2017
-# - Wen Guan <wguan.icedew@gmail.com>, 2014-2016
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2020
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2016
+# - Martin Barisits <martin.barisits@cern.ch>, 2014-2020
+# - Wen Guan <wen.guan@cern.ch>, 2014-2016
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2016
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2016
 # - Brian Bockelman <bbockelm@cse.unl.edu>, 2018
 # - Eric Vaandering <ericvaandering@gmail.com>, 2018
+# - dciangot <diego.ciangottini@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - maatthias <maatthias@gmail.com>, 2019
 # - Gabriele Fronze' <gfronze@cern.ch>, 2019
-# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -460,7 +463,7 @@ def get_conveyor_rses(rses=None, include_rses=None, exclude_rses=None):
     if include_rses:
         try:
             parsed_rses = parse_expression(include_rses, session=None)
-        except InvalidRSEExpression as error:
+        except InvalidRSEExpression:
             logging.error("Invalid RSE exception %s to include RSEs", include_rses)
         else:
             for rse in parsed_rses:

--- a/lib/rucio/daemons/hermes/hermes2.py
+++ b/lib/rucio/daemons/hermes/hermes2.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2020 CERN
+# Copyright 2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #
 # Authors:
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -174,7 +175,7 @@ def hermes2(once=False, thread=0, bulk=1000, sleep_time=10):
     try:
         services_list = get('hermes', 'services_list')
         services_list = services_list.split(',')
-    except ConfigNotFound as err:
+    except ConfigNotFound:
         logging.debug('No services found, exiting')
         sys.exit(1)
     if 'influx' in services_list:

--- a/lib/rucio/daemons/judge/cleaner.py
+++ b/lib/rucio/daemons/judge/cleaner.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,13 +13,14 @@
 # limitations under the License.
 #
 # Authors:
-# - Martin Barisits <martin.barisits@cern.ch>, 2013-2016
+# - Martin Barisits <martin.barisits@cern.ch>, 2013-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2013-2015
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013
-# - Vincent Garonne <vgaronne@gmail.com>, 2014-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -123,7 +124,7 @@ def rule_cleaner(once=False):
                         else:
                             logging.error(traceback.format_exc())
                             record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
-                    except RuleNotFound as e:
+                    except RuleNotFound:
                         pass
         except (DatabaseException, DatabaseError) as e:
             if match('.*QueuePool.*', str(e.args[0])):

--- a/lib/rucio/daemons/judge/evaluator.py
+++ b/lib/rucio/daemons/judge/evaluator.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,15 @@
 # limitations under the License.
 #
 # Authors:
-# - Martin Barisits <martin.barisits@cern.ch>, 2013-2017
+# - Martin Barisits <martin.barisits@cern.ch>, 2013-2020
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2013
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013
-# - Vincent Garonne <vgaronne@gmail.com>, 2016-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2016-2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -128,7 +129,7 @@ def re_evaluator(once=False):
                         logging.debug('re_evaluator[%s/%s]: evaluation of %s:%s took %f' % (heartbeat['assign_thread'], heartbeat['nr_threads'], did.scope, did.name, time.time() - start_time))
                         delete_updated_did(id=did.id)
                         done_dids[did_tag].append(did.rule_evaluation_action)
-                    except DataIdentifierNotFound as e:
+                    except DataIdentifierNotFound:
                         delete_updated_did(id=did.id)
                     except (DatabaseException, DatabaseError) as e:
                         if match('.*ORA-00054.*', str(e.args[0])):

--- a/lib/rucio/daemons/judge/injector.py
+++ b/lib/rucio/daemons/judge/injector.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,11 @@
 #
 # Authors:
 # - Martin Barisits <martin.barisits@cern.ch>, 2015-2017
-# - Vincent Garonne <vgaronne@gmail.com>, 2018
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -127,9 +128,9 @@ def rule_injector(once=False):
                         paused_rules[rule_id] = datetime.utcnow() + timedelta(seconds=randint(60, 600))
                         logging.warning('rule_injector[%s/%s]: ReplicationRuleCreationTemporaryFailed for rule %s' % (heartbeat['assign_thread'], heartbeat['nr_threads'], rule_id))
                         record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
-                    except RuleNotFound as e:
+                    except RuleNotFound:
                         pass
-                    except InsufficientAccountLimit as e:
+                    except InsufficientAccountLimit:
                         # A rule with InsufficientAccountLimit on injection hangs there potentially forever
                         # It should be marked as SUSPENDED
                         logging.info('rule_injector[%s/%s]: Marking rule %s as SUSPENDED due to InsufficientAccountLimit' % (heartbeat['assign_thread'], heartbeat['nr_threads'], rule_id))

--- a/lib/rucio/daemons/reaper/reaper2.py
+++ b/lib/rucio/daemons/reaper/reaper2.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2016-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne <vgaronne@gmail.com>, 2016-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2016-2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2016-2020
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2016-2020
 # - Wen Guan <wguan.icedew@gmail.com>, 2016
@@ -21,8 +21,11 @@
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2019
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2019-2020
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -531,7 +534,7 @@ def reaper(rses, include_rses, exclude_rses, chunk_size=100, once=False, greedy=
                         logging.debug('%s delete_replicas successed on %s : %s replicas in %s seconds', prepend_str, rse_name, len(deleted_files), time.time() - del_start)
                         monitor.record_counter(counters='reaper.deletion.done', delta=len(deleted_files))
                         DELETION_COUNTER.inc(len(deleted_files))
-                except Exception as error:
+                except Exception:
                     logging.critical('%s %s', prepend_str, str(traceback.format_exc()))
 
             if once:

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,15 +16,17 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2020
 # - Vincent Garonne <vgaronne@gmail.com>, 2014-2018
 # - David Cameron <d.g.cameron@gmail.com>, 2014
-# - Mario Lassnig <mario.lassnig@cern.ch>, 2015
-# - Wen Guan <wguan.icedew@gmail.com>, 2015
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2015-2018
+# - Wen Guan <wen.guan@cern.ch>, 2015
 # - Martin Barisits <martin.barisits@cern.ch>, 2016-2017
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Robert Illingworth <illingwo@fnal.gov>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -406,7 +408,7 @@ def transmogrifier(bulk=5, once=False, sleep_time=60):
                                             # Errors to be retried
                                             logging.error(prepend_str + '%s Will perform an other attempt %i/%i' % (str(error), attempt + 1, nattempt))
                                             monitor.record_counter(counters='transmogrifier.addnewrule.errortype.%s' % (str(error.__class__.__name__)), delta=1)
-                                        except Exception as error:
+                                        except Exception:
                                             # Unexpected errors
                                             monitor.record_counter(counters='transmogrifier.addnewrule.errortype.unknown', delta=1)
                                             exc_type, exc_value, exc_traceback = exc_info()

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +13,22 @@
 # limitations under the License.
 #
 # Authors:
-# - Wen Guan <wguan.icedew@gmail.com>, 2014-2016
-# - Vincent Garonne <vgaronne@gmail.com>, 2014-2018
+# - Wen Guan <wen.guan@cern.ch>, 2014-2016
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2016
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2016-2019
-# - Tobias Wegner <twegner@cern.ch>, 2017
+# - Tobias Wegner <twegner@cern.ch>, 2017-2019
 # - Nicolo Magini <Nicolo.Magini@cern.ch>, 2018-2019
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
-# - Frank Berghaus <frank.berghaus@cern.ch>, 2018
+# - Frank Berghaus <berghaus@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Gabriele Fronze' <gfronze@cern.ch>, 2019
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019
+# - Tomas Javurek <tomas.javurek@cern.ch>, 2020
+# - Martin Barisits <martin.barisits@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -315,7 +321,7 @@ class Default(protocol.RSEProtocol):
             if status:
                 return False
             return True
-        except exception.SourceNotFound as error:
+        except exception.SourceNotFound:
             return False
         except Exception as error:
             raise exception.ServiceUnavailable(error)

--- a/lib/rucio/rse/protocols/sftp.py
+++ b/lib/rucio/rse/protocols/sftp.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,14 @@
 #
 # Authors:
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2012-2014
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
 # - Angelos Molfetas <Angelos.Molfetas@cern.ch>, 2012
 # - Yun-Pin Sun <winter0128@gmail.com>, 2012
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2013
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
-# - Nicolo Magini, <nicolo.magini@cern.ch>, 2018
+# - Nicolo Magini <nicolo.magini@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -121,7 +123,7 @@ class Default(protocol.RSEProtocol):
             sf = source
         try:
             self.__connection.put(sf, self.pfn2path(target))
-        except IOError as e:
+        except IOError:
             try:
                 self.__connection.execute('mkdir -p %s' % '/'.join(self.pfn2path(target).split('/')[0:-1]))
                 self.__connection.put(sf, self.pfn2path(target))

--- a/lib/rucio/rse/protocols/storm.py
+++ b/lib/rucio/rse/protocols/storm.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2019-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +13,16 @@
 # limitations under the License.
 #
 # Authors:
-# - Tomas Javor Javurek <tomas.javurek@cern.ch>, 2019
-# - Mario Lassnig <mario.lassnig@cern.ch>, 2019
+# - Tomas Javurek <tomas.javurek@cern.ch>, 2019-2020
+# - Boris Bauermeister <boris.bauermeister@fysik.su.se>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
-
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2019
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import os
 import requests
 
-from exceptions import NotImplementedError
 from xml.dom import minidom
 
 from rucio.common import exception

--- a/lib/rucio/rse/protocols/webdav.py
+++ b/lib/rucio/rse/protocols/webdav.py
@@ -1,20 +1,31 @@
-'''
-  Copyright European Organization for Nuclear Research (CERN)
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  You may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Authors:
-  - Cedric Serfon <cedric.serfon@cern.ch>, 2012-2017
-  - Vincent Garonne, <vincent.garonne@cern.ch>, 2013-2017
-  - Sylvain Blunier, <sylvain.blunier@cern.ch>, 2016
-  - Nicolo Magini, <nicolo.magini@cern.ch>, 2018
-  - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2019
-
-  PY3K COMPATIBLE
-'''
+# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2012-2017
+# - Ralph Vigne <ralph.vigne@cern.ch>, 2013
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2013-2017
+# - David Cameron <david.cameron@cern.ch>, 2014
+# - Sylvain Blunier <sylvain.blunier@cern.ch>, 2016
+# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
+# - Nicolo Magini <nicolo.magini@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Eric Vaandering <ericvaandering@gmail.com>, 2019
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+#
+# PY3K COMPATIBLE
 
 from __future__ import print_function, division
 import os
@@ -524,7 +535,7 @@ class Default(protocol.RSEProtocol):
             usedsize = root[0][1][0].find('{DAV:}quota-used-bytes').text
             try:
                 unusedsize = root[0][1][0].find('{DAV:}quota-available-bytes').text
-            except Exception as error:
+            except Exception:
                 print('No free space given, return -999')
                 unusedsize = -999
             totalsize = int(usedsize) + int(unusedsize)

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,22 +14,27 @@
 #
 # Authors:
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2012-2015
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2018
-# - Cedric Serfon <cedric.serfon@cern.ch>, 2012-2017
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2012-2019
 # - Yun-Pin Sun <winter0128@gmail.com>, 2013
-# - Wen Guan <wguan.icedew@gmail.com>, 2014-2017
-# - Martin Barisits <martin.barisits@cern.ch>, 2017-2019
-# - Tobias Wegner <twegner@cern.ch>, 2017-2018
+# - Wen Guan <wen.guan@cern.ch>, 2014-2017
+# - Martin Barisits <martin.barisits@cern.ch>, 2017-2020
+# - Tobias Wegner <twegner@cern.ch>, 2017-2019
 # - Brian Bockelman <bbockelm@cse.unl.edu>, 2018
 # - Frank Berghaus <frank.berghaus@cern.ch>, 2018-2019
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Nicolo Magini <nicolo.magini@cern.ch>, 2018
+# - Tomas Javurek <tomas.javurek@cern.ch>, 2018-2020
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2019
-# - Gabriele Fronze' <gfronze@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Gabriele Fronze' <gfronze@cern.ch>, 2019
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -415,7 +420,7 @@ def upload(rse_settings, lfns, domain='wan', source_dir=None, force_pfn=None, fo
                             valid = True
                         else:
                             raise exception.RucioException('Checksum not validated')
-                    except exception.RSEChecksumUnavailable as e:
+                    except exception.RSEChecksumUnavailable:
                         if rse_settings['verify_checksum'] is False:
                             valid = True
                         else:
@@ -471,7 +476,7 @@ def upload(rse_settings, lfns, domain='wan', source_dir=None, force_pfn=None, fo
                             valid = True
                         else:
                             raise exception.RucioException('Checksum not validated')
-                    except exception.RSEChecksumUnavailable as e:
+                    except exception.RSEChecksumUnavailable:
                         if rse_settings['verify_checksum'] is False:
                             valid = True
                         else:
@@ -728,9 +733,9 @@ def _retry_protocol_stat(protocol, pfn):
         except exception.RSEChecksumUnavailable as e:
             # The stat succeeded here, but the checksum failed
             raise e
-        except NotImplementedError as e:
+        except NotImplementedError:
             break
-        except Exception as e:
+        except Exception:
             sleep(2**attempt)
     return protocol.stat(pfn)
 

--- a/lib/rucio/tests/test_auditor.py
+++ b/lib/rucio/tests/test_auditor.py
@@ -1,31 +1,46 @@
-'''
-  Copyright European Organization for Nuclear Research (CERN)
-
- Licensed under the Apache License, Version 2.0 (the "License");
- You may not use this file except in compliance with the License.
- You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-
- Authors:
- - Vincent Garonne,  <vincent.garonne@cern.ch> , 2017
- - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
- - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
-
- PY3K COMPATIBLE
-'''
+# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Fernando Lopez <fernando.e.lopez@gmail.com>, 2015
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2017
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+#
+# PY3K COMPATIBLE
 
 from __future__ import division
-from datetime import datetime
-from datetime import timedelta
-from nose.tools import eq_
-from nose.tools import ok_
-from rucio.daemons import auditor
 
 import bz2
 import collections
-import mock
 import multiprocessing
 import os
+import sys
 import tempfile
+from datetime import datetime
+from datetime import timedelta
+
+from nose.tools import eq_
+from nose.tools import ok_
+
+from rucio.daemons import auditor
+
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
 
 
 def test_auditor_guess_replica_info():

--- a/lib/rucio/tests/test_auditor_hdfs.py
+++ b/lib/rucio/tests/test_auditor_hdfs.py
@@ -1,27 +1,40 @@
-'''
-  Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Fernando Lopez <fernando.e.lopez@gmail.com>, 2015-2016
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2017
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+#
+# PY3K COMPATIBLE
 
- Licensed under the Apache License, Version 2.0 (the "License");
- You may not use this file except in compliance with the License.
- You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-
- Authors:
- - Vincent Garonne,  <vincent.garonne@cern.ch> , 2017
- - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2019
-
- PY3K COMPATIBLE
-'''
 import os
 import shutil
 import string
+import sys
 import tempfile
-
-import mock
-
 from datetime import datetime
+
 from nose.tools import eq_
 
 from rucio.daemons.auditor import hdfs
+
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
 
 
 class FakeHDFSGet(object):

--- a/lib/rucio/tests/test_auditor_srmdumps.py
+++ b/lib/rucio/tests/test_auditor_srmdumps.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,20 @@
 # Authors:
 # - Fernando Lopez <fernando.e.lopez@gmail.com>, 2015
 # - Martin Barisits <martin.barisits@cern.ch>, 2017
-# - Vincent Garonne <vgaronne@gmail.com>, 2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2018
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
-# PY3K
+# PY3K COMPATIBLE
 
-import mock
+import sys
+from datetime import datetime
+
+from nose.tools import eq_
+from nose.tools import raises
+
+from rucio.daemons.auditor import srmdumps
 
 try:
     # PY2
@@ -29,10 +36,11 @@ try:
 except ImportError:
     # PY3
     from configparser import ConfigParser
-from datetime import datetime
-from nose.tools import eq_
-from nose.tools import raises
-from rucio.daemons.auditor import srmdumps
+
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
 
 
 def test_patterns_on_file_names():

--- a/lib/rucio/tests/test_boolean.py
+++ b/lib/rucio/tests/test_boolean.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,8 @@
 # limitations under the License.
 #
 # Authors:
-# - Mario Lassnig <mario.lassnig@cern.ch>, 2018
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2018-2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -21,7 +22,8 @@ from __future__ import print_function
 
 from nose.tools import assert_equal
 
-from rucio.client import AccountClient, RSEClient
+from rucio.client.accountclient import AccountClient
+from rucio.client.rseclient import RSEClient
 from rucio.common.utils import generate_uuid
 from rucio.tests.common import rse_name_generator
 

--- a/lib/rucio/tests/test_didtype.py
+++ b/lib/rucio/tests/test_didtype.py
@@ -1,4 +1,4 @@
-# Copyright 2019 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2019-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 #
 # Authors:
 # - Tobias Wegner <twegner@cern.ch>, 2019
-
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 from rucio.common.didtype import DIDType
 from rucio.common.exception import DIDTypeError
@@ -84,21 +84,21 @@ class TestDIDType(object):
             DIDType('non.implicit.single.string')
             print('Exception for invalid DID did not work!')
             self.success = False
-        except DIDTypeError as err:
+        except DIDTypeError:
             pass
 
         try:
             DIDType('invalid', 'user.implicit:user:invalid')
             print('Exception for invalid DID did not work!')
             self.success = False
-        except DIDTypeError as err:
+        except DIDTypeError:
             pass
 
         try:
             DIDType('user.implicit:user:invalid')
             print('Exception for invalid DID did not work!')
             self.success = False
-        except DIDTypeError as err:
+        except DIDTypeError:
             pass
 
         nose.tools.assert_true(self.success)

--- a/lib/rucio/tests/test_dumper.py
+++ b/lib/rucio/tests/test_dumper.py
@@ -1,35 +1,34 @@
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#              http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Fernando Lopez, <felopez@cern.ch>, 2015
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2017
+# - Fernando Lopez <fernando.e.lopez@gmail.com>, 2015
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2017
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 import json
 import os
+import sys
 import tempfile
-
-import bz2file
-import mock
-import requests
-
-try:
-    # PY2
-    from StringIO import StringIO
-except ImportError:
-    # PY3
-    from io import StringIO
-
 from datetime import datetime
 
+import bz2file
+import requests
 from nose.tools import eq_
 from nose.tools import ok_
 from nose.tools import raises
@@ -39,6 +38,18 @@ from rucio.common import dumper
 from rucio.tests.common import make_temp_file
 from rucio.tests.common import mock_open
 from rucio.tests.mocks import gfal2
+
+try:
+    # PY2
+    from StringIO import StringIO
+except ImportError:
+    # PY3
+    from io import StringIO
+
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
 
 
 DATE_SECONDS = "2015-03-10 14:00:35"

--- a/lib/rucio/tests/test_dumper_consistency.py
+++ b/lib/rucio/tests/test_dumper_consistency.py
@@ -1,20 +1,28 @@
-'''
-  Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Fernando Lopez <fernando.e.lopez@gmail.com>, 2015
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2017
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  You may not use this file except in compliance with the License.
-  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-  Authors:
-  - Fernando Lopez, <felopez@cern.ch>, 2015
-  - Vincent Garonne, <vincent.garonne@cern.ch>, 2017
-'''
-import os
 import json
+import os
 import shutil
+import sys
 import tempfile
-
-import mock
 from datetime import datetime
 
 from nose.tools import eq_
@@ -28,6 +36,11 @@ from rucio.common.dumper.consistency import gnu_sort
 from rucio.common.dumper.consistency import min3
 from rucio.common.dumper.consistency import parse_and_filter_file
 from rucio.tests.common import make_temp_file
+
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
 
 
 def mocked_requests(*args, **kwargs):

--- a/lib/rucio/tests/test_dumper_data_model.py
+++ b/lib/rucio/tests/test_dumper_data_model.py
@@ -1,28 +1,42 @@
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Fernando Lopez, <felopez@cern.ch>, 2015
-# - Martin Barisits, <martin.barisits@cern.ch>, 2017
+# - Fernando Lopez <fernando.e.lopez@gmail.com>, 2015
+# - Martin Barisits <martin.barisits@cern.ch>, 2017
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import glob
-import shutil
 import os
+import shutil
+import sys
 import tempfile
 from datetime import datetime
+
 import requests
-
-
-import mock
-
 from nose.tools import eq_
 from nose.tools import ok_
 from nose.tools import raises
+
 from rucio.common import dumper
 from rucio.common.dumper import data_models
+
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
 
 
 def mocked_requests_head(*args, **kwargs):

--- a/lib/rucio/tests/test_oauthmanager.py
+++ b/lib/rucio/tests/test_oauthmanager.py
@@ -1,23 +1,34 @@
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2019-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Jaroslav Guenther, <jaroslav.guenther@cern.ch>, 2019
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 from __future__ import print_function
 
 import datetime
 import json
+import sys
 from time import sleep
 
-from mock import MagicMock, patch
 from nose.tools import assert_true
 from oic import rndstr
+from sqlalchemy import and_, or_
+from sqlalchemy.sql.expression import true
+
 from rucio.api.account import add_account, del_account
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import Duplicate
@@ -25,8 +36,11 @@ from rucio.common.types import InternalAccount
 from rucio.daemons.oauthmanager.oauthmanager import run, stop
 from rucio.db.sqla import models
 from rucio.db.sqla.session import get_session
-from sqlalchemy import and_, or_
-from sqlalchemy.sql.expression import true
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import MagicMock, patch
+else:
+    from mock import MagicMock, patch
 
 new_token_dict = {'access_token': '',
                   'expires_in': 3599,

--- a/lib/rucio/tests/test_oidc.py
+++ b/lib/rucio/tests/test_oidc.py
@@ -1,43 +1,58 @@
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-# - Jaroslav Guenther, <jaroslav.guenther@cern.ch>, 2019-2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 from __future__ import print_function
 
+import sys
 import time
 import traceback
-
 from datetime import datetime, timedelta
-from mock import MagicMock, patch
+
 from nose.tools import assert_true, assert_false
 from oic import rndstr
-from rucio.core.account import add_account
-from rucio.core.identity import add_account_identity
+
 from rucio.common.config import config_get, config_get_bool
+from rucio.common.exception import (CannotAuthenticate, DatabaseException)
 from rucio.common.exception import Duplicate
 from rucio.common.types import InternalAccount
 from rucio.common.utils import oidc_identity_string
-from rucio.db.sqla.constants import IdentityType
+from rucio.core.account import add_account
+from rucio.core.authentication import redirect_auth_oidc, validate_auth_token
+from rucio.core.identity import add_account_identity
 from rucio.core.oidc import (get_auth_oidc, get_token_oidc,
                              get_token_for_account_operation, EXPECTED_OIDC_AUDIENCE, EXPECTED_OIDC_SCOPE)
-from rucio.core.authentication import redirect_auth_oidc, validate_auth_token
-from rucio.common.exception import (CannotAuthenticate, DatabaseException)
 from rucio.db.sqla import models
-from rucio.db.sqla.session import get_session
 from rucio.db.sqla.constants import AccountType
+from rucio.db.sqla.constants import IdentityType
+from rucio.db.sqla.session import get_session
+
 try:
     # Python 2
     from urlparse import urlparse, parse_qs
 except ImportError:
     # Python 3
     from urllib.parse import urlparse, parse_qs
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import MagicMock, patch
+else:
+    from mock import MagicMock, patch
 
 NEW_TOKEN_DICT = {'access_token': 'eyJ3bG...',
                   'expires_in': 3599,

--- a/lib/rucio/tests/test_replica_sorting.py
+++ b/lib/rucio/tests/test_replica_sorting.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,12 +15,13 @@
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2018
-# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 from nose.tools import assert_equal, assert_in, assert_not_in
 
-from rucio.client import ReplicaClient
+from rucio.client.replicaclient import ReplicaClient
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.replica import add_replicas, delete_replicas

--- a/lib/rucio/tests/test_root_proxy.py
+++ b/lib/rucio/tests/test_root_proxy.py
@@ -15,9 +15,13 @@
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2017-2020
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2018
+# - Martin Barisits <martin.barisits@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
-# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -31,7 +35,7 @@ except ImportError:
 from nose.tools import assert_equal, assert_in, assert_not_in
 from paste.fixture import TestApp
 
-from rucio.client import ReplicaClient
+from rucio.client.replicaclient import ReplicaClient
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.config import set as config_set

--- a/lib/rucio/web/rest/webpy/v1/authentication.py
+++ b/lib/rucio/web/rest/webpy/v1/authentication.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,17 +16,18 @@
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2018
 # - Angelos Molfetas <Angelos.Molfetas@cern.ch>, 2012
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2017
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2017
 # - Yun-Pin Sun <winter0128@gmail.com>, 2012-2013
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2013-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014
-# - Martin Barisits <martin.barisits@cern.ch>, 2017
+# - Martin Barisits <martin.barisits@cern.ch>, 2017-2020
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
+# - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019-2020
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -300,23 +301,19 @@ class RedirectOIDC(RucioController):
         except AccessDenied:
             render = template.render(join(dirname(__file__), '../auth_templates/'))
             return render.auth_crash('contact')
-            raise generate_http_error(401, 'CannotAuthenticate', 'Cannot contact the Rucio Authentication Server.')
 
-        except RucioException as error:
+        except RucioException:
             render = template.render(join(dirname(__file__), '../auth_templates/'))
             return render.auth_crash('internal_error')
-            raise generate_http_error(500, error.__class__.__name__, error.args[0])
 
-        except Exception as error:
+        except Exception:
             print(format_exc())
             render = template.render(join(dirname(__file__), '../auth_templates/'))
             return render.auth_crash('internal_error')
-            raise InternalError(error)
 
         if not result:
             render = template.render(join(dirname(__file__), '../auth_templates/'))
             return render.auth_crash('no_token')
-            raise generate_http_error(401, 'CannotAuthenticate', 'Cannot contact the Rucio Authentication Server.')
         if fetchtoken:
             # this is only a case of returning the final token to the Rucio Client polling
             # or requesting token after copy-pasting the Rucio code from the web page page
@@ -387,21 +384,17 @@ class CodeOIDC(RucioController):
         except AccessDenied:
             render = template.render(join(dirname(__file__), '../auth_templates/'))
             return render.auth_crash('contact')
-            raise generate_http_error(401, 'CannotAuthorize', 'Cannot authorize token request.')
-        except RucioException as error:
+        except RucioException:
             render = template.render(join(dirname(__file__), '../auth_templates/'))
             return render.auth_crash('internal_error')
-            raise generate_http_error(500, error.__class__.__name__, error.args[0])
-        except Exception as error:
+        except Exception:
             print(format_exc())
             render = template.render(join(dirname(__file__), '../auth_templates/'))
             return render.auth_crash('internal_error')
-            raise InternalError(error)
 
         render = template.render(join(dirname(__file__), '../auth_templates/'))
         if not result:
             return render.auth_crash('no_result')
-            raise generate_http_error(401, 'CannotAuthorize', 'Cannot authorize token request.')
         if 'fetchcode' in result:
             authcode = result['fetchcode']
             return render.auth_granted(authcode)
@@ -410,7 +403,6 @@ class CodeOIDC(RucioController):
             return render.auth_granted(authcode)
         else:
             return render.auth_crash('bad_request')
-            raise BadRequest()
 
 
 class TokenOIDC(RucioController):

--- a/tools/bootstrap_stresstest.py
+++ b/tools/bootstrap_stresstest.py
@@ -1,21 +1,28 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#                       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Ralph Vigne, <ralph.vigne@cern.ch>, 2013
-# - Martin Barisits, <martin.barisits@cern.ch>, 2019
+# - Ralph Vigne <ralph.vigne@cern.ch>, 2013-2014
+# - Wen Guan <wen.guan@cern.ch>, 2014
+# - Martin Barisits <martin.barisits@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import json
 import sys
 import traceback
-
-from uuid import uuid4 as uuid
 
 from rucio.client import Client
 from rucio.common.exception import Duplicate
@@ -55,11 +62,11 @@ if __name__ == '__main__':
             volatile = repo_data[rse].get('volatile', False)
             c.add_rse(rse, deterministic=deterministic, volatile=volatile)
         except Duplicate:
-            print '%(rse)s already added' % locals()
+            print('%(rse)s already added' % locals())
         except:
             errno, errstr = sys.exc_info()[:2]
             trcbck = traceback.format_exc()
-            print 'Interrupted processing with %s %s %s.' % (errno, errstr, trcbck)
+            print('Interrupted processing with %s %s %s.' % (errno, errstr, trcbck))
         rses_total -= 1
         for p_id in repo_data[rse]['protocols']['supported']:
             try:
@@ -70,12 +77,13 @@ if __name__ == '__main__':
             except Exception:
                 errno, errstr = sys.exc_info()[:2]
                 trcbck = traceback.format_exc()
-                print 'Interrupted processing with %s %s %s.' % (errno, errstr, trcbck)
+                print('Interrupted processing with %s %s %s.' % (errno, errstr, trcbck))
                 sys.exit(CRITICAL)
-    print '1. Importing RSE repository file finished.'
+
+    print('1. Importing RSE repository file finished.')
     # 2. Fill up th DB wo 130 sites with an avg. 6 protocols per site
     protocol = {'impl': 'rucio.rse.protocols.mock.Default',
-                'hostame': 'rucio.cern.ch' % uuid(),
+                'hostame': 'rucio.cern.ch',
                 'port': 42,
                 'domains': {'LAN': {'read': 1, 'write': 1, 'delete': 1},
                             'WAN': {'read': 1, 'write': 1, 'delete': 1}
@@ -91,22 +99,22 @@ if __name__ == '__main__':
         except Exception:
             errno, errstr = sys.exc_info()[:2]
             trcbck = traceback.format_exc()
-            print 'Interrupted processing with %s %s %s.' % (errno, errstr, trcbck)
+            print('Interrupted processing with %s %s %s.' % (errno, errstr, trcbck))
             sys.exit(CRITICAL)
         rses_total -= 1
-    print '2. Adding %s artificial RSEs finished.' % tmp
+    print('2. Adding %s artificial RSEs finished.' % tmp)
 
     # 3. Create known users
     tmp = users_total
     for user in known_users:
-        print 'Adding account %s' % user[0]
+        print('Adding account %s' % user[0])
         try:
             c.add_account(user[0], user[1], None)
             c.add_scope(user[0], user[0])  # Adding default scope
         except Duplicate:
-            print 'User %s already exists' % user[0]
+            print('User %s already exists' % user[0])
         users_total -= 1
-    print '3. Adding %s known users finished.' % (tmp - users_total)
+    print('3. Adding %s known users finished.' % (tmp - users_total))
     tmp = users_total
     # 4. Fill up DB to total number of Users
     while users_total:
@@ -114,9 +122,9 @@ if __name__ == '__main__':
             c.add_account('user%s' % users_total, 'user', None)  # Adding user
             c.add_scope('user%s' % users_total, 'user%s' % users_total)  # Adding default scope
         except Duplicate:
-            print 'User user%s already exists' % users_total
+            print('User user%s already exists' % users_total)
         users_total -= 1
-    print '4. Adding %s artificial users (and default scopes) finished.' % tmp
+    print('4. Adding %s artificial users (and default scopes) finished.' % tmp)
 
     # 5. Create known scopes
     tmp = scopes_total
@@ -129,10 +137,10 @@ if __name__ == '__main__':
             except Exception:
                 errno, errstr = sys.exc_info()[:2]
                 trcbck = traceback.format_exc()
-                print 'Interrupted processing with %s %s %s.' % (errno, errstr, trcbck)
+                print('Interrupted processing with %s %s %s.' % (errno, errstr, trcbck))
                 sys.exit(CRITICAL)
             scopes_total -= 1
-    print '5. Adding %s known scopes finished.' % (tmp - scopes_total)
+    print('5. Adding %s known scopes finished.' % (tmp - scopes_total))
     tmp = scopes_total
     # 6. Fill up DB to total number of scopes
     while scopes_total:
@@ -143,10 +151,10 @@ if __name__ == '__main__':
         except Exception:
             errno, errstr = sys.exc_info()[:2]
             trcbck = traceback.format_exc()
-            print 'Interrupted processing with %s %s %s.' % (errno, errstr, trcbck)
+            print('Interrupted processing with %s %s %s.' % (errno, errstr, trcbck))
             sys.exit(CRITICAL)
         scopes_total -= 1
-    print '6. Adding %s artificial scopes for the user root finished' % tmp
+    print('6. Adding %s artificial scopes for the user root finished' % tmp)
 
     # 7. Define meta data
     for key, key_type, value_regexp, values in meta_keys:
@@ -154,21 +162,21 @@ if __name__ == '__main__':
             try:
                 c.add_key(key=key, key_type=key_type, value_regexp=value_regexp)
             except Duplicate:
-                print '%(key)s already added' % locals()
+                print('%(key)s already added' % locals())
 
             for value in values:
 
                 try:
                     c.add_value(key=key, value=value)
                 except Duplicate:
-                    print '%(key)s:%(value)s already added' % locals()
+                    print('%(key)s:%(value)s already added' % locals())
 
                 if key == 'project':
                     try:
                         c.add_scope('root', value)
                     except Duplicate:
-                        print 'Scope %(value)s already added' % locals()
+                        print('Scope %(value)s already added' % locals())
         except:
             errno, errstr = sys.exc_info()[:2]
             trcbck = traceback.format_exc()
-            print 'Interrupted processing with %s %s %s.' % (errno, errstr, trcbck)
+            print('Interrupted processing with %s %s %s.' % (errno, errstr, trcbck))

--- a/tools/check_lost_file.py
+++ b/tools/check_lost_file.py
@@ -1,13 +1,23 @@
-#!/usr/bin/env sh
-# Copyright European Organization for Nuclear Research (CERN)
+#!/usr/bin/env python
+# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Wen Guan, <wen.guan@cern.ch>, 2015
-# - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
+# - Wen Guan <wen.guan@cern.ch>, 2015
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2015
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import commands
 import logging
@@ -39,7 +49,7 @@ class Worker(Thread):
                 func, args, kargs = self.tasks.get()
                 try:
                     func(*args, **kargs)
-                except Exception, e:
+                except Exception as e:
                     logging.warning("ThreadPool Worker func exception: %s, %s" % (str(e), traceback.format_exc()))
                 except:
                     logging.warning("ThreadPool Worker func unknow exception: %s" % traceback.format_exc())
@@ -71,9 +81,9 @@ def check_file_path(scope, name, rse_id, dest_url):
         return True
     else:
         if "No such file or directory" in output:
-            print "LOST: scope %s, name %s, rse_id %s, url: %s" % (scope, name, rse_id, dest_url)
+            print("LOST: scope %s, name %s, rse_id %s, url: %s" % (scope, name, rse_id, dest_url))
         else:
-            print "UNKNOWN: scope %s, name %s, rse_id %s, url: %s, error: %s" % (scope, name, rse_id, dest_url, output)
+            print("UNKNOWN: scope %s, name %s, rse_id %s, url: %s, error: %s" % (scope, name, rse_id, dest_url, output))
     return False
 
 
@@ -119,10 +129,10 @@ for scope, name, rse_name in lost_requests:
         pfn = protocols[rse_name].lfns2pfns([lfn])['%s:%s' % (scope, name)]
     except ReplicaNotFound:
         # for stagin rses, it's undeterminstric, but the path is not set. here protocol.lfns2pfns will throw an exception
-        print "ReplicaNotFound: scope %s, name %s, rse_id %s, rse %s" % (scope, name, rse_id, rse_name)
+        print("ReplicaNotFound: scope %s, name %s, rse_id %s, rse %s" % (scope, name, rse_id, rse_name))
         continue
     except:
-        print "Unknow: scope %s, name %s, rse_id %s, rse %s" % (scope, name, rse_id, rse_name)
+        print("Unknow: scope %s, name %s, rse_id %s, rse %s" % (scope, name, rse_id, rse_name))
         continue
 
     threadPool.add_task(check_file_path, scope, name, rse_id, pfn)

--- a/tools/delegate_proxy_fts3.py
+++ b/tools/delegate_proxy_fts3.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2014
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2014
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import commands
 import os
@@ -25,8 +34,8 @@ s = '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=rucio01/CN=663551/CN=Robot: Ruc
 if '--ddmadmin' in sys.argv:
     c = '/opt/rucio/tools/x509up'
     s = '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=ddmadmin/CN=531497/CN=Robot: ATLAS Data Management/CN=proxy/CN=proxy/CN=proxy'
-print c
-print s
+print(c)
+print(s)
 
 h = 'https://fts3-pilot.cern.ch:8446'
 if '--prod' in sys.argv:
@@ -35,7 +44,7 @@ elif '--devel' in sys.argv:
     h = 'https://fts3-devel.cern.ch:8446'
 elif '--raltest' in sys.argv:
     h = 'https://fts3-test.gridpp.rl.ac.uk:8446'
-print h
+print(h)
 
 w = requests.get('%s/whoami' % h, verify=False, cert=c).json()
 pprint.pprint(w)
@@ -56,7 +65,8 @@ while at < bt:
     commands.getstatusoutput('/usr/bin/openssl ca -in /tmp/fts3request.pem -preserveDN -days 365 -cert %s -keyfile %s -md sha1 -out /tmp/fts3proxy.pem -subj "%s" -policy policy_anything -batch' % (c, c, s))
     commands.getstatusoutput('/bin/cat /tmp/fts3proxy.pem %s > /tmp/fts3full.pem' % c)
 
-    print requests.put('%s/delegation/%s/credential' % (h, w['delegation_id']), verify=False, cert=c, data=open('/tmp/fts3full.pem', 'r')).text
+    print(requests.put('%s/delegation/%s/credential' % (h, w['delegation_id']), verify=False, cert=c,
+                       data=open('/tmp/fts3full.pem', 'r')).text)
     a = requests.get('%s/delegation/%s' % (h, w['delegation_id']), verify=False, cert=c).json()
     pprint.pprint(a)
     if a is not None:
@@ -67,5 +77,5 @@ while at < bt:
     os.unlink('/tmp/fts3full.pem')
 
     if at < bt:
-        print 'retrying'
+        print('retrying')
         time.sleep(1)

--- a/tools/extract_agis_srm.py
+++ b/tools/extract_agis_srm.py
@@ -1,12 +1,22 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2014
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2014
+# - Martin Barisits <martin.barisits@cern.ch>, 2017
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import requests
 import urlparse
@@ -33,7 +43,7 @@ def run():
 
     res.sort()
     for r in res:
-        print '%s:%s' % (r[1], ':'.join(r[0].split(':')[1:]))
+        print('%s:%s' % (r[1], ':'.join(r[0].split(':')[1:])))
 
 
 if __name__ == '__main__':

--- a/tools/extract_agis_webdav.py
+++ b/tools/extract_agis_webdav.py
@@ -1,12 +1,22 @@
-#!/opt/rucio/.venv/bin/python
-# Copyright European Organization for Nuclear Research (CERN)
+#!/usr/bin/env python
+# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2014
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2014
+# - Martin Barisits <martin.barisits@cern.ch>, 2017
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import requests
 import urlparse
@@ -39,7 +49,7 @@ def run():
 
     res.sort()
     for r in res:
-        print r
+        print(r)
 
 
 if __name__ == '__main__':

--- a/tools/generateDatasetDistribution.py
+++ b/tools/generateDatasetDistribution.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#                       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2013-2014
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2014
+# - Martin Barisits <martin.barisits@cern.ch>, 2016
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import os
 import random
@@ -38,14 +47,14 @@ def createScope():
     # add_account('tier0', 'user', 'root')
     # add_scope('data12_8TeV', 'root', 'root')
     add_scope('mc12_8TeV', 'root', 'root')
-    for i in xrange(0, 20):
-        print i
+    for i in range(0, 20):
+        print(i)
         group = 'group%i' % (i)
         try:
             add_account(group, 'user', 'root')
             add_scope('group.%s' % (group), group, 'root')
-        except Duplicate, e:
-            print e
+        except Duplicate as e:
+            print(e)
 
 
 def createMetadata():
@@ -61,7 +70,7 @@ def createMetadata():
 
 def createRSEs():
     # Add test RSEs
-    for i in xrange(0, 3):
+    for i in range(0, 3):
         rse1 = str(uuid())
         rse2 = str(uuid())
         add_rse(rse1, issuer='root')
@@ -71,7 +80,7 @@ def createRSEs():
         add_rse_attribute(rse1, "DISK", True, issuer='root')
         add_rse_attribute(rse2, "TAPE", True, issuer='root')
 
-    for i in xrange(0, 10):
+    for i in range(0, 10):
         rse1 = str(uuid())
         add_rse(rse1, issuer='root')
         add_rse_attribute(rse1, "T2", True, issuer='root')
@@ -84,7 +93,7 @@ def createRSEs():
 
 def populateDB(filename=None):
     listrses = list_rses(filters={'deterministic': 1})
-    print listrses
+    print(listrses)
     listrses = map(lambda x: x['rse'], listrses)
     account = 'root'
     nbDatasets = 0
@@ -109,7 +118,7 @@ def populateDB(filename=None):
     f.close()
 
     # Generate 200000 datasets according to the dataset distribution
-    for i in xrange(0, 200000):
+    for i in range(200000):
         rnd = random.random() * nbDatasets
         for lower, upper in dictDistrib:
             if (rnd > lower) and (rnd < upper):
@@ -155,34 +164,34 @@ def populateDB(filename=None):
                     run_number_string = str(run_number)
                     run_number_string = run_number_string.rjust(7, '0')
                     dsn = '%s.%s.%s.%s.%s.%s' % (project, run_number_string, stream_name, prod_step, datatype, tag)
-                    print '%i Creating %s:%s with %i files of size %i located at %i sites' % (i, scope, dsn, nbfiles, filesize, len(source_rses))
+                    print('%i Creating %s:%s with %i files of size %i located at %i sites' % (i, scope, dsn, nbfiles, filesize, len(source_rses)))
                     stime1 = time.time()
                     add_identifier(scope=scope, name=dsn, type='dataset', issuer=account, statuses={'monotonic': True}, meta=dataset_meta)
                     stime2 = time.time()
-                    print 'Time to generate a dataset : %s' % str(stime2 - stime1)
+                    print('Time to generate a dataset : %s' % str(stime2 - stime1))
                     monitor.record(timeseries='dbfiller.addnewdataset', delta=1)
-                    files = ['file_%s' % uuid() for i in xrange(nbfiles)]
+                    files = ['file_%s' % uuid() for i in range(nbfiles)]
                     listfiles = []
                     for file in files:
                         listfiles.append({'scope': scope, 'name': file, 'size': filesize})
                         for source_rse in source_rses:
                             add_file_replica(source_rse, scope, file, filesize, issuer=account)
                     stime3 = time.time()
-                    print 'Time to create replicas : %s' % str(stime3 - stime2)
+                    print('Time to create replicas : %s' % str(stime3 - stime2))
                     monitor.record(timeseries='dbfiller.addreplicas', delta=nbfiles * len(source_rses))
                     attach_identifier(scope, name=dsn, dids=listfiles, issuer=account)
                     stime4 = time.time()
-                    print 'Time to attach files : %s' % str(stime4 - stime3)
+                    print('Time to attach files : %s' % str(stime4 - stime3))
                     monitor.record(timeseries='dbfiller.addnewfile', delta=nbfiles)
                     for source_rse in source_rses:
                         try:
                             add_replication_rule(dids=[{'scope': scope, 'name': dsn}], account=account, copies=1, rse_expression=source_rse,
                                                  grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None, issuer='root')
                             monitor.record(timeseries='dbfiller.addreplicationrules', delta=1)
-                        except InvalidReplicationRule, e:
-                            print e
+                        except InvalidReplicationRule as e:
+                            print(e)
                     stime5 = time.time()
-                    print 'Time to attach files : %s' % str(stime5 - stime4)
+                    print('Time to attach files : %s' % str(stime5 - stime4))
 
 
 def main(argv):
@@ -193,7 +202,7 @@ def main(argv):
     try:
         filename = argv[0]
     except IndexError:
-        print 'Will use the default file : data12_8TeV_distribution.txt'
+        print('Will use the default file : data12_8TeV_distribution.txt')
     populateDB(filename)
 
 

--- a/tools/generateDatasetsforPanda.py
+++ b/tools/generateDatasetsforPanda.py
@@ -1,14 +1,22 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#                       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2013
-
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2014
+# - Martin Barisits <martin.barisits@cern.ch>, 2016-2017
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import random
 
@@ -32,7 +40,7 @@ def createMetadata():
 
 def createRSEs():
     # Add test RSEs
-    for i in xrange(0, 3):
+    for i in range(3):
         rse1 = str(uuid())
         rse2 = str(uuid())
         add_rse(rse1, issuer='root')
@@ -42,7 +50,7 @@ def createRSEs():
         add_rse_attribute(rse1, "DISK", True, issuer='root')
         add_rse_attribute(rse2, "TAPE", True, issuer='root')
 
-    for i in xrange(0, 10):
+    for i in range(10):
         rse1 = str(uuid())
         add_rse(rse1, issuer='root')
         add_rse_attribute(rse1, "T2", True, issuer='root')
@@ -55,7 +63,7 @@ def createRSEs():
 
 def populateDB():
     listrses = list_rses({'T1': '1'})
-    print len(listrses), listrses
+    print(len(listrses), listrses)
     # listrses = list_rses()
     # print len(listrses), listrses
     # sys.exit()
@@ -67,8 +75,8 @@ def populateDB():
                    {'datatype': 'AOD', 'prodstep': 'recon', 'nbfiles': 858, 'totfilesize': 182186965627, 'nbreplicas': 1}]
 
     for d in dictDistrib:
-        for day in xrange(0, 180):
-            for i in xrange(0, 30):
+        for day in range(180):
+            for i in range(30):
                 scope = project
                 prod_step = d['prodstep']
                 datatype = d['datatype']
@@ -89,9 +97,9 @@ def populateDB():
 
                     try:
                         dsn = '%s.%s.%s.%i.%i' % (project, prod_step, datatype, day, i)
-                        print '%i Creating %s with %i files of size %i located at %i sites' % (i, dsn, nbfiles, filesize, len(source_rses))
+                        print('%i Creating %s with %i files of size %i located at %i sites' % (i, dsn, nbfiles, filesize, len(source_rses)))
                         add_identifier(scope=scope, name=dsn, type='dataset', issuer=account, statuses={'monotonic': True}, meta=dataset_meta)
-                        files = ['file_%s' % uuid() for i in xrange(nbfiles)]
+                        files = ['file_%s' % uuid() for i in range(nbfiles)]
                         listfiles = []
                         for file in files:
                             listfiles.append({'scope': scope, 'name': file, 'size': filesize})
@@ -102,12 +110,10 @@ def populateDB():
                             try:
                                 add_replication_rule(dids=[{'scope': scope, 'name': dsn}], account=account, copies=1, rse_expression=source_rse,
                                                      grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None, issuer='root')
-                            except InvalidReplicationRule, e:
-                                print e
-                    except RucioException, e:
-                        print e
+                            except InvalidReplicationRule as e:
+                                print(e)
+                    except RucioException as e:
+                        print(e)
 
 
-# createRSEs()
-# createMetadata()
 populateDB()

--- a/tools/generateUserDatasets.py
+++ b/tools/generateUserDatasets.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#                       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2013
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2014
+# - Martin Barisits <martin.barisits@cern.ch>, 2016
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import random
 import sys
@@ -36,10 +45,10 @@ def generatePDF():
     cumul = []
     pdf = []
     cumul.append(0)
-    for i in xrange(1, 2000):
+    for i in range(1, 2000):
         cumul.append(cumul[i - 1] + fitfunc(i))
-    print cumul[1999]
-    print pdf
+    print(cumul[1999])
+    print(pdf)
     for i in cumul:
         pdf.append(i / cumul[1999])
     return pdf
@@ -47,20 +56,20 @@ def generatePDF():
 
 def getRandomScope(pdf):
     rnd = random.random()
-    for i in xrange(0, 2001):
+    for i in range(2001):
         if (rnd >= pdf[i]) and (rnd < pdf[i + 1]):
             return i
 
 
 def createScope():
-    for i in xrange(0, 2000):
-        print i
+    for i in range(2000):
+        print(i)
         user = 'user%i' % (i)
         try:
             add_account(user, 'user', 'root')
-            add_scope('user.%s' % (user), user, 'root')
-        except Duplicate, e:
-            print e
+            add_scope('user.%s' % user, user, 'root')
+        except Duplicate as e:
+            print(e)
 
 
 def populateDB(filename=None):
@@ -71,21 +80,21 @@ def populateDB(filename=None):
     pdf = generatePDF()
 
     # Generate 200000 datasets according to the dataset distribution
-    for index in xrange(0, 20000):
+    for index in range(20000):
         scope_nb = getRandomScope(pdf)
         project = 'user.user%i' % (scope_nb)
         scope = 'user.user%i' % (scope_nb)
         account = 'user%i' % (scope_nb)
-        print scope
+        print(scope)
         nbfiles = 53
         filesize = 78000000
         uid = uuid()
         dsn = '%s.%s' % (project, uid)
         rnd_site = random.choice(listrses)
-        print '%i Creating %s with %i files of size %i located at %s' % (index, dsn, nbfiles, filesize, rnd_site)
+        print('%i Creating %s with %i files of size %i located at %s' % (index, dsn, nbfiles, filesize, rnd_site))
         add_identifier(scope=scope, name=dsn, type='dataset', issuer=account, statuses={'monotonic': True})
         monitor.record(timeseries='dbfiller.addnewdataset', delta=1)
-        files = ['file_%s' % uuid() for i in xrange(nbfiles)]
+        files = ['file_%s' % uuid() for i in range(nbfiles)]
         listfiles = []
         for file in files:
             listfiles.append({'scope': scope, 'name': file, 'size': filesize})
@@ -97,8 +106,8 @@ def populateDB(filename=None):
             add_replication_rule(dids=[{'scope': scope, 'name': dsn}], account=account, copies=1, rse_expression=rnd_site,
                                  grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None, issuer=account)
             monitor.record(timeseries='dbfiller.addreplicationrules', delta=1)
-        except InvalidReplicationRule, e:
-            print e
+        except InvalidReplicationRule as e:
+            print(e)
 
 
 def main(argv):

--- a/tools/install_venv.py
+++ b/tools/install_venv.py
@@ -1,21 +1,35 @@
-#    copyright: European Organization for Nuclear Research (CERN)
-#    @author:
-#    - Vincent Garonne, <vincent.garonne@cern.ch>, 2011-1013
-#    @contact: U{ph-adp-ddm-lab@cern.ch<mailto:ph-adp-ddm-lab@cern.ch>}
-#    @license: Licensed under the Apache License, Version 2.0 (the "License");
-#    You may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at U{http://www.apache.org/licenses/LICENSE-2.0}
+# Copyright 2011-2020 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2011-2013
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2012
+# - Martin Barisits <martin.barisits@cern.ch>, 2017-2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+
 """
 Installation script Rucio's development virtualenv
 """
 
+from __future__ import print_function
+
 import errno
 import optparse
 import os
-import subprocess
 import shutil
+import subprocess
 import sys
-
 
 ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 VENV = os.path.join(ROOT, '.venv')
@@ -25,7 +39,7 @@ PIP_REQUIRES_TEST = os.path.join(ROOT, 'etc', 'pip-requires-test')
 
 
 def die(message, *args):
-    print >> sys.stderr, message % args
+    print(message % args, file=sys.stderr)
     sys.exit(1)
 
 
@@ -56,10 +70,10 @@ def check_dependencies():
     """Make sure virtualenv is in the path."""
 
     if not HAS_VIRTUALENV:
-        print 'virtualenv not found.'
+        print('virtualenv not found.')
         # Try installing it via curl/pip/easy_install...
         if HAS_PIP:
-            print 'Installing virtualenv via pip...',
+            print('Installing virtualenv via pip...', end=' ')
             if not run_command(['which', 'pip']):
                 die('ERROR: virtualenv not found.\n\n'
                     'Rucio development requires virtualenv, please install'
@@ -67,9 +81,9 @@ def check_dependencies():
             else:
                 if not run_command(['pip', 'install', 'virtualenv']).strip():
                     die("Failed to install virtualenv.")
-            print 'done.'
+            print('done.')
         elif HAS_EASY_INSTALL:
-            print 'Installing virtualenv via easy_install...',
+            print('Installing virtualenv via easy_install...', end=' ')
             if not run_command(['which', 'easy_install']):
                 die('ERROR: virtualenv not found.\n\n'
                     'Rucio development requires virtualenv, please install'
@@ -77,8 +91,8 @@ def check_dependencies():
             else:
                 if not run_command(['easy_install', 'virtualenv']).strip():
                     die("Failed to install virtualenv.")
-            print 'done.'
-    print 'done.'
+            print('done.')
+    print('done.')
 
 
 def create_virtualenv(venv=VENV):
@@ -87,21 +101,21 @@ def create_virtualenv(venv=VENV):
     virtual environment
     """
     if HAS_VIRTUALENV:
-        print 'Creating venv...'
+        print('Creating venv...')
         run_command(['virtualenv', '-q', '--no-site-packages', VENV])
     elif HAS_CURL:
-        print 'Creating venv via curl...',
+        print('Creating venv via curl...', end=' ')
         if not run_command("curl -s https://raw.github.com/pypa/virtualenv/master/virtualenv.py | %s - --no-site-packages %s" % (sys.executable, VENV), shell=True):
             die('Failed to install virtualenv with curl.')
-    print 'done.'
-    print 'Installing pip in virtualenv...',
+    print('done.')
+    print('Installing pip in virtualenv...', end=' ')
     if not run_command(['tools/with_venv.sh', 'pip', 'install', 'pip>=9.0.1']).strip():
         die("Failed to install pip.")
-    print 'done.'
+    print('done.')
 
 
 def install_dependencies(venv=VENV, client=False):
-    print 'Installing dependencies with pip (this can take a while)...'
+    print('Installing dependencies with pip (this can take a while)...')
 
     run_command(['.venv/bin/pip', 'install', '-r', PIP_REQUIRES_CLIENT], redirect_output=False)
 
@@ -127,7 +141,7 @@ def _detect_python_version(venv):
 
 
 def create_symlinks(venv=VENV, atlas_clients=False):
-    print 'Installing binaries symlinks ...'
+    print('Installing binaries symlinks ...')
     bin_dir = os.path.join(ROOT, "bin")
     venv_bin_dir = os.path.join(venv, "bin")
     binaries = os.listdir(bin_dir)
@@ -136,14 +150,14 @@ def create_symlinks(venv=VENV, atlas_clients=False):
         link_name = os.path.join(venv_bin_dir, binary)
         try:
             os.path.exists(link_name) and source != os.readlink(link_name)
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.EINVAL:
-                print 'Delete broken symlink: %(link_name)s -> %(source)s' % locals()
+                print('Delete broken symlink: %(link_name)s -> %(source)s' % locals())
                 os.remove(link_name)
             else:
                 raise e
         if not os.path.exists(link_name):
-            print 'Create the symlink: %(link_name)s -> %(source)s' % locals()
+            print('Create the symlink: %(link_name)s -> %(source)s' % locals())
             os.symlink(source, link_name)
 
     if atlas_clients:
@@ -151,20 +165,20 @@ def create_symlinks(venv=VENV, atlas_clients=False):
         link_name = os.path.join(venv, "etc")
         try:
             os.path.exists(link_name) and source != os.readlink(link_name)
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.EINVAL:
-                print 'Delete broken symlink: %(link_name)s -> %(source)s' % locals()
+                print('Delete broken symlink: %(link_name)s -> %(source)s' % locals())
                 os.remove(link_name)
             else:
                 raise e
         if not os.path.exists(link_name):
-            print 'Create the symlink: %(link_name)s -> %(source)s' % locals()
+            print('Create the symlink: %(link_name)s -> %(source)s' % locals())
             os.symlink(source, link_name)
 
         cfg_name = os.path.join(link_name, 'rucio.cfg')
         tpl_cfg_name = os.path.join(link_name, 'rucio.cfg.template')
         if not os.path.exists(cfg_name):
-            print 'Configuring Rucio with etc/rucio.cfg.template'
+            print('Configuring Rucio with etc/rucio.cfg.template')
             shutil.copy(src=tpl_cfg_name, dst=cfg_name)
 
 
@@ -187,7 +201,7 @@ def print_help():
 
  Also, make test will automatically use the virtualenv.
     """
-    print help
+    print(help)
 
 
 if __name__ == '__main__':

--- a/tools/make_release.py
+++ b/tools/make_release.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#                       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2014
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2015
+# - Martin Barisits <martin.barisits@cern.ch>, 2017
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import argparse
 import sys
@@ -37,7 +46,7 @@ def query_yes_no(question, default="yes"):
 
     while True:
         sys.stdout.write(question + prompt)
-        choice = raw_input().lower()
+        choice = raw_input().lower()  # noqa: F821
         if default is not None and choice == '':
             return valid[default]
         elif choice in valid:
@@ -80,23 +89,23 @@ if __name__ == '__main__':
     if answer:
 
         cmd = "git remote set-url --push upstream https://gitlab.cern.ch/rucio01/rucio.git"
-        print cmd
+        print(cmd)
 
         cmd = "git tag -a %(new_version)s -m 'Version %(new_version)s'" % locals()
-        print cmd
+        print(cmd)
         # status, output = getstatusoutput(cmd)
 
         cmd = "git push origin %(new_version)s" % locals()
-        print cmd
+        print(cmd)
         cmd = "git push upstream %(new_version)s" % locals()
-        print cmd
+        print(cmd)
 
         cmd = "git remote set-url --push upstream xxx"
-        print cmd
+        print(cmd)
 
         # status, output = getstatusoutput(cmd)
-        print '\n# To undo the release'
+        print('\n# To undo the release')
         cmd = "git push --delete origin %(new_version)s" % locals()
-        print cmd
+        print(cmd)
         cmd = "git tag -d %(new_version)s" % locals()
-        print cmd
+        print(cmd)

--- a/tools/sync_ldap_accounts.py
+++ b/tools/sync_ldap_accounts.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python
-
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Cheng-Hsi Chao, <cheng-hsi.chaos@cern.ch>, 2014
-# - Martin Barisits, <martin.barisits@cern.ch>, 2019
+# - Cheng-Hsi Chao <cheng-hsi.chao@cern.ch>, 2014
+# - Martin Barisits <martin.barisits@cern.ch>, 2017-2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
@@ -60,10 +67,9 @@ def initiate_ldap():
             try:
                 ldap_obj.whoami_s()
             except ldap.UNWILLING_TO_PERFORM:
-                print 'Anonymous binding is disabled by server'
+                print('Anonymous binding is disabled by server')
                 raise SystemExit
         return ldap_obj
-        break
 
 
 def add_identity(ldapObject):
@@ -78,7 +84,7 @@ def add_identity(ldapObject):
             else:
                 account = result[1]['uid'][0]
             if not re.match(r'^[a-z0-9-_]{1,30}$', account):
-                print 'account: \'' + account + '\' is invalid as Rucio account'
+                print('account: \'' + account + '\' is invalid as Rucio account')
                 continue
             if 'auth_type' in retrieveAttributes:
                 authtype = result[1]['auth_type'][0]
@@ -88,12 +94,12 @@ def add_identity(ldapObject):
             email = result[1]['mail'][0]
             add_account(account)
             client.add_identity(account, identity, authtype, email)  # pylint: disable:no-value-for-parameter
-            print 'Added new identity to account: %s-%s' % (identity, account)
+            print('Added new identity to account: %s-%s' % (identity, account))
         except KeyError as e:
-            print 'Attribute', e, 'for account \'' + account + '\' is missing'
+            print('Attribute', e, 'for account \'' + account + '\' is missing')
             continue
         except exception.Duplicate as e:
-            print e[0][0]
+            print(e[0][0])
             continue
 
 
@@ -104,12 +110,12 @@ def add_account(account):
     type = 'USER'
     try:
         client.get_account(account)
-        print 'Account \'' + account + '\' is already registered as Rucio account'
+        print('Account \'' + account + '\' is already registered as Rucio account')
     except exception.AccountNotFound:
         client.add_account(account, type, None)
         pass
     except exception.InvalidObject as e:
-        print e[0][0]
+        print(e[0][0])
         pass
 
 

--- a/tools/sync_rses.py
+++ b/tools/sync_rses.py
@@ -1,16 +1,24 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#                       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Ralph Vigne, <ralph.vigne@cern.ch>, 2013-2014
-# - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2019
-# - Cedric Serfon, <cedric.serfom@cern.ch>, 2020
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2013
+# - Ralph Vigne <ralph.vigne@cern.ch>, 2013-2014
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import json
 import sys
@@ -65,7 +73,7 @@ def main(argv):
                 print(rse, e)
             except Duplicate as e:
                 print(rse, e)
-            except Exception as e:
+            except Exception:
                 errno, errstr = sys.exc_info()[:2]
                 trcbck = traceback.format_exc()
                 print('Interrupted processing for %s with %s %s %s.' % (rse, errno, errstr, trcbck))

--- a/tools/test/install_script.sh
+++ b/tools/test/install_script.sh
@@ -22,13 +22,11 @@
 
 set -eo pipefail
 
-echo "* Running tests with $(python --version) and $(pip --version)"
+echo "* Running tests with $(python --version 2>&1) and $(pip --version 2>&1)"
 
 if [[ $SUITE == "client" ]]; then
     cd /usr/local/src/rucio
-    pip install -r etc/pip-requires
-    pip install setuptools_scm
-    pip install -r etc/pip-requires-test
+    python -m pip install setuptools_scm
     python setup_rucio_client.py install
     cp etc/docker/test/extra/rucio_client.cfg etc/rucio.cfg
 
@@ -37,10 +35,6 @@ if [[ $SUITE == "client" ]]; then
 
 elif [[ $SUITE == "syntax" ]]; then
     cd /usr/local/src/rucio
-    pip install setuptools_scm google_compute_engine
+    python -m pip install setuptools_scm google_compute_engine
     cp etc/docker/test/extra/rucio_syntax.cfg etc/rucio.cfg
-
-elif [[ $SUITE == "python3" ]]; then
-    cd /usr/local/src/rucio
-    pip install -r etc/pip-requires-test
 fi


### PR DESCRIPTION
Apart from fixing the Python 3 syntax problems, fixes isort dependency below version 5 as version 5 seems to be the default for Python 3 and pylint can currently not use isort >= 5.