### PR TITLE
Added m-VO database conversion script, Closes #3914

### DIFF
--- a/doc/source/multi_vo_rucio.rst
+++ b/doc/source/multi_vo_rucio.rst
@@ -59,3 +59,116 @@ Managing VOs
 
 In addition to creating VOs, the description and email for a VO can be altered using ``update_vo``. If the root user of a VO loses access to their account, the super_root can
 associate a new identity with it using ``recover_vo_root_identity``. Finally, a list of current VOs and their descriptions is accessible via ``list_vos``.
+
+
+Converting Existing Instances
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As opposed to starting a new M-VO instance from scratch, it may be desirable to
+convert the database for an existing (S-VO) Rucio instance into a M-VO instance
+so that additional VOs can be added without disrupting the original VO or
+needing to create a second instance. Conversely, one VO within a M-VO instance may
+grow to the point where it needs its own dedicated instance, and so converting
+data from M-VO to S-VO may also be desirable. These operations can be performed
+using utility functions included with Rucio.
+
+As mentioned above, in order to configure a M-VO instance of Rucio only the
+config file needs to change. However for an existing instance any entries already
+in the database will not be associated with a VO (or associated with their old
+one if previously in M-VO mode). In order to change these, direct operations on
+the database are required. These commands are generated using SQLAlchemy, and
+can either be run directly on the database or printed out and run manually.
+
+Practicalities
+--------------
+
+Before attempting to convert existing data, it is recommended that a backup of
+the database is taken in case an issue arises. Furthermore, of the databases
+supported by Rucio, only PostgreSQL has been tested on real data. Based on this
+test (which was performed on a machine with 64GB memory and four Intel Xeon E5-2430 v2),
+the tables with 2 columns that needed updating were converted at a rate of 5GB
+of data per hour. However many tables do not need any changes, so the process
+will likely be faster than this in practice. Another approach to speed up the
+conversion is to skip the "history" tables, as these can be very large. Unlike
+other tables these do not have foreign key constraints set, and so do not need
+to be updated in order to use the database. While the history will be
+inaccessible from the new VO, it will still exist in the database and could be
+accessed using the ``super_root`` account if needed.
+
+S-VO to M-VO
+------------
+
+Before starting, ensure that ``multi_vo`` is set to ``True`` in the config file.
+The SQL commands needed to convert the database involve dropping foreign key
+constraints that affect accounts/scopes, then altering the relevant columns,
+before re-adding the constraints. The 3 character identifier for the VO, a full
+description and an admin email should be provided::
+
+  $ tools/convert_database_vo.py convert_to_mvo new "New VO for existing data" rucio@email.com
+  ALTER TABLE account_limits DROP CONSTRAINT "ACCOUNT_LIMITS_ACCOUNT_FK";
+  ...
+  UPDATE account_limits SET account=(split_part(account_limits.account, '@', 1) || CAST('@new' AS CHAR(4))) WHERE split_part(account_limits.account, '@', 2) = '';
+  ...
+  ALTER TABLE account_limits ADD CONSTRAINT "ACCOUNT_LIMITS_ACCOUNT_FK" FOREIGN KEY(account) REFERENCES accounts (account);
+
+In this example, no changes will be made to the database by running the script,
+and so the SQL will need to be run manually. After running the commands, a 
+``super_root`` account should be setup to allow administrative functions like
+adding more VOs::
+
+  $ python
+  >>> from rucio.db.sqla.util import create_root_account
+  >>> create_root_account(create_counters=False)
+
+Alternatively by specifying ``--commit_changes`` the script will attempt to
+modify the database as it runs, however this requires the account used by the
+Rucio instance to access the database to have sufficient permissions to alter
+the tables. In this case, the ``super_root`` account is added as part of the
+script. If there is an error during the conversion, then none of the changes
+will be committed.
+
+  $ tools/convert_database_vo.py --commit_changes convert_to_mvo new "New VO for existing data" rucio@email.com
+
+Finally, there is the option to skip the (potentially very large) tables of
+historical data using ``--skip_history``. In this case the commands to alter
+those tables are omitted::
+
+  $ tools/convert_database_vo.py --skip_history convert_to_mvo new "New VO for existing data" rucio@email.com
+
+
+M-VO to S-VO
+------------
+
+Before starting, ensure that ``multi_vo`` is set to ``True`` in the config file
+(this option can be removed after completing the conversion). The first stage
+of the conversion is the same as before, dropping foreign key constraints and
+renaming the entries that were associated with the old VO. The name of this VO
+is the only required argument::
+
+  $ tools/convert_database_vo.py convert_to_svo old
+  ALTER TABLE account_limits DROP CONSTRAINT "ACCOUNT_LIMITS_ACCOUNT_FK";
+  ...
+  UPDATE account_limits SET account=split_part(account_limits.account, '@', 1) WHERE split_part(account_limits.account, '@', 2) = 'old';
+  ...
+  ALTER TABLE account_limits ADD CONSTRAINT "ACCOUNT_LIMITS_ACCOUNT_FK" FOREIGN KEY(account) REFERENCES accounts (account);
+
+By default data associated with any other VOs is left in the database, but will be
+inaccessible to Rucio users. By setting pass the argument ``--delete_vos``, these
+entries will be deleted from the database completely::
+
+  $ tools/convert_database_vo.py convert_to_svo old --delete_vos
+  ...
+  DELETE FROM account_limits WHERE split_part(account_limits.account, '@', 2) = 'xyz';
+  ...
+  DELETE FROM account_limits WHERE split_part(account_limits.account, '@', 2) = '123';
+  ...
+
+Once again, historical tables skipped with ``--skip_history``, and the commands
+can be run directly against the database using the ``--commit_changes`` argument;
+if this is not set then the ``super_root`` account should be manually deleted
+after running the SQL::
+
+  $ python
+  >>> from rucio.common.types import InternalAccount
+  >>> from rucio.core.account import del_account
+  >>> del_account(InternalAccount('super_root', vo='def'))

--- a/tools/convert_database_vo.py
+++ b/tools/convert_database_vo.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python
+# Copyright 2020 CERN for the benefit of the ATLAS collaboration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+
+import argparse
+from datetime import datetime
+from traceback import format_exc
+
+from sqlalchemy import func
+from sqlalchemy.engine import reflection
+from sqlalchemy.schema import AddConstraint, DropConstraint, ForeignKeyConstraint, MetaData, Table
+from sqlalchemy.sql import bindparam
+from sqlalchemy.sql.expression import cast
+from sqlalchemy.types import CHAR
+
+from rucio.common.config import config_get_bool
+from rucio.common.types import InternalAccount
+from rucio.core.account import del_account
+from rucio.core.vo import list_vos
+from rucio.db.sqla import session
+from rucio.db.sqla.util import create_root_account
+
+
+def split_vo(dialect, column, return_vo=False):
+    """
+    Utility script for extracting the name and VO from InternalAccount/Scope entries in the DB.
+
+    :param dialect:   The dialct of the DB.
+    :param column:    The column to perform the operation on.
+    :param return_vo: If True, return the 3 characters after the '@' symbol, else return everything before it.
+    """
+    if dialect == 'postgresql':
+        if return_vo:
+            return func.split_part(column, bindparam('split_character'), bindparam('int_2'))
+        else:
+            return func.split_part(column, bindparam('split_character'), bindparam('int_1'))
+    else:
+        # Dialects other than postgresql haven't been tested
+        i = func.INSTR(column, bindparam('split_character'))
+        if return_vo:
+            return func.SUBSTR(column, i + 1)
+        else:
+            return func.SUBSTR(column, bindparam('int_1'), i - 1)
+
+
+def rename_vo(old_vo, new_vo, insert_new_vo=False, description=None, email=None, commit_changes=False, skip_history=False, echo=True):
+    """
+    Updates rows so that entries associated with `old_vo` are now associated with `new_vo` as part of multi-VO migration.
+
+    :param old_vo:         The 3 character string for the current VO (for a single-VO instance this will be 'def').
+    :param new_vo:         The 3 character string for the new VO.
+    :param insert_new_vo:  If True then an entry for `new_vo` is created in the database.
+    :param description:    Full description of the new VO, unused if `insert_new_vo` is False.
+    :param email:          Admin email for the new VO, unused if `insert_new_vo` is False.
+    :param commit_changes: If True then changes are made against the database directly.
+                           If False, then nothing is commited and the commands needed are dumped to be run later.
+    :param skip_history:   If True then tables without FKC containing historical data will not be converted to save time.
+    """
+    success = True
+    engine = session.get_engine(echo=echo)
+    conn = engine.connect()
+    trans = conn.begin()
+    inspector = reflection.Inspector.from_engine(engine)
+    metadata = MetaData(bind=conn, reflect=True)
+    dialect = engine.dialect.name
+
+    # Gather all the columns that need updating and all relevant foreign key constraints
+    all_fks = []
+    tables_and_columns = []
+    for table_name in inspector.get_table_names():
+        if skip_history and ('_history' in table_name or '_hist_recent' in table_name):
+            continue
+        fks = []
+        table = Table(table_name, metadata)
+        for column in table.c:
+            if 'scope' in column.name or column.name == 'account':
+                tables_and_columns.append((table, column))
+        for fk in inspector.get_foreign_keys(table_name):
+            if not fk['name']:
+                continue
+            if 'scope' in fk['referred_columns'] or 'account' in fk['referred_columns']:
+                fks.append(ForeignKeyConstraint(fk['constrained_columns'], [fk['referred_table'] + '.' + r for r in fk['referred_columns']],
+                                                name=fk['name'], table=table, **fk['options']))
+        all_fks.extend(fks)
+
+    try:
+        bound_params = {'old_vo': old_vo,
+                        'new_vo': new_vo,
+                        'old_vo_suffix': '' if old_vo == 'def' else old_vo,
+                        'new_vo_suffix': '' if new_vo == 'def' else '@%s' % new_vo,
+                        'split_character': '@',
+                        'int_1': 1,
+                        'int_2': 2,
+                        'description': description,
+                        'email': email,
+                        'datetime': datetime.utcnow()}
+
+        bound_params_text = {}
+        for key in bound_params:
+            if isinstance(bound_params[key], int):
+                bound_params_text[key] = bound_params[key]
+            else:
+                bound_params_text[key] = "'%s'" % bound_params[key]
+
+        if insert_new_vo:
+            table = Table('vos', metadata)
+            insert_command = table.insert().values(vo=bindparam('new_vo'),
+                                                   description=bindparam('description'),
+                                                   email=bindparam('email'),
+                                                   updated_at=bindparam('datetime'),
+                                                   created_at=bindparam('datetime'))
+            print(str(insert_command) % bound_params_text + ';')
+            if commit_changes:
+                conn.execute(insert_command, bound_params)
+
+        # Drop all FKCs affecting InternalAccounts/Scopes
+        for fk in all_fks:
+            print(str(DropConstraint(fk)) + ';')
+            if commit_changes:
+                conn.execute(DropConstraint(fk))
+
+        # Update columns
+        for table, column in tables_and_columns:
+            update_command = table.update().where(split_vo(dialect, column, return_vo=True) == bindparam('old_vo_suffix'))
+
+            if new_vo == 'def':
+                update_command = update_command.values({column.name: split_vo(dialect, column)})
+            else:
+                update_command = update_command.values({column.name: split_vo(dialect, column) + cast(bindparam('new_vo_suffix'), CHAR(4))})
+
+            print(str(update_command) % bound_params_text + ';')
+            if commit_changes:
+                conn.execute(update_command, bound_params)
+
+        table = Table('rses', metadata)
+        update_command = table.update().where(table.c.vo == bindparam('old_vo')).values(vo=bindparam('new_vo'))
+        print(str(update_command) % bound_params_text + ';')
+        if commit_changes:
+            conn.execute(update_command, bound_params)
+
+        # Re-add the FKCs we dropped
+        for fkc in all_fks:
+            print(str(AddConstraint(fkc)) + ';')
+            if commit_changes:
+                conn.execute(AddConstraint(fkc))
+    except:
+        success = False
+        print(format_exc())
+        print('Exception occured, changes not committed to DB.')
+
+    if commit_changes and success:
+        trans.commit()
+    trans.close()
+
+
+def remove_vo(vo, commit_changes=False, skip_history=False, echo=True):
+    """
+    Deletes rows associated with `vo` as part of multi-VO migration.
+
+    :param vo:             The 3 character string for the VO being removed from the DB.
+    :param commit_changes: If True then changes are made against the database directly.
+                           If False, then nothing is commited and the commands needed are dumped to be run later.
+    :param skip_history:   If True then tables without FKC containing historical data will not be converted to save time.
+    """
+    success = True
+    engine = session.get_engine(echo=echo)
+    conn = engine.connect()
+    trans = conn.begin()
+    inspector = reflection.Inspector.from_engine(engine)
+    metadata = MetaData(bind=conn, reflect=True)
+    dialect = engine.dialect.name
+
+    # Gather all the columns that need deleting and all relevant foreign key constraints
+    all_fks = []
+    tables_and_columns = []
+    tables_and_columns_rse = []
+    for table_name in inspector.get_table_names():
+        if skip_history and ('_history' in table_name or '_hist_recent' in table_name):
+            continue
+        fks = []
+        table = Table(table_name, metadata)
+        for column in table.c:
+            if 'scope' in column.name or column.name == 'account':
+                tables_and_columns.append((table, column))
+            if 'rse_id' in column.name:
+                tables_and_columns_rse.append((table, column))
+        for fk in inspector.get_foreign_keys(table_name):
+            if not fk['name']:
+                continue
+            if 'scope' in fk['referred_columns'] or 'account' in fk['referred_columns'] or ('rse' in fk['referred_table'] and 'id' in fk['referred_columns']):
+                fks.append(ForeignKeyConstraint(fk['constrained_columns'], [fk['referred_table'] + '.' + r for r in fk['referred_columns']],
+                                                name=fk['name'], table=table, **fk['options']))
+        all_fks.extend(fks)
+
+    try:
+        bound_params = {'vo': vo,
+                        'vo_suffix': '' if vo == 'def' else vo,
+                        'split_character': '@',
+                        'int_1': 1,
+                        'int_2': 2}
+
+        bound_params_text = {}
+        for key in bound_params:
+            if isinstance(bound_params[key], int):
+                bound_params_text[key] = bound_params[key]
+            else:
+                bound_params_text[key] = "'%s'" % bound_params[key]
+
+        # Drop all FKCs affecting InternalAccounts/Scopes or RSE IDs
+        for fk in all_fks:
+            print(str(DropConstraint(fk)) + ';')
+            if commit_changes:
+                conn.execute(DropConstraint(fk))
+
+        # Delete rows
+        for table, column in tables_and_columns:
+            delete_command = table.delete().where(split_vo(dialect, column, return_vo=True) == bindparam('vo_suffix'))
+            print(str(delete_command) % bound_params_text + ';')
+            if commit_changes:
+                conn.execute(delete_command, bound_params)
+
+        rse_table = Table('rses', metadata)
+        for table, column in tables_and_columns_rse:
+            delete_command = table.delete().where(column == rse_table.c.id).where(rse_table.c.vo == bindparam('vo'))
+            print(str(delete_command) % bound_params_text + ';')
+            if commit_changes:
+                conn.execute(delete_command, bound_params)
+
+        delete_command = rse_table.delete().where(rse_table.c.vo == bindparam('vo'))
+        print(str(delete_command) % bound_params_text + ';')
+        if commit_changes:
+            conn.execute(delete_command, bound_params)
+
+        table = Table('vos', metadata)
+        delete_command = table.delete().where(table.c.vo == bindparam('vo'))
+        print(str(delete_command) % bound_params_text + ';')
+        if commit_changes:
+            conn.execute(delete_command, bound_params)
+
+        # Re-add the FKCs we dropped
+        for fkc in all_fks:
+            print(str(AddConstraint(fkc)) + ';')
+            if commit_changes:
+                conn.execute(AddConstraint(fkc))
+    except:
+        success = False
+        print(format_exc())
+        print('Exception occured, changes not committed to DB.')
+
+    if commit_changes and success:
+        trans.commit()
+    trans.close()
+
+
+def convert_to_mvo(new_vo, description, email, commit_changes=False, skip_history=False, echo=True):
+    """
+    Converts a single-VO database to a multi-VO one with the specified VO details.
+
+    :param new_vo:         The 3 character string for the new VO.
+    :param description:    Full description of the new VO.
+    :param email:          Admin email for the new VO.
+    :param commit_changes: If True then changes are made against the database directly, and a super_root account is created.
+                           If False, then nothing is commited and the commands needed are dumped to be run later.
+    :param skip_history:   If True then tables without FKC containing historical data will not be converted to save time.
+    """
+    if not config_get_bool('common', 'multi_vo', False, False):
+        print('Multi-VO mode is not enabled in the config file, aborting conversion.')
+        return
+
+    s = session.get_session()
+    vos = [vo['vo'] for vo in list_vos(session=s)]
+    if new_vo not in vos:
+        insert_new_vo = True
+    else:
+        insert_new_vo = False
+
+    rename_vo('def', new_vo, insert_new_vo=insert_new_vo, description=description, email=email,
+              commit_changes=commit_changes, skip_history=skip_history, echo=echo)
+    if commit_changes:
+        create_root_account(create_counters=False)
+    s.close()
+
+
+def convert_to_svo(old_vo, delete_vos=False, commit_changes=False, skip_history=False, echo=True):
+    """
+    Converts a multi-VO database to a single-VO one by renaming the given VO and (optionally) deleting entries for other VOs and the super_root.
+    Intended to be run on a copy of the original database that contains several VOs.
+
+    :param old_vo:         The 3 character string for the old VO.
+    :param delete_vos:     If True then all entries associated with a VO other than `old_vo` will be deleted.
+    :param commit_changes: If True then changes are made against the database directly and the old super_root account will be (soft) deleted.
+                           If False, then nothing is commited and the commands needed are dumped to be run later.
+    :param skip_history:   If True then tables without FKC containing historical data will not be converted to save time.
+    """
+    if not config_get_bool('common', 'multi_vo', False, False):
+        print('Multi-VO mode is not enabled in the config file, aborting conversion.')
+        return
+
+    rename_vo(old_vo, 'def', commit_changes=commit_changes, skip_history=skip_history, echo=echo)
+    s = session.get_session()
+    if delete_vos:
+        for vo in list_vos(session=s):
+            if vo['vo'] != 'def':
+                remove_vo(vo['vo'], commit_changes=commit_changes, skip_history=skip_history, echo=echo)
+        if commit_changes:
+            del_account(InternalAccount('super_root', vo='def'), session=s)
+    s.close()
+
+
+def main():
+    """
+    Parses the arguments and determines which operation to call.
+    """
+    parser = argparse.ArgumentParser(description='Utility script for associating database entries with a different VO in order to convert an instance to/from multi-VO mode.')
+    parser.add_argument('--commit_changes', '-cc', action='store_true',
+                        help='Attempts to commit changes to the database. If not provided then the SQL commands printed need to be run manually along with account creation/deletion.')
+    parser.add_argument('--skip_history', '-sh', action='store_true', help='Skips the potentially large historical tables to speed up the operation.')
+    subparsers = parser.add_subparsers(title='operation', description='The operation to perform on the database.')
+
+    parser_mvo = subparsers.add_parser('convert_to_mvo', help='Associates all entries in an existing s-VO database with the VO provided, making the database m-VO compatible.')
+    parser_mvo.add_argument('new_vo', help='Three character string to identify the new VO. Will be added to the database if it doesn\'t already exist.')
+    parser_mvo.add_argument('description', help='Full description of the VO to be used.')
+    parser_mvo.add_argument('email', help='Admin email for the new VO.')
+
+    parser_svo = subparsers.add_parser('convert_to_svo', help='Entries associated with the VO provided have this association removed, making the database s-VO compatible.')
+    parser_svo.add_argument('old_vo', help='Three character string to identify the old VO. Data associated with this VO will be converted.')
+    parser_svo.add_argument('--delete_vos', '-dv', action='store_true', help='If specified any data not associated with `old_vo` will be deleted from the database.')
+
+    args = parser.parse_args()
+    if 'new_vo' in args:
+        convert_to_mvo(**vars(args))
+    if 'old_vo' in args:
+        convert_to_svo(**vars(args))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Added m-VO database conversion script
------------------

- Added script that generates SQL commands using SQLAlchemy that change references to the VO in the database so that the data from an existing instance can be used in a m-VO instance (or vice versa).
- Made some changes to `create_root_account()` so creating account counters is optional, and it doesn't raise an exception if identities are already present in the database (both would be an issue when using it for a m-VO database conversion).
- Added some documentation on how to use the script, and practical considerations (such as skipping large historical data to make the process faster).
