### PR TITLE
Deletion: remove redundant all_rses option, Fixes #3933

### DIFF
--- a/bin/rucio-dark-reaper
+++ b/bin/rucio-dark-reaper
@@ -34,7 +34,6 @@ def get_parser():
     """
     parser = argparse.ArgumentParser(description="The Dark-Reaper daemon is responsible for the deletion of quarantined replicas.")
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
-    parser.add_argument("--all-rses", action="store_true", default=False, help='Select RSEs from the quarantined queues')
     parser.add_argument("--total-workers", action="store", default=1, type=int, help='Total number of workers per process')
     parser.add_argument("--chunk-size", action="store", default=10, type=int, help='Chunk size')
     parser.add_argument("--scheme", action="store", default=None, type=str, help='Force the reaper to use a particular protocol, e.g., mock.')
@@ -51,7 +50,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     try:
         run(total_workers=args.total_workers, chunk_size=args.chunk_size,
-            once=args.run_once, scheme=args.scheme, rses=args.rses, all_rses=args.all_rses,
+            once=args.run_once, scheme=args.scheme, rses=args.rses,
             exclude_rses=args.exclude_rses, include_rses=args.include_rses, vos=args.vos)
     except KeyboardInterrupt:
         stop()

--- a/bin/rucio-light-reaper
+++ b/bin/rucio-light-reaper
@@ -34,7 +34,6 @@ def get_parser():
     """
     parser = argparse.ArgumentParser(description="The light-reaper is responsible of deletion of temporary files")
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
-    parser.add_argument("--all-rses", action="store_true", default=False, help='Select RSEs from the quarantined queues')
     parser.add_argument("--total-workers", action="store", default=1, type=int, help='Total number of workers per process')
     parser.add_argument("--chunk-size", action="store", default=10, type=int, help='Chunk size')
     parser.add_argument("--scheme", action="store", default=None, type=str, help='Force the reaper to use a particular protocol, e.g., mock.')
@@ -51,7 +50,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     try:
         run(total_workers=args.total_workers, chunk_size=args.chunk_size,
-            once=args.run_once, scheme=args.scheme, rses=args.rses, all_rses=args.all_rses,
+            once=args.run_once, scheme=args.scheme, rses=args.rses,
             exclude_rses=args.exclude_rses, include_rses=args.include_rses, vos=args.vos)
     except KeyboardInterrupt:
         stop()

--- a/lib/rucio/daemons/reaper/dark_reaper.py
+++ b/lib/rucio/daemons/reaper/dark_reaper.py
@@ -180,7 +180,7 @@ def stop(signum=None, frame=None):
     GRACEFUL_STOP.set()
 
 
-def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None, all_rses=False,
+def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None,
         exclude_rses=None, include_rses=None, vos=None, delay_seconds=0):
     """
     Starts up the reaper threads.
@@ -202,11 +202,6 @@ def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None, all_r
         if vos:
             logging.warning('Ignoring argument vos, this is only applicable in a multi-VO setup.')
         vos = ['def']
-
-        # Preserve the old behaviour until a feature release
-        all_rses = list_rses()
-        if all_rses:
-            rses = all_rses
     else:
         if vos:
             invalid = set(vos) - set([v['vo'] for v in list_vos()])
@@ -217,31 +212,31 @@ def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None, all_r
             vos = [v['vo'] for v in list_vos()]
         logging.info('Dark Reaper: This instance will work on VO%s: %s' % ('s' if len(vos) > 1 else '', ', '.join([v for v in vos])))
 
-        all_rses = []
-        for vo in vos:
-            all_rses.extend(list_rses(filters={'vo': vo}))
+    all_rses = []
+    for vo in vos:
+        all_rses.extend(list_rses(filters={'vo': vo}))
 
-        if rses:
-            invalid = set(rses) - set([rse['rse'] for rse in all_rses])
-            if invalid:
-                msg = 'RSE{} {} cannot be found'.format('s' if len(invalid) > 1 else '',
-                                                        ', '.join([repr(rse) for rse in invalid]))
-                raise RSENotFound(msg)
-            rses = [rse for rse in all_rses if rse['rse'] in rses]
-        else:
-            rses = all_rses
+    if rses:
+        invalid = set(rses) - set([rse['rse'] for rse in all_rses])
+        if invalid:
+            msg = 'RSE{} {} cannot be found'.format('s' if len(invalid) > 1 else '',
+                                                    ', '.join([repr(rse) for rse in invalid]))
+            raise RSENotFound(msg)
+        rses = [rse for rse in all_rses if rse['rse'] in rses]
+    else:
+        rses = all_rses
 
-        if exclude_rses:
-            excluded_rses = parse_expression(exclude_rses)
-            rses = [rse for rse in rses if rse not in excluded_rses]
+    if exclude_rses:
+        excluded_rses = parse_expression(exclude_rses)
+        rses = [rse for rse in rses if rse not in excluded_rses]
 
-        if include_rses:
-            included_rses = parse_expression(include_rses)
-            rses = [rse for rse in rses if rse in included_rses]
+    if include_rses:
+        included_rses = parse_expression(include_rses)
+        rses = [rse for rse in rses if rse in included_rses]
 
-        if not rses:
-            logging.error('Dark Reaper: No RSEs found. Exiting.')
-            return
+    if not rses:
+        logging.error('Dark Reaper: No RSEs found. Exiting.')
+        return
 
     threads = []
     for worker in range(total_workers):


### PR DESCRIPTION
Remove redundant all_rses option
------------------

Options for `rses`, `include_rses` and `exclude_rses` will now be accepted by light/dark reaper. Running on all RSEs can still be achieved by simply not specifying any of these options. This is in line with how the main reaper handles RSE selection.