### PR TITLE
Release management: Change copyright in add_header

### DIFF
--- a/tools/add_header
+++ b/tools/add_header
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -129,9 +129,9 @@ def main(arguments):
         if arguments.documentation:
 
             if int(min) == int(max):
-                header += '..  Copyright %s CERN for the benefit of the ATLAS collaboration.\n' % max
+                header += '..  Copyright %s CERN\n' % max
             else:
-                header += '..  Copyright %s-%s CERN for the benefit of the ATLAS collaboration.\n' % (min, max)
+                header += '..  Copyright %s-%s CERN\n' % (min, max)
             header += '''    Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
@@ -168,9 +168,9 @@ def main(arguments):
             header += '# -*- coding: utf-8 -*-\n'
 
         if int(min) == int(max):
-            header += '# Copyright %s CERN for the benefit of the ATLAS collaboration.\n' % max
+            header += '# Copyright %s CERN\n' % max
         else:
-            header += '# Copyright %s-%s CERN for the benefit of the ATLAS collaboration.\n' % (min, max)
+            header += '# Copyright %s-%s CERN\n' % (min, max)
 
         header += '''#
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/prepare-commit-msg
+++ b/tools/prepare-commit-msg
@@ -9,7 +9,7 @@ else
     if echo $EDITMSG | grep "# Please enter the commit message for your changes.*"
     then
 	echo "No commit message given, preparing template for editing."
-	sed -i "1s/^/\<component\>: \<message\>; Fix \#$NUMBER/" $1
+	sed -i "1s/^/\#\<component\>: \<message\>; Fix \#$NUMBER\n/" $1
     else
 	echo "Using CLI commit message."
     fi


### PR DESCRIPTION
Change copyright in add_header
Comment and separate prepare-commit-msg line, so that existing commit messages aren't destroyed on commit --amend.