### PR TITLE
Core & Internals: Add is_old_db method; Fix #1157

### DIFF
--- a/lib/rucio/alembicrevision.py
+++ b/lib/rucio/alembicrevision.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+
+ALEMBIC_REVISION = '50280c53117c'  # the current alembic head revision

--- a/lib/rucio/daemons/abacus/account.py
+++ b/lib/rucio/daemons/abacus/account.py
@@ -1,4 +1,5 @@
-# Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,13 +14,12 @@
 # limitations under the License.
 #
 # Authors:
-# - Martin Barisits <martin.barisits@cern.ch>, 2014-2016
-# - Vincent Garonne <vgaronne@gmail.com>, 2014-2018
+# - Martin Barisits <martin.barisits@cern.ch>, 2014-2019
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Abacus-Account is a daemon to update Account counters.
@@ -33,10 +33,12 @@ import threading
 import time
 import traceback
 
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get
 from rucio.common.utils import get_thread_with_periodic_running_function
-from rucio.core.heartbeat import live, die, sanity_check
 from rucio.core.account_counter import get_updated_account_counters, update_account_counter, fill_account_counter_history_table
+from rucio.core.heartbeat import live, die, sanity_check
 
 graceful_stop = threading.Event()
 
@@ -109,6 +111,9 @@ def run(once=False, threads=1, fill_history_table=False):
     """
     Starts up the Abacus-Account threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
+
     executable = 'abacus-account'
     hostname = socket.gethostname()
     sanity_check(executable=executable, hostname=hostname)

--- a/lib/rucio/daemons/abacus/collection_replica.py
+++ b/lib/rucio/daemons/abacus/collection_replica.py
@@ -1,4 +1,5 @@
-# Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +14,9 @@
 # limitations under the License.
 #
 # Authors:
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Abacus-Collection-Replica is a daemon to update collection replica.
@@ -28,6 +30,8 @@ import threading
 import time
 import traceback
 
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get
 from rucio.core.heartbeat import live, die, sanity_check
 from rucio.core.replica import get_cleaned_updated_collection_replicas, update_collection_replica
@@ -102,6 +106,9 @@ def run(once=False, threads=1):
     """
     Starts up the Abacus-Collection-Replica threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
+
     executable = 'abacus-collection-replica'
     hostname = socket.gethostname()
     sanity_check(executable=executable, hostname=hostname)

--- a/lib/rucio/daemons/abacus/rse.py
+++ b/lib/rucio/daemons/abacus/rse.py
@@ -1,4 +1,5 @@
-# Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +15,11 @@
 #
 # Authors:
 # - Martin Barisits <martin.barisits@cern.ch>, 2014-2016
-# - Vincent Garonne <vgaronne@gmail.com>, 2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Abacus-RSE is a daemon to update RSE counters.
@@ -33,6 +33,8 @@ import threading
 import time
 import traceback
 
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get
 from rucio.common.utils import get_thread_with_periodic_running_function
 from rucio.core.heartbeat import live, die, sanity_check
@@ -108,6 +110,9 @@ def run(once=False, threads=1, fill_history_table=False):
     """
     Starts up the Abacus-RSE threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
+
     executable = 'abacus-rse'
     hostname = socket.gethostname()
     sanity_check(executable=executable, hostname=hostname)

--- a/lib/rucio/daemons/badreplicas/minos.py
+++ b/lib/rucio/daemons/badreplicas/minos.py
@@ -1,4 +1,5 @@
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +22,6 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
 
 from __future__ import division
 
@@ -30,27 +29,24 @@ import logging
 import math
 import os
 import socket
-import traceback
 import threading
 import time
-
+import traceback
 from datetime import datetime
 from sys import stdout
 
-from rucio.db.sqla.constants import BadFilesStatus, BadPFNStatus, ReplicaState
-
-from rucio.db.sqla.session import get_session
+import rucio.db.sqla.util
 from rucio.common.config import config_get
+from rucio.common.exception import UnsupportedOperation, DataIdentifierNotFound, ReplicaNotFound, DatabaseException
 from rucio.common.utils import chunks
-from rucio.common.exception import UnsupportedOperation, DataIdentifierNotFound, ReplicaNotFound
+from rucio.core import heartbeat
 from rucio.core.did import get_metadata
 from rucio.core.replica import (get_bad_pfns, get_pfn_to_rse, declare_bad_file_replicas,
                                 get_did_from_pfns, update_replicas_states, bulk_add_bad_replicas,
                                 bulk_delete_bad_pfns, get_replicas_state)
 from rucio.core.rse import get_rse_name
-
-from rucio.core import heartbeat
-
+from rucio.db.sqla.constants import BadFilesStatus, BadPFNStatus, ReplicaState
+from rucio.db.sqla.session import get_session
 
 logging.basicConfig(stream=stdout,
                     level=getattr(logging,
@@ -271,6 +267,8 @@ def run(threads=1, bulk=100, once=False, sleep_time=60):
     """
     Starts up the minos threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException('Database was not updated, daemon won\'t start')
 
     if once:
         logging.info('Will run only one iteration in a single threaded mode')

--- a/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
+++ b/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
@@ -1,4 +1,5 @@
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,37 +14,33 @@
 # limitations under the License.
 #
 # Authors:
-# - Cedric Serfon <cedric.serfon@cern.ch>, 2018-2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2018-2019
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
 
 import logging
 import math
 import os
 import socket
 import threading
-import traceback
 import time
-
+import traceback
 from sys import stdout
 
-from rucio.db.sqla.constants import BadFilesStatus, ReplicaState
-
-from rucio.db.sqla.session import get_session
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get
-from rucio.common.utils import chunks
 from rucio.common.exception import DataIdentifierNotFound, ReplicaNotFound
+from rucio.common.utils import chunks
+from rucio.core import heartbeat
 from rucio.core.did import get_metadata
 from rucio.core.replica import (update_replicas_states,
                                 bulk_delete_bad_replicas, list_expired_temporary_unavailable_replicas)
-
-from rucio.core import heartbeat
-
+from rucio.db.sqla.constants import BadFilesStatus, ReplicaState
+from rucio.db.sqla.session import get_session
 
 logging.basicConfig(stream=stdout,
                     level=getattr(logging,
@@ -163,6 +160,8 @@ def run(threads=1, bulk=100, once=False, sleep_time=60):
     """
     Starts up the minos threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     if once:
         logging.info('Will run only one iteration in a single threaded mode')

--- a/lib/rucio/daemons/badreplicas/necromancer.py
+++ b/lib/rucio/daemons/badreplicas/necromancer.py
@@ -1,4 +1,5 @@
-# Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +19,10 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2015
 # - Wen Guan <wguan.icedew@gmail.com>, 2015
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Martin Barisits <martin.barisits@cern.ch>, 2019
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 from __future__ import division
 
@@ -30,19 +31,19 @@ import os
 import socket
 import threading
 import time
-
 from math import ceil
 from sys import exc_info, stdout
 from traceback import format_exception
 
-from rucio.db.sqla.constants import ReplicaState
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get
-from rucio.common.utils import chunks
 from rucio.common.exception import DatabaseException
+from rucio.common.utils import chunks
 from rucio.core import monitor, heartbeat
 from rucio.core.replica import list_bad_replicas, get_replicas_state, list_bad_replicas_history, update_bad_replicas_history
 from rucio.core.rule import update_rules_for_lost_replica, update_rules_for_bad_replica
-
+from rucio.db.sqla.constants import ReplicaState
 
 logging.basicConfig(stream=stdout,
                     level=getattr(logging,
@@ -150,6 +151,8 @@ def run(threads=1, bulk=100, once=False):
     """
     Starts up the necromancer threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     if once:
         logging.info('Will run only one iteration in a single threaded mode')

--- a/lib/rucio/daemons/c3po/c3po.py
+++ b/lib/rucio/daemons/c3po/c3po.py
@@ -1,4 +1,5 @@
-# Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2015-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,11 +15,11 @@
 #
 # Authors:
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2015-2017
-# - Vincent Garonne <vgaronne@gmail.com>, 2017-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2017-2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 '''
 Dynamic data placement daemon.
@@ -28,27 +29,29 @@ import logging
 from datetime import datetime
 from hashlib import md5
 from json import dumps
-try:
-    from Queue import Queue
-except ImportError:
-    from queue import Queue
-from six import string_types
 from sys import stdout
-from time import sleep
 from threading import Event, Thread
+from time import sleep
 from uuid import uuid4
 
 from requests import post
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
+from six import string_types
 
+import rucio.db.sqla.util
 from rucio.client import Client
+from rucio.common import exception
 from rucio.common.config import config_get, config_get_options
-from rucio.common.exception import RucioException
 from rucio.common.types import InternalScope
 from rucio.daemons.c3po.collectors.free_space import FreeSpaceCollector
 from rucio.daemons.c3po.collectors.jedi_did import JediDIDCollector
 from rucio.daemons.c3po.collectors.workload import WorkloadCollector
+
+try:
+    from Queue import Queue
+except ImportError:
+    from queue import Queue
 
 logging.basicConfig(stream=stdout,
                     level=getattr(logging,
@@ -256,7 +259,7 @@ def place_replica(once=False,
                         # DO IT!
                         try:
                             add_rule(client, {'scope': did[0].external, 'name': did[1]}, decision.get('source_rse'), decision.get('destination_rse'))
-                        except RucioException as e:
+                        except exception.RucioException as e:
                             logging.debug(e)
 
             w = 0
@@ -289,6 +292,9 @@ def run(once=False,
     """
     Starts up the main thread
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
+
     logging.info('activating C-3PO')
 
     thread_list = []
@@ -327,5 +333,5 @@ def run(once=False,
 
         while len(thread_list) > 0:
             [t.join(timeout=3) for t in thread_list if t and t.isAlive()]
-    except Exception as exception:
-        logging.critical(exception)
+    except Exception as error:
+        logging.critical(error)

--- a/lib/rucio/daemons/conveyor/fts_throttler.py
+++ b/lib/rucio/daemons/conveyor/fts_throttler.py
@@ -1,4 +1,5 @@
-# Copyright 2019 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2019-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +14,11 @@
 # limitations under the License.
 #
 # Authors:
-# - Dilaksun Bavarajan <dilaksun@hotmail.com>, 2019
+# - Dilaksun Bavarajan <dilaksun.bavarajan@cern.ch>, 2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Conveyor FTS Throttler is a daemon that will configure a fts storage's transfer settings
@@ -28,18 +28,20 @@ alleviated by limiting the transfer settings of FTS transfers on the particular 
 """
 from __future__ import division
 
+import datetime
+import json
 import logging
-import sys
-import threading
 import os
 import socket
+import sys
+import threading
 import time
 import traceback
-import json
-import datetime
+
 import requests
 
-
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get
 from rucio.core import heartbeat
 from rucio.transfertool.fts3 import FTS3Transfertool
@@ -437,6 +439,8 @@ def run(once=False, cycle_interval=3600):
     """
     Starts up the conveyer fts throttler thread.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     logging.info('starting throttler thread')
     fts_throttler_thread = threading.Thread(target=fts_throttler, kwargs={'once': once, 'cycle_interval': cycle_interval})

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2013-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,14 +16,15 @@
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2013-2020
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2018
-# - Vincent Garonne <vgaronne@gmail.com>, 2014-2018
-# - Wen Guan <wguan.icedew@gmail.com>, 2014-2016
-# - Martin Barisits <martin.barisits@cern.ch>, 2016-2017
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2018
+# - Wen Guan <wen.guan@cern.ch>, 2014-2016
+# - Martin Barisits <martin.barisits@cern.ch>, 2016-2020
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - maatthias <maatthias@gmail.com>, 2019
+# - Brandon White <bjwhite@fnal.gov>, 2019
+# - Nick Smith <nick.smith@cern.ch>, 2020
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Conveyor is a daemon to manage file transfers.
@@ -40,21 +42,23 @@ import sys
 import threading
 import time
 import traceback
-
 from collections import defaultdict
-try:
-    from ConfigParser import NoOptionError  # py2
-except Exception:
-    from configparser import NoOptionError  # py3
+
 from requests.exceptions import RequestException
 from sqlalchemy.exc import DatabaseError
 
+import rucio.db.sqla.util
 from rucio.common.config import config_get
 from rucio.common.exception import DatabaseException, TransferToolTimeout, TransferToolWrongAnswer
 from rucio.common.utils import chunks
 from rucio.core import heartbeat, transfer as transfer_core, request as request_core
 from rucio.core.monitor import record_timer, record_counter
 from rucio.db.sqla.constants import RequestState, RequestType
+
+try:
+    from ConfigParser import NoOptionError  # py2
+except Exception:
+    from configparser import NoOptionError  # py3
 
 
 logging.basicConfig(stream=sys.stdout,
@@ -179,6 +183,8 @@ def run(once=False, sleep_time=60, activities=None,
     """
     Starts up the conveyer threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException('Database was not updated, daemon won\'t start')
 
     if activity_shares:
 

--- a/lib/rucio/daemons/conveyor/poller_latest.py
+++ b/lib/rucio/daemons/conveyor/poller_latest.py
@@ -1,4 +1,5 @@
-# Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2015-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +14,12 @@
 # limitations under the License.
 #
 # Authors:
-# - Wen Guan <wguan.icedew@gmail.com>, 2015-2016
-# - Vincent Garonne <vgaronne@gmail.com>, 2015-2018
+# - Wen Guan <wen.guan@cern.ch>, 2015-2016
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2015-2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2016-2017
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2018
-#
-# PY3K COMPATIBLE
+# - Thomas Beermann <thomas.beermann@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Conveyor is a daemon to manage file transfers.
@@ -27,19 +28,20 @@ Conveyor is a daemon to manage file transfers.
 import datetime
 import logging
 import os
-import sys
 import socket
+import sys
 import threading
 import time
 import traceback
 
 from requests.exceptions import RequestException
 
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get
 from rucio.core import heartbeat, transfer, request
 from rucio.core.monitor import record_timer, record_counter
 from rucio.db.sqla.constants import FTSState
-
 
 logging.basicConfig(stream=sys.stdout,
                     level=getattr(logging,
@@ -135,6 +137,8 @@ def run(once=False, last_nhours=1, external_hosts=None, fts_wait=1800, total_thr
     """
     Starts up the conveyer threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     if not external_hosts:
         external_hosts = []

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -1,4 +1,5 @@
-# Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2015-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,17 +14,16 @@
 # limitations under the License.
 #
 # Authors:
-# - Wen Guan <wguan.icedew@gmail.com>, 2015-2016
+# - Wen Guan <wen.guan@cern.ch>, 2015-2016
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2015
 # - Martin Barisits <martin.barisits@cern.ch>, 2015-2018
-# - Vincent Garonne <vgaronne@gmail.com>, 2015-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2015-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2018
 # - Robert Illingworth <illingwo@fnal.gov>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Conveyor is a daemon to manage file transfers.
@@ -43,13 +43,14 @@ import traceback
 
 import stomp
 
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.policy import get_policy
 from rucio.core import heartbeat, request
 from rucio.core.monitor import record_counter
 from rucio.core.transfer import set_transfer_update_time
 from rucio.db.sqla.constants import RequestState, FTSCompleteState
-
 
 logging.getLogger("stomp").setLevel(logging.CRITICAL)
 
@@ -291,6 +292,8 @@ def run(once=False, total_threads=1, full_mode=False):
     """
     Starts up the receiver thread
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     logging.info('starting receiver thread')
     threads = [threading.Thread(target=receiver, kwargs={'id': i,

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -1,4 +1,5 @@
-# Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2015-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +14,15 @@
 # limitations under the License.
 #
 # Authors:
-# - Wen Guan <wguan.icedew@gmail.com>, 2015-2016
+# - Wen Guan <wen.guan@cern.ch>, 2015-2016
 # - Martin Barisits <martin.barisits@cern.ch>, 2015-2017
-# - Vincent Garonne <vgaronne@gmail.com>, 2016-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2016-2018
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2017-2020
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2018-2019
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Conveyor stager is a daemon to manage stagein file transfers.
@@ -37,13 +37,10 @@ import sys
 import threading
 import time
 import traceback
-
 from collections import defaultdict
-try:
-    from ConfigParser import NoOptionError  # py2
-except Exception:
-    from configparser import NoOptionError  # py3
 
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get, config_get_bool
 from rucio.core import heartbeat
 from rucio.core.monitor import record_counter, record_timer
@@ -51,6 +48,12 @@ from rucio.core.request import set_requests_state
 from rucio.core.staging import get_stagein_requests_and_source_replicas
 from rucio.daemons.conveyor.common import submit_transfer, bulk_group_transfer, get_conveyor_rses
 from rucio.db.sqla.constants import RequestState
+
+try:
+    from ConfigParser import NoOptionError  # py2
+except Exception:
+    from configparser import NoOptionError  # py3
+
 
 logging.basicConfig(stream=sys.stdout,
                     level=getattr(logging,
@@ -193,6 +196,8 @@ def run(once=False, total_threads=1, group_bulk=1, group_policy='rule', mock=Fal
     """
     Starts up the conveyer threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     if mock:
         logging.info('mock source replicas: enabled')

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2013-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,17 +17,20 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2013-2015
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2019
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2013
-# - Vincent Garonne <vgaronne@gmail.com>, 2014-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2014-2020
-# - Wen Guan <wguan.icedew@gmail.com>, 2014-2016
-# - Tomas Kouba <tomas.kouba@cern.ch>, 2014
-# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2016
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Wen Guan <wen.guan@cern.ch>, 2014-2016
+# - Tomáš Kouba <tomas.kouba@cern.ch>, 2014
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2016
+# - dciangot <diego.ciangottini@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - maatthias <maatthias@gmail.com>, 2019
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
+# - Nick Smith <nick.smith@cern.ch>, 2020
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Conveyor transfer submitter is a daemon to manage non-tape file transfers.
@@ -42,21 +46,25 @@ import sys
 import threading
 import time
 import traceback
-
 from collections import defaultdict
-try:
-    from ConfigParser import NoOptionError  # py2
-except Exception:
-    from configparser import NoOptionError  # py3
-from six import iteritems
-from prometheus_client import Counter
 
+from prometheus_client import Counter
+from six import iteritems
+
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.schema import get_schema_value
 from rucio.core import heartbeat, request as request_core, transfer as transfer_core
 from rucio.core.monitor import record_counter, record_timer
 from rucio.daemons.conveyor.common import submit_transfer, bulk_group_transfer, get_conveyor_rses, USER_ACTIVITY
 from rucio.db.sqla.constants import RequestState
+
+try:
+    from ConfigParser import NoOptionError  # py2
+except Exception:
+    from configparser import NoOptionError  # py3
+
 
 logging.basicConfig(stream=sys.stdout,
                     level=getattr(logging,
@@ -249,6 +257,8 @@ def run(once=False, group_bulk=1, group_policy='rule', mock=False,
     """
     Starts up the conveyer threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     if mock:
         logging.info('mock source replicas: enabled')

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -1,4 +1,5 @@
-# Copyright 2016-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2016-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,17 +14,15 @@
 # limitations under the License.
 #
 # Authors:
-# - Wen Guan <wguan.icedew@gmail.com>, 2016
-# - Vincent Garonne <vgaronne@gmail.com>, 2016-2018
+# - Wen Guan <wen.guan@cern.ch>, 2016
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2016-2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2017
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2018
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
-# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Conveyor throttler is a daemon to manage rucio internal queue.
@@ -40,7 +39,8 @@ import threading
 import time
 import traceback
 
-
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get
 from rucio.common.utils import get_parsed_throttler_mode
 from rucio.core import heartbeat, config as config_core
@@ -126,6 +126,9 @@ def run(once=False, sleep_time=600):
     """
     Starts up the conveyer threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
+
     if once:
         logging.info('running throttler one iteration only')
         throttler(once=True, sleep_time=sleep_time)

--- a/lib/rucio/daemons/follower/follower.py
+++ b/lib/rucio/daemons/follower/follower.py
@@ -1,4 +1,5 @@
-# Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2019-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,21 +14,22 @@
 # limitations under the License.
 #
 # Authors:
-# - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
-#
-# PY3K COMPATIBLE
+# - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 import logging
 import os
 import socket
+import sys
 import threading
 import time
-import sys
 
-from rucio.common.utils import get_thread_with_periodic_running_function
-from rucio.core.heartbeat import live, die, sanity_check
-from rucio.core.did import create_reports
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get
+from rucio.common.utils import get_thread_with_periodic_running_function
+from rucio.core.did import create_reports
+from rucio.core.heartbeat import live, die, sanity_check
 
 graceful_stop = threading.Event()
 
@@ -78,6 +80,9 @@ def run(once=False, threads=1):
     """
     Starts up the follower threads
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
+
     hostname = socket.gethostname()
     sanity_check(executable='rucio-follower', hostname=hostname)
 

--- a/lib/rucio/daemons/hermes/hermes.py
+++ b/lib/rucio/daemons/hermes/hermes.py
@@ -1,4 +1,5 @@
-# Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,12 +16,13 @@
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2014-2018
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2014-2020
-# - Wen Guan <wguan.icedew@gmail.com>, 2014-2015
-# - Vincent Garonne <vgaronne@gmail.com>, 2015-2018
-# - Martin Barisits <martin.barisits@cern.ch>, 2016-2017
+# - Wen Guan <wen.guan@cern.ch>, 2014-2015
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2015-2018
+# - Martin Barisits <martin.barisits@cern.ch>, 2016-2019
 # - Robert Illingworth <illingwo@fnal.gov>, 2018
-#
-# PY3K COMPATIBLE
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Eric Vaandering <ewv@fnal.gov>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 '''
    Hermes is a daemon to deliver messages: to a messagebroker via STOMP, or emails via SMTP.
@@ -36,19 +38,19 @@ import sys
 import threading
 import time
 import traceback
-
 from email.mime.text import MIMEText
-from six import PY2
-from prometheus_client import Counter
-from sqlalchemy.orm.exc import NoResultFound
 
 import stomp
+from prometheus_client import Counter
+from six import PY2
+from sqlalchemy.orm.exc import NoResultFound
 
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get, config_get_int, config_get_bool
 from rucio.core.heartbeat import live, die, sanity_check
 from rucio.core.message import retrieve_messages, delete_messages
 from rucio.core.monitor import record_counter
-
 
 logging.getLogger('requests').setLevel(logging.CRITICAL)
 logging.getLogger('stomp').setLevel(logging.CRITICAL)
@@ -396,6 +398,8 @@ def run(once=False, send_email=True, threads=1, bulk=1000, delay=10, broker_time
     '''
     Starts up the hermes threads.
     '''
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     logging.info('resolving brokers')
 

--- a/lib/rucio/daemons/judge/cleaner.py
+++ b/lib/rucio/daemons/judge/cleaner.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2013-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +22,6 @@
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
 
 """
 Judge-Cleaner is a daemon to clean expired replication rules.
@@ -35,20 +34,20 @@ import sys
 import threading
 import time
 import traceback
-
-
 from copy import deepcopy
 from datetime import datetime, timedelta
-from re import match
 from random import randint
+from re import match
 
 from sqlalchemy.exc import DatabaseError
 
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get
 from rucio.common.exception import DatabaseException, UnsupportedOperation, RuleNotFound
 from rucio.core.heartbeat import live, die, sanity_check
-from rucio.core.rule import delete_rule, get_expired_rules
 from rucio.core.monitor import record_counter
+from rucio.core.rule import delete_rule, get_expired_rules
 from rucio.db.sqla.util import get_db_time
 
 graceful_stop = threading.Event()
@@ -156,6 +155,9 @@ def run(once=False, threads=1):
     """
     Starts up the Judge-Clean threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
+
     client_time, db_time = datetime.utcnow(), get_db_time()
     max_offset = timedelta(hours=1, seconds=10)
     if type(db_time) is datetime:

--- a/lib/rucio/daemons/judge/evaluator.py
+++ b/lib/rucio/daemons/judge/evaluator.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2013-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,8 +23,6 @@
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
 
 """
 Judge-Evaluator is a daemon to re-evaluate and execute replication rules.
@@ -36,21 +35,21 @@ import sys
 import threading
 import time
 import traceback
-
 from datetime import datetime, timedelta
-from re import match
 from random import randint
-from six import iteritems
+from re import match
 
+from six import iteritems
 from sqlalchemy.exc import DatabaseError
 from sqlalchemy.orm.exc import FlushError
 
+import rucio.db.sqla.util
 from rucio.common.config import config_get
 from rucio.common.exception import DatabaseException, DataIdentifierNotFound, ReplicationRuleCreationTemporaryFailed
 from rucio.common.types import InternalScope
 from rucio.core.heartbeat import live, die, sanity_check
-from rucio.core.rule import re_evaluate_did, get_updated_dids, delete_updated_did
 from rucio.core.monitor import record_counter
+from rucio.core.rule import re_evaluate_did, get_updated_dids, delete_updated_did
 
 graceful_stop = threading.Event()
 
@@ -183,6 +182,8 @@ def run(once=False, threads=1):
     """
     Starts up the Judge-Eval threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException('Database was not updated, daemon won\'t start')
 
     executable = 'judge-evaluator'
     hostname = socket.gethostname()

--- a/lib/rucio/daemons/judge/injector.py
+++ b/lib/rucio/daemons/judge/injector.py
@@ -1,4 +1,5 @@
-# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2015-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +21,6 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Eric Vaandering <ewv@fnal.gov>, 2020
-#
-# PY3K COMPATIBLE
 
 """
 Judge-Injector is a daemon to asynchronously create replication rules
@@ -34,20 +33,20 @@ import sys
 import threading
 import time
 import traceback
-
 from copy import deepcopy
 from datetime import datetime, timedelta
-from re import match
 from random import randint
+from re import match
 
 from sqlalchemy.exc import DatabaseError
 
+import rucio.db.sqla.util
 from rucio.common.config import config_get
 from rucio.common.exception import (DatabaseException, RuleNotFound, RSEBlacklisted, RSEWriteBlocked,
                                     ReplicationRuleCreationTemporaryFailed, InsufficientAccountLimit)
 from rucio.core.heartbeat import live, die, sanity_check
-from rucio.core.rule import inject_rule, get_injected_rules, update_rule
 from rucio.core.monitor import record_counter
+from rucio.core.rule import inject_rule, get_injected_rules, update_rule
 
 graceful_stop = threading.Event()
 
@@ -168,6 +167,8 @@ def run(once=False, threads=1):
     """
     Starts up the Judge-Injector threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException('Database was not updated, daemon won\'t start')
 
     executable = 'judge-injector'
     hostname = socket.gethostname()

--- a/lib/rucio/daemons/judge/repairer.py
+++ b/lib/rucio/daemons/judge/repairer.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2013-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,13 +15,12 @@
 #
 # Authors:
 # - Martin Barisits <martin.barisits@cern.ch>, 2013-2016
-# - Vincent Garonne <vgaronne@gmail.com>, 2014-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2014-2015
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Judge-Repairer is a daemon to repair stuck replication rules.
@@ -33,19 +33,20 @@ import sys
 import threading
 import time
 import traceback
-
 from copy import deepcopy
 from datetime import datetime, timedelta
-from re import match
 from random import randint
+from re import match
 
 from sqlalchemy.exc import DatabaseError
 
+import rucio.db.sqla.util
+from rucio.common import exception
 from rucio.common.config import config_get
 from rucio.common.exception import DatabaseException
 from rucio.core.heartbeat import live, die, sanity_check
-from rucio.core.rule import repair_rule, get_stuck_rules
 from rucio.core.monitor import record_counter
+from rucio.core.rule import repair_rule, get_stuck_rules
 
 graceful_stop = threading.Event()
 
@@ -153,6 +154,8 @@ def run(once=False, threads=1):
     """
     Starts up the Judge-Repairer threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     executable = 'judge-repairer'
     hostname = socket.gethostname()

--- a/lib/rucio/daemons/oauthmanager/oauthmanager.py
+++ b/lib/rucio/daemons/oauthmanager/oauthmanager.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2019-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +15,9 @@
 # limitations under the License.
 #
 # Authors:
-#  - Jaroslav Guenther, <jaroslav.guenther@cern.ch>, 2019
-#  - Thomas Beermann <thomas.beermann@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
+# - Thomas Beermann <thomas.beermann@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 OAuth Manager is a daemon which is reponsible for:
@@ -43,13 +43,15 @@ import traceback
 from re import match
 from sys import stdout
 
+from sqlalchemy.exc import DatabaseError
+
+import rucio.db.sqla.util
 from rucio.common.config import config_get
 from rucio.common.exception import DatabaseException
 from rucio.core.authentication import delete_expired_tokens
 from rucio.core.heartbeat import die, live, sanity_check
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core.oidc import delete_expired_oauthrequests, refresh_jwt_tokens
-from sqlalchemy.exc import DatabaseError
 
 logging.basicConfig(stream=stdout,
                     level=getattr(logging,
@@ -184,6 +186,8 @@ def run(once=False, threads=1, loop_rate=300, max_rows=100):
     """
     Starts up the OAuth Manager threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException('Database was not updated, daemon won\'t start')
 
     sanity_check(executable='OAuthManager', hostname=socket.gethostname())
 

--- a/lib/rucio/daemons/reaper/light_reaper.py
+++ b/lib/rucio/daemons/reaper/light_reaper.py
@@ -1,4 +1,5 @@
-# Copyright 2016-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2016-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +14,13 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne <vgaronne@gmail.com>, 2016-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2016-2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 '''
 Light Reaper is a daemon to manage temporary object/file deletion.
@@ -36,6 +36,7 @@ import threading
 import time
 import traceback
 
+import rucio.db.sqla.util
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import (SourceNotFound, DatabaseException, ServiceUnavailable,
                                     RSEAccessDenied, RSENotFound, ResourceTemporaryUnavailable, VONotFound)
@@ -44,9 +45,8 @@ from rucio.core.heartbeat import live, die, sanity_check
 from rucio.core.message import add_message
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.temporary_did import (list_expired_temporary_dids, delete_temporary_dids)
-from rucio.rse import rsemanager as rsemgr
 from rucio.core.vo import list_vos
-
+from rucio.rse import rsemanager as rsemgr
 
 logging.getLogger("requests").setLevel(logging.CRITICAL)
 
@@ -196,6 +196,9 @@ def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None,
     :param vos: VOs on which to look for RSEs. Only used in multi-VO mode.
                 If None, we either use all VOs if run from "def", or the current VO otherwise.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException('Database was not updated, daemon won\'t start')
+
     logging.info('main: starting processes')
 
     multi_vo = config_get_bool('common', 'multi_vo', raise_exception=False, default=False)

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -1,4 +1,5 @@
-# Copyright 2016-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2016-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,17 +14,17 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne <vgaronne@gmail.com>, 2016-2018
-# - Martin Barisits <martin.barisits@cern.ch>, 2016
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2016-2018
+# - Martin Barisits <martin.barisits@cern.ch>, 2016-2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2016-2019
-# - Wen Guan <wguan.icedew@gmail.com>, 2016
+# - Wen Guan <wen.guan@cern.ch>, 2016
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2019
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 '''
 Reaper is a daemon to manage file deletion.
@@ -43,7 +44,7 @@ import threading
 import time
 import traceback
 
-from rucio.db.sqla.constants import ReplicaState
+import rucio.db.sqla.util
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import (SourceNotFound, ServiceUnavailable, RSEAccessDenied,
                                     ReplicaUnAvailable, ResourceTemporaryUnavailable,
@@ -60,8 +61,8 @@ from rucio.core.replica import (list_unlocked_replicas, update_replicas_states,
 from rucio.core.rse import get_rse_attribute, sort_rses, get_rse_name
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.vo import list_vos
+from rucio.db.sqla.constants import ReplicaState
 from rucio.rse import rsemanager as rsemgr
-
 
 logging.getLogger("requests").setLevel(logging.CRITICAL)
 
@@ -366,6 +367,9 @@ def run(total_workers=1, chunk_size=100, threads_per_worker=None, once=False, gr
     :param vos: VOs on which to look for RSEs. Only used in multi-VO mode.
                 If None, we either use all VOs if run from "def", or the current VO otherwise.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException('Database was not updated, daemon won\'t start')
+
     logging.info('main: starting processes')
 
     multi_vo = config_get_bool('common', 'multi_vo', raise_exception=False, default=False)

--- a/lib/rucio/daemons/reaper/reaper2.py
+++ b/lib/rucio/daemons/reaper/reaper2.py
@@ -1,4 +1,5 @@
-# Copyright 2016-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2016-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,8 +28,6 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-#
-# PY3K COMPATIBLE
 
 '''
 Reaper is a daemon to manage file deletion.
@@ -38,23 +37,23 @@ from __future__ import print_function, division
 
 import logging
 import os
-import socket
 import random
+import socket
 import sys
 import threading
 import time
 import traceback
-
+from collections import OrderedDict
 from datetime import datetime, timedelta
 from math import ceil
 from operator import itemgetter
-from collections import OrderedDict
 
 from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 from prometheus_client import Counter
 from sqlalchemy.exc import DatabaseError, IntegrityError
 
+import rucio.db.sqla.util
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import (DatabaseException, RSENotFound, ConfigNotFound,
                                     ReplicaUnAvailable, ReplicaNotFound, ServiceUnavailable,
@@ -72,7 +71,6 @@ from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.rule import get_evaluation_backlog
 from rucio.core.vo import list_vos
 from rucio.rse import rsemanager as rsemgr
-
 
 logging.getLogger("reaper").setLevel(logging.CRITICAL)
 
@@ -616,6 +614,9 @@ def run(threads=1, chunk_size=100, once=False, greedy=False, rses=None, scheme=N
     :param delay_seconds:      The delay to query replicas in BEING_DELETED state.
     :param sleep_time:         Time between two cycles.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException('Database was not updated, daemon won\'t start')
+
     logging.info('main: starting processes')
 
     rses_to_process = get_rses_to_process(rses, include_rses, exclude_rses, vos)

--- a/lib/rucio/daemons/sonar/distribution/distribution_daemon.py
+++ b/lib/rucio/daemons/sonar/distribution/distribution_daemon.py
@@ -1,4 +1,5 @@
-# Copyright 2017-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2017-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +16,9 @@
 # Authors:
 # - Vitjan Zavrtanik <vitjan.zavrtanik@cern.ch>, 2017
 # - Vincent Garonne <vgaronne@gmail.com>, 2017-2018
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Eric Vaandering <ewv@fnal.gov>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Daemon for distributing sonar test files to available RSE's
@@ -31,10 +32,11 @@ import sys
 import threading
 import time
 
+import rucio.db.sqla.util
 from rucio.client.client import Client
+from rucio.common import exception
 from rucio.common.config import config_get
-from rucio.common.exception import (DuplicateRule, InsufficientAccountLimit, ReplicationRuleCreationTemporaryFailed,
-                                    RSEBlacklisted, RSEWriteBlocked)
+from rucio.common.exception import DuplicateRule, InsufficientAccountLimit, RSEBlacklisted, RSEWriteBlocked, ReplicationRuleCreationTemporaryFailed
 
 GRACEFUL_STOP = threading.Event()
 logging.basicConfig(stream=sys.stdout,
@@ -133,6 +135,9 @@ def run():
     """
     Runs the distribution daemon
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
+
     thread = threading.Thread(target=run_distribution, kwargs={})
     thread.start()
     while thread and thread.isAlive():

--- a/lib/rucio/daemons/sonar/sonar/sonar_v3_dev_daemon.py
+++ b/lib/rucio/daemons/sonar/sonar/sonar_v3_dev_daemon.py
@@ -1,4 +1,5 @@
-# Copyright 2017-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2017-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +16,10 @@
 # Authors:
 # - Vitjan Zavrtanik <vitjan.zavrtanik@cern.ch>, 2017
 # - Vincent Garonne <vgaronne@gmail.com>, 2017-2018
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Eric Vaandering <ewv@fnal.gov>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 """
 Daemon for sending Sonar tests to available RSE's.
@@ -34,9 +35,11 @@ import threading
 import time
 
 from requests import ConnectionError
+
+import rucio.db.sqla.util
 from rucio.client.client import Client
 from rucio.common.config import config_get
-from rucio.common.exception import (AccessDenied, DuplicateRule, RSEBlacklisted, RSEWriteBlocked,
+from rucio.common.exception import (AccessDenied, DatabaseException, DuplicateRule, RSEBlacklisted, RSEWriteBlocked,
                                     ReplicationRuleCreationTemporaryFailed, RuleNotFound)
 from rucio.daemons.sonar.sonar.get_current_traffic import get_link_traffic
 
@@ -417,6 +420,9 @@ def run():
     """
     Starts the Sonar thread.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException('Database was not updated, daemon won\'t start')
+
     threads = []
     threads.append(threading.Thread(target=sonar_tests, kwargs={}, name='Sonar_test_v3'))
     for thread in threads:

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -1,4 +1,5 @@
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2013-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,8 +29,6 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Eric Vaandering <ewv@fnal.gov>, 2020
-#
-# PY3K COMPATIBLE
 
 import logging
 import os
@@ -37,21 +36,19 @@ import re
 import socket
 import threading
 import time
-
 from datetime import datetime
 from json import loads
 from math import exp
 from sys import exc_info, stdout
 from traceback import format_exception
 
-
-from rucio.db.sqla.constants import DIDType, SubscriptionState
+import rucio.db.sqla.util
+from rucio.common.config import config_get
 from rucio.common.exception import (DatabaseException, DataIdentifierNotFound, InvalidReplicationRule, DuplicateRule,
                                     RSEBlacklisted, RSEWriteBlocked, InvalidRSEExpression, InsufficientTargetRSEs,
                                     InsufficientAccountLimit, InputValidationError, RSEOverQuota,
                                     ReplicationRuleCreationTemporaryFailed, InvalidRuleWeight,
                                     StagingAreaRuleRequiresLifetime, SubscriptionWrongParameter, SubscriptionNotFound)
-from rucio.common.config import config_get
 from rucio.common.schema import validate_schema
 from rucio.common.utils import chunks
 from rucio.core import monitor, heartbeat
@@ -61,7 +58,7 @@ from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.rse_selector import RSESelector
 from rucio.core.rule import add_rule, list_rules, get_rule
 from rucio.core.subscription import list_subscriptions, update_subscription
-
+from rucio.db.sqla.constants import DIDType, SubscriptionState
 
 logging.basicConfig(stream=stdout,
                     level=getattr(logging,
@@ -469,6 +466,8 @@ def run(threads=1, bulk=100, once=False, sleep_time=60):
     """
     Starts up the transmogrifier threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException('Database was not updated, daemon won\'t start')
 
     if once:
         logging.info('Will run only one iteration in a single threaded mode')

--- a/lib/rucio/daemons/undertaker/undertaker.py
+++ b/lib/rucio/daemons/undertaker/undertaker.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2013-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +17,13 @@
 # - Vincent Garonne <vgaronne@gmail.com>, 2013-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2015
 # - Martin Barisits <martin.barisits@cern.ch>, 2016-2019
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Brandon White <bjwhite@fnal.gov>, 2019-2020
+# - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 '''
 Undertaker is a daemon to manage expired did.
@@ -29,26 +31,26 @@ Undertaker is a daemon to manage expired did.
 
 import logging
 import os
-import sys
 import socket
+import sys
 import threading
 import time
 import traceback
-
 from copy import deepcopy
 from datetime import datetime, timedelta
-from re import match
 from random import randint
+from re import match
 
 from sqlalchemy.exc import DatabaseError
 
+import rucio.db.sqla.util
 from rucio.common.config import config_get
 from rucio.common.exception import DatabaseException, UnsupportedOperation, RuleNotFound
 from rucio.common.types import InternalAccount
 from rucio.common.utils import chunks
+from rucio.core.did import list_expired_dids, delete_dids
 from rucio.core.heartbeat import live, die, sanity_check
 from rucio.core.monitor import record_counter
-from rucio.core.did import list_expired_dids, delete_dids
 
 logging.getLogger("requests").setLevel(logging.CRITICAL)
 
@@ -135,6 +137,9 @@ def run(once=False, total_workers=1, chunk_size=10):
     """
     Starts up the undertaker threads.
     """
+    if rucio.db.sqla.util.is_old_db():
+        raise DatabaseException('Database was not updated, daemon won\'t start')
+
     logging.info('main: starting threads')
     threads = [threading.Thread(target=undertaker, kwargs={'worker_number': i, 'total_workers': total_workers, 'once': once, 'chunk_size': chunk_size}) for i in range(0, total_workers)]
     [t.start() for t in threads]

--- a/lib/rucio/tests/test_abacus_account.py
+++ b/lib/rucio/tests/test_abacus_account.py
@@ -1,4 +1,5 @@
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +21,6 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
 
 import os
 import unittest
@@ -45,30 +44,31 @@ from rucio.tests.common import file_generator
 
 
 class TestAbacusAccount(unittest.TestCase):
+    rse = 'MOCK4'
+    file_sizes = 2
+    vo = {}
 
-    def setUp(self):
-        self.rse = 'MOCK4'
-        self.file_sizes = 2
-        self.upload_client = UploadClient()
-        self.account_client = AccountClient()
-        self.session = get_session()
+    @classmethod
+    def setUpClass(cls):
+        cls.upload_client = UploadClient()
+        cls.account_client = AccountClient()
+        cls.session = get_session()
 
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
-        else:
-            self.vo = {}
+            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
 
-        self.account = InternalAccount('root', **self.vo)
-        self.scope = InternalScope('mock', **self.vo)
-        self.rse_id = get_rse_id(self.rse, session=self.session, **self.vo)
+        cls.account = InternalAccount('root', **cls.vo)
+        cls.scope = InternalScope('mock', **cls.vo)
+        cls.rse_id = get_rse_id(cls.rse, session=cls.session, **cls.vo)
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         undertaker.run(once=True)
         cleaner.run(once=True)
-        if self.vo:
-            reaper.run(once=True, include_rses='vo=%s&(%s)' % (self.vo['vo'], self.rse), greedy=True)
+        if cls.vo:
+            reaper.run(once=True, include_rses='vo=%s&(%s)' % (cls.vo['vo'], cls.rse), greedy=True)
         else:
-            reaper.run(once=True, include_rses=self.rse, greedy=True)
+            reaper.run(once=True, include_rses=cls.rse, greedy=True)
 
     def test_abacus_account(self):
         """ ABACUS (ACCOUNT): Test update of account usage """

--- a/lib/rucio/tests/test_abacus_collection_replica.py
+++ b/lib/rucio/tests/test_abacus_collection_replica.py
@@ -1,4 +1,5 @@
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +19,6 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
 
 import os
 import unittest
@@ -42,33 +41,34 @@ from rucio.tests.common import file_generator
 
 
 class TestAbacusCollectionReplica(unittest.TestCase):
+    account = 'root'
+    scope = 'mock'
+    rse = 'MOCK5'
+    file_sizes = 2
+    vo = {}
 
-    def setUp(self):
-        self.account = 'root'
-        self.scope = 'mock'
-        self.rse = 'MOCK5'
-        self.file_sizes = 2
-        self.dataset = 'dataset_%s' % generate_uuid()
+    @classmethod
+    def setUpClass(cls):
+        cls.dataset = 'dataset_%s' % generate_uuid()
 
-        self.rule_client = RuleClient()
-        self.did_client = DIDClient()
-        self.replica_client = ReplicaClient()
-        self.upload_client = UploadClient()
+        cls.rule_client = RuleClient()
+        cls.did_client = DIDClient()
+        cls.replica_client = ReplicaClient()
+        cls.upload_client = UploadClient()
 
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
-        else:
-            self.vo = {}
+            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
 
-        self.rse_id = get_rse_id(rse=self.rse, **self.vo)
+        cls.rse_id = get_rse_id(rse=cls.rse, **cls.vo)
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         undertaker.run(once=True)
         cleaner.run(once=True)
-        if self.vo:
-            reaper.run(once=True, include_rses='vo=%s&(%s)' % (self.vo['vo'], self.rse), greedy=True)
+        if cls.vo:
+            reaper.run(once=True, include_rses='vo=%s&(%s)' % (cls.vo['vo'], cls.rse), greedy=True)
         else:
-            reaper.run(once=True, include_rses=self.rse, greedy=True)
+            reaper.run(once=True, include_rses=cls.rse, greedy=True)
 
     def test_abacus_collection_replica(self):
         """ ABACUS (COLLECTION REPLICA): Test update of collection replica. """

--- a/lib/rucio/tests/test_abacus_rse.py
+++ b/lib/rucio/tests/test_abacus_rse.py
@@ -1,4 +1,5 @@
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,8 +20,6 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
 
 import os
 import unittest
@@ -39,29 +38,30 @@ from rucio.tests.common import file_generator
 
 
 class TestAbacusRSE(unittest.TestCase):
+    account = 'root'
+    scope = 'mock'
+    rse = 'MOCK4'
+    file_sizes = 2
+    vo = {}
 
-    def setUp(self):
-        self.account = 'root'
-        self.scope = 'mock'
-        self.rse = 'MOCK4'
-        self.file_sizes = 2
-        self.upload_client = UploadClient()
-        self.session = get_session()
+    @classmethod
+    def setUpClass(cls):
+        cls.upload_client = UploadClient()
+        cls.session = get_session()
 
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
-        else:
-            self.vo = {}
+            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
 
-        self.rse_id = get_rse_id(self.rse, session=self.session, **self.vo)
+        cls.rse_id = get_rse_id(cls.rse, session=cls.session, **cls.vo)
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         undertaker.run(once=True)
         cleaner.run(once=True)
-        if self.vo:
-            reaper.run(once=True, include_rses='vo=%s&(%s)' % (self.vo['vo'], self.rse), greedy=True)
+        if cls.vo:
+            reaper.run(once=True, include_rses='vo=%s&(%s)' % (cls.vo['vo'], cls.rse), greedy=True)
         else:
-            reaper.run(once=True, include_rses=self.rse, greedy=True)
+            reaper.run(once=True, include_rses=cls.rse, greedy=True)
 
     def test_abacus_rse(self):
         """ ABACUS (RSE): Test update of RSE usage. """

--- a/lib/rucio/tests/test_daemons.py
+++ b/lib/rucio/tests/test_daemons.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+#
+# PY3K COMPATIBLE
+
+import sys
+
+import pytest
+
+import rucio.db.sqla.util
+from rucio.common import exception
+from rucio.daemons.abacus import account, collection_replica, rse
+from rucio.daemons.atropos import atropos
+from rucio.daemons.automatix import automatix
+from rucio.daemons.badreplicas import minos, minos_temporary_expiration, necromancer
+from rucio.daemons.c3po import c3po
+from rucio.daemons.cache import consumer
+from rucio.daemons.conveyor import finisher, fts_throttler, poller, poller_latest, receiver, stager, submitter, throttler
+from rucio.daemons.follower import follower
+from rucio.daemons.hermes import hermes, hermes2
+from rucio.daemons.judge import cleaner, evaluator, injector, repairer
+from rucio.daemons.oauthmanager import oauthmanager
+from rucio.daemons.reaper import dark_reaper, light_reaper, reaper, reaper2
+from rucio.daemons.replicarecoverer import suspicious_replica_recoverer
+from rucio.daemons.sonar.distribution import distribution_daemon
+from rucio.daemons.tracer import kronos
+from rucio.daemons.transmogrifier import transmogrifier
+from rucio.daemons.undertaker import undertaker
+
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
+
+
+DAEMONS = [
+    account,
+    collection_replica,
+    rse,
+    atropos,
+    automatix,
+    minos,
+    minos_temporary_expiration,
+    necromancer,
+    c3po,
+    consumer,
+    finisher,
+    fts_throttler,
+    poller,
+    poller_latest,
+    receiver,
+    stager,
+    submitter,
+    throttler,
+    follower,
+    hermes,
+    hermes2,
+    cleaner,
+    evaluator,
+    injector,
+    repairer,
+    oauthmanager,
+    dark_reaper,
+    light_reaper,
+    reaper,
+    reaper2,
+    suspicious_replica_recoverer,
+    distribution_daemon,
+    # sonar_v3_dev_daemon,  -- lib/rucio/common/config.py:55: NoSectionError: No section: 'sonar'
+    kronos,
+    transmogrifier,
+    undertaker,
+]
+
+
+@pytest.mark.parametrize('daemon', DAEMONS)
+@mock.patch('rucio.db.sqla.util.is_old_db')
+def test_fail_on_old_database(mock_is_old_db, daemon):
+    """ DAEMON: Test daemon failure on old database """
+    mock_is_old_db.return_value = True
+    assert rucio.db.sqla.util.is_old_db() is True
+
+    with pytest.raises(exception.DatabaseException, match='Database was not updated, daemon won\'t start'):
+        daemon.run()
+
+    assert mock_is_old_db.call_count > 1

--- a/tools/add_header
+++ b/tools/add_header
@@ -61,6 +61,7 @@ author_map = {
     ("Fernando López", "<fernando.e.lopez@gmail.com>"): ("Fernando López", "<felopez@cern.ch>"),
     ("Lister", "<andrew.lister@stfc.ac.uk>"): ("Andrew Lister", "<andrew.lister@stfc.ac.uk>"),
     ("javor", "<33832672+TomasJavurek@users.noreply.github.com>"): ("Tomas Javurek", "<tomas.javurek@cern.ch>"),
+    ("cserf", "<cedric.serfon@cern.ch>"): ("Cedric Serfon", "<cedric.serfon@cern.ch>"),
 }
 
 

--- a/tools/alembic_migration.sh
+++ b/tools/alembic_migration.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2020 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+
+set -euo pipefail
+IFS=$'\n\t'
+
+echo "Downgrading the DB to base"
+alembic downgrade base
+
+echo "Check if is_old_db function is returning false after the full downgrade (tests it without alembic)"
+PYTHONPATH=lib python -c 'import sys; import rucio.db.sqla.util; sys.exit(1 if rucio.db.sqla.util.is_old_db() else 0);'
+
+echo "Updating the DB to head-1"
+alembic upgrade head-1
+
+echo "Check if is_old_db function is returning true before the full upgrade"
+PYTHONPATH=lib python -c 'import sys; import rucio.db.sqla.util; sys.exit(0 if rucio.db.sqla.util.is_old_db() else 1);'
+
+echo "Upgrading the DB to head"
+alembic upgrade head
+
+echo "Check if is_old_db function returns false after the full upgrade"
+PYTHONPATH=lib python -c 'import sys; import rucio.db.sqla.util; sys.exit(1 if rucio.db.sqla.util.is_old_db() else 0);'

--- a/tools/run_multi_vo_tests_docker.sh
+++ b/tools/run_multi_vo_tests_docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2017-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -72,14 +72,9 @@ if [ -f /tmp/rucio.db ]; then
 fi
 
 echo 'Running full alembic migration'
-alembic -c /opt/rucio/etc/alembic.ini downgrade base
+ALEMBIC_CONFIG="/opt/rucio/etc/alembic.ini" tools/alembic_migration.sh
 if [ $? != 0 ]; then
-    echo 'Failed to downgrade the database!'
-    exit 1
-fi
-alembic -c /opt/rucio/etc/alembic.ini upgrade head
-if [ $? != 0 ]; then
-    echo 'Failed to upgrade the database!'
+    echo 'Failed to run alembic migration!'
     exit 1
 fi
 

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -117,15 +117,10 @@ fi
 
 if test ${alembic}; then
     echo 'Running full alembic migration'
-    alembic downgrade base
+    tools/alembic_migration.sh
     if [ $? != 0 ]; then
-        echo 'Failed to downgrade the database!'
-        exit
-    fi
-    alembic upgrade head
-    if [ $? != 0 ]; then
-        echo 'Failed to upgrade the database!'
-        exit
+        echo 'Failed to run alembic migration!'
+        exit 1
     fi
 fi
 

--- a/tools/run_tests_docker.sh
+++ b/tools/run_tests_docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2017-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -92,15 +92,10 @@ if [ -f /tmp/rucio.db ]; then
     chmod 777 /tmp/rucio.db
 fi
 
-echo 'Running full alembic migration'
-alembic -c /opt/rucio/etc/alembic.ini downgrade base
+echo "Running full alembic migration"
+ALEMBIC_CONFIG="/opt/rucio/etc/alembic.ini" tools/alembic_migration.sh
 if [ $? != 0 ]; then
-    echo 'Failed to downgrade the database!'
-    exit 1
-fi
-alembic -c /opt/rucio/etc/alembic.ini upgrade head
-if [ $? != 0 ]; then
-    echo 'Failed to upgrade the database!'
+    echo 'Failed to run alembic migration!'
     exit 1
 fi
 


### PR DESCRIPTION
Add is_old_db method to test for an old alembic revision in the database.
Move alembic migration to tools/alembic_migration.sh.
Add is_old_db test in alembic_migration.sh.
Add startup tests for old DB in all daemons.
Add test_daemons.py for testing all daemons on that behavior.