### PR TITLE
core: fix long parameter in dids/search REST #3762

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -47,6 +47,7 @@ Individual contributors to the source code
 - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 - Rob Barnsley <R.Barnsley@skatelescope.org>, 2020
+- Alan Malta Rodrigues <alan.malta@cern.ch>, 2020
 
 Organisations employing contributors
 ------------------------------------

--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -68,14 +68,13 @@ class DIDClient(BaseClient):
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), 'dids', 'search'])
         payload = {}
-        if long:
-            payload['long'] = 1
 
         for k, v in list(filters.items()):
             if k in ('created_before', 'created_after'):
                 payload[k] = date_to_str(v)
             else:
                 payload[k] = v
+        payload['long'] = long
         payload['type'] = type
         payload['recursive'] = recursive
 
@@ -101,14 +100,13 @@ class DIDClient(BaseClient):
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), 'dids', 'search_extended'])
         payload = {}
-        if long:
-            payload['long'] = 1
 
         for k, v in list(filters.items()):
             if k in ('created_before', 'created_after'):
                 payload[k] = date_to_str(v)
             else:
                 payload[k] = v
+        payload['long'] = long
         payload['type'] = type
         payload['recursive'] = recursive
 

--- a/lib/rucio/web/rest/flaskapi/v1/did.py
+++ b/lib/rucio/web/rest/flaskapi/v1/did.py
@@ -170,7 +170,7 @@ class Search(MethodView):
             elif k == 'limit':
                 limit = v[0]
             elif k == 'long':
-                long = v == '1'
+                long = v == 'True'
             elif k == 'recursive':
                 recursive = v == 'True'
             else:
@@ -252,7 +252,7 @@ class SearchExtended(MethodView):
             elif k == 'limit':
                 limit = v[0]
             elif k == 'long':
-                long = v == '1'
+                long = v == 'True'
             elif k == 'recursive':
                 recursive = v == 'True'
             else:

--- a/lib/rucio/web/rest/webpy/v1/did.py
+++ b/lib/rucio/web/rest/webpy/v1/did.py
@@ -151,7 +151,7 @@ class Search(RucioController):
                 elif k == 'limit':
                     limit = v[0]
                 elif k == 'long':
-                    long = v[0] == '1'
+                    long = v[0] == 'True'
                 elif k == 'recursive':
                     recursive = v[0] == 'True'
                 else:
@@ -201,7 +201,7 @@ class SearchExtended(RucioController):
                 elif k == 'limit':
                     limit = v[0]
                 elif k == 'long':
-                    long = v[0] == '1'
+                    long = v[0] == 'True'
                 elif k == 'recursive':
                     recursive = v[0] == 'True'
                 else:


### PR DESCRIPTION
Patch: Properly deal with the `long` parameter in the `dids/search` and `dids/search_extended` RESTful APIs (it expects a boolean, not 1 | 0).