### PR TITLE
Clients, bug: explicitly sort protocols by scheme, Fixes #3854

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -561,13 +561,13 @@ def info_rse(args):
         print('  ' + attribute + ': ' + str(attributes[attribute]))
     print('Protocols:')
     print('==========')
-    for protocol in sorted(rseinfo['protocols']):
+    for protocol in sorted(rseinfo['protocols'], key=lambda x: x['scheme']):
         print('  ' + protocol['scheme'])
         for item in sorted(protocol):
             print('    ' + item + ': ' + str(protocol[item]))
     print('Usage:')
     print('======')
-    for elem in sorted(usage):
+    for elem in sorted(usage, key=lambda x: x['source']):
         print('  ' + elem['source'])
         for item in sorted(elem):
             print('    ' + item + ': ' + str(elem[item]))


### PR DESCRIPTION
Explicitly sort protocols by scheme
------------------

When sorting the RSE protocols for the CLI to print, sort them by the value of `'scheme'` to prevent the error `'<' not supported between instances of 'dict' and 'dict'` that was occurring when simply sorting the dicts directly.
