### PR TITLE
Testing: Add COPY_AUTOTEST_LOGS option

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,15 +101,19 @@ There is also a local shell script to run the same autotests: :code:`tools/run_a
 
 By default the tool uses 3 worker processes to run all tests that are defined in :code:`etc/docker/test/matrix.yml`. Feel free to modify the matrix to your needs, but be sure to not unintentionally commit your changes to it. The tests run at most 6 hours - after that a TimeoutError will be raised, causing the script to fail. Running the autotests like this can be parameterized with environment variables as follows:
 
+* :code:`USE_PODMAN` 0/1 (default: depends on whether the docker command points to podman)
+   Use podman and therefore pods to run the tests.
 * :code:`PARALLEL_AUTOTESTS` 0/1 (default: 1)
    1 enables multiple processes to run autotests and 0 disables it.
-   When enabled, logs of the running autotests will be written to the .autotest directory created in the working directory. Otherwise the log output will be written to the console (stderr).
+   When enabled, logs of the running autotests will be written to the :code:`.autotest` directory created in the working directory. Otherwise the log output will be written to the console (stderr).
 
    *Note that when tests are not running in parallel mode, the test run will always fail fast.*
 * :code:`PARALLEL_AUTOTESTS_PROCNUM` (1,) (default: 3)
    Specifies the number of processes to run and therefor the concurrently run autotests. 3 will usually result in more than 8 GB RAM usage and a fair amount of load on the PC.
 * :code:`PARALLEL_AUTOTESTS_FAILFAST` 0/1 (default: 0)
    Will abort the parallel run of autotests as soon as possible after at least one autotest failed. Enabling this will leave containers running in case of a failure even on podman.
+* :code:`COPY_AUTOTEST_LOGS` 0/1 (default: 0)
+   Copies :code:`/var/log` from the rucio container into the :code:`.autotest` directory after the test run. Each test case will have it's specific naming as with the logs from the parallel run above.
 
 
 Human Review

--- a/tools/run_autotests.sh
+++ b/tools/run_autotests.sh
@@ -19,9 +19,12 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-if [ -x /usr/bin/podman -a ! -x /usr/bin/docker ] || grep -q /usr/bin/podman /usr/bin/docker; then
-    echo "Detected podman environment"
-    export USE_PODMAN=1
+USE_PODMAN=${USE_PODMAN-}
+if [ -z "$USE_PODMAN" ]; then
+    if [ -x /usr/bin/podman -a ! -x /usr/bin/docker ] || grep -q /usr/bin/podman /usr/bin/docker; then
+        echo "Detected podman environment"
+        export USE_PODMAN=1
+    fi
 fi
 
 PARALLEL_AUTOTESTS=${PARALLEL_AUTOTESTS-}


### PR DESCRIPTION
Adds COPY_AUTOTEST_LOGS option.

`COPY_AUTOTEST_LOGS` 0/1 (default: 0)
Copies `/var/log` from the rucio container into the `.autotest` directory after the test run. Each test case will have it's specific naming as with the logs created by the parallel run.