### PR TITLE
Core & Internals: support policy packages for multi-VO Rucio #3542

### DIFF
--- a/lib/rucio/api/account.py
+++ b/lib/rucio/api/account.py
@@ -43,7 +43,7 @@ def add_account(account, type, email, issuer, vo='def'):
 
     """
 
-    validate_schema(name='account', obj=account)
+    validate_schema(name='account', obj=account, vo=vo)
 
     kwargs = {'account': account, 'type': type}
     if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_account', kwargs=kwargs):
@@ -97,7 +97,7 @@ def update_account(account, key, value, issuer='root', vo='def'):
     :param issuer: The issuer account
     :param vo: The VO to act on.
     """
-    validate_schema(name='account', obj=account)
+    validate_schema(name='account', obj=account, vo=vo)
     kwargs = {}
     if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='update_account', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not change %s  of the account' % (issuer, key))
@@ -180,8 +180,8 @@ def add_account_attribute(key, value, account, issuer, vo='def'):
     :param issuer: The issuer account.
     :param vo: The VO to act on.
     """
-    validate_schema(name='account_attribute', obj=key)
-    validate_schema(name='account_attribute', obj=value)
+    validate_schema(name='account_attribute', obj=key, vo=vo)
+    validate_schema(name='account_attribute', obj=value, vo=vo)
 
     kwargs = {'account': account, 'key': key, 'value': value}
     if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_attribute', kwargs=kwargs):

--- a/lib/rucio/api/did.py
+++ b/lib/rucio/api/did.py
@@ -51,7 +51,7 @@ def list_dids(scope, filters, type='collection', ignore_case=False, limit=None, 
     :param recursive: Recursively list DIDs content.
     :param vo: The VO to act on.
     """
-    validate_schema(name='did_filters', obj=filters)
+    validate_schema(name='did_filters', obj=filters, vo=vo)
 
     scope = InternalScope(scope, vo=vo)
 
@@ -80,7 +80,7 @@ def list_dids_extended(scope, filters, type='collection', ignore_case=False, lim
     :param long: Long format option to display more information for each DID.
     :param recursive: Recursively list DIDs content.
     """
-    validate_schema(name='did_filters', obj=filters)
+    validate_schema(name='did_filters', obj=filters, vo=vo)
     scope = InternalScope(scope, vo=vo)
 
     if 'account' in filters:
@@ -113,9 +113,9 @@ def add_did(scope, name, type, issuer, account=None, statuses={}, meta={}, rules
     :param vo: The VO to act on.
     """
     v_did = {'name': name, 'type': type.upper(), 'scope': scope}
-    validate_schema(name='did', obj=v_did)
-    validate_schema(name='dids', obj=dids)
-    validate_schema(name='rse', obj=rse)
+    validate_schema(name='did', obj=v_did, vo=vo)
+    validate_schema(name='dids', obj=dids, vo=vo)
+    validate_schema(name='rse', obj=rse, vo=vo)
     kwargs = {'scope': scope, 'name': name, 'type': type, 'issuer': issuer, 'account': account, 'statuses': statuses, 'meta': meta, 'rules': rules, 'lifetime': lifetime}
     if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_did', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not add data identifier to scope %s' % (issuer, scope))
@@ -191,7 +191,7 @@ def attach_dids(scope, name, attachment, issuer, vo='def'):
     :param issuer: The issuer account.
     :param vo: The VO to act on.
     """
-    validate_schema(name='attachment', obj=attachment)
+    validate_schema(name='attachment', obj=attachment, vo=vo)
 
     rse_id = None
     if 'rse' in attachment:
@@ -231,7 +231,7 @@ def attach_dids_to_dids(attachments, issuer, ignore_duplicate=False, vo='def'):
     :param ignore_duplicate: If True, ignore duplicate entries.
     :param vo: The VO to act on.
     """
-    validate_schema(name='attachments', obj=attachments)
+    validate_schema(name='attachments', obj=attachments, vo=vo)
 
     for a in attachments:
         if 'rse' in a:
@@ -443,7 +443,7 @@ def get_metadata_bulk(dids, vo='def', session=None):
     :param session: The database session in use.
     """
 
-    validate_schema(name='dids', obj=dids)
+    validate_schema(name='dids', obj=dids, vo=vo)
     for entry in dids:
         entry['scope'] = InternalScope(entry['scope'], vo=vo)
     meta = did.get_metadata_bulk(dids)
@@ -553,7 +553,7 @@ def resurrect(dids, issuer, vo='def'):
     kwargs = {'issuer': issuer}
     if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='resurrect', kwargs=kwargs):
         raise rucio.common.exception.AccessDenied('Account %s can not resurrect data identifiers' % (issuer))
-    validate_schema(name='dids', obj=dids)
+    validate_schema(name='dids', obj=dids, vo=vo)
 
     for d in dids:
         d['scope'] = InternalScope(d['scope'], vo=vo)

--- a/lib/rucio/api/importer.py
+++ b/lib/rucio/api/importer.py
@@ -28,7 +28,7 @@ def import_data(data, issuer, vo='def'):
     :param vo: the VO of the issuer.
     """
     kwargs = {'issuer': issuer}
-    validate_schema(name='import', obj=data)
+    validate_schema(name='import', obj=data, vo=vo)
     if not permission.has_permission(issuer=issuer, vo=vo, action='import', kwargs=kwargs):
         raise exception.AccessDenied('Account %s can not import data' % issuer)
 

--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -162,7 +162,7 @@ def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
     :param issuer: The issuer account.
     :param vo: The VO to act on.
     """
-    validate_schema(name='r_dids', obj=dids)
+    validate_schema(name='r_dids', obj=dids, vo=vo)
 
     # Allow selected authenticated users to retrieve signed URLs.
     # Unauthenticated users, or permission-less users will get the raw URL without the signature.
@@ -220,7 +220,7 @@ def add_replicas(rse, files, issuer, ignore_availability=False, vo='def'):
     """
     for v_file in files:
         v_file.update({"type": "FILE"})  # Make sure DIDs are identified as files for checking
-    validate_schema(name='dids', obj=files)
+    validate_schema(name='dids', obj=files, vo=vo)
 
     rse_id = get_rse_id(rse=rse, vo=vo)
 
@@ -251,7 +251,7 @@ def delete_replicas(rse, files, issuer, ignore_availability=False, vo='def'):
 
     :returns: True is successful, False otherwise
     """
-    validate_schema(name='r_dids', obj=files)
+    validate_schema(name='r_dids', obj=files, vo=vo)
 
     rse_id = get_rse_id(rse=rse, vo=vo)
 
@@ -278,7 +278,7 @@ def update_replicas_states(rse, files, issuer, vo='def'):
     """
     for v_file in files:
         v_file.update({"type": "FILE"})  # Make sure DIDs are identified as files for checking
-    validate_schema(name='dids', obj=files)
+    validate_schema(name='dids', obj=files, vo=vo)
 
     rse_id = get_rse_id(rse=rse, vo=vo)
 
@@ -321,7 +321,7 @@ def list_dataset_replicas_bulk(dids, vo='def'):
     :returns: A list of dict dataset replicas
     """
 
-    validate_schema(name='dids', obj=dids)
+    validate_schema(name='dids', obj=dids, vo=vo)
     names_by_scope = dict()
     for d in dids:
         if d['scope'] in names_by_scope:

--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -61,7 +61,7 @@ def add_rse(rse, issuer, vo='def', deterministic=True, volatile=False, city=None
     :param ASN: Access service network.
     :param availability: Availability.
     """
-    validate_schema(name='rse', obj=rse)
+    validate_schema(name='rse', obj=rse, vo=vo)
     kwargs = {'rse': rse}
     if not permission.has_permission(issuer=issuer, vo=vo, action='add_rse', kwargs=kwargs):
         raise exception.AccessDenied('Account %s can not add RSE' % (issuer))

--- a/lib/rucio/api/rule.py
+++ b/lib/rucio/api/rule.py
@@ -69,7 +69,7 @@ def add_replication_rule(dids, copies, rse_expression, weight, lifetime, groupin
               'ask_approval': ask_approval, 'asynchronous': asynchronous, 'priority': priority, 'split_container': split_container,
               'meta': meta}
 
-    validate_schema(name='rule', obj=kwargs)
+    validate_schema(name='rule', obj=kwargs, vo=vo)
 
     if not has_permission(issuer=issuer, vo=vo, action='add_rule', kwargs=kwargs):
         raise AccessDenied('Account %s can not add replication rule' % (issuer))

--- a/lib/rucio/api/scope.py
+++ b/lib/rucio/api/scope.py
@@ -51,7 +51,7 @@ def add_scope(scope, account, issuer, vo='def'):
     :param vo: The VO to act on.
     """
 
-    validate_schema(name='scope', obj=scope)
+    validate_schema(name='scope', obj=scope, vo=vo)
 
     kwargs = {'scope': scope, 'account': account}
     if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_scope', kwargs=kwargs):

--- a/lib/rucio/api/subscription.py
+++ b/lib/rucio/api/subscription.py
@@ -64,13 +64,13 @@ def add_subscription(name, account, filter, replication_rules, comments, lifetim
         if filter:
             if not isinstance(filter, dict):
                 raise TypeError('filter should be a dict')
-            validate_schema(name='subscription_filter', obj=filter)
+            validate_schema(name='subscription_filter', obj=filter, vo=vo)
         if replication_rules:
             if not isinstance(replication_rules, list):
                 raise TypeError('replication_rules should be a list')
             else:
                 for rule in replication_rules:
-                    validate_schema(name='activity', obj=rule.get('activity', 'default'))
+                    validate_schema(name='activity', obj=rule.get('activity', 'default'), vo=vo)
         else:
             raise InvalidObject('You must specify a rule')
     except ValueError as error:
@@ -114,13 +114,13 @@ def update_subscription(name, account, metadata=None, issuer=None, vo='def'):
         if 'filter' in metadata and metadata['filter']:
             if not isinstance(metadata['filter'], dict):
                 raise TypeError('filter should be a dict')
-            validate_schema(name='subscription_filter', obj=metadata['filter'])
+            validate_schema(name='subscription_filter', obj=metadata['filter'], vo=vo)
         if 'replication_rules' in metadata and metadata['replication_rules']:
             if not isinstance(metadata['replication_rules'], list):
                 raise TypeError('replication_rules should be a list')
             else:
                 for rule in metadata['replication_rules']:
-                    validate_schema(name='activity', obj=rule.get('activity', 'default'))
+                    validate_schema(name='activity', obj=rule.get('activity', 'default'), vo=vo)
     except ValueError as error:
         raise TypeError(error)
 

--- a/lib/rucio/api/vo.py
+++ b/lib/rucio/api/vo.py
@@ -37,7 +37,7 @@ def add_vo(new_vo, issuer, description=None, email=None, vo='def'):
     :param vo: The vo of the user issuing the command.
     '''
 
-    validate_schema('vo', new_vo)
+    validate_schema('vo', new_vo, vo=vo)
 
     kwargs = {}
     if not has_permission(issuer=issuer, action='add_vo', kwargs=kwargs, vo=vo):

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -33,15 +33,14 @@ from dogpile.cache.api import NoValue
 from hashlib import sha256
 from six import add_metaclass
 
-from rucio.common import schema
 from rucio.common.config import config_get
 from rucio.common.exception import InvalidRSEExpression, RSEBlacklisted
 from rucio.core.rse import list_rses, get_rses_with_attribute, get_rse_attribute
 from rucio.db.sqla.session import transactional_session
 
 
-DEFAULT_RSE_ATTRIBUTE = schema.get_schema_value('DEFAULT_RSE_ATTRIBUTE')['pattern']
-RSE_ATTRIBUTE = schema.get_schema_value('RSE_ATTRIBUTE')['pattern']
+DEFAULT_RSE_ATTRIBUTE = r'([A-Z0-9]+([_-][A-Z0-9]+)*)'
+RSE_ATTRIBUTE = r'([A-Za-z0-9\._-]+[=<>][A-Za-z0-9_-]+)'
 PRIMITIVE = r'(\(*(%s|%s|%s)\)*)' % (RSE_ATTRIBUTE, DEFAULT_RSE_ATTRIBUTE, r'\*')
 UNION = r'(\|%s)' % (PRIMITIVE)
 INTERSECTION = r'(\&%s)' % (PRIMITIVE)

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -1300,7 +1300,7 @@ def update_rule(rule_id, options, session=None):
                 rule.source_replica_expression = options['source_replica_expression']
 
             if key == 'activity':
-                validate_schema('activity', options['activity'])
+                validate_schema('activity', options['activity'], vo=rule.account.vo)
                 rule.activity = options['activity']
                 # Cancel transfers and re-submit them:
                 for lock in session.query(models.ReplicaLock).filter_by(rule_id=rule.id, state=LockState.REPLICATING).all():

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -308,7 +308,7 @@ def transmogrifier(bulk=5, once=False, sleep_time=60):
                                     copies = int(rule_dict['copies'])
                                     activity = rule_dict.get('activity', 'User Subscriptions')
                                     try:
-                                        validate_schema(name='activity', obj=activity)
+                                        validate_schema(name='activity', obj=activity, vo=account.vo)
                                     except InputValidationError as error:
                                         logging.error(prepend_str + 'Error validating the activity %s' % (str(error)))
                                         activity = 'User Subscriptions'

--- a/lib/rucio/web/rest/flaskapi/v1/archive.py
+++ b/lib/rucio/web/rest/flaskapi/v1/archive.py
@@ -52,7 +52,7 @@ class Archive(MethodView):
         :status 500: Internal Error.
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(vo):
                 for file in list_archive_content(scope=scope, name=name, vo=vo):

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -96,17 +96,18 @@ def check_accept_header_wrapper_flask(supported_content_types):
     return wrapper
 
 
-def parse_scope_name(scope_name):
+def parse_scope_name(scope_name, vo):
     """
     Parses the given scope_name according to the schema's
     SCOPE_NAME_REGEXP and returns a (scope, name) tuple.
 
     :param scope_name: the scope_name string to be parsed.
+    :param vo: the vo currently in use.
     :raises ValueError: when scope_name could not be parsed.
     :returns: a (scope, name) tuple.
     """
     # why again does that regex start with a slash?
-    scope_name = re.match(get_schema_value('SCOPE_NAME_REGEXP'), '/' + scope_name)
+    scope_name = re.match(get_schema_value('SCOPE_NAME_REGEXP', vo), '/' + scope_name)
     if scope_name is None:
         raise ValueError('cannot parse scope and name')
     return scope_name.group(1, 2)

--- a/lib/rucio/web/rest/flaskapi/v1/did.py
+++ b/lib/rucio/web/rest/flaskapi/v1/did.py
@@ -427,7 +427,7 @@ class DIDs(MethodView):
         :returns: Dictionary with DID metadata
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
             dynamic = 'dynamic' in request.args
             did = get_did(scope=scope, name=name, dynamic=dynamic, vo=request.environ.get('vo'))
             return Response(render_json(**did), content_type='application/json')
@@ -478,7 +478,7 @@ class DIDs(MethodView):
         :status 500: Database Exception
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:
@@ -556,7 +556,7 @@ class DIDs(MethodView):
         :status 500: Database Exception
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:
@@ -625,7 +625,7 @@ class Attachment(MethodView):
         :returns: Dictionary with DID metadata
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(vo):
                 for did in list_content(scope=scope, name=name, vo=vo):
@@ -675,7 +675,7 @@ class Attachment(MethodView):
         :status 500: Database Exception
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:
@@ -721,7 +721,7 @@ class Attachment(MethodView):
         :status 500: Database Exception
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:
@@ -769,7 +769,7 @@ class AttachmentHistory(MethodView):
         :returns: Stream of dictionarys with DIDs
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(vo):
                 for did in list_content_history(scope=scope, name=name, vo=vo):
@@ -808,7 +808,7 @@ class Files(MethodView):
         long = 'long' in request.args
 
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(vo):
                 for file in list_files(scope=scope, name=name, long=long, vo=vo):
@@ -844,7 +844,7 @@ class Parents(MethodView):
         :returns: A list of dictionary containing all dataset information.
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(vo):
                 for dataset in list_parent_dids(scope=scope, name=name, vo=vo):
@@ -881,7 +881,7 @@ class Meta(MethodView):
         :returns: A dictionary containing all meta.
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:
@@ -921,7 +921,7 @@ class Meta(MethodView):
 
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:
@@ -970,7 +970,7 @@ class Meta(MethodView):
             404 KeyNotFound
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:
@@ -1017,7 +1017,7 @@ class Rules(MethodView):
         :returns: List of replication rules.
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(vo):
                 for rule in list_replication_rules({'scope': scope, 'name': name}, vo=vo):
@@ -1096,7 +1096,7 @@ class AssociatedRules(MethodView):
         :returns: List of associated rules.
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(vo):
                 for rule in list_associated_replication_rules_for_file(scope=scope, name=name, vo=vo):
@@ -1286,7 +1286,7 @@ class Follow(MethodView):
         :status 406: Not Acceptable
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(vo):
                 for user in get_users_following_did(scope=scope, name=name, vo=vo):
@@ -1320,7 +1320,7 @@ class Follow(MethodView):
         :param scope_name: data identifier (scope)/(name).
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:
@@ -1362,7 +1362,7 @@ class Follow(MethodView):
         :param scope_name: data identifier (scope)/(name).
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:

--- a/lib/rucio/web/rest/flaskapi/v1/lock.py
+++ b/lib/rucio/web/rest/flaskapi/v1/lock.py
@@ -89,7 +89,7 @@ class LockByScopeName(MethodView):
         """
         did_type = request.args.get('did_type', None)
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
             if did_type == 'dataset':
                 def generate(vo):
                     for lock in get_dataset_locks(scope, name, vo=vo):

--- a/lib/rucio/web/rest/flaskapi/v1/redirect.py
+++ b/lib/rucio/web/rest/flaskapi/v1/redirect.py
@@ -71,7 +71,7 @@ class MetaLinkRedirector(MethodView):
         headers.set('Access-Control-Allow-Credentials', 'true')
 
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request_header_ensure_string('X-Rucio-VO', 'def'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0], headers=headers)
         except Exception as error:
@@ -199,7 +199,7 @@ class HeaderRedirector(MethodView):
         headers.set('Access-Control-Allow-Credentials', 'true')
 
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request_header_ensure_string('X-Rucio-VO', 'def'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0], headers=headers)
         except Exception as error:

--- a/lib/rucio/web/rest/flaskapi/v1/replica.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replica.py
@@ -92,7 +92,7 @@ class Replicas(MethodView):
         :returns: A metalink description of replicas if metalink(4)+xml is specified in Accept:
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:
@@ -812,7 +812,7 @@ class DatasetReplicas(MethodView):
         :returns: A dictionary containing all replicas information.
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(deep, vo):
                 for row in list_dataset_replicas(scope=scope, name=name, deep=deep, vo=vo):
@@ -898,7 +898,7 @@ class DatasetReplicasVP(MethodView):
         :returns: If VP exists a list of dicts of sites, otherwise nothing
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(deep, vo):
                 for row in list_dataset_replicas_vp(scope=scope, name=name, deep=deep, vo=vo):

--- a/lib/rucio/web/rest/flaskapi/v1/request.py
+++ b/lib/rucio/web/rest/flaskapi/v1/request.py
@@ -61,7 +61,7 @@ class RequestGet(MethodView):
         :status 406: Not Acceptable.
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, f_request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:

--- a/lib/rucio/web/rest/flaskapi/v1/rule.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rule.py
@@ -484,7 +484,7 @@ class RuleHistoryFull(MethodView):
         :returns: JSON dict containing informations about the requested user.
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(vo):
                 for history in list_replication_rule_full_history(scope, name, vo=vo):

--- a/lib/rucio/web/rest/webpy/v1/archive.py
+++ b/lib/rucio/web/rest/webpy/v1/archive.py
@@ -29,14 +29,14 @@ from traceback import format_exc
 from web import application, ctx, loadhook, header, InternalError
 
 from rucio.api.did import list_archive_content
-from rucio.common.schema import get_schema_value
+from rucio.common.schema import insert_scope_name
 from rucio.web.rest.common import rucio_loadhook, RucioController, check_accept_header_wrapper
 
 LOGGER, SH = getLogger("rucio.meta"), StreamHandler()
 SH.setLevel(DEBUG)
 LOGGER.addHandler(SH)
 
-URLS = ('%s/files' % get_schema_value('SCOPE_NAME_REGEXP'), 'Archive')
+URLS = insert_scope_name(('%s/files', 'Archive'))
 
 
 class Archive(RucioController):

--- a/lib/rucio/web/rest/webpy/v1/did.py
+++ b/lib/rucio/web/rest/webpy/v1/did.py
@@ -52,7 +52,7 @@ from rucio.common.exception import (ScopeNotFound, DataIdentifierNotFound,
                                     UnsupportedStatus, UnsupportedOperation,
                                     RSENotFound, RucioException, RuleNotFound,
                                     InvalidMetadata)
-from rucio.common.schema import get_schema_value
+from rucio.common.schema import insert_scope_name
 from rucio.common.utils import render_json, APIEncoder, parse_response
 from rucio.web.rest.common import rucio_loadhook, RucioController, check_accept_header_wrapper
 from rucio.web.rest.utils import generate_http_error
@@ -62,30 +62,30 @@ try:
 except ImportError:
     from urllib.parse import parse_qs
 
-URLS = (
+URLS = insert_scope_name((
     '/(.*)/$', 'Scope',
     '/(.*)/guid', 'GUIDLookup',
     '/(.*)/dids/search', 'Search',
     '/(.*)/dids/search_extended', 'SearchExtended',
-    '%s/files' % get_schema_value('SCOPE_NAME_REGEXP'), 'Files',
-    '%s/dids/history' % get_schema_value('SCOPE_NAME_REGEXP'), 'AttachmentHistory',
-    '%s/dids' % get_schema_value('SCOPE_NAME_REGEXP'), 'Attachment',
-    '%s/meta/(.*)' % get_schema_value('SCOPE_NAME_REGEXP'), 'Meta',
-    '%s/meta' % get_schema_value('SCOPE_NAME_REGEXP'), 'Meta',
-    '%s/status' % get_schema_value('SCOPE_NAME_REGEXP'), 'DIDs',
-    '%s/rules' % get_schema_value('SCOPE_NAME_REGEXP'), 'Rules',
-    '%s/parents' % get_schema_value('SCOPE_NAME_REGEXP'), 'Parents',
-    '%s/associated_rules' % get_schema_value('SCOPE_NAME_REGEXP'), 'AssociatedRules',
-    '%s/did_meta' % get_schema_value('SCOPE_NAME_REGEXP'), 'DidMeta',
+    '%s/files', 'Files',
+    '%s/dids/history', 'AttachmentHistory',
+    '%s/dids', 'Attachment',
+    '%s/meta/(.*)', 'Meta',
+    '%s/meta', 'Meta',
+    '%s/status', 'DIDs',
+    '%s/rules', 'Rules',
+    '%s/parents', 'Parents',
+    '%s/associated_rules', 'AssociatedRules',
+    '%s/did_meta', 'DidMeta',
     '/(.*)/(.*)/(.*)/(.*)/(.*)/sample', 'Sample',
-    '%s' % get_schema_value('SCOPE_NAME_REGEXP'), 'DIDs',
     '', 'BulkDIDS',
     '/attachments', 'Attachments',
     '/new', 'NewDIDs',
     '/resurrect', 'Resurrect',
-    '%s/follow' % get_schema_value('SCOPE_NAME_REGEXP'), 'Follow',
+    '%s/follow', 'Follow',
     '/bulkmeta', 'BulkMeta',
-)
+    '%s', 'DIDs',
+))
 
 
 class Scope(RucioController):

--- a/lib/rucio/web/rest/webpy/v1/lock.py
+++ b/lib/rucio/web/rest/webpy/v1/lock.py
@@ -31,7 +31,7 @@ from web import application, ctx, header, InternalError, loadhook
 
 from rucio.api.lock import get_dataset_locks_by_rse, get_dataset_locks
 from rucio.common.exception import RucioException, RSENotFound
-from rucio.common.schema import get_schema_value
+from rucio.common.schema import insert_scope_name
 from rucio.common.utils import render_json
 from rucio.web.rest.common import rucio_loadhook, check_accept_header_wrapper
 from rucio.web.rest.utils import generate_http_error
@@ -46,8 +46,8 @@ SH = StreamHandler()
 SH.setLevel(DEBUG)
 LOGGER.addHandler(SH)
 
-URLS = ('%s' % get_schema_value('SCOPE_NAME_REGEXP'), 'LockByScopeName',
-        '/(.*)', 'LockByRSE')
+URLS = insert_scope_name(('%s', 'LockByScopeName',
+                          '/(.*)', 'LockByRSE'))
 
 
 class LockByRSE(object):

--- a/lib/rucio/web/rest/webpy/v1/main.py
+++ b/lib/rucio/web/rest/webpy/v1/main.py
@@ -20,7 +20,7 @@
 
 from web import application, loadhook
 
-from rucio.common.schema import get_schema_value
+from rucio.common.schema import insert_scope_name
 from rucio.web.rest.common import rucio_loadhook
 from rucio.web.rest.account import (Attributes as AAttributes, Scopes as AScopes, Identities as AIdentities,  # NOQA: F401
                                     LocalAccountLimits as ALocalAccountLimits, GlobalAccountLimits as  # NOQA: F401
@@ -95,7 +95,7 @@ URLS += [
     '/accountlimits/(.+)/(.+)', 'ALLocalAccountLimit',
 ]
 
-URLS += ['/archives%s/files' % get_schema_value('SCOPE_NAME_REGEXP'), 'AVArchive']
+URLS += insert_scope_name(('/archives%s/files', 'AVArchive'))
 
 URLS += [
     '/config/(.+)/(.+)/(.*)', 'COptionSet',
@@ -104,30 +104,30 @@ URLS += [
     '/config', 'CConfig'
 ]
 
-URLS += [
+URLS += insert_scope_name((
     '/dids/(.*)/$', 'DScope',
     '/dids/(.*)/guid', 'DGUIDLookup',
     '/dids/(.*)/dids/search', 'DSearch',
-    '/dids%s/files' % get_schema_value('SCOPE_NAME_REGEXP'), 'DFiles',
-    '/dids%s/dids/history' % get_schema_value('SCOPE_NAME_REGEXP'), 'DAttachmentHistory',
-    '/dids%s/dids' % get_schema_value('SCOPE_NAME_REGEXP'), 'DAttachment',
-    '/dids%s/meta/(.*)' % get_schema_value('SCOPE_NAME_REGEXP'), 'DMeta',
-    '/dids%s/meta' % get_schema_value('SCOPE_NAME_REGEXP'), 'DMeta',
-    '/dids%s/status' % get_schema_value('SCOPE_NAME_REGEXP'), 'DDIDs',
-    '/dids%s/rules' % get_schema_value('SCOPE_NAME_REGEXP'), 'DRules',
-    '/dids%s/parents' % get_schema_value('SCOPE_NAME_REGEXP'), 'DParents',
-    '/dids%s/associated_rules' % get_schema_value('SCOPE_NAME_REGEXP'), 'DAssociatedRules',
-    '/dids%s/did_meta' % get_schema_value('SCOPE_NAME_REGEXP'), 'DDidMeta',
+    '/dids%s/files', 'DFiles',
+    '/dids%s/dids/history', 'DAttachmentHistory',
+    '/dids%s/dids', 'DAttachment',
+    '/dids%s/meta/(.*)', 'DMeta',
+    '/dids%s/meta', 'DMeta',
+    '/dids%s/status', 'DDIDs',
+    '/dids%s/rules', 'DRules',
+    '/dids%s/parents', 'DParents',
+    '/dids%s/associated_rules', 'DAssociatedRules',
+    '/dids%s/did_meta', 'DDidMeta',
     '/dids/(.*)/(.*)/(.*)/(.*)/(.*)/sample', 'DSample',
-    '/dids%s' % get_schema_value('SCOPE_NAME_REGEXP'), 'DDIDs',
+    '/dids%s', 'DDIDs',
     '/dids', 'DBulkDIDS',
     '/dids/attachments', 'DAttachments',
     '/dids/new', 'DNewDIDs',
     '/dids/resurrect', 'DResurrect',
     '/dids/list_dids_by_meta', 'DListByMeta',
-    '/dids%s/follow' % get_schema_value('SCOPE_NAME_REGEXP'), 'DFollow',
+    '/dids%s/follow', 'DFollow',
     '/dids/bulkmeta', 'DBulkMeta',
-]
+))
 
 URLS += [
     '/export/', 'EExport',
@@ -153,10 +153,10 @@ URLS += [
     '/lifetime_exceptions/(.+)', 'LELifetimeExceptionId'
 ]
 
-URLS += [
-    '/locks%s' % get_schema_value('SCOPE_NAME_REGEXP'), 'LLockByScopeName',
+URLS += insert_scope_name((
+    '/locks%s', 'LLockByScopeName',
     '/locks/(.*)', 'LLockByRSE'
-]
+))
 
 URLS += [
     '/meta/(.+)/(.+)', 'MValues',
@@ -165,7 +165,7 @@ URLS += [
     '/meta/', 'MMeta'
 ]
 
-URLS += [
+URLS += insert_scope_name((
     '/replicas/list/?$', 'RPListReplicas',
     '/replicas/?$', 'RPReplicas',
     '/replicas/suspicious/?$', 'RPSuspiciousReplicas',
@@ -175,16 +175,16 @@ URLS += [
     '/replicas/rse/(.*)/?$', 'RPReplicasRSE',
     '/replicas/bad/?$', 'RPBadReplicas',
     '/replicas/dids/?$', 'RPReplicasDIDs',
-    '/replicas%s/datasets$' % get_schema_value('SCOPE_NAME_REGEXP'), 'RPDatasetReplicas',
-    '/replicas%s/datasets_vp$' % get_schema_value('SCOPE_NAME_REGEXP'), 'RPDatasetReplicasVP',
-    '/replicas%s/?$' % get_schema_value('SCOPE_NAME_REGEXP'), 'RPReplicas',
+    '/replicas%s/datasets$', 'RPDatasetReplicas',
+    '/replicas%s/datasets_vp$', 'RPDatasetReplicasVP',
+    '/replicas%s/?$', 'RPReplicas',
     '/replicas/tombstone/?$', 'RPTombstone'
-]
+))
 
-URLS += [
-    '/requests/%s/(.+)' % get_schema_value('SCOPE_NAME_REGEXP'), 'RQRequestGet',
+URLS += insert_scope_name((
+    '/requests/%s/(.+)', 'RQRequestGet',
     '/requests/list', 'RQRequestsGet'
-]
+))
 
 URLS += [
     '/rses/(.+)/attr/(.+)', 'RAttributes',
@@ -206,16 +206,16 @@ URLS += [
     '/rses/', 'RRSEs',
 ]
 
-URLS += [
+URLS += insert_scope_name((
     '/rules/(.+)/locks', 'RUReplicaLocks',
     '/rules/(.+)/reduce', 'RUReduceRule',
     '/rules/(.+)/move', 'RUMoveRule',
-    '/rules%s/history' % get_schema_value('SCOPE_NAME_REGEXP'), 'RURuleHistoryFull',
+    '/rules%s/history', 'RURuleHistoryFull',
     '/rules/(.+)/history', 'RURuleHistory',
     '/rules/(.+)/analysis', 'RURuleAnalysis',
     '/rules/', 'RUAllRule',
     '/rules/(.+)', 'RURule'
-]
+))
 
 URLS += [
     '/scopes/', 'SCScope',

--- a/lib/rucio/web/rest/webpy/v1/redirect.py
+++ b/lib/rucio/web/rest/webpy/v1/redirect.py
@@ -35,7 +35,7 @@ from web import application, ctx, header, seeother, InternalError
 from rucio.api.replica import list_replicas
 from rucio.common.exception import RucioException, DataIdentifierNotFound, ReplicaNotFound
 from rucio.common.replica_sorter import sort_random, sort_geoip, sort_closeness, sort_ranking, sort_dynamic, site_selector
-from rucio.common.schema import get_schema_value
+from rucio.common.schema import insert_scope_name
 from rucio.web.rest.common import RucioController, check_accept_header_wrapper
 from rucio.web.rest.utils import generate_http_error
 
@@ -50,8 +50,8 @@ SH = StreamHandler()
 SH.setLevel(DEBUG)
 LOGGER.addHandler(SH)
 
-URLS = ('%s/metalink?$' % get_schema_value('SCOPE_NAME_REGEXP'), 'MetaLinkRedirector',
-        '%s/?$' % get_schema_value('SCOPE_NAME_REGEXP'), 'HeaderRedirector')
+URLS = insert_scope_name(('%s/metalink?$', 'MetaLinkRedirector',
+                          '%s/?$', 'HeaderRedirector'))
 
 
 class MetaLinkRedirector(RucioController):

--- a/lib/rucio/web/rest/webpy/v1/replica.py
+++ b/lib/rucio/web/rest/webpy/v1/replica.py
@@ -54,7 +54,7 @@ from rucio.common.exception import (AccessDenied, DataIdentifierAlreadyExists, I
                                     RSENotFound, UnsupportedOperation, ReplicaNotFound,
                                     InvalidObject, ScopeNotFound)
 from rucio.common.replica_sorter import sort_random, sort_geoip, sort_closeness, sort_dynamic, sort_ranking
-from rucio.common.schema import get_schema_value
+from rucio.common.schema import insert_scope_name
 from rucio.common.utils import parse_response, APIEncoder, render_json_list
 from rucio.db.sqla.constants import BadFilesStatus
 from rucio.web.rest.common import rucio_loadhook, rucio_unloadhook, RucioController, check_accept_header_wrapper
@@ -67,20 +67,20 @@ except ImportError:
     from urllib.parse import unquote
     from urllib.parse import parse_qs
 
-URLS = ('/list/?$', 'ListReplicas',
-        '/?$', 'Replicas',
-        '/suspicious/?$', 'SuspiciousReplicas',
-        '/bad/states/?$', 'BadReplicasStates',
-        '/bad/summary/?$', 'BadReplicasSummary',
-        '/bad/pfns/?$', 'BadPFNs',
-        '/rse/(.*)/?$', 'ReplicasRSE',
-        '/bad/?$', 'BadReplicas',
-        '/dids/?$', 'ReplicasDIDs',
-        '%s/datasets$' % get_schema_value('SCOPE_NAME_REGEXP'), 'DatasetReplicas',
-        '/datasets_bulk/?$', 'DatasetReplicasBulk',
-        '%s/datasets_vp$' % get_schema_value('SCOPE_NAME_REGEXP'), 'DatasetReplicasVP',
-        '%s/?$' % get_schema_value('SCOPE_NAME_REGEXP'), 'Replicas',
-        '/tombstone/?$', 'Tombstone')
+URLS = insert_scope_name(('/list/?$', 'ListReplicas',
+                          '/?$', 'Replicas',
+                          '/suspicious/?$', 'SuspiciousReplicas',
+                          '/bad/states/?$', 'BadReplicasStates',
+                          '/bad/summary/?$', 'BadReplicasSummary',
+                          '/bad/pfns/?$', 'BadPFNs',
+                          '/rse/(.*)/?$', 'ReplicasRSE',
+                          '/bad/?$', 'BadReplicas',
+                          '/dids/?$', 'ReplicasDIDs',
+                          '%s/datasets$', 'DatasetReplicas',
+                          '/datasets_bulk/?$', 'DatasetReplicasBulk',
+                          '%s/datasets_vp$', 'DatasetReplicasVP',
+                          '%s/?$', 'Replicas',
+                          '/tombstone/?$', 'Tombstone'))
 
 
 class Replicas(RucioController):

--- a/lib/rucio/web/rest/webpy/v1/request.py
+++ b/lib/rucio/web/rest/webpy/v1/request.py
@@ -31,7 +31,7 @@ from logging import getLogger, StreamHandler, DEBUG
 from web import application, ctx, loadhook, header
 
 from rucio.api import request
-from rucio.common.schema import get_schema_value
+from rucio.common.schema import insert_scope_name
 from rucio.common.utils import render_json
 from rucio.core.rse import get_rses_with_attribute_value, get_rse_name
 from rucio.db.sqla.constants import RequestState
@@ -49,8 +49,8 @@ SH = StreamHandler()
 SH.setLevel(DEBUG)
 LOGGER.addHandler(SH)
 
-URLS = ('%s/(.+)' % get_schema_value('SCOPE_NAME_REGEXP'), 'RequestGet',
-        '/list', 'RequestsGet')
+URLS = insert_scope_name(('%s/(.+)', 'RequestGet',
+                          '/list', 'RequestsGet'))
 
 
 class RequestGet(RucioController):

--- a/lib/rucio/web/rest/webpy/v1/rule.py
+++ b/lib/rucio/web/rest/webpy/v1/rule.py
@@ -44,7 +44,7 @@ from rucio.common.exception import (InsufficientAccountLimit, RuleNotFound, Acce
                                     ReplicationRuleCreationTemporaryFailed, InvalidRuleWeight, StagingAreaRuleRequiresLifetime,
                                     DuplicateRule, InvalidObject, AccountNotFound, RuleReplaceFailed, ScratchDiskLifetimeConflict,
                                     ManualRuleApprovalBlocked, UnsupportedOperation)
-from rucio.common.schema import get_schema_value
+from rucio.common.schema import insert_scope_name
 from rucio.common.utils import render_json, APIEncoder
 from rucio.web.rest.common import rucio_loadhook, check_accept_header_wrapper
 from rucio.web.rest.utils import generate_http_error
@@ -59,14 +59,14 @@ SH = StreamHandler()
 SH.setLevel(DEBUG)
 LOGGER.addHandler(SH)
 
-URLS = ('/(.+)/locks', 'ReplicaLocks',
-        '/(.+)/reduce', 'ReduceRule',
-        '/(.+)/move', 'MoveRule',
-        '%s/history' % get_schema_value('SCOPE_NAME_REGEXP'), 'RuleHistoryFull',
-        '/(.+)/history', 'RuleHistory',
-        '/(.+)/analysis', 'RuleAnalysis',
-        '/', 'AllRule',
-        '/(.+)', 'Rule',)
+URLS = insert_scope_name(('/(.+)/locks', 'ReplicaLocks',
+                          '/(.+)/reduce', 'ReduceRule',
+                          '/(.+)/move', 'MoveRule',
+                          '%s/history', 'RuleHistoryFull',
+                          '/(.+)/history', 'RuleHistory',
+                          '/(.+)/analysis', 'RuleAnalysis',
+                          '/', 'AllRule',
+                          '/(.+)', 'Rule',))
 
 
 class Rule:


### PR DESCRIPTION
This adds full support for policy packages in multi-VO Rucio. The main change is to the REST APIs where it is now necessary to generate separate URLs for each unique SCOPE_NAME_REGEXP in use. Permission and schema modules are now loaded on-demand when multi_vo is enabled. This is because the test scripts import the schema before the database is initialised so it is not possible to iterate over the VOs at that point.
