### PR TITLE
Testing: Fix tests in docker-compose dev env

### DIFF
--- a/etc/docker/dev/docker-compose-storage-localhost.yml
+++ b/etc/docker/dev/docker-compose-storage-localhost.yml
@@ -21,6 +21,7 @@ services:
     environment:
       - X509_USER_CERT=/opt/rucio/etc/usercert.pem
       - X509_USER_KEY=/opt/rucio/etc/userkey.pem
+      - RDBMS=postgres11
   ruciodb:
     image: postgres:11
     environment:

--- a/etc/docker/dev/docker-compose-storage-monit.yml
+++ b/etc/docker/dev/docker-compose-storage-monit.yml
@@ -24,6 +24,7 @@ services:
     environment:
       - X509_USER_CERT=/opt/rucio/etc/usercert.pem
       - X509_USER_KEY=/opt/rucio/etc/userkey.pem
+      - RDBMS=postgres11
     command: ["/monit-entrypoint.sh"]
   ruciodb:
     image: postgres:11

--- a/etc/docker/dev/docker-compose-storage.yml
+++ b/etc/docker/dev/docker-compose-storage.yml
@@ -21,6 +21,7 @@ services:
     environment:
       - X509_USER_CERT=/opt/rucio/etc/usercert.pem
       - X509_USER_KEY=/opt/rucio/etc/userkey.pem
+      - RDBMS=postgres11
   ruciodb:
     image: postgres:11
     environment:

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - X509_USER_CERT=/opt/rucio/etc/usercert.pem
       - X509_USER_KEY=/opt/rucio/etc/userkey.pem
+      - RDBMS=postgres11
   ruciodb:
     image: postgres:11
     environment:


### PR DESCRIPTION
Tests currently fail when running tools/run_tests_docker.sh inside the docker dev environment:
* XFAIL multi_vo tests without multi_vo instead of logging a warning.
* Add RDBMS variable to rucio-dev container for tests with database-specific checks.