### PR TITLE
Consistency checks, bug: dark reaper early exit, #3952

### DIFF
--- a/lib/rucio/daemons/reaper/dark_reaper.py
+++ b/lib/rucio/daemons/reaper/dark_reaper.py
@@ -205,8 +205,6 @@ def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None, all_r
 
         # Preserve the old behaviour until a feature release
         all_rses = list_rses()
-        if all_rses:
-            rses = all_rses
     else:
         if vos:
             invalid = set(vos) - set([v['vo'] for v in list_vos()])
@@ -219,8 +217,13 @@ def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None, all_r
 
         all_rses = []
         for vo in vos:
-            all_rses.extend(list_rses(filters={'vo': vo}))
+            vo_rses = list_rses(filters={'vo': vo})
+            if vo_rses:
+                all_rses.extend(vo_rses)
 
+    if all_rses:
+        rses = all_rses
+    else:
         if rses:
             invalid = set(rses) - set([rse['rse'] for rse in all_rses])
             if invalid:

--- a/lib/rucio/daemons/reaper/light_reaper.py
+++ b/lib/rucio/daemons/reaper/light_reaper.py
@@ -200,8 +200,6 @@ def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None, all_r
 
         # Preserve the old behaviour until a feature release
         all_rses = rse_core.list_rses()
-        if all_rses:
-            rses = all_rses
     else:
         if vos:
             invalid = set(vos) - set([v['vo'] for v in list_vos()])
@@ -215,8 +213,13 @@ def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None, all_r
         # Only use the include/exclude RSE options for m-VO until a feature release
         all_rses = []
         for vo in vos:
-            all_rses.extend(rse_core.list_rses(filters={'vo': vo}))
+            vo_rses = rse_core.list_rses(filters={'vo': vo})
+            if vo_rses:
+                all_rses.extend(vo_rses)
 
+    if all_rses:
+        rses = all_rses
+    else:
         if rses:
             invalid = set(rses) - set([rse['rse'] for rse in all_rses])
             if invalid:


### PR DESCRIPTION
dark reaper early exit
------------------

The changes to enable VO handling by the dark reaper (#3888) ended up preventing it from exiting early in the case of no RSEs with quarantined replicas (instead resulting in an error when the list of RSEs turned out to be `None` later in the execution).

This shouldn't be a problem for the master branch/1.24 as the change to remove the `--all-rses` option (#3943) will also prevent this error, so making the PR against 1.23 branch.