### PR TITLE
Core & Internals: Fix Flask endpoints; #1817

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/account_limit.py
+++ b/lib/rucio/web/rest/flaskapi/v1/account_limit.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,10 +21,14 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Muhammad Aditya Hilmy <didithilmy@gmail.com>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 from __future__ import print_function
+
 from json import loads
 from logging import getLogger, StreamHandler, DEBUG
 from traceback import format_exc
@@ -31,11 +36,10 @@ from traceback import format_exc
 from flask import Flask, Blueprint, request
 from flask.views import MethodView
 
-from rucio.api.account_limit import set_local_account_limit, delete_local_account_limit
+from rucio.api.account_limit import set_local_account_limit, delete_local_account_limit, set_global_account_limit, delete_global_account_limit
 from rucio.common.exception import RSENotFound, AccessDenied, AccountNotFound
 from rucio.common.utils import generate_http_error_flask
 from rucio.web.rest.flaskapi.v1.common import before_request, after_request
-
 
 LOGGER = getLogger("rucio.account_limit")
 SH = StreamHandler()
@@ -43,14 +47,11 @@ SH.setLevel(DEBUG)
 LOGGER.addHandler(SH)
 
 
-class AccountLimit(MethodView):
-    '''
-    AccountLimit
-    '''
+class LocalAccountLimit(MethodView):
     def post(self, account, rse):
         """ Create or update an account limit.
 
-        .. :quickref: AccountLimit; Create/update account limits.
+        .. :quickref: LocalAccountLimit; Create/update local account limits.
 
         :param account: Account name.
         :param rse: RSE name.
@@ -66,30 +67,31 @@ class AccountLimit(MethodView):
             return generate_http_error_flask(400, 'ValueError', 'cannot decode json parameter dictionary')
         try:
             bytes = parameter['bytes']
-        except KeyError as exception:
-            if exception.args[0] == 'type':
-                return generate_http_error_flask(400, 'KeyError', '%s not defined' % str(exception))
+        except KeyError as error:
+            if error.args[0] == 'type':
+                return generate_http_error_flask(400, 'KeyError', '%s not defined' % str(error))
+            raise
         except TypeError:
             return generate_http_error_flask(400, 'TypeError', 'body must be a json dictionary')
 
         try:
             set_local_account_limit(account=account, rse=rse, bytes=bytes, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
-        except AccessDenied as exception:
-            return generate_http_error_flask(401, 'AccessDenied', exception.args[0])
-        except RSENotFound as exception:
-            return generate_http_error_flask(404, 'RSENotFound', exception.args[0])
-        except AccountNotFound as exception:
-            return generate_http_error_flask(404, 'AccountNotFound', exception.args[0])
-        except Exception as exception:
+        except AccessDenied as error:
+            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
+        except RSENotFound as error:
+            return generate_http_error_flask(404, 'RSENotFound', error.args[0])
+        except AccountNotFound as error:
+            return generate_http_error_flask(404, 'AccountNotFound', error.args[0])
+        except Exception as error:
             print(format_exc())
-            return exception, 500
+            return str(error), 500
 
-        return "Created", 201
+        return 'Created', 201
 
     def delete(self, account, rse):
         """ Delete an account limit.
 
-        .. :quickref: AccountLimit; Delete account limits.
+        .. :quickref: LocalAccountLimit; Delete local account limits.
 
         :param account: Account name.
         :param rse: RSE name.
@@ -100,22 +102,92 @@ class AccountLimit(MethodView):
         """
         try:
             delete_local_account_limit(account=account, rse=rse, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
-        except AccessDenied as exception:
-            return generate_http_error_flask(401, 'AccessDenied', exception.args[0])
-        except AccountNotFound as exception:
-            return generate_http_error_flask(404, 'AccountNotFound', exception.args[0])
-        except RSENotFound as exception:
-            return generate_http_error_flask(404, 'RSENotFound', exception.args[0])
-        except Exception as exception:
+        except AccessDenied as error:
+            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
+        except AccountNotFound as error:
+            return generate_http_error_flask(404, 'AccountNotFound', error.args[0])
+        except RSENotFound as error:
+            return generate_http_error_flask(404, 'RSENotFound', error.args[0])
+        except Exception as error:
             print(format_exc())
-            return exception, 500
-        return "OK", 200
+            return str(error), 500
+        return '', 200
+
+
+class GlobalAccountLimit(MethodView):
+    def post(self, account, rse_expression):
+        """ Create or update an account limit.
+
+        .. :quickref: GlobalAccountLimit; Create/update global account limits.
+
+        :param account: Account name.
+        :param rse_expression: RSE name.
+        :status 201: Successfully created or updated.
+        :status 401: Invalid auth token.
+        :status 404: RSE not found.
+        :status 404: Account not found
+        """
+        json_data = request.data
+        try:
+            parameter = loads(json_data)
+        except ValueError:
+            return generate_http_error_flask(400, 'ValueError', 'cannot decode json parameter dictionary')
+        try:
+            bytes = parameter['bytes']
+        except KeyError as error:
+            if error.args[0] == 'type':
+                return generate_http_error_flask(400, 'KeyError', '%s not defined' % str(error))
+            raise
+        except TypeError:
+            return generate_http_error_flask(400, 'TypeError', 'body must be a json dictionary')
+
+        try:
+            set_global_account_limit(account=account, rse_expression=rse_expression, bytes=bytes, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+        except AccessDenied as error:
+            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
+        except RSENotFound as error:
+            return generate_http_error_flask(404, 'RSENotFound', error.args[0])
+        except AccountNotFound as error:
+            return generate_http_error_flask(404, 'AccountNotFound', error.args[0])
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500
+
+        return 'Created', 201
+
+    def delete(self, account, rse_expression):
+        """ Delete an account limit.
+
+        .. :quickref: GlobalAccountLimit; Delete global account limits.
+
+        :param account: Account name.
+        :param rse_expression: RSE name.
+        :status 200: Successfully deleted.
+        :status 401: Invalid auth token.
+        :status 404: RSE not found.
+        :status 404: Account not found
+        """
+        try:
+            delete_global_account_limit(account=account, rse_expression=rse_expression, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+        except AccessDenied as error:
+            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
+        except AccountNotFound as error:
+            return generate_http_error_flask(404, 'AccountNotFound', error.args[0])
+        except RSENotFound as error:
+            return generate_http_error_flask(404, 'RSENotFound', error.args[0])
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500
+        return '', 200
 
 
 bp = Blueprint('account_limit', __name__)
 
-account_limit_view = AccountLimit.as_view('account_limit')
-bp.add_url_rule('/<account>/<rse>', view_func=account_limit_view, methods=['post', 'delete'])
+local_account_limit_view = LocalAccountLimit.as_view('local_account_limit')
+bp.add_url_rule('/local/<account>/<rse>', view_func=local_account_limit_view, methods=['post', 'delete'])
+# removed for doc: bp.add_url_rule('/<account>/<rse>', view_func=local_account_limit_view, methods=['post', 'delete'])
+global_account_limit_view = GlobalAccountLimit.as_view('global_account_limit')
+bp.add_url_rule('/global/<account>/<rse_expression>', view_func=global_account_limit_view, methods=['post', 'delete'])
 
 application = Flask(__name__)
 application.register_blueprint(bp)

--- a/lib/rucio/web/rest/flaskapi/v1/authentication.py
+++ b/lib/rucio/web/rest/flaskapi/v1/authentication.py
@@ -27,16 +27,36 @@
 from __future__ import print_function
 
 import base64
+import imp
+import time
 from re import search
 from traceback import format_exc
 
-from flask import Flask, Blueprint, request, Response
+from flask import Flask, Blueprint, request, Response, redirect
 from flask.views import MethodView
+from werkzeug.datastructures import Headers
 
-from rucio.api.authentication import get_auth_token_user_pass, get_auth_token_gss, get_auth_token_x509, get_auth_token_ssh, get_ssh_challenge_token, validate_auth_token
+from rucio.api.authentication import get_auth_token_user_pass, get_auth_token_gss, get_auth_token_x509, get_auth_token_ssh, get_ssh_challenge_token, validate_auth_token, get_auth_oidc, redirect_auth_oidc, get_token_oidc, refresh_cli_auth_token, \
+    get_auth_token_saml
+from rucio.common.config import config_get
 from rucio.common.exception import AccessDenied, IdentityError, RucioException
-from rucio.common.utils import generate_http_error_flask, date_to_str
+from rucio.common.utils import generate_http_error_flask, date_to_str, urlparse
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask
+
+# Extra modules: Only imported if available
+EXTRA_MODULES = {'onelogin': False}
+
+for extra_module in EXTRA_MODULES:
+    try:
+        imp.find_module(extra_module)
+        EXTRA_MODULES[extra_module] = True
+    except ImportError:
+        EXTRA_MODULES[extra_module] = False
+
+if EXTRA_MODULES['onelogin']:
+    from onelogin.saml2.auth import OneLogin_Saml2_Auth
+    from web import cookies
+    from rucio.web.ui.common.utils import prepare_saml_request
 
 
 class UserPass(MethodView):
@@ -56,13 +76,13 @@ class UserPass(MethodView):
         :status 200: OK
         """
 
-        response = Response(status=200)
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
-        return response
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        return '', 200, headers
 
     @check_accept_header_wrapper_flask(['application/octet-stream'])
     def get(self):
@@ -86,46 +106,400 @@ class UserPass(MethodView):
         :status 404: Invalid credentials
         """
 
-        response = Response()
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
 
-        response.headers['Content-Type'] = 'application/octet-stream'
-        response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-        response.headers['Cache-Control'] = 'post-check=0, pre-check=0'
-        response.headers['Pragma'] = 'no-cache'
+        headers['Content-Type'] = 'application/octet-stream'
+        headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers['Pragma'] = 'no-cache'
 
-        vo = request.environ.get('HTTP_X_RUCIO_VO', 'def')
-        account = request.environ.get('HTTP_X_RUCIO_ACCOUNT')
-        username = request.environ.get('HTTP_X_RUCIO_USERNAME')
-        password = request.environ.get('HTTP_X_RUCIO_PASSWORD')
-        appid = request.environ.get('HTTP_X_RUCIO_APPID')
-        if appid is None:
-            appid = 'unknown'
-        ip = request.environ.get('HTTP_X_FORWARDED_FOR')
-        if ip is None:
-            ip = request.remote_addr
+        vo = request.headers.get('X-Rucio-VO', 'def')
+        account = request.headers.get('X-Rucio-Account')
+        username = request.headers.get('X-Rucio-Username')
+        password = request.headers.get('X-Rucio-Password')
+        appid = request.headers.get('X-Rucio-AppID', 'unknown')
+        ip = request.headers.get('X-Forwarded-For', request.remote_addr)
 
-        print(account, username, password, appid)
+        if not account or not username or not password:
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate without passing all required arguments', headers=headers)
+
         try:
             result = get_auth_token_user_pass(account, username, password, appid, ip, vo=vo)
         except AccessDenied:
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals())
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals(), headers=headers)
         except RucioException as error:
-            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0], headers=headers)
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500, headers
 
         if not result:
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals())
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals(), headers=headers)
 
-        response.headers['X-Rucio-Auth-Token'] = result.token
-        response.headers['X-Rucio-Auth-Token-Expires'] = date_to_str(result.expired_at)
-        return response
+        headers['X-Rucio-Auth-Token'] = result.token
+        headers['X-Rucio-Auth-Token-Expires'] = date_to_str(result.expired_at)
+        return '', 200, headers
+
+
+class OIDC(MethodView):
+    """
+    Requests a user specific Authorization URL (assigning a user session state,
+    nonce, Rucio OIDC Client ID with the correct issuers authentication endpoint).
+    """
+
+    def options(self):
+        """
+        Allow cross-site scripting. Explicit for Authentication.
+
+        :status 200: OK
+        """
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        return '', 200, headers
+
+    @check_accept_header_wrapper_flask(['application/octet-stream'])
+    def get(self):
+        """
+
+        .. :quickref: OIDC; Authenticate with OIDC
+
+        :status 200: OK
+        :status 401: Unauthorized
+        :resheader X-Rucio-OIDC-Auth-URL: User & Rucio OIDC Client specific Authorization URL
+        """
+        headers = Headers()
+
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+
+        headers.set('Content-Type', 'application/octet-stream')
+        headers.set('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers.set('Pragma', 'no-cache')
+
+        vo = request.headers.get('X-Rucio-VO', 'def')
+        account = request.environ.get('HTTP_X_RUCIO_ACCOUNT', 'webui')
+        auth_scope = request.environ.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_SCOPE', "")
+        audience = request.environ.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_AUDIENCE', "")
+        auto = request.environ.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_AUTO', False)
+        issuer = request.environ.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_ISSUER', None)
+        polling = request.environ.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_POLLING', False)
+        refresh_lifetime = request.environ.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_REFRESH_LIFETIME', None)
+        auto = (auto == 'True' or auto == 'true')
+        polling = (polling == 'True' or polling == 'true')
+        if refresh_lifetime == 'None':
+            refresh_lifetime = None
+        ip = request.headers.get('X-Forwarded-For', request.remote_addr)
+        try:
+            kwargs = {'auth_scope': auth_scope,
+                      'audience': audience,
+                      'issuer': issuer,
+                      'auto': auto,
+                      'polling': polling,
+                      'refresh_lifetime': refresh_lifetime,
+                      'ip': ip}
+            result = get_auth_oidc(account, vo=vo, **kwargs)
+        except AccessDenied:
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot get authentication URL from Rucio Authentication Server for account %(account)s' % locals(), headers=headers)
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0], headers=headers)
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500, headers
+
+        if not result:
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot get authentication URL from Rucio Authentication Server for account %(account)s' % locals(), headers=headers)
+
+        headers.set('X-Rucio-OIDC-Auth-URL', result)
+        return '', 200, headers
+
+
+class RedirectOIDC(MethodView):
+    """
+    Authenticate a Rucio account via
+    an Identity Provider (XDC IAM as of June 2019).
+    """
+
+    def options(self):
+        """
+        Allow cross-site scripting. Explicit for Authentication.
+
+        :status 200: OK
+        """
+        headers = Headers()
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+        return '', 200, headers
+
+    @check_accept_header_wrapper_flask(['application/octet-stream', 'text/html'])
+    def get(self):
+        """
+        .. :quickref: OIDC;
+
+        :status 200: OK
+        :status 303: Redirect
+        :status 401: Unauthorized
+        :resheader X-Rucio-Auth-Token: The authentication token
+        """
+        headers = Headers()
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+
+        # interaction with web browser - display response in html format
+        headers.set('Content-Type', 'text/html')
+        headers.set('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers.set('Pragma', 'no-cache')
+
+        try:
+            fetchtoken = (request.headers.get('X-Rucio-Client-Fetch-Token') == 'True')
+            query_string = request.query_string.decode(encoding='utf-8')
+            result = redirect_auth_oidc(query_string, fetchtoken)
+
+            # FIXME: render auth template on error
+        except AccessDenied:
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot get authentication URL from Rucio Authentication Server for account %(account)s' % locals(), headers=headers)
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0], headers=headers)
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500, headers
+
+        if not result:
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot get authentication URL from Rucio Authentication Server for account %(account)s' % locals(), headers=headers)
+        if fetchtoken:
+            # this is only a case of returning the final token to the Rucio Client polling
+            # or requesting token after copy-pasting the Rucio code from the web page page
+            headers.set('Content-Type', 'application/octet-stream')
+            headers.set('X-Rucio-Auth-Token', result)
+            return '', 200, headers
+        else:
+            response = redirect(result, code=303)
+            response.headers.extend(headers)
+            return response
+
+
+class CodeOIDC(MethodView):
+    """
+    IdP redirects to this endpoint with the AuthZ code
+    Rucio Auth server will request new token. This endpoint should be reached
+    only if the request/ IdP login has been made through web browser. Then the response
+    content will be in html (including the potential errors displayed).
+    The token will be saved in the Rucio DB, but only Rucio code will
+    be returned on the web page, or, in case of polling is True, successful
+    operation is confirmed waiting for the Rucio client to get the token automatically.
+    """
+
+    def options(self):
+        """
+        HTTP Success:
+            200 OK
+
+        Allow cross-site scripting. Explicit for Authentication.
+        """
+        headers = Headers()
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+        return '', 200, headers
+
+    @check_accept_header_wrapper_flask(['application/octet-stream', 'text/html'])
+    def get(self):
+        """
+        .. :quickref: OIDC;
+
+        :status 200: OK
+        :status 401: Unauthorized
+        """
+        headers = Headers()
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+
+        headers.set('Content-Type', 'text/html')
+        headers.set('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers.set('Pragma', 'no-cache')
+
+        query_string = request.query_string.decode(encoding='utf-8')
+        ip = request.headers.get('X-Forwarded-For', request.remote_addr)
+
+        try:
+            result = get_token_oidc(query_string, ip)
+        except AccessDenied:
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot get authentication code from Rucio Authentication Server for account %(account)s' % locals(), headers=headers)
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0], headers=headers)
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500, headers
+
+        if not result:
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot get authentication code from Rucio Authentication Server for account %(account)s' % locals(), headers=headers)
+        if 'fetchcode' in result:
+            msg = 'Please copy-paste the following code to the open terminal session with Rucio Client in order to get your access token: <b>' + result['fetchcode'] + '</b>'
+            return msg, 200, headers
+        elif 'polling' in result and result['polling'] is True:
+            return 'Rucio Client should now be able to fetch your token automatically.', 200, headers
+        else:
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot get authentication code from Rucio Authentication Server for account %(account)s' % locals(), headers=headers)
+
+
+class TokenOIDC(MethodView):
+    """
+    Authenticate a Rucio account temporarily via ID,
+    access (eventually save new refresh token)
+    received from an Identity Provider.
+    """
+
+    def options(self):
+        """
+        Allow cross-site scripting. Explicit for Authentication.
+
+        :status 200: OK
+        """
+        headers = Headers()
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+        return '', 200, headers
+
+    @check_accept_header_wrapper_flask(['application/octet-stream'])
+    def get(self):
+        """
+        .. :quickref: OIDC;
+
+        :status 200: OK
+        :status 401: Unauthorized
+        :resheader X-Rucio-Auth-Token: The authentication token
+        :resheader X-Rucio-Auth-Token-Expires: The time when the token expires
+        """
+        headers = Headers()
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+
+        headers.set('Content-Type', 'application/octet-stream')
+        headers.set('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers.set('Pragma', 'no-cache')
+
+        query_string = request.query_string.decode(encoding='utf-8')
+        ip = request.headers.get('X-Forwarded-For', request.remote_addr)
+
+        try:
+            result = get_token_oidc(query_string, ip)
+        except AccessDenied:
+            return generate_http_error_flask(401, 'CannotAuthorize', 'Cannot authorize token request.', headers=headers)
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0], headers=headers)
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500, headers
+
+        if not result:
+            return generate_http_error_flask(401, 'CannotAuthorize', 'Cannot authorize token request.', headers=headers)
+        if 'token' in result and 'webhome' not in result:
+            headers.set('X-Rucio-Auth-Token', result['token'].token)
+            headers.set('X-Rucio-Auth-Token-Expires', date_to_str(result['token'].expired_at))
+            return '', 200, headers
+        elif 'webhome' in result:
+            webhome = result['webhome']
+            if webhome is None:
+                return generate_http_error_flask(401, 'CannotAuthorize', 'Unknown identity.', headers=headers)
+            # domain setting is necessary so that the token gets distributed also to the webui server
+            domain = '.'.join(urlparse.urlparse(webhome).netloc.split('.')[1:])
+            response = redirect(webhome, code=303)
+            response.headers.extend(headers)
+            response.set_cookie('x-rucio-auth-token', value=result['token'].token, domain=domain, path='/')
+            response.set_cookie('rucio-auth-token-created-at', value=str(time.time()), domain=domain, path='/')
+            return response
+        else:
+            return '', 400, headers
+
+
+class RefreshOIDC(MethodView):
+    """
+    For a presented and access token which has equivalent in Rucio DB
+    (and also has refrech token in the Rucio DB) the class will attempt
+    token refresh and return a user a new refreshed token. If the presented token
+    is a result of a previous refresh happening in the last 10 min, the same token will be returned.
+    """
+
+    def options(self):
+        """
+        Allow cross-site scripting. Explicit for Authentication.
+
+        :status 200: OK
+        """
+        headers = Headers()
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+        headers.set('Access-Control-Expose-Headers', 'X-Rucio-Auth-Token')
+        return '', 200, headers
+
+    @check_accept_header_wrapper_flask(['application/octet-stream'])
+    def get(self):
+        """
+        .. :quickref: OIDC;
+
+        :status 200: OK
+        :status 401: Unauthorized
+        :resheader X-Rucio-Auth-Token: The authentication token
+        """
+        headers = Headers()
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+        headers.set('Access-Control-Expose-Headers', 'X-Rucio-Auth-Token')
+
+        headers.set('Content-Type', 'application/octet-stream')
+        headers.set('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers.set('Pragma', 'no-cache')
+
+        vo = request.headers.get('X-Rucio-VO', 'def')
+        account = request.headers.get('X-Rucio-Account')
+        token = request.headers.get('X-Rucio-Auth-Token')
+        if token is None or account is None:
+            return generate_http_error_flask(401, 'CannotAuthorize', 'Cannot authorize token request.', headers=headers)
+
+        try:
+            result = refresh_cli_auth_token(token, account, vo=vo)
+        except AccessDenied:
+            return generate_http_error_flask(401, 'CannotAuthorize', 'Cannot authorize token request.', headers=headers)
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500, headers
+
+        if result is not None and len(result) > 1:
+            headers.set('X-Rucio-Auth-Token', str(result[0]))
+            headers.set('X-Rucio-Auth-Token-Expires', str(result[1]))
+        else:
+            headers.set('X-Rucio-Auth-Token', '')
+            headers.set('X-Rucio-Auth-Token-Expires', '')
+        return '', 200, headers
 
 
 class GSS(MethodView):
@@ -141,13 +515,13 @@ class GSS(MethodView):
         Allow cross-site scripting. Explicit for Authentication.
         """
 
-        response = Response(status=200)
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
-        return response
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        return '', 200, headers
 
     @check_accept_header_wrapper_flask(['application/octet-stream'])
     def get(self):
@@ -170,39 +544,35 @@ class GSS(MethodView):
         :status 404: Invalid credentials
         """
 
-        response = Response()
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
 
-        response.headers['Content-Type'] = 'application/octet-stream'
-        response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-        response.headers['Cache-Control'] = 'post-check=0, pre-check=0'
-        response.headers['Pragma'] = 'no-cache'
+        headers['Content-Type'] = 'application/octet-stream'
+        headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers['Pragma'] = 'no-cache'
 
-        vo = request.environ.get('HTTP_X_RUCIO_VO', 'def')
-        account = request.environ.get('HTTP_X_RUCIO_ACCOUNT')
+        vo = request.headers.get('X-Rucio-VO', 'def')
+        account = request.headers.get('X-Rucio-Account')
         gsscred = request.environ.get('REMOTE_USER')
-        appid = request.environ.get('HTTP_X_RUCIO_APPID')
-        if appid is None:
-            appid = 'unknown'
-        ip = request.environ.get('HTTP_X_FORWARDED_FOR')
-        if ip is None:
-            ip = request.remote_addr
+        appid = request.headers.get('X-Rucio-AppID', 'unknown')
+        ip = request.headers.get('X-Forwarded-For', request.remote_addr)
 
         try:
             result = get_auth_token_gss(account, gsscred, appid, ip, vo=vo)
         except AccessDenied:
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals())
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals(), headers=headers)
 
         if result is None:
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals())
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals(), headers=headers)
 
-        response.headers['X-Rucio-Auth-Token'] = result.token
-        response.headers['X-Rucio-Auth-Token-Expires'] = date_to_str(result.expired_at)
-        return response
+        headers['X-Rucio-Auth-Token'] = result.token
+        headers['X-Rucio-Auth-Token-Expires'] = date_to_str(result.expired_at)
+        return '', 200, headers
 
 
 class x509(MethodView):
@@ -218,13 +588,13 @@ class x509(MethodView):
         Allow cross-site scripting. Explicit for Authentication.
         """
 
-        response = Response(status=200)
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
-        return response
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        return '', 200, headers
 
     @check_accept_header_wrapper_flask(['application/octet-stream'])
     def get(self):
@@ -247,32 +617,28 @@ class x509(MethodView):
         :status 404: Invalid credentials
         """
 
-        response = Response()
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
 
-        response.headers['Content-Type'] = 'application/octet-stream'
-        response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-        response.headers['Cache-Control'] = 'post-check=0, pre-check=0'
-        response.headers['Pragma'] = 'no-cache'
+        headers['Content-Type'] = 'application/octet-stream'
+        headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers['Pragma'] = 'no-cache'
 
-        vo = request.environ.get('HTTP_X_RUCIO_VO', 'def')
-        account = request.environ.get('HTTP_X_RUCIO_ACCOUNT')
+        vo = request.headers.get('X-Rucio-VO', 'def')
+        account = request.headers.get('X-Rucio-Account')
         dn = request.environ.get('SSL_CLIENT_S_DN')
         if not dn:
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot get DN')
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot get DN', headers=headers)
         if not dn.startswith('/'):
             dn = '/%s' % '/'.join(dn.split(',')[::-1])
 
-        appid = request.environ.get('HTTP_X_RUCIO_APPID')
-        if appid is None:
-            appid = 'unknown'
-        ip = request.environ.get('HTTP_X_FORWARDED_FOR')
-        if ip is None:
-            ip = request.remote_addr
+        appid = request.headers.get('X-Rucio-AppID', 'unknown')
+        ip = request.headers.get('X-Forwarded-For', request.remote_addr)
 
         # If we get a valid proxy certificate we have to strip this postfix,
         # otherwise we would have to store the proxy DN in the database as well.
@@ -293,18 +659,18 @@ class x509(MethodView):
             result = get_auth_token_x509(account, dn, appid, ip, vo=vo)
         except AccessDenied:
             print('Cannot Authenticate', account, dn, appid, ip, vo)
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals())
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals(), headers=headers)
         except IdentityError:
             print('Cannot Authenticate', account, dn, appid, ip, vo)
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'No default account set for %(dn)s' % locals())
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'No default account set for %(dn)s' % locals(), headers=headers)
 
         if not result:
             print('Cannot Authenticate', account, dn, appid, ip, vo)
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals())
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals(), headers=headers)
 
-        response.headers['X-Rucio-Auth-Token'] = result.token
-        response.headers['X-Rucio-Auth-Token-Expires'] = date_to_str(result.expired_at)
-        return response
+        headers['X-Rucio-Auth-Token'] = result.token
+        headers['X-Rucio-Auth-Token-Expires'] = date_to_str(result.expired_at)
+        return '', 200, headers
 
 
 class SSH(MethodView):
@@ -319,14 +685,13 @@ class SSH(MethodView):
 
         Allow cross-site scripting. Explicit for Authentication.
         """
-
-        response = Response(status=200)
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
-        return response
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        return '', 200, headers
 
     @check_accept_header_wrapper_flask(['application/octet-stream'])
     def get(self):
@@ -349,50 +714,46 @@ class SSH(MethodView):
         :status 404: Invalid credentials
         """
 
-        response = Response()
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
 
-        response.headers['Content-Type'] = 'application/octet-stream'
-        response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-        response.headers['Cache-Control'] = 'post-check=0, pre-check=0'
-        response.headers['Pragma'] = 'no-cache'
+        headers['Content-Type'] = 'application/octet-stream'
+        headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers['Pragma'] = 'no-cache'
 
-        vo = request.environ.get('HTTP_X_RUCIO_VO', 'def')
-        account = request.environ.get('HTTP_X_RUCIO_ACCOUNT')
-        signature = request.environ.get('HTTP_X_RUCIO_SSH_SIGNATURE')
-        appid = request.environ.get('HTTP_X_RUCIO_APPID')
-        if appid is None:
-            appid = 'unknown'
-        ip = request.environ.get('HTTP_X_FORWARDED_FOR')
-        if ip is None:
-            ip = request.remote_addr
+        vo = request.headers.get('X-Rucio-VO', 'def')
+        account = request.headers.get('X-Rucio-Account')
+        signature = request.headers.get('X-Rucio-SSH-Signature')
+        appid = request.headers.get('X-Rucio-AppID', 'unknown')
+        ip = request.headers.get('X-Forwarded-For', request.remote_addr)
 
         # decode the signature which must come in base64 encoded
         try:
             signature = base64.b64decode(signature)
-        except Exception as error:  # noqa: F841
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with malformed signature' % locals())
+        except TypeError:
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with malformed signature' % locals(), headers=headers)
 
         try:
             result = get_auth_token_ssh(account, signature, appid, ip, vo=vo)
         except AccessDenied:
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals())
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals(), headers=headers)
         except RucioException as error:
-            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0], headers=headers)
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
         if not result:
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals())
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals(), headers=headers)
 
-        response.headers['X-Rucio-Auth-Token'] = result.token
-        response.headers['X-Rucio-Auth-Token-Expires'] = date_to_str(result.expired_at)
-        return response
+        headers['X-Rucio-Auth-Token'] = result.token
+        headers['X-Rucio-Auth-Token-Expires'] = date_to_str(result.expired_at)
+        return '', 200, headers
 
 
 class SSHChallengeToken(MethodView):
@@ -408,20 +769,20 @@ class SSHChallengeToken(MethodView):
         Allow cross-site scripting. Explicit for Authentication.
         """
 
-        response = Response(status=200)
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
-        return response
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        return '', 200, headers
 
     @check_accept_header_wrapper_flask(['application/octet-stream'])
     def get(self):
         """
         Request a challenge token for SSH authentication
 
-        .. :quickref: SSHChallengeToken; Request SSH Challenge Token
+        .. :quickref: SSH; Request SSH Challenge Token
 
         :reqheader Rucio-VO: VO name as a string (Multi-VO only).
         :reqheader Rucio-Account: Account identifier as a string.
@@ -431,46 +792,147 @@ class SSHChallengeToken(MethodView):
         :resheader Access-Control-Allow-Methods:
         :resheader Access-Control-Allow-Credentials:
         :resheader Access-Control-Expose-Headers:
-        :resheader X-Rucio-Auth-Token: The authentication token
+        :resheader X-Rucio-SSH-Challenge-Token: The SSH challenge token
+        :resheader X-Rucio-SSH-Challenge-Token-Expires: The expiry time of the token
         :status 200: Successfully authenticated
         :status 404: Invalid credentials
         """
 
-        response = Response()
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
 
-        response.headers['Content-Type'] = 'application/octet-stream'
-        response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-        response.headers['Cache-Control'] = 'post-check=0, pre-check=0'
-        response.headers['Pragma'] = 'no-cache'
+        headers['Content-Type'] = 'application/octet-stream'
+        headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers['Pragma'] = 'no-cache'
 
-        vo = request.environ.get('HTTP_X_RUCIO_VO', 'def')
-        account = request.environ.get('HTTP_X_RUCIO_ACCOUNT')
-        appid = request.environ.get('HTTP_X_RUCIO_APPID')
-        if appid is None:
-            appid = 'unknown'
-        ip = request.environ.get('HTTP_X_FORWARDED_FOR')
-        if ip is None:
-            ip = request.remote_addr
+        vo = request.headers.get('X-Rucio-VO', 'def')
+        account = request.headers.get('X-Rucio-Account')
+        appid = request.headers.get('X-Rucio-AppID', 'unknown')
+        ip = request.headers.get('X-Forwarded-For', request.remote_addr)
 
         try:
             result = get_ssh_challenge_token(account, appid, ip, vo=vo)
         except RucioException as error:
-            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0], headers=headers)
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500, headers
 
         if not result:
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot generate challenge for account %(account)s' % locals())
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot generate challenge for account %(account)s' % locals(), headers=headers)
 
-        response.headers['X-Rucio-Auth-Token'] = result.token
-        response.headers['X-Rucio-Auth-Token-Expires'] = date_to_str(result.expired_at)
-        return response
+        headers['X-Rucio-SSH-Challenge-Token'] = result.token
+        headers['X-Rucio-SSH-Challenge-Token-Expires'] = date_to_str(result.expired_at)
+        return '', 200, headers
+
+
+class SAML(MethodView):
+    """
+    Authenticate a Rucio account temporarily via CERN SSO.
+    """
+
+    def options(self):
+        """
+        Allow cross-site scripting. Explicit for Authentication.
+
+        :status 200: OK
+        """
+        headers = Headers()
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+        headers.set('Access-Control-Expose-Headers', 'X-Rucio-Auth-Token')
+        return '', 200, headers
+
+    @check_accept_header_wrapper_flask(['application/octet-stream'])
+    def get(self):
+        """
+        .. :quickref: SAML;
+
+        :status 200: OK
+        :status 401: Unauthorized
+        :reqheader Rucio-VO: VO name as a string (Multi-VO only)
+        :reqheader Rucio-Account: Account identifier as a string.
+        :reqheader Rucio-Username: Username as a string.
+        :reqheader Rucio-Password: Password as a string.
+        :reqheader Rucio-AppID: Application identifier as a string.
+        :resheader X-Rucio-SAML-Auth-URL: as a variable-length string header.
+        """
+        headers = Headers()
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+        headers.set('Access-Control-Expose-Headers', 'X-Rucio-Auth-Token')
+
+        headers.set('Content-Type', 'application/octet-stream')
+        headers.set('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers.set('Pragma', 'no-cache')
+
+        if not EXTRA_MODULES['onelogin']:
+            return "SAML not configured on the server side.", 400, headers
+
+        saml_nameid = cookies().get('saml-nameid')
+        vo = request.headers.get('X-Rucio-VO', 'def')
+        account = request.headers.get('X-Rucio-Account')
+        appid = request.headers.get('X-Rucio-AppID', 'unknown')
+        ip = request.headers.get('X-Forwarded-For', request.remote_addr)
+
+        if saml_nameid:
+            try:
+                result = get_auth_token_saml(account, saml_nameid, appid, ip, vo=vo)
+            except AccessDenied:
+                return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals(), headers=headers)
+            except RucioException as error:
+                return generate_http_error_flask(500, error.__class__.__name__, error.args[0], headers=headers)
+            except Exception as error:
+                print(format_exc())
+                return str(error), 500, headers
+
+            if not result:
+                return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals(), headers=headers)
+
+            headers.set('X-Rucio-Auth-Token', result.token)
+            headers.set('X-Rucio-Auth-Token-Expires', date_to_str(result.expired_at))
+            return '', 200, headers
+
+        # Path to the SAML config folder
+        SAML_PATH = config_get('saml', 'config_path')
+
+        req = prepare_saml_request(request.environ, dict(request.args.items(multi=False)))
+        auth = OneLogin_Saml2_Auth(req, custom_base_path=SAML_PATH)
+
+        headers.set('X-Rucio-SAML-Auth-URL', auth.login())
+        return '', 200, headers
+
+    def post(self):
+        """
+        .. :quickref: SAML;
+
+        :status 200: OK
+        """
+        if not EXTRA_MODULES['onelogin']:
+            return "SAML not configured on the server side.", 200, [('X-Rucio-Auth-Token', '')]
+
+        SAML_PATH = config_get('saml', 'config_path')
+        req = prepare_saml_request(request.environ, dict(request.args.items(multi=False)))
+        auth = OneLogin_Saml2_Auth(req, custom_base_path=SAML_PATH)
+
+        auth.process_response()
+        errors = auth.get_errors()
+        if not errors:
+            if auth.is_authenticated():
+                response = Response()
+                response.set_cookie('saml-nameid', value=auth.get_nameid(), path='/')
+                return response
+        return '', 200
 
 
 class Validate(MethodView):
@@ -486,13 +948,13 @@ class Validate(MethodView):
         Allow cross-site scripting. Explicit for Authentication.
         """
 
-        response = Response(status=200)
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
-        return response
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        return '', 200, headers
 
     @check_accept_header_wrapper_flask(['application/octet-stream'])
     def get(self):
@@ -506,26 +968,25 @@ class Validate(MethodView):
         :returns: Tuple(account name, token lifetime).
         """
 
-        response = Response()
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        headers = Headers()
+        headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
+        headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        headers['Access-Control-Allow-Methods'] = '*'
+        headers['Access-Control-Allow-Credentials'] = 'true'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
 
-        response.headers['Content-Type'] = 'application/octet-stream'
-        response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-        response.headers['Cache-Control'] = 'post-check=0, pre-check=0'
-        response.headers['Pragma'] = 'no-cache'
+        headers['Content-Type'] = 'application/octet-stream'
+        headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers['Pragma'] = 'no-cache'
 
-        token = request.environ.get('HTTP_X_RUCIO_AUTH_TOKEN')
+        token = request.headers.get('X-Rucio-Auth-Token')
 
         result = validate_auth_token(token)
         if not result:
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals())
+            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals(), headers=headers)
 
-        response.set_data(result)
-        return response
+        return str(result), 200, headers
 
 
 bp = Blueprint('authentication', __name__)
@@ -541,8 +1002,20 @@ ssh_view = SSH.as_view('ssh')
 bp.add_url_rule('/ssh', view_func=ssh_view, methods=['get', 'options'])
 ssh_challenge_token_view = SSHChallengeToken.as_view('ssh_challenge_token')
 bp.add_url_rule('/ssh_challenge_token', view_func=ssh_challenge_token_view, methods=['get', 'options'])
+saml_view = SAML.as_view('saml')
+bp.add_url_rule('/saml', view_func=saml_view, methods=['get', 'post', 'options'])
 validate_view = Validate.as_view('validate')
 bp.add_url_rule('/validate', view_func=validate_view, methods=['get', 'options'])
+oidc_view = OIDC.as_view('oidc_view')
+bp.add_url_rule('/oidc', view_func=oidc_view, methods=['get', 'options'])
+token_oidc_view = TokenOIDC.as_view('token_oidc_view')
+bp.add_url_rule('/oidc_token', view_func=token_oidc_view, methods=['get', 'options'])
+code_oidc_view = CodeOIDC.as_view('code_oidc_view')
+bp.add_url_rule('/oidc_code', view_func=code_oidc_view, methods=['get', 'options'])
+redirect_oidc_view = RedirectOIDC.as_view('redirect_oidc_view')
+bp.add_url_rule('/oidc_redirect', view_func=redirect_oidc_view, methods=['get', 'options'])
+refresh_oidc_view = RefreshOIDC.as_view('refresh_oidc_view')
+bp.add_url_rule('/oidc_refresh', view_func=refresh_oidc_view, methods=['get', 'options'])
 
 application = Flask(__name__)
 application.register_blueprint(bp)

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -1,4 +1,5 @@
-# Copyright 2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,22 +14,28 @@
 # limitations under the License.
 #
 # Authors:
-# - Thomas Beermann <thomas.beermann@cern.ch>, 2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2014-2018
+# - Thomas Beermann <thomas.beermann@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 from __future__ import print_function
+
+import itertools
+import re
 from functools import wraps
-from flask import request
 from time import time
 from traceback import format_exc
 
+from flask import request, Response
+
 from rucio.api.authentication import validate_auth_token
 from rucio.common.exception import RucioException
+from rucio.common.schema import get_schema_value
 from rucio.common.utils import generate_http_error_flask, generate_uuid
 
 
@@ -36,7 +43,7 @@ def before_request():
     if request.environ.get('REQUEST_METHOD') == 'OPTIONS':
         return '', 200
 
-    auth_token = request.environ.get('HTTP_X_RUCIO_AUTH_TOKEN')
+    auth_token = request.headers.get('X-Rucio-Auth-Token')
 
     try:
         auth = validate_auth_token(auth_token)
@@ -44,7 +51,7 @@ def before_request():
         return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
     except Exception as error:
         print(format_exc())
-        return error, 500
+        return str(error), 500
 
     if auth is None:
         return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate with given credentials')
@@ -75,22 +82,53 @@ def check_accept_header_wrapper_flask(supported_content_types):
     def wrapper(f):
         @wraps(f)
         def decorated(*args, **kwargs):
-            requested_content_type = request.environ.get('HTTP_ACCEPT')
-            request_type_allowed = True
-            if requested_content_type:
-                if ',' in requested_content_type:
-                    for content_type in requested_content_type.replace(' ', '').split(','):
-                        if content_type in supported_content_types or '*/*' in content_type:
-                            request_type_allowed = True
-                            break
-                        else:
-                            request_type_allowed = False
-                else:
-                    if requested_content_type not in supported_content_types and '*/*' not in requested_content_type:
-                        request_type_allowed = False
+            if not request.accept_mimetypes.provided:
+                # accept anything, if Accept header is not provided
+                return f(*args, **kwargs)
 
-            if not request_type_allowed:
-                return generate_http_error_flask(406, 'UnsupportedRequestedContentType', 'The requested content type %s is not supported. Use %s.' % (requested_content_type, ','.join(supported_content_types)))
-            return f(*args, **kwargs)
+            for supported in supported_content_types:
+                if supported in request.accept_mimetypes:
+                    return f(*args, **kwargs)
+
+            # none matched..
+            return generate_http_error_flask(406, 'UnsupportedRequestedContentType', 'The requested content type %s is not supported. Use %s.' % (request.environ.get("HTTP_ACCEPT"), str(supported_content_types)))
         return decorated
     return wrapper
+
+
+def parse_scope_name(scope_name):
+    """
+    Parses the given scope_name according to the schema's
+    SCOPE_NAME_REGEXP and returns a (scope, name) tuple.
+
+    :param scope_name: the scope_name string to be parsed.
+    :raises ValueError: when scope_name could not be parsed.
+    :returns: a (scope, name) tuple.
+    """
+    # why again does that regex start with a slash?
+    scope_name = re.match(get_schema_value('SCOPE_NAME_REGEXP'), '/' + scope_name)
+    if scope_name is None:
+        raise ValueError('cannot parse scope and name')
+    return scope_name.group(1, 2)
+
+
+def try_stream(generator, content_type=None):
+    """
+    Peeks at the first element of the passed generator and raises
+    an error, if yielding raises. Otherwise returns
+    a flask.Response object.
+
+    :param generator: a generator function or an iterator.
+    :param content_type: the response's Content-Type.
+                         'application/x-json-stream' by default.
+    :returns: a flask.Response object with the specified Content-Type.
+    """
+    if not content_type:
+        content_type = 'application/x-json-stream'
+
+    it = iter(generator)
+    try:
+        peek = next(it)
+        return Response(itertools.chain((peek,), it), content_type=content_type)
+    except StopIteration:
+        return Response('', content_type=content_type)

--- a/lib/rucio/web/rest/flaskapi/v1/credential.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credential.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,24 +17,28 @@
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 from __future__ import print_function
+
 from traceback import format_exc
+
+from flask import Flask, Blueprint, request, Response
+from flask.views import MethodView
+
+from rucio.api.credential import get_signed_url
+from rucio.common.exception import RucioException
+from rucio.common.utils import generate_http_error_flask
+from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask
+
 try:
     from urlparse import parse_qs
 except ImportError:
     from urllib.parse import parse_qs
-from rucio.api.authentication import validate_auth_token
-from rucio.api.credential import get_signed_url
-from rucio.common.exception import AccessDenied, RucioException
-from rucio.common.utils import generate_http_error_flask
-from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask
-
-from flask import Flask, Blueprint, request, Response
-from flask.views import MethodView
 
 
 class SignURL(MethodView):
@@ -69,12 +74,6 @@ class SignURL(MethodView):
         :reqheader X-Rucio-VO: VO name as a string (Multi-VO only).
         :reqheader X-Rucio-Account: Account identifier as a string.
         :reqheader X-Rucio-AppID: Application identifier as a string.
-        :resheader Access-Control-Allow-Origin:
-        :resheader Access-Control-Allow-Headers:
-        :resheader Access-Control-Allow-Methods:
-        :resheader Access-Control-Allow-Credentials:
-        :resheader Access-Control-Expose-Headers:
-        :resheader X-Rucio-Auth-Token: The authentication token
         :status 200: Successfully signed URL
         :status 400: Bad Request
         :status 401: Unauthorized
@@ -82,45 +81,20 @@ class SignURL(MethodView):
         :status 500: Internal Server Error
         """
 
-        response = Response()
-        response.headers['Access-Control-Allow-Origin'] = request.environ.get('HTTP_ORIGIN')
-        response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response.headers['Access-Control-Allow-Methods'] = '*'
-        response.headers['Access-Control-Allow-Credentials'] = 'true'
-        response.headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
-
-        response.headers['Content-Type'] = 'application/octet-stream'
-        response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-        response.headers['Cache-Control'] = 'post-check=0, pre-check=0'
-        response.headers['Pragma'] = 'no-cache'
-
-        vo = request.environ.get('HTTP_X_RUCIO_VO', 'def')
-        account = request.environ.get('HTTP_X_RUCIO_ACCOUNT')
-        appid = request.environ.get('HTTP_X_RUCIO_APPID')
-        if appid is None:
-            appid = 'unknown'
-        ip = request.environ.get('HTTP_X_FORWARDED_FOR')
-        if ip is None:
-            ip = request.remote_addr
-
-        try:
-            validate_auth_token(request.environ.get('HTTP_X_RUCIO_AUTH_TOKEN'))
-        except AccessDenied:
-            return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot authenticate to account %(account)s with given credentials' % locals())
-        except RucioException as error:
-            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
-        except Exception as error:
-            print(format_exc())
-            return error, 500
+        vo = request.headers.get('X-Rucio-VO', 'def')
+        account = request.headers.get('X-Rucio-Account')
+        appid = request.headers.get('X-Rucio-AppID', 'unknown')
+        ip = request.headers.get('X-Forwarded-For', request.remote_addr)
 
         rse, svc, operation, url = None, None, None, None
         try:
-            params = parse_qs(request.query[1:])
+            query_string = request.query_string.decode(encoding='utf-8')
+            params = parse_qs(query_string)
+            rse = params.get('rse', [None])[0]
             lifetime = params.get('lifetime', [600])[0]
             service = params.get('svc', ['gcs'])[0]
             operation = params.get('op', ['read'])[0]
             url = params.get('url', [None])[0]
-            rse = params.get('rse', [None])[0]
         except ValueError:
             return generate_http_error_flask(400, 'ValueError', 'Cannot decode json parameter list')
 
@@ -142,18 +116,20 @@ class SignURL(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
         if not result:
             return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot generate signed URL for account %(account)s' % locals())
 
-        return response
+        return str(result), 200
 
 
 bp = Blueprint('credential', __name__)
 
 signurl_view = SignURL.as_view('signurl')
 bp.add_url_rule('/signurl', view_func=signurl_view, methods=['get', 'options'])
+# yes, /signur ~= '/signurl?$'
+bp.add_url_rule('/signur', view_func=signurl_view, methods=['get', 'options'])
 application = Flask(__name__)
 application.register_blueprint(bp)
 

--- a/lib/rucio/web/rest/flaskapi/v1/exporter.py
+++ b/lib/rucio/web/rest/flaskapi/v1/exporter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +17,13 @@
 # Authors:
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Muhammad Aditya Hilmy <didithilmy@gmail.com>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
-
-from flask import Flask, Blueprint, request
+from flask import Flask, Blueprint, request, Response
 from flask.views import MethodView
 
 from rucio.api.exporter import export_data
@@ -62,7 +65,7 @@ class Export(MethodView):
         """
 
         try:
-            return render_json(**export_data(issuer=request.environ.get('issuer'), vo=request.environ.get('vo')))
+            return Response(render_json(**export_data(issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))), content_type='application/json')
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
 
@@ -71,6 +74,7 @@ bp = Blueprint('export', __name__)
 
 export_view = Export.as_view('scope')
 bp.add_url_rule('/', view_func=export_view, methods=['get', ])
+# FIXME: Add '' rule
 
 application = Flask(__name__)
 application.register_blueprint(bp)

--- a/lib/rucio/web/rest/flaskapi/v1/heartbeat.py
+++ b/lib/rucio/web/rest/flaskapi/v1/heartbeat.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,20 +18,24 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2014-2018
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2017
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2018
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 import json
 from logging import getLogger, StreamHandler, DEBUG
+from traceback import format_exc
+
 from flask import Flask, Blueprint, Response, request
 from flask.views import MethodView
 
 from rucio.api.heartbeat import list_heartbeats
-from rucio.common.utils import APIEncoder
+from rucio.common.exception import RucioException
+from rucio.common.utils import APIEncoder, generate_http_error_flask
 from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask
-
 
 LOGGER = getLogger("rucio.heartbeat")
 SH = StreamHandler()
@@ -54,9 +59,14 @@ class Heartbeat(MethodView):
         :status 406: Not Acceptable.
         :returns: List of heartbeats.
         """
-
-        return Response(json.dumps(list_heartbeats(issuer=request.environ.get('issuer'), vo=request.environ.get('vo')),
-                                   cls=APIEncoder, content_type="application/json"))
+        try:
+            return Response(json.dumps(list_heartbeats(issuer=request.environ.get('issuer'), vo=request.environ.get('vo')),
+                                       cls=APIEncoder), content_type='application/json')
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500
 
 
 """----------------------
@@ -65,6 +75,7 @@ class Heartbeat(MethodView):
 bp = Blueprint('heartbeat', __name__)
 
 heartbeat_view = Heartbeat.as_view('heartbeat')
+# FIXME: Replace with '' rule
 bp.add_url_rule('/', view_func=heartbeat_view, methods=['get', ])
 
 application = Flask(__name__)

--- a/lib/rucio/web/rest/flaskapi/v1/importer.py
+++ b/lib/rucio/web/rest/flaskapi/v1/importer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +17,9 @@
 # Authors:
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Muhammad Aditya Hilmy <didithilmy@gmail.com>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -53,10 +57,8 @@ class Import(MethodView):
 
             HTTP/1.1 201 OK
             Vary: Accept
-            Content-Type: application/x-json-stream
 
             Created
-        :resheader Content-Type: application/json
         :status 200: DIDs found
         :status 401: Invalid Auth Token
         :returns: dictionary with rucio data
@@ -79,6 +81,7 @@ bp = Blueprint('import', __name__)
 
 import_view = Import.as_view('scope')
 bp.add_url_rule('/', view_func=import_view, methods=['post', ])
+# FIXME: Add '' rule
 
 application = Flask(__name__)
 application.register_blueprint(bp)

--- a/lib/rucio/web/rest/flaskapi/v1/lock.py
+++ b/lib/rucio/web/rest/flaskapi/v1/lock.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,18 +20,22 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2018
 # - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 from logging import getLogger, StreamHandler, DEBUG
-from flask import Flask, Blueprint, Response, request
+from traceback import format_exc
+
+from flask import Flask, Blueprint, request
 from flask.views import MethodView
 
 from rucio.api.lock import get_dataset_locks_by_rse, get_dataset_locks
 from rucio.common.exception import RucioException, RSENotFound
 from rucio.common.utils import generate_http_error_flask, render_json
-from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask
+from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask, parse_scope_name, try_stream
 
 LOGGER = getLogger("rucio.lock")
 SH = StreamHandler()
@@ -58,10 +63,11 @@ class LockByRSE(MethodView):
         did_type = request.args.get('did_type', None)
         try:
             if did_type == 'dataset':
-                data = ""
-                for lock in get_dataset_locks_by_rse(rse, vo=request.environ.get('vo')):
-                    data += render_json(**lock) + '\n'
-                return Response(data, content_type="application/x-json-stream")
+                def generate(vo):
+                    for lock in get_dataset_locks_by_rse(rse, vo=vo):
+                        yield render_json(**lock) + '\n'
+
+                return try_stream(generate(vo=request.environ.get('vo')))
             else:
                 return 'Wrong did_type specified', 500
         except RSENotFound as error:
@@ -69,18 +75,18 @@ class LockByRSE(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            return error, 500
+            print(format_exc())
+            return str(error), 500
 
 
 class LockByScopeName(MethodView):
     """ REST APIs for dataset locks. """
 
     @check_accept_header_wrapper_flask(['application/x-json-stream'])
-    def GET(self, scope, name):
+    def get(self, scope_name):
         """ get locks for a given scope, name.
 
-        :param scope: The DID scope.
-        :param name: The DID name.
+        :param scope_name: data identifier (scope)/(name).
         :query did_type: The type used to filter, e.g., DATASET, CONTAINER.
         :resheader Content-Type: application/x-json-stream
         :status 200: OK.
@@ -89,31 +95,35 @@ class LockByScopeName(MethodView):
         :status 500: Internal Error.
         :returns: Line separated list of dictionary with lock information.
         """
-
         did_type = request.args.get('did_type', None)
         try:
+            scope, name = parse_scope_name(scope_name)
             if did_type == 'dataset':
-                data = ""
-                for lock in get_dataset_locks(scope, name, vo=request.environ.get('vo')):
-                    data += render_json(**lock) + '\n'
-                return Response(data, content_type="application/x-json-stream")
+                def generate(vo):
+                    for lock in get_dataset_locks(scope, name, vo=vo):
+                        yield render_json(**lock) + '\n'
+
+                return try_stream(generate(vo=request.environ.get('vo')))
             else:
                 return 'Wrong did_type specified', 500
+        except ValueError as error:
+            return generate_http_error_flask(400, 'ValueError', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            return error, 500
+            print(format_exc())
+            return str(error), 500
 
 
 """----------------------
    Web service startup
 ----------------------"""
-bp = Blueprint('lifetime_exception', __name__)
+bp = Blueprint('lock', __name__)
 
 lock_by_rse_view = LockByRSE.as_view('lock_by_rse')
 bp.add_url_rule('/<rse>', view_func=lock_by_rse_view, methods=['get', ])
 lock_by_scope_name_view = LockByScopeName.as_view('lock_by_scope_name')
-bp.add_url_rule('/<scope>/<name>', view_func=lock_by_scope_name_view, methods=['get', ])
+bp.add_url_rule('/<path:scope_name>', view_func=lock_by_scope_name_view, methods=['get', ])
 
 application = Flask(__name__)
 application.register_blueprint(bp)

--- a/lib/rucio/web/rest/flaskapi/v1/nongrid_trace.py
+++ b/lib/rucio/web/rest/flaskapi/v1/nongrid_trace.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2015-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,18 +16,21 @@
 #
 # Authors:
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2015-2018
-# - Mario Lassnig <mario.lassnig>, 2018
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 from __future__ import print_function
+
 import json
 import time
 import traceback
 
 from flask import Flask, Blueprint, request
 from flask.views import MethodView
+from werkzeug.datastructures import Headers
 
 from rucio.common.utils import generate_http_error_flask
 from rucio.core.nongrid_trace import trace
@@ -46,6 +50,13 @@ class XAODTrace(MethodView):
         :status 400: Cannot decode json data.
         :status 500: Internal Error.
         """
+        headers = Headers()
+        headers.set('Content-Type', 'application/octet-stream')
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+
         try:
             payload = json.loads(request.data)
 
@@ -53,19 +64,17 @@ class XAODTrace(MethodView):
             payload['timeentry'] = int(time.time())
 
             # guess client IP
-            payload['ip'] = request.environ.get('HTTP_X_FORWARDED_FOR')
-            if payload['ip'] is None:
-                payload['ip'] = request.remote_addr
+            payload['ip'] = request.headers.get('X-Forwarded-For', request.remote_addr)
 
             trace(payload=payload)
 
         except ValueError:
-            return generate_http_error_flask(400, 'ValueError', 'Cannot decode json data')
+            return generate_http_error_flask(400, 'ValueError', 'Cannot decode json parameter list', headers=headers)
         except Exception as error:
             print(traceback.format_exc())
-            return error, 500
+            return str(error), 500, headers
 
-        return "Created", 201
+        return 'Created', 201, headers
 
 
 """----------------------

--- a/lib/rucio/web/rest/flaskapi/v1/ping.py
+++ b/lib/rucio/web/rest/flaskapi/v1/ping.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,14 +18,16 @@
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2017
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2012-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2014-2018
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
-from json import dumps
 from logging import getLogger, StreamHandler, DEBUG
-from flask import Flask, Blueprint, Response
+
+from flask import Flask, Blueprint, jsonify, request
 from flask.views import MethodView
+from werkzeug.datastructures import Headers
 
 from rucio import version
 from rucio.web.rest.flaskapi.v1.common import after_request, check_accept_header_wrapper_flask
@@ -70,7 +73,19 @@ class Ping(MethodView):
         :status 500: Internal Error.
         :returns: JSON dictionary with the version.
         """
-        return Response(dumps({"version": version.version_string()}), content_type="application/json")
+        headers = Headers()
+        headers.set('Access-Control-Allow-Origin', request.environ.get('HTTP_ORIGIN'))
+        headers.set('Access-Control-Allow-Headers', request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS'))
+        headers.set('Access-Control-Allow-Methods', '*')
+        headers.set('Access-Control-Allow-Credentials', 'true')
+
+        headers.set('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
+        headers.add('Cache-Control', 'post-check=0, pre-check=0')
+        headers.set('Pragma', 'no-cache')
+
+        response = jsonify(version=version.version_string())
+        response.headers.extend(headers)
+        return response
 
 
 # ----------------------
@@ -80,6 +95,7 @@ bp = Blueprint('ping', __name__)
 
 ping_view = Ping.as_view('ping')
 bp.add_url_rule('/', view_func=ping_view, methods=['get', ])
+# FIXME: Add '' rule
 
 application = Flask(__name__)
 application.register_blueprint(bp)

--- a/lib/rucio/web/rest/flaskapi/v1/replica.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replica.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2013-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,21 +20,24 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2014-2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2019
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 from __future__ import print_function
+
 from datetime import datetime
-from json import dumps
-from six import string_types
+from json import dumps, loads
 from traceback import format_exc
+from xml.sax.saxutils import escape
 
 from flask import Flask, Blueprint, Response, request
 from flask.views import MethodView
 from geoip2.errors import AddressNotFoundError
-from xml.sax.saxutils import escape
+from six import string_types
 
 from rucio.api.replica import (add_replicas, list_replicas, list_dataset_replicas, list_dataset_replicas_bulk,
                                delete_replicas,
@@ -41,25 +45,34 @@ from rucio.api.replica import (add_replicas, list_replicas, list_dataset_replica
                                declare_bad_file_replicas, add_bad_pfns, get_suspicious_files,
                                declare_suspicious_file_replicas, list_bad_replicas_status,
                                get_bad_replicas_summary, list_datasets_per_rse,
-                               set_tombstone)
-from rucio.db.sqla.constants import BadFilesStatus
+                               set_tombstone, list_dataset_replicas_vp)
+from rucio.common.config import config_get
+from rucio.common.constants import SUPPORTED_PROTOCOLS
 from rucio.common.exception import (AccessDenied, DataIdentifierAlreadyExists, InvalidType,
                                     DataIdentifierNotFound, Duplicate, InvalidPath,
                                     ResourceTemporaryUnavailable, RucioException,
                                     RSENotFound, UnsupportedOperation, ReplicaNotFound, InvalidObject)
 from rucio.common.replica_sorter import sort_random, sort_geoip, sort_closeness, sort_dynamic, sort_ranking
 from rucio.common.utils import generate_http_error_flask, parse_response, APIEncoder, render_json_list
-from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask
+from rucio.db.sqla.constants import BadFilesStatus
+from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask, try_stream, parse_scope_name
+
+try:
+    from urllib import unquote
+    from urlparse import parse_qs
+except ImportError:
+    from urllib.parse import unquote
+    from urllib.parse import parse_qs
 
 
 class Replicas(MethodView):
 
     @check_accept_header_wrapper_flask(['application/x-json-stream', 'application/metalink4+xml'])
-    def get(self, scope, name):
+    def get(self, scope_name):
         """
         List all replicas for data identifiers.
 
-        .. :quickref: Replicas; List all replicas for did
+        .. :quickref: Replicas; List replicas for DID.
         HTTP Success:
             200 OK
 
@@ -68,8 +81,7 @@ class Replicas(MethodView):
             500 InternalError
 
         :reqheader HTTP_ACCEPT: application/metalink4+xml
-        :param scope: data identifier scope.
-        :param name: data identifier name.
+        :param scope_name: data identifier (scope)/(name).
         :resheader Content-Type: application/x-json-stream
         :resheader Content-Type: application/metalink4+xml
         :status 200: OK.
@@ -80,12 +92,16 @@ class Replicas(MethodView):
         :returns: A dictionary containing all replicas information.
         :returns: A metalink description of replicas if metalink(4)+xml is specified in Accept:
         """
+        try:
+            scope, name = parse_scope_name(scope_name)
+        except ValueError as error:
+            return generate_http_error_flask(400, 'ValueError', error.args[0])
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500
 
-        metalink = False
-        if request.environ.get('HTTP_ACCEPT') is not None:
-            tmp = request.environ.get('HTTP_ACCEPT').split(',')
-            if 'application/metalink4+xml' in tmp:
-                metalink = True
+        content_type = request.accept_mimetypes.best_match(['application/x-json-stream', 'application/metalink4+xml'], 'application/x-json-stream')
+        metalink = (content_type == 'application/metalink4+xml')
 
         dids, schemes, select, limit = [{'scope': scope, 'name': name}], None, None, None
 
@@ -95,69 +111,79 @@ class Replicas(MethodView):
         if limit:
             limit = int(limit)
 
-        data = ""
-        content_type = 'application/x-json-stream'
+        # Resolve all reasonable protocols when doing metalink for maximum access possibilities
+        if metalink and schemes is None:
+            schemes = SUPPORTED_PROTOCOLS
+
         try:
-            # first, set the appropriate content type, and stream the header
-            if metalink:
-                content_type = 'application/metalink4+xml'
-                data += '<?xml version="1.0" encoding="UTF-8"?>\n<metalink xmlns="urn:ietf:params:xml:ns:metalink">\n'
+            client_ip = request.headers.get('X-Forwarded-For', request.remote_addr)
 
-            # then, stream the replica information
-            for rfile in list_replicas(dids=dids, schemes=schemes, vo=request.environ.get('vo')):
-                client_ip = request.environ.get('HTTP_X_FORWARDED_FOR')
-                if client_ip is None:
-                    client_ip = request.remote_addr
+            def generate(vo):
+                # we need to call list_replicas before starting to reply
+                # otherwise the exceptions won't be propagated correctly
+                first = metalink
 
-                replicas = []
-                dictreplica = {}
-                for rse in rfile['rses']:
-                    for replica in rfile['rses'][rse]:
-                        replicas.append(replica)
-                        dictreplica[replica] = rse
-                if select == 'geoip':
-                    try:
-                        replicas = sort_geoip(dictreplica, client_ip)
-                    except AddressNotFoundError:
-                        pass
-                else:
-                    replicas = sort_random(dictreplica)
-                if not metalink:
-                    data += dumps(rfile) + '\n'
-                else:
-                    data += ' <file name="' + rfile['name'] + '">\n'
-                    data += '  <identity>' + rfile['scope'] + ':' + rfile['name'] + '</identity>\n'
+                try:
+                    # then, stream the replica information
+                    for rfile in list_replicas(dids=dids, schemes=schemes, vo=vo):
+                        if first and metalink:
+                            # first, set the appropriate content type, and stream the header
+                            yield '<?xml version="1.0" encoding="UTF-8"?>\n<metalink xmlns="urn:ietf:params:xml:ns:metalink">\n'
+                            first = False
 
-                    if rfile['adler32'] is not None:
-                        data += '  <hash type="adler32">' + rfile['adler32'] + '</hash>\n'
-                    if rfile['md5'] is not None:
-                        data += '  <hash type="md5">' + rfile['md5'] + '</hash>\n'
+                        replicas = []
+                        dictreplica = {}
+                        for rse in rfile['rses']:
+                            for replica in rfile['rses'][rse]:
+                                replicas.append(replica)
+                                dictreplica[replica] = rse
+                        if select == 'geoip':
+                            try:
+                                replicas = sort_geoip(dictreplica, client_ip)
+                            except AddressNotFoundError:
+                                pass
+                        else:
+                            replicas = sort_random(dictreplica)
+                        if not metalink:
+                            yield dumps(rfile) + '\n'
+                        else:
+                            yield ' <file name="' + rfile['name'] + '">\n'
+                            yield '  <identity>' + rfile['scope'] + ':' + rfile['name'] + '</identity>\n'
 
-                    data += '  <size>' + str(rfile['bytes']) + '</size>\n'
+                            if rfile['adler32'] is not None:
+                                yield '  <hash type="adler32">' + rfile['adler32'] + '</hash>\n'
+                            if rfile['md5'] is not None:
+                                yield '  <hash type="md5">' + rfile['md5'] + '</hash>\n'
 
-                    data += '  <glfn name="/atlas/rucio/%s:%s">' % (rfile['scope'], rfile['name'])
-                    data += '</glfn>\n'
+                            yield '  <size>' + str(rfile['bytes']) + '</size>\n'
 
-                    idx = 0
-                    for replica in replicas:
-                        data += '   <url location="' + str(dictreplica[replica]) + '" priority="' + str(idx + 1) + '">' + escape(replica) + '</url>\n'
-                        idx += 1
-                        if limit and limit == idx:
-                            break
-                    data += ' </file>\n'
+                            yield '  <glfn name="/atlas/rucio/%s:%s">' % (rfile['scope'], rfile['name'])
+                            yield '</glfn>\n'
 
-            # don't forget to send the metalink footer
-            if metalink:
-                data += '</metalink>\n'
+                            idx = 0
+                            for replica in replicas:
+                                yield '   <url location="' + str(dictreplica[replica]) + '" priority="' + str(idx + 1) + '">' + escape(replica) + '</url>\n'
+                                idx += 1
+                                if limit and limit == idx:
+                                    break
+                            yield ' </file>\n'
 
-            return Response(data, content_type=content_type)
+                    if metalink and first:
+                        # if still first output, i.e. there were no replicas
+                        yield '<?xml version="1.0" encoding="UTF-8"?>\n<metalink xmlns="urn:ietf:params:xml:ns:metalink">\n</metalink>\n'
+                finally:
+                    # don't forget to send the metalink footer
+                    if metalink and not first:
+                        yield '</metalink>\n'
+
+            return try_stream(generate(vo=request.environ.get('vo')), content_type=content_type)
         except DataIdentifierNotFound as error:
             return generate_http_error_flask(404, 'DataIdentifierNotFound', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
     def post(self):
         """
@@ -202,7 +228,7 @@ class Replicas(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
         return 'Created', 201
 
     def put(self):
@@ -234,8 +260,8 @@ class Replicas(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-        return 'OK', 200
+            return str(error), 500
+        return '', 200
 
     def delete(self):
         """
@@ -275,8 +301,8 @@ class Replicas(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-        return 'OK', 200
+            return str(error), 500
+        return '', 200
 
 
 class ListReplicas(MethodView):
@@ -286,7 +312,7 @@ class ListReplicas(MethodView):
         """
         List all replicas for data identifiers.
 
-        .. :quickref: ListReplicas; List all replicas for did.
+        .. :quickref: Replicas; List replicas for multiple DIDs.
 
         :reqheader HTTP_ACCEPT: application/metalink4+xml
         :query schemes: A list of schemes to filter the replicas.
@@ -311,23 +337,19 @@ class ListReplicas(MethodView):
         :returns: A metalink description of replicas if metalink(4)+xml is specified in Accept:
         """
 
-        metalink = False
-        if request.environ.get('HTTP_ACCEPT') is not None:
-            tmp = request.environ.get('HTTP_ACCEPT').split(',')
-            if 'application/metalink4+xml' in tmp:
-                metalink = True
+        content_type = request.accept_mimetypes.best_match(['application/x-json-stream', 'application/metalink4+xml'], 'application/x-json-stream')
+        metalink = (content_type == 'application/metalink4+xml')
 
-        client_ip = request.environ.get('HTTP_X_FORWARDED_FOR')
-        if client_ip is None:
-            client_ip = request.remote_addr
+        client_ip = request.headers.get('X-Forwarded-For', request.remote_addr)
 
         dids, schemes, select, unavailable, limit = [], None, None, False, None
-        ignore_availability, rse_expression, all_states = False, None, False
+        ignore_availability, rse_expression, all_states, domain = False, None, False, None
+        signature_lifetime, resolve_archives, resolve_parents = None, True, False
+        updated_after = None
         client_location = {}
 
-        json_data = request.data
         try:
-            params = parse_response(json_data)
+            params = parse_response(request.data)
             if 'dids' in params:
                 dids = params['dids']
             if 'schemes' in params:
@@ -346,82 +368,148 @@ class ListReplicas(MethodView):
                 select = params['sort']
             if 'domain' in params:
                 domain = params['domain']
+            if 'resolve_archives' in params:
+                resolve_archives = params['resolve_archives']
+            if 'resolve_parents' in params:
+                resolve_parents = params['resolve_parents']
+
+            if 'signature_lifetime' in params:
+                signature_lifetime = params['signature_lifetime']
+            else:
+                # hardcoded default of 10 minutes if config is not parseable
+                signature_lifetime = config_get('credentials', 'signature_lifetime', raise_exception=False, default=600)
+
+            if 'updated_after' in params:
+                if isinstance(params['updated_after'], (int, float)):
+                    # convert from epoch time stamp to datetime object
+                    updated_after = datetime.utcfromtimestamp(params['updated_after'])
+                else:
+                    # attempt UTC format '%Y-%m-%dT%H:%M:%S' conversion
+                    updated_after = datetime.strptime(params['updated_after'], '%Y-%m-%dT%H:%M:%S')
+
         except ValueError:
             return generate_http_error_flask(400, 'ValueError', 'Cannot decode json parameter list')
 
-        schemes = request.args.get('schemes', None)
-        select = request.args.get('select', None)
-        select = request.args.get('sort', None)
+        if request.query_string:
+            query_string = request.query_string.decode(encoding='utf-8')
+            params = parse_qs(query_string)
+            if 'select' in params:
+                select = params['select'][0]
+            if 'limit' in params:
+                limit = params['limit'][0]
+            if 'sort' in params:
+                select = params['sort']
 
-        data = ""
-        content_type = 'application/x-json-stream'
+        # Resolve all reasonable protocols when doing metalink for maximum access possibilities
+        if metalink and schemes is None:
+            schemes = SUPPORTED_PROTOCOLS
+
+        content_type = 'application/metalink4+xml' if metalink else 'application/x-json-stream'
+
         try:
-            # first, set the appropriate content type, and stream the header
-            if metalink:
-                content_type = 'application/metalink4+xml'
-                data += '<?xml version="1.0" encoding="UTF-8"?>\n<metalink xmlns="urn:ietf:params:xml:ns:metalink">\n'
+            def generate(request_id, issuer, vo):
+                # we need to call list_replicas before starting to reply
+                # otherwise the exceptions won't be propagated correctly
+                first = metalink
 
-            # then, stream the replica information
-            for rfile in list_replicas(dids=dids, schemes=schemes,
-                                       unavailable=unavailable,
-                                       request_id=request.environ.get('request_id'),
-                                       ignore_availability=ignore_availability,
-                                       all_states=all_states,
-                                       rse_expression=rse_expression,
-                                       client_location=client_location,
-                                       domain=domain, vo=request.environ.get('vo')):
-                replicas = []
-                dictreplica = {}
-                for rse in rfile['rses']:
-                    for replica in rfile['rses'][rse]:
-                        replicas.append(replica)
-                        dictreplica[replica] = rse
+                try:
+                    for rfile in list_replicas(dids=dids, schemes=schemes,
+                                               unavailable=unavailable,
+                                               request_id=request_id,
+                                               ignore_availability=ignore_availability,
+                                               all_states=all_states,
+                                               rse_expression=rse_expression,
+                                               client_location=client_location,
+                                               domain=domain, signature_lifetime=signature_lifetime,
+                                               resolve_archives=resolve_archives,
+                                               resolve_parents=resolve_parents,
+                                               updated_after=updated_after,
+                                               issuer=issuer,
+                                               vo=vo):
 
-                if not metalink:
-                    data += dumps(rfile, cls=APIEncoder) + '\n'
-                else:
-                    data += ' <file name="' + rfile['name'] + '">\n'
-                    data += '  <identity>' + rfile['scope'] + ':' + rfile['name'] + '</identity>\n'
-                    if rfile['adler32'] is not None:
-                        data += '  <hash type="adler32">' + rfile['adler32'] + '</hash>\n'
-                    if rfile['md5'] is not None:
-                        data += '  <hash type="md5">' + rfile['md5'] + '</hash>\n'
-                    data += '  <size>' + str(rfile['bytes']) + '</size>\n'
+                        # in first round, set the appropriate content type, and stream the header
+                        if first and metalink:
+                            yield '<?xml version="1.0" encoding="UTF-8"?>\n<metalink xmlns="urn:ietf:params:xml:ns:metalink">\n'
+                        first = False
 
-                    data += '  <glfn name="/atlas/rucio/%s:%s">' % (rfile['scope'], rfile['name'])
-                    data += '</glfn>\n'
+                        if not metalink:
+                            yield dumps(rfile, cls=APIEncoder) + '\n'
+                        else:
+                            replicas = []
+                            dictreplica = {}
+                            for replica in rfile['pfns'].keys():
+                                replicas.append(replica)
+                                dictreplica[replica] = (rfile['pfns'][replica]['domain'],
+                                                        rfile['pfns'][replica]['priority'],
+                                                        rfile['pfns'][replica]['rse'],
+                                                        rfile['pfns'][replica]['client_extract'])
 
-                    if select == 'geoip':
-                        replicas = sort_geoip(dictreplica, client_location['ip'])
-                    elif select == 'closeness':
-                        replicas = sort_closeness(dictreplica, client_location)
-                    elif select == 'dynamic':
-                        replicas = sort_dynamic(dictreplica, client_location)
-                    elif select == 'ranking':
-                        replicas = sort_ranking(dictreplica, client_location)
-                    else:
-                        replicas = sort_random(dictreplica)
+                            yield ' <file name="' + rfile['name'] + '">\n'
 
-                    idx = 0
-                    for replica in replicas:
-                        data += '   <url location="' + str(dictreplica[replica]) + '" priority="' + str(idx + 1) + '">' + escape(replica) + '</url>\n'
-                        idx += 1
-                        if limit and limit == idx:
-                            break
-                    data += ' </file>\n'
+                            if 'parents' in rfile and rfile['parents']:
+                                yield '  <parents>\n'
+                                for parent in rfile['parents']:
+                                    yield '   <did>' + parent + '</did>\n'
+                                yield '  </parents>\n'
 
-            # don't forget to send the metalink footer
-            if metalink:
-                data += '</metalink>\n'
+                            yield '  <identity>' + rfile['scope'] + ':' + rfile['name'] + '</identity>\n'
+                            if rfile['adler32'] is not None:
+                                yield '  <hash type="adler32">' + rfile['adler32'] + '</hash>\n'
+                            if rfile['md5'] is not None:
+                                yield '  <hash type="md5">' + rfile['md5'] + '</hash>\n'
+                            yield '  <size>' + str(rfile['bytes']) + '</size>\n'
 
-            return Response(data, content_type=content_type)
+                            yield '  <glfn name="/%s/rucio/%s:%s"></glfn>\n' % (config_get('policy', 'schema',
+                                                                                           raise_exception=False,
+                                                                                           default='generic'),
+                                                                                rfile['scope'],
+                                                                                rfile['name'])
+
+                            # TODO: deprecate this
+                            if select == 'geoip':
+                                replicas = sort_geoip(dictreplica, client_location['ip'])
+                            elif select == 'closeness':
+                                replicas = sort_closeness(dictreplica, client_location)
+                            elif select == 'dynamic':
+                                replicas = sort_dynamic(dictreplica, client_location)
+                            elif select == 'ranking':
+                                replicas = sort_ranking(dictreplica, client_location)
+                            elif select == 'random':
+                                replicas = sort_random(dictreplica)
+                            else:
+                                replicas = sorted(dictreplica, key=dictreplica.get)
+
+                            idx = 0
+                            for replica in replicas:
+                                yield '  <url location="' + str(dictreplica[replica][2]) \
+                                    + '" domain="' + str(dictreplica[replica][0]) \
+                                    + '" priority="' + str(dictreplica[replica][1]) \
+                                    + '" client_extract="' + str(dictreplica[replica][3]).lower() \
+                                    + '">' + escape(replica) + '</url>\n'
+                                idx += 1
+                                if limit and limit == idx:
+                                    break
+                            yield ' </file>\n'
+
+                    if metalink and first:
+                        # if still first output, i.e. there were no replicas
+                        yield '<?xml version="1.0" encoding="UTF-8"?>\n<metalink xmlns="urn:ietf:params:xml:ns:metalink">\n</metalink>\n'
+                finally:
+                    # don't forget to send the metalink footer
+                    if metalink and not first:
+                        yield '</metalink>\n'
+
+            return try_stream(generate(request_id=request.environ.get('request_id'),
+                                       issuer=request.environ.get('issuer'),
+                                       vo=request.environ.get('vo')),
+                              content_type=content_type)
         except DataIdentifierNotFound as error:
             return generate_http_error_flask(404, 'DataIdentifierNotFound', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
 
 class ReplicasDIDs(MethodView):
@@ -455,19 +543,23 @@ class ReplicasDIDs(MethodView):
             return generate_http_error_flask(400, 'ValueError', 'Cannot decode json parameter list')
 
         try:
-            data = ""
-            for pfn in get_did_from_pfns(pfns, rse, vo=request.environ.get('vo')):
-                data += dumps(pfn) + '\n'
-            return Response(data, content_type='application/x-json-string')
+            def generate(vo):
+                for pfn in get_did_from_pfns(pfns, rse, vo=vo):
+                    yield dumps(pfn) + '\n'
+
+            return try_stream(generate(vo=request.environ.get('vo')))
+        except AccessDenied as error:
+            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
 
 class BadReplicas(MethodView):
 
+    @check_accept_header_wrapper_flask(['application/json'])
     def post(self):
         """
         Declare a list of bad replicas.
@@ -476,7 +568,7 @@ class BadReplicas(MethodView):
 
         :<json string pfns: The list of PFNs.
         :<json string reason: The reason of the loss.
-        :resheader Content-Type: application/x-json-string
+        :resheader Content-Type: application/json
         :status 201: Created.
         :status 400: Cannot decode json parameter list.
         :status 401: Invalid auth token.
@@ -499,18 +591,21 @@ class BadReplicas(MethodView):
         not_declared_files = {}
         try:
             not_declared_files = declare_bad_file_replicas(pfns=pfns, reason=reason, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+        except AccessDenied as error:
+            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
         except ReplicaNotFound as error:
             return generate_http_error_flask(404, 'ReplicaNotFound', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-        return Response(dumps(not_declared_files), status=201, content_type='application/x-json-stream')
+            return str(error), 500
+        return Response(dumps(not_declared_files), status=201, content_type='application/json')
 
 
 class SuspiciousReplicas(MethodView):
 
+    @check_accept_header_wrapper_flask(['application/json'])
     def post(self):
         """
         Declare a list of suspicious replicas.
@@ -519,7 +614,7 @@ class SuspiciousReplicas(MethodView):
 
         :<json string pfns: The list of PFNs.
         :<json string reason: The reason of the loss.
-        :resheader Content-Type: application/x-json-string
+        :resheader Content-Type: application/json
         :status 201: Created.
         :status 400: Cannot decode json parameter list.
         :status 401: Invalid auth token.
@@ -541,14 +636,14 @@ class SuspiciousReplicas(MethodView):
         not_declared_files = {}
         try:
             not_declared_files = declare_suspicious_file_replicas(pfns=pfns, reason=reason, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
-        except ReplicaNotFound as error:
-            return generate_http_error_flask(404, 'ReplicaNotFound', error.args[0])
+        except AccessDenied as error:
+            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-        return Response(dumps(not_declared_files), status=201, content_type='application/x-json-stream')
+            return str(error), 500
+        return Response(dumps(not_declared_files), status=201, content_type='application/json')
 
     @check_accept_header_wrapper_flask(['application/json'])
     def get(self):
@@ -564,11 +659,20 @@ class SuspiciousReplicas(MethodView):
         :returns: List of suspicious file replicas.
         """
         result = []
-        rse_expression = request.args.get('rse_expression', None)
-        younger_than = request.args.get('younger_than', None)
-        nattempts = request.args.get('nattempts', None)
-        if younger_than:
-            younger_than = datetime.strptime(younger_than, "%Y-%m-%dT%H:%M:%S.%f")
+        rse_expression, younger_than, nattempts = None, None, None
+        if request.query_string:
+            query_string = request.query_string.decode(encoding='utf-8')
+            try:
+                params = loads(unquote(query_string))
+            except ValueError:
+                params = parse_qs(query_string)
+            print(params)
+            if 'rse_expression' in params:
+                rse_expression = params['rse_expression'][0]
+            if 'younger_than' in params and params['younger_than'][0]:
+                younger_than = datetime.strptime(params['younger_than'][0], "%Y-%m-%dT%H:%M:%S")
+            if 'nattempts' in params:
+                nattempts = int(params['nattempts'][0])
 
         try:
             result = get_suspicious_files(rse_expression=rse_expression, younger_than=younger_than, nattempts=nattempts, vo=request.environ.get('vo'))
@@ -576,8 +680,8 @@ class SuspiciousReplicas(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-        return render_json_list(result)
+            return str(error), 500
+        return Response(render_json_list(result), 200, content_type='application/json')
 
 
 class BadReplicasStates(MethodView):
@@ -602,37 +706,41 @@ class BadReplicasStates(MethodView):
         :status 500: Internal Error.
         :returns: List of dicts of bad file replicas.
         """
-        result = []
-        state = request.args.get('state', None)
-        rse = request.args.get('rse', None)
-        younger_than = request.args.get('younger_than', None)
-        older_than = request.args.get('older_than', None)
-        limit = request.args.get('limit', None)
-        list_pfns = request.args.get('list_pfns', None)
-
-        if isinstance(state, string_types):
-            state = BadFilesStatus.from_string(state)
-        if younger_than:
-            younger_than = datetime.strptime(younger_than, "%Y-%m-%dT%H:%M:%S.%f")
-        if older_than:
-            older_than = datetime.strptime(older_than, "%Y-%m-%dT%H:%M:%S.%f")
-        if 'limit':
-            limit = int(limit)
-        if 'list_pfns':
-            list_pfns = bool(list_pfns)
+        state, rse, younger_than, older_than, limit, list_pfns = None, None, None, None, None, None
+        if request.query_string:
+            query_string = request.query_string.decode(encoding='utf-8')
+            try:
+                params = loads(unquote(query_string))
+            except ValueError:
+                params = parse_qs(query_string)
+            if 'state' in params:
+                state = params['state'][0]
+            if isinstance(state, string_types):
+                state = BadFilesStatus.from_string(state)
+            if 'rse' in params:
+                rse = params['rse'][0]
+            if 'younger_than' in params:
+                younger_than = datetime.strptime(params['younger_than'][0], "%Y-%m-%dT%H:%M:%S.%f")
+            if 'older_than' in params and params['older_than']:
+                older_than = datetime.strptime(params['older_than'][0], "%Y-%m-%dT%H:%M:%S.%f")
+            if 'limit' in params:
+                limit = int(params['limit'][0])
+            if 'list_pfns' in params:
+                list_pfns = bool(params['list_pfns'][0])
 
         try:
-            result = list_bad_replicas_status(state=state, rse=rse, younger_than=younger_than, older_than=older_than, limit=limit, list_pfns=list_pfns, vo=request.environ.get('vo'))
+            def generate(vo):
+                for row in list_bad_replicas_status(state=state, rse=rse, younger_than=younger_than,
+                                                    older_than=older_than, limit=limit, list_pfns=list_pfns,
+                                                    vo=vo):
+                    yield dumps(row, cls=APIEncoder) + '\n'
+
+            return try_stream(generate(vo=request.environ.get('vo')))
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-        data = ""
-        for row in result:
-            data += dumps(row, cls=APIEncoder) + '\n'
-
-        return Response(data, content_type='application/x-json-stream')
+            return str(error), 500
 
 
 class BadReplicasSummary(MethodView):
@@ -654,39 +762,44 @@ class BadReplicasSummary(MethodView):
         :status 500: Internal Error.
         :returns: List of bad replicas by incident.
         """
-        result = []
-        rse_expression = request.args.get('rse_expression', None)
-        from_date = request.args.get('from_date', None)
-        to_date = request.args.get('to_date', None)
-
-        if from_date:
-            from_date = datetime.strptime(from_date, "%Y-%m-%d")
-        if to_date:
-            to_date = datetime.strptime(to_date, "%Y-%m-%d")
+        rse_expression, from_date, to_date = None, None, None
+        if request.query_string:
+            query_string = request.query_string.decode(encoding='utf-8')
+            try:
+                params = loads(unquote(query_string))
+            except ValueError:
+                params = parse_qs(query_string)
+            if 'rse_expression' in params:
+                rse_expression = params['rse_expression'][0]
+            if 'from_date' in params and params['from_date'][0]:
+                from_date = datetime.strptime(params['from_date'][0], "%Y-%m-%d")
+            if 'to_date' in params:
+                to_date = datetime.strptime(params['to_date'][0], "%Y-%m-%d")
 
         try:
-            result = get_bad_replicas_summary(rse_expression=rse_expression, from_date=from_date, to_date=to_date, vo=request.environ.get('vo'))
+            def generate(vo):
+                for row in get_bad_replicas_summary(rse_expression=rse_expression, from_date=from_date,
+                                                    to_date=to_date, vo=vo):
+                    yield dumps(row, cls=APIEncoder) + '\n'
+
+            return try_stream(generate(vo=request.environ.get('vo')))
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-        data = ""
-        for row in result:
-            data += dumps(row, cls=APIEncoder) + '\n'
-
-        return Response(data, content_type='application/x-json-stream')
+            return str(error), 500
 
 
 class DatasetReplicas(MethodView):
 
     @check_accept_header_wrapper_flask(['application/x-json-stream'])
-    def get(self, scope, name):
+    def get(self, scope_name):
         """
         List dataset replicas.
 
         .. :quickref: DatasetReplicas; List dataset replicas.
 
+        :param scope_name: data identifier (scope)/(name).
         :query deep: Flag to ennable lookup at the file level.
         :resheader Content-Type: application/x-json-stream
         :status 200: OK.
@@ -695,17 +808,21 @@ class DatasetReplicas(MethodView):
         :status 500: Internal Error.
         :returns: A dictionary containing all replicas information.
         """
-        deep = request.args.get('deep', False)
         try:
-            data = ""
-            for row in list_dataset_replicas(scope=scope, name=name, deep=deep, vo=request.environ.get('vo')):
-                data += dumps(row, cls=APIEncoder) + '\n'
-            return Response(data, content_type='application/x-json-stream')
+            scope, name = parse_scope_name(scope_name)
+
+            def generate(deep, vo):
+                for row in list_dataset_replicas(scope=scope, name=name, deep=deep, vo=vo):
+                    yield dumps(row, cls=APIEncoder) + '\n'
+
+            return try_stream(generate(deep=request.args.get('deep', False), vo=request.environ.get('vo')))
+        except ValueError as error:
+            return generate_http_error_flask(400, 'ValueError', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
 
 class DatasetReplicasBulk(MethodView):
@@ -715,7 +832,7 @@ class DatasetReplicasBulk(MethodView):
         """
         List dataset replicas for multiple DIDs.
 
-        .. :quickref: DatasetReplicasBulk; List dataset replicas (bulk).
+        .. :quickref: DatasetReplicas; List replicas for multiple DIDs.
 
         :<json list dids: List of DIDs for querying the datasets.
         :resheader Content-Type: application/x-json-stream
@@ -740,21 +857,58 @@ class DatasetReplicasBulk(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
         if didslength == 0:
             return generate_http_error_flask(400, 'ValueError', 'List of DIDs is empty')
         try:
-            data = ""
-            for row in list_dataset_replicas_bulk(dids=dids, vo=request.environ.get('vo')):
-                data += dumps(row, cls=APIEncoder) + '\n'
-            return Response(data, content_type='application/x-json-stream')
+            def generate(vo):
+                for row in list_dataset_replicas_bulk(dids=dids, vo=vo):
+                    yield dumps(row, cls=APIEncoder) + '\n'
+
+            return try_stream(generate(vo=request.environ.get('vo')))
         except InvalidObject as error:
             return generate_http_error_flask(400, 'InvalidObject', 'Cannot validate DIDs: %s' % (str(error)))
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
+
+
+class DatasetReplicasVP(MethodView):
+    @check_accept_header_wrapper_flask(['application/x-json-stream'])
+    def get(self, scope_name):
+        """
+        List dataset replicas using the Virtual Placement service.
+
+        NOTICE: This is an RnD function and might change or go away at any time.
+
+        .. :quickref: DatasetReplicas; List dataset replicas with VP.
+
+        :param scope_name: data identifier (scope)/(name).
+        :query deep: Flag to ennable lookup at the file level.
+        :resheader Content-Type: application/x-json-stream
+        :status 200: OK.
+        :status 401: Invalid auth token.
+        :status 406: Not Acceptable.
+        :status 500: Internal Error.
+        :returns: If VP exists a list of dicts of sites, otherwise nothing
+        """
+        try:
+            scope, name = parse_scope_name(scope_name)
+
+            def generate(deep, vo):
+                for row in list_dataset_replicas_vp(scope=scope, name=name, deep=deep, vo=vo):
+                    yield dumps(row, cls=APIEncoder) + '\n'
+
+            return try_stream(generate(deep=request.args.get('deep', False), vo=request.environ.get('vo')))
+        except ValueError as error:
+            return generate_http_error_flask(400, 'ValueError', error.args[0])
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500
 
 
 class ReplicasRSE(MethodView):
@@ -774,15 +928,16 @@ class ReplicasRSE(MethodView):
         :returns: A dictionary containing all replicas on the RSE.
         """
         try:
-            data = ""
-            for row in list_datasets_per_rse(rse=rse, vo=request.environ.get('vo')):
-                data += dumps(row, cls=APIEncoder) + '\n'
-            return Response(data, content_type='application/x-json-stream')
+            def generate(vo):
+                for row in list_datasets_per_rse(rse=rse, vo=vo):
+                    yield dumps(row, cls=APIEncoder) + '\n'
+
+            return try_stream(generate(vo=request.environ.get('vo')))
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
 
 class BadPFNs(MethodView):
@@ -817,11 +972,9 @@ class BadPFNs(MethodView):
                 pfns = params['pfns']
             if 'reason' in params:
                 reason = params['reason']
-            if 'reason' in params:
-                reason = params['reason']
             if 'state' in params:
-                reason = params['state']
-            if 'expires_at' in params:
+                state = params['state']
+            if 'expires_at' in params and params['expires_at']:
                 expires_at = datetime.strptime(params['expires_at'], "%Y-%m-%dT%H:%M:%S.%f")
             add_bad_pfns(pfns=pfns, issuer=request.environ.get('issuer'), state=state, reason=reason, expires_at=expires_at, vo=request.environ.get('vo'))
         except (ValueError, InvalidType) as error:
@@ -836,7 +989,7 @@ class BadPFNs(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
         return 'Created', 201
 
 
@@ -875,37 +1028,51 @@ class Tombstone(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
         return 'Created', 201
 
 
-bp = Blueprint('did', __name__)
+bp = Blueprint('replica', __name__)
 
 list_replicas_view = ListReplicas.as_view('list_replicas')
 bp.add_url_rule('/list', view_func=list_replicas_view, methods=['post', ])
+# removed for doc: bp.add_url_rule('/list/', view_func=list_replicas_view, methods=['post', ])
 replicas_view = Replicas.as_view('replicas')
 bp.add_url_rule('/', view_func=replicas_view, methods=['post', 'put', 'delete'])
-bp.add_url_rule('/<scope>/<name>', view_func=replicas_view, methods=['get', ])
-bad_replicas_view = BadReplicas.as_view('bad_replicas')
-bp.add_url_rule('/bad', view_func=bad_replicas_view, methods=['post', ])
-bad_replicas_states_view = BadReplicasStates.as_view('bad_replicas_states')
-bp.add_url_rule('/bad/states', view_func=bad_replicas_states_view, methods=['get', ])
-bad_replicas_summary_view = BadReplicasSummary.as_view('bad_replicas_summary')
-bp.add_url_rule('/bad/summary', view_func=bad_replicas_summary_view, methods=['get', ])
-bad_replicas_pfn_view = BadPFNs.as_view('add_bad_pfns')
-bp.add_url_rule('/bad/pfns', view_func=bad_replicas_pfn_view, methods=['post', ])
-replicas_rse_view = ReplicasRSE.as_view('replicas_rse')
-bp.add_url_rule('/rse/<rse>', view_func=replicas_rse_view, methods=['get', ])
-dataset_replicas_view = DatasetReplicas.as_view('dataset_replicas')
-bp.add_url_rule('/<scope>/<name>/datasets', view_func=dataset_replicas_view, methods=['get', ])
-dataset_replicas_bulk_view = DatasetReplicasBulk.as_view('dataset_replicas_bulk')
-bp.add_url_rule('/datasets_bulk', view_func=dataset_replicas_bulk_view, methods=['post', ])
-replicas_dids_view = ReplicasDIDs.as_view('replicas_dids')
-bp.add_url_rule('/dids', view_func=replicas_dids_view, methods=['post', ])
+# FIXME: Add '' rule
 suspicious_replicas_view = SuspiciousReplicas.as_view('suspicious_replicas')
 bp.add_url_rule('/suspicious', view_func=suspicious_replicas_view, methods=['post', ])
+# removed for doc: bp.add_url_rule('/suspicious/', view_func=suspicious_replicas_view, methods=['post', ])
+bad_replicas_states_view = BadReplicasStates.as_view('bad_replicas_states')
+bp.add_url_rule('/bad/states', view_func=bad_replicas_states_view, methods=['get', ])
+# removed for doc: bp.add_url_rule('/bad/states/', view_func=bad_replicas_states_view, methods=['get', ])
+bad_replicas_summary_view = BadReplicasSummary.as_view('bad_replicas_summary')
+bp.add_url_rule('/bad/summary', view_func=bad_replicas_summary_view, methods=['get', ])
+# removed for doc: bp.add_url_rule('/bad/summary/', view_func=bad_replicas_summary_view, methods=['get', ])
+bad_replicas_pfn_view = BadPFNs.as_view('add_bad_pfns')
+bp.add_url_rule('/bad/pfns', view_func=bad_replicas_pfn_view, methods=['post', ])
+# removed for doc: bp.add_url_rule('/bad/pfns/', view_func=bad_replicas_pfn_view, methods=['post', ])
+replicas_rse_view = ReplicasRSE.as_view('replicas_rse')
+bp.add_url_rule('/rse/<rse>', view_func=replicas_rse_view, methods=['get', ])
+# removed for doc: bp.add_url_rule('/rse/<rse>/', view_func=replicas_rse_view, methods=['get', ])
+bad_replicas_view = BadReplicas.as_view('bad_replicas')
+bp.add_url_rule('/bad', view_func=bad_replicas_view, methods=['post', ])
+# removed for doc: bp.add_url_rule('/bad/', view_func=bad_replicas_view, methods=['post', ])
+replicas_dids_view = ReplicasDIDs.as_view('replicas_dids')
+bp.add_url_rule('/dids', view_func=replicas_dids_view, methods=['post', ])
+# removed for doc: bp.add_url_rule('/dids/', view_func=replicas_dids_view, methods=['post', ])
+dataset_replicas_view = DatasetReplicas.as_view('dataset_replicas')
+bp.add_url_rule('/<path:scope_name>/datasets', view_func=dataset_replicas_view, methods=['get', ])
+dataset_replicas_bulk_view = DatasetReplicasBulk.as_view('dataset_replicas_bulk')
+bp.add_url_rule('/datasets_bulk', view_func=dataset_replicas_bulk_view, methods=['post', ])
+# removed for doc: bp.add_url_rule('/datasets_bulk/', view_func=dataset_replicas_bulk_view, methods=['post', ])
+dataset_replicas_vp_view = DatasetReplicasVP.as_view('dataset_replicas_vp')
+# removed for doc: bp.add_url_rule('/<path:scope_name>/datasets_vp', view_func=dataset_replicas_vp_view, methods=['get', ])
+bp.add_url_rule('/<path:scope_name>', view_func=replicas_view, methods=['get', ])
+# removed for doc: bp.add_url_rule('/<path:scope_name>/', view_func=replicas_view, methods=['get', ])
 set_tombstone_view = Tombstone.as_view('set_tombstone')
 bp.add_url_rule('/tombstone', view_func=set_tombstone_view, methods=['post', ])
+# removed for doc: bp.add_url_rule('/tombstone/', view_func=set_tombstone_view, methods=['post', ])
 
 application = Flask(__name__)
 application.register_blueprint(bp)

--- a/lib/rucio/web/rest/flaskapi/v1/request.py
+++ b/lib/rucio/web/rest/flaskapi/v1/request.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,26 +18,32 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2014-2018
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2017
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2018
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 import json
-
 from logging import getLogger, StreamHandler, DEBUG
+from traceback import format_exc
 
 from flask import Flask, Blueprint, Response, request as f_request
 from flask.views import MethodView
 
 from rucio.api import request
-from rucio.db.sqla.constants import RequestState
+from rucio.common.exception import RucioException
+from rucio.common.utils import generate_http_error_flask, APIEncoder, render_json
 from rucio.core.rse import get_rses_with_attribute_value, get_rse_name
-from rucio.common.utils import generate_http_error_flask, APIEncoder
-from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask
+from rucio.db.sqla.constants import RequestState
+from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask, parse_scope_name, try_stream
 
+try:
+    from urlparse import parse_qs
+except ImportError:
+    from urllib.parse import parse_qs
 
 LOGGER = getLogger("rucio.request")
 SH = StreamHandler()
@@ -48,36 +55,35 @@ class RequestGet(MethodView):
     """ REST API to get requests. """
 
     @check_accept_header_wrapper_flask(['application/json'])
-    def get(self, scope, name, rse):
+    def get(self, scope_name, rse):
         """
         List request for given DID to a destination RSE.
 
         .. :quickref: RequestGet; list requests
 
-        :param scope: data identifier scope.
-        :param name: data identifier name.
+        :param scope_name: data identifier (scope)/(name).
         :param rse: destination RSE.
         :reqheader Content-Type: application/json
         :status 200: Request found.
         :status 404: Request not found.
         :status 406: Not Acceptable.
         """
+        try:
+            scope, name = parse_scope_name(scope_name)
+        except ValueError as error:
+            return generate_http_error_flask(400, 'ValueError', error.args[0])
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500
 
         try:
-            res = json.dumps(request.get_request_by_did(scope=scope,
-                                                        name=name,
-                                                        rse=rse,
-                                                        issuer=f_request.environ.get('issuer'),
-                                                        vo=f_request.environ.get('vo')),
-                             cls=APIEncoder)
-            return Response(res, content_type="application/json")
+            request_data = request.get_request_by_did(scope=scope, name=name, rse=rse, issuer=f_request.environ.get('issuer'), vo=f_request.environ.get('vo'))
+            return Response(json.dumps(request_data, cls=APIEncoder), content_type='application/json')
         except Exception:
-            return generate_http_error_flask(404, 'RequestNotFound', 'No request found for DID %s:%s at RSE %s' % (scope,
-                                                                                                                   name,
-                                                                                                                   rse))
+            return generate_http_error_flask(404, 'RequestNotFound', 'No request found for DID %s:%s at RSE %s' % (scope, name, rse))
 
 
-class RequestsGet(MethodView):
+class RequestList(MethodView):
     """ REST API to get requests. """
 
     @check_accept_header_wrapper_flask(['application/x-json-stream'])
@@ -92,49 +98,57 @@ class RequestsGet(MethodView):
         :status 404: Request not found.
         :status 406: Not Acceptable.
         """
-
-        src_rse = f_request.get('src_rse')
-        dst_rse = f_request.get('dst_rse')
-        src_site = f_request.get('src_site')
-        dst_site = f_request.get('dst_site')
-        request_states = f_request.get('request_states')
-
-        if not request_states:
-            return generate_http_error_flask(400, 'MissingParameter', 'Request state is missing')
-        if src_rse and not dst_rse:
-            return generate_http_error_flask(400, 'MissingParameter', 'Destination RSE is missing')
-        elif dst_rse and not src_rse:
-            return generate_http_error_flask(400, 'MissingParameter', 'Source RSE is missing')
-        elif src_site and not dst_site:
-            return generate_http_error_flask(400, 'MissingParameter', 'Destination site is missing')
-        elif dst_site and not src_site:
-            return generate_http_error_flask(400, 'MissingParameter', 'Source site is missing')
-
         try:
-            states = [RequestState.from_string(state) for state in request_states.split(',')]
-        except ValueError:
-            return generate_http_error_flask(400, 'Invalid', 'Request state value is invalid')
+            query_string = f_request.query_string.decode(encoding='utf-8')
+            params = parse_qs(query_string)
+            src_rse = params.get('src_rse', [None])[0]
+            dst_rse = params.get('dst_rse', [None])[0]
+            src_site = params.get('src_site', [None])[0]
+            dst_site = params.get('dst_site', [None])[0]
+            request_states = params.get('request_states', [None])[0]
 
-        src_rses = []
-        dst_rses = []
-        if src_site:
-            src_rses = get_rses_with_attribute_value(key='site', value=src_site, lookup_key='site', vo=f_request.environ.get('vo'))
-            if not src_rses:
-                return generate_http_error_flask(404, 'NotFound', 'Could not resolve site name %s to RSE' % src_site)
-            src_rses = [get_rse_name(rse['rse_id']) for rse in src_rses]
-            dst_rses = get_rses_with_attribute_value(key='site', value=dst_site, lookup_key='site', vo=f_request.environ.get('vo'))
-            if not dst_rses:
-                return generate_http_error_flask(404, 'NotFound', 'Could not resolve site name %s to RSE' % dst_site)
-            dst_rses = [get_rse_name(rse['rse_id']) for rse in dst_rses]
-        else:
-            dst_rses = [dst_rse]
-            src_rses = [src_rse]
+            if not request_states:
+                return generate_http_error_flask(400, 'MissingParameter', 'Request state is missing')
+            if src_rse and not dst_rse:
+                return generate_http_error_flask(400, 'MissingParameter', 'Destination RSE is missing')
+            elif dst_rse and not src_rse:
+                return generate_http_error_flask(400, 'MissingParameter', 'Source RSE is missing')
+            elif src_site and not dst_site:
+                return generate_http_error_flask(400, 'MissingParameter', 'Destination site is missing')
+            elif dst_site and not src_site:
+                return generate_http_error_flask(400, 'MissingParameter', 'Source site is missing')
 
-        results = []
-        for result in request.list_requests(src_rses, dst_rses, states, issuer=f_request.environ.get('issuer'), vo=f_request.environ.get('vo')):
-            del result['_sa_instance_state']
-            results.append(result)
-        return json.dumps(results, cls=APIEncoder)
+            try:
+                states = [RequestState.from_string(state) for state in request_states.split(',')]
+            except ValueError:
+                return generate_http_error_flask(400, 'Invalid', 'Request state value is invalid')
+
+            src_rses = []
+            dst_rses = []
+            if src_site:
+                src_rses = get_rses_with_attribute_value(key='site', value=src_site, lookup_key='site', vo=f_request.environ.get('vo'))
+                if not src_rses:
+                    return generate_http_error_flask(404, 'NotFound', 'Could not resolve site name %s to RSE' % src_site)
+                src_rses = [get_rse_name(rse['rse_id']) for rse in src_rses]
+                dst_rses = get_rses_with_attribute_value(key='site', value=dst_site, lookup_key='site', vo=f_request.environ.get('vo'))
+                if not dst_rses:
+                    return generate_http_error_flask(404, 'NotFound', 'Could not resolve site name %s to RSE' % dst_site)
+                dst_rses = [get_rse_name(rse['rse_id']) for rse in dst_rses]
+            else:
+                dst_rses = [dst_rse]
+                src_rses = [src_rse]
+
+            def generate(issuer, vo):
+                for result in request.list_requests(src_rses, dst_rses, states, issuer=issuer, vo=vo):
+                    del result['_sa_instance_state']
+                    yield render_json(**result) + '\n'
+
+            return try_stream(generate(issuer=f_request.environ.get('issuer'), vo=f_request.environ.get('vo')))
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500
 
 
 """----------------------
@@ -143,9 +157,9 @@ class RequestsGet(MethodView):
 
 bp = Blueprint('request', __name__)
 request_get_view = RequestGet.as_view('request_get')
-requests_get_view = RequestsGet.as_view('requests_get')
-bp.add_url_rule('/<scope>/<name>/<rse>', view_func=request_get_view, methods=['get', ])
-bp.add_url_rule('/list', view_func=requests_get_view, methods=['get', ])
+bp.add_url_rule('/<path:scope_name>/<rse>', view_func=request_get_view, methods=['get', ])
+request_list_view = RequestList.as_view('request_list')
+bp.add_url_rule('/list', view_func=request_list_view, methods=['get', ])
 
 application = Flask(__name__)
 application.register_blueprint(bp)

--- a/lib/rucio/web/rest/flaskapi/v1/rse.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rse.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,18 +16,21 @@
 #
 # Authors:
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2018
-# - Vincent Garonne <vgaronne@gmail.com>, 2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018-2020
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 from __future__ import print_function
+
 from json import dumps, loads
 from traceback import format_exc
-from flask import Flask, Blueprint, Response, request
+
+from flask import Flask, Blueprint, Response, request, jsonify
 from flask.views import MethodView
 
 from rucio.api.account_limit import get_rse_account_usage
@@ -44,8 +48,8 @@ from rucio.common.exception import (Duplicate, AccessDenied, RSENotFound, RucioE
                                     RSEProtocolPriorityError, InvalidRSEExpression,
                                     RSEAttributeNotFound, CounterNotFound)
 from rucio.common.utils import generate_http_error_flask, render_json, APIEncoder
-from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask
 from rucio.rse import rsemanager
+from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask, try_stream
 
 
 class RSEs(MethodView):
@@ -65,16 +69,15 @@ class RSEs(MethodView):
         :status 406: Not Acceptable.
         :status 500: Internal Error.
         :returns: A list containing all RSEs.
-
         """
-        expression = request.args.get('name', None)
+        expression = request.args.get('expression')
         if expression:
             try:
-                data = ""
-                for rse in parse_rse_expression(expression, vo=request.environ.get('vo')):
-                    item = {'rse': rse}
-                    data += render_json(**item) + '\n'
-                return Response(data, content_type="application/x-json-stream")
+                def generate(vo):
+                    for rse in parse_rse_expression(expression, vo=vo):
+                        yield render_json(rse=rse) + '\n'
+
+                return try_stream(generate(vo=request.environ.get('vo')))
             except InvalidRSEExpression as error:
                 return generate_http_error_flask(400, 'InvalidRSEExpression', error.args[0])
             except InvalidObject as error:
@@ -82,10 +85,11 @@ class RSEs(MethodView):
             except RucioException as error:
                 return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         else:
-            data = ""
-            for rse in list_rses(vo=request.environ.get('vo')):
-                data += render_json(**rse) + '\n'
-            return Response(data, content_type="application/x-json-stream")
+            def generate(vo):
+                for rse in list_rses(vo=vo):
+                    yield render_json(**rse) + '\n'
+
+            return try_stream(generate(vo=request.environ.get('vo')))
 
 
 class RSE(MethodView):
@@ -119,7 +123,7 @@ class RSE(MethodView):
         :status 500: Internal Error.
 
         """
-        json_data = request.data
+        json_data = request.data.decode()
         kwargs = {'deterministic': True,
                   'volatile': False, 'city': None, 'staging_area': False,
                   'region_code': None, 'country_name': None,
@@ -149,11 +153,10 @@ class RSE(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
-        return "Created", 201
+        return 'Created', 201
 
     def put(self, rse):
         """ Update RSE properties (e.g. name, availability).
@@ -193,11 +196,10 @@ class RSE(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
-        return "Created", 201
+        return 'Created', 201
 
     @check_accept_header_wrapper_flask(['application/json'])
     def get(self, rse):
@@ -233,20 +235,19 @@ class RSE(MethodView):
         :status 401: Invalid Auth Token.
         :status 404: RSE not found.
         :status 500: Internal Error.
-
         """
         try:
             del_rse(rse=rse, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
         except RSENotFound as error:
             return generate_http_error_flask(404, 'RSENotFound', error.args[0])
+        except RSEOperationNotSupported as error:
+            return generate_http_error_flask(404, 'RSEOperationNotSupported', error.args[0])
         except AccessDenied as error:
             return generate_http_error_flask(401, 'AccessDenied', error.args[0])
-        except RSEOperationNotSupported as error:
-            return generate_http_error_flask(404, 'RSEOperationNotsupported', error.args[0])
         except CounterNotFound as error:
             return generate_http_error_flask(404, 'CounterNotFound', error.args[0])
 
-        return "OK", 200
+        return '', 200
 
 
 class Attributes(MethodView):
@@ -268,7 +269,7 @@ class Attributes(MethodView):
         :status 500: Internal Error.
 
         """
-        json_data = request.data
+        json_data = request.data.decode()
         try:
             parameter = loads(json_data)
         except ValueError:
@@ -286,9 +287,10 @@ class Attributes(MethodView):
         except Duplicate as error:
             return generate_http_error_flask(409, 'Duplicate', error.args[0])
         except Exception as error:
-            return error, 500
+            print(format_exc())
+            return str(error), 500
 
-        return "Created", 201
+        return 'Created', 201
 
     @check_accept_header_wrapper_flask(['application/json'])
     def get(self, rse):
@@ -304,7 +306,6 @@ class Attributes(MethodView):
         :status 406: Not Acceptable.
         :status 500: Internal Error.
         :returns: A list containing all RSE attributes.
-
         """
         try:
             rse_attr = list_rse_attributes(rse, vo=request.environ.get('vo'))
@@ -313,8 +314,10 @@ class Attributes(MethodView):
         except RSENotFound as error:
             return generate_http_error_flask(404, 'RSENotFound', error.args[0])
         except Exception as error:
-            return error, 500
-        return Response(dumps(rse_attr), content_type="application/json")
+            print(format_exc())
+            return str(error), 500
+
+        return jsonify(rse_attr)
 
     def delete(self, rse, key):
         """ Delete an RSE attribute for given RSE name.
@@ -338,12 +341,13 @@ class Attributes(MethodView):
         except RSEAttributeNotFound as error:
             return generate_http_error_flask(404, 'RSEAttributeNotFound', error.args[0])
         except Exception as error:
-            return error, 500
+            print(format_exc())
+            return str(error), 500
 
-        return "OK", 200
+        return '', 200
 
 
-class Protocols(MethodView):
+class ProtocolList(MethodView):
     """ List supported protocols. """
 
     @check_accept_header_wrapper_flask(['application/json'])
@@ -363,7 +367,6 @@ class Protocols(MethodView):
         :status 406: Not Acceptable.
         :status 500: Internal Error.
         :returns: A list containing all supported protocols and all their attributes.
-
         """
         p_list = None
         try:
@@ -377,11 +380,10 @@ class Protocols(MethodView):
         except RSEProtocolDomainNotSupported as error:
             return generate_http_error_flask(404, 'RSEProtocolDomainNotSupported', error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
         if len(p_list['protocols']):
-            return Response(dumps(p_list['protocols']), content_type="application/json")
+            return jsonify(p_list['protocols'])
         else:
             return generate_http_error_flask(404, 'RSEProtocolNotSupported', 'No protocols found for this RSE')
 
@@ -412,19 +414,25 @@ class LFNS2PFNS(MethodView):
         :status 406: Not Acceptable.
         :status 500: Internal Error.
         :returns: A list with detailed PFN information.
-
         """
         lfns = []
-        scheme = request.get('scheme', None)
-        domain = request.get('domain', 'wan')
-        operation = request.get('operation', 'write')
-        p_lfns = request.get('lfn', None)
-        if p_lfns:
-            info = p_lfns.split(":", 1)
-            if len(info) != 2:
-                return generate_http_error_flask(400, 'InvalidPath', 'LFN in invalid format')
-            lfn_dict = {'scope': info[0], 'name': info[1]}
-            lfns.append(lfn_dict)
+        scheme = None
+        domain = 'wan'
+        operation = 'write'
+        if request.query_string:
+            for key, val in request.args.items():
+                if key == 'lfn':
+                    info = val.split(":", 1)
+                    if len(info) != 2:
+                        return generate_http_error_flask(400, 'InvalidPath', 'LFN in invalid format')
+                    lfn_dict = {'scope': info[0], 'name': info[1]}
+                    lfns.append(lfn_dict)
+                elif key == 'scheme':
+                    scheme = val
+                elif key == 'domain':
+                    domain = val
+                elif key == 'operation':
+                    operation = val
 
         rse_settings = None
         try:
@@ -436,12 +444,11 @@ class LFNS2PFNS(MethodView):
         except RSEProtocolDomainNotSupported as error:
             return generate_http_error_flask(404, 'RSEProtocolDomainNotSupported', error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
         pfns = rsemanager.lfns2pfns(rse_settings, lfns, operation=operation, scheme=scheme, domain=domain)
-        return Response(dumps(pfns), content_type="application/json")
+        return jsonify(pfns)
 
 
 class Protocol(MethodView):
@@ -465,7 +472,7 @@ class Protocol(MethodView):
         :status 500: Internal Error.
 
         """
-        json_data = request.data
+        json_data = request.data.decode()
         try:
             parameters = loads(json_data)
         except ValueError:
@@ -491,10 +498,9 @@ class Protocol(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
-        return "Created", 201
+            return str(error), 500
+        return 'Created', 201
 
     @check_accept_header_wrapper_flask(['application/json'])
     def get(self, rse, scheme):
@@ -524,10 +530,9 @@ class Protocol(MethodView):
         except RSEProtocolDomainNotSupported as error:
             return generate_http_error_flask(404, 'RSEProtocolDomainNotSupported', error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
-        return Response(dumps(p_list), content_type="application/json")
+            return str(error), 500
+        return jsonify(p_list)
 
     def put(self, rse, scheme, hostname=None, port=None):
         """
@@ -551,7 +556,7 @@ class Protocol(MethodView):
         :status 500: Internal Error.
 
         """
-        json_data = request.data
+        json_data = request.data.decode()
         try:
             parameter = loads(json_data)
         except ValueError:
@@ -572,11 +577,10 @@ class Protocol(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
-        return "OK", 200
+        return '', 200
 
     def delete(self, rse, scheme, hostname=None, port=None):
         """
@@ -604,11 +608,10 @@ class Protocol(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
-        return "OK", 200
+        return '', 200
 
 
 class Usage(MethodView):
@@ -633,23 +636,20 @@ class Usage(MethodView):
         :returns: A list of dictionaries with the usage information.
 
         """
-        usage = None
-        source = request.args.get('source', None)
-        per_account = request.args.get('per_account', False) == 'True'
         try:
-            usage = get_rse_usage(rse, issuer=request.environ.get('issuer'), source=source, per_account=per_account, vo=request.environ.get('vo'))
+            def generate(issuer, source, per_account, vo):
+                for usage in get_rse_usage(rse, issuer=issuer, source=source, per_account=per_account, vo=vo):
+                    yield render_json(**usage) + '\n'
+
+            return try_stream(generate(issuer=request.environ.get('issuer'), source=request.args.get('source'),
+                                       per_account=(request.args.get('per_account') == 'True'), vo=request.environ.get('vo')))
         except RSENotFound as error:
             return generate_http_error_flask(404, 'RSENotFound', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-
-        data = ""
-        for u in usage:
-            data = render_json(**u) + '\n'
-        return Response(data, content_type="application/x-json-stream")
+            return str(error), 500
 
     def put(self, rse):
         """ Update RSE usage information.
@@ -665,7 +665,7 @@ class Usage(MethodView):
         :status 500: Internal Error.
 
         """
-        json_data = request.data
+        json_data = request.data.decode()
         try:
             parameter = loads(json_data)
         except ValueError:
@@ -681,9 +681,9 @@ class Usage(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
-        return "OK", 200
+        return '', 200
 
 
 class UsageHistory(MethodView):
@@ -706,20 +706,19 @@ class UsageHistory(MethodView):
         :returns: Line separated list of dictionary with RSE usage information.
 
         """
-        source = request.args.get('source', None)
-
         try:
-            data = ""
-            for usage in list_rse_usage_history(rse=rse, issuer=request.environ.get('issuer'), source=source, vo=request.environ.get('vo')):
-                data = render_json(**usage) + '\n'
-            return Response(data, content_type="application/x-json-stream")
+            def generate(issuer, source, vo):
+                for usage in list_rse_usage_history(rse=rse, issuer=issuer, source=source, vo=vo):
+                    yield render_json(**usage) + '\n'
+
+            return try_stream(generate(issuer=request.environ.get('issuer'), source=request.args.get('source'), vo=request.environ.get('vo')))
         except RSENotFound as error:
             return generate_http_error_flask(404, 'RSENotFound', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
 
 class Limits(MethodView):
@@ -751,7 +750,7 @@ class Limits(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
     def put(self, rse):
         """ Update RSE limits.
@@ -781,9 +780,9 @@ class Limits(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
-        return "OK", 200
+        return '', 200
 
 
 class RSEAccountUsageLimit(MethodView):
@@ -804,21 +803,20 @@ class RSEAccountUsageLimit(MethodView):
         :status 406: Not Acceptable.
         :status 500: Internal Error.
         :returns: Line separated list of dict with account usage and limits.
-
         """
         try:
-            usage = get_rse_account_usage(rse=rse, vo=request.environ.get('vo'))
-            data = ""
-            for row in usage:
-                data = dumps(row, cls=APIEncoder) + '\n'
-            return Response(data, content_type="application/json")
+            def generate(vo):
+                for usage in get_rse_account_usage(rse=rse, vo=vo):
+                    yield render_json(**usage) + '\n'
+
+            return try_stream(generate(vo=request.environ.get('vo')), content_type='application/json')
         except RSENotFound as error:
             return generate_http_error_flask(404, 'RSENotFound', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
 
 class Distance(MethodView):
@@ -839,7 +837,6 @@ class Distance(MethodView):
         :status 406: Not Acceptable.
         :status 500: Internal Error.
         :returns: List of dictionaries with RSE distances.
-
         """
         try:
             distance = get_distance(source=source,
@@ -853,7 +850,7 @@ class Distance(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
     def post(self, source, destination):
         """ Create distance information between source RSE and destination RSE.
@@ -867,9 +864,8 @@ class Distance(MethodView):
         :status 401: Invalid Auth Token.
         :status 404: RSE Not Found.
         :status 500: Internal Error.
-
         """
-        json_data = request.data
+        json_data = request.data.decode()
         try:
             parameter = loads(json_data)
         except ValueError:
@@ -888,8 +884,8 @@ class Distance(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-        return "Created", 201
+            return str(error), 500
+        return 'Created', 201
 
     def put(self, source, destination):
         """ Update distance information between source RSE and destination RSE.
@@ -904,7 +900,7 @@ class Distance(MethodView):
         :status 404: RSE Not Found.
         :status 500: Internal Error.
         """
-        json_data = request.data
+        json_data = request.data.decode()
         try:
             parameters = loads(json_data)
         except ValueError:
@@ -922,12 +918,64 @@ class Distance(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-        return "OK", 200
+            return str(error), 500
+        return '', 200
 
 
 class QoSPolicy(MethodView):
-    """ Create/Update and list QoS policies of RSEs. """
+    """ Add/Delete/List QoS policies on an RSE. """
+
+    @check_accept_header_wrapper_flask(['application/json'])
+    def post(self, rse, policy):
+        """
+        Add QoS policy to RSE
+
+        .. :quickref: QoSPolicy; Add QoS policy to RSE.
+
+        :param rse: The RSE name.
+        :param policy: The QoS policy name.
+        :status 201: Created.
+        :status 401: Invalid Auth Token.
+        :status 404: RSE Not Found.
+        :status 500: Internal Error.
+        """
+        try:
+            add_qos_policy(rse=rse, qos_policy=policy, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+        except RSENotFound as error:
+            return generate_http_error_flask(404, 'RSENotFound', error.args[0])
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500
+
+        return 'Created', 201
+
+    @check_accept_header_wrapper_flask(['application/json'])
+    def delete(self, rse, policy):
+        """
+        Delete QoS policy from RSE.
+
+        .. :quickref: QoSPolicy; Delete QoS policy from RSE.
+
+        :param rse: The RSE name.
+        :param policy: The QoS policy name.
+        :status 200: OK.
+        :status 401: Invalid Auth Token.
+        :status 404: RSE not found.
+        :status 500: Internal Error.
+        """
+        try:
+            delete_qos_policy(rse=rse, qos_policy=policy, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+        except RSENotFound as error:
+            return generate_http_error_flask(404, 'RSENotFound', error.args[0])
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500
+
+        return '', 200
 
     @check_accept_header_wrapper_flask(['application/json'])
     def get(self, rse):
@@ -943,70 +991,16 @@ class QoSPolicy(MethodView):
         :status 500: Internal Error.
         :returns: List of QoS policies
         """
-
         try:
             qos_policies = list_qos_policies(rse=rse, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
-            return Response(dumps(qos_policies, cls=APIEncoder), content_type="application/json")
+            return Response(dumps(qos_policies, cls=APIEncoder), content_type='application/json')
         except RSENotFound as error:
             return generate_http_error_flask(404, 'RSENotFound', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-
-    @check_accept_header_wrapper_flask(['application/json'])
-    def post(self, rse, qos_policy):
-        """
-        Add QoS policy to RSE
-
-        .. :quickref: QoSPolicy; Add QoS policy to RSE.
-
-        :param rse: The RSE name.
-        :param qos_policy: The QoS policy name.
-        :status 201: Created.
-        :status 401: Invalid Auth Token.
-        :status 404: RSE Not Found.
-        :status 500: Internal Error.
-        """
-        try:
-            add_qos_policy(rse=rse, qos_policy=qos_policy, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
-        except RSENotFound as error:
-            return generate_http_error_flask(404, 'RSENotFound', error.args[0])
-        except RucioException as error:
-            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
-        except Exception as error:
-            print(format_exc())
-            return error, 500
-
-        return "Created", 201
-
-    @check_accept_header_wrapper_flask(['application/json'])
-    def delete(self, rse, qos_policy):
-        """
-        Delete QoS policy from RSE.
-
-        .. :quickref: QoSPolicy; Delete QoS policy from RSE.
-
-        :param rse: The RSE name.
-        :param qos_policy: The QoS policy name.
-        :status 200: OK.
-        :status 401: Invalid Auth Token.
-        :status 404: RSE not found.
-        :status 500: Internal Error.
-        """
-
-        try:
-            delete_qos_policy(rse=rse, qos_policy=qos_policy, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
-        except RSENotFound as error:
-            return generate_http_error_flask(404, 'RSENotFound', error.args[0])
-        except RucioException as error:
-            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
-        except Exception as error:
-            print(format_exc())
-            return error, 500
-
-        return "OK", 200
+            return str(error), 500
 
 
 """----------------------
@@ -1016,14 +1010,15 @@ bp = Blueprint('rse', __name__)
 
 attributes_view = Attributes.as_view('attributes')
 bp.add_url_rule('/<rse>/attr/<key>', view_func=attributes_view, methods=['post', 'delete'])
-bp.add_url_rule('/<rse>/attr', view_func=attributes_view, methods=['get', ])
+bp.add_url_rule('/<rse>/attr/', view_func=attributes_view, methods=['get', ])
 distance_view = Distance.as_view('distance')
-bp.add_url_rule('/<source>/attr/<destination>', view_func=distance_view, methods=['get', 'post', 'put'])
-protocols_view = Protocols.as_view('protocols')
-bp.add_url_rule('/<rse>/protocols', view_func=protocols_view, methods=['get', ])
+bp.add_url_rule('/<source>/distances/<destination>', view_func=distance_view, methods=['get', 'post', 'put'])
 protocol_view = Protocol.as_view('protocol')
-bp.add_url_rule('/<rse>/protocols/<scheme>', view_func=protocol_view, methods=['get', 'post'])
 bp.add_url_rule('/<rse>/protocols/<scheme>/<hostname>/<port>', view_func=protocol_view, methods=['delete', 'put'])
+bp.add_url_rule('/<rse>/protocols/<scheme>/<hostname>', view_func=protocol_view, methods=['delete', 'put'])
+bp.add_url_rule('/<rse>/protocols/<scheme>', view_func=protocol_view, methods=['get', 'post', 'delete', 'put'])
+protocol_list_view = ProtocolList.as_view('protocol_list')
+bp.add_url_rule('/<rse>/protocols', view_func=protocol_list_view, methods=['get', ])
 lfns2pfns_view = LFNS2PFNS.as_view('lfns2pfns')
 bp.add_url_rule('/<rse>/lfns2pfns', view_func=lfns2pfns_view, methods=['get', ])
 rse_account_usage_limit_view = RSEAccountUsageLimit.as_view('rse_account_usage_limit')

--- a/lib/rucio/web/rest/flaskapi/v1/rule.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rule.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,12 +24,16 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Muhammad Aditya Hilmy <didithilmy@gmail.com>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 from __future__ import print_function
-from logging import getLogger, StreamHandler, DEBUG
+
 from json import dumps, loads
+from logging import getLogger, StreamHandler, DEBUG
 from traceback import format_exc
 
 from flask import Flask, Blueprint, request, Response
@@ -44,7 +49,7 @@ from rucio.common.exception import (InsufficientAccountLimit, RuleNotFound, Acce
                                     DuplicateRule, InvalidObject, AccountNotFound, RuleReplaceFailed, ScratchDiskLifetimeConflict,
                                     ManualRuleApprovalBlocked, UnsupportedOperation)
 from rucio.common.utils import generate_http_error_flask, render_json, APIEncoder
-from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask
+from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask, parse_scope_name, try_stream
 
 LOGGER = getLogger("rucio.rule")
 SH = StreamHandler()
@@ -69,8 +74,7 @@ class Rule(MethodView):
         """
         try:
             estimate_ttc = False
-            json_data = request.data
-            params = loads(json_data)
+            params = loads(request.data)
             if 'estimate_ttc' in params:
                 estimate_ttc = params['estimate_ttc']
         except ValueError:
@@ -82,7 +86,8 @@ class Rule(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            return error, 500
+            print(format_exc())
+            return str(error), 500
 
         return Response(render_json(**rule), content_type="application/json")
 
@@ -115,7 +120,7 @@ class Rule(MethodView):
             return generate_http_error_flask(409, 'UnsupportedOperation', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
-        return "OK", 200
+        return '', 200
 
     def delete(self, rule_id):
         """
@@ -145,8 +150,9 @@ class Rule(MethodView):
         except RuleNotFound as error:
             return generate_http_error_flask(404, 'RuleNotFound', error.args[0])
         except Exception as error:
-            return error, 500
-        return "OK", 200
+            print(format_exc())
+            return str(error), 500
+        return '', 200
 
 
 class AllRule(MethodView):
@@ -166,21 +172,17 @@ class AllRule(MethodView):
         :status 406: Not Acceptable
         :query scope: The scope name.
         """
-        filters = {}
-        if request.args:
-            params = dict(request.args)
-            filters.update(params)
-
         try:
-            data = ""
-            for rule in list_replication_rules(filters=filters, vo=request.environ.get('vo')):
-                data += dumps(rule, cls=APIEncoder) + '\n'
-            return Response(data, content_type="application/x-json-stream")
+            def generate(filters, vo):
+                for rule in list_replication_rules(filters=filters, vo=vo):
+                    yield dumps(rule, cls=APIEncoder) + '\n'
+
+            return try_stream(generate(filters=dict(request.args.items(multi=False)), vo=request.environ.get('vo')))
         except RuleNotFound as error:
             return generate_http_error_flask(404, 'RuleNotFound', error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
     def post(self):
         """
@@ -325,9 +327,8 @@ class AllRule(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
         return Response(dumps(rule_ids), status=201)
 
@@ -347,17 +348,16 @@ class ReplicaLocks(MethodView):
         :returns: JSON dict containing informations about the requested user.
         """
         try:
-            locks = get_replica_locks_for_rule_id(rule_id)
+            def generate(vo):
+                for lock in get_replica_locks_for_rule_id(rule_id, vo=vo):
+                    yield render_json(**lock) + '\n'
+
+            return try_stream(generate(vo=request.environ.get('vo')))
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            return error, 500
-
-        data = ""
-        for lock in locks:
-            data += dumps(lock, cls=APIEncoder) + '\n'
-
-        return Response(data, content_type="application/x-json-stream")
+            print(format_exc())
+            return str(error), 500
 
 
 class ReduceRule(MethodView):
@@ -400,9 +400,8 @@ class ReduceRule(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
         return Response(dumps(rule_ids), status=201)
 
@@ -442,9 +441,8 @@ class MoveRule(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
         return Response(dumps(rule_ids), status=201)
 
@@ -465,56 +463,61 @@ class RuleHistory(MethodView):
         :returns: JSON dict containing informations about the requested user.
         """
         try:
-            history = list_replication_rule_history(rule_id, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+            def generate(issuer, vo):
+                for history in list_replication_rule_history(rule_id, issuer=issuer, vo=vo):
+                    yield render_json(**history) + '\n'
+
+            return try_stream(generate(issuer=request.environ.get('issuer'), vo=request.environ.get('vo')))
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            return error, 500
-
-        data = ""
-        for hist in history:
-            data += dumps(hist, cls=APIEncoder) + '\n'
-        return Response(data, content_type="application/x-json-stream")
+            print(format_exc())
+            return str(error), 500
 
 
 class RuleHistoryFull(MethodView):
     """ REST APIs for rule history for DIDs. """
 
     @check_accept_header_wrapper_flask(['application/x-json-stream'])
-    def get(self, scope, name):
+    def get(self, scope_name):
         """ get history for a given DID.
 
         .. :quickref: RuleHistoryFull; get rule history for DID
 
         :resheader Content-Type: application/x-json-stream
+        :param scope_name: data identifier (scope)/(name).
         :status 200: Rule found
         :status 406: Not Acceptable
         :status 500: Database Exception
         :returns: JSON dict containing informations about the requested user.
         """
         try:
-            history = list_replication_rule_full_history(scope, name, vo=request.environ.get('vo'))
+            scope, name = parse_scope_name(scope_name)
+
+            def generate(vo):
+                for history in list_replication_rule_full_history(scope, name, vo=vo):
+                    yield render_json(**history) + '\n'
+
+            return try_stream(generate(vo=request.environ.get('vo')))
+        except ValueError as error:
+            return generate_http_error_flask(400, 'ValueError', error.args[0])
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            return error, 500
-
-        data = ""
-        for hist in history:
-            data += dumps(hist, cls=APIEncoder) + '\n'
-        return Response(data, content_type="application/x-json-stream")
+            print(format_exc())
+            return str(error), 500
 
 
 class RuleAnalysis(MethodView):
     """ REST APIs for rule analysis. """
 
-    @check_accept_header_wrapper_flask(['application/x-json-stream'])
+    @check_accept_header_wrapper_flask(['application/json'])
     def get(self, rule_id):
         """ get analysis for given rule.
 
         .. :quickref: RuleAnalysis; analyse rule,
 
-        :resheader Content-Type: application/x-json-stream
+        :resheader Content-Type: application/json
         :status 200: Rule found
         :status 406: Not Acceptable
         :status 500: Database Exception
@@ -522,12 +525,12 @@ class RuleAnalysis(MethodView):
         """
         try:
             analysis = examine_replication_rule(rule_id, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+            return Response(render_json(**analysis), content_type='application/json')
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            return error, 500
-
-        return Response(render_json(**analysis), content_type="application/x-json-stream")
+            print(format_exc())
+            return str(error), 500
 
 
 """----------------------
@@ -545,11 +548,11 @@ bp.add_url_rule('/<rule_id>/locks', view_func=replica_locks_view, methods=['get'
 reduce_rule_view = ReduceRule.as_view('reduce_rule')
 bp.add_url_rule('/<rule_id>/reduce', view_func=reduce_rule_view, methods=['post', ])
 move_rule_view = MoveRule.as_view('move_rule')
-bp.add_url_rule('/<rule_id>/mode', view_func=move_rule_view, methods=['post', ])
+bp.add_url_rule('/<rule_id>/move', view_func=move_rule_view, methods=['post', ])
 rule_history_view = RuleHistory.as_view('rule_history')
 bp.add_url_rule('/<rule_id>/history', view_func=rule_history_view, methods=['get', ])
 rule_history_full_view = RuleHistoryFull.as_view('rule_history_full')
-bp.add_url_rule('/<scope>/<name>/history', view_func=rule_history_full_view, methods=['get', ])
+bp.add_url_rule('/<path:scope_name>/history', view_func=rule_history_full_view, methods=['get', ])
 rule_analysis_view = RuleAnalysis.as_view('rule_analysis')
 bp.add_url_rule('/<rule_id>/analysis', view_func=rule_analysis_view, methods=['get', ])
 

--- a/lib/rucio/web/rest/flaskapi/v1/scope.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scope.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,21 +18,22 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2012-2018
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2017
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
-from json import dumps
+from traceback import format_exc
 
-from rucio.api.scope import add_scope, list_scopes
+from flask import Flask, Blueprint, request, jsonify
+from flask.views import MethodView
+
+from rucio.api.scope import add_scope, list_scopes, get_scopes
 from rucio.common.exception import AccountNotFound, Duplicate, RucioException
 from rucio.common.utils import generate_http_error_flask
 from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask
-
-from flask import Flask, Blueprint, request
-from flask.views import MethodView
 
 
 class Scope(MethodView):
@@ -64,7 +66,7 @@ class Scope(MethodView):
         :status 406: Not Acceptable
         :returns: :class:`String`
         """
-        return dumps(list_scopes(vo=request.environ.get('vo')))
+        return jsonify(list_scopes(vo=request.environ.get('vo')))
 
     def post(self, account, scope):
         """Add a new scope.
@@ -87,16 +89,48 @@ class Scope(MethodView):
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            return error, 500
+            print(format_exc())
+            return str(error), 500
 
-        return "OK", 201
+        return 'Created', 201
+
+
+class AccountScopeList(MethodView):
+
+    @check_accept_header_wrapper_flask(['application/json'])
+    def get(self, account):
+        """List account scopes.
+
+        .. :quickref: Scopes; Get scopes for account.
+
+        :resheader Content-Type: application/json
+        :status 200: Scopes found
+        :status 404: Account not found
+        :status 404: No scopes for this account
+        :status 406: Not Acceptable
+        :returns: A list containing all scope names for an account.
+        """
+        try:
+            scopes = get_scopes(account, vo=request.environ.get('vo'))
+        except AccountNotFound as error:
+            return generate_http_error_flask(404, 'AccountNotFound', error.args[0])
+        except Exception as error:
+            print(format_exc())
+            return str(error), 500
+
+        if not len(scopes):
+            return generate_http_error_flask(404, 'ScopeNotFound', 'no scopes found for account ID \'%s\'' % account)
+
+        return jsonify(scopes)
 
 
 bp = Blueprint('scope', __name__)
 
 scope_view = Scope.as_view('scope')
-bp.add_url_rule('/', view_func=scope_view, methods=['GET', ])
-bp.add_url_rule('/<account>/<scope>', view_func=scope_view, methods=['POST', ])
+bp.add_url_rule('/', view_func=scope_view, methods=['get', ])
+bp.add_url_rule('/<account>/<scope>', view_func=scope_view, methods=['post', ])
+account_scope_list_view = AccountScopeList.as_view('account_scope_list')
+bp.add_url_rule('/<account>/scopes', view_func=account_scope_list_view, methods=['get', ])
 
 application = Flask(__name__)
 application.register_blueprint(bp)

--- a/lib/rucio/web/rest/flaskapi/v1/temporary_did.py
+++ b/lib/rucio/web/rest/flaskapi/v1/temporary_did.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2016-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,16 +16,21 @@
 #
 # Authors:
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2016
-# - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2018
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Muhammad Aditya Hilmy <didithilmy@gmail.com>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 #
 # PY3K COMPATIBLE
 
 from __future__ import print_function
+
 from json import loads
 from traceback import format_exc
+
 from flask import Flask, Blueprint, request
 from flask.views import MethodView
 
@@ -61,14 +67,8 @@ class BulkDIDS(MethodView):
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
             print(format_exc())
-            return error, 500
-        return "Created", 201
-
-
-class Compose(MethodView):
-
-    def POST(self):
-        return "Created", 201
+            return str(error), 500
+        return 'Created', 201
 
 
 """----------------------
@@ -78,6 +78,7 @@ bp = Blueprint('temporary_did', __name__)
 
 bulk_dids_view = BulkDIDS.as_view('bulk_dids')
 bp.add_url_rule('/', view_func=bulk_dids_view, methods=['post', ])
+# FIXME: replace with '' rule
 
 application = Flask(__name__)
 application.register_blueprint(bp)

--- a/lib/rucio/web/rest/flaskapi/v1/vo.py
+++ b/lib/rucio/web/rest/flaskapi/v1/vo.py
@@ -1,4 +1,5 @@
-# Copyright 2019 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,17 +15,18 @@
 #
 # Authors:
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 from json import loads
 from traceback import format_exc
 
-from flask import Flask, Blueprint, Response, request
+from flask import Flask, Blueprint, request
 from flask.views import MethodView
 
 from rucio.api.vo import add_vo, list_vos, recover_vo_root_identity, update_vo
 from rucio.common.exception import AccessDenied, AccountNotFound, Duplicate, RucioException, VONotFound, UnsupportedOperation
-from rucio.common.utils import generate_http_error, render_json
-from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask
+from rucio.common.utils import render_json, generate_http_error_flask
+from rucio.web.rest.flaskapi.v1.common import before_request, after_request, check_accept_header_wrapper_flask, try_stream
 
 
 class VOs(MethodView):
@@ -45,31 +47,31 @@ class VOs(MethodView):
 
         """
         try:
-            data = ""
-            for vo in list_vos(issuer=request.environ.get('issuer'), vo=request.environ.get('vo')):
-                data += render_json(**vo) + '\n'
-            return Response(data, content_type="application/x-json-stream")
+            def generate(issuer, vo):
+                for vo in list_vos(issuer=issuer, vo=vo):
+                    yield render_json(**vo) + '\n'
+
+            return try_stream(generate(issuer=request.environ.get('issuer'), vo=request.environ.get('vo')))
         except AccessDenied as error:
-            return generate_http_error(401, 'AccessDenied', error.args[0])
+            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
         except UnsupportedOperation as error:
-            return generate_http_error(409, 'UnsupportedOperation', error.args[0])
+            return generate_http_error_flask(409, 'UnsupportedOperation', error.args[0])
         except RucioException as error:
-            return generate_http_error(500, error.__class__.__name__, error.args[0])
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
 
 class VO(MethodView):
     """ Add and update a VO. """
 
-    def post(self, new_vo):
+    def post(self, vo):
         """ Add a VO with a given name.
 
         .. :quickref: VO; Add a VOs.
 
-        :param new_vo: VO to be added.
+        :param vo: VO to be added.
         :<json string description: Desciption of VO.
         :<json string email: Admin email for VO.
         :status 201: VO created successfully.
@@ -78,7 +80,7 @@ class VO(MethodView):
         :status 500: Internal Error.
 
         """
-        json_data = request.data
+        json_data = request.data.decode()
         kwargs = {'description': None, 'email': None}
 
         try:
@@ -88,33 +90,32 @@ class VO(MethodView):
                     if param in parameters:
                         kwargs[param] = parameters[param]
         except ValueError:
-            return generate_http_error(400, 'ValueError', 'Cannot decode json parameter dictionary')
+            return generate_http_error_flask(400, 'ValueError', 'Cannot decode json parameter dictionary')
         kwargs['issuer'] = request.environ.get('issuer')
         kwargs['vo'] = request.environ.get('vo')
 
         try:
-            add_vo(new_vo=new_vo, **kwargs)
+            add_vo(new_vo=vo, **kwargs)
         except AccessDenied as error:
-            return generate_http_error(401, 'AccessDenied', error.args[0])
+            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
         except UnsupportedOperation as error:
-            return generate_http_error(409, 'UnsupportedOperation', error.args[0])
+            return generate_http_error_flask(409, 'UnsupportedOperation', error.args[0])
         except Duplicate as error:
-            return generate_http_error(409, 'Duplicate', error.args[0])
+            return generate_http_error_flask(409, 'Duplicate', error.args[0])
         except RucioException as error:
-            return generate_http_error(500, error.__class__.__name__, error.args[0])
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
-        return "Created", 201
+        return 'Created', 201
 
-    def put(self, updated_vo):
+    def put(self, vo):
         """ Update the details for a given VO
 
         .. :quickref: VO; Update a VOs.
 
-        :param updated_vo: VO to be updated.
+        :param vo: VO to be updated.
         :<json string description: Desciption of VO.
         :<json string email: Admin email for VO.
         :status 200: VO updated successfully.
@@ -124,40 +125,39 @@ class VO(MethodView):
         :status 500: Internal Error.
 
         """
-        json_data = request.data
+        json_data = request.data.decode()
 
         try:
             parameters = loads(json_data)
         except ValueError:
-            return generate_http_error(400, 'ValueError', 'cannot decode json parameter dictionary')
+            return generate_http_error_flask(400, 'ValueError', 'cannot decode json parameter dictionary')
 
         try:
-            update_vo(updated_vo=updated_vo, parameters=parameters, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+            update_vo(updated_vo=vo, parameters=parameters, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
         except AccessDenied as error:
-            return generate_http_error(401, 'AccessDenied', error.args[0])
+            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
         except VONotFound as error:
-            return generate_http_error(404, 'VONotFound', error.args[0])
+            return generate_http_error_flask(404, 'VONotFound', error.args[0])
         except UnsupportedOperation as error:
-            return generate_http_error(409, 'UnsupportedOperation', error.args[0])
+            return generate_http_error_flask(409, 'UnsupportedOperation', error.args[0])
         except RucioException as error:
-            return generate_http_error(500, error.__class__.__name__, error.args[0])
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
-        return "OK", 200
+        return '', 200
 
 
 class RecoverVO(MethodView):
     """ Recover root identity for a VO. """
 
-    def post(self, root_vo):
+    def post(self, vo):
         """ Recover root identity for a given VO
 
         .. :quickref: RecoverVO; Recover VO root identity.
 
-        :param root_vo: VO to be recovered.
+        :param vo: VO to be recovered.
         :<json string identity: Identity key to use.
         :<json string authtype: Type of identity.
         :<json string email: Admin email for VO.
@@ -170,12 +170,12 @@ class RecoverVO(MethodView):
         :status 500: Internal Error.
 
         """
-        json_data = request.data
+        json_data = request.data.decode()
 
         try:
             parameter = loads(json_data)
         except ValueError:
-            return generate_http_error(400, 'ValueError', 'cannot decode json parameter dictionary')
+            return generate_http_error_flask(400, 'ValueError', 'cannot decode json parameter dictionary')
 
         try:
             identity = parameter['identity']
@@ -185,12 +185,12 @@ class RecoverVO(MethodView):
             default = parameter.get('default', False)
         except KeyError as error:
             if error.args[0] == 'authtype' or error.args[0] == 'identity' or error.args[0] == 'email':
-                return generate_http_error(400, 'KeyError', '%s not defined' % str(error))
+                return generate_http_error_flask(400, 'KeyError', '%s not defined' % str(error))
         except TypeError:
-            return generate_http_error(400, 'TypeError', 'body must be a json dictionary')
+            return generate_http_error_flask(400, 'TypeError', 'body must be a json dictionary')
 
         try:
-            recover_vo_root_identity(root_vo=root_vo,
+            recover_vo_root_identity(root_vo=vo,
                                      identity_key=identity,
                                      id_type=authtype,
                                      email=email,
@@ -199,19 +199,18 @@ class RecoverVO(MethodView):
                                      issuer=request.environ.get('issuer'),
                                      vo=request.environ.get('vo'))
         except AccessDenied as error:
-            return generate_http_error(401, 'AccessDenied', error.args[0])
+            return generate_http_error_flask(401, 'AccessDenied', error.args[0])
         except AccountNotFound as error:
-            return generate_http_error(404, 'AccountNotFound', error.args[0])
+            return generate_http_error_flask(404, 'AccountNotFound', error.args[0])
         except Duplicate as error:
-            return generate_http_error(409, 'Duplicate', error.args[0])
+            return generate_http_error_flask(409, 'Duplicate', error.args[0])
         except RucioException as error:
-            return generate_http_error(500, error.__class__.__name__, error.args[0])
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
-            print(error)
             print(format_exc())
-            return error, 500
+            return str(error), 500
 
-        return "Created", 201
+        return 'Created', 201
 
 
 """----------------------

--- a/lib/rucio/web/rest/webpy/v1/authentication.py
+++ b/lib/rucio/web/rest/webpy/v1/authentication.py
@@ -65,7 +65,7 @@ for extra_module in EXTRA_MODULES:
 if EXTRA_MODULES['onelogin']:
     from onelogin.saml2.auth import OneLogin_Saml2_Auth
     from web import cookies
-    from rucio.web.ui.common.utils import prepare_webpy_request
+    from rucio.web.ui.common.utils import prepare_saml_request
 
 URLS = (
     '/userpass', 'UserPass',
@@ -963,7 +963,7 @@ class SAML(RucioController):
 
         request = ctx.env
         data = dict(param_input())
-        req = prepare_webpy_request(request, data)
+        req = prepare_saml_request(request, data)
         auth = OneLogin_Saml2_Auth(req, custom_base_path=SAML_PATH)
 
         header('X-Rucio-SAML-Auth-URL', auth.login())
@@ -976,9 +976,7 @@ class SAML(RucioController):
             return "SAML not configured on the server side."
 
         SAML_PATH = config_get('saml', 'config_path')
-        request = ctx.env
-        data = dict(param_input())
-        req = prepare_webpy_request(request, data)
+        req = prepare_saml_request(ctx.env, dict(param_input()))
         auth = OneLogin_Saml2_Auth(req, custom_base_path=SAML_PATH)
 
         auth.process_response()

--- a/lib/rucio/web/ui/common/utils.py
+++ b/lib/rucio/web/ui/common/utils.py
@@ -1,29 +1,38 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# -*- coding: utf-8 -*-
+# Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2014-2020
-# - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
-# - Jaroslav Guenther, <jaroslav.guenther@cern.ch>, 2019-2020
-# - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
+# - Thomas Beermann <thomas.beermann@cern.ch>, 2014-2020
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2014-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2015
+# - Martin Barisits <martin.barisits@cern.ch>, 2016-2020
+# - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
-#
-# TO-DO !!! Remove passing data with account and other params to the functions
-# catch these from the webpy input() storage object
-# will allow to remove also lines around each use of select_account_name
 
 import re
 import sys
 from json import dumps, load
 from os.path import dirname, join
 from time import time
+
 from web import cookies, ctx, input, setcookie, template, seeother
 
 from rucio import version
@@ -32,7 +41,6 @@ from rucio.api.account import account_exists, get_account_info, list_account_att
 from rucio.common.config import config_get, config_get_bool
 from rucio.core import identity as identity_core, vo as vo_core
 from rucio.db.sqla.constants import AccountType, IdentityType
-
 
 if sys.version_info > (3, 0):
     long = int
@@ -45,7 +53,6 @@ try:
 except ImportError:
     import cgi
     escapefunc = cgi.escape
-
 
 try:
     from onelogin.saml2.auth import OneLogin_Saml2_Auth
@@ -80,12 +87,16 @@ MULTI_VO = config_get_bool('common', 'multi_vo', raise_exception=False, default=
 # excluded characters for injected JavaScript variables
 VARIABLE_VALUE_REGEX = re.compile(r"^[\w\- /=,.+*#()\[\]]*$", re.UNICODE)
 
+# TO-DO !!! Remove passing data with account and other params to the functions
+# catch these from the webpy input() storage object
+# will allow to remove also lines around each use of select_account_name
+
 
 def html_escape(s, quote=True):
     return escapefunc(s, quote)
 
 
-def prepare_webpy_request(request, data):
+def prepare_saml_request(request, data):
     """
     Prepare a webpy request for SAML
     :param request: webpy request object
@@ -443,7 +454,7 @@ def saml_auth(method, data=None):
     :returns: rendered final page or a page with error message
     """
     SAML_PATH = join(dirname(__file__), 'saml/')
-    req = prepare_webpy_request(ctx.env, dict(input()))
+    req = prepare_saml_request(ctx.env, dict(input()))
     samlauth = OneLogin_Saml2_Auth(req, custom_base_path=SAML_PATH)
     saml_user_data = cookies().get('saml-user-data')
     if not MULTI_VO:


### PR DESCRIPTION
Rename lock, replica blueprints, because of duplicate naming resulting in errors when adding both to the same application.
Fix Flask endpoints compared to web.py.
Add global account limit endpoint to Flask.
Add `parse_scope_name` for parsing scope and name following the schema.
Add `try_stream` for all streaming endpoints.
Fix did endpoint and add missing follow endpoint.
Fix archive endpoint.
Add missing authentication endpoints.

Caveats
-----------

OIDC authentication templates were created for web.py only. The outputs on the Flask side are simple one-liners in text instead of HTML. As those endpoints shouldn't be handled as REST APIs, this doesn't break anything.