### PR TITLE
Clients: log level propagation - #3912

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -72,7 +72,7 @@ from rucio.common.exception import (DataIdentifierAlreadyExists, AccessDenied, D
                                     RuleNotFound, CannotAuthenticate, MissingDependency, UnsupportedOperation,
                                     RucioException, DuplicateRule, InvalidType)
 from rucio.common.utils import sizefmt, Color, detect_client_location, chunks, parse_did_filter_from_string, \
-    extract_scope
+    extract_scope, setup_logger, server_client_mode
 from rucio.tests.test_rucio_server import TestRucioClient
 
 try:
@@ -91,44 +91,11 @@ gfal2_logger = logging.getLogger("gfal2")
 tablefmt = 'psql'
 
 
-def setup_logger(logger):
-    logger.setLevel(logging.INFO)
-    hdlr = logging.StreamHandler()
-
-    def emit_decorator(fnc):
-        def func(*args):
-            if 'RUCIO_LOGGING_FORMAT' not in os.environ:
-                levelno = args[0].levelno
-                format_str = '%(asctime)s\t%(levelname)s\t%(message)s\033[0m'
-                if levelno >= logging.CRITICAL:
-                    color = '\033[31;1m'
-                elif levelno >= logging.ERROR:
-                    color = '\033[31;1m'
-                elif levelno >= logging.WARNING:
-                    color = '\033[33;1m'
-                elif levelno >= logging.INFO:
-                    color = '\033[32;1m'
-                elif levelno >= logging.DEBUG:
-                    color = '\033[36;1m'
-                    format_str = '%(asctime)s\t%(levelname)s\t%(filename)s\t%(funcName)s\t%(message)s\033[0m'
-                else:
-                    color = '\033[0m'
-                formatter = logging.Formatter('{0}{1}'.format(color, format_str))
-            else:
-                formatter = logging.Formatter(os.environ['RUCIO_LOGGING_FORMAT'])
-            hdlr.setFormatter(formatter)
-            return fnc(*args)
-        return func
-    hdlr.emit = emit_decorator(hdlr.emit)
-    logger.addHandler(hdlr)
-
-
 def setup_gfal2_logger(logger):
     logger.setLevel(logging.CRITICAL)
     logger.addHandler(logging.StreamHandler())
 
 
-setup_logger(logger)
 setup_gfal2_logger(gfal2_logger)
 
 
@@ -280,7 +247,7 @@ def get_client(args):
                         account=args.account,
                         auth_type=auth_type, creds=creds,
                         ca_cert=args.ca_certificate, timeout=args.timeout,
-                        user_agent=args.user_agent, vo=args.vo)
+                        user_agent=args.user_agent, vo=args.vo, logger_level=downstream_logger_level)
     except CannotAuthenticate as error:
         logger.error(error)
         if 'alert certificate expired' in str(error):
@@ -975,7 +942,7 @@ def upload(args):
 
     client = get_client(args)
     from rucio.client.uploadclient import UploadClient
-    upload_client = UploadClient(client, logger)
+    upload_client = UploadClient(client, logger, logger_level=downstream_logger_level)
     summary_file_path = 'rucio_upload.json' if args.summary else None
     upload_client.upload(items, summary_file_path)
     return SUCCESS
@@ -1023,7 +990,7 @@ def download(args):
 
     client = get_client(args)
     from rucio.client.downloadclient import DownloadClient
-    download_client = DownloadClient(client=client, logger=logger, check_admin=args.allow_tape)
+    download_client = DownloadClient(client=client, logger=logger, check_admin=args.allow_tape, logger_level=downstream_logger_level)
 
     result = None
     item_defaults = {}
@@ -2344,10 +2311,21 @@ if __name__ == '__main__':
         sys.exit(FAILURE)
 
     args = oparser.parse_args(arguments)
-
+    SERVER_MODE, CLIENT_MODE = server_client_mode()
     try:
-        if args.verbose:
-            logger.setLevel(logging.DEBUG)
+        if args.verbose and SERVER_MODE:
+            downstream_logger_level = logging.WARNING
+            this_logger_level = logging.DEBUG
+        elif args.verbose and CLIENT_MODE:
+            downstream_logger_level = logging.DEBUG
+            this_logger_level = logging.DEBUG
+        elif SERVER_MODE:
+            downstream_logger_level = logging.WARNING
+            this_logger_level = logging.INFO
+        else:
+            downstream_logger_level = logging.INFO
+            this_logger_level = logging.INFO
+        setup_logger(logger, logger_level=this_logger_level)
         start_time = time.time()
         result = args.function(args)
         end_time = time.time()
@@ -2355,5 +2333,5 @@ if __name__ == '__main__':
             print("Completed in %-0.4f sec." % (end_time - start_time))
         sys.exit(result)
     except Exception as error:
-        logger.error("Strange error: {0}".format(error))
+        print("Strange error: {0}".format(error))
         sys.exit(FAILURE)

--- a/bin/rucio
+++ b/bin/rucio
@@ -2314,7 +2314,7 @@ if __name__ == '__main__':
     SERVER_MODE, CLIENT_MODE = server_client_mode()
     try:
         if args.verbose and SERVER_MODE:
-            downstream_logger_level = logging.INFO
+            downstream_logger_level = logging.DEBUG
             this_logger_level = logging.DEBUG
         elif args.verbose and CLIENT_MODE:
             downstream_logger_level = logging.DEBUG

--- a/bin/rucio
+++ b/bin/rucio
@@ -2314,7 +2314,7 @@ if __name__ == '__main__':
     SERVER_MODE, CLIENT_MODE = server_client_mode()
     try:
         if args.verbose and SERVER_MODE:
-            downstream_logger_level = logging.WARNING
+            downstream_logger_level = logging.INFO
             this_logger_level = logging.DEBUG
         elif args.verbose and CLIENT_MODE:
             downstream_logger_level = logging.DEBUG

--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -32,13 +32,14 @@ try:
     from urllib import quote_plus
 except ImportError:
     from urllib.parse import quote_plus
+import logging
 
 from json import dumps
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice
-from rucio.common.utils import build_url
+from rucio.common.utils import build_url, setup_logger
 
 
 class AccountClient(BaseClient):
@@ -47,8 +48,11 @@ class AccountClient(BaseClient):
 
     ACCOUNTS_BASEURL = 'accounts'
 
-    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
-        super(AccountClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo)
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
+        super(AccountClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
+        self.logger_level = logger_level
+        self.logger = logging.getLogger(__name__)
+        setup_logger(self.logger, logger_level=self.logger_level)
 
     def add_account(self, account, type, email):
         """
@@ -167,6 +171,7 @@ class AccountClient(BaseClient):
         :return: a list of attributes for the account. None if failure.
         :raises AccountNotFound: if account doesn't exist.
         """
+        self.logger.debug('Account base url: {}'.format(self.ACCOUNTS_BASEURL))
         return self.get_account('whoami')
 
     def add_identity(self, account, identity, authtype, email, default=False, password=None):

--- a/lib/rucio/client/accountlimitclient.py
+++ b/lib/rucio/client/accountlimitclient.py
@@ -42,9 +42,9 @@ class AccountLimitClient(BaseClient):
     ACCOUNTLIMIT_BASEURL = 'accountlimits'
 
     def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None,
-                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
+                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
         super(AccountLimitClient, self).__init__(rucio_host, auth_host, account, ca_cert,
-                                                 auth_type, creds, timeout, user_agent, vo=vo)
+                                                 auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def set_account_limit(self, account, rse, bytes, locality):
         """

--- a/lib/rucio/client/client.py
+++ b/lib/rucio/client/client.py
@@ -68,7 +68,7 @@ class Client(AccountClient,
 
     """Main client class for accessing Rucio resources. Handles the authentication."""
 
-    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
         """
         Constructor for the Rucio main client class.
 
@@ -81,4 +81,4 @@ class Client(AccountClient,
         :param timeout: Float describes the timeout of the request (in seconds).
         :param vo: The vo that the client will interact with.
         """
-        super(Client, self).__init__(rucio_host=rucio_host, auth_host=auth_host, account=account, ca_cert=ca_cert, auth_type=auth_type, creds=creds, timeout=timeout, user_agent=user_agent, vo=vo)
+        super(Client, self).__init__(rucio_host=rucio_host, auth_host=auth_host, account=account, ca_cert=ca_cert, auth_type=auth_type, creds=creds, timeout=timeout, user_agent=user_agent, vo=vo, logger_level=logger_level)

--- a/lib/rucio/client/configclient.py
+++ b/lib/rucio/client/configclient.py
@@ -41,8 +41,8 @@ class ConfigClient(BaseClient):
 
     CONFIG_BASEURL = 'config'
 
-    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
-        super(ConfigClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo)
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
+        super(ConfigClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def get_config(self, section=None, option=None):
         """

--- a/lib/rucio/client/credentialclient.py
+++ b/lib/rucio/client/credentialclient.py
@@ -31,9 +31,9 @@ class CredentialClient(BaseClient):
     CREDENTIAL_BASEURL = 'credentials'
 
     def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None,
-                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
+                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
         super(CredentialClient, self).__init__(rucio_host, auth_host, account, ca_cert,
-                                               auth_type, creds, timeout, user_agent, vo=vo)
+                                               auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def get_signed_url(self, rse, service, operation, url, lifetime=3600):
         """

--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -52,9 +52,9 @@ class DIDClient(BaseClient):
     ARCHIVES_BASEURL = 'archives'
 
     def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None,
-                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
+                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
         super(DIDClient, self).__init__(rucio_host, auth_host, account, ca_cert,
-                                        auth_type, creds, timeout, user_agent, vo=vo)
+                                        auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def list_dids(self, scope, filters, type='collection', long=False, recursive=False):
         """

--- a/lib/rucio/client/diracclient.py
+++ b/lib/rucio/client/diracclient.py
@@ -35,9 +35,9 @@ class DiracClient(BaseClient):
     DIRAC_BASEURL = 'dirac'
 
     def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None,
-                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
+                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
         super(DiracClient, self).__init__(rucio_host, auth_host, account, ca_cert,
-                                          auth_type, creds, timeout, user_agent, vo=vo)
+                                          auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def add_files(self, lfns, ignore_availability=False):
         """

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -45,7 +45,7 @@ from rucio.common.exception import (InputValidationError, NoFilesDownloaded, Not
 from rucio.common.didtype import DIDType
 from rucio.common.pcache import Pcache
 from rucio.common.utils import adler32, detect_client_location, generate_uuid, parse_replicas_from_string, \
-    send_trace, sizefmt, execute, parse_replicas_from_file
+    send_trace, sizefmt, execute, parse_replicas_from_file, setup_logger
 from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS, CHECKSUM_ALGO_DICT, PREFERRED_CHECKSUM
 from rucio.rse import rsemanager as rsemgr
 from rucio import version
@@ -118,7 +118,7 @@ class BaseExtractionTool:
 
 class DownloadClient:
 
-    def __init__(self, client=None, logger=None, tracing=True, check_admin=False, check_pcache=False):
+    def __init__(self, client=None, logger=None, tracing=True, check_admin=False, check_pcache=False, logger_level=None):
         """
         Initialises the basic settings for an DownloadClient object
 
@@ -132,6 +132,7 @@ class DownloadClient:
 
         self.check_pcache = check_pcache
         self.logger = logger
+        setup_logger(self.logger, logger_level=logger_level)
         self.tracing = tracing
         if not self.tracing:
             logger.debug('Tracing is turned off.')

--- a/lib/rucio/client/exportclient.py
+++ b/lib/rucio/client/exportclient.py
@@ -31,9 +31,9 @@ class ExportClient(BaseClient):
     EXPORT_BASEURL = 'export'
 
     def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None,
-                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
+                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
         super(ExportClient, self).__init__(rucio_host, auth_host, account, ca_cert,
-                                           auth_type, creds, timeout, user_agent, vo=vo)
+                                           auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def export_data(self):
         """

--- a/lib/rucio/client/importclient.py
+++ b/lib/rucio/client/importclient.py
@@ -31,9 +31,9 @@ class ImportClient(BaseClient):
     IMPORT_BASEURL = 'import'
 
     def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None,
-                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
+                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
         super(ImportClient, self).__init__(rucio_host, auth_host, account, ca_cert,
-                                           auth_type, creds, timeout, user_agent, vo=vo)
+                                           auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def import_data(self, data):
         """

--- a/lib/rucio/client/lockclient.py
+++ b/lib/rucio/client/lockclient.py
@@ -40,9 +40,9 @@ class LockClient(BaseClient):
     LOCKS_BASEURL = 'locks'
 
     def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None,
-                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
+                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
         super(LockClient, self).__init__(rucio_host, auth_host, account, ca_cert,
-                                         auth_type, creds, timeout, user_agent, vo=vo)
+                                         auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def get_dataset_locks(self, scope, name):
         """

--- a/lib/rucio/client/metaclient.py
+++ b/lib/rucio/client/metaclient.py
@@ -42,8 +42,8 @@ class MetaClient(BaseClient):
 
     META_BASEURL = 'meta'
 
-    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
-        super(MetaClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo)
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
+        super(MetaClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def add_key(self, key, key_type, value_type=None, value_regexp=None):
         """

--- a/lib/rucio/client/pingclient.py
+++ b/lib/rucio/client/pingclient.py
@@ -32,8 +32,8 @@ class PingClient(BaseClient):
 
     """Ping client class"""
 
-    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
-        super(PingClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo)
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
+        super(PingClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def ping(self):
         """

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -45,8 +45,8 @@ class ReplicaClient(BaseClient):
 
     REPLICAS_BASEURL = 'replicas'
 
-    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
-        super(ReplicaClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo)
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
+        super(ReplicaClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def declare_bad_file_replicas(self, pfns, reason):
         """

--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -33,9 +33,9 @@ class RequestClient(BaseClient):
     REQUEST_BASEURL = 'requests'
 
     def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None,
-                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
+                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
         super(RequestClient, self).__init__(rucio_host, auth_host, account, ca_cert,
-                                            auth_type, creds, timeout, user_agent, vo=vo)
+                                            auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def list_request_by_did(self, name, rse, scope=None):
         """Return latest request details for a DID

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -43,9 +43,9 @@ class RSEClient(BaseClient):
     RSE_BASEURL = 'rses'
 
     def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None,
-                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
+                 auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
         super(RSEClient, self).__init__(rucio_host, auth_host, account, ca_cert,
-                                        auth_type, creds, timeout, user_agent, vo=vo)
+                                        auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def get_rse(self, rse):
         """

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -41,8 +41,8 @@ class RuleClient(BaseClient):
 
     RULE_BASEURL = 'rules'
 
-    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, dq2_wrapper=False, vo=None):
-        super(RuleClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, dq2_wrapper, vo=vo)
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, dq2_wrapper=False, vo=None, logger_level=None):
+        super(RuleClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, dq2_wrapper, vo=vo, logger_level=logger_level)
 
     def add_replication_rule(self, dids, copies, rse_expression, weight=None, lifetime=None, grouping='DATASET', account=None,
                              locked=False, source_replica_expression=None, activity=None, notify='N', purge_replicas=False,

--- a/lib/rucio/client/scopeclient.py
+++ b/lib/rucio/client/scopeclient.py
@@ -43,8 +43,8 @@ class ScopeClient(BaseClient):
 
     SCOPE_BASEURL = 'accounts'
 
-    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
-        super(ScopeClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo)
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
+        super(ScopeClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def add_scope(self, account, scope):
         """

--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -36,8 +36,8 @@ class SubscriptionClient(BaseClient):
 
     SUB_BASEURL = 'subscriptions'
 
-    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
-        super(SubscriptionClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo)
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
+        super(SubscriptionClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def add_subscription(self, name, account, filter, replication_rules, comments, lifetime, retroactive, dry_run, priority=3):
         """

--- a/lib/rucio/client/touchclient.py
+++ b/lib/rucio/client/touchclient.py
@@ -38,8 +38,8 @@ class TouchClient(BaseClient):
     DIDS_BASEURL = 'dids'
     TRACES_BASEURL = 'traces'
 
-    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None):
-        super(TouchClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo)
+    def __init__(self, rucio_host=None, auth_host=None, account=None, ca_cert=None, auth_type=None, creds=None, timeout=600, user_agent='rucio-clients', vo=None, logger_level=None):
+        super(TouchClient, self).__init__(rucio_host, auth_host, account, ca_cert, auth_type, creds, timeout, user_agent, vo=vo, logger_level=logger_level)
 
     def touch(self, scope, name, rse=None):
         """

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -52,14 +52,14 @@ from rucio.common.exception import (RucioException, RSEBlacklisted, DataIdentifi
                                     DataIdentifierNotFound, NoFilesUploaded, NotAllFilesUploaded, FileReplicaAlreadyExists,
                                     ResourceTemporaryUnavailable, ServiceUnavailable, InputValidationError, RSEChecksumUnavailable)
 from rucio.common.utils import (adler32, detect_client_location, execute, generate_uuid, make_valid_did, md5, send_trace,
-                                retry, GLOBALLY_SUPPORTED_CHECKSUMS)
+                                retry, GLOBALLY_SUPPORTED_CHECKSUMS, setup_logger)
 from rucio.rse import rsemanager as rsemgr
 from rucio import version
 
 
 class UploadClient:
 
-    def __init__(self, _client=None, logger=None, tracing=True):
+    def __init__(self, _client=None, logger=None, tracing=True, logger_level=None):
         """
         Initialises the basic settings for an UploadClient object
 
@@ -71,6 +71,7 @@ class UploadClient:
             logger.disabled = True
 
         self.logger = logger
+        setup_logger(logger, logger_level=logger_level)
 
         self.client = _client if _client else Client()
         self.client_location = detect_client_location()

--- a/lib/rucio/common/.vim_runtime/my_configs.vim
+++ b/lib/rucio/common/.vim_runtime/my_configs.vim
@@ -1,0 +1,1 @@
+set mouse-=a


### PR DESCRIPTION
Propagation of log level
------------------------

- the log level has to be propagated through all clients downstream to baseclient, which is inheriting from them
- further propagation to rsemgr still has to be done
- distinguishing log level by server/client mode and verbosity set in bin/rucio
    - the full logic can be seen at the end of bin/rucio
- the log level is decided centrally in bin/rucio for all the downstream modules
- if cli is not used, there's a default within setup_logger method in common/utils.py, this would be used for api calls.

Outcomes:
----------
- #3912 is solved by this
- The general formatter is now applied to almost all loggers in clients.
- There should be way less logger load on the servers when testing.