### PR TITLE
Core & Internals: Update cx_oracle to 7.3; #3420

### DIFF
--- a/etc/docker/test/centos7.Dockerfile
+++ b/etc/docker/test/centos7.Dockerfile
@@ -73,7 +73,7 @@ RUN rpm -i etc/docker/test/extra/oic.rpm; \
 
 # pre-install requirements
 RUN python -m pip --no-cache-dir install --upgrade -r etc/pip-requires -r etc/pip-requires-client -r etc/pip-requires-test \
-    'cx_oracle==6.3.1' 'psycopg2-binary>=2.4.2,<2.8' 'PyMySQL' 'kerberos>=1.3.0' 'pykerberos>=1.2.1' 'requests-kerberos>=0.12.0' 'python3-saml>=1.6.0'
+    'cx_oracle==7.3' 'psycopg2-binary>=2.4.2,<2.8' 'PyMySQL' 'kerberos>=1.3.0' 'pykerberos>=1.2.1' 'requests-kerberos>=0.12.0' 'python3-saml>=1.6.0'
 
 # copy everything else (anything above is cache-friendly)
 COPY . .

--- a/setup_rucio.py
+++ b/setup_rucio.py
@@ -162,7 +162,7 @@ def write_requirements():
         req_file.close()
 
 
-oracle_extras = ['cx_oracle==6.3.1']
+oracle_extras = ['cx_oracle==7.3']
 postgresql_extras = ['psycopg2-binary>=2.4.2,<2.8']
 mysql_extras = ['PyMySQL']
 kerberos_extras = ['kerberos>=1.3.0', 'pykerberos>=1.2.1', 'requests-kerberos>=0.12.0']


### PR DESCRIPTION
Update cx_oracle to 7.3. It supports Python 2.7 and Python 3.5 up until 3.8.