### PR TITLE
Clients: Fix loading data generating empty string

### DIFF
--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -346,7 +346,8 @@ class BaseClient(object):
         elif 'content-type' in response.headers and response.headers['content-type'] == 'application/json':
             yield parse_response(response.text)
         else:  # Exception ?
-            yield response.text
+            if response.text:
+                yield response.text
 
     def _send_request(self, url, headers=None, type='GET', data=None, params=None, stream=False):
         """


### PR DESCRIPTION
Fix loading data generating empty string when Content-Type is not a json type and response is empty.

Should maybe be merged as a feature, since it changes client's return values, if anything unexpected happens.