### PR TITLE
Core & Internals: Fix long errors on the API; Fix #3981

### DIFF
--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -480,7 +480,10 @@ def _error_response(exc_cls, exc_msg):
     exc_msg = strip_newlines(exc_msg)
     if exc_msg:
         # Truncate too long exc_msg
-        exc_msg = exc_msg[:min(len(exc_msg), 15000)]
+        oldlen = len(exc_msg)
+        exc_msg = exc_msg[:min(oldlen, 125)]
+        if len(exc_msg) != oldlen:
+            exc_msg = exc_msg + '...'
     headers = {'Content-Type': 'application/octet-stream',
                'ExceptionClass': strip_newlines(exc_cls),
                'ExceptionMessage': exc_msg}

--- a/lib/rucio/tests/test_dataset_replicas.py
+++ b/lib/rucio/tests/test_dataset_replicas.py
@@ -1,4 +1,5 @@
-# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2015-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,10 +27,13 @@
 
 import unittest
 
+import pytest
+
 from rucio.client.didclient import DIDClient
 from rucio.client.replicaclient import ReplicaClient
 from rucio.client.ruleclient import RuleClient
 from rucio.common.config import config_get, config_get_bool
+from rucio.common.exception import InvalidObject
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.did import attach_dids, add_did, add_dids
@@ -77,6 +81,10 @@ class TestDatasetReplicaClient(unittest.TestCase):
         rule_client.add_replication_rule(dids=dids,
                                          account='root', copies=1, rse_expression='MOCK',
                                          grouping='DATASET')
+
+        with pytest.raises(InvalidObject):
+            replica_client.list_dataset_replicas_bulk(dids=[{'type': "I'm Different"}])
+
         replicas = list(replica_client.list_dataset_replicas_bulk(dids=dids))
 
         assert len(replicas) == 2


### PR DESCRIPTION
Fix long errors on the API: reduce error message in header to 128 characters max. mod_wsgi crashes with very long header values and does not log anything. I am just assuming that 128 characters is a good maximum value.

Add test for InvalidObject to `test_list_dataset_replicas_bulk` to check for the correct error on objects with invalid schema.

Depends on #4003 

On the side: The full error is still propagated to the client in the response body and it is shown when using the clients. There is no other change here other than the exception message in the response's headers.