### PR TITLE
CMS: Fix did name check in schema; #3981

### DIFF
--- a/lib/rucio/common/schema/cms.py
+++ b/lib/rucio/common/schema/cms.py
@@ -271,7 +271,7 @@ DID = {"description": "Data Identifier(DID)",
            ], },
                "then": {"properties": {"name": {"pattern": "^/store/user/rucio/"}}}},
            {"if": {"properties": {"scope": {"const": "cms"}}},
-            "then": {"not": {"properties": {"name": {"pattern": "^/store/user/"}}}}},
+            "then": {"properties": {"name": {"not": {"pattern": "^/store/user/"}}}}},
        ],
        "required": ["scope", "name", "type"],
        "additionalProperties": False}


### PR DESCRIPTION
I stumbled across this when fixing #3981 and suggested to @ericvaandering to open a PR about this quick fix.

Before this change a certain invalid simple dids list had a weird validation error:
```
jsonschema.exceptions.ValidationError: {'properties': {'name': {'pattern': '^/store/user/'}}} is not allowed for {'type': 'Whatevv'}
Failed validating 'not' in schema['items']['allOf'][5]['if']['then']:
    {'not': {'properties': {'name': {'pattern': '^/store/user/'}}}}

On instance[0]:
    {'type': 'Whatevv'}
```

And with this change the validation error is much clearer: `Details: Problem validating dids : 'scope' is a required property`