### PR TITLE
Release management: Downgrade docutils; Fix #4006

### DIFF
--- a/etc/pip-requires-test
+++ b/etc/pip-requires-test
@@ -10,7 +10,7 @@ sphinx-rtd-theme==0.5.0; python_version >= '3.5'
 sphinxcontrib-httpdomain==1.7.0                   # Provides a Sphinx domain for describing RESTful HTTP APIs
 Pygments==2.5.2; python_version < '3.5'           # Python Syntax highlighter (2.5.2 last Py27 compatible version)
 Pygments==2.6.1; python_version >= '3.5'
-docutils==0.16                                    # Needed for sphinx
+docutils>=0.15,<0.16                              # Needed for sphinx
 pyflakes==2.1.1                                   # Passive checker of Python programs
 flake8==3.7.8                                     # Wrapper around PyFlakes&pep8
 pylint==1.9.4; python_version < '3.5'             # static code analysis. 1.9.5 last 2.7 compatible release

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -49,7 +49,7 @@ sphinx-rtd-theme==0.5.0; python_version >= '3.5'
 sphinxcontrib-httpdomain==1.7.0                   # Provides a Sphinx domain for describing RESTful HTTP APIs
 Pygments==2.5.2; python_version < '3.5'           # Python Syntax highlighter (2.5.2 last Py27 compatible version)
 Pygments==2.6.1; python_version >= '3.5'
-docutils==0.16                                    # Needed for sphinx
+docutils>=0.15,<0.16                              # Needed for sphinx
 pyflakes==2.1.1                                   # Passive checker of Python programs
 flake8==3.7.8                                     # Wrapper around PyFlakes&pep8
 pylint==1.9.4; python_version < '3.5'             # static code analysis. 1.9.5 last 2.7 compatible release


### PR DESCRIPTION
Downgrades docutils to below version 0.16 as our boto3 dependency requires. This works fine with the new pip resolver (`--use-feature=2020-resolver`).