### PR TITLE
Testing: Ensure the image tag is always lower-case

### DIFF
--- a/tools/test/build_images.py
+++ b/tools/test/build_images.py
@@ -60,9 +60,9 @@ def main():
                                           buildargs._asdict().items()))
             if buildargs_tags:
                 buildargs_tags = '-' + buildargs_tags
-            imagetag = f'rucio-autotest:{dist}{buildargs_tags}'
+            imagetag = f'rucio-autotest:{dist.lower()}{buildargs_tags}'
             if script_args.cache_repo:
-                imagetag = script_args.cache_repo + '/' + imagetag
+                imagetag = script_args.cache_repo.lower() + '/' + imagetag
 
             cache_args = ()
             if script_args.build_no_cache:


### PR DESCRIPTION
Fixes problems on some forks with upper-case characters in the GitHub URL.