### PR TITLE
REST API: Add RSENotFound to /replicas/bad; Fix #3409

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -411,7 +411,7 @@ def declare_bad_file_replicas(pfns, reason, issuer, status=BadFilesStatus.BAD, s
     scheme, files_to_declare, unknown_replicas = get_pfn_to_rse(pfns, vo=issuer.vo, session=session)
     for rse_id in files_to_declare:
         notdeclared = __declare_bad_file_replicas(files_to_declare[rse_id], rse_id, reason, issuer, status=status, scheme=scheme, session=session)
-        if notdeclared != []:
+        if notdeclared:
             unknown_replicas[rse_id] = notdeclared
     return unknown_replicas
 

--- a/lib/rucio/web/rest/flaskapi/v1/replica.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replica.py
@@ -571,6 +571,7 @@ class BadReplicas(MethodView):
         :status 201: Created.
         :status 400: Cannot decode json parameter list.
         :status 401: Invalid auth token.
+        :status 404: RSE not found.
         :status 404: Replica not found.
         :status 500: Internal Error.
         :returns: A list of not successfully declared files.
@@ -592,6 +593,8 @@ class BadReplicas(MethodView):
             not_declared_files = declare_bad_file_replicas(pfns=pfns, reason=reason, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
         except AccessDenied as error:
             return generate_http_error_flask(401, 'AccessDenied', error.args[0])
+        except RSENotFound as error:
+            return generate_http_error_flask(404, 'RSENotFound', error.args[0])
         except ReplicaNotFound as error:
             return generate_http_error_flask(404, 'ReplicaNotFound', error.args[0])
         except RucioException as error:

--- a/lib/rucio/web/rest/webpy/v1/replica.py
+++ b/lib/rucio/web/rest/webpy/v1/replica.py
@@ -578,6 +578,8 @@ class BadReplicas(RucioController):
             not_declared_files = declare_bad_file_replicas(pfns=pfns, reason=reason, issuer=ctx.env.get('issuer'), vo=ctx.env.get('vo'))
         except AccessDenied as error:
             raise generate_http_error(401, 'AccessDenied', error.args[0])
+        except RSENotFound as error:
+            raise generate_http_error(404, 'RSENotFound', error.args[0])
         except ReplicaNotFound as error:
             raise generate_http_error(404, 'ReplicaNotFound', error.args[0])
         except RucioException as error:


### PR DESCRIPTION
Add support for `RSENotFound` exception on the `/replicas/bad` endpoint. Fixes #3409