### PR TITLE
logging: adding logger factory - #3912

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -72,7 +72,7 @@ from rucio.common.exception import (DataIdentifierAlreadyExists, AccessDenied, D
                                     RuleNotFound, CannotAuthenticate, MissingDependency, UnsupportedOperation,
                                     RucioException, DuplicateRule, InvalidType)
 from rucio.common.utils import sizefmt, Color, detect_client_location, chunks, parse_did_filter_from_string, \
-    extract_scope
+    extract_scope, setup_logger
 from rucio.tests.test_rucio_server import TestRucioClient
 
 try:
@@ -86,41 +86,8 @@ FAILURE = 1
 DEFAULT_SECURE_PORT = 443
 DEFAULT_PORT = 80
 
-logger = logging.getLogger("user")
 gfal2_logger = logging.getLogger("gfal2")
 tablefmt = 'psql'
-
-
-def setup_logger(logger):
-    logger.setLevel(logging.INFO)
-    hdlr = logging.StreamHandler()
-
-    def emit_decorator(fnc):
-        def func(*args):
-            if 'RUCIO_LOGGING_FORMAT' not in os.environ:
-                levelno = args[0].levelno
-                format_str = '%(asctime)s\t%(levelname)s\t%(message)s\033[0m'
-                if levelno >= logging.CRITICAL:
-                    color = '\033[31;1m'
-                elif levelno >= logging.ERROR:
-                    color = '\033[31;1m'
-                elif levelno >= logging.WARNING:
-                    color = '\033[33;1m'
-                elif levelno >= logging.INFO:
-                    color = '\033[32;1m'
-                elif levelno >= logging.DEBUG:
-                    color = '\033[36;1m'
-                    format_str = '%(asctime)s\t%(levelname)s\t%(filename)s\t%(funcName)s\t%(message)s\033[0m'
-                else:
-                    color = '\033[0m'
-                formatter = logging.Formatter('{0}{1}'.format(color, format_str))
-            else:
-                formatter = logging.Formatter(os.environ['RUCIO_LOGGING_FORMAT'])
-            hdlr.setFormatter(formatter)
-            return fnc(*args)
-        return func
-    hdlr.emit = emit_decorator(hdlr.emit)
-    logger.addHandler(hdlr)
 
 
 def setup_gfal2_logger(logger):
@@ -128,7 +95,6 @@ def setup_gfal2_logger(logger):
     logger.addHandler(logging.StreamHandler())
 
 
-setup_logger(logger)
 setup_gfal2_logger(gfal2_logger)
 
 
@@ -2345,9 +2311,9 @@ if __name__ == '__main__':
 
     args = oparser.parse_args(arguments)
 
+    logger = None
     try:
-        if args.verbose:
-            logger.setLevel(logging.DEBUG)
+        logger = setup_logger(module_name=__name__, logger_name='user', verbose=args.verbose)
         start_time = time.time()
         result = args.function(args)
         end_time = time.time()

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -50,7 +50,6 @@ import sys
 import traceback
 import time
 
-from logging import getLogger, StreamHandler, ERROR
 from os import environ, fdopen, path, makedirs, geteuid
 from shutil import move
 from tempfile import mkstemp
@@ -60,7 +59,7 @@ from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.exception import (CannotAuthenticate, ClientProtocolNotSupported,
                                     NoAuthInformation, MissingClientParameter,
                                     MissingModuleException, ServerConnectionException)
-from rucio.common.utils import build_url, get_tmp_dir, my_key_generator, parse_response, ssh_sign
+from rucio.common.utils import build_url, get_tmp_dir, my_key_generator, parse_response, ssh_sign, setup_logger
 from rucio import version
 
 try:
@@ -91,12 +90,7 @@ for extra_module in EXTRA_MODULES:
 if EXTRA_MODULES['requests_kerberos']:
     from requests_kerberos import HTTPKerberosAuth  # pylint: disable=import-error
 
-
-LOG = getLogger(__name__)
-SH = StreamHandler()
-SH.setLevel(ERROR)
-LOG.addHandler(SH)
-
+LOG = setup_logger(module_name=__name__)
 
 REGION = make_region(function_key_generator=my_key_generator).configure(
     'dogpile.cache.memory',

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -60,7 +60,7 @@ from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.exception import (CannotAuthenticate, ClientProtocolNotSupported,
                                     NoAuthInformation, MissingClientParameter,
                                     MissingModuleException, ServerConnectionException)
-from rucio.common.utils import build_url, get_tmp_dir, my_key_generator, parse_response, ssh_sign
+from rucio.common.utils import build_url, get_tmp_dir, my_key_generator, parse_response, ssh_sign, setup_logger
 from rucio import version
 
 try:
@@ -92,11 +92,7 @@ if EXTRA_MODULES['requests_kerberos']:
     from requests_kerberos import HTTPKerberosAuth  # pylint: disable=import-error
 
 
-LOG = getLogger(__name__)
-SH = StreamHandler()
-SH.setLevel(ERROR)
-LOG.addHandler(SH)
-
+LOG = setup_logger(module_name=__name__)
 
 REGION = make_region(function_key_generator=my_key_generator).configure(
     'dogpile.cache.memory',

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -43,6 +43,7 @@ import getpass
 import hashlib
 import imp
 import json
+import logging
 import os
 import os.path
 import re
@@ -52,8 +53,6 @@ import tempfile
 import threading
 import time
 import zlib
-from logging import getLogger, Formatter
-from logging.handlers import RotatingFileHandler
 from uuid import uuid4 as uuid
 from xml.etree import ElementTree
 
@@ -515,9 +514,9 @@ def my_key_generator(namespace, fn, **kw):
 
 
 def get_logger(name):
-    logger = getLogger(name)
-    hdlr = RotatingFileHandler('%s/%s.log' % (config_get('common', 'logdir'), name), maxBytes=1000000000, backupCount=10)
-    formatter = Formatter('%(asctime)s\t%(process)d\t%(levelname)s\t%(message)s')
+    logger = logging.getLogger(name)
+    hdlr = logging.RotatingFileHandler('%s/%s.log' % (config_get('common', 'logdir'), name), maxBytes=1000000000, backupCount=10)
+    formatter = logging.Formatter('%(asctime)s\t%(process)d\t%(levelname)s\t%(message)s')
     hdlr.setFormatter(formatter)
     logger.addHandler(hdlr)
     logger.setLevel(config_get('common', 'loglevel').upper())
@@ -1288,6 +1287,84 @@ def query_bunches(query, bunch_by):
     if item_bunch:
         filtered_bunches.append(item_bunch)
     return filtered_bunches
+
+
+def setup_logger(module_name=None, logger_name=None, logger_level=None, verbose=False):
+    '''
+    Factory method to set logger with handlers.
+    :param module_name: __name__ of the module that is calling this method
+    :param logger_name: name of the logger, typically name of the module.
+    :param logger_level: if not given, fetched from config.
+    :param verbose: verbose option set in bin/rucio
+    '''
+    # helper method for cfg check
+    def _force_cfg_log_level(cfg_option):
+        cfg_forced_modules = config_get('logging', cfg_option, raise_exception=False, default=None)
+        if cfg_forced_modules:
+            if re.match(str(cfg_forced_modules), module_name):
+                return True
+        return False
+
+    # creating log
+    if not logger_name:
+        if not module_name:
+            logger_name = 'usr'
+        else:
+            logger_name = module_name.split('.')[-1]
+    logger = logging.getLogger(logger_name)
+
+    # extracting the log level
+    if not logger_level:
+        logger_level = logging.WARNING
+        if verbose:
+            logger_level = logging.DEBUG
+
+        # overriding by the config
+        cfg_levels = filter(lambda x: True if type(x)==str else False, logging._levelNames.keys())  # ['INFO', 'WARNING', etc.]
+        for level in cfg_levels:
+            cfg_opt = 'forceloglevel' + level.lower()
+            if _force_cfg_log_level(cfg_opt):
+                logger_level = level
+
+    # setting the log level
+    logger.setLevel(logger_level)
+
+    # preferred logger handling
+    def add_handler(logger):
+        hdlr = logging.StreamHandler()
+
+        def emit_decorator(fnc):
+            def func(*args):
+                if 'RUCIO_LOGGING_FORMAT' not in os.environ:
+                    levelno = args[0].levelno
+                    format_str = '%(asctime)s\t%(levelname)s\t%(message)s\033[0m'
+                    if levelno >= logging.CRITICAL:
+                        color = '\033[31;1m'
+                    elif levelno >= logging.ERROR:
+                        color = '\033[31;1m'
+                    elif levelno >= logging.WARNING:
+                        color = '\033[33;1m'
+                    elif levelno >= logging.INFO:
+                        color = '\033[32;1m'
+                    elif levelno >= logging.DEBUG:
+                        color = '\033[36;1m'
+                        format_str = '%(asctime)s\t%(levelname)s\t%(filename)s\t%(message)s\033[0m'
+                    else:
+                        color = '\033[0m'
+                    formatter = logging.Formatter('{0}{1}'.format(color, format_str))
+                else:
+                    formatter = logging.Formatter(os.environ['RUCIO_LOGGING_FORMAT'])
+                hdlr.setFormatter(formatter)
+                return fnc(*args)
+            return func
+        hdlr.emit = emit_decorator(hdlr.emit)
+        logger.addHandler(hdlr)
+
+    # setting handler and formatter
+    if not logger.handlers:
+        add_handler(logger)
+
+    return logger
 
 
 class retry:


### PR DESCRIPTION
Adding the setup_logger, that can be used everywhere. This pr also solves the original problem of 3912. Once this is merged, we can start to propagate verbose options everywhere downstream. 