### PR TITLE
Testing: Add test for list_replicas streaming on error

### DIFF
--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -25,6 +25,8 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
+from __future__ import print_function
+
 import contextlib
 import itertools
 import os
@@ -172,3 +174,15 @@ def vohdr(vo):
 def hdrdict(dictionary):
     for key in dictionary:
         yield str(key), str(dictionary[key])
+
+
+def accept(mimetype):
+    yield 'Accept', mimetype
+
+
+class Mime:
+    """ Enum-type class for mimetypes. """
+    METALINK = 'application/metalink4+xml'
+    JSON = 'application/json'
+    JSON_STREAM = 'application/x-json-stream'
+    BINARY = 'application/octet-stream'

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -15,6 +15,9 @@
 #
 # Authors:
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+
+from __future__ import print_function
+
 import importlib
 import os
 import traceback
@@ -62,8 +65,9 @@ def rest_client():
             def __init__(self, *args, **kwargs):
                 super(WrappedFlaskClient, self).__init__(*args, **kwargs)
 
-            def open(self, *args, **kwargs):
-                response = super(WrappedFlaskClient, self).open(*args, **kwargs)
+            def open(self, path='/', *args, **kwargs):
+                print(kwargs.get('method', 'GET'), path)
+                response = super(WrappedFlaskClient, self).open(path, *args, **kwargs)
                 try:
                     print_response(response)
                 except Exception:
@@ -114,10 +118,10 @@ def rest_client():
                         return path, endpoint_client.open
                 return path, super(WrappedTestClient, self).open
 
-            def open(self, *args, **kwargs):
-                path, open_method = self._endpoint_specials(args[0])
-
-                response = open_method(path, *args[1:], **kwargs)
+            def open(self, path='/', *args, **kwargs):
+                newpath, open_method = self._endpoint_specials(path)
+                print(kwargs.get('method', 'GET'), path)
+                response = open_method(newpath, *args, **kwargs)
                 try:
                     print_response(response)
                 except Exception:


### PR DESCRIPTION
List replicas and test for behavior when an error occurs while streaming metalink or json.
In the test I am mocking the wsgi frameworks, because the wsgi test clients failed, showing different behavior than on the apache webserver. Running the code against the apache web server instance was problematic, because it was not possible to inject raising an error after returning an element from the API without breaking the test suite. Adding a new test suite just for this test seemed a bit too much on the other hand.