### PR TITLE
Testing: Disable most py2 tests

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -5,20 +5,6 @@ on:
   - push
 
 jobs:
-  pr_setup:
-    if: 'github.event_name == ''pull_request'' && !startsWith(github.event.pull_request.base.ref, ''release'') && !startsWith(github.event.pull_request.head.ref, ''feature'')'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Grab latest release branch
-        id: grabrelease
-        run: echo "::set-output name=release_branch::$(echo "${{ github.event.repository.branches_url }}" | ./tools/github/workflow/grabrelease.py)"
-      - name: Fetch pull request commit range
-        id: prcommits
-        run: echo "::set-output name=source_commits::$(echo "${{ github.event.pull_request.commits_url }}" | ./tools/github/workflow/prcommits.py)"
-    outputs:
-      release_branch: ${{ steps.grabrelease.outputs.release_branch }}
-      source_commits: ${{ steps.prcommits.outputs.source_commits }}
   setup:
     runs-on: ubuntu-latest
     steps:
@@ -32,10 +18,8 @@ jobs:
         run: echo "::set-output name=matrix::$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix.yml)"
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
-  pr_releasetest:
-    needs:
-      - setup
-      - pr_setup
+  test:
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -43,19 +27,6 @@ jobs:
         cfg: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v2
-      - name: Update pip
-        run: python3 -m pip install -U pip setuptools
-      - name: Install python requirements for mergetest.py
-        run: python3 -m pip install -U sh
-      - name: Test cherry-picking pull request changes
-        run: |
-          echo '{
-            "source_remote_name": "${{ github.actor }}",
-            "source_remote": "${{ github.event.pull_request.head.repo.full_name }}",
-            "source_commits": "${{ needs.pr_setup.outputs.source_commits }}",
-            "target_remote": "${{ github.event.pull_request.base.repo.full_name }}",
-            "target_branch": "${{ needs.pr_setup.outputs.release_branch }}"
-          }' | ./tools/github/workflow/mergetest.py
       - name: Build images
         id: images
         shell: bash
@@ -75,15 +46,59 @@ jobs:
           echo "::set-output name=images::$IMAGES"
       - name: Run test with cfg
         run: 'echo ''{"matrix": ${{ toJson(matrix.cfg) }}, "images": ${{ steps.images.outputs.images }} }'' | ./tools/test/run_tests.py'
-  test:
-    needs: setup
+  release-patch-setup:
+    if: 'github.event_name == ''pull_request'' && !startsWith(github.event.pull_request.base.ref, ''release'') && !startsWith(github.event.pull_request.head.ref, ''feature'')'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update pip
+        run: python3 -m pip install -U pip setuptools
+      - name: Install python requirements for matrix_parser.py
+        run: python3 -m pip install -U sh PyYAML
+      - name: Grab latest release branch
+        id: grabrelease
+        run: echo "::set-output name=release_branch::$(echo "${{ github.event.repository.branches_url }}" | ./tools/github/workflow/grabrelease.py)"
+      - name: Fetch pull request commit range
+        id: prcommits
+        run: echo "::set-output name=source_commits::$(echo "${{ github.event.pull_request.commits_url }}" | ./tools/github/workflow/prcommits.py)"
+      - name: Test cherry-picking pull request changes
+        run: |
+          echo '{
+            "source_remote_name": "${{ github.actor }}",
+            "source_remote": "${{ github.event.pull_request.head.repo.full_name }}",
+            "source_commits": "${{ steps.prcommits.outputs.source_commits }}",
+            "target_remote": "${{ github.event.pull_request.base.repo.full_name }}",
+            "target_branch": "${{ steps.grabrelease.outputs.release_branch }}"
+          }' | ./tools/github/workflow/mergetest.py
+      - name: Identify Matrix
+        id: matrix
+        run: echo "::set-output name=matrix::$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix.yml)"
+    outputs:
+      release_branch: ${{ steps.grabrelease.outputs.release_branch }}
+      source_commits: ${{ steps.prcommits.outputs.source_commits }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+  release-patch-test:
+    needs: release-patch-setup
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        cfg: ${{ fromJson(needs.setup.outputs.matrix) }}
+        cfg: ${{ fromJson(needs.release-patch-setup.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v2
+      - name: Update pip
+        run: python3 -m pip install -U pip setuptools
+      - name: Install python requirements for mergetest.py
+        run: python3 -m pip install -U sh
+      - name: Cherry-pick pull request changes
+        run: |
+          echo '{
+            "source_remote_name": "${{ github.actor }}",
+            "source_remote": "${{ github.event.pull_request.head.repo.full_name }}",
+            "source_commits": "${{ needs.release-patch-setup.outputs.source_commits }}",
+            "target_remote": "${{ github.event.pull_request.base.repo.full_name }}",
+            "target_branch": "${{ needs.release-patch-setup.outputs.release_branch }}"
+          }' | ./tools/github/workflow/mergetest.py
       - name: Build images
         id: images
         shell: bash

--- a/bin/rucio-abacus-account
+++ b/bin/rucio-abacus-account
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-abacus-collection-replica
+++ b/bin/rucio-abacus-collection-replica
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-abacus-rse
+++ b/bin/rucio-abacus-rse
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-atropos
+++ b/bin/rucio-atropos
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2016-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-auditor
+++ b/bin/rucio-auditor
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-automatix
+++ b/bin/rucio-automatix
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-bb8
+++ b/bin/rucio-bb8
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2016-2020 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-c3po
+++ b/bin/rucio-c3po
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-cache-consumer
+++ b/bin/rucio-cache-consumer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-finisher
+++ b/bin/rucio-conveyor-finisher
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-fts-throttler
+++ b/bin/rucio-conveyor-fts-throttler
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2019 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-poller
+++ b/bin/rucio-conveyor-poller
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-poller-latest
+++ b/bin/rucio-conveyor-poller-latest
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-receiver
+++ b/bin/rucio-conveyor-receiver
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-stager
+++ b/bin/rucio-conveyor-stager
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-submitter
+++ b/bin/rucio-conveyor-submitter
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-throttler
+++ b/bin/rucio-conveyor-throttler
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2016-2019 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-dark-reaper
+++ b/bin/rucio-dark-reaper
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2016-2019 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-dumper
+++ b/bin/rucio-dumper
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-follower
+++ b/bin/rucio-follower
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-hermes
+++ b/bin/rucio-hermes
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-hermes2
+++ b/bin/rucio-hermes2
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-judge-cleaner
+++ b/bin/rucio-judge-cleaner
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-judge-evaluator
+++ b/bin/rucio-judge-evaluator
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-judge-injector
+++ b/bin/rucio-judge-injector
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-judge-repairer
+++ b/bin/rucio-judge-repairer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-kronos
+++ b/bin/rucio-kronos
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-light-reaper
+++ b/bin/rucio-light-reaper
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2016-2019 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-minos
+++ b/bin/rucio-minos
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-minos-temporary-expiration
+++ b/bin/rucio-minos-temporary-expiration
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-necromancer
+++ b/bin/rucio-necromancer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-oauth-manager
+++ b/bin/rucio-oauth-manager
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-reaper
+++ b/bin/rucio-reaper
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2012-2019 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-reaper2
+++ b/bin/rucio-reaper2
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014-2019 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-replica-recoverer
+++ b/bin/rucio-replica-recoverer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-sonar-distribution
+++ b/bin/rucio-sonar-distribution
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2017-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-transmogrifier
+++ b/bin/rucio-transmogrifier
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-undertaker
+++ b/bin/rucio-undertaker
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/etc/docker/dev/README.rst
+++ b/etc/docker/dev/README.rst
@@ -53,9 +53,9 @@ To verify that everything is in order, you can now either run the full unit test
 Alternatively, you can bootstrap the test environment once with the `-i` option and then selectively or repeatedly run test case modules, test case groups, or even single test cases, for example::
 
     tools/run_tests_docker.sh -i
-    pytest -v --full-trace lib/rucio/tests/test_replica.py
-    pytest -v --full-trace lib/rucio/tests/test_replica.py:TestReplicaCore
-    pytest -v --full-trace lib/rucio/tests/test_replica.py:TestReplicaCore.test_delete_replicas_from_datasets
+    pytest -vvvrxs lib/rucio/tests/test_replica.py
+    pytest -vvvrxs lib/rucio/tests/test_replica.py:TestReplicaCore
+    pytest -vvvrxs --full-trace lib/rucio/tests/test_replica.py:TestReplicaCore.test_delete_replicas_from_datasets
 
 Using the environment including storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/etc/docker/dev/docker-compose-storage-localhost.yml
+++ b/etc/docker/dev/docker-compose-storage-localhost.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   rucio:
-    image: rucio/rucio-dev
+    image: rucio/rucio-dev:py3
     hostname: rucio
     ports:
       - "127.0.0.1:443:443"

--- a/etc/docker/dev/docker-compose-storage-monit.yml
+++ b/etc/docker/dev/docker-compose-storage-monit.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   rucio:
-    image: rucio/rucio-dev
+    image: rucio/rucio-dev:py3
     hostname: rucio
     ports:
       - "443:443"

--- a/etc/docker/dev/docker-compose-storage.yml
+++ b/etc/docker/dev/docker-compose-storage.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   rucio:
-    image: rucio/rucio-dev
+    image: rucio/rucio-dev:py3
     hostname: rucio
     ports:
       - "443:443"

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   rucio:
-    image: rucio/rucio-dev
+    image: rucio/rucio-dev:py3
     hostname: rucio
     ports:
       - "443:443"

--- a/etc/docker/test/matrix.yml
+++ b/etc/docker/test/matrix.yml
@@ -6,13 +6,24 @@ dists:
         - "3.6"
         - "3.7"
 python:
-  - "2.7"
+  - id: "2.7"
+    allow:
+      suites:
+        - client
+        - client_syntax
   - "3.6"
   - "3.7"
   - "3.8"
 suites:
   - id: syntax
     SYNTAX_REPORT: 1
+    RUN_HTTPD: false
+  - id: client_syntax
+    RUN_HTTPD: false
+    allow:
+      python: "2.7"
+  - id: client
+    RDBMS: sqlite
   - id: all
     RDBMS:
       - oracle
@@ -31,11 +42,6 @@ suites:
         - postgres9
         - postgres12
         - sqlite
-  - id: client
-    RDBMS: sqlite
-    REST_BACKEND:
-      - webpy
-      - flask
   - id: multi_vo
     RDBMS: postgres12
     REST_BACKEND:

--- a/etc/pip-requires-test
+++ b/etc/pip-requires-test
@@ -12,8 +12,8 @@ Pygments==2.6.1; python_version >= '3.5'
 docutils>=0.15,<0.16                              # Needed for sphinx
 pyflakes==2.1.1                                   # Passive checker of Python programs
 flake8==3.7.8                                     # Wrapper around PyFlakes&pep8
-pylint==1.9.4; python_version < '3.5'             # static code analysis. 1.9.5 last 2.7 compatible release
-pylint==2.5.3; python_version >= '3.5'
+pylint==1.9.4; python_version < '3.6'             # static code analysis. 1.9.5 last 2.7 compatible release
+pylint==2.6.0; python_version >= '3.6'
 isort>=4.2.5,<5                                   # pylint up to now (2.5.3) does not support isort 5
 virtualenv==20.0.12                               # Virtual Python Environment builder
 xmltodict==0.12.0                                 # Makes working with XML feel like you are working with JSON

--- a/lib/rucio/api/dirac.py
+++ b/lib/rucio/api/dirac.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/diracclient.py
+++ b/lib/rucio/client/diracclient.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/log.py
+++ b/lib/rucio/common/log.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright European Organization for Nuclear Research (CERN)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -465,15 +465,12 @@ def execute(cmd, blocking=True):
                                stdin=subprocess.PIPE,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
-    out = ''
-    err = ''
-    exitcode = 0
 
     if blocking:
         result = process.communicate()
         (out, err) = result
         exitcode = process.returncode
-        return exitcode, out, err
+        return exitcode, out.decode(), err.decode()
     return process
 
 

--- a/lib/rucio/core/dirac.py
+++ b/lib/rucio/core/dirac.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/permission/belleii.py
+++ b/lib/rucio/core/permission/belleii.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/quarantined_replica.py
+++ b/lib/rucio/core/quarantined_replica.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2016-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/hermes/__init__.py
+++ b/lib/rucio/daemons/hermes/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright European Organization for Nuclear Research (CERN)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/hermes/hermes2.py
+++ b/lib/rucio/daemons/hermes/hermes2.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2014-2020 CERN
 #

--- a/lib/rucio/daemons/oauthmanager/oauthmanager.py
+++ b/lib/rucio/daemons/oauthmanager/oauthmanager.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2019-2020 CERN
 #

--- a/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
+++ b/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2018-2020 CERN
 #

--- a/lib/rucio/db/sqla/migrate_repo/versions/a193a275255c_add_status_column_in_messages.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a193a275255c_add_status_column_in_messages.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/sautils.py
+++ b/lib/rucio/db/sqla/sautils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright European Organization for Nuclear Research (CERN)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -30,7 +30,6 @@ from __future__ import print_function
 import contextlib
 import itertools
 import os
-import subprocess
 import tempfile
 from random import choice
 from string import ascii_uppercase
@@ -38,32 +37,9 @@ from string import ascii_uppercase
 import pytest
 from six import PY3
 
-from rucio.common.utils import generate_uuid as uuid
+from rucio.common.utils import generate_uuid as uuid, execute
 
 skip_rse_tests_with_accounts = pytest.mark.skipif(not os.path.exists('etc/rse-accounts.cfg'), reason='fails if no rse-accounts.cfg found')
-
-
-def execute(cmd):
-    """
-    Executes a command in a subprocess. Returns a tuple
-    of (exitcode, out, err), where out is the string output
-    from stdout and err is the string output from stderr when
-    executing the command.
-
-    :param cmd: Command string to execute
-    """
-
-    process = subprocess.Popen(cmd,
-                               shell=True,
-                               stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
-
-    result = process.communicate()
-    (out, err) = result
-    exitcode = process.returncode
-
-    return exitcode, out.decode(), err.decode()
 
 
 def account_name_generator():

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -1,4 +1,5 @@
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +18,7 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2019
 # - Angelos Molfetas <Angelos.Molfetas@cern.ch>, 2012
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2012
-# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2014-2018
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2014-2018
 # - Cheng-Hsi Chao <cheng-hsi.chao@cern.ch>, 2014
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2015
 # - Martin Barisits <martin.barisits@cern.ch>, 2015-2019
@@ -28,14 +29,15 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-#
-# PY3K COMPATIBLE
 
 from __future__ import print_function
 
+import os
 import re
 import unittest
 from os import remove, unlink, listdir, rmdir, stat, path, environ
+
+import pytest
 
 from rucio.client.accountlimitclient import AccountLimitClient
 from rucio.client.didclient import DIDClient
@@ -45,7 +47,6 @@ from rucio.client.ruleclient import RuleClient
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.types import InternalScope, InternalAccount
 from rucio.common.utils import generate_uuid, get_tmp_dir, md5, render_json
-from rucio.daemons.abacus import account as abacus_account
 from rucio.rse import rsemanager as rsemgr
 from rucio.tests.common import execute, account_name_generator, rse_name_generator, file_generator, scope_name_generator
 
@@ -1337,37 +1338,39 @@ class TestBinRucio(unittest.TestCase):
         self.account_client.set_local_account_limit(account, rse, -1)
         self.account_client.set_global_account_limit(account, rse_exp, -1)
 
+    @pytest.mark.skipif('SUITE' in os.environ and os.environ['SUITE'] == 'client', reason='uses abacus daemon and core functions')
     def test_list_account_usage(self):
         """ CLIENT (USER): list account usage. """
-        if environ.get('SUITE', 'all') != 'client':
-            from rucio.db.sqla import session, models
-            from rucio.core.account_counter import increase
-            db_session = session.get_session()
-            db_session.query(models.AccountUsage).delete()
-            db_session.query(models.AccountLimit).delete()
-            db_session.query(models.AccountGlobalLimit).delete()
-            db_session.query(models.UpdatedAccountCounter).delete()
-            db_session.commit()
-            rse = 'MOCK4'
-            rse_id = self.rse_client.get_rse(rse)['id']
-            rse_exp = 'MOCK|MOCK4'
-            account = 'root'
-            usage = 4
-            local_limit = 10
-            local_left = local_limit - usage
-            global_limit = 20
-            global_left = global_limit - usage
-            self.account_client.set_local_account_limit(account, rse, local_limit)
-            self.account_client.set_global_account_limit(account, rse_exp, global_limit)
-            increase(rse_id, InternalAccount(account, **self.vo), 1, usage)
-            abacus_account.run(once=True)
-            cmd = 'rucio list-account-usage {0}'.format(account)
-            exitcode, out, err = execute(cmd)
-            assert re.search('.*{0}.*{1}.*{2}.*{3}'.format(rse, usage, local_limit, local_left), out) is not None
-            assert re.search('.*{0}.*{1}.*{2}.*{3}'.format(rse_exp, usage, global_limit, global_left), out) is not None
-            cmd = 'rucio list-account-usage --rse {0} {1}'.format(rse, account)
-            exitcode, out, err = execute(cmd)
-            assert re.search('.*{0}.*{1}.*{2}.*{3}'.format(rse, usage, local_limit, local_left), out) is not None
-            assert re.search('.*{0}.*{1}.*{2}.*{3}'.format(rse_exp, usage, global_limit, global_left), out) is not None
-            self.account_client.set_local_account_limit(account, rse, -1)
-            self.account_client.set_global_account_limit(account, rse_exp, -1)
+        from rucio.db.sqla import session, models
+        from rucio.core.account_counter import increase
+        from rucio.daemons.abacus import account as abacus_account
+
+        db_session = session.get_session()
+        db_session.query(models.AccountUsage).delete()
+        db_session.query(models.AccountLimit).delete()
+        db_session.query(models.AccountGlobalLimit).delete()
+        db_session.query(models.UpdatedAccountCounter).delete()
+        db_session.commit()
+        rse = 'MOCK4'
+        rse_id = self.rse_client.get_rse(rse)['id']
+        rse_exp = 'MOCK|MOCK4'
+        account = 'root'
+        usage = 4
+        local_limit = 10
+        local_left = local_limit - usage
+        global_limit = 20
+        global_left = global_limit - usage
+        self.account_client.set_local_account_limit(account, rse, local_limit)
+        self.account_client.set_global_account_limit(account, rse_exp, global_limit)
+        increase(rse_id, InternalAccount(account, **self.vo), 1, usage)
+        abacus_account.run(once=True)
+        cmd = 'rucio list-account-usage {0}'.format(account)
+        exitcode, out, err = execute(cmd)
+        assert re.search('.*{0}.*{1}.*{2}.*{3}'.format(rse, usage, local_limit, local_left), out) is not None
+        assert re.search('.*{0}.*{1}.*{2}.*{3}'.format(rse_exp, usage, global_limit, global_left), out) is not None
+        cmd = 'rucio list-account-usage --rse {0} {1}'.format(rse, account)
+        exitcode, out, err = execute(cmd)
+        assert re.search('.*{0}.*{1}.*{2}.*{3}'.format(rse, usage, local_limit, local_left), out) is not None
+        assert re.search('.*{0}.*{1}.*{2}.*{3}'.format(rse_exp, usage, global_limit, global_left), out) is not None
+        self.account_client.set_local_account_limit(account, rse, -1)
+        self.account_client.set_global_account_limit(account, rse_exp, -1)

--- a/lib/rucio/tests/test_dirac.py
+++ b/lib/rucio/tests/test_dirac.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2020 CERN for the benefit of the ATLAS collaboration.
 #

--- a/lib/rucio/tests/test_module_import.py
+++ b/lib/rucio/tests/test_module_import.py
@@ -1,4 +1,5 @@
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,32 +27,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
-import subprocess
-
-
-def execute(cmd):
-    """
-    Executes a command in a subprocess. Returns a tuple
-    of (exitcode, out, err), where out is the string output
-    from stdout and err is the string output from stderr when
-    executing the command.
-    :param cmd: Command string to execute
-    """
-
-    process = subprocess.Popen(cmd,
-                               shell=True,
-                               stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
-    out = ''
-    err = ''
-    exitcode = 0
-
-    result = process.communicate()
-    (out, err) = result
-    exitcode = process.returncode
-
-    return exitcode, out, err
+from rucio.common.utils import execute
 
 
 class TestModuleImport():
@@ -59,8 +35,6 @@ class TestModuleImport():
         """ """
         cmd = 'rucio --version'
         exitcode, out, err = execute(cmd)
-        out = out.decode()
-        err = err.decode()
         assert 'ImportError' not in err
         assert 'ImportError' not in out
         assert 'Exception' not in err

--- a/lib/rucio/tests/test_rucio_server.py
+++ b/lib/rucio/tests/test_rucio_server.py
@@ -1,4 +1,5 @@
-# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2014-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,42 +14,17 @@
 # limitations under the License.
 #
 # Authors:
-# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2014-2018
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2014-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2015
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 from __future__ import print_function
 
-import subprocess
 import unittest
 from os import remove
 
-from rucio.common.utils import generate_uuid as uuid
-
-
-def execute(cmd):
-    """
-    Executes a command in a subprocess. Returns a tuple
-    of (exitcode, out, err), where out is the string output
-    from stdout and err is the string output from stderr when
-    executing the command.
-
-    :param cmd: Command string to execute
-    """
-    process = subprocess.Popen(cmd,
-                               shell=True,
-                               stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
-    out = ''
-    err = ''
-    exitcode = 0
-
-    result = process.communicate()
-    (out, err) = result
-    exitcode = process.returncode
-    return exitcode, out, err
+from rucio.common.utils import generate_uuid as uuid, execute
 
 
 def file_generator(size=2048, namelen=10):

--- a/lib/rucio/web/rest/flaskapi/v1/account.py
+++ b/lib/rucio/web/rest/flaskapi/v1/account.py
@@ -43,7 +43,7 @@ from rucio.api.rule import list_replication_rules
 from rucio.api.scope import add_scope, get_scopes
 from rucio.common.exception import AccountNotFound, Duplicate, AccessDenied, RucioException, RuleNotFound, RSENotFound, IdentityError, CounterNotFound
 from rucio.common.utils import APIEncoder, render_json
-from rucio.web.rest.flaskapi.v1.common import request_auth_env, response_headers, check_accept_header_wrapper_flask, try_stream, request_header_ensure_string
+from rucio.web.rest.flaskapi.v1.common import request_auth_env, response_headers, check_accept_header_wrapper_flask, try_stream
 from rucio.web.rest.utils import generate_http_error_flask
 
 
@@ -226,7 +226,7 @@ class AccountParameter(MethodView):
         """
         if account == 'whoami':
             # Redirect to the account uri
-            frontend = request_header_ensure_string('X-Requested-Host')
+            frontend = request.headers.get('X-Requested-Host', default=None)
             if frontend:
                 return redirect(frontend + "/accounts/%s" % (request.environ.get('issuer')), code=302)
             return redirect(request.environ.get('issuer'), code=303)

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -29,7 +29,6 @@ from functools import wraps
 from time import time
 from traceback import format_exc
 
-import six
 from flask import request, Response
 
 from rucio.api.authentication import validate_auth_token
@@ -43,7 +42,7 @@ def request_auth_env():
     if request.environ.get('REQUEST_METHOD') == 'OPTIONS':
         return '', 200
 
-    auth_token = request_header_ensure_string('X-Rucio-Auth-Token')
+    auth_token = request.headers.get('X-Rucio-Auth-Token', default=None)
 
     try:
         auth = validate_auth_token(auth_token)
@@ -132,24 +131,3 @@ def try_stream(generator, content_type=None):
         return Response(itertools.chain((peek,), it), content_type=content_type)
     except StopIteration:
         return Response('', content_type=content_type)
-
-
-def request_header_ensure_string(key, default=None):
-    """
-    Supplement for request.headers.get(...), which returns
-    unicode strings for Python 2.
-
-    :param key: the header name (case-insensitive).
-    :param default: the value to return, if the header is absent.
-        Returns None by default.
-    :raises TypeError: when the header value was not of binary type.
-    :returns: default, if the key is not present or a str type
-        corresponding to the header's value.
-    """
-    hdrval = request.headers.get(key, default=default, as_bytes=True)
-    if hdrval is None or hdrval == default:
-        return hdrval
-    elif isinstance(hdrval, six.binary_type):
-        return six.ensure_str(hdrval)
-    else:
-        raise TypeError("Unexpected header value type: " + str(type(hdrval)))

--- a/lib/rucio/web/rest/flaskapi/v1/credential.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credential.py
@@ -29,7 +29,7 @@ from flask.views import MethodView
 
 from rucio.api.credential import get_signed_url
 from rucio.common.exception import RucioException
-from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, request_header_ensure_string
+from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask
 from rucio.web.rest.utils import generate_http_error_flask
 
 try:
@@ -78,10 +78,10 @@ class SignURL(MethodView):
         :status 500: Internal Server Error
         """
 
-        vo = request_header_ensure_string('X-Rucio-VO', 'def')
-        account = request_header_ensure_string('X-Rucio-Account')
-        appid = request_header_ensure_string('X-Rucio-AppID', 'unknown')
-        ip = request_header_ensure_string('X-Forwarded-For', request.remote_addr)
+        vo = request.headers.get('X-Rucio-VO', default='def')
+        account = request.headers.get('X-Rucio-Account', default=None)
+        appid = request.headers.get('X-Rucio-AppID', default='unknown')
+        ip = request.headers.get('X-Forwarded-For', default=request.remote_addr)
 
         rse, svc, operation, url = None, None, None, None
         try:

--- a/lib/rucio/web/rest/flaskapi/v1/identity.py
+++ b/lib/rucio/web/rest/flaskapi/v1/identity.py
@@ -29,7 +29,7 @@ from flask import Flask, Blueprint, request, jsonify
 from flask.views import MethodView
 
 from rucio.api.identity import add_identity, add_account_identity, list_accounts_for_identity
-from rucio.web.rest.flaskapi.v1.common import request_auth_env, response_headers, check_accept_header_wrapper_flask, request_header_ensure_string
+from rucio.web.rest.flaskapi.v1.common import request_auth_env, response_headers, check_accept_header_wrapper_flask
 
 
 class UserPass(MethodView):
@@ -50,9 +50,9 @@ class UserPass(MethodView):
         :status 401: Invalid Auth Token.
         :status 500: Internal Error.
         """
-        username = request_header_ensure_string('X-Rucio-Username')
-        password = request_header_ensure_string('X-Rucio-Password')
-        email = request_header_ensure_string('X-Rucio-Email')
+        username = request.headers.get('X-Rucio-Username', default=None)
+        password = request.headers.get('X-Rucio-Password', default=None)
+        email = request.headers.get('X-Rucio-Email', default=None)
 
         if not username or not password:
             return 'Username and Password must be set.', 400
@@ -91,7 +91,7 @@ class X509(MethodView):
         :status 500: Internal Error.
         """
         dn = request.environ.get('SSL_CLIENT_S_DN')
-        email = request_header_ensure_string('X-Rucio-Email')
+        email = request.headers.get('X-Rucio-Email', default=None)
 
         try:
             add_identity(dn, 'x509', email=email)
@@ -127,7 +127,7 @@ class GSS(MethodView):
         :status 500: Internal Error.
         """
         gsscred = request.environ.get('REMOTE_USER')
-        email = request_header_ensure_string('X-Rucio-Email')
+        email = request.headers.get('X-Rucio-Email', default=None)
 
         try:
             add_identity(gsscred, 'gss', email=email)

--- a/lib/rucio/web/rest/flaskapi/v1/main.py
+++ b/lib/rucio/web/rest/flaskapi/v1/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2020 CERN
 #

--- a/lib/rucio/web/rest/flaskapi/v1/nongrid_trace.py
+++ b/lib/rucio/web/rest/flaskapi/v1/nongrid_trace.py
@@ -30,7 +30,7 @@ from flask.views import MethodView
 from werkzeug.datastructures import Headers
 
 from rucio.core.nongrid_trace import trace
-from rucio.web.rest.flaskapi.v1.common import response_headers, request_header_ensure_string
+from rucio.web.rest.flaskapi.v1.common import response_headers
 from rucio.web.rest.utils import generate_http_error_flask
 
 
@@ -61,7 +61,7 @@ class XAODTrace(MethodView):
             payload['timeentry'] = int(time.time())
 
             # guess client IP
-            payload['ip'] = request_header_ensure_string('X-Forwarded-For', request.remote_addr)
+            payload['ip'] = request.headers.get('X-Forwarded-For', default=request.remote_addr)
 
             trace(payload=payload)
 

--- a/lib/rucio/web/rest/flaskapi/v1/redirect.py
+++ b/lib/rucio/web/rest/flaskapi/v1/redirect.py
@@ -36,7 +36,7 @@ from werkzeug.datastructures import Headers
 from rucio.api.replica import list_replicas
 from rucio.common.exception import RucioException, DataIdentifierNotFound, ReplicaNotFound
 from rucio.common.replica_sorter import sort_random, sort_geoip, sort_closeness, sort_ranking, sort_dynamic, site_selector
-from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, parse_scope_name, try_stream, request_header_ensure_string
+from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, parse_scope_name, try_stream
 from rucio.web.rest.utils import generate_http_error_flask
 
 try:
@@ -81,7 +81,7 @@ class MetaLinkRedirector(MethodView):
         dids, schemes, select = [{'scope': scope, 'name': name}], ['http', 'https', 'root', 'gsiftp', 'srm', 'davs'], None
 
         # set the correct client IP
-        client_ip = request_header_ensure_string('X-Forwarded-For', request.remote_addr)
+        client_ip = request.headers.get('X-Forwarded-For', default=request.remote_addr)
 
         client_location = {'ip': client_ip,
                            'fqdn': None,
@@ -105,7 +105,7 @@ class MetaLinkRedirector(MethodView):
                 client_location['site'] = params['site'][0]
 
         # get vo if given
-        vo = request_header_ensure_string('X-Rucio-VO', 'def')
+        vo = request.headers.get('X-Rucio-VO', default='def')
 
         try:
             replicas_iter = list_replicas(dids=dids, schemes=schemes, client_location=client_location, vo=vo)
@@ -211,7 +211,7 @@ class HeaderRedirector(MethodView):
             # use the default HTTP protocols if no scheme is given
             select, rse, site, schemes = 'random', None, None, ['davs', 'http', 'https']
 
-            client_ip = request_header_ensure_string('X-Forwarded-For', request.remote_addr)
+            client_ip = request.headers.get('X-Forwarded-For', default=request.remote_addr)
 
             client_location = {'ip': client_ip,
                                'fqdn': None,
@@ -249,7 +249,7 @@ class HeaderRedirector(MethodView):
                 schemes = [schemes]  # list_replicas needs a list
 
             # get vo if given
-            vo = request_header_ensure_string('X-Rucio-VO', 'def')
+            vo = request.headers.get('X-Rucio-VO', default='def')
 
             replicas = [r for r in list_replicas(dids=[{'scope': scope, 'name': name, 'type': 'FILE'}],
                                                  schemes=schemes, client_location=client_location, vo=vo)]

--- a/lib/rucio/web/rest/flaskapi/v1/replica.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replica.py
@@ -19,7 +19,7 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2014-2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Martin Barisits <martin.barisits@cern.ch>, 2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2019-2020
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
@@ -53,7 +53,7 @@ from rucio.common.exception import (AccessDenied, DataIdentifierAlreadyExists, I
 from rucio.common.replica_sorter import sort_random, sort_geoip, sort_closeness, sort_dynamic, sort_ranking
 from rucio.common.utils import parse_response, APIEncoder, render_json_list
 from rucio.db.sqla.constants import BadFilesStatus
-from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, try_stream, parse_scope_name, request_auth_env, response_headers, request_header_ensure_string
+from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, try_stream, parse_scope_name, request_auth_env, response_headers
 from rucio.web.rest.utils import generate_http_error_flask
 
 try:
@@ -115,7 +115,7 @@ class Replicas(MethodView):
             schemes = SUPPORTED_PROTOCOLS
 
         try:
-            client_ip = request_header_ensure_string('X-Forwarded-For', request.remote_addr)
+            client_ip = request.headers.get('X-Forwarded-For', default=request.remote_addr)
 
             def generate(vo):
                 # we need to call list_replicas before starting to reply
@@ -341,7 +341,7 @@ class ListReplicas(MethodView):
         content_type = request.accept_mimetypes.best_match(['application/x-json-stream', 'application/metalink4+xml'], 'application/x-json-stream')
         metalink = (content_type == 'application/metalink4+xml')
 
-        client_ip = request_header_ensure_string('X-Forwarded-For', request.remote_addr)
+        client_ip = request.headers.get('X-Forwarded-For', default=request.remote_addr)
 
         dids, schemes, select, unavailable, limit = [], None, None, False, None
         ignore_availability, rse_expression, all_states, domain = False, None, False, None

--- a/lib/rucio/web/rest/flaskapi/v1/trace.py
+++ b/lib/rucio/web/rest/flaskapi/v1/trace.py
@@ -33,7 +33,7 @@ from flask.views import MethodView
 from werkzeug.datastructures import Headers
 
 from rucio.core.trace import trace
-from rucio.web.rest.flaskapi.v1.common import response_headers, request_header_ensure_string
+from rucio.web.rest.flaskapi.v1.common import response_headers
 from rucio.web.rest.utils import generate_http_error_flask
 
 
@@ -65,7 +65,7 @@ class Trace(MethodView):
             payload['traceTimeentryUnix'] = calendar.timegm(payload['traceTimeentry'].timetuple()) + payload['traceTimeentry'].microsecond / 1e6
 
             # guess client IP
-            payload['traceIp'] = request_header_ensure_string('X-Forwarded-For', request.remote_addr)
+            payload['traceIp'] = request.headers.get('X-Forwarded-For', default=request.remote_addr)
 
             # generate unique ID
             payload['traceId'] = str(uuid.uuid4()).replace('-', '').lower()

--- a/lib/rucio/web/rest/webpy/v1/account.py
+++ b/lib/rucio/web/rest/webpy/v1/account.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2012-2020 CERN
 #
@@ -35,12 +35,6 @@ from json import dumps, loads
 from logging import getLogger, StreamHandler, DEBUG
 from traceback import format_exc
 
-from rucio.web.rest.utils import generate_http_error
-
-try:
-    from urlparse import parse_qsl
-except ImportError:
-    from urllib.parse import parse_qsl
 from web import application, ctx, data, header, BadRequest, Created, InternalError, OK, loadhook, redirect, seeother
 
 from rucio.api.account import add_account, del_account, get_account_info, list_accounts, list_identities, list_account_attributes, add_account_attribute, del_account_attribute, update_account, get_usage_history
@@ -51,6 +45,12 @@ from rucio.api.scope import add_scope, get_scopes
 from rucio.common.exception import AccountNotFound, Duplicate, AccessDenied, RucioException, RuleNotFound, RSENotFound, IdentityError, CounterNotFound
 from rucio.common.utils import APIEncoder, render_json
 from rucio.web.rest.common import rucio_loadhook, RucioController, check_accept_header_wrapper
+from rucio.web.rest.utils import generate_http_error
+
+try:
+    from urlparse import parse_qsl
+except ImportError:
+    from urllib.parse import parse_qsl
 
 
 LOGGER = getLogger("rucio.account")

--- a/lib/rucio/web/rest/webpy/v1/account_limit.py
+++ b/lib/rucio/web/rest/webpy/v1/account_limit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2014-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/archive.py
+++ b/lib/rucio/web/rest/webpy/v1/archive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/webpy/v1/authentication.py
+++ b/lib/rucio/web/rest/webpy/v1/authentication.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2018-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/config.py
+++ b/lib/rucio/web/rest/webpy/v1/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2018-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/credential.py
+++ b/lib/rucio/web/rest/webpy/v1/credential.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2012-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/did.py
+++ b/lib/rucio/web/rest/webpy/v1/did.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2018-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/dirac.py
+++ b/lib/rucio/web/rest/webpy/v1/dirac.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/exporter.py
+++ b/lib/rucio/web/rest/webpy/v1/exporter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2018-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/heartbeat.py
+++ b/lib/rucio/web/rest/webpy/v1/heartbeat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/webpy/v1/identity.py
+++ b/lib/rucio/web/rest/webpy/v1/identity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/webpy/v1/importer.py
+++ b/lib/rucio/web/rest/webpy/v1/importer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2018-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/lifetime_exception.py
+++ b/lib/rucio/web/rest/webpy/v1/lifetime_exception.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2016-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/lock.py
+++ b/lib/rucio/web/rest/webpy/v1/lock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2014-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/main.py
+++ b/lib/rucio/web/rest/webpy/v1/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/meta.py
+++ b/lib/rucio/web/rest/webpy/v1/meta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2012-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/nongrid_trace.py
+++ b/lib/rucio/web/rest/webpy/v1/nongrid_trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2015-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/ping.py
+++ b/lib/rucio/web/rest/webpy/v1/ping.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/webpy/v1/redirect.py
+++ b/lib/rucio/web/rest/webpy/v1/redirect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2014-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/replica.py
+++ b/lib/rucio/web/rest/webpy/v1/replica.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2013-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/request.py
+++ b/lib/rucio/web/rest/webpy/v1/request.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2014-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/rse.py
+++ b/lib/rucio/web/rest/webpy/v1/rse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2012-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/rule.py
+++ b/lib/rucio/web/rest/webpy/v1/rule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2012-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/scope.py
+++ b/lib/rucio/web/rest/webpy/v1/scope.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2012-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/subscription.py
+++ b/lib/rucio/web/rest/webpy/v1/subscription.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2013-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/temporary_did.py
+++ b/lib/rucio/web/rest/webpy/v1/temporary_did.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2016-2020 CERN
 #

--- a/lib/rucio/web/rest/webpy/v1/trace.py
+++ b/lib/rucio/web/rest/webpy/v1/trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2013-2020 CERN
 #

--- a/lib/rucio/web/ui/common/utils.py
+++ b/lib/rucio/web/ui/common/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2014-2020 CERN
 #
@@ -24,8 +24,6 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-#
-# PY3K COMPATIBLE
 
 import re
 import sys
@@ -49,10 +47,10 @@ if sys.version_info > (3, 0):
 escapefunc = None
 try:
     import html
-    escapefunc = html.escape
+    escapefunc = html.escape  # noqa: E1101
 except ImportError:
     import cgi
-    escapefunc = cgi.escape
+    escapefunc = cgi.escape  # noqa: E1101
 
 try:
     from onelogin.saml2.auth import OneLogin_Saml2_Auth

--- a/lib/rucio/web/ui/main.py
+++ b/lib/rucio/web/ui/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2014-2020 CERN
 #

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -51,8 +51,8 @@ Pygments==2.6.1; python_version >= '3.5'
 docutils>=0.15,<0.16                              # Needed for sphinx
 pyflakes==2.1.1                                   # Passive checker of Python programs
 flake8==3.7.8                                     # Wrapper around PyFlakes&pep8
-pylint==1.9.4; python_version < '3.5'             # static code analysis. 1.9.5 last 2.7 compatible release
-pylint==2.5.3; python_version >= '3.5'
+pylint==1.9.4; python_version < '3.6'             # static code analysis. 1.9.5 last 2.7 compatible release
+pylint==2.6.0; python_version >= '3.6'
 isort>=4.2.5,<5                                   # pylint up to now (2.5.3) does not support isort 5
 virtualenv==20.0.12                               # Virtual Python Environment builder
 xmltodict==0.12.0                                 # Makes working with XML feel like you are working with JSON

--- a/tools/add_header
+++ b/tools/add_header
@@ -166,8 +166,6 @@ def main(arguments):
             sys.exit(0)
 
         if str(MyFile).endswith('.py'):
-            if arguments.script:
-                header += '#!/usr/bin/env python\n'
             header += '# -*- coding: utf-8 -*-\n'
 
         if int(min) == int(max):
@@ -211,7 +209,7 @@ def main(arguments):
                     raise RuntimeError('Cannot read file ' + str(MyFile)) from e
 
                 with open(MyFile, 'w') as modified:
-                    if not arguments.script and lines[0].rstrip() == '#!/usr/bin/env python':
+                    if lines[0].startswith('#!/usr/bin/env python'):
                         modified.write(lines[0])
                     elif lines[0].rstrip() == '#!/bin/bash':
                         modified.write(lines[0])
@@ -237,8 +235,6 @@ def main(arguments):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--script', '-s', dest='script', action='store_true', default=False,
-                        help='Generate header for python script.')
     parser.add_argument('--documentation', '-D', dest='documentation', action='store_true', default=False,
                         help='Generate header for documentation file.')
     parser.add_argument('--in-place', '-i', action='store_true', default=False,

--- a/tools/alembic_migration.sh
+++ b/tools/alembic_migration.sh
@@ -23,16 +23,16 @@ echo "Downgrading the DB to base"
 alembic downgrade base
 
 echo "Check if is_old_db function is returning false after the full downgrade (tests it without alembic)"
-PYTHONPATH=lib python -c 'import sys; import rucio.db.sqla.util; sys.exit(1 if rucio.db.sqla.util.is_old_db() else 0);'
+PYTHONPATH=lib python3 -c 'import sys; import rucio.db.sqla.util; sys.exit(1 if rucio.db.sqla.util.is_old_db() else 0);'
 
 echo "Updating the DB to head-1"
 alembic upgrade head-1
 
 echo "Check if is_old_db function is returning true before the full upgrade"
-PYTHONPATH=lib python -c 'import sys; import rucio.db.sqla.util; sys.exit(0 if rucio.db.sqla.util.is_old_db() else 1);'
+PYTHONPATH=lib python3 -c 'import sys; import rucio.db.sqla.util; sys.exit(0 if rucio.db.sqla.util.is_old_db() else 1);'
 
 echo "Upgrading the DB to head"
 alembic upgrade head
 
 echo "Check if is_old_db function returns false after the full upgrade"
-PYTHONPATH=lib python -c 'import sys; import rucio.db.sqla.util; sys.exit(1 if rucio.db.sqla.util.is_old_db() else 0);'
+PYTHONPATH=lib python3 -c 'import sys; import rucio.db.sqla.util; sys.exit(1 if rucio.db.sqla.util.is_old_db() else 0);'

--- a/tools/bootstrap_tests.py
+++ b/tools/bootstrap_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright European Organization for Nuclear Research (CERN)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/reset_database.py
+++ b/tools/reset_database.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright European Organization for Nuclear Research (CERN)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run_multi_vo_tests_docker.sh
+++ b/tools/run_multi_vo_tests_docker.sh
@@ -117,7 +117,7 @@ if test ${init_only}; then
 fi
 
 echo 'Running tests on VO "tst"'
-pytest -v --full-trace
+python -bb -m pytest -vvvrxs
 if [ $? != 0 ]; then
     echo 'Tests on first VO failed, not attempting tests at second VO'
     exit 1
@@ -163,7 +163,7 @@ if test ${activate_rse}; then
 fi
 
 echo 'Running tests on VO "ts2"'
-pytest -v --full-trace
+python -bb -m pytest -vvvrxs
 
 if [ $? != 0 ]; then
     echo 'Tests on second VO failed'

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -140,7 +140,7 @@ fi
 for i in $iterations
 do
     echo 'Running test iteration' $i
-        echo pytest -v --full-trace $pytestextra $stop_on_failure
-        pytest -v --full-trace $pytestextra $stop_on_failure
+        echo python -bb -m pytest -vvvrxs $stop_on_failure $pytestextra
+        python -bb -m pytest -vvvrxs $stop_on_failure $pytestextra
     fi
 done

--- a/tools/run_tests_docker.sh
+++ b/tools/run_tests_docker.sh
@@ -147,10 +147,10 @@ fi
 
 if test ${special}; then
     echo 'Using the special config and only running test_dirac'
-    pytest -v --full-trace lib/rucio/tests/test_dirac.py
+    python -bb -m pytest -vvvrxs lib/rucio/tests/test_dirac.py
 else
     echo 'Running tests'
-    pytest -v --full-trace
+    python -bb -m pytest -vvvrxs
 fi
 
 exit $?

--- a/tools/test/before_script.sh
+++ b/tools/test/before_script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 
 set -eo pipefail
+
+# Note: this file is not run when RUN_HTTPD is defined as false for the test suite.
 
 echo "* docker $CONTAINER_RUNTIME_ARGS info"
 docker $CONTAINER_RUNTIME_ARGS info

--- a/tools/test/build_images.py
+++ b/tools/test/build_images.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-# Copyright 2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +21,7 @@ import argparse
 import collections
 import itertools
 import json
+import os
 import pathlib
 import subprocess
 import sys
@@ -52,6 +54,7 @@ def main():
     make_buildargs = partial(map, lambda argdict: BuildArgs(**argdict))
     distribution_buildargs = {dist: set(make_buildargs(filter_build_args(args))) for dist, args in
                               itertools.groupby(matrix, lambda d: d[DIST_KEY])}
+    use_podman = 'USE_PODMAN' in os.environ and os.environ['USE_PODMAN'] == '1'
 
     images = dict()
     for dist, buildargs_list in distribution_buildargs.items():
@@ -66,7 +69,7 @@ def main():
 
             cache_args = ()
             if script_args.build_no_cache:
-                cache_args = ('--no-cache',)
+                cache_args = ('--no-cache', '--pull-always' if use_podman else '--pull')
             elif script_args.cache_repo:
                 args = ('docker', 'pull', imagetag)
                 print("Running", " ".join(args), file=sys.stderr)

--- a/tools/test/check_syntax.sh
+++ b/tools/test/check_syntax.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,24 @@
 # - Vincent Garonne <vgaronne@gmail.com>, 2018
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
+if [ -z "$SYNTAX_FLAKE_ARGS" ]; then
+    SYNTAX_FLAKE_ARGS="--exclude=\"*.cfg\" bin/* lib/ tools/*.py"
+fi
+
+if [ -z "$SYNTAX_PYLINT_ARGS" ]; then
+    SYNTAX_PYLINT_ARGS="--ignore=lib/rucio/tests,lib/rucio/tests/mock lib/rucio/"
+fi
+
+if [ -z "$SYNTAX_PYLINT_BIN_ARGS" ]; then
+    SYNTAX_PYLINT_BIN_ARGS="bin/*"
+fi
+
+
 echo '==============================='
 echo 'Running flake8                 '
 echo '==============================='
 
-flake8 --ignore=E501,E722,W503 --exclude="*.cfg" bin/* lib/ tools/*.py
+flake8 --ignore=E501,E722,W503 $SYNTAX_FLAKE_ARGS
 
 if [ $? -ne 0 ]; then
     exit 1
@@ -32,31 +45,30 @@ echo '==============================='
 echo 'Running pylint                 '
 echo '==============================='
 
-pylint --rcfile=pylintrc --errors-only --ignore=lib/rucio/tests lib/rucio/ bin/*
+pylint --rcfile=pylintrc --errors-only $SYNTAX_PYLINT_ARGS
 
 if [ $? -ne 0 ]; then
-    echo "PYLINT FAILED"
+    echo "PYLINT on $SYNTAX_PYLINT_ARGS FAILED"
     exit 1
 else
-    echo "PYLINT PASSED"
+    echo "PYLINT on $SYNTAX_PYLINT_ARGS PASSED"
+fi
+
+# disable no-name-in-module since bin/rucio clashes with lib/rucio
+PYTHONPATH=lib pylint --rcfile=pylintrc --errors-only --disable no-name-in-module $SYNTAX_PYLINT_BIN_ARGS
+
+if [ $? -ne 0 ]; then
+    echo "PYLINT on $SYNTAX_PYLINT_BIN_ARGS FAILED"
+    exit 1
+else
+    echo "PYLINT on $SYNTAX_PYLINT_BIN_ARGS PASSED"
 fi
 
 
-if [ -n "$SYNTAX_REPORT" -a "$SYNTAX_REPORT" -eq "1" ]; then
+if [[ "$SYNTAX_REPORT" && "$SYNTAX_REPORT" == "1" ]]; then
     echo '==============================='
     echo 'Pylint report                  '
     echo '==============================='
 
-    pylint --rcfile=pylintrc --reports y --exit-zero lib/rucio/ bin/*
-fi
-
-
-echo '==============================='
-echo 'Running Sphinx                 '
-echo '==============================='
-
-RUCIO_HOME=/usr/local/src/rucio sphinx-build -avT doc/source/ doc/build/html
-
-if [ $? -ne 0 ]; then
-    exit 1
+    pylint --rcfile=pylintrc --reports y --exit-zero $SYNTAX_PYLINT_ARGS
 fi

--- a/tools/test/ignoretool.py
+++ b/tools/test/ignoretool.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2020 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+
+from __future__ import print_function
+
+import argparse
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import List
+
+
+# from setup_rucio_clients
+PACKAGES = [
+    'rucio',
+    'rucio.client',
+    'rucio.common',
+    'rucio.common.schema',
+    'rucio.rse.protocols',
+    'rucio.rse',
+    # 'rucio.tests'  do not include tests
+]  # type: List[str]
+
+
+def package_directories(packages):
+    for directory in map(lambda p: 'lib/' + p.replace('.', '/'), packages):
+        yield directory
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Returns ignore-strings for client files')
+    parser.add_argument('-l', '--pylint', dest='pylint', action='store_true',
+                        help='build a list for pylint with the --ignore flag')
+    parser.add_argument('-f', '--flake8', dest='flake8', action='store_true',
+                        help='build a list for flake8 tool')
+    script_args = parser.parse_args()
+
+    if script_args.flake8:
+        print(' '.join(map(lambda d: d + '/*.py', package_directories(PACKAGES))))
+    elif script_args.pylint:
+        ignore_dirs = []
+        include_dirs = set(package_directories(PACKAGES))
+
+        for root, dirs, files in os.walk('lib/'):
+            if '__pycache__' not in root and root != 'lib/' and root not in include_dirs:
+                ignore_dirs.append(root)
+
+        if ignore_dirs:
+            print('--ignore=' + ','.join(ignore_dirs), 'lib/rucio/')
+        else:
+            print('lib/rucio/')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/test/install_script.sh
+++ b/tools/test/install_script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,17 +24,12 @@ set -eo pipefail
 
 echo "* Running tests with $(python --version 2>&1) and $(pip --version 2>&1)"
 
-if [[ $SUITE == "client" ]]; then
+if [ "$SUITE" == "client" -o "$SUITE" == "client_syntax" ]; then
     cd /usr/local/src/rucio
-    python -m pip install setuptools_scm
     python setup_rucio_client.py install
     cp etc/docker/test/extra/rucio_client.cfg etc/rucio.cfg
 
-    # initialize tests
-    tools/run_tests_docker.sh -i
-
-elif [[ $SUITE == "syntax" ]]; then
+elif [ "$SUITE" == "syntax" ]; then
     cd /usr/local/src/rucio
-    python -m pip install setuptools_scm google_compute_engine
     cp etc/docker/test/extra/rucio_syntax.cfg etc/rucio.cfg
 fi

--- a/tools/test/sphinx_build.sh
+++ b/tools/test/sphinx_build.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3
-# Copyright 2017-2018 CERN for the benefit of the ATLAS collaboration.
+#!/bin/bash
+# Copyright 2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,23 +14,16 @@
 # limitations under the License.
 #
 # Authors:
-# - Vitjan Zavrtanik, <vitjan.zavrtanik@cern.ch>, 2017
-# - Vincent Garonne, <vgaronne@gmail.com>, 2018
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2018
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
-'''
-Sonar is a daemon that tests inactive links.
-'''
+set -euo pipefail
 
-import signal
+echo '==============================='
+echo 'Running Sphinx                 '
+echo '==============================='
 
-from rucio.daemons.sonar.sonar.sonar_v3_dev_daemon import run, stop
+sphinx-build -avT doc/source/ doc/build/html
 
-if __name__ == "__main__":
-    signal.signal(signal.SIGTERM, stop)
-    try:
-        run()
-    except KeyboardInterrupt:
-        stop()
+if [ $? -ne 0 ]; then
+    exit 1
+fi

--- a/tools/test/test.sh
+++ b/tools/test/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,20 +23,32 @@ function srchome() {
     cd $RUCIO_HOME
 }
 
-if [[ $SUITE == "syntax" ]]; then
+if [ "$SUITE" == "syntax" ]; then
     srchome
     tools/test/check_syntax.sh
-fi
+    tools/test/sphinx_build.sh
 
-if [[ $SUITE == "client" ]]; then
+elif [[ "$SUITE" =~ ^client.* ]]; then
+    if [ "$SUITE" == "client" ]; then
+        tools/run_tests_docker.sh -i
+    fi
+
     srchome
-    pytest -v --full-trace lib/rucio/tests/test_clients.py lib/rucio/tests/test_bin_rucio.py lib/rucio/tests/test_module_import.py
-fi
+    TEST_FILES="lib/rucio/tests/test_clients.py lib/rucio/tests/test_bin_rucio.py lib/rucio/tests/test_module_import.py"
 
-if [[ $SUITE == "all" ]]; then
+    if [ "$SUITE" == "client" ]; then
+        python -bb -m pytest -vvvrxs $TEST_FILES
+    elif [ "$SUITE" == "client_syntax" ]; then
+        CLIENT_BIN_FILES="bin/rucio bin/rucio-admin"
+        export SYNTAX_PYLINT_ARGS="$(tools/test/ignoretool.py --pylint)"
+        export SYNTAX_PYLINT_BIN_ARGS="$CLIENT_BIN_FILES"
+        export SYNTAX_FLAKE_ARGS="$(tools/test/ignoretool.py --flake8) $CLIENT_BIN_FILES $TEST_FILES"
+        tools/test/check_syntax.sh
+    fi
+
+elif [ "$SUITE" == "all" ]; then
     tools/run_tests_docker.sh
-fi
 
-if [[ $SUITE == "multi_vo" ]]; then
+elif [ "$SUITE" == "multi_vo" ]; then
     tools/run_multi_vo_tests_docker.sh
 fi


### PR DESCRIPTION
Disable most py2 tests and make it possible to run tests without httpd in the autotesting framework.

The work in this PR got a bit out of hand and therefor this wandered a bit to a "move to Python 3".