### PR TITLE
Replicas: Improve sorting replicas; #4017

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,9 +41,6 @@
 # - Jason Nielsen <jnielsen@ucsc.edu>, 2020
 # - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-# - javor <33832672+TomasJavurek@users.noreply.github.com>, 2020
-#
-# PY3K COMPATIBLE
 
 from __future__ import print_function
 
@@ -1773,7 +1770,7 @@ To list the missing replica of a dataset of a given RSE::
     list_file_replicas_parser.add_argument('--missing', dest='missing', default=False, action='store_true', help='To list missing replicas at a RSE. Must be used with --rse option', required=False)
     list_file_replicas_parser.add_argument('--metalink', dest='metalink', default=False, action='store_true', help='Output available replicas as metalink.', required=False)
     list_file_replicas_parser.add_argument('--no-resolve-archives', dest='no_resolve_archives', default=False, action='store_true', help='Do not resolve archives which may contain the files.', required=False)
-    list_file_replicas_parser.add_argument('--sort', dest='sort', default=None, action='store', help='Replica sort algorithm. Available options: random (default), geoip', required=False)
+    list_file_replicas_parser.add_argument('--sort', dest='sort', default=None, action='store', help='Replica sort algorithm. Available options: geoip (default), random', required=False)
     list_file_replicas_parser.add_argument('--expression', dest='rse_expression', default=None, action='store', help='The RSE filter expression. A comprehensive help about RSE expressions\
             can be found in ' + Color.BOLD + 'http://rucio.cern.ch/client_tutorial.html#adding-rules-for-replication' + Color.END)
 

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -29,6 +29,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Tomas Javurek <tomas.javurek@cern.ch>, 2020
 
 from __future__ import print_function
 
@@ -735,11 +736,13 @@ class TestBinRucio(unittest.TestCase):
         # Use filter and metalink option
         cmd = 'rucio download --scope mock --filter size=1 --metalink=test'
         exitcode, out, err = execute(cmd)
+        print(out, err)
         assert 'Arguments filter and metalink cannot be used together' in err
 
         # Use did and metalink option
         cmd = 'rucio download --metalink=test mock:test'
         exitcode, out, err = execute(cmd)
+        print(out, err)
         assert 'Arguments dids and metalink cannot be used together' in err
 
         # Download only with metalink file
@@ -747,14 +750,17 @@ class TestBinRucio(unittest.TestCase):
         tmp_file_name = tmp_file[5:]
         cmd = 'rucio upload --rse {0} --scope {1} {2}'.format(self.def_rse, scope, tmp_file)
         exitcode, out, err = execute(cmd)
+        print(out, err)
         replica_file = ReplicaClient().list_replicas([{'scope': scope, 'name': tmp_file_name}], metalink=True)
         with open(metalink_file_path, 'w+') as metalink_file:
             metalink_file.write(replica_file)
         cmd = 'rucio download --dir /tmp --metalink {0}'.format(metalink_file_path)
         exitcode, out, err = execute(cmd)
+        print(out, err)
         remove(metalink_file_path)
         cmd = 'ls /tmp/{0}'.format(scope)
         exitcode, out, err = execute(cmd)
+        print(out, err)
         assert re.search(tmp_file_name, out) is not None
 
     def test_download_succeeds_md5only(self):

--- a/lib/rucio/tests/test_replica_sorting.py
+++ b/lib/rucio/tests/test_replica_sorting.py
@@ -1,4 +1,5 @@
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2020 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,212 +20,338 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
-import unittest
+import copy
+import json
+import os
+from unittest import mock
+from urllib.parse import urlparse
 
-from rucio.client.replicaclient import ReplicaClient
-from rucio.common.config import config_get, config_get_bool
+import pytest
+
 from rucio.common.types import InternalAccount, InternalScope
+from rucio.common.utils import parse_replicas_from_string
+from rucio.core import rse_expression_parser, replica_sorter
 from rucio.core.replica import add_replicas, delete_replicas
-from rucio.core.rse import add_rse, del_rse, add_rse_attribute, add_protocol
-from rucio.tests.common import rse_name_generator
+from rucio.core.rse import add_rse, del_rse, add_rse_attribute, add_protocol, del_rse_attribute
+from rucio.tests.common import rse_name_generator, headers, auth, vohdr, Mime, accept
+
+base_rse_info = [
+    {'site': 'APERTURE', 'address': 'aperture.com'},
+    {'site': 'BLACKMESA', 'address': 'blackmesa.com'},
+]
+schemes = ['root', 'gsiftp', 'davs']
 
 
-class TestReplicaSorting(unittest.TestCase):
+@pytest.fixture
+def protocols_setup(vo):
+    rse_info = copy.deepcopy(base_rse_info)
 
-    def setUp(self):
-        if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
-        else:
-            self.vo = {}
+    files = [{'scope': InternalScope('mock', vo=vo), 'name': 'element_0', 'bytes': 1234, 'adler32': 'deadbeef'}]
+    root = InternalAccount('root', vo=vo)
 
-    def test_replica_sorting(self):
-        """ REPLICA (CORE): Test the correct sorting of the replicas across WAN and LAN """
+    for idx in range(len(rse_info)):
+        rse_info[idx]['name'] = '%s_%s' % (rse_info[idx]['site'], rse_name_generator())
+        rse_info[idx]['id'] = add_rse(rse_info[idx]['name'], vo=vo)
+        add_rse_attribute(rse_id=rse_info[idx]['id'], key='site', value=base_rse_info[idx]['site'])
+        add_replicas(rse_id=rse_info[idx]['id'], files=files, account=root)
 
-        self.rc = ReplicaClient()
+    # invalidate cache for parse_expression('site=…')
+    rse_expression_parser.REGION.invalidate()
 
-        self.rse1 = 'APERTURE_%s' % rse_name_generator()
-        self.rse2 = 'BLACKMESA_%s' % rse_name_generator()
-        self.rse1_id = add_rse(self.rse1, **self.vo)
-        self.rse2_id = add_rse(self.rse2, **self.vo)
-        add_rse_attribute(rse_id=self.rse1_id, key='site', value='APERTURE')
-        add_rse_attribute(rse_id=self.rse2_id, key='site', value='BLACKMESA')
+    # check sites
+    for idx in range(len(rse_info)):
+        site_rses = rse_expression_parser.parse_expression('site=' + base_rse_info[idx]['site'])
+        assert len(site_rses) > 0
+        assert rse_info[idx]['id'] in [rse['id'] for rse in site_rses]
 
-        self.files = [{'scope': InternalScope('mock', **self.vo), 'name': 'element_0',
-                       'bytes': 1234, 'adler32': 'deadbeef'}]
-        root = InternalAccount('root', **self.vo)
-        add_replicas(rse_id=self.rse1_id, files=self.files, account=root)
-        add_replicas(rse_id=self.rse2_id, files=self.files, account=root)
+    add_protocol(rse_info[0]['id'], {'scheme': schemes[0],
+                                     'hostname': ('root.%s' % base_rse_info[0]['address']),
+                                     'port': 1409,
+                                     'prefix': '//test/chamber/',
+                                     'impl': 'rucio.rse.protocols.xrootd.Default',
+                                     'domains': {
+                                         'lan': {'read': 1, 'write': 1, 'delete': 1},
+                                         'wan': {'read': 1, 'write': 1, 'delete': 1}}})
+    add_protocol(rse_info[0]['id'], {'scheme': schemes[2],
+                                     'hostname': ('davs.%s' % base_rse_info[0]['address']),
+                                     'port': 443,
+                                     'prefix': '/test/chamber/',
+                                     'impl': 'rucio.rse.protocols.gfal.Default',
+                                     'domains': {
+                                         'lan': {'read': 2, 'write': 2, 'delete': 2},
+                                         'wan': {'read': 2, 'write': 2, 'delete': 2}}})
+    add_protocol(rse_info[0]['id'], {'scheme': schemes[1],
+                                     'hostname': ('gsiftp.%s' % base_rse_info[0]['address']),
+                                     'port': 8446,
+                                     'prefix': '/test/chamber/',
+                                     'impl': 'rucio.rse.protocols.gfal.Default',
+                                     'domains': {
+                                         'lan': {'read': 0, 'write': 0, 'delete': 0},
+                                         'wan': {'read': 3, 'write': 3, 'delete': 3}}})
 
-        add_protocol(self.rse1_id, {'scheme': 'root',
-                                    'hostname': 'root.aperture.com',
-                                    'port': 1409,
-                                    'prefix': '//test/chamber/',
-                                    'impl': 'rucio.rse.protocols.xrootd.Default',
-                                    'domains': {
-                                        'lan': {'read': 1, 'write': 1, 'delete': 1},
-                                        'wan': {'read': 1, 'write': 1, 'delete': 1}}})
-        add_protocol(self.rse1_id, {'scheme': 'davs',
-                                    'hostname': 'davs.aperture.com',
-                                    'port': 443,
-                                    'prefix': '/test/chamber/',
-                                    'impl': 'rucio.rse.protocols.gfal.Default',
-                                    'domains': {
-                                        'lan': {'read': 2, 'write': 2, 'delete': 2},
-                                        'wan': {'read': 2, 'write': 2, 'delete': 2}}})
-        add_protocol(self.rse1_id, {'scheme': 'gsiftp',
-                                    'hostname': 'gsiftp.aperture.com',
-                                    'port': 8446,
-                                    'prefix': '/test/chamber/',
-                                    'impl': 'rucio.rse.protocols.gfal.Default',
-                                    'domains': {
-                                        'lan': {'read': 0, 'write': 0, 'delete': 0},
-                                        'wan': {'read': 3, 'write': 3, 'delete': 3}}})
+    add_protocol(rse_info[1]['id'], {'scheme': schemes[1],
+                                     'hostname': ('gsiftp.%s' % base_rse_info[1]['address']),
+                                     'port': 8446,
+                                     'prefix': '/lambda/complex/',
+                                     'impl': 'rucio.rse.protocols.gfal.Default',
+                                     'domains': {
+                                         'lan': {'read': 2, 'write': 2, 'delete': 2},
+                                         'wan': {'read': 1, 'write': 1, 'delete': 1}}})
+    add_protocol(rse_info[1]['id'], {'scheme': schemes[2],
+                                     'hostname': ('davs.%s' % base_rse_info[1]['address']),
+                                     'port': 443,
+                                     'prefix': '/lambda/complex/',
+                                     'impl': 'rucio.rse.protocols.gfal.Default',
+                                     'domains': {
+                                         'lan': {'read': 0, 'write': 0, 'delete': 0},
+                                         'wan': {'read': 2, 'write': 2, 'delete': 2}}})
+    add_protocol(rse_info[1]['id'], {'scheme': schemes[0],
+                                     'hostname': ('root.%s' % base_rse_info[1]['address']),
+                                     'port': 1409,
+                                     'prefix': '//lambda/complex/',
+                                     'impl': 'rucio.rse.protocols.xrootd.Default',
+                                     'domains': {
+                                         'lan': {'read': 1, 'write': 1, 'delete': 1},
+                                         'wan': {'read': 3, 'write': 3, 'delete': 3}}})
 
-        add_protocol(self.rse2_id, {'scheme': 'gsiftp',
-                                    'hostname': 'gsiftp.blackmesa.com',
-                                    'port': 8446,
-                                    'prefix': '/lambda/complex/',
-                                    'impl': 'rucio.rse.protocols.gfal.Default',
-                                    'domains': {
-                                        'lan': {'read': 2, 'write': 2, 'delete': 2},
-                                        'wan': {'read': 1, 'write': 1, 'delete': 1}}})
-        add_protocol(self.rse2_id, {'scheme': 'davs',
-                                    'hostname': 'davs.blackmesa.com',
-                                    'port': 443,
-                                    'prefix': '/lambda/complex/',
-                                    'impl': 'rucio.rse.protocols.gfal.Default',
-                                    'domains': {
-                                        'lan': {'read': 0, 'write': 0, 'delete': 0},
-                                        'wan': {'read': 2, 'write': 2, 'delete': 2}}})
-        add_protocol(self.rse2_id, {'scheme': 'root',
-                                    'hostname': 'root.blackmesa.com',
-                                    'port': 1409,
-                                    'prefix': '//lambda/complex/',
-                                    'impl': 'rucio.rse.protocols.xrootd.Default',
-                                    'domains': {
-                                        'lan': {'read': 1, 'write': 1, 'delete': 1},
-                                        'wan': {'read': 3, 'write': 3, 'delete': 3}}})
+    yield {'files': files, 'rse_info': rse_info}
 
-        replicas = [r for r in self.rc.list_replicas(dids=[{'scope': 'mock',
-                                                            'name': f['name'],
-                                                            'type': 'FILE'} for f in self.files],
-                                                     schemes=['root', 'gsiftp', 'davs'],
-                                                     client_location={'site': 'APERTURE'})]
-        pfns = [r['pfns'] for r in replicas][0]
-        assert len(pfns.keys()) == 5
-        assert pfns['root://root.aperture.com:1409//test/chamber/mock/58/b5/element_0']['domain'] == 'lan'
-        assert pfns['root://root.aperture.com:1409//test/chamber/mock/58/b5/element_0']['priority'] == 1
-        assert pfns['davs://davs.aperture.com:443/test/chamber/mock/58/b5/element_0']['domain'] == 'lan'
-        assert pfns['davs://davs.aperture.com:443/test/chamber/mock/58/b5/element_0']['priority'] == 2
-        assert pfns['gsiftp://gsiftp.blackmesa.com:8446/lambda/complex/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['gsiftp://gsiftp.blackmesa.com:8446/lambda/complex/mock/58/b5/element_0']['priority'] == 3
-        assert pfns['davs://davs.blackmesa.com:443/lambda/complex/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['davs://davs.blackmesa.com:443/lambda/complex/mock/58/b5/element_0']['priority'] == 4
-        assert pfns['root://root.blackmesa.com:1409//lambda/complex/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['root://root.blackmesa.com:1409//lambda/complex/mock/58/b5/element_0']['priority'] == 5
-        replicas = [r for r in self.rc.list_replicas(dids=[{'scope': 'mock',
-                                                            'name': f['name'],
-                                                            'type': 'FILE'} for f in self.files],
-                                                     schemes=['root', 'gsiftp', 'davs'],
-                                                     client_location={'site': 'BLACKMESA'})]
-        pfns = [r['pfns'] for r in replicas][0]
-        assert len(pfns.keys()) == 5
-        assert pfns['root://root.blackmesa.com:1409//lambda/complex/mock/58/b5/element_0']['domain'] == 'lan'
-        assert pfns['root://root.blackmesa.com:1409//lambda/complex/mock/58/b5/element_0']['priority'] == 1
-        assert pfns['gsiftp://gsiftp.blackmesa.com:8446/lambda/complex/mock/58/b5/element_0']['domain'] == 'lan'
-        assert pfns['gsiftp://gsiftp.blackmesa.com:8446/lambda/complex/mock/58/b5/element_0']['priority'] == 2
-        assert pfns['root://root.aperture.com:1409//test/chamber/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['root://root.aperture.com:1409//test/chamber/mock/58/b5/element_0']['priority'] == 3
-        assert pfns['davs://davs.aperture.com:443/test/chamber/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['davs://davs.aperture.com:443/test/chamber/mock/58/b5/element_0']['priority'] == 4
-        assert pfns['gsiftp://gsiftp.aperture.com:8446/test/chamber/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['gsiftp://gsiftp.aperture.com:8446/test/chamber/mock/58/b5/element_0']['priority'] == 5
-        replicas = [r for r in self.rc.list_replicas(dids=[{'scope': 'mock',
-                                                            'name': f['name'],
-                                                            'type': 'FILE'} for f in self.files],
-                                                     schemes=['root', 'gsiftp', 'davs'],
-                                                     client_location={'site': 'XEN'})]
-        pfns = [r['pfns'] for r in replicas][0]
-        assert len(pfns.keys()) == 6
-        # TODO: intractable until RSE sorting is enabled
-        assert pfns['gsiftp://gsiftp.blackmesa.com:8446/lambda/complex/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['gsiftp://gsiftp.blackmesa.com:8446/lambda/complex/mock/58/b5/element_0']['priority'] in [1, 2]
-        assert pfns['root://root.aperture.com:1409//test/chamber/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['root://root.aperture.com:1409//test/chamber/mock/58/b5/element_0']['priority'] in [1, 2]
-        assert pfns['davs://davs.aperture.com:443/test/chamber/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['davs://davs.aperture.com:443/test/chamber/mock/58/b5/element_0']['priority'] in [3, 4]
-        assert pfns['davs://davs.blackmesa.com:443/lambda/complex/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['davs://davs.blackmesa.com:443/lambda/complex/mock/58/b5/element_0']['priority'] in [3, 4]
-        assert pfns['gsiftp://gsiftp.aperture.com:8446/test/chamber/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['gsiftp://gsiftp.aperture.com:8446/test/chamber/mock/58/b5/element_0']['priority'] in [5, 6]
-        assert pfns['root://root.blackmesa.com:1409//lambda/complex/mock/58/b5/element_0']['domain'] == 'wan'
-        assert pfns['root://root.blackmesa.com:1409//lambda/complex/mock/58/b5/element_0']['priority'] in [5, 6]
+    for info in rse_info:
+        delete_replicas(rse_id=info['id'], files=files)
+        del_rse_attribute(rse_id=info['id'], key='site')
+        del_rse(info['id'])
 
-        ml = self.rc.list_replicas(dids=[{'scope': 'mock',
-                                          'name': f['name'],
-                                          'type': 'FILE'} for f in self.files],
-                                   schemes=['root', 'gsiftp', 'davs'],
-                                   metalink=True,
-                                   client_location={'site': 'APERTURE'})
-        assert 'domain="lan" priority="1" client_extract="false">root://root.aperture.com:1409//test/chamber/mock/58/b5/element_0' in ml
-        assert 'domain="lan" priority="2" client_extract="false">davs://davs.aperture.com:443/test/chamber/mock/58/b5/element_0' in ml
-        assert 'domain="wan" priority="3" client_extract="false">gsiftp://gsiftp.blackmesa.com:8446/lambda/complex/mock/58/b5/element_0' in ml
-        assert 'domain="wan" priority="4" client_extract="false">davs://davs.blackmesa.com:443/lambda/complex/mock/58/b5/element_0' in ml
-        assert 'domain="wan" priority="5" client_extract="false">root://root.blackmesa.com:1409//lambda/complex/mock/58/b5/element_0' in ml
-        assert 'priority="6"' not in ml
 
-        ml = self.rc.list_replicas(dids=[{'scope': 'mock',
-                                          'name': f['name'],
-                                          'type': 'FILE'} for f in self.files],
-                                   schemes=['root', 'gsiftp', 'davs'],
-                                   metalink=True,
-                                   client_location={'site': 'BLACKMESA'})
-        assert 'domain="lan" priority="1" client_extract="false">root://root.blackmesa.com:1409//lambda/complex/mock/58/b5/element_0' in ml
-        assert 'domain="lan" priority="2" client_extract="false">gsiftp://gsiftp.blackmesa.com:8446/lambda/complex/mock/58/b5/element_0' in ml
-        assert 'domain="wan" priority="3" client_extract="false">root://root.aperture.com:1409//test/chamber/mock/58/b5/element_0' in ml
-        assert 'domain="wan" priority="4" client_extract="false">davs://davs.aperture.com:443/test/chamber/mock/58/b5/element_0' in ml
-        assert 'domain="wan" priority="5" client_extract="false">gsiftp://gsiftp.aperture.com:8446/test/chamber/mock/58/b5/element_0' in ml
-        assert 'priority="6"' not in ml
+@pytest.mark.parametrize("content_type", [
+    Mime.METALINK,
+    pytest.param(Mime.JSON_STREAM, marks=pytest.mark.xfail(reason='see https://github.com/rucio/rucio/issues/4105')),
+])
+def test_sort_geoip_wan(vo, rest_client, auth_token, protocols_setup, content_type):
+    """Replicas: test sorting a few WANs via geoip."""
+    n = 10
+    nmap = {}
 
-        # TODO: intractable until RSE sorting is enabled
-        # ml = self.rc.list_replicas(dids=[{'scope': 'mock',
-        #                                   'name': f['name'],
-        #                                   'type': 'FILE'} for f in self.files],
-        #                            schemes=['root', 'gsiftp', 'davs'],
-        #                            metalink=True,
-        #                            client_location={'site': 'XEN'})
-        # assert 'domain="wan" priority="1">root://root.aperture.com:1409//test/chamber/mock/58/b5/element_0' in ml
-        # assert 'domain="wan" priority="2">gsiftp://gsiftp.blackmesa.com:8446/lambda/complex/mock/58/b5/element_0' in ml
-        # assert 'domain="wan" priority="3">davs://davs.aperture.com:443/test/chamber/mock/58/b5/element_0' in ml
-        # assert 'domain="wan" priority="4">davs://davs.blackmesa.com:443/lambda/complex/mock/58/b5/element_0' in ml
-        # assert 'domain="wan" priority="5">gsiftp://gsiftp.aperture.com:8446/test/chamber/mock/58/b5/element_0' in ml
-        # assert 'domain="wan" priority="6">root://root.blackmesa.com:1409//lambda/complex/mock/58/b5/element_0' in ml
-        # assert 'priority="7"' not in ml
+    def fake_get_distance(se1, se2, *args, **kwargs):
+        nonlocal n, nmap
+        n = n - 1
+        print("fake_get_distance", {'se1': se1, 'se2': se2, 'n': n})
+        assert se1, 'pfn host must be se1 for this test'
+        nmap[se1] = n
+        return n
 
-        # ensure correct handling of disabled protocols
-        add_protocol(self.rse1_id, {'scheme': 'root',
-                                    'hostname': 'root2.aperture.com',
-                                    'port': 1409,
-                                    'prefix': '//test/chamber/',
-                                    'impl': 'rucio.rse.protocols.xrootd.Default',
-                                    'domains': {
-                                        'lan': {'read': 1, 'write': 1, 'delete': 1},
-                                        'wan': {'read': 0, 'write': 0, 'delete': 0}}})
+    data = {
+        'dids': [{'scope': f['scope'].external, 'name': f['name'], 'type': 'FILE'} for f in protocols_setup['files']],
+        'schemes': schemes,
+        'sort': 'geoip',
+    }
 
-        ml = self.rc.list_replicas(dids=[{'scope': 'mock',
-                                          'name': f['name'],
-                                          'type': 'FILE'} for f in self.files],
-                                   schemes=['root', 'gsiftp', 'davs'],
-                                   metalink=True,
-                                   client_location={'site': 'BLACKMESA'})
-        assert 'domain="lan" priority="1" client_extract="false">root://root.blackmesa.com:1409//lambda/complex/mock/58/b5/element_0' in ml
-        assert 'domain="lan" priority="2" client_extract="false">gsiftp://gsiftp.blackmesa.com:8446/lambda/complex/mock/58/b5/element_0' in ml
-        assert 'domain="wan" priority="3" client_extract="false">root://root.aperture.com:1409//test/chamber/mock/58/b5/element_0' in ml
-        assert 'domain="wan" priority="4" client_extract="false">davs://davs.aperture.com:443/test/chamber/mock/58/b5/element_0' in ml
-        assert 'domain="wan" priority="5" client_extract="false">gsiftp://gsiftp.aperture.com:8446/test/chamber/mock/58/b5/element_0' in ml
-        assert 'priority="6"' not in ml
+    with mock.patch('rucio.core.replica_sorter.__get_distance', side_effect=fake_get_distance):
+        response = rest_client.post(
+            '/replicas/list',
+            headers=headers(auth(auth_token), vohdr(vo), accept(content_type)),
+            json=data
+        )
+    assert response.status_code == 200
 
-        delete_replicas(rse_id=self.rse1_id, files=self.files)
-        delete_replicas(rse_id=self.rse2_id, files=self.files)
-        del_rse(self.rse1_id)
-        del_rse(self.rse2_id)
+    replicas_response = response.get_data(as_text=True)
+    assert replicas_response
+
+    # because urlparse hostname result is lower case
+    sorted_hosts = list(map(str.lower, sorted(nmap, key=nmap.get)))
+
+    if content_type == Mime.METALINK:
+        replicas = parse_replicas_from_string(replicas_response)
+        print(replicas)
+        assert len(replicas) == 1
+        sources_list = replicas[0]['sources']
+        print(sources_list)
+        assert len(sources_list) == 6
+
+        sorted_replica_hosts = list(sorted(sources_list, key=lambda source: source['priority']))
+        sorted_replica_hosts = list(map(lambda source: urlparse(source['pfn']).hostname, sorted_replica_hosts))
+        assert sorted_hosts == sorted_replica_hosts, 'assert sorting of result as distance suggested'
+
+    elif content_type == Mime.JSON_STREAM:
+        replicas = list(map(json.loads, filter(bool, map(str.strip, replicas_response.splitlines(keepends=False)))))
+        print(replicas)
+        assert len(replicas) == 1
+        sources_dict = replicas[0]['pfns']
+        assert len(sources_dict) == 6
+
+        sorted_replica_hosts = list(sorted(sources_dict, key=lambda pfn: sources_dict[pfn]['priority']))
+        sorted_replica_hosts = list(map(lambda source: urlparse(source).hostname, sorted_replica_hosts))
+        assert sorted_hosts == sorted_replica_hosts, 'assert sorting of result as distance suggested'
+
+
+argvalues = [
+    (Mime.METALINK, 0),
+    (Mime.METALINK, 1),
+    pytest.param(Mime.JSON_STREAM, 0, marks=pytest.mark.xfail(reason='see https://github.com/rucio/rucio/issues/4105')),
+    pytest.param(Mime.JSON_STREAM, 1, marks=pytest.mark.xfail(reason='see https://github.com/rucio/rucio/issues/4105')),
+]
+rargvalues = map(lambda p: p.values if hasattr(p, 'values') else p, argvalues)
+ids = [f'mime={repr(mime)}, lan-site={repr(base_rse_info[iid]["site"])}' for mime, iid in rargvalues]
+
+
+@pytest.mark.parametrize("content_type,info_id", argvalues=argvalues, ids=ids)
+def test_sort_geoip_lan_before_wan(vo, rest_client, auth_token, protocols_setup, content_type, info_id):
+    """Replicas: test sorting LAN sites before WANs via geoip."""
+    n = 2
+    nmap = {}
+
+    def fake_get_distance(se1, se2, *args, **kwargs):
+        nonlocal n, nmap
+        n = n - 1
+        print("fake_get_distance", {'se1': se1, 'se2': se2, 'n': n})
+        assert se1, 'pfn host must be se1 for this test'
+        nmap[se1] = n
+        return n
+
+    data = {
+        'dids': [{'scope': f['scope'].external, 'name': f['name'], 'type': 'FILE'} for f in protocols_setup['files']],
+        'client_location': {'site': protocols_setup['rse_info'][info_id]['site']},
+        'schemes': schemes,
+        'sort': 'geoip',
+    }
+
+    with mock.patch('rucio.core.replica_sorter.__get_distance', side_effect=fake_get_distance):
+        response = rest_client.post(
+            '/replicas/list',
+            headers=headers(auth(auth_token), vohdr(vo), accept(content_type)),
+            json=data
+        )
+    assert response.status_code == 200
+
+    replicas_response = response.get_data(as_text=True)
+    assert replicas_response
+
+    # because urlparse hostname result is lower case
+    sorted_wan_hosts = list(map(str.lower, sorted(nmap, key=nmap.get)))
+
+    if content_type == Mime.METALINK:
+        replicas = parse_replicas_from_string(replicas_response)
+        print(replicas)
+        assert len(replicas) == 1
+        sources_list = replicas[0]['sources']
+        print(sources_list)
+        # 3 for wan and 2 for lan, since one is blocked for lan for each site
+        assert len(sources_list) == 5
+
+        sorted_replica_hosts = list(sorted(sources_list, key=lambda source: source['priority']))
+        print(sorted_replica_hosts)
+        lan_pfns = list(filter(lambda source: source['domain'] == 'lan', sorted_replica_hosts))
+        assert len(lan_pfns) == 2
+        for lanpfn in lan_pfns:
+            assert protocols_setup['rse_info'][info_id]['name'] == lanpfn['rse']
+
+        sorted_replica_wan_hosts = list(map(lambda source: urlparse(source['pfn']).hostname,
+                                            filter(lambda source: source['domain'] != 'lan', sorted_replica_hosts)))
+        assert sorted_wan_hosts == sorted_replica_wan_hosts
+
+    elif content_type == Mime.JSON_STREAM:
+        replicas = list(map(json.loads, filter(bool, map(str.strip, replicas_response.splitlines(keepends=False)))))
+        print(replicas)
+        assert len(replicas) == 1
+        sources_dict = replicas[0]['pfns']
+        # 3 for wan and 2 for lan, since one is blocked for lan for each site
+        assert len(sources_dict) == 5
+
+        sorted_replica_hosts = list(sorted(sources_dict, key=lambda pfn: sources_dict[pfn]['priority']))
+        lan_pfns = list(filter(lambda pfn: sources_dict[pfn]['domain'] == 'lan', sorted_replica_hosts))
+        assert len(lan_pfns) == 2
+        for lanpfn in lan_pfns:
+            assert protocols_setup['rse_info'][info_id]['id'] == sources_dict[lanpfn]['rse_id']
+
+        wan_pfns = filter(lambda pfn: sources_dict[pfn]['domain'] != 'lan', sorted_replica_hosts)
+        sorted_replica_wan_hosts = list(map(lambda pfn: urlparse(pfn).hostname, wan_pfns))
+        assert sorted_wan_hosts == sorted_replica_wan_hosts
+
+
+@pytest.mark.parametrize("content_type", [Mime.METALINK, Mime.JSON_STREAM])
+def test_not_sorting_lan_replicas(vo, rest_client, auth_token, protocols_setup, content_type):
+    """Replicas: test not sorting only LANs."""
+
+    data = {
+        'dids': [{'scope': f['scope'].external, 'name': f['name'], 'type': 'FILE'} for f in protocols_setup['files']],
+        # yes, this is rather a hack (but works on the API as well). I would like to have an rse_expression parameter instead.
+        'client_location': {'site': '|site='.join(map(lambda info: info['site'], protocols_setup['rse_info']))},
+        'schemes': schemes,
+    }
+
+    rest_backend = os.environ.get('REST_BACKEND', 'webpy')
+    if rest_backend == 'webpy':
+        sort_replicas_mock_target = 'rucio.web.rest.replica.sort_replicas'
+    elif rest_backend == 'flask':
+        sort_replicas_mock_target = 'rucio.web.rest.flaskapi.v1.replica.sort_replicas'
+    else:
+        return pytest.xfail('unknown REST_BACKEND: ' + rest_backend)
+
+    def fake_sort_replicas(dictreplica, *args, **kwargs):
+        # test that nothing is passed to sort_replicas
+        assert not dictreplica
+        return []
+
+    with mock.patch(sort_replicas_mock_target, side_effect=fake_sort_replicas):
+        response = rest_client.post(
+            '/replicas/list',
+            headers=headers(auth(auth_token), vohdr(vo), accept(content_type)),
+            json=data
+        )
+    assert response.status_code == 200
+
+    replicas_response = response.get_data(as_text=True)
+    assert replicas_response
+
+    if content_type == Mime.METALINK:
+        replicas = parse_replicas_from_string(replicas_response)
+        print(replicas)
+        assert len(replicas) == 1
+        sources_list = replicas[0]['sources']
+        print(sources_list)
+        # 4 for lan, since one is blocked for lan for each site
+        assert len(sources_list) == 4
+
+    elif content_type == Mime.JSON_STREAM:
+        replicas = list(map(json.loads, filter(bool, map(str.strip, replicas_response.splitlines(keepends=False)))))
+        print(replicas)
+        assert len(replicas) == 1
+        sources_dict = replicas[0]['pfns']
+        # 4 for lan, since one is blocked for lan for each site
+        assert len(sources_dict) == 4
+
+
+@pytest.mark.parametrize("content_type", [
+    Mime.METALINK,
+    pytest.param(Mime.JSON_STREAM, marks=pytest.mark.xfail(reason='see https://github.com/rucio/rucio/issues/4105')),
+])
+def test_sort_geoip_address_not_found_error(vo, rest_client, auth_token, protocols_setup, content_type):
+    """Replicas: test sorting via geoip with ignoring geoip errors."""
+
+    class MockedGeoIPError(Exception):
+        def __init__(self, *args):
+            super(MockedGeoIPError, self).__init__(*args)
+
+    def fake_get_geoip_db(*args, **kwargs):
+        raise MockedGeoIPError()
+
+    data = {
+        'dids': [{'scope': f['scope'].external, 'name': f['name'], 'type': 'FILE'} for f in protocols_setup['files']],
+        'schemes': schemes,
+        'sort': 'geoip',
+    }
+
+    # invalidate cache for __get_distance so that __get_geoip_db is called
+    replica_sorter.REGION.invalidate()
+
+    with mock.patch('rucio.core.replica_sorter.__get_geoip_db', side_effect=fake_get_geoip_db) as get_geoip_db_mock:
+        response = rest_client.post(
+            '/replicas/list',
+            headers=headers(auth(auth_token), vohdr(vo), accept(content_type)),
+            json=data
+        )
+        assert response.status_code == 200
+
+        replicas_response = response.get_data(as_text=True)
+        assert replicas_response
+
+        get_geoip_db_mock.assert_called()


### PR DESCRIPTION
Improve sorting replicas

Deduplicate code related to replica sorting
Set geoip as default sorting option for all
Return lan locations always before wan locations for list_replicas
Replace tests for geoip replica sorting
Fix setting priority to the order of what the sort returns on list_replicas endpoint