### PR TITLE
Allow protocol swap - discussion only

### DIFF
--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -97,14 +97,25 @@ class Default(protocol.RSEProtocol):
                 path = lfn['path'] if 'path' in lfn and lfn['path'] else self._get_path(scope=scope, name=name)
                 if self.attributes['scheme'] != 'root' and path.startswith('/'):  # do not modify path if it is root
                     path = path[1:]
-                pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'], '://', hostname, web_service_path, prefix, path])
+                print('With port %s' % path)
+                if re.match('\w+://', path):
+                    pfns['%s:%s' % (scope, name)] = path  # Algorithm gave us a full URI. Use it
+                else:
+                    pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'], '://', hostname,
+                                                             web_service_path, prefix, path])
         else:
             for lfn in lfns:
                 scope, name = str(lfn['scope']), lfn['name']
                 path = lfn['path'] if 'path' in lfn and lfn['path'] else self._get_path(scope=scope, name=name)
                 if self.attributes['scheme'] != 'root' and path.startswith('/'):  # do not modify path if it is root
                     path = path[1:]
-                pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'], '://', hostname, ':', str(self.attributes['port']), web_service_path, prefix, path])
+                print('Without port %s' % path)
+                if re.match('\w+://', path):
+                    pfns['%s:%s' % (scope, name)] = path  # Algorithm gave us a full URI. Use it
+                else:
+                    pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'], '://', hostname, ':',
+                                                             str(self.attributes['port']), web_service_path, prefix,
+                                                             path])
 
         # self.logger.debug('count of pfns: {}'.format(len(list(pfns))))
 

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -97,7 +97,6 @@ class Default(protocol.RSEProtocol):
                 path = lfn['path'] if 'path' in lfn and lfn['path'] else self._get_path(scope=scope, name=name)
                 if self.attributes['scheme'] != 'root' and path.startswith('/'):  # do not modify path if it is root
                     path = path[1:]
-                print('With port %s' % path)
                 if re.match('\w+://', path):
                     pfns['%s:%s' % (scope, name)] = path  # Algorithm gave us a full URI. Use it
                 else:
@@ -109,7 +108,6 @@ class Default(protocol.RSEProtocol):
                 path = lfn['path'] if 'path' in lfn and lfn['path'] else self._get_path(scope=scope, name=name)
                 if self.attributes['scheme'] != 'root' and path.startswith('/'):  # do not modify path if it is root
                     path = path[1:]
-                print('Without port %s' % path)
                 if re.match('\w+://', path):
                     pfns['%s:%s' % (scope, name)] = path  # Algorithm gave us a full URI. Use it
                 else:

--- a/lib/rucio/rse/protocols/srm.py
+++ b/lib/rucio/rse/protocols/srm.py
@@ -48,7 +48,7 @@ class Default(protocol.RSEProtocol):
         :param path: The path to the file.
         :returns: Fully qualified PFN.
         """
-        print('LFNs to PFNs called')
+
         pfns = {}
         prefix = self.attributes['prefix']
         if self.attributes['extended_attributes'] is not None and\
@@ -74,7 +74,6 @@ class Default(protocol.RSEProtocol):
                     path = self._get_path(scope=scope, name=name)
                 if path.startswith('/'):
                     path = path[1:]
-                print('With port %s' % path)
                 if re.match('\w+://', path):
                     pfns['%s:%s' % (scope, name)] = path  # Algorithm gave us a full URI. Use it
                 else:
@@ -87,7 +86,6 @@ class Default(protocol.RSEProtocol):
                     path = self._get_path(scope=scope, name=name)
                 if path.startswith('/'):
                     path = path[1:]
-                print('Without port %s' % path)
                 if re.match('\w+://', path):
                     pfns['%s:%s' % (scope, name)] = path  # Algorithm gave us a full URI. Use it
                 else:
@@ -106,7 +104,6 @@ class Default(protocol.RSEProtocol):
         :returns: a dict containing all known parts of the PFN for the protocol e.g. scheme, path, filename
         :raises RSEFileNameNotSupported: if the provided PFN doesn't match with the protocol settings
         """
-        print('Parse PFNs called')
 
         ret = dict()
         pfns = [pfns] if isinstance(pfns, string_types) else pfns
@@ -166,7 +163,6 @@ class Default(protocol.RSEProtocol):
         :param path: The path to the file.
         :returns: Fully qualified PFN.
         """
-        print('Path to PFNs called')
 
         if path.startswith("srm://"):
             return path

--- a/lib/rucio/rse/protocols/srm.py
+++ b/lib/rucio/rse/protocols/srm.py
@@ -48,7 +48,7 @@ class Default(protocol.RSEProtocol):
         :param path: The path to the file.
         :returns: Fully qualified PFN.
         """
-
+        print('LFNs to PFNs called')
         pfns = {}
         prefix = self.attributes['prefix']
         if self.attributes['extended_attributes'] is not None and\
@@ -106,6 +106,7 @@ class Default(protocol.RSEProtocol):
         :returns: a dict containing all known parts of the PFN for the protocol e.g. scheme, path, filename
         :raises RSEFileNameNotSupported: if the provided PFN doesn't match with the protocol settings
         """
+        print('Parse PFNs called')
 
         ret = dict()
         pfns = [pfns] if isinstance(pfns, string_types) else pfns
@@ -165,6 +166,7 @@ class Default(protocol.RSEProtocol):
         :param path: The path to the file.
         :returns: Fully qualified PFN.
         """
+        print('Path to PFNs called')
 
         if path.startswith("srm://"):
             return path

--- a/lib/rucio/rse/protocols/srm.py
+++ b/lib/rucio/rse/protocols/srm.py
@@ -74,8 +74,11 @@ class Default(protocol.RSEProtocol):
                     path = self._get_path(scope=scope, name=name)
                 if path.startswith('/'):
                     path = path[1:]
-                pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'], '://',
-                                                         hostname, web_service_path, prefix, path])
+                if re.match('\w+://', path):
+                    pfns['%s:%s' % (scope, name)] = path  # Algorithm gave us a full URI. Use it
+                else:
+                    pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'], '://',
+                                                             hostname, web_service_path, prefix, path])
         else:
             for lfn in lfns:
                 scope, name, path = lfn['scope'], lfn['name'], lfn.get('path')
@@ -83,9 +86,12 @@ class Default(protocol.RSEProtocol):
                     path = self._get_path(scope=scope, name=name)
                 if path.startswith('/'):
                     path = path[1:]
-                pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'], '://',
-                                                         hostname, ':', str(self.attributes['port']),
-                                                         web_service_path, prefix, path])
+                if re.match('\w+://', path):
+                    pfns['%s:%s' % (scope, name)] = path  # Algorithm gave us a full URI. Use it
+                else:
+                    pfns['%s:%s' % (scope, name)] = ''.join([self.attributes['scheme'], '://',
+                                                             hostname, ':', str(self.attributes['port']),
+                                                             web_service_path, prefix, path])
 
         return pfns
 

--- a/lib/rucio/rse/protocols/srm.py
+++ b/lib/rucio/rse/protocols/srm.py
@@ -74,6 +74,7 @@ class Default(protocol.RSEProtocol):
                     path = self._get_path(scope=scope, name=name)
                 if path.startswith('/'):
                     path = path[1:]
+                print('With port %s' % path)
                 if re.match('\w+://', path):
                     pfns['%s:%s' % (scope, name)] = path  # Algorithm gave us a full URI. Use it
                 else:
@@ -86,6 +87,7 @@ class Default(protocol.RSEProtocol):
                     path = self._get_path(scope=scope, name=name)
                 if path.startswith('/'):
                     path = path[1:]
+                print('Without port %s' % path)
                 if re.match('\w+://', path):
                     pfns['%s:%s' % (scope, name)] = path  # Algorithm gave us a full URI. Use it
                 else:


### PR DESCRIPTION
Please don't merge this, I want to check this. The CMS mechanism to generate a PFN allows different protocols for different paths. For instance, Fermilab has one portion which has these protocols for two paths:
```
{u'cms:/store/user': u'srm://cmsdcadisk.fnal.gov:8443/srm/managerv2?SFN=/dcache/uscmsdisk/store/user'}
{u'cms:/store/temp/user': u'gsiftp://cmseos-gridftp.fnal.gov/eos/uscms/store/temp/user'}
```

where it wants to switch protocol itself to gsiftp. 

To hack this in, I changed gfal.py such that if it gets something that looks like a URI already instead of a path from the LFN to PFN algorithm, it just passes it along. What do you think of this @bari12 ? Can we turn this into a real pull request?

I don't think we need SRM to do this, but perhaps.

You can see this is rough, I still have lots of debug messages in it and so forth.



Pull request title
------------------

The format of the Pull request title must be:

    <component>: <short_change_message> #<issue number>

If you add a [github-recognised keyword](https://help.github.com/articles/closing-issues-using-keywords/) then
the associated issue can be closed automatically once the pull request is merged, e.g.::

    <component>: <short_change_message> Fix #<issue number>
