### PR TITLE
Replace calls for removed method to get headers

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/did.py
+++ b/lib/rucio/web/rest/flaskapi/v1/did.py
@@ -1015,7 +1015,7 @@ class SingleMeta(MethodView):
 
         """
         try:
-            scope, name = parse_scope_name(scope_name)
+            scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0])
         except Exception as error:

--- a/lib/rucio/web/rest/flaskapi/v1/redirect.py
+++ b/lib/rucio/web/rest/flaskapi/v1/redirect.py
@@ -71,7 +71,7 @@ class MetaLinkRedirector(MethodView):
         headers.set('Access-Control-Allow-Credentials', 'true')
 
         try:
-            scope, name = parse_scope_name(scope_name, request_header_ensure_string('X-Rucio-VO', 'def'))
+            scope, name = parse_scope_name(scope_name, request.headers.get('X-Rucio-VO', default='def'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0], headers=headers)
         except Exception as error:
@@ -199,7 +199,7 @@ class HeaderRedirector(MethodView):
         headers.set('Access-Control-Allow-Credentials', 'true')
 
         try:
-            scope, name = parse_scope_name(scope_name, request_header_ensure_string('X-Rucio-VO', 'def'))
+            scope, name = parse_scope_name(scope_name, request.headers.get('X-Rucio-VO', default='def'))
         except ValueError as error:
             return generate_http_error_flask(400, 'ValueError', error.args[0], headers=headers)
         except Exception as error:


### PR DESCRIPTION
Quick fix for `request_header_ensure_string` and `parse_scope_name` usage.
