### PR TITLE
Validate against r_dids instead of dids

### DIFF
--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -23,6 +23,7 @@
 # - Luc Goossens <luc.goossens@cern.ch>, 2020
 # - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Eric Vaandering <ewv@fnal.gov>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -321,7 +322,7 @@ def list_dataset_replicas_bulk(dids, vo='def'):
     :returns: A list of dict dataset replicas
     """
 
-    validate_schema(name='dids', obj=dids, vo=vo)
+    validate_schema(name='r_dids', obj=dids, vo=vo)
     names_by_scope = dict()
     for d in dids:
         if d['scope'] in names_by_scope:


### PR DESCRIPTION
I didn't open an issue for this bug. This was introduced in code by @bziemons and it causes problems for CMS. R_DIDS is the right thing to validate against, not DIDS since the DIDS already exist. 

The reason this is an issue for CMS is that on DIDs we require a type to be provided during the validation because we have different RegEx for files, datasets, and containers. For RDIDs we don't care. 

As long as there is no argument that r_dids is the right thing to validate against, please get this into 1.23.11
