### PR TITLE
Update APIs to return error details if RSENotFound - Fix #4008

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/rse.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rse.py
@@ -285,6 +285,8 @@ class Attributes(MethodView):
             return generate_http_error_flask(401, 'AccessDenied', error.args[0])
         except Duplicate as error:
             return generate_http_error_flask(409, 'Duplicate', error.args[0])
+        except RSENotFound as error:
+            return generate_http_error_flask(404, 'RSENotFound', error.args[0])
         except Exception as error:
             print(format_exc())
             return str(error), 500

--- a/lib/rucio/web/rest/webpy/v1/rse.py
+++ b/lib/rucio/web/rest/webpy/v1/rse.py
@@ -299,6 +299,8 @@ class Attributes(RucioController):
             raise generate_http_error(401, 'AccessDenied', error.args[0])
         except Duplicate as error:
             raise generate_http_error(409, 'Duplicate', error.args[0])
+        except RSENotFound as error:
+            raise generate_http_error(404, 'RSENotFound', error.args[0])
         except Exception as error:
             raise InternalError(error)
 


### PR DESCRIPTION
Simple API update to handle `RSENotFound` exceptions clearly.

Instead of:
```
# rucio-admin rse set-attribute --key whatever --value true --rse I_DO_NOT_EXIST
An unknown exception occurred.
Details: no error information passed (http status code: 500 ('internal_server_error', 'server_error', '/o\\', '\xe2\x9c\x97'))
```

now the error is rendered as:
```
# rucio-admin rse set-attribute --key whatever --value true --rse I_DO_NOT_EXIST
RSE does not exist.
Details: RSE 'I_DO_NOT_EXIST' cannot be found in vo 'def'
This means that the Rucio Storage Element you provided is not known by Rucio.
```