### PR TITLE
Testing: Fix py2 test container using py3 pip

### DIFF
--- a/tools/test/install_script.sh
+++ b/tools/test/install_script.sh
@@ -22,7 +22,7 @@
 
 set -eo pipefail
 
-echo "* Running tests with $(python --version 2>&1) and $(pip --version 2>&1)"
+echo "* Using $(which python) $(python --version 2>&1) and $(which pip) $(pip --version 2>&1)"
 
 if [ "$SUITE" == "client" -o "$SUITE" == "client_syntax" ]; then
     cd /usr/local/src/rucio

--- a/tools/test/run_tests.py
+++ b/tools/test/run_tests.py
@@ -169,6 +169,8 @@ def run_case(caseenv, image, use_podman, use_namespace, use_httpd, copy_rucio_lo
         namespace_args = ()
         namespace_env = {}
 
+    run('docker', 'image', 'ls', image)
+
     pod = ""
     if use_podman:
         print("*** Starting with pod for", {**caseenv, "IMAGE": image}, file=sys.stderr, flush=True)


### PR DESCRIPTION
The autotest container image is using the wrong pip for running the python 2.7 client tests, because the `python36u-pip` package installs their pip to `/usr/local/bin` and thus two pip executables exist in PATH.