### PR TITLE
Monitoring & Logging: Add utils.formatted_logger; #4220

### DIFF
--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2020 CERN
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2012-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2020
-# - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2020
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2021
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2013
 # - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2015-2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2016-2020
@@ -31,7 +31,7 @@
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 from __future__ import print_function
 
@@ -45,6 +45,7 @@ import base64
 import copy
 import datetime
 import errno
+import functools
 import getpass
 import hashlib
 import json
@@ -59,7 +60,6 @@ import tempfile
 import threading
 import time
 import zlib
-
 from enum import Enum
 from logging import getLogger, Formatter  # NOQA: F401
 from logging.handlers import RotatingFileHandler
@@ -1448,3 +1448,19 @@ class retry:
                     logger.debug(str(e))
                 attempt -= 1
         return self.func(*self.args, **self.kwargs)
+
+
+def formatted_logger(innerfunc, formatstr="%s"):
+    """
+    Decorates the passed function, formatting log input by
+    the passed formatstr. The format string must always include a %s.
+
+    :param innerfunc: function to be decorated. Must take (level, msg) arguments.
+    :type innerfunc: Callable
+    :param formatstr: format string with %s as placeholder.
+    :type formatstr: str
+    """
+    @functools.wraps(innerfunc)
+    def log_format(level, msg, *args, **kwargs):
+        return innerfunc(level, formatstr % msg, *args, **kwargs)
+    return log_format

--- a/lib/rucio/tests/test_utils.py
+++ b/lib/rucio/tests/test_utils.py
@@ -1,4 +1,5 @@
-# Copyright 2017-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2017-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +17,10 @@
 # - Frank Berghaus <frank.berghaus@cern.ch>, 2017-2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 import datetime
+import logging
 import tempfile
 import unittest
 from re import match
@@ -28,7 +28,7 @@ from re import match
 import pytest
 
 from rucio.common.exception import InvalidType
-from rucio.common.utils import md5, adler32, parse_did_filter_from_string
+from rucio.common.utils import md5, adler32, parse_did_filter_from_string, formatted_logger
 
 
 class TestUtils(unittest.TestCase):
@@ -88,3 +88,16 @@ class TestUtils(unittest.TestCase):
         with pytest.raises(InvalidType):
             input = 'type=g'
             parse_did_filter_from_string(input)
+
+
+def test_formatted_logger():
+    result = None
+
+    def log_func(level, msg, *args, **kwargs):
+        nonlocal result
+        result = (level, msg)
+
+    new_log_func = formatted_logger(log_func, "a %s c")
+
+    new_log_func(logging.INFO, "b")
+    assert result == (logging.INFO, "a b c")


### PR DESCRIPTION
… and apply it to the preparer daemon. The decorator can be used with
`logging.log` to prefix log messages with daemon thread information.
