### PR TITLE
Core & Internals: Check json support before falling back to json

### DIFF
--- a/doc/source/did_meta.rst
+++ b/doc/source/did_meta.rst
@@ -64,7 +64,7 @@ The module you develop needs to extend the [DidMetaPlugin](/) Abstract class. Th
     For long = False return should be a list of strings containing the did names.
     """
 
-    manages_key(key)
+    manages_key(key, session=None)
     """
     Returns if Plugin is willing to manage metadata with given KEY.
     Some Plugins might decide to accept only specific hardcoded keys, others might match against a particular regex while other might accept all possible keys.

--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -97,7 +97,7 @@ def set_metadata(scope, name, key, value, recursive=False, session=None):
     :param session: (Optional)  The database session in use.
     """
     for meta_handler in METADATA_HANDLERS:
-        if meta_handler.manages_key(key):
+        if meta_handler.manages_key(key, session=session):
             meta_handler.set_metadata(scope, name, key, value, recursive, session=session)
             break
 
@@ -120,7 +120,7 @@ def set_metadata_bulk(scope, name, meta, recursive=False, session=None):
     for meta_handler in METADATA_HANDLERS:
         pluginmeta = {}
         for key, value in remainder.items():
-            if meta_handler.manages_key(key):
+            if meta_handler.manages_key(key, session=session):
                 pluginmeta[key] = value
         if pluginmeta:
             for key in pluginmeta:
@@ -137,7 +137,7 @@ def delete_metadata(scope, name, key, session=None):
     :param key: Key of the metadata.
     """
     for meta_handler in METADATA_HANDLERS:
-        if meta_handler.manages_key(key):
+        if meta_handler.manages_key(key, session=session):
             meta_handler.delete_metadata(scope, name, key, session=session)
 
 
@@ -169,11 +169,11 @@ def list_dids(scope=None, filters=None, type='collection', ignore_case=False, li
             continue
         if meta_handler_to_use is None:
             for meta_handler in METADATA_HANDLERS:
-                if meta_handler.manages_key(key):
+                if meta_handler.manages_key(key, session=session):
                     meta_handler_to_use = meta_handler
                     break
         else:
-            if not meta_handler_to_use.manages_key(key):
+            if not meta_handler_to_use.manages_key(key, session=session):
                 # Mix case, difficult, slow and will probably blow up memory
                 raise NotImplementedError('Filter keys used do not all belong on the same metadata plugin.')
 

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -351,17 +351,8 @@ class DidColumnMeta(DidMetaPlugin):
         """
         raise NotImplementedError('The DidColumnMeta plugin does not currently support deleting metadata.')
 
-    def manages_key(self, key):
-        """
-        Returns wether key is managed by this plugin or not.
-
-        :param key: Key of the metadata.
-        :returns (Boolean)
-        """
-        if key in HARDCODED_KEYS:  # or hasattr(models.DataIdentifier, key):
-            return True
-
-        return False
+    def manages_key(self, key, session=None):
+        return key in HARDCODED_KEYS  # alternatively hasattr(models.DataIdentifier, key)
 
     def get_plugin_name(self):
         """

--- a/lib/rucio/core/did_meta_plugins/did_meta_plugin_interface.py
+++ b/lib/rucio/core/did_meta_plugins/did_meta_plugin_interface.py
@@ -107,11 +107,11 @@ class DidMetaPlugin(object):
         pass
 
     @abstractmethod
-    def manages_key(self, key):
+    def manages_key(self, key, session=None):
         """
         Returns whether key is managed by this plugin or not.
-        JSON plugin should be considered a wildcard.
         :param key: Key of the metadata.
+        :param session: The database session in use.
         :returns (Boolean)
         """
         pass

--- a/lib/rucio/core/did_meta_plugins/json_meta.py
+++ b/lib/rucio/core/did_meta_plugins/json_meta.py
@@ -176,14 +176,9 @@ class JSONDidMeta(DidMetaPlugin):
             for row in query.yield_per(5):
                 yield row.name
 
-    def manages_key(self, key):
-        """
-        Returns whether key is managed by this plugin or not.
-        JSON plugin should be considered a wildcard.
-        :param key: Key of the metadata.
-        :returns (Boolean)
-        """
-        return True
+    @read_session
+    def manages_key(self, key, session=None):
+        return self.json_implemented(session=session)
 
     def get_plugin_name(self):
         """


### PR DESCRIPTION
Check json support before falling back to json. <del>This means all unknown meta data will be silently ignored instead of always trying to set them in the JSONDidMeta.</del> An error will be thrown on unknown metadata keys, added check in #4255 
Additionally this adds the (optional) session argument to `DidMetaPlugin.manages_key`.

