### PR TITLE
Core & Internals: Add panda metadata keys

### DIFF
--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 CERN
+# Copyright 2020-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
 #
 # Authors:
 # - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 import importlib
 
 from rucio.common import config
-from rucio.common.exception import PolicyPackageNotFound
+from rucio.common.exception import PolicyPackageNotFound, InvalidMetadata
 from rucio.db.sqla.session import read_session
 
 try:
@@ -92,14 +92,18 @@ def set_metadata(scope, name, key, value, recursive=False, session=None):
     :param name: The name of the did.
     :param key: Key of the metadata.
     :param value: Value of the metadata.
-    :param did: (Optional) The data identifier info.
     :param recursive: (Optional) Option to propagate the metadata change to content.
-    :param session: (Optional)  The database session in use.
+    :param session: (Optional) The database session in use.
     """
+    meta_was_set = False
     for meta_handler in METADATA_HANDLERS:
         if meta_handler.manages_key(key, session=session):
             meta_handler.set_metadata(scope, name, key, value, recursive, session=session)
+            meta_was_set = True
             break
+
+    if not meta_was_set:
+        raise InvalidMetadata('No plugin accepts metadata key %s on DID %s:%s' % (key, scope, name))
 
 
 def set_metadata_bulk(scope, name, meta, recursive=False, session=None):
@@ -112,19 +116,34 @@ def set_metadata_bulk(scope, name, meta, recursive=False, session=None):
 
     :param scope: The scope name.
     :param name: The data identifier name.
-    :param meta: all key-values to set.
-    :param recursive: Option to propagate the metadata change to content.
-    :param session: The database session in use.
+    :param meta: The key-value mapping of metadata to set.
+    :param recursive: (Optional) Option to propagate the metadata change to content.
+    :param session: (Optional) The database session in use.
     """
-    remainder = dict(meta)
-    for meta_handler in METADATA_HANDLERS:
-        pluginmeta = {}
-        for key, value in remainder.items():
+    denied_keys = list()
+    if not isinstance(meta, dict):
+        # always convert to dict, so that .items() can be called
+        meta = dict(meta)
+    meta_handler_keys = {meta_handler: [] for meta_handler in METADATA_HANDLERS}
+
+    for key, value in meta.items():
+        meta_is_included = False
+        # using METADATA_HANDLERS here to ensure the order of plugins applied
+        for meta_handler in METADATA_HANDLERS:
             if meta_handler.manages_key(key, session=session):
-                pluginmeta[key] = value
-        if pluginmeta:
-            for key in pluginmeta:
-                del remainder[key]
+                meta_handler_keys[meta_handler].append(key)
+                meta_is_included = True
+                break
+
+        if not meta_is_included:
+            denied_keys.append(key)
+
+    if denied_keys:
+        raise InvalidMetadata('No plugin accepted metadata keys %s on DID %s:%s' % (denied_keys, scope, name))
+
+    for meta_handler, key_list in meta_handler_keys.items():
+        if key_list:
+            pluginmeta = {key: meta[key] for key in key_list}
             meta_handler.set_metadata_bulk(scope, name, meta=pluginmeta, recursive=recursive, session=session)
 
 

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2020 CERN
+# Copyright 2013-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 # - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
 # - Brandon White, <bjwhite@fnal.gov>, 2019
 # - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 from datetime import datetime, timedelta
 
@@ -49,19 +49,14 @@ from rucio.db.sqla.constants import DIDType
 from rucio.db.sqla.session import stream_session, read_session, transactional_session
 
 HARDCODED_KEYS = [
+    # specials (keys not backed by the did table)
     "lifetime",
+    # fields on the did table
+    "hidden",
+    "is_new",
+    "events",
     "guid",
-    "events",
-    "adler32",
-    "bytes",
-    "events",
-
-    # Fields on the did table
-    "length",
-    "md5",
-    # "expired_at",
-    # "purge_replicas",
-    "deleted_at",
+    "purge_replicas",
     "project",
     "datatype",
     "run_number",
@@ -81,18 +76,25 @@ HARDCODED_KEYS = [
     "is_archive",
     "constituent",
     "access_cnt",
-    "is_new",
+    # all keys in constants.RESERVED_KEYS should be read-only from the API,
+    # but could be used in internal calls to set_metadata_*
+    # fields in did table and constants.RESERVED_KEYS
+    "name"
+    "length",
+    "md5",
+    "expired_at",
+    "deleted_at",
+    # fields in did table and constants.RESERVED_KEYS, but special handling
+    "bytes",
+    "adler32",
 
     # Keys used while listing dids
     "created_before",
     "created_after",
-    "guid",
     "length.gt",
     "length.lt",
     "length.gte",
     "length.lte",
-    "length",
-    "name"
 ]
 
 

--- a/lib/rucio/core/did_meta_plugins/json_meta.py
+++ b/lib/rucio/core/did_meta_plugins/json_meta.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2020 CERN
+# Copyright 2013-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 # - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
 # - Brandon White, <bjwhite@fnal.gov>, 2019
 # - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 import json as json_lib
 
@@ -42,6 +42,7 @@ from rucio.common import exception
 from rucio.core.did_meta_plugins.did_meta_plugin_interface import DidMetaPlugin
 from rucio.db.sqla import models
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
+from rucio.db.sqla.util import json_implemented
 
 
 class JSONDidMeta(DidMetaPlugin):
@@ -62,7 +63,7 @@ class JSONDidMeta(DidMetaPlugin):
         :param name: The data identifier name.
         :param session: The database session in use.
         """
-        if not self.json_implemented(session):
+        if not json_implemented(session=session):
             raise NotImplementedError
 
         try:
@@ -77,7 +78,7 @@ class JSONDidMeta(DidMetaPlugin):
 
     @transactional_session
     def set_metadata_bulk(self, scope, name, meta, recursive=False, session=None):
-        if not self.json_implemented(session):
+        if not json_implemented(session=session):
             raise NotImplementedError
 
         if session.query(models.DataIdentifier).filter_by(scope=scope, name=name).one_or_none() is None:
@@ -120,7 +121,7 @@ class JSONDidMeta(DidMetaPlugin):
         :param name: the name of the did
         :param key: the key to be deleted
         """
-        if not self.json_implemented(session):
+        if not json_implemented(session=session):
             raise NotImplementedError
 
         try:
@@ -150,7 +151,7 @@ class JSONDidMeta(DidMetaPlugin):
     def list_dids(self, scope, filters, type='collection', ignore_case=False, limit=None,
                   offset=None, long=False, recursive=False, session=None):
         # Currently for sqlite only add, get and delete is implemented.
-        if not self.json_implemented(session):
+        if not json_implemented(session=session):
             raise NotImplementedError
 
         query = session.query(models.DidMeta)
@@ -178,7 +179,7 @@ class JSONDidMeta(DidMetaPlugin):
 
     @read_session
     def manages_key(self, key, session=None):
-        return self.json_implemented(session=session)
+        return json_implemented(session=session)
 
     def get_plugin_name(self):
         """
@@ -186,22 +187,3 @@ class JSONDidMeta(DidMetaPlugin):
         This can then be used when listing the metadata of did to only provide dids from this plugin.
         """
         return self.plugin_name
-
-    def json_implemented(self, session=None):
-        """
-        Checks if the database on the current server installation can support json fields.
-        Check if did meta json table exists.
-
-        :param session: (Optional) The active session of the database.
-
-        :returns: True, if json is supported, False otherwise.
-        """
-        # if session is None:
-        #     session = se.get_session()
-        if session.bind.dialect.name == 'oracle':
-            oracle_version = int(session.connection().connection.version.split('.')[0])
-            if oracle_version < 12:
-                return False
-        if session.bind.dialect.name == 'sqlite':
-            return False
-        return True

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -325,10 +325,12 @@ class TestBinRucio(unittest.TestCase):
         if environ.get('SUITE', 'all') != 'client':
             from rucio.db.sqla import session, models
             db_session = session.get_session()
-            db_session.query(models.RSEFileAssociation).filter_by(name=tmp_file1_name, scope=InternalScope(self.user, **self.vo)).delete()
+            internal_scope = InternalScope(self.user, **self.vo)
+            db_session.query(models.RSEFileAssociation).filter_by(name=tmp_file1_name, scope=internal_scope).delete()
             db_session.query(models.ReplicaLock).delete()
-            db_session.query(models.ReplicationRule).filter_by(name=tmp_file1_name, scope=InternalScope(self.user, **self.vo)).delete()
-            db_session.query(models.DataIdentifier).filter_by(name=tmp_file1_name, scope=InternalScope(self.user, **self.vo)).delete()
+            db_session.query(models.ReplicationRule).filter_by(name=tmp_file1_name, scope=internal_scope).delete()
+            db_session.query(models.DidMeta).filter_by(name=tmp_file1_name, scope=internal_scope).delete()
+            db_session.query(models.DataIdentifier).filter_by(name=tmp_file1_name, scope=internal_scope).delete()
             db_session.commit()
             tmp_file4 = file_generator()
             checksum_tmp_file4 = md5(tmp_file4)

--- a/lib/rucio/tests/test_did_meta_plugins.py
+++ b/lib/rucio/tests/test_did_meta_plugins.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 CERN
+# Copyright 2020-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 # Authors:
 # - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 import unittest
 
@@ -28,12 +28,12 @@ from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.did import add_did, delete_dids, set_metadata_bulk
 from rucio.core.did_meta_plugins import list_dids, get_metadata, set_metadata
-from rucio.core.did_meta_plugins.json_meta import JSONDidMeta
 from rucio.db.sqla.session import get_session
+from rucio.db.sqla.util import json_implemented
 
 
 def skip_without_json():
-    if not JSONDidMeta().json_implemented(get_session()):
+    if not json_implemented():
         pytest.skip("JSON support is not implemented in this database")
 
 
@@ -217,7 +217,6 @@ class TestDidMetaClient(unittest.TestCase):
         self.did_client = DIDClient()
         self.tmp_scope = 'mock'
         self.session = get_session()
-        self.json_implemented = JSONDidMeta().json_implemented(self.session)
 
     def tearDown(self):
         self.session.commit()  # pylint: disable=no-member
@@ -228,7 +227,7 @@ class TestDidMetaClient(unittest.TestCase):
         self.did_client.add_did(scope=self.tmp_scope, name=tmp_name, type="DATASET")
 
         # Test JSON case
-        if self.json_implemented:
+        if json_implemented(session=self.session):
             # data1 = ["key1": "value_" + str(generate_uuid()), "key2": "value_" + str(generate_uuid()), "key3": "value_" + str(generate_uuid())]
             value1 = "value_" + str(generate_uuid())
             value2 = "value_" + str(generate_uuid())
@@ -278,7 +277,7 @@ class TestDidMetaClient(unittest.TestCase):
         self.did_client.add_did(scope=self.tmp_scope, name=tmp_name, type="DATASET")
 
         # Test JSON case
-        if self.json_implemented:
+        if json_implemented(session=self.session):
             value1 = "value_" + str(generate_uuid())
             value2 = "value_" + str(generate_uuid())
 
@@ -296,7 +295,7 @@ class TestDidMetaClient(unittest.TestCase):
         assert self.did_client.get_metadata(scope=self.tmp_scope, name=tmp_name)['project'] == 'data12_14TeV'
 
         # Test Mixed case
-        if self.json_implemented:
+        if json_implemented(session=self.session):
             all_metadata = self.did_client.get_metadata(scope=self.tmp_scope, name=tmp_name, plugin="ALL")
             assert all_metadata['key1'] == value1
             assert all_metadata['key2'] == value2
@@ -354,7 +353,7 @@ class TestDidMetaClient(unittest.TestCase):
             assert dsn in results
 
         # Test JSON use case
-        if self.json_implemented:
+        if json_implemented(session=self.session):
             did1 = 'name_%s' % generate_uuid()
             did2 = 'name_%s' % generate_uuid()
             did3 = 'name_%s' % generate_uuid()

--- a/lib/rucio/tests/test_undertaker.py
+++ b/lib/rucio/tests/test_undertaker.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2013-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,14 +16,14 @@
 # Authors:
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2013-2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2015-2017
-# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
 # - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 import unittest
 from datetime import datetime, timedelta
@@ -38,6 +39,7 @@ from rucio.core.replica import get_replica
 from rucio.core.rse import get_rse_id, add_rse
 from rucio.core.rule import add_rules, list_rules
 from rucio.daemons.undertaker.undertaker import undertaker
+from rucio.db.sqla.util import json_implemented
 from rucio.tests.common import rse_name_generator
 
 LOG = getLogger(__name__)
@@ -79,12 +81,10 @@ class TestUndertaker(unittest.TestCase):
 
         add_dids(dids=dsns1 + dsns2, account=root)
 
-        # Add generic metadata on did
-        try:
+        # arbitrary keys do not work without JSON support (sqlite, Oracle < 12)
+        if json_implemented():
+            # Add generic metadata on did
             set_metadata(tmp_scope, dsns1[0]['name'], "test_key", "test_value")
-        except NotImplementedError:
-            # add_did_meta is not Implemented for Oracle < 12
-            pass
 
         replicas = list()
         for dsn in dsns1 + dsns2:


### PR DESCRIPTION
Add metadata keys `hidden` and `purge_replicas` to `did_column_meta.HARDCODED_KEYS` for panda. Additionally add `expired_at` as read-only from the API.
Add check for any keys not set by the metadata plugins and raise `InvalidMetadata` exception when that happens.
`InvalidMetadata` is already handled by the REST API and an HTTP error 400 is propagated.