### PR TITLE
API: Fixes error with non-existent endpoints config value

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/main.py
+++ b/lib/rucio/web/rest/flaskapi/v1/main.py
@@ -64,7 +64,7 @@ def apply_endpoints(app, modules):
 
 
 try:
-    endpoints = config_get('api', 'endpoints', raise_exception=False, default=None)
+    endpoints = config_get('api', 'endpoints', raise_exception=False, default='')
     endpoints = list(filter(bool, map(str.strip, endpoints.split(sep=','))))
 except RuntimeError:
     endpoints = None


### PR DESCRIPTION
I noticed this problem in PR 4281, see https://github.com/rucio/rucio/pull/4281#issuecomment-770701860

Edit: this is for merging into `master` only.