### PR TITLE
Messaging: Don't encode subject for python3 Fix #4289

### DIFF
--- a/lib/rucio/daemons/hermes/hermes.py
+++ b/lib/rucio/daemons/hermes/hermes.py
@@ -21,7 +21,7 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2016-2019
 # - Robert Illingworth <illingwo@fnal.gov>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
-# - Eric Vaandering <ewv@fnal.gov>, 2019
+# - Eric Vaandering <ewv@fnal.gov>, 2019-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
 '''

--- a/lib/rucio/daemons/hermes/hermes.py
+++ b/lib/rucio/daemons/hermes/hermes.py
@@ -112,7 +112,10 @@ def deliver_emails(once=False, send_email=True, thread=0, bulk=1000, delay=10):
 
                 msg['From'] = email_from
                 msg['To'] = ', '.join(message['payload']['to'])
-                msg['Subject'] = message['payload']['subject'].encode('utf-8')
+                if PY2:
+                    msg['Subject'] = message['payload']['subject'].encode('utf-8')
+                else:
+                    msg['Subject'] = message['payload']['subject']
 
                 if send_email:
                     smtp = smtplib.SMTP()

--- a/lib/rucio/daemons/hermes/hermes2.py
+++ b/lib/rucio/daemons/hermes/hermes2.py
@@ -17,6 +17,7 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
+# - Eric Vaandering <ewv@fnal.gov>, 2021
 
 '''
    Hermes2 is a daemon that get the messages and sends them to external services (influxDB, ES, ActiveMQ).
@@ -279,7 +280,10 @@ def deliver_emails(messages, prepend_str):
 
             msg['From'] = email_from
             msg['To'] = ', '.join(message['payload']['to'])
-            msg['Subject'] = message['payload']['subject'].encode('utf-8')
+            if PY2:
+                msg['Subject'] = message['payload']['subject'].encode('utf-8')
+            else:
+                msg['Subject'] = message['payload']['subject']
 
             try:
                 smtp = smtplib.SMTP()


### PR DESCRIPTION
Skip the encoding of the subject for python3.

