### PR TITLE
api & client: set config value via request body. Closes #3283

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,6 +49,7 @@ Individual contributors to the source code
 - Rob Barnsley <R.Barnsley@skatelescope.org>, 2020
 - Alan Malta Rodrigues <alan.malta@cern.ch>, 2020
 - Ian Johnson, <ian.johnson@stfc.ac.uk>, 2021
+- Radu Carpa <radu.carpa@cern.ch>, 2021
 
 Organisations employing contributors
 ------------------------------------

--- a/lib/rucio/client/configclient.py
+++ b/lib/rucio/client/configclient.py
@@ -20,10 +20,12 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 
 from requests.status_codes import codes
+from json import dumps
 
 try:
     from exceptions import ValueError
@@ -71,19 +73,34 @@ class ConfigClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def set_config_option(self, section, option, value):
+    def set_config_option(self, section, option, value, use_body_for_value=True):
         """
         Sends the request to create or set an option within a section. Missing sections will be created.
 
         :param section: the name of the section.
         :param option: the name of the option.
+        :param value: the value to set on the config option
+        :param use_body_for_value: send value in a json-encoded request body instead of url-encoded
+        TODO: remove this parameter
+        The format of the /config endpoint was recently changed. We migrated from setting values
+        inside the request path ("/config/<section>/<option>/<value>") to sending the value using a json-
+        encoded body. This was done to fix multiple un-wanted side effects related to how the middleware
+        treats values encoded in a path.
+        For a smooth transition, we allow both cases for now, but we should migrate to only passing
+        values via the request body.
         :return: True if option was removed successfully. False otherwise.
         """
 
-        path = '/'.join([self.CONFIG_BASEURL, section, option, value])
-        url = build_url(choice(self.list_hosts), path=path)
+        data = None
+        if use_body_for_value:
+            data = dumps({'value': value})
+            path = '/'.join([self.CONFIG_BASEURL, section, option])
+            url = build_url(choice(self.list_hosts), path=path)
+        else:
+            path = '/'.join([self.CONFIG_BASEURL, section, option, value])
+            url = build_url(choice(self.list_hosts), path=path)
 
-        r = self._send_request(url, type='PUT')
+        r = self._send_request(url, type='PUT', data=data)
         if r.status_code == codes.created:
             return True
         else:

--- a/lib/rucio/web/rest/webpy/v1/main.py
+++ b/lib/rucio/web/rest/webpy/v1/main.py
@@ -30,7 +30,7 @@ from rucio.web.rest.account import (Attributes as AAttributes, Scopes as AScopes
                                     AAccount)  # NOQA: F401
 from rucio.web.rest.account_limit import LocalAccountLimit as ALLocalAccountLimit, GlobalAccountLimit as ALGlobalAccountLimit  # NOQA: F401
 from rucio.web.rest.archive import Archive as AVArchive  # NOQA: F401
-from rucio.web.rest.config import OptionSet as COptionSet, OptionGetDel as COptionGetDel, Section as CSection, Config as CConfig  # NOQA: F401
+from rucio.web.rest.config import OptionSetByPath as COptionSetByPath, Option as COption, Section as CSection, Config as CConfig  # NOQA: F401
 from rucio.web.rest.did import (Scope as DScope, GUIDLookup as DGUIDLookup, Search as DSearch, Files as DFiles,  # NOQA: F401
                                     AttachmentHistory as DAttachmentHistory, Attachment as DAttachment,  # NOQA: F401
                                     Meta as DMeta, DIDs as DDIDs, Rules as DRules, Parents as DParents,  # NOQA: F401
@@ -98,8 +98,8 @@ URLS += [
 URLS += insert_scope_name(('/archives%s/files', 'AVArchive'))
 
 URLS += [
-    '/config/(.+)/(.+)/(.*)', 'COptionSet',
-    '/config/(.+)/(.+)', 'COptionGetDel',
+    '/config/(.+)/(.+)/(.*)', 'COptionSetByPath',
+    '/config/(.+)/(.+)', 'COption',
     '/config/(.+)', 'CSection',
     '/config', 'CConfig'
 ]


### PR DESCRIPTION
Before this patch, the config values where passed to the
api endpoint via the url. This resulted in some undesired
behaviors. For example, as stated by the linked issue,
the value '.' was interpreted by the web server and never
passed to rucio logic. Other edge cases where also
possible. For example setting the following values:
'../../', 'a?x=y' would not work correctly.

A possible solution would be to percent-encode special
chars, but we already have other api endpoints with
similar behavior which take the input value via a json
attribute. As a result, we decided to use the same
convention here, even if it changes the endpoint format.

To maintain compatibility with existing clients, we support
both formats for the time being.

Rename the handler classes to better represent their
current behavior: OptionGetDel now handles everything
related to an option, including set. So rename it
to 'Option'.

Maintain compatibility in the ConfigClient class to
use it in tests and check non-regression on the deprecated
endpoint.