### PR TITLE
api & client: set config value via request body. Closes #3283

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,6 +49,7 @@ Individual contributors to the source code
 - Rob Barnsley <R.Barnsley@skatelescope.org>, 2020
 - Alan Malta Rodrigues <alan.malta@cern.ch>, 2020
 - Ian Johnson, <ian.johnson@stfc.ac.uk>, 2021
+- Radu Carpa <radu.carpa@cern.ch>, 2021
 
 Organisations employing contributors
 ------------------------------------

--- a/lib/rucio/tests/test_config.py
+++ b/lib/rucio/tests/test_config.py
@@ -130,3 +130,31 @@ class TestConfigClients(unittest.TestCase):
 
         with pytest.raises(exception.ConfigNotFound):
             self.c.get_config(self.test_section_1, 'no_option')
+
+    def test_set_and_get_config_value_special_strings(self):
+        for test_option_description, option_value in [
+            ('dot', '.'),
+            ('slash', '/'),
+            ('aPath', 'a/b/c/../'),
+            ('percentEncodedSpecialChar', '%2E'),
+            ('urlParameters', 'a?x=y'),
+        ]:
+            self.c.set_config_option(self.test_section_1, test_option_description, option_value)
+            retrieved_value = self.c.get_config(self.test_section_1, test_option_description)
+            assert retrieved_value == option_value
+
+    def test_set_config_option_via_deprecated_url(self):
+        """
+        The format of the /config endpoint was recently changed, but we still support the old
+        format for API calls for the transition period.
+        TODO: remove this test
+        """
+        self.c.set_config_option(self.test_section_1, self.test_option_s + 'ViaUrl', self.test_option_sv, use_body_for_params=False)
+        self.c.set_config_option(self.test_section_1, self.test_option_b + 'ViaUrl', self.test_option_bv, use_body_for_params=False)
+        self.c.set_config_option(self.test_section_2, self.test_option_i + 'ViaUrl', self.test_option_iv, use_body_for_params=False)
+        self.c.set_config_option(self.test_section_2, self.test_option_f + 'ViaUrl', self.test_option_fv, use_body_for_params=False)
+        tmp = self.c.get_config(None, None)
+        assert self.test_option_s + 'ViaUrl' in tmp[self.test_section_1]
+        assert self.test_option_b + 'ViaUrl' in tmp[self.test_section_1]
+        assert self.test_option_i + 'ViaUrl' in tmp[self.test_section_2]
+        assert self.test_option_f + 'ViaUrl' in tmp[self.test_section_2]

--- a/lib/rucio/web/rest/flaskapi/v1/config.py
+++ b/lib/rucio/web/rest/flaskapi/v1/config.py
@@ -142,6 +142,7 @@ class OptionGetDel(MethodView):
         """
         try:
             config.remove_option(section=section, option=option, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+            return 'OK', 200
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:

--- a/lib/rucio/web/rest/flaskapi/v1/config.py
+++ b/lib/rucio/web/rest/flaskapi/v1/config.py
@@ -22,8 +22,10 @@
 # - Muhammad Aditya Hilmy <didithilmy@gmail.com>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 import logging
+from json import loads
 
 from flask import Flask, Blueprint, request as request, jsonify
 from flask.views import MethodView
@@ -32,6 +34,19 @@ from rucio.api import config
 from rucio.common.exception import ConfigurationError, RucioException, AccessDenied, ConfigNotFound
 from rucio.web.rest.flaskapi.v1.common import request_auth_env, response_headers, check_accept_header_wrapper_flask
 from rucio.web.rest.utils import generate_http_error_flask
+
+
+def _config_items_from_input(input_data):
+    """
+    extract section, option, value from a dict with format {section: {option: value}}.
+    """
+    try:
+        for section, section_config in input_data.items():
+            for option, value in section_config.items():
+                return section, option, value
+    except ValueError:
+        return None, None, None
+    return None, None, None
 
 
 class Config(MethodView):
@@ -58,6 +73,39 @@ class Config(MethodView):
                     res[section][item[0]] = item[1]
 
             return jsonify(res)
+        except RucioException as error:
+            return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
+        except Exception as error:
+            logging.exception("Internal Error")
+            return str(error), 500
+
+    def post(self):
+        """
+        Create or set the configuration option in the requested section.
+        The request body is expected to contain a json {"section": {"option": "value"}}.
+
+        .. :quickref: Config; set config value
+
+        :status 201: Option successfully created or updated.
+        :status 400: The input data is invalid or incomplete.
+        :status 401: Invalid Auth Token.
+        :status 500: Configuration Error.
+        """
+        json_data = request.data.decode()
+        try:
+            input_data = loads(json_data)
+        except ValueError:
+            return generate_http_error_flask(400, 'ValueError', 'Cannot decode json parameter dictionary')
+
+        section, option, value = _config_items_from_input(input_data)
+        if section is None or option is None or value is None:
+            return generate_http_error_flask(400, 'ValueError', 'Invalid input')
+
+        try:
+            config.set(section=section, option=option, value=value, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+            return 'Created', 201
+        except ConfigurationError:
+            return generate_http_error_flask(500, 'ConfigurationError', 'Could not set value \'%s\' for section \'%s\' option \'%s\'' % (value, section, option))
         except RucioException as error:
             return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
         except Exception as error:
@@ -157,6 +205,7 @@ class OptionSet(MethodView):
         """
         Set the value of an option.
         If the option does not exist, create it.
+        TODO: remove this endpoint after migrating all clients to pass input data via a json body
 
         .. :quickref: OptionSet; set config value.
 
@@ -186,7 +235,7 @@ def blueprint():
     section_view = Section.as_view('section')
     bp.add_url_rule('/<section>', view_func=section_view, methods=['get', ])
     config_view = Config.as_view('config')
-    bp.add_url_rule('', view_func=config_view, methods=['get', ])
+    bp.add_url_rule('', view_func=config_view, methods=['get', 'post'])
 
     bp.before_request(request_auth_env)
     bp.after_request(response_headers)


### PR DESCRIPTION
Before this patch, the config values where passed to the api endpoint
via the url. This resulted in some undesired behaviors. For example, as
stated by the linked issue, the value '.' was interpreted by the web
server and never passed to rucio logic. Other edge cases where also
possible. For example setting the following values: '../../', 'a?x=y'
would not work correctly.

Introduce a new POST /config endpoint which accepts json of format
{"section": {"option": "value"}}.
To maintain compatibility with existing clients, we support the old
endpoint for the time being.

Maintain compatibility in the ConfigClient class to use it in tests and 
check non-regression on the deprecated endpoint.