### PR TITLE
Update cli_admin_examples.rst

### DIFF
--- a/doc/source/cli_admin_examples.rst
+++ b/doc/source/cli_admin_examples.rst
@@ -91,7 +91,10 @@ To create a new RSE::
 To add a RSE attribute::
 
   $ rucio-admin rse set-attribute --rse SITE2_SCRATCH --key country --value xyz
-  $ rse get-attribute SITE2_SCRATCH
+
+To check an RSE attribute::
+
+  $ rucio-admin rse get-attribute SITE2_SCRATCH
   country: xyz
 
 


### PR DESCRIPTION
Documentation: CLI-admin example modification #4315 
------------------

Minor bug on documentation. The command `rucio-admin` was missing in the example.