### PR TITLE
Clients: Improve general error logging; #4220

### DIFF
--- a/lib/rucio/tests/test_multi_vo.py
+++ b/lib/rucio/tests/test_multi_vo.py
@@ -1000,7 +1000,7 @@ class TestMultiVOBinRucio(unittest.TestCase):
         exitcode, out, err = execute(cmd)
         print(out, err)
         assert len(out) == 0
-        assert 'Cannot retrieve authentication token!' in err
+        assert 'Details: CannotAuthenticate' in err
 
         cmd = 'rucio-admin rse list'
         print(self.marker + cmd)
@@ -1030,7 +1030,7 @@ class TestMultiVOBinRucio(unittest.TestCase):
         exitcode, out, err = execute(cmd)
         print(out, err)
         assert len(out) == 0
-        assert 'Cannot retrieve authentication token!' in err
+        assert 'Details: CannotAuthenticate' in err
 
         cmd = 'rucio list-rses'
         print(self.marker + cmd)


### PR DESCRIPTION
Use body data before response headers.
Fixes handling of responses where body could not be parsed for whatever reasons.
Error headers continued to exist and will be used as a fallback here.

Fixes occurrences like `Details: no error information passed (http status code: 500 ('internal_server_error', 'server_error', '/o\\\\', '\u2717'))`