### PR TITLE
Clients: re-download existing files if checksum is wrong. Fixes #4323

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -41,6 +41,7 @@
 # - Jason Nielsen <jnielsen@ucsc.edu>, 2020
 # - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -2113,7 +2114,7 @@ You can filter by key/value, e.g.::
         selected_parser.add_argument('--protocol', action='store', help='Force the protocol to use.')
         selected_parser.add_argument('--nrandom', type=int, action='store', help='Download N random files from the DID.')
         selected_parser.add_argument('--ndownloader', type=int, default=3, action='store', help='Choose the number of parallel processes for download.')
-        selected_parser.add_argument('--no-subdir', action='store_true', default=False, help="Don't create a subdirectory for the scope of the files. Existing files in the directory will be overwritten.")
+        selected_parser.add_argument('--no-subdir', action='store_true', default=False, help="Don't create a subdirectory for the scope of the files.")
         selected_parser.add_argument('--pfn', dest='pfn', action='store', help="Specify the exact PFN for the download.")
         selected_parser.add_argument('--archive-did', action='store', dest='archive_did', help="Download from archive is transparent. This option is obsolete.")
         selected_parser.add_argument('--no-resolve-archives', action='store_true', default=False, help="If set archives will not be considered for download.")


### PR DESCRIPTION
Also update the "no-subdir" option documentation.

In the past, rucio was changing its behavior of overwriting existing
files depending on the 'no-subdir' option. If this option was set,
local files were always overwritten. If the option was not set, the
files were always let intact. This was counter-intuitive and was fixed
in a recent commit as being a bug. Leaving an incorrect documentation.

The discussion in the linked issue suggested that it will be the most
intuitive to check the checksum of existing files. If their checksum
is correct: leave them intact, but overwrite files in case of a
miss-match.
