### PR TITLE
Core & Api & Clients: Possibility to inject rules delayed. Closes #2639

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -1192,7 +1192,8 @@ def add_rule(args):
                                                activity=args.activity,
                                                comment=args.comment,
                                                ask_approval=args.ask_approval,
-                                               asynchronous=args.asynchronous)
+                                               asynchronous=args.asynchronous,
+                                               delay_injection=args.delay_injection)
     except DuplicateRule as error:
         if args.ignore_duplicate:
             for did in dids:
@@ -1210,7 +1211,8 @@ def add_rule(args):
                                                           activity=args.activity,
                                                           comment=args.comment,
                                                           ask_approval=args.ask_approval,
-                                                          asynchronous=args.asynchronous)
+                                                          asynchronous=args.asynchronous,
+                                                          delay_injection=args.delay_injection)
                     rule_ids.extend(rule_id)
                 except DuplicateRule:
                     print('Duplicate rule for %s:%s found; Skipping.' % (did['scope'], did['name']))
@@ -2185,6 +2187,7 @@ You can filter by key/value, e.g.::
     add_rule_parser.add_argument('--comment', dest='comment', action='store', help='Comment about the replication rule')
     add_rule_parser.add_argument('--ask-approval', dest='ask_approval', action='store_true', help='Ask for rule approval')
     add_rule_parser.add_argument('--asynchronous', dest='asynchronous', action='store_true', help='Create rule asynchronously')
+    add_rule_parser.add_argument('--delay-injection', dest='delay_injection', action='store', type=int, help='Delay (in seconds) to wait before starting applying the rule. This option implies --asynchronous.')
     add_rule_parser.add_argument('--account', dest='rule_account', action='store', help='The account owning the rule')
     add_rule_parser.add_argument('--skip-duplicates', dest='ignore_duplicate', action='store_true', help='Skip duplicate rules')
 

--- a/lib/rucio/api/rule.py
+++ b/lib/rucio/api/rule.py
@@ -13,17 +13,18 @@
   - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
   - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
   - Ian Johnson, <ian.johnson@stfc.ac.uk>, 2021
+  - Radu Carpa <radu.carpa@cern.ch>, 2021
 
   PY3K COMPATIBLE
 '''
 
 from rucio.api.permission import has_permission
+from rucio.common.config import config_get_bool
 from rucio.common.exception import AccessDenied
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import api_update_return_dict
 from rucio.core import rule
-from rucio.common.config import config_get_bool
 
 
 def is_multi_vo():
@@ -35,8 +36,8 @@ def is_multi_vo():
 
 
 def add_replication_rule(dids, copies, rse_expression, weight, lifetime, grouping, account, locked, subscription_id, source_replica_expression,
-                         activity, notify, purge_replicas, ignore_availability, comment, ask_approval, asynchronous, priority, split_container,
-                         meta, issuer, vo='def'):
+                         activity, notify, purge_replicas, ignore_availability, comment, ask_approval, asynchronous, delay_injection, priority,
+                         split_container, meta, issuer, vo='def'):
     """
     Adds a replication rule.
 
@@ -76,8 +77,8 @@ def add_replication_rule(dids, copies, rse_expression, weight, lifetime, groupin
               'grouping': grouping, 'account': account, 'locked': locked, 'subscription_id': subscription_id,
               'source_replica_expression': source_replica_expression, 'notify': notify, 'activity': activity,
               'purge_replicas': purge_replicas, 'ignore_availability': ignore_availability, 'comment': comment,
-              'ask_approval': ask_approval, 'asynchronous': asynchronous, 'priority': priority, 'split_container': split_container,
-              'meta': meta}
+              'ask_approval': ask_approval, 'asynchronous': asynchronous, 'delay_injection': delay_injection, 'priority': priority,
+              'split_container': split_container, 'meta': meta}
 
     validate_schema(name='rule', obj=kwargs, vo=vo)
 
@@ -105,6 +106,7 @@ def add_replication_rule(dids, copies, rse_expression, weight, lifetime, groupin
                          comment=comment,
                          ask_approval=ask_approval,
                          asynchronous=asynchronous,
+                         delay_injection=delay_injection,
                          priority=priority,
                          split_container=split_container,
                          meta=meta)

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -19,6 +19,7 @@
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
 # - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 
@@ -46,8 +47,8 @@ class RuleClient(BaseClient):
 
     def add_replication_rule(self, dids, copies, rse_expression, weight=None, lifetime=None, grouping='DATASET', account=None,
                              locked=False, source_replica_expression=None, activity=None, notify='N', purge_replicas=False,
-                             ignore_availability=False, comment=None, ask_approval=False, asynchronous=False, priority=3,
-                             meta=None):
+                             ignore_availability=False, comment=None, ask_approval=False, asynchronous=False, delay_injection=None,
+                             priority=3, meta=None):
         """
         :param dids:                       The data identifier set.
         :param copies:                     The number of replicas.
@@ -78,7 +79,7 @@ class RuleClient(BaseClient):
                       'account': account, 'locked': locked, 'source_replica_expression': source_replica_expression,
                       'activity': activity, 'notify': notify, 'purge_replicas': purge_replicas,
                       'ignore_availability': ignore_availability, 'comment': comment, 'ask_approval': ask_approval,
-                      'asynchronous': asynchronous, 'priority': priority, 'meta': meta})
+                      'asynchronous': asynchronous, 'delay_injection': delay_injection, 'priority': priority, 'meta': meta})
         r = self._send_request(url, type='POST', data=data)
         if r.status_code == codes.created:
             return loads(r.text)

--- a/lib/rucio/common/schema/atlas.py
+++ b/lib/rucio/common/schema/atlas.py
@@ -17,13 +17,13 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 
 from jsonschema import validate, ValidationError
 
 from rucio.common.exception import InvalidObject
-
 
 ACCOUNT_LENGTH = 25
 
@@ -81,6 +81,9 @@ ASK_APPROVAL = {"description": "Rule approval request",
 
 ASYNCHRONOUS = {"description": "Asynchronous rule creation",
                 "type": ["boolean", "null"]}
+
+DELAY_INJECTION = {"description": "Time (in seconds) to wait before starting applying the rule. Implies asynchronous rule creation.",
+                   "type": ["integer", "null"]}
 
 PURGE_REPLICAS = {"description": "Rule purge replica status",
                   "type": "boolean"}
@@ -190,6 +193,7 @@ RULE = {"description": "Replication rule",
                        "comment": COMMENT,
                        "ask_approval": ASK_APPROVAL,
                        "asynchronous": ASYNCHRONOUS,
+                       "delay_injection": DELAY_INJECTION,
                        "priority": PRIORITY,
                        'split_container': SPLIT_CONTAINER,
                        'meta': METADATA},

--- a/lib/rucio/common/schema/belleii.py
+++ b/lib/rucio/common/schema/belleii.py
@@ -18,13 +18,13 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 
 from jsonschema import validate, ValidationError
 
 from rucio.common.exception import InvalidObject
-
 
 ACCOUNT_LENGTH = 25
 
@@ -80,6 +80,9 @@ ASK_APPROVAL = {"description": "Rule approval request",
 
 ASYNCHRONOUS = {"description": "Asynchronous rule creation",
                 "type": ["boolean", "null"]}
+
+DELAY_INJECTION = {"description": "Time (in seconds) to wait before starting applying the rule. Implies asynchronous rule creation.",
+                   "type": ["integer", "null"]}
 
 PURGE_REPLICAS = {"description": "Rule purge replica status",
                   "type": "boolean"}
@@ -189,6 +192,7 @@ RULE = {"description": "Replication rule",
                        "comment": COMMENT,
                        "ask_approval": ASK_APPROVAL,
                        "asynchronous": ASYNCHRONOUS,
+                       "delay_injection": DELAY_INJECTION,
                        "priority": PRIORITY,
                        'split_container': SPLIT_CONTAINER,
                        'meta': METADATA},

--- a/lib/rucio/common/schema/cms.py
+++ b/lib/rucio/common/schema/cms.py
@@ -22,13 +22,13 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 
 from jsonschema import validate, ValidationError
 
 from rucio.common.exception import InvalidObject
-
 
 ACCOUNT_LENGTH = 25
 
@@ -93,6 +93,9 @@ ASK_APPROVAL = {"description": "Rule approval request",
 
 ASYNCHRONOUS = {"description": "Asynchronous rule creation",
                 "type": ["boolean", "null"]}
+
+DELAY_INJECTION = {"description": "Time (in seconds) to wait before starting applying the rule. Implies asynchronous rule creation.",
+                   "type": ["integer", "null"]}
 
 PURGE_REPLICAS = {"description": "Rule purge replica status",
                   "type": "boolean"}
@@ -202,6 +205,7 @@ RULE = {"description": "Replication rule",
                        "comment": COMMENT,
                        "ask_approval": ASK_APPROVAL,
                        "asynchronous": ASYNCHRONOUS,
+                       "delay_injection": DELAY_INJECTION,
                        "priority": PRIORITY,
                        'split_container': SPLIT_CONTAINER,
                        'meta': METADATA},

--- a/lib/rucio/common/schema/domatpc.py
+++ b/lib/rucio/common/schema/domatpc.py
@@ -17,13 +17,13 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 
 from jsonschema import validate, ValidationError
 
 from rucio.common.exception import InvalidObject
-
 
 ACCOUNT_LENGTH = 25
 
@@ -74,6 +74,9 @@ ASK_APPROVAL = {"description": "Rule approval request",
 
 ASYNCHRONOUS = {"description": "Asynchronous rule creation",
                 "type": ["boolean", "null"]}
+
+DELAY_INJECTION = {"description": "Time (in seconds) to wait before starting applying the rule. Implies asynchronous rule creation.",
+                   "type": ["integer", "null"]}
 
 PURGE_REPLICAS = {"description": "Rule purge replica status",
                   "type": "boolean"}
@@ -183,6 +186,7 @@ RULE = {"description": "Replication rule",
                        "comment": COMMENT,
                        "ask_approval": ASK_APPROVAL,
                        "asynchronous": ASYNCHRONOUS,
+                       "delay_injection": DELAY_INJECTION,
                        "priority": PRIORITY,
                        'split_container': SPLIT_CONTAINER,
                        'meta': METADATA},

--- a/lib/rucio/common/schema/generic.py
+++ b/lib/rucio/common/schema/generic.py
@@ -20,13 +20,13 @@
 # - Jaroslav Guenther <jaroslav.guenther@gmail.com>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 
 from jsonschema import validate, ValidationError
 
 from rucio.common.exception import InvalidObject
-
 
 ACCOUNT_LENGTH = 25
 
@@ -82,6 +82,9 @@ ASK_APPROVAL = {"description": "Rule approval request",
 
 ASYNCHRONOUS = {"description": "Asynchronous rule creation",
                 "type": ["boolean", "null"]}
+
+DELAY_INJECTION = {"description": "Time (in seconds) to wait before starting applying the rule. Implies asynchronous rule creation.",
+                   "type": ["integer", "null"]}
 
 PURGE_REPLICAS = {"description": "Rule purge replica status",
                   "type": "boolean"}
@@ -191,6 +194,7 @@ RULE = {"description": "Replication rule",
                        "comment": COMMENT,
                        "ask_approval": ASK_APPROVAL,
                        "asynchronous": ASYNCHRONOUS,
+                       "delay_injection": DELAY_INJECTION,
                        "priority": PRIORITY,
                        'split_container': SPLIT_CONTAINER,
                        'meta': METADATA},

--- a/lib/rucio/common/schema/generic_multi_vo.py
+++ b/lib/rucio/common/schema/generic_multi_vo.py
@@ -20,6 +20,7 @@
 # - Jaroslav Guenther <jaroslav.guenther@gmail.com>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 
@@ -32,6 +33,7 @@ ACCOUNT_LENGTH = 29
 ACCOUNT = {"description": "Account name",
            "type": "string",
            "pattern": "^[a-z0-9-_]{1,%s}$" % (ACCOUNT_LENGTH - 4)}
+
 
 ACCOUNTS = {"description": "Array of accounts",
             "type": "array",
@@ -81,6 +83,9 @@ ASK_APPROVAL = {"description": "Rule approval request",
 
 ASYNCHRONOUS = {"description": "Asynchronous rule creation",
                 "type": ["boolean", "null"]}
+
+DELAY_INJECTION = {"description": "Time (in seconds) to wait before starting applying the rule. Implies asynchronous rule creation.",
+                   "type": ["integer", "null"]}
 
 PURGE_REPLICAS = {"description": "Rule purge replica status",
                   "type": "boolean"}
@@ -190,6 +195,7 @@ RULE = {"description": "Replication rule",
                        "comment": COMMENT,
                        "ask_approval": ASK_APPROVAL,
                        "asynchronous": ASYNCHRONOUS,
+                       "delay_injection": DELAY_INJECTION,
                        "priority": PRIORITY,
                        'split_container': SPLIT_CONTAINER,
                        'meta': METADATA},

--- a/lib/rucio/common/schema/icecube.py
+++ b/lib/rucio/common/schema/icecube.py
@@ -19,13 +19,13 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 
 from jsonschema import validate, ValidationError
 
 from rucio.common.exception import InvalidObject
-
 
 ACCOUNT_LENGTH = 25
 
@@ -81,6 +81,9 @@ ASK_APPROVAL = {"description": "Rule approval request",
 
 ASYNCHRONOUS = {"description": "Asynchronous rule creation",
                 "type": ["boolean", "null"]}
+
+DELAY_INJECTION = {"description": "Time (in seconds) to wait before starting applying the rule. Implies asynchronous rule creation.",
+                   "type": ["integer", "null"]}
 
 PURGE_REPLICAS = {"description": "Rule purge replica status",
                   "type": "boolean"}
@@ -190,6 +193,7 @@ RULE = {"description": "Replication rule",
                        "comment": COMMENT,
                        "ask_approval": ASK_APPROVAL,
                        "asynchronous": ASYNCHRONOUS,
+                       "delay_injection": DELAY_INJECTION,
                        "priority": PRIORITY,
                        'split_container': SPLIT_CONTAINER,
                        'meta': METADATA},

--- a/lib/rucio/tests/test_api_external_representation.py
+++ b/lib/rucio/tests/test_api_external_representation.py
@@ -24,6 +24,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 
@@ -420,7 +421,7 @@ class TestApiExternalRepresentation(unittest.TestCase):
                              lifetime=180, grouping='DATASET', account=new_acc_name, locked=False, subscription_id=sub_id,
                              source_replica_expression=self.rse4_name, activity='User Subscriptions', notify=None,
                              purge_replicas=False, ignore_availability=False, comment='', ask_approval=False, asynchronous=False,
-                             priority=0, split_container=False, meta='', issuer='root', **self.new_vo)
+                             delay_injection=None, priority=0, split_container=False, meta='', issuer='root', **self.new_vo)
 
         out = list_subscriptions(sub, **self.new_vo)
         out = list(out)

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -30,12 +30,14 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Tomas Javurek <tomas.javurek@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
 import os
 import re
 import unittest
+from datetime import datetime, timedelta
 from os import remove, unlink, listdir, rmdir, stat, path, environ
 
 import pytest
@@ -919,13 +921,61 @@ class TestBinRucio(unittest.TestCase):
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out)
+        assert not err
         rule = out[:-1]  # triming new line character
+        assert re.match(r'^\w+$', rule)
         # check if rule exist for the file
         cmd = "rucio list-rules {0}:{1}".format(self.user, tmp_file1[5:])
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
         assert re.search(rule, out) is not None
+
+    def test_create_rule_delayed(self):
+        """CLIENT(USER): Rucio add rule delayed"""
+        tmp_file1 = file_generator()
+        # add files
+        cmd = 'rucio upload --rse {0} --scope {1} {2}'.format(self.def_rse, self.user, tmp_file1)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add rse
+        tmp_rse = rse_name_generator()
+        cmd = 'rucio-admin rse add {0}'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add quota
+        self.account_client.set_local_account_limit('root', tmp_rse, -1)
+        # add rse atributes
+        cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASRULEDELAYED'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # try adding rule with an incorrect delay-injection. Must fail
+        cmd = "rucio add-rule --delay-injection asdsaf {0}:{1} 1 'spacetoken=ATLASRULEDELAYED'".format(self.user, tmp_file1[5:])
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        assert err
+        # Add a correct rule
+        cmd = "rucio add-rule --delay-injection 3600 {0}:{1} 1 'spacetoken=ATLASRULEDELAYED'".format(self.user, tmp_file1[5:])
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        assert not err
+        rule = out[:-1]  # triming new line character
+        cmd = "rucio rule-info {0}".format(rule)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        out_lines = out.splitlines()
+        assert any(re.match(r'State:.* INJECT', line) for line in out_lines)
+        assert any(re.match(r'Locks OK/REPLICATING/STUCK:.* 0/0/0', line) for line in out_lines)
+        # Check that "Created at" is approximately 3600 seconds in the future
+        [created_at_line] = filter(lambda x: "Created at" in x, out_lines)
+        created_at = re.search(r'Created at:\s+(\d.*\d)$', created_at_line).group(1)
+        created_at = datetime.strptime(created_at, "%Y-%m-%d %H:%M:%S")
+        assert datetime.utcnow() + timedelta(seconds=3550) < created_at < datetime.utcnow() + timedelta(seconds=3650)
 
     def test_delete_rule(self):
         """CLIENT(USER): rule deletion"""

--- a/lib/rucio/tests/test_judge_injector.py
+++ b/lib/rucio/tests/test_judge_injector.py
@@ -22,8 +22,10 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 import unittest
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -38,6 +40,8 @@ from rucio.core.rse import add_rse_attribute, get_rse_id
 from rucio.core.rule import add_rule, get_rule, approve_rule, deny_rule, list_rules
 from rucio.daemons.judge.injector import rule_injector
 from rucio.db.sqla.constants import DIDType, RuleState
+from rucio.db.sqla.models import ReplicationRule
+from rucio.db.sqla.session import transactional_session
 from rucio.tests.test_rule import create_files, tag_generator
 
 
@@ -107,6 +111,39 @@ class TestJudgeEvaluator(unittest.TestCase):
         for file in files:
             assert(len(get_replica_locks(scope=file['scope'], name=file['name'])) == 2)
         assert(get_rule(rule_id)['state'] == RuleState.REPLICATING)
+
+    def test_judge_inject_delayed_rule(self):
+        """ JUDGE INJECTOR: Test the judge when injecting a delayed rule"""
+        scope = InternalScope('mock', **self.vo)
+        files = create_files(1, scope, self.rse1_id)
+        dataset = 'dataset_' + str(uuid())
+        add_did(scope, dataset, DIDType.DATASET, self.jdoe)
+        attach_dids(scope, dataset, files, self.jdoe)
+        [file] = files
+
+        # Add a delayed rule
+        rule_id = add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=2, rse_expression=self.T1, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None, delay_injection=3600)[0]
+
+        rule = get_rule(rule_id)
+        assert rule['state'] == RuleState.INJECT
+        assert rule['updated_at'] < rule['created_at']
+        assert datetime.utcnow() + timedelta(seconds=3550) < rule['created_at'] < datetime.utcnow() + timedelta(seconds=3650)
+
+        # The time to create the rule has not yet arrived. The injector must skip this rule, no locks must be created
+        rule_injector(once=True)
+        assert get_rule(rule_id)['state'] == RuleState.INJECT
+        assert not get_replica_locks(scope=file['scope'], name=file['name'])
+
+        # simulate that time to inject the rule has arrived
+        @transactional_session
+        def __update_created_at(session=None):
+            session.query(ReplicationRule).filter_by(id=rule_id).one().created_at = datetime.utcnow()
+        __update_created_at()
+
+        # The injector must create the locks now
+        rule_injector(once=True)
+        assert get_rule(rule_id)['state'] == RuleState.REPLICATING
+        assert len(get_replica_locks(scope=file['scope'], name=file['name'])) == 2
 
     def test_judge_ask_approval(self):
         """ JUDGE INJECTOR: Test the judge when asking approval for a rule"""

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -26,6 +26,7 @@
 # - Muhammad Aditya Hilmy <didithilmy@gmail.com>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from json import dumps
 
@@ -207,6 +208,7 @@ class AllRule(ErrorHandlingMethodView):
                 comment=param_get(parameters, 'comment', default=None),
                 ask_approval=param_get(parameters, 'ask_approval', default=False),
                 asynchronous=param_get(parameters, 'asynchronous', default=False),
+                delay_injection=param_get(parameters, 'delay_injection', default=None),
                 priority=param_get(parameters, 'priority', default=3),
                 split_container=param_get(parameters, 'split_container', default=False),
                 meta=param_get(parameters, 'meta', default=None),

--- a/lib/rucio/web/rest/webpy/v1/rule.py
+++ b/lib/rucio/web/rest/webpy/v1/rule.py
@@ -26,6 +26,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -224,9 +225,9 @@ class AllRule:
         json_data = data()
         try:
             grouping, weight, lifetime, locked, subscription_id, source_replica_expression, activity, notify,\
-                purge_replicas, ignore_availability, comment, ask_approval, asynchronous, priority,\
+                purge_replicas, ignore_availability, comment, ask_approval, asynchronous, delay_injection, priority,\
                 split_container, meta = 'DATASET', None, None, False, None, None, None, None, False, False, None,\
-                False, False, 3, False, None
+                False, False, None, 3, False, None
 
             params = loads(json_data)
             dids = params['dids']
@@ -259,6 +260,8 @@ class AllRule:
                 ask_approval = params['ask_approval']
             if 'asynchronous' in params:
                 asynchronous = params['asynchronous']
+            if 'delay_injection' in params:
+                delay_injection = params['delay_injection']
             if 'priority' in params:
                 priority = params['priority']
             if 'split_container' in params:
@@ -287,6 +290,7 @@ class AllRule:
                                             comment=comment,
                                             ask_approval=ask_approval,
                                             asynchronous=asynchronous,
+                                            delay_injection=delay_injection,
                                             priority=priority,
                                             split_container=split_container,
                                             meta=meta,


### PR DESCRIPTION
Add a new API option and associated CLI implementation to enable
delayed creation of requests for replication rules.

Rules are inserted with "created_at" set in the future. The injector
is also changed to take into consideration this case. It creates
requests for rules in "INJECT" state only if their created_at time has
arrived.

Also fix the test_create_rule in rucio bin tests. On errors, stdout
was empty, so the search regexp was empty and didn't catch errors.