### PR TITLE
Core: Added importlib for compatibility; Fix #4372

### DIFF
--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -39,10 +39,10 @@ from __future__ import division
 
 import copy
 import datetime
-import imp
 import json
 import logging
 import re
+import sys
 import time
 from typing import TYPE_CHECKING
 
@@ -82,11 +82,21 @@ if TYPE_CHECKING:
 EXTRA_MODULES = {'globus_sdk': False}
 
 for extra_module in EXTRA_MODULES:
-    try:
-        imp.find_module(extra_module)
-        EXTRA_MODULES[extra_module] = True
-    except ImportError:
-        EXTRA_MODULES[extra_module] = False
+    if sys.version_info < (3, 5):
+        try:
+            import imp
+            imp.find_module(extra_module)
+            EXTRA_MODULES[extra_module] = True
+        except ImportError:
+            EXTRA_MODULES[extra_module] = False
+
+    else:
+        try:
+            import importlib
+            importlib.util.find_spec(extra_module)
+            EXTRA_MODULES[extra_module] = True
+        except ModuleNotFoundError:
+            EXTRA_MODULES[extra_module] = False
 
 if EXTRA_MODULES['globus_sdk']:
     from rucio.transfertool.globus import GlobusTransferTool  # pylint: disable=import-error


### PR DESCRIPTION
Core: Added importlib for compatibility; Fix #4372
------------------

Used sys.version_info to determine the version of the interpreter in order to use a suitable package for dynamic importing. 
Bypassed use of importlib.find_loader [https://docs.python.org/3/library/importlib.html#importlib.find_loader](url) to use imp, Since py3.3 and 3.4 are backwards compatible with imp.
