### PR TITLE
Core: don't filter to 'root' for list_replicas on archives. #2961

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -36,6 +36,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eric Vaandering <ewv@fnal.gov>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -834,15 +835,6 @@ def _list_replicas(dataset_clause, file_clause, state_clause, show_pfns,
             # if the file is a constituent, find the available archives and add them to the list of possible PFNs
             # taking into account the original rse_expression
             if '%s:%s' % (scope.internal, name) in constituents:
-
-                # special protocol handling for constituents
-                # force the use of root if client didn't specify
-                if not schemes:
-                    schemes = ['root']
-                else:
-                    # always add root for archives
-                    schemes.append('root')
-                    schemes = list(set(schemes))
 
                 archive_result = list_replicas(dids=constituents['%s:%s' % (scope.internal, name)],
                                                schemes=schemes, client_location=client_location,


### PR DESCRIPTION
Because of the filter, the 'pfn' field is not filled correctly, so the client doesn't
show the replica.

The change was introduced in #2313, resulting in list_replicas being
broken for any RSE which is not 'root'. The reason of the breakage is
that 'schemes' is a filter which means "all protocols" if empty.
Initializing it to ['root'] restricts the search to only this protocol.
This doesn't seem to be the intended goal of the commit introducing the
regression.
Later in the code, the root protocol is already prioritized if it
exists in the returned 'archive_result'.