### PR TITLE
Testing: Reorganize reaper2 tests #1431

### DIFF
--- a/lib/rucio/tests/test_multi_vo.py
+++ b/lib/rucio/tests/test_multi_vo.py
@@ -19,10 +19,10 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 # - Martin Barisits <martin.barisits@cern.ch>, 2020-2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 import os
 import unittest
-from datetime import datetime, timedelta
 from logging import getLogger
 from os import remove
 from random import choice
@@ -42,7 +42,7 @@ from rucio.api.did import add_did, list_dids
 from rucio.api.identity import add_account_identity, list_accounts_for_identity
 from rucio.api.lock import get_replica_locks_for_rule_id
 from rucio.api.replica import list_replicas
-from rucio.api.rse import add_protocol, add_rse, add_rse_attribute, list_rses, set_rse_limits, set_rse_usage
+from rucio.api.rse import add_protocol, add_rse, add_rse_attribute, list_rses
 from rucio.api.rule import delete_replication_rule, get_replication_rule
 from rucio.api.scope import add_scope, list_scopes
 from rucio.api.subscription import add_subscription, list_subscriptions
@@ -66,7 +66,6 @@ from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.rule import add_rule
 from rucio.core.vo import add_vo, vo_exists
 from rucio.daemons.automatix.automatix import automatix
-from rucio.daemons.reaper.reaper2 import run as run_reaper
 from rucio.db.sqla import models, session as db_session
 from rucio.tests.common import execute, headers, hdrdict, vohdr, auth, loginhdr
 from rucio.tests.test_authentication import PRIVATE_KEY, PUBLIC_KEY
@@ -1084,123 +1083,3 @@ class TestMultiVODaemons(unittest.TestCase):
         replicas_new = list(list_replicas(did_dicts, rse_expression=shr_rse, **self.new_vo))
         assert len(replicas_tst) != 0
         assert len(replicas_new) == 0
-
-    def test_reaper(self):
-        """ MULTI VO (DAEMON): Test that reaper runs on the specified VO(s) """
-        rse_str = ''.join(choice(ascii_uppercase) for x in range(10))
-        rse_name = 'SHR_%s' % rse_str
-        rse_id_tst = add_rse(rse_name, 'root', **self.vo)
-        rse_id_new = add_rse(rse_name, 'root', **self.new_vo)
-
-        mock_protocol = {'scheme': 'MOCK',
-                         'hostname': 'localhost',
-                         'port': 123,
-                         'prefix': '/test/reaper',
-                         'impl': 'rucio.rse.protocols.mock.Default',
-                         'domains': {
-                             'lan': {'read': 1,
-                                     'write': 1,
-                                     'delete': 1},
-                             'wan': {'read': 1,
-                                     'write': 1,
-                                     'delete': 1}}}
-        add_protocol(rse=rse_name, data=mock_protocol, issuer='root', **self.vo)
-        add_protocol(rse=rse_name, data=mock_protocol, issuer='root', **self.new_vo)
-
-        scope_uuid = str(generate_uuid()).lower()[:16]
-        scope_name = 'shr_%s' % scope_uuid
-        scope_tst = InternalScope(scope_name, **self.vo)
-        scope_new = InternalScope(scope_name, **self.new_vo)
-        add_scope(scope_name, 'root', 'root', **self.vo)
-        add_scope(scope_name, 'root', 'root', **self.new_vo)
-
-        nb_files = 30
-        file_size = 200  # 2G
-
-        names = []
-        for i in range(nb_files):
-            name = 'lfn%s' % generate_uuid()
-            names.append(name)
-            add_replica(rse_id=rse_id_tst, scope=scope_tst, name=name, bytes=file_size, account=InternalAccount('root', **self.vo),
-                        adler32=None, md5=None, tombstone=datetime.utcnow() - timedelta(days=1))
-            add_replica(rse_id=rse_id_new, scope=scope_new, name=name, bytes=file_size, account=InternalAccount('root', **self.new_vo),
-                        adler32=None, md5=None, tombstone=datetime.utcnow() - timedelta(days=1))
-
-        set_rse_usage(rse=rse_name, source='storage', used=nb_files * file_size, free=1, issuer='root', **self.vo)
-        set_rse_limits(rse=rse_name, name='MinFreeSpace', value=5 * 200, issuer='root', **self.vo)
-        set_rse_limits(rse=rse_name, name='MaxBeingDeletedFiles', value=10, issuer='root', **self.vo)
-
-        set_rse_usage(rse=rse_name, source='storage', used=nb_files * file_size, free=1, issuer='root', **self.new_vo)
-        set_rse_limits(rse=rse_name, name='MinFreeSpace', value=5 * 200, issuer='root', **self.new_vo)
-        set_rse_limits(rse=rse_name, name='MaxBeingDeletedFiles', value=10, issuer='root', **self.new_vo)
-
-        # Check we start of with the expected number of replicas
-        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.vo))) == nb_files
-        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.new_vo))) == nb_files
-
-        # Check we reap all VOs by default
-        from rucio.daemons.reaper.reaper2 import REGION
-        REGION.invalidate()
-        run_reaper(once=True, rses=[rse_name])
-        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.vo))) == 25
-        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.new_vo))) == 25
-
-    def test_reaper_affect_other_vo(self):
-        """ MULTI VO (DAEMON): Test that reaper runs on the specified VO(s) and does not reap others"""
-        rse_str = ''.join(choice(ascii_uppercase) for x in range(10))
-        rse_name = 'SHR_%s' % rse_str
-        rse_id_tst = add_rse(rse_name, 'root', **self.vo)
-        rse_id_new = add_rse(rse_name, 'root', **self.new_vo)
-
-        mock_protocol = {'scheme': 'MOCK',
-                         'hostname': 'localhost',
-                         'port': 123,
-                         'prefix': '/test/reaper',
-                         'impl': 'rucio.rse.protocols.mock.Default',
-                         'domains': {
-                             'lan': {'read': 1,
-                                     'write': 1,
-                                     'delete': 1},
-                             'wan': {'read': 1,
-                                     'write': 1,
-                                     'delete': 1}}}
-        add_protocol(rse=rse_name, data=mock_protocol, issuer='root', **self.vo)
-        add_protocol(rse=rse_name, data=mock_protocol, issuer='root', **self.new_vo)
-
-        scope_uuid = str(generate_uuid()).lower()[:16]
-        scope_name = 'shr_%s' % scope_uuid
-        scope_tst = InternalScope(scope_name, **self.vo)
-        scope_new = InternalScope(scope_name, **self.new_vo)
-        add_scope(scope_name, 'root', 'root', **self.vo)
-        add_scope(scope_name, 'root', 'root', **self.new_vo)
-
-        nb_files = 30
-        file_size = 200  # 2G
-
-        names = []
-        for i in range(nb_files):
-            name = 'lfn%s' % generate_uuid()
-            names.append(name)
-            add_replica(rse_id=rse_id_tst, scope=scope_tst, name=name, bytes=file_size, account=InternalAccount('root', **self.vo),
-                        adler32=None, md5=None, tombstone=datetime.utcnow() - timedelta(days=1))
-            add_replica(rse_id=rse_id_new, scope=scope_new, name=name, bytes=file_size, account=InternalAccount('root', **self.new_vo),
-                        adler32=None, md5=None, tombstone=datetime.utcnow() - timedelta(days=1))
-
-        set_rse_usage(rse=rse_name, source='storage', used=nb_files * file_size, free=1, issuer='root', **self.vo)
-        set_rse_limits(rse=rse_name, name='MinFreeSpace', value=5 * 200, issuer='root', **self.vo)
-        set_rse_limits(rse=rse_name, name='MaxBeingDeletedFiles', value=10, issuer='root', **self.vo)
-
-        set_rse_usage(rse=rse_name, source='storage', used=nb_files * file_size, free=1, issuer='root', **self.new_vo)
-        set_rse_limits(rse=rse_name, name='MinFreeSpace', value=5 * 200, issuer='root', **self.new_vo)
-        set_rse_limits(rse=rse_name, name='MaxBeingDeletedFiles', value=10, issuer='root', **self.new_vo)
-
-        # Check we start of with the expected number of replicas
-        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.vo))) == nb_files
-        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.new_vo))) == nb_files
-
-        # Check we don't affect a second VO that isn't specified
-        from rucio.daemons.reaper.reaper2 import REGION
-        REGION.invalidate()
-        run_reaper(once=True, rses=[rse_name], vos=['new'])
-        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.vo))) == nb_files
-        assert len(list(list_replicas([{'scope': scope_name, 'name': n} for n in names], rse_expression=rse_name, **self.new_vo))) == 25

--- a/lib/rucio/tests/test_reaper2.py
+++ b/lib/rucio/tests/test_reaper2.py
@@ -18,111 +18,109 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from datetime import datetime, timedelta
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core import replica as replica_core
 from rucio.core import rse as rse_core
 from rucio.core import scope as scope_core
 from rucio.core import vo as vo_core
-from rucio.daemons.reaper.reaper2 import reaper
+from rucio.daemons.reaper.reaper2 import reaper, REGION
 from rucio.tests.common import rse_name_generator
 
+__mock_protocol = {'scheme': 'MOCK',
+                   'hostname': 'localhost',
+                   'port': 123,
+                   'prefix': '/test/reaper',
+                   'impl': 'rucio.rse.protocols.mock.Default',
+                   'domains': {
+                       'lan': {'read': 1,
+                               'write': 1,
+                               'delete': 1},
+                       'wan': {'read': 1,
+                               'write': 1,
+                               'delete': 1}}}
 
-@pytest.mark.noparallel(reason='fails when run in parallel')
-def test_reaper():
+
+def __add_test_rse_and_replicas(vo, scope, nb_files, file_size):
+    rse_name = rse_name_generator()
+    rse_id = rse_core.add_rse(rse_name, vo=vo)
+
+    rse_core.add_protocol(rse_id=rse_id, parameter=__mock_protocol)
+
+    dids = []
+    for i in range(nb_files):
+        file_name = 'lfn' + generate_uuid()
+        dids.append({'scope': scope, 'name': file_name})
+        replica_core.add_replica(rse_id=rse_id, scope=scope,
+                                 name=file_name, bytes=file_size,
+                                 tombstone=datetime.utcnow() - timedelta(days=1),
+                                 account=InternalAccount('root', vo=vo), adler32=None, md5=None)
+    return rse_name, rse_id, dids
+
+
+@pytest.mark.noparallel(reason='fails when run in parallel. It resets some memcached values.')
+def test_reaper(vo):
     """ REAPER2 (DAEMON): Test the reaper2 daemon."""
-    if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-        vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
-        new_vo = {'vo': 'new'}
-        if not vo_core.vo_exists(**new_vo):
-            vo_core.add_vo(description='Test', email='rucio@email.com', **new_vo)
-        if not scope_core.check_scope(InternalScope('data13_hip', **new_vo)):
-            scope_core.add_scope(InternalScope('data13_hip', **new_vo), InternalAccount('root', **new_vo))
-        nb_rses = 2
-    else:
-        vo = {}
-        new_vo = {}
-        nb_rses = 1
-
-    mock_protocol = {'scheme': 'MOCK',
-                     'hostname': 'localhost',
-                     'port': 123,
-                     'prefix': '/test/reaper',
-                     'impl': 'rucio.rse.protocols.mock.Default',
-                     'domains': {
-                         'lan': {'read': 1,
-                                 'write': 1,
-                                 'delete': 1},
-                         'wan': {'read': 1,
-                                 'write': 1,
-                                 'delete': 1}}}
+    scope = InternalScope('data13_hip', vo=vo)
 
     nb_files = 250
     file_size = 200  # 2G
+    rse_name, rse_id, dids = __add_test_rse_and_replicas(vo=vo, scope=scope, nb_files=nb_files, file_size=file_size)
 
-    rse_names = []
-    all_file_names = []
-    for j in range(nb_rses):
-        rse_name = rse_name_generator()
-        rse_names.append(rse_name)
-        rse_id = rse_core.add_rse(rse_name, **vo)
-        rse_core.add_protocol(rse_id=rse_id, parameter=mock_protocol)
-        if new_vo:
-            rse_id_new = rse_core.add_rse(rse_name, **new_vo)
-            rse_core.add_protocol(rse_id=rse_id_new, parameter=mock_protocol)
+    rse_core.set_rse_limits(rse_id=rse_id, name='MinFreeSpace', value=50 * file_size)
+    assert len(list(replica_core.list_replicas(dids=dids, rse_expression=rse_name))) == nb_files
 
-        file_names = []
-        for i in range(nb_files):
-            file_name = 'lfn' + generate_uuid()
-            file_names.append(file_name)
-            replica_core.add_replica(rse_id=rse_id, scope=InternalScope('data13_hip', **vo),
-                                     name=file_name, bytes=file_size,
-                                     tombstone=datetime.utcnow() - timedelta(days=1),
-                                     account=InternalAccount('root', **vo), adler32=None, md5=None)
-            if new_vo:
-                replica_core.add_replica(rse_id=rse_id_new, scope=InternalScope('data13_hip', **new_vo),
-                                         name=file_name, bytes=file_size,
-                                         tombstone=datetime.utcnow() - timedelta(days=1),
-                                         account=InternalAccount('root', **new_vo), adler32=None, md5=None)
-
-        all_file_names.append(file_names)
-        rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=1)
-        rse_core.set_rse_limits(rse_id=rse_id, name='MinFreeSpace', value=50 * file_size)
-        # rse_core.set_rse_limits(rse_id=rse_id, name='MaxBeingDeletedFiles', value=10)
-        if new_vo:
-            rse_core.set_rse_usage(rse_id=rse_id_new, source='storage', used=nb_files * file_size, free=1)
-            rse_core.set_rse_limits(rse_id=rse_id_new, name='MinFreeSpace', value=50 * file_size)
-            # rse_core.set_rse_limits(rse_id=rse_id_new, name='MaxBeingDeletedFiles', value=10)
-
-    from rucio.daemons.reaper.reaper2 import REGION
+    # Check first if the reaper does not delete anything if no space is needed
     REGION.invalidate()
-    if not vo:
-        assert len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip', **vo), 'name': n} for n in all_file_names[0]],
-                                                   rse_expression=rse_name))) == nb_files
-        # Check first if the reaper does not delete anything if no space is needed
-        rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=323000000000)
-        reaper(once=True, rses=[], include_rses=rse_names[0], exclude_rses=[])
-        assert len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip', **vo), 'name': n} for n in all_file_names[0]],
-                                                   rse_expression=rse_name))) == nb_files
-        # Now put it over threshold and delete
-        rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=1)
-        from rucio.daemons.reaper.reaper2 import REGION
-        REGION.invalidate()
-        reaper(once=True, rses=[], include_rses=rse_names[0], exclude_rses=[])
-        reaper(once=True, rses=[], include_rses=rse_names[0], exclude_rses=[])
-        assert len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip', **vo), 'name': n} for n in all_file_names[0]],
-                                                   rse_expression=rse_name))) == 200
-    else:
-        # Check we reap all VOs by default
-        reaper(once=True, rses=[], include_rses=rse_names[0], exclude_rses=[])
-        reaper(once=True, rses=[], include_rses=rse_names[0], exclude_rses=[])
-        assert len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip', **vo), 'name': n} for n in all_file_names[0]],
-                                                   rse_expression=rse_names[0]))) == 200
-        assert len(list(replica_core.list_replicas(dids=[{'scope': InternalScope('data13_hip', **new_vo), 'name': n} for n in all_file_names[0]],
-                                                   rse_expression=rse_names[0]))) == 200
+    rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=323000000000)
+    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None)
+    assert len(list(replica_core.list_replicas(dids=dids, rse_expression=rse_name))) == nb_files
+
+    # Now put it over threshold and delete
+    REGION.invalidate()
+    rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=1)
+    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None)
+    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None)
+    assert len(list(replica_core.list_replicas(dids, rse_expression=rse_name))) == 200
+
+
+@pytest.mark.noparallel(reason='fails when run in parallel. It resets some memcached values.')
+def test_reaper_multi_vo(vo):
+    """ REAPER2 (DAEMON): Test the reaper2 daemon with multiple vo."""
+    multi_vo = config_get_bool('common', 'multi_vo', raise_exception=False, default=False)
+    if not multi_vo:
+        pytest.skip()
+
+    vo1 = vo
+    vo2 = 'new'
+    if not vo_core.vo_exists(vo=vo2):
+        vo_core.add_vo(vo=vo2, description='Test', email='rucio@email.com')
+    scope1 = InternalScope('data13_hip', vo=vo1)
+    scope2 = InternalScope('data13_hip', vo=vo2)
+    if not scope_core.check_scope(scope2):
+        scope_core.add_scope(scope2, InternalAccount('root', vo=vo2))
+
+    nb_files = 250
+    file_size = 200  # 2G
+    rse1_name, rse1_id, dids1 = __add_test_rse_and_replicas(vo=vo1, scope=scope1, nb_files=nb_files, file_size=file_size)
+    rse2_name, rse2_id, dids2 = __add_test_rse_and_replicas(vo=vo2, scope=scope2, nb_files=nb_files, file_size=file_size)
+
+    rse_core.set_rse_limits(rse_id=rse1_id, name='MinFreeSpace', value=50 * file_size)
+    rse_core.set_rse_limits(rse_id=rse2_id, name='MinFreeSpace', value=50 * file_size)
+
+    # Check we reap all VOs by default
+    REGION.invalidate()
+    rse_core.set_rse_usage(rse_id=rse1_id, source='storage', used=nb_files * file_size, free=1)
+    rse_core.set_rse_usage(rse_id=rse2_id, source='storage', used=nb_files * file_size, free=1)
+    both_rses = '%s|%s' % (rse1_name, rse2_name)
+    reaper(once=True, rses=[], include_rses=both_rses, exclude_rses=None)
+    reaper(once=True, rses=[], include_rses=both_rses, exclude_rses=None)
+    assert len(list(replica_core.list_replicas(dids=dids1, rse_expression=both_rses))) == 200
+    assert len(list(replica_core.list_replicas(dids=dids2, rse_expression=both_rses))) == 200


### PR DESCRIPTION
Split the existing test into two: single vo; and multi vo. Skip the
later in single-vo environments.

The existing test was difficult to follow and understand. I have a
strong feeling that some parts of the tests were not working as
intended. For example: always using rse_names[0] and all_file_names[0]
(and never the second elements of the arrays) in the multi-vo code path
doesn't seem right. Also, exclude_rses was provided an empty list,
which suggests that the author expected include_rses to also take a
list. This is not the case: both take an rse expression string.

Move the relevant multi_vo tests to tests_reaper2.py and merge
duplicate code.