### PR TITLE
Clients: scale default download client timeout with file size. Closes #4374

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -996,6 +996,7 @@ def download(args):
     item_defaults['base_dir'] = args.dir
     item_defaults['no_subdir'] = args.no_subdir
     item_defaults['transfer_timeout'] = args.transfer_timeout
+    item_defaults['transfer_speed_timeout'] = args.transfer_speed_timeout
     item_defaults['no_resolve_archives'] = args.no_resolve_archives
     archive_did = args.archive_did
     if archive_did:
@@ -1045,6 +1046,8 @@ def download(args):
             logger.warning('Ignoring --aria option because --pfn option given')
         if args.protocol:
             logger.warning('Ignoring --protocol option because --pfn option given')
+        if args.transfer_speed_timeout:
+            logger.warning("Download with --pfn doesn't support --transfer-speed-timeout")
         num_dids = len(args.dids)
         did_str = args.dids[0]
         if num_dids > 1:
@@ -2151,7 +2154,8 @@ You can filter by key/value, e.g.::
         selected_parser.add_argument('--pfn', dest='pfn', action='store', help="Specify the exact PFN for the download.")
         selected_parser.add_argument('--archive-did', action='store', dest='archive_did', help="Download from archive is transparent. This option is obsolete.")
         selected_parser.add_argument('--no-resolve-archives', action='store_true', default=False, help="If set archives will not be considered for download.")
-        selected_parser.add_argument('--transfer-timeout', dest='transfer_timeout', type=float, action='store', default=config_get('download', 'transfer_timeout', False, 360), help='Transfer timeout (in seconds).')
+        selected_parser.add_argument('--transfer-timeout', dest='transfer_timeout', type=float, action='store', default=config_get('download', 'transfer_timeout', False, None), help='Transfer timeout (in seconds). Default: computed dynamically from --transfer-speed-timeout. If set to any value >= 0, --transfer-speed-timeout is ignored.')
+        selected_parser.add_argument('--transfer-speed-timeout', dest='transfer_speed_timeout', type=float, action='store', default=config_get('download', 'transfer_speed_timeout', False, None), help='Minimum allowed average transfer speed (in bps). Default: 1000000(i.e. 1Mbps). Used to dynamically compute the timeout if --transfer-timeout not set. Is not supported for --pfn.')
         selected_parser.add_argument('--aria', action='store_true', default=False, help="Use aria2c utility if possible. (EXPERIMENTAL)")
         selected_parser.add_argument('--trace_appid', dest='trace_appid', action='store', default=os.environ.get('RUCIO_TRACE_APPID', None), help=argparse.SUPPRESS)
         selected_parser.add_argument('--trace_dataset', dest='trace_dataset', action='store', default=os.environ.get('RUCIO_TRACE_DATASET', None), help=argparse.SUPPRESS)

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1022,13 +1022,8 @@ class DownloadClient:
                     options = did_to_options.setdefault(resolved_did_str, {})
                     options.setdefault('destinations', set()).add((base_dir, no_subdir))
 
-                    if resolved_did_str in all_resolved_did_strs:
-                        # in this case the DID was already given in another item
-                        # the options of this DID will be ignored and the options of the first item that contained the DID will be used
-                        # another approach would be to compare the options and apply the more relaxed options
-                        logger(logging.DEBUG, 'Ignoring further options of DID: %s' % resolved_did_str)
-                        continue
-
+                    # Merge some options
+                    # The other options of this DID will be inherited from the first item that contained the DID
                     options['ignore_checksum'] = (options.get('ignore_checksum') or ignore_checksum)
                     cur_transfer_timeout = options.setdefault('transfer_timeout', None)
                     if cur_transfer_timeout is not None and new_transfer_timeout is not None:
@@ -1036,8 +1031,9 @@ class DownloadClient:
                     elif new_transfer_timeout is not None:
                         options['transfer_timeout'] = int(new_transfer_timeout)
 
-                    resolved_dids.append({'scope': did_scope, 'name': did_name})
-                    all_resolved_did_strs.add(resolved_did_str)
+                    if resolved_did_str not in all_resolved_did_strs:
+                        resolved_dids.append({'scope': did_scope, 'name': did_name})
+                        all_resolved_did_strs.add(resolved_did_str)
 
             if len(resolved_dids) == 0:
                 logger(logging.WARNING, 'An item didnt have any DIDs after resolving the input. Ignoring it.')

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -275,9 +275,7 @@ class DownloadClient:
         trace_custom_fields['uuid'] = generate_uuid()
 
         logger(logging.INFO, 'Processing %d item(s) for input' % len(items))
-        download_info = self._resolve_and_merge_input_items(copy.deepcopy(items))
-        did_to_options = download_info['did_to_options']
-        merged_items = download_info['merged_items']
+        did_to_options, merged_items = self._resolve_and_merge_input_items(copy.deepcopy(items))
 
         self.logger(logging.DEBUG, 'num_unmerged_items=%d; num_dids=%d; num_merged_items=%d' % (len(items), len(did_to_options), len(merged_items)))
 
@@ -705,9 +703,7 @@ class DownloadClient:
             item['force_scheme'] = ['https', 'davs']
 
         logger(logging.INFO, 'Processing %d item(s) for input' % len(items))
-        download_info = self._resolve_and_merge_input_items(copy.deepcopy(items))
-        did_to_options = download_info['did_to_options']
-        merged_items = download_info['merged_items']
+        did_to_options, merged_items = self._resolve_and_merge_input_items(copy.deepcopy(items))
 
         self.logger(logging.DEBUG, 'num_unmerged_items=%d; num_dids=%d; num_merged_items=%d' % (len(items), len(did_to_options), len(merged_items)))
 
@@ -960,7 +956,7 @@ class DownloadClient:
 
         :param items: List of dictionaries. Each dictionary describing an input item
 
-        :returns: a dictionary with a dictionary that maps the input DIDs to options
+        :returns: a dictionary that maps the input DIDs to options
                   and a list with a dictionary for each merged download item
 
         :raises InputValidationError: if one of the input items is in the wrong format
@@ -987,8 +983,6 @@ class DownloadClient:
 
         did_to_options = {}
         merged_items = []
-        download_info = {'did_to_options': did_to_options,
-                         'merged_items': merged_items}
 
         while len(items) > 0:
             item = items.pop()
@@ -1052,7 +1046,7 @@ class DownloadClient:
             if not was_merged:
                 item['dids'] = resolved_dids
                 merged_items.append(item)
-        return download_info
+        return did_to_options, merged_items
 
     def _get_sources(self, merged_items, resolve_archives=True):
         """

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -733,6 +733,32 @@ class TestBinRucio(unittest.TestCase):
         print(out, err)
         assert re.search(tmp_file1[5:], out) is not None
 
+    def test_download_timeout_options_accepted(self):
+        """CLIENT(USER): Rucio download timeout options """
+        tmp_file1 = file_generator()
+        # add files
+        cmd = 'rucio upload --rse {0} --scope {1} {2}'.format(self.def_rse, self.user, tmp_file1)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # download files
+        cmd = 'rucio download --dir /tmp --transfer-timeout 3 --transfer-speed-timeout 1000 {0}:{1}'.format(self.user, tmp_file1[5:])  # triming '/tmp/' from filename
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        assert not err
+        # search for the files with ls
+        cmd = 'ls /tmp/'    # search in /tmp/
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+
+        # Check that PFN the transfer-speed-timeout option is not accepted for --pfn
+        cmd = 'rucio -v download --rse {0} --transfer-speed-timeout 1 --pfn http://a.b.c/ {1}:{2}'.format(self.def_rse, self.user, tmp_file1)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        assert "Download with --pfn doesn't support --transfer-speed-timeout" in err
+
     def test_download_metalink_file(self):
         """CLIENT(USER): Rucio download with metalink file"""
         metalink_file_path = generate_uuid()


### PR DESCRIPTION
If --transfer-timeout is set, it will be used as before. However,
if it is not set, DownloadClient will compute the timeout from the
file size and the expected minimum download speed.
--transfer-speed-timeout can be used to adjust the download speed
assumed when computing the dynamic value.