### PR TITLE
Transfers: Disable transfertool filter of requests/RSEs; #4216

### DIFF
--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -648,15 +648,17 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
     :returns:                     transfers, reqs_no_source, reqs_scheme_mismatch, reqs_only_tape_source
     """
 
-    req_sources = __list_transfer_requests_and_source_replicas(total_workers=total_workers,
-                                                               worker_number=worker_number,
-                                                               limit=limit,
-                                                               activity=activity,
-                                                               older_than=older_than,
-                                                               rses=rses,
-                                                               request_state=RequestState.QUEUED,
-                                                               transfertool=transfertool,
-                                                               session=session)
+    req_sources = __list_transfer_requests_and_source_replicas(
+        total_workers=total_workers,
+        worker_number=worker_number,
+        limit=limit,
+        activity=activity,
+        older_than=older_than,
+        rses=rses,
+        request_state=RequestState.QUEUED,
+        # transfertool=transfertool,  disabled; using config variable transfertool must work without preparer
+        session=session,
+    )
 
     unavailable_read_rse_ids = __get_unavailable_rse_ids(operation='read', session=session)
     unavailable_write_rse_ids = __get_unavailable_rse_ids(operation='write', session=session)
@@ -721,7 +723,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
         # In case of non-connected, the list contains all the intermediary RSEs
         list_hops = []
         include_multihop = False
-        if transfertool in ['fts', None]:
+        if transfertool in ['fts3', None]:
             include_multihop = core_config_get('transfers', 'use_multihop', default=False, expiration_time=600, session=session)
 
         try:

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -121,16 +121,19 @@ def poller(once=False, activities=None, sleep_time=60,
                     continue
 
                 start_time = time.time()
-                logger(logging.DEBUG, 'Start to poll transfers older than %i seconds for activity %s using transfer tool: %s' % (older_than, activity, TRANSFER_TOOL))
-                transfs = request_core.get_next(request_type=[RequestType.TRANSFER, RequestType.STAGEIN, RequestType.STAGEOUT],
-                                                state=[RequestState.SUBMITTED],
-                                                limit=db_bulk,
-                                                older_than=datetime.datetime.utcnow() - datetime.timedelta(seconds=older_than),
-                                                total_workers=heart_beat['nr_threads'], worker_number=heart_beat['assign_thread'],
-                                                mode_all=False, hash_variable='id',
-                                                activity=activity,
-                                                activity_shares=activity_shares,
-                                                transfertool=TRANSFER_TOOL)
+                # logger(logging.DEBUG, 'Start to poll transfers older than %i seconds for activity %s using transfer tool: %s' % (older_than, activity, TRANSFER_TOOL))
+                logger(logging.DEBUG, 'Start to poll transfers older than %i seconds for activity %s' % (older_than, activity))
+                transfs = request_core.get_next(
+                    request_type=[RequestType.TRANSFER, RequestType.STAGEIN, RequestType.STAGEOUT],
+                    state=[RequestState.SUBMITTED],
+                    limit=db_bulk,
+                    older_than=datetime.datetime.utcnow() - datetime.timedelta(seconds=older_than),
+                    total_workers=heart_beat['nr_threads'], worker_number=heart_beat['assign_thread'],
+                    mode_all=False, hash_variable='id',
+                    activity=activity,
+                    activity_shares=activity_shares,
+                    # transfertool=TRANSFER_TOOL,  disabled; using config variable transfertool must work without preparer
+                )
 
                 record_timer('daemons.conveyor.poller.000-get_next', (time.time() - start_time) * 1000)
 


### PR DESCRIPTION
Since filtering by transfertool lead to no requests being worked on in staging, because the transfertool config variable is in use without using the preparer.
