### PR TITLE
Client: list-rse-attribute crashed cli Fix #2258

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -59,7 +59,7 @@ import uuid
 from functools import wraps
 
 import argcomplete
-import tabulate
+from tabulate import tabulate
 
 # rucio module has the same name as this executable module, so this rule fails. pylint: disable=no-name-in-module
 from rucio import version
@@ -341,7 +341,7 @@ def list_dataset_replicas(args):
     else:
         for dsn in result:
             print('\nDATASET: %s' % (dsn))
-            print(tabulate.tabulate(list(result[dsn].values()), tablefmt=tablefmt, headers=['RSE', 'FOUND', 'TOTAL']))
+            print(tabulate(list(result[dsn].values()), tablefmt=tablefmt, headers=['RSE', 'FOUND', 'TOTAL']))
     return SUCCESS
 
 
@@ -390,7 +390,7 @@ def list_file_replicas(args):
             for replica in replicas:
                 if replica['states'].get(args.selected_rse) != 'AVAILABLE':
                     table.append([replica['scope'], replica['name']])
-            print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['SCOPE', 'NAME']))
+            print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE', 'NAME']))
         elif args.link:
             pfn_dir, dst_dir = args.link.split(':')
             for replica in replicas:
@@ -424,7 +424,7 @@ def list_file_replicas(args):
                                     table.append([replica['scope'], replica['name'], sizefmt(replica['bytes'], args.human), replica['adler32'], '{0}: {1}'.format(rse, pfn)])
                             else:
                                 table.append([replica['scope'], replica['name'], sizefmt(replica['bytes'], args.human), replica['adler32'], '{0}: {1}'.format(rse, pfn)])
-            print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['SCOPE', 'NAME', 'FILESIZE', 'ADLER32', 'RSE: REPLICA']))
+            print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE', 'NAME', 'FILESIZE', 'ADLER32', 'RSE: REPLICA']))
 
     return SUCCESS
 
@@ -570,7 +570,7 @@ def list_dids(args):
         for did, dummy in table:
             print(did)
     else:
-        print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
+        print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
     return SUCCESS
 
 
@@ -624,7 +624,7 @@ def list_dids_extended(args):
         for did, dummy in table:
             print(did)
     else:
-        print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
+        print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
     return SUCCESS
 
 
@@ -707,7 +707,7 @@ def list_files(args):
                 else:
                     guid = '(None)'
                 table.append(['%s:%s' % (file['scope'], file['name']), guid, 'ad:%s' % file['adler32'], sizefmt(file['bytes'], args.human), file['events']])
-            print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', 'GUID', 'ADLER32', 'FILESIZE', 'EVENTS']))
+            print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', 'GUID', 'ADLER32', 'FILESIZE', 'EVENTS']))
             print('Total files : %s' % totfiles)
             print('Total size : %s' % sizefmt(totsize, args.human))
             if totevents:
@@ -732,7 +732,7 @@ def list_content(args):
         for did, dummy in table:
             print(did)
     else:
-        print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
+        print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
     return SUCCESS
 
 
@@ -749,7 +749,7 @@ def list_content_history(args):
         scope, name = get_scope(did, client)
         for content in client.list_content_history(scope=scope, name=name):
             table.append(['%s:%s' % (content['scope'], content['name']), content['type'].upper()])
-    print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
+    print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
     return SUCCESS
 
 
@@ -796,7 +796,7 @@ def list_parent_dids(args):
         scope, name = get_scope(args.did, client)
         for dataset in client.list_parent_dids(scope=scope, name=name):
             table.append(['%s:%s' % (dataset['scope'], dataset['name']), dataset['type']])
-        print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
+        print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
     else:
         print('At least one option has to be given. Use -h to list the options.')
         return FAILURE
@@ -847,7 +847,7 @@ def stat(args):
         scope, name = get_scope(did, client)
         info = client.get_did(scope=scope, name=name)
         table = [(k + ':', str(v)) for (k, v) in sorted(info.items())]
-        print(tabulate.tabulate(table, tablefmt='plain'))
+        print(tabulate(table, tablefmt='plain', disable_numparse=True))
     return SUCCESS
 
 
@@ -1108,7 +1108,7 @@ def get_metadata(args):
         scope, name = get_scope(did, client)
         meta = client.get_metadata(scope=scope, name=name, plugin=plugin)
         table = [(k + ':', str(v)) for (k, v) in sorted(meta.items())]
-        print(tabulate.tabulate(table, tablefmt='plain'))
+        print(tabulate(table, tablefmt='plain', disable_numparse=True))
     return SUCCESS
 
 
@@ -1439,7 +1439,8 @@ def list_rules(args):
                           rule['copies'],
                           rule['expires_at'],
                           rule['created_at']])
-        print(tabulate.tabulate(table, tablefmt='simple', headers=['ID', 'ACCOUNT', 'SCOPE:NAME', 'STATE[OK/REPL/STUCK]', 'RSE_EXPRESSION', 'COPIES', 'EXPIRES (UTC)', 'CREATED (UTC)']))
+        print(tabulate(table, tablefmt='simple',
+                       headers=['ID', 'ACCOUNT', 'SCOPE:NAME', 'STATE[OK/REPL/STUCK]', 'RSE_EXPRESSION', 'COPIES', 'EXPIRES (UTC)', 'CREATED (UTC)']))
     return SUCCESS
 
 
@@ -1499,8 +1500,8 @@ def list_rse_attributes(args):
     """
     client = get_client(args)
     attributes = client.list_rse_attributes(rse=args.rse)
-    table = [(k + ':', str(v)) for (k, v) in sorted(attributes.items())]
-    print(tabulate.tabulate(table, tablefmt='plain'))
+    table = [(k + ':', str(v)) for (k, v) in sorted(attributes.items())]  # columns hav mixed datatypes
+    print(tabulate(table, tablefmt='plain', disable_numparse=True))  # disabling number parsing
     return SUCCESS
 
 
@@ -1561,7 +1562,7 @@ def list_account_limits(args):
     for limit in list(limits.items()):
         table.append([limit[0], sizefmt(limit[1], args.human)])
     table.sort()
-    print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['RSE', 'LIMIT']))
+    print(tabulate(table, tablefmt=tablefmt, headers=['RSE', 'LIMIT']))
 
     table = []
     limits = client.get_global_account_limits(account=args.limit_account)
@@ -1569,7 +1570,7 @@ def list_account_limits(args):
         if (args.rse and args.rse in limit[1]['resolved_rses']) or not args.rse:
             table.append([limit[0], sizefmt(limit[1]['limit'], args.human)])
     table.sort()
-    print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['RSE EXPRESSION', 'LIMIT']))
+    print(tabulate(table, tablefmt=tablefmt, headers=['RSE EXPRESSION', 'LIMIT']))
 
     return SUCCESS
 
@@ -1592,7 +1593,7 @@ def list_account_usage(args):
         remaining = 0 if float(item['bytes_remaining']) < 0 else float(item['bytes_remaining'])
         table.append([item['rse'], sizefmt(item['bytes'], args.human), sizefmt(item['bytes_limit'], args.human), sizefmt(remaining, args.human)])
     table.sort()
-    print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['RSE', 'USAGE', 'LIMIT', 'QUOTA LEFT']))
+    print(tabulate(table, tablefmt=tablefmt, headers=['RSE', 'USAGE', 'LIMIT', 'QUOTA LEFT']))
 
     table = []
     usage = client.get_global_account_usage(account=args.usage_account)
@@ -1601,7 +1602,7 @@ def list_account_usage(args):
             remaining = 0 if float(item['bytes_remaining']) < 0 else float(item['bytes_remaining'])
             table.append([item['rse_expression'], sizefmt(item['bytes'], args.human), sizefmt(item['bytes_limit'], args.human), sizefmt(remaining, args.human)])
     table.sort()
-    print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['RSE EXPRESSION', 'USAGE', 'LIMIT', 'QUOTA LEFT']))
+    print(tabulate(table, tablefmt=tablefmt, headers=['RSE EXPRESSION', 'USAGE', 'LIMIT', 'QUOTA LEFT']))
 
     return SUCCESS
 
@@ -1620,7 +1621,7 @@ def list_datasets_rse(args):
         for dsn in client.list_datasets_per_rse(args.rse):
             table.append(['%s:%s' % (dsn['scope'], dsn['name']), '%s/%s' % (str(dsn['available_length']), str(dsn['length'])), '%s/%s' % (str(dsn['available_bytes']), str(dsn['bytes']))])
         table.sort()
-        print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['DID', 'LOCAL FILES/TOTAL FILES', 'LOCAL BYTES/TOTAL BYTES']))
+        print(tabulate(table, tablefmt=tablefmt, headers=['DID', 'LOCAL FILES/TOTAL FILES', 'LOCAL BYTES/TOTAL BYTES']))
     else:
         dsns = list(set(['%s:%s' % (dsn['scope'], dsn['name']) for dsn in client.list_datasets_per_rse(args.rse)]))
         dsns.sort()

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -54,7 +54,7 @@ import traceback
 from functools import wraps
 
 import argcomplete
-import tabulate
+from tabulate import tabulate
 
 from rucio import version
 from rucio.client import Client
@@ -935,7 +935,7 @@ def list_account_attributes(args):
     table = []
     for attr in attributes:
         table.append([attr['key'], attr['value']])
-    print(tabulate.tabulate(table, tablefmt=tablefmt, headers=['Key', 'Value']))
+    print(tabulate(table, tablefmt=tablefmt, headers=['Key', 'Value']))
     return SUCCESS
 
 

--- a/lib/rucio/common/dumper/data_models.py
+++ b/lib/rucio/common/dumper/data_models.py
@@ -21,7 +21,7 @@ import logging
 import operator
 import os
 import re
-import tabulate
+from tabulate import tabulate
 
 from rucio.common.dumper import DUMPS_CACHE_DIR
 from rucio.common.dumper import HTTPDownloadFailed
@@ -121,7 +121,7 @@ class DataModel(object):
 
     @classmethod
     def tabulate_from(cls, iter, format='simple', fields=None):
-        return tabulate.tabulate(
+        return tabulate(
             (row.formated_fields(fields) for row in iter),
             (t[0] for t in cls.SCHEMA),
             format,


### PR DESCRIPTION
Disabled number parsing in tabulate to allow displaying of multi datatype columns
Refactored the imports and function calls to improves readability

Client: list-rse-attribute crashed cli Fix #2258

The main change is this, rest is either refractoring or same change required at another place: 
```
table = [(k + ':', str(v)) for (k, v) in sorted(attributes.items())]  # columns hav mixed datatypes
 print(tabulate(table, tablefmt='plain', disable_numparse=True))  # disabling number parsing
```

Input:
> table = [["r1", "20"], ["r2", "True"], ["r3", "1.1"]]

Current Behaviour: 
> print(tabulate(table))
>>Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "\anaconda3\lib\site-packages\tabulate.py", line 1591, in tabulate
    cols = [
  File "\anaconda3\lib\site-packages\tabulate.py", line 1592, in <listcomp>
    [_format(v, ct, fl_fmt, miss_v, has_invisible) for v in c]
  File "\anaconda3\lib\site-packages\tabulate.py", line 1592, in <listcomp>
    [_format(v, ct, fl_fmt, miss_v, has_invisible) for v in c]
  File "\anaconda3\lib\site-packages\tabulate.py", line 996, in _format
    return format(float(val), floatfmt)
ValueError: could not convert string to float: 'True'

Fixed Behabiour:
>print(tabulate(table, disable_numparse=True))
>>--  ----
>>r1  20
>>r2  True
>>r3  1.1
>>--  ----
