### PR TITLE
Core: FTSState moved to common/constants Fix #4241

### DIFF
--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -15,6 +15,7 @@
 Constants.
 
 """
+from collections import namedtuple
 
 RESERVED_KEYS = ['scope', 'name', 'account', 'did_type', 'is_open', 'monotonic', 'obsolete', 'complete',
                  'availability', 'suppressed', 'bytes', 'length', 'md5', 'adler32', 'rule_evaluation_action',
@@ -33,3 +34,7 @@ SCHEME_MAP = {'srm': ['srm', 'gsiftp'],
               's3': ['https', 'davs', 's3']}
 
 SUPPORTED_PROTOCOLS = ['gsiftp', 'srm', 'root', 'davs', 'http', 'https', 'file', 's3', 's3+rucio', 's3+https', 'storm']
+
+
+FTSState_Tuple = namedtuple("FTSState_Tuple", ['SUBMITTED', 'READY', 'ACTIVE', 'FAILED', 'FINISHED', 'FINISHEDDIRTY', 'CANCELED'])
+FTSState = FTSState_Tuple('SUBMITTED', 'READY', 'ACTIVE', 'FAILED', 'FINISHED', 'FINISHEDDIRTY', 'CANCELED')

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -53,7 +53,7 @@ from sqlalchemy.sql.expression import false
 
 from rucio.common import constants
 from rucio.common.config import config_get
-from rucio.common.constants import SUPPORTED_PROTOCOLS
+from rucio.common.constants import SUPPORTED_PROTOCOLS, FTSState
 from rucio.common.exception import (InvalidRSEExpression, NoDistance,
                                     RequestNotFound, RSEProtocolNotSupported,
                                     RucioException, UnsupportedOperation)
@@ -69,7 +69,7 @@ from rucio.core.request import queue_requests, set_requests_state
 from rucio.core.rse import get_rse_name, get_rse_vo, list_rses, get_rse_supported_checksums
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla import models, filter_thread_work
-from rucio.db.sqla.constants import DIDType, RequestState, FTSState, RSEType, RequestType, ReplicaState
+from rucio.db.sqla.constants import DIDType, RequestState, RSEType, RequestType, ReplicaState
 from rucio.db.sqla.session import read_session, transactional_session
 from rucio.rse import rsemanager as rsemgr
 from rucio.transfertool.fts3 import FTS3Transfertool
@@ -305,11 +305,11 @@ def bulk_query_transfers(request_host, transfer_ids, transfertool='fts3', timeou
                 fts_resps[transfer_id] = Exception("Transfer id %s is not returned" % transfer_id)
             if fts_resps[transfer_id] and not isinstance(fts_resps[transfer_id], Exception):
                 for request_id in fts_resps[transfer_id]:
-                    if fts_resps[transfer_id][request_id]['file_state'] in (str(FTSState.FAILED.name),
-                                                                            str(FTSState.FINISHEDDIRTY.name),
-                                                                            str(FTSState.CANCELED.name)):
+                    if fts_resps[transfer_id][request_id]['file_state'] in (FTSState.FAILED,
+                                                                            FTSState.FINISHEDDIRTY,
+                                                                            FTSState.CANCELED):
                         fts_resps[transfer_id][request_id]['new_state'] = RequestState.FAILED
-                    elif fts_resps[transfer_id][request_id]['file_state'] in str(FTSState.FINISHED.name):
+                    elif fts_resps[transfer_id][request_id]['file_state'] == FTSState.FINISHED:
                         fts_resps[transfer_id][request_id]['new_state'] = RequestState.DONE
         return fts_resps
     elif transfertool == 'globus':

--- a/lib/rucio/daemons/conveyor/poller_latest.py
+++ b/lib/rucio/daemons/conveyor/poller_latest.py
@@ -39,9 +39,9 @@ from requests.exceptions import RequestException
 import rucio.db.sqla.util
 from rucio.common import exception
 from rucio.common.logging import setup_logging
+from rucio.common.constants import FTSState
 from rucio.core import heartbeat, transfer, request
 from rucio.core.monitor import record_timer, record_counter
-from rucio.db.sqla.constants import FTSState
 
 graceful_stop = threading.Event()
 
@@ -73,10 +73,10 @@ def poller_latest(external_hosts, once=False, last_nhours=1, fts_wait=1800):
                 logging.debug('polling latest %s hours on host: %s' % (last_nhours, external_host))
                 ts = time.time()
                 resps = None
-                state = [str(FTSState.FINISHED.name),
-                         str(FTSState.FAILED.name),
-                         str(FTSState.FINISHEDDIRTY.name),
-                         str(FTSState.CANCELED.name)]
+                state = [FTSState.FINISHED,
+                         FTSState.FAILED,
+                         FTSState.FINISHEDDIRTY,
+                         FTSState.CANCELED]
                 try:
                     resps = transfer.query_latest(external_host, state=state, last_nhours=last_nhours)
                 except Exception:

--- a/lib/rucio/db/sqla/constants.py
+++ b/lib/rucio/db/sqla/constants.py
@@ -90,16 +90,6 @@ class FTSCompleteState(Enum):
     ERROR = 'E'
 
 
-class FTSState(Enum):
-    SUBMITTED = 'S'
-    READY = 'R'
-    ACTIVE = 'A'
-    FAILED = 'F'
-    FINISHED = 'X'
-    FINISHEDDIRTY = 'D'
-    CANCELED = 'C'
-
-
 class IdentityType(Enum):
     X509 = 'X509'
     GSS = 'GSS'


### PR DESCRIPTION
Named tuples are used for readability - allows dot notation
Named tuples prevent direct modification of constant, thus preventing accidental changes to constants

Additional insight - 
str() is redundant around enum.VAR.name
> class color(Enum):
>>   RED = 1
>>   GREEN = 2

> type(color.RED.name)
>><class 'str'>
