### PR TITLE
WebUI: Removed the old dashboard link Fix #3691

### DIFF
--- a/lib/rucio/web/ui/static/rule.js
+++ b/lib/rucio/web/ui/static/rule.js
@@ -219,24 +219,6 @@ function link_to_new_atlas_dashboard(file, scope, rse) {
     return url;
 }
 
-function link_to_old_atlas_dashboard(file, scope, rse) {
-    var items = rse.split("_");
-    var site = items.slice(0,-1).join('_');
-    var token = items.slice(-1)[0];
-    var link = "http://dashb-atlas-ddm-old.cern.ch/ddm2/#d.dst.site=";
-    link += site;
-    link += "&d.dst.token=";
-    link += token;
-    link += "&d.name=";
-    link += file;
-    link += "&d.scope=";
-    link += scope;
-    link += "&grouping.dst=%28site,token%29&tab=details";
-
-    url = '<a target="_blank" href=' + link + ">old</a>";
-    return url;
-}
-
 
 function show_details(file_data) {
     columns = [{'data': 'name'},
@@ -283,7 +265,7 @@ function show_details(file_data) {
         $.each(sorted_rses, function(index, rse) {
             var state = rses[rse];
             str_rses += "<font color=";
-            dashboard += "<div>" + link_to_new_atlas_dashboard(name, scope, rse) + " (" + link_to_old_atlas_dashboard(name, scope, rse) + ")</div>";
+            dashboard += "<div>" + link_to_new_atlas_dashboard(name, scope, rse) + "</div>";
             if (state == 'OK') {
                 str_rses += "green>" + rse;
                 ftsmon += '<div style="visibility: hidden;">.</div>';


### PR DESCRIPTION
Removed Old Dashboard Link In WebUI
------------------
This PR aims to remove the redundant link & hence the implementation in the WebUI of Rucio
The newer Dashboard is still present ... Removed only the old irrelevant dashboard link 

Thanks :)