### PR TITLE
Core: added docstring for correct parameters Fix #4417

### DIFF
--- a/lib/rucio/core/quarantined_replica.py
+++ b/lib/rucio/core/quarantined_replica.py
@@ -82,8 +82,7 @@ def delete_quarantined_replicas(rse_id, replicas, session=None):
     Delete file replicas.
 
     :param rse_id: the rse id.
-    :param files: the list of files to delete.
-    :param ignore_availability: Ignore the RSE blacklisting.
+    :param replicas: A list of dicts with the replica information.
     :param session: The database session in use.
     """
 


### PR DESCRIPTION
Core: added docstring for correct parameters Fix #4417 

Added doctring for *replicas* and removed for non-parameters, *files* and *ignore_availability*. 