### PR TITLE
Clients: remove several dependencies from client #4097

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -60,7 +60,6 @@ import unittest
 import uuid
 from functools import wraps
 
-import argcomplete
 from tabulate import tabulate
 
 # rucio module has the same name as this executable module, so this rule fails. pylint: disable=no-name-in-module
@@ -2391,7 +2390,11 @@ if __name__ == '__main__':
             os.environ['RUCIO_CONFIG'] = arguments[argi + 1]
 
     oparser = get_parser()
-    argcomplete.autocomplete(oparser)
+    try:
+        import argcomplete
+        argcomplete.autocomplete(oparser)
+    except ImportError:
+        pass
 
     if len(sys.argv) == 1:
         oparser.print_help()

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -55,7 +55,6 @@ import time
 import traceback
 from functools import wraps
 
-import argcomplete
 from tabulate import tabulate
 
 from rucio import version
@@ -2158,7 +2157,11 @@ def get_parser():
 
 if __name__ == '__main__':
     oparser = get_parser()
-    argcomplete.autocomplete(oparser)
+    try:
+        import argcomplete
+        argcomplete.autocomplete(oparser)
+    except ImportError:
+        pass
 
     if len(sys.argv) == 1:
         oparser.print_help()

--- a/etc/pip-requires
+++ b/etc/pip-requires
@@ -16,7 +16,5 @@ Flask==1.1.2                                      # Python web framework
 oic==1.2.1                                        # for authentication via OpenID Connect protocol
 prometheus_client==0.9.0                          # Python client for the Prometheus monitoring system
 python-magic>=0.4.15,<0.5.0                       # File type identification using libmagic
-futures>=3.2.0; python_version < '3.0'            # Clean single-source support for Python 3 and 2
-boto>=2.49.0,<2.50.0                              # S3 boto protocol
 boto3>=1.9.130,<1.17.0                            # S3 boto protocol (new version)
-pysftp>=0.2.9,<0.3                                # Used by sftp protocol
+jsonschema>=3.2.0                                 # For JSON schema validation (Policy modules)

--- a/etc/pip-requires
+++ b/etc/pip-requires
@@ -17,4 +17,3 @@ oic==1.2.1                                        # for authentication via OpenI
 prometheus_client==0.9.0                          # Python client for the Prometheus monitoring system
 python-magic>=0.4.15,<0.5.0                       # File type identification using libmagic
 boto3>=1.9.130,<1.17.0                            # S3 boto protocol (new version)
-jsonschema>=3.2.0                                 # For JSON schema validation (Policy modules)

--- a/etc/pip-requires
+++ b/etc/pip-requires
@@ -15,3 +15,8 @@ paramiko==2.7.2                                   # SSH2 protocol library
 Flask==1.1.2                                      # Python web framework
 oic==1.2.1                                        # for authentication via OpenID Connect protocol
 prometheus_client==0.9.0                          # Python client for the Prometheus monitoring system
+python-magic>=0.4.15,<0.5.0                       # File type identification using libmagic
+futures>=3.2.0; python_version < '3.0'            # Clean single-source support for Python 3 and 2
+boto>=2.49.0,<2.50.0                              # S3 boto protocol
+boto3>=1.9.130,<1.17.0                            # S3 boto protocol (new version)
+pysftp>=0.2.9,<0.3                                # Used by sftp protocol

--- a/etc/pip-requires-client
+++ b/etc/pip-requires-client
@@ -1,18 +1,9 @@
 # All dependencies needed to run rucio client should be defined here
 setuptools>=36.8.0,<45.0.0; python_version < '3.0'          # Python packaging utilities (36.8.0 last py2.6 compatible version, 45.0 only Py3 compatible)
 setuptools>=45.0.0,<=50.3.2; python_version >= '3.0'        # Python packaging utilities
-argcomplete>=1.9.0,<=1.12.2                                 # Bash tab completion for argparse
 requests>=2.20.0,<=2.25.0                                   # Python HTTP for Humans.
 urllib3>=1.24.2,<=1.26.4                                    # HTTP library with thread-safe connection pooling, file post, etc.
 dogpile.cache>=0.6.5,<0.7.0; python_version < '3.0'         # Caching API plugins (0.7.0 only Py3 compatible)
 dogpile.cache>=0.6.5,<=1.1.1; python_version >= '3.0'       # Caching API plugins
-boto>=2.49.0,<2.50.0                                        # S3 boto protocol
 tabulate>=0.8.0,<0.9.0                                      # Pretty-print tabular data
-progressbar2>=3.39.0,<=3.53.1                               # Text progress bar
-bz2file>=0.98,<0.99                                         # Read and write bzip2-compressed files.
-python-magic>=0.4.15,<0.5.0                                 # File type identification using libmagic
-futures>=3.2.0; python_version < '3.0'                      # Clean single-source support for Python 3 and 2
 six>=1.12.0<1.16.0                                          # Python 2 and 3 compatibility utilities
-boto3>=1.9.130,<1.17.0                                      # S3 boto protocol (new version)
-pysftp>=0.2.9,<0.3                                          # Used by sftp protocol
-jsonschema>=3.2.0                                           # For JSON schema validation (Policy modules)

--- a/etc/pip-requires-client
+++ b/etc/pip-requires-client
@@ -7,3 +7,4 @@ dogpile.cache>=0.6.5,<0.7.0; python_version < '3.0'         # Caching API plugin
 dogpile.cache>=0.6.5,<=1.1.1; python_version >= '3.0'       # Caching API plugins
 tabulate>=0.8.0,<0.9.0                                      # Pretty-print tabular data
 six>=1.12.0<1.16.0                                          # Python 2 and 3 compatibility utilities
+jsonschema>=3.2.0                                 # For JSON schema validation (Policy modules)

--- a/etc/pip-requires-test
+++ b/etc/pip-requires-test
@@ -20,4 +20,5 @@ pydoc-markdown~=3.11.0; python_version >= '3.5'   # Used for generating Markdown
 docspec_python==0.1.0; python_version >= '3.5'    # FIX incompatibility with pydoc-markdown
 sh~=1.14.1                                        # Convenience library for running subprocesses in Python
 bz2file>=0.98,<0.99                               # Read and write bzip2-compressed files.
-jsonschema>=3.2.0                                 # For JSON schema validation (Policy modules)
+boto>=2.49.0,<2.50.0                              # S3 boto protocol
+pysftp>=0.2.9,<0.3                                # Used by sftp protocol

--- a/etc/pip-requires-test
+++ b/etc/pip-requires-test
@@ -19,3 +19,5 @@ PyYAML==5.4                                       # Used for reading test config
 pydoc-markdown~=3.11.0; python_version >= '3.5'   # Used for generating Markdown documentation for docusaurus
 docspec_python==0.1.0; python_version >= '3.5'    # FIX incompatibility with pydoc-markdown
 sh~=1.14.1                                        # Convenience library for running subprocesses in Python
+bz2file>=0.98,<0.99                               # Read and write bzip2-compressed files.
+jsonschema>=3.2.0                                 # For JSON schema validation (Policy modules)

--- a/setup_rucio_client.py
+++ b/setup_rucio_client.py
@@ -59,9 +59,15 @@ if os.path.exists('lib/rucio.egg-info/'):
 SSH_EXTRAS = ['paramiko==1.18.4']
 KERBEROS_EXTRAS = ['kerberos>=1.2.5', 'pykerberos>=1.1.14', 'requests-kerberos>=0.11.0']
 SWIFT_EXTRAS = ['python-swiftclient>=3.5.0', ]
+ARGCOMPLETE_EXTRAS = ['argcomplete>=1.9.0,<=1.12.2']
+S3_EXTRAS = ['boto>=2.49.0,<2.50.0']
+SFTP_EXTRAS = ['pysftp>=0.2.9,<0.3']
 EXTRAS_REQUIRES = dict(ssh=SSH_EXTRAS,
                        kerberos=KERBEROS_EXTRAS,
-                       swift=SWIFT_EXTRAS)
+                       swift=SWIFT_EXTRAS,
+                       argcomplete=ARGCOMPLETE_EXTRAS,
+                       s3=S3_EXTRAS,
+                       sftp=SFTP_EXTRAS)
 
 if '--release' in COPY_ARGS:
     IS_RELEASE = True


### PR DESCRIPTION
This is a second try at removing some dependencies from the client and making others optional. There are two differences from my first PR:

1. tabulate is no longer being removed
2. progressbar has been removed for consistency since it was only used in one protocol, instead of being made optional
