### PR TITLE
Transfers: Submit requests in creation order. Closes #4375

### DIFF
--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -33,6 +33,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import division
 
@@ -100,7 +101,6 @@ Requests accessed by request_id  are covered in the core request.py
 REGION_SHORT = make_region().configure('dogpile.cache.memcached',
                                        expiration_time=600,
                                        arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
-TRANSFER_TOOL = config_get('conveyor', 'transfertool', False, None)
 ALLOW_USER_OIDC_TOKENS = config_get('conveyor', 'allow_user_oidc_tokens', False, False)
 REQUEST_OIDC_SCOPE = config_get('conveyor', 'request_oidc_scope', False, 'fts:submit-transfer')
 REQUEST_OIDC_AUDIENCE = config_get('conveyor', 'request_oidc_audience', False, 'fts:example')
@@ -875,10 +875,10 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                 source_globus_endpoint_id = rse_attrs[source_rse_id].get('globus_endpoint_id', None)
                 dest_globus_endpoint_id = rse_attrs[dest_rse_id].get('globus_endpoint_id', None)
 
-                if TRANSFER_TOOL == 'fts3' and not fts_hosts:
+                if transfertool == 'fts3' and not fts_hosts:
                     logger(logging.ERROR, 'Destination RSE %s FTS attribute not defined - SKIP REQUEST %s', dest_rse_name, req_id)
                     continue
-                if TRANSFER_TOOL == 'globus' and (not dest_globus_endpoint_id or not source_globus_endpoint_id):
+                if transfertool == 'globus' and (not dest_globus_endpoint_id or not source_globus_endpoint_id):
                     logger(logging.ERROR, 'Destination RSE %s Globus endpoint attributes not defined - SKIP REQUEST %s', dest_rse_name, req_id)
                     continue
                 if retry_count is None:

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2020 CERN
+# Copyright 2014-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 # - dciangot <diego.ciangottini@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - maatthias <maatthias@gmail.com>, 2019
+# - Matt Snyder <msnyder@bnl.gov>, 2019
 # - Gabriele Fronze' <gfronze@cern.ch>, 2019
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
@@ -63,7 +63,7 @@ USER_TRANSFERS = config_get('conveyor', 'user_transfers', False, None)
 TRANSFER_TOOL = config_get('conveyor', 'transfertool', False, None)
 
 
-def submit_transfer(external_host, job, submitter='submitter', timeout=None, user_transfer_job=False, logger=logging.log):
+def submit_transfer(external_host, job, submitter='submitter', timeout=None, user_transfer_job=False, logger=logging.log, transfertool=TRANSFER_TOOL):
     """
     Submit a transfer or staging request
 
@@ -124,7 +124,7 @@ def submit_transfer(external_host, job, submitter='submitter', timeout=None, use
         # A eid is returned if the job is properly submitted otherwise an exception is raised
         eid = transfer_core.submit_bulk_transfers(external_host,
                                                   files=job['files'],
-                                                  transfertool=TRANSFER_TOOL,
+                                                  transfertool=transfertool,
                                                   job_params=job['job_params'],
                                                   timeout=timeout,
                                                   user_transfer_job=user_transfer_job)
@@ -171,7 +171,7 @@ def submit_transfer(external_host, job, submitter='submitter', timeout=None, use
                 logger(logging.INFO, 'About to submit job to %s with timeout %s', external_host, timeout)
                 eid = transfer_core.submit_bulk_transfers(external_host,
                                                           files=[t_file],
-                                                          transfertool=TRANSFER_TOOL,
+                                                          transfertool=transfertool,
                                                           job_params=job['job_params'],
                                                           timeout=timeout,
                                                           user_transfer_job=user_transfer_job)

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -31,6 +31,7 @@
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Conveyor transfer submitter is a daemon to manage non-tape file transfers.
@@ -186,7 +187,7 @@ def submitter(once=False, rses=None, mock=False,
                 logger(logging.INFO, 'Starting to group transfers for %s', activity)
                 start_time = time.time()
 
-                grouped_jobs = bulk_group_transfer(transfers, group_policy, group_bulk, source_strategy, max_time_in_queue)
+                grouped_jobs = bulk_group_transfer(transfers, group_policy, group_bulk, source_strategy, max_time_in_queue, group_by_scope=user_transfer)
                 record_timer('daemons.conveyor.transfer_submitter.bulk_group_transfer', (time.time() - start_time) * 1000 / (len(transfers) if transfers else 1))
 
                 logger(logging.INFO, 'Starting to submit transfers for %s', activity)

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -77,7 +77,8 @@ GET_TRANSFERS_COUNTER = Counter('rucio_daemons_conveyor_submitter_get_transfers'
 
 def submitter(once=False, rses=None, mock=False,
               bulk=100, group_bulk=1, group_policy='rule', source_strategy=None,
-              activities=None, sleep_time=600, max_sources=4, retry_other_fts=False):
+              activities=None, sleep_time=600, max_sources=4, retry_other_fts=False,
+              filter_transfertool=FILTER_TRANSFERTOOL, transfertool=TRANSFER_TOOL, transfertype=TRANSFER_TYPE):
     """
     Main loop to submit a new transfer primitive to a transfertool.
     """
@@ -120,8 +121,8 @@ def submitter(once=False, rses=None, mock=False,
     if activities:
         activities.sort()
         executable += '--activities ' + str(activities)
-    if FILTER_TRANSFERTOOL:
-        executable += ' --filter-transfertool ' + FILTER_TRANSFERTOOL
+    if filter_transfertool:
+        executable += ' --filter-transfertool ' + filter_transfertool
 
     hostname = socket.getfqdn()
     pid = os.getpid()
@@ -132,7 +133,8 @@ def submitter(once=False, rses=None, mock=False,
     logger = formatted_logger(logging.log, prefix + '%s')
     logger(logging.INFO, 'Submitter starting with timeout %s', timeout)
 
-    time.sleep(10)  # To prevent running on the same partition if all the poller restart at the same time
+    if not mock:
+        time.sleep(10)  # To prevent running on the same partition if all the poller restart at the same time
     heart_beat = heartbeat.live(executable, hostname, pid, hb_thread)
     prefix = 'conveyor-submitter[%i/%i] : ' % (heart_beat['assign_thread'], heart_beat['nr_threads'])
     logger = formatted_logger(logging.log, prefix + '%s')
@@ -174,7 +176,7 @@ def submitter(once=False, rses=None, mock=False,
                                             max_sources=max_sources,
                                             bring_online=bring_online,
                                             retry_other_fts=retry_other_fts,
-                                            transfertool=FILTER_TRANSFERTOOL,
+                                            transfertool=filter_transfertool,
                                             logger=logger)
 
                 record_timer('daemons.conveyor.transfer_submitter.get_transfers.per_transfer', (time.time() - start_time) * 1000 / (len(transfers) if transfers else 1))
@@ -192,21 +194,21 @@ def submitter(once=False, rses=None, mock=False,
 
                 logger(logging.INFO, 'Starting to submit transfers for %s', activity)
 
-                if TRANSFER_TOOL in ['fts3', 'mock']:
+                if transfertool in ['fts3', 'mock']:
                     for external_host in grouped_jobs:
                         if not user_transfer:
                             for job in grouped_jobs[external_host]:
                                 # submit transfers
                                 submit_transfer(external_host=external_host, job=job, submitter='transfer_submitter',
-                                                timeout=timeout, logger=logger)
+                                                timeout=timeout, logger=logger, transfertool=transfertool)
                         else:
                             for _, jobs in iteritems(grouped_jobs[external_host]):
                                 # submit transfers
                                 for job in jobs:
                                     submit_transfer(external_host=external_host, job=job, submitter='transfer_submitter',
-                                                    timeout=timeout, user_transfer_job=user_transfer, logger=logger)
-                elif TRANSFER_TOOL == 'globus':
-                    if TRANSFER_TYPE == 'bulk':
+                                                    timeout=timeout, user_transfer_job=user_transfer, logger=logger, transfertool=transfertool)
+                elif transfertool == 'globus':
+                    if transfertype == 'bulk':
                         # build bulk job file list per external host to send to submit_transfer
                         for external_host in grouped_jobs:
                             # pad the job with job_params; irrelevant for globus but needed for further rucio parsing
@@ -214,7 +216,8 @@ def submitter(once=False, rses=None, mock=False,
                             for job in grouped_jobs[external_host]:
                                 submitjob.get('files').append(job.get('files')[0])
                             logger(logging.DEBUG, 'submitjob: %s' % submitjob)
-                            submit_transfer(external_host=external_host, job=submitjob, submitter='transfer_submitter', timeout=timeout, logger=logger)
+                            submit_transfer(external_host=external_host, job=submitjob, submitter='transfer_submitter',
+                                            timeout=timeout, logger=logger, transfertool=transfertool)
                     else:
                         # build single job files and individually send to submit_transfer
                         job_params = grouped_jobs[''][0].get('job_params') if grouped_jobs else None
@@ -223,7 +226,8 @@ def submitter(once=False, rses=None, mock=False,
                                 for file in job['files']:
                                     singlejob = {'files': [file], 'job_params': job_params}
                                     logger(logging.DEBUG, 'singlejob: %s' % singlejob)
-                                    submit_transfer(external_host=external_host, job=singlejob, submitter='transfer_submitter', timeout=timeout, logger=logger)
+                                    submit_transfer(external_host=external_host, job=singlejob, submitter='transfer_submitter',
+                                                    timeout=timeout, logger=logger, transfertool=transfertool)
                 else:
                     logger(logging.ERROR, 'Unknown transfer tool')
 
@@ -442,6 +446,6 @@ def __mock_sources(sources):
 
     tmp_sources = []
     for source in sources:
-        tmp_sources.append((source[0], ':'.join(['mock'] + source[1].split(':')[1:]), source[2], source[3]))
+        tmp_sources.append((source[0], ':'.join(['mock'] + source[1].split(':')[1:]), source[2], source[3], source[4]))
     sources = tmp_sources
     return tmp_sources

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 CERN
+# Copyright 2020-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #
 # Authors:
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -142,3 +143,33 @@ def auth_token(rest_client, vo):
     token = auth_response.headers.get('X-Rucio-Auth-Token')
     assert token
     return str(token)
+
+
+@pytest.fixture(scope='module')
+def mock_scope(vo):
+    from rucio.common.types import InternalScope
+
+    return InternalScope('mock', vo=vo)
+
+
+@pytest.fixture(scope='module')
+def root_account(vo):
+    from rucio.common.types import InternalAccount
+
+    return InternalAccount('root', vo=vo)
+
+
+@pytest.fixture
+def rse_factory(vo):
+    from rucio.tests.temp_factories import TemporaryRSEFactory
+
+    with TemporaryRSEFactory(vo=vo) as factory:
+        yield factory
+
+
+@pytest.fixture
+def file_factory(vo, mock_scope):
+    from rucio.tests.temp_factories import TemporaryFileFactory
+
+    with TemporaryFileFactory(vo=vo, default_scope=mock_scope) as factory:
+        yield factory

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
+
+import os
+
+from sqlalchemy import or_, and_
+
+from rucio.client.client import Client
+from rucio.client.uploadclient import UploadClient
+from rucio.common.types import InternalScope
+from rucio.common.utils import generate_uuid
+from rucio.core import replica as replica_core
+from rucio.core import rse as rse_core
+from rucio.core import rule as rule_core
+from rucio.db.sqla import models
+from rucio.db.sqla.session import transactional_session
+from rucio.tests.common import file_generator
+from rucio.tests.common import rse_name_generator
+
+
+class TemporaryRSEFactory:
+    """
+    Factory which keeps track of created RSEs and cleans up everything related to these RSEs at the end
+    """
+    def __init__(self, vo, **kwargs):
+        self.vo = vo
+
+        self.created_rses = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup()
+
+    @transactional_session
+    def cleanup(self, session=None):
+        if not self.created_rses:
+            return
+        # Cleanup Transfers
+        session.query(models.Source).filter(or_(models.Source.dest_rse_id.in_(self.created_rses),
+                                                models.Source.rse_id.in_(self.created_rses))).delete(synchronize_session=False)
+        session.query(models.Request).filter(or_(models.Request.dest_rse_id.in_(self.created_rses),
+                                                 models.Request.source_rse_id.in_(self.created_rses))).delete(synchronize_session=False)
+
+        # Cleanup Locks and Rules
+        query = session.query(models.ReplicationRule.id). \
+            join(models.ReplicaLock, models.ReplicationRule.id == models.ReplicaLock.rule_id). \
+            filter(models.ReplicaLock.rse_id.in_(self.created_rses)).distinct()
+        for rule_id, in query:
+            rule_core.delete_rule(rule_id, session=session)
+
+        # Cleanup Replicas and Parent Datasets
+        query = session.query(models.RSEFileAssociation.scope, models.RSEFileAssociation.name, models.RSEFileAssociation.rse_id). \
+            filter(models.RSEFileAssociation.rse_id.in_(self.created_rses))
+        dids_by_rse = {}
+        for scope, name, rse_id in query:
+            dids_by_rse.setdefault(rse_id, []).append({'scope': scope, 'name': name})
+        for rse_id, dids in dids_by_rse.items():
+            replica_core.delete_replicas(rse_id=rse_id, files=dids, session=session)
+
+        # Cleanup RSEs
+        for model in (models.RSEAttrAssociation, models.RSEProtocols, models.UpdatedRSECounter,
+                      models.RSEUsage, models.RSELimit, models.RSETransferLimit, models.RSEQoSAssociation):
+            session.query(model).filter(model.rse_id.in_(self.created_rses)).delete(synchronize_session=False)
+
+        session.query(models.Distance).filter(or_(models.Distance.src_rse_id.in_(self.created_rses),
+                                                  models.Distance.dest_rse_id.in_(self.created_rses))).delete(synchronize_session=False)
+        for rse_id in self.created_rses:
+            # Only archive RSE instead of deleting. Account handling code doesn't expect RSEs to ever be deleted.
+            # So running test in parallel results in some tests failing on foreign key errors.
+            rse_core.del_rse(rse_id, session=session)
+
+    def _make_rse(self, scheme, protocol_impl):
+        rse_name = rse_name_generator()
+        rse_id = rse_core.add_rse(rse_name, vo=self.vo)
+        rse_core.add_protocol(rse_id=rse_id, parameter={
+            'scheme': scheme,
+            'hostname': 'host%d' % len(self.created_rses),
+            'port': 0,
+            'prefix': '/test',
+            'impl': protocol_impl,
+            'domains': {
+                'wan': {
+                    'read': 1,
+                    'write': 1,
+                    'delete': 1,
+                    'third_party_copy': 1
+                }
+            }
+        })
+        self.created_rses.append(rse_id)
+        return rse_name, rse_id
+
+    def make_posix_rse(self):
+        return self._make_rse(scheme='file', protocol_impl='rucio.rse.protocols.posix.Default')
+
+    def make_mock_rse(self):
+        return self._make_rse(scheme='MOCK', protocol_impl='rucio.rse.protocols.mock.Default')
+
+    def make_xroot_rse(self):
+        return self._make_rse(scheme='root', protocol_impl='rucio.rse.protocols.xrootd.Default')
+
+
+class TemporaryFileFactory:
+    """
+    Factory which keeps track of uploaded files and cleans up everything related to these files at the end
+    """
+    def __init__(self, default_scope, vo):
+        self.default_scope = default_scope
+        self.vo = vo
+
+        self._client = None
+        self._upload_client = None
+
+        self.created_rses = []
+        self.created_dids = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup()
+
+    @property
+    def client(self):
+        if not self._client:
+            self._client = Client()
+        return self._client
+
+    @property
+    def upload_client(self):
+        if not self._upload_client:
+            self._upload_client = UploadClient(self.client)
+        return self._upload_client
+
+    @transactional_session
+    def cleanup(self, session=None):
+        if not self.created_dids:
+            return
+
+        # Cleanup Transfers
+        session.query(models.Source).filter(or_(and_(models.Source.scope == did['scope'],
+                                                     models.Source.name == did['name'])
+                                                for did in self.created_dids)).delete(synchronize_session=False)
+        session.query(models.Request).filter(or_(and_(models.Request.scope == did['scope'],
+                                                      models.Request.name == did['name'])
+                                                 for did in self.created_dids)).delete(synchronize_session=False)
+
+        # Cleanup Locks Rules
+        query = session.query(models.ReplicationRule.id).filter(or_(and_(models.ReplicationRule.scope == did['scope'],
+                                                                         models.ReplicationRule.name == did['name'])
+                                                                    for did in self.created_dids))
+        for rule_id, in query:
+            rule_core.delete_rule(rule_id, session=session)
+
+        # Cleanup Replicas and Parent Datasets
+        dids_by_rse = {}
+        replicas = list(replica_core.list_replicas(self.created_dids, all_states=True, session=session))
+        for replica in replicas:
+            for rse_id in replica['rses']:
+                dids_by_rse.setdefault(rse_id, []).append({'scope': replica['scope'], 'name': replica['name']})
+        for rse_id, dids in dids_by_rse.items():
+            replica_core.delete_replicas(rse_id=rse_id, files=dids, session=session)
+
+    def upload_test_file(self, rse_name, scope=None, name=None, path=None, return_full_item=False):
+        if not scope:
+            scope = self.default_scope
+        elif isinstance(scope, str):
+            scope = InternalScope(scope, vo=self.vo)
+        if not path:
+            path = file_generator()
+        if not name:
+            name = os.path.basename(path)
+        item = {
+            'path': path,
+            'rse': rse_name,
+            'did_scope': str(scope),
+            'did_name': name,
+            'guid': generate_uuid(),
+        }
+        self.upload_client.upload([item])
+        did = {'scope': scope, 'name': name}
+        self.created_dids.append(did)
+        return item if return_full_item else did

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -16,11 +16,18 @@
 # Authors:
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 
+import itertools
+from datetime import datetime, timedelta
+from random import randint
+from unittest.mock import patch
+
 from rucio.core import distance as distance_core
 from rucio.core import request as request_core
 from rucio.core import rule as rule_core
 from rucio.daemons.conveyor.submitter import submitter
+from rucio.db.sqla.models import Request
 from rucio.db.sqla.constants import RequestState
+from rucio.db.sqla.session import transactional_session
 
 
 def test_request_submitted(rse_factory, file_factory, root_account):
@@ -43,3 +50,56 @@ def test_request_submitted(rse_factory, file_factory, root_account):
     submitter(once=True, rses=[{'id': dst_rse_id}], mock=True, transfertool='mock', transfertype='bulk', filter_transfertool=None, bulk=None)
     request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
     assert request['state'] == RequestState.SUBMITTED
+
+
+def test_request_submitted_in_order(rse_factory, file_factory, root_account):
+
+    src_rses = [rse_factory.make_posix_rse() for _ in range(2)]
+    dst_rses = [rse_factory.make_posix_rse() for _ in range(3)]
+    for _, src_rse_id in src_rses:
+        for _, dst_rse_id in dst_rses:
+            distance_core.add_distance(src_rse_id=src_rse_id, dest_rse_id=dst_rse_id, ranking=10)
+            distance_core.add_distance(src_rse_id=dst_rse_id, dest_rse_id=src_rse_id, ranking=10)
+
+    # Create a certain number of files on source RSEs with replication rules towards random destination RSEs
+    nb_files = 15
+    dids = []
+    requests = []
+    src_rses_iterator = itertools.cycle(src_rses)
+    dst_rses_iterator = itertools.cycle(dst_rses)
+    for _ in range(nb_files):
+        src_rse_name, src_rse_id = next(src_rses_iterator)
+        dst_rse_name, dst_rse_id = next(dst_rses_iterator)
+        did = file_factory.upload_test_file(rse_name=src_rse_name)
+        rule_core.add_rule(dids=[did], account=root_account, copies=1, rse_expression=dst_rse_name, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
+        requests.append(request_core.get_request_by_did(rse_id=dst_rse_id, **did))
+        dids.append(did)
+
+    # Forge request creation time to a random moment in the past hour
+    @transactional_session
+    def _forge_requests_creation_time(session=None):
+        base_time = datetime.utcnow().replace(microsecond=0, minute=0) - timedelta(hours=1)
+        assigned_times = set()
+        for request in requests:
+            request_creation_time = None
+            while not request_creation_time or request_creation_time in assigned_times:
+                # Ensure uniqueness to avoid multiple valid submission orders and make tests deterministic with simple sorting techniques
+                request_creation_time = base_time + timedelta(minutes=randint(0, 3600))
+            assigned_times.add(request_creation_time)
+            session.query(Request).filter(Request.id == request['id']).update({'created_at': request_creation_time})
+            request['created_at'] = request_creation_time
+
+    _forge_requests_creation_time()
+    requests = sorted(requests, key=lambda r: r['created_at'])
+
+    requests_id_in_submission_order = []
+    with patch('rucio.transfertool.mock.MockTransfertool.submit') as mock_transfertool_submit:
+        # Record the order of requests passed to MockTranfertool.submit()
+        mock_transfertool_submit.side_effect = lambda jobs, _: requests_id_in_submission_order.extend([j['metadata']['request_id'] for j in jobs])
+
+        submitter(once=True, rses=[{'id': rse_id} for _, rse_id in dst_rses], mock=True, transfertool='mock', transfertype='single', filter_transfertool=None)
+    # Requests must be submitted in the order of their creation
+    assert requests_id_in_submission_order == [r['id'] for r in requests]
+
+    for request in requests:
+        assert request_core.get_request(request_id=request['id'])['state'] == RequestState.SUBMITTED

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
+
+from rucio.core import distance as distance_core
+from rucio.core import request as request_core
+from rucio.core import rule as rule_core
+from rucio.daemons.conveyor.submitter import submitter
+from rucio.db.sqla.constants import RequestState
+
+
+def test_request_submitted(rse_factory, file_factory, root_account):
+    """ Conveyor (DAEMON): Test the submitter"""
+    src_rse_name, src_rse_id = rse_factory.make_posix_rse()
+    dst_rse_name, dst_rse_id = rse_factory.make_posix_rse()
+    distance_core.add_distance(src_rse_id=src_rse_id, dest_rse_id=dst_rse_id, ranking=10)
+    distance_core.add_distance(src_rse_id=dst_rse_id, dest_rse_id=src_rse_id, ranking=10)
+    did = file_factory.upload_test_file(rse_name=src_rse_name)
+
+    rule_core.add_rule(dids=[did], account=root_account, copies=1, rse_expression=dst_rse_name, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
+    request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
+    assert request['state'] == RequestState.QUEUED
+
+    # run submitter with a RSE filter which doesn't contain the needed one
+    submitter(once=True, rses=[{'id': src_rse_id}], mock=True, transfertool='mock', transfertype='bulk', filter_transfertool=None, bulk=None)
+    request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
+    assert request['state'] == RequestState.QUEUED
+
+    submitter(once=True, rses=[{'id': dst_rse_id}], mock=True, transfertool='mock', transfertype='bulk', filter_transfertool=None, bulk=None)
+    request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
+    assert request['state'] == RequestState.SUBMITTED

--- a/lib/rucio/transfertool/mock.py
+++ b/lib/rucio/transfertool/mock.py
@@ -1,3 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020-2021 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Nick Smith <nick.smith@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
+
 from rucio.transfertool.transfertool import Transfertool
 import uuid
 
@@ -13,7 +32,7 @@ class MockTransfertool(Transfertool):
         super(MockTransfertool, self).__init__(external_host)
 
     def submit(self, files, job_params, timeout=None):
-        return uuid.uuid1()
+        return str(uuid.uuid1())
 
     def query(self, transfer_ids, details=False, timeout=None):
         return [{'status': 'ok'}]


### PR DESCRIPTION
If requests are not submitted in FIFO order, it can lead to delay when
there is a backlog.

To be able to test the submitter, do some small fixes to existing code.

Because we create many requests in the newly added tests, tests start
to fail after a couple of runs if the DB container is not re-created. This is
due to #4405. As a workaround, cleanup created RSEs /rules/dids/etc at
the end of the test. To achieve the goal, I add a factory class and a
fixture which takes care of cleanup. We could potentially re-use these
components later in other tests later to enable auto-cleanup.