### PR TITLE
WebUI: R2D2 wrongly creates a container Fix #583

### DIFF
--- a/lib/rucio/web/ui/static/request_rule.js
+++ b/lib/rucio/web/ui/static/request_rule.js
@@ -829,7 +829,12 @@ create_rules = function(approval) {
 
     var request_container = null;
     if ((selected_dids.length > 1) && (approval)) {
-        request_container = create_request_container(selected_dids);
+        $.each(selected_dids, function(index, did){
+            if (did['did_type']!='FILE'){
+                request_container = create_request_container(selected_dids);
+                return false;
+            }
+        });
     }
 
     rse_expr = storage.get('rse_expr');


### PR DESCRIPTION
R2D2 wrongly creates a container if the list of dids is containing only files Fix #583
------------------
The change is that instead of directly calling request_container, it first checks if there is is even one in the list of dids which is not of file type, and then calls request_container.
