### PR TITLE
Testing: use unique attribute filter in rucio_bin rule tests. Fixes #4438

### DIFF
--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -996,12 +996,12 @@ class TestBinRucio(unittest.TestCase):
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
 
         # add rse atributes
-        cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
+        cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASDELETERULE'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
         # add rules
-        cmd = "rucio add-rule {0}:{1} 1 'spacetoken=ATLASSCRATCHDISK'".format(self.user, tmp_file1[5:])
+        cmd = "rucio add-rule {0}:{1} 1 'spacetoken=ATLASDELETERULE'".format(self.user, tmp_file1[5:])
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(err)


### PR DESCRIPTION
Create_rule and delete_rule use the same token. Due to tests running
in parallel now, they fail because rse expression parsing is cached
and will not return the up-to-date list of rses.