### PR TITLE
Core: fix metadata json_exists expression for OracleDB Fix #4360

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,6 +51,7 @@ Individual contributors to the source code
 - Mayank Sharma <mayank.sharma@cern.ch>, 2020
 - Ian Johnson, <ian.johnson@stfc.ac.uk>, 2021
 - Radu Carpa <radu.carpa@cern.ch>, 2021
+- Rizart Dona <rizart.dona@cern.ch>, 2021
 
 
 Organisations employing contributors

--- a/lib/rucio/core/did_meta_plugins/json_meta.py
+++ b/lib/rucio/core/did_meta_plugins/json_meta.py
@@ -30,6 +30,7 @@
 # - Brandon White, <bjwhite@fnal.gov>, 2019
 # - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Rizart Dona <rizart.dona@cern.ch>, 2021
 
 import json as json_lib
 
@@ -160,7 +161,7 @@ class JSONDidMeta(DidMetaPlugin):
         filters.pop('name', None)
         for k, v in iteritems(filters):
             if session.bind.dialect.name == 'oracle':
-                query = query.filter(text("json_exists(meta,'$.%s?(@==''%s'')')" % (k, v)))
+                query = query.filter(text("json_exists(meta,'$?(@.{} == \"{}\")')".format(k, v)))
             else:
                 query = query.filter(cast(models.DidMeta.meta[k], String) == type_coerce(v, JSON))
 


### PR DESCRIPTION
I changed the ```json_exists``` expression that OracleDB expects in order to search the metadata ```key:value``` pair inside a column value.

[Reference Documentation](https://docs.oracle.com/en/database/oracle/oracle-database/19/adjsn/condition-JSON_EXISTS.html#GUID-D60A7E52-8819-4D33-AEDB-223AB7BDE60A)