### PR TITLE
Documentation: Removed Non Functional Pages Fix #4435

### DIFF
--- a/doc/source/advanced_usage.rst
+++ b/doc/source/advanced_usage.rst
@@ -1,2 +1,0 @@
-Advanced Usage
-==============

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -58,7 +58,6 @@ User Documentation
     man/rucio-admin
     rse_expressions
     clients
-    advanced_usage
 
 
 Operator Documentation

--- a/doc/source/installing_clients.rst
+++ b/doc/source/installing_clients.rst
@@ -55,5 +55,3 @@ Otherwise, you can install from the distribution using the ``setup.py`` script::
 
    $> python setup.py install
 
-Installing with docker
-~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Removed Non-Functional Pages/Sections (Advanced Usage & Installing Docker Section of Clients)
------------------
This PR aims to remove the sections of the documentations that are not functional or are redundant
Thanks :)