### PR TITLE
Testing: Widen noparallel mark for TestBaseClient

### DIFF
--- a/lib/rucio/tests/test_clients.py
+++ b/lib/rucio/tests/test_clients.py
@@ -39,6 +39,7 @@ from rucio.common.exception import CannotAuthenticate, ClientProtocolNotSupporte
 from rucio.common.utils import get_tmp_dir
 
 
+@pytest.mark.noparallel(reason='fails when run in parallel')
 class TestBaseClient(unittest.TestCase):
     """ To test Clients"""
 
@@ -86,7 +87,6 @@ class TestBaseClient(unittest.TestCase):
                  'client_key': self.userkey}
         BaseClient(account='root', ca_cert=self.cacert, auth_type='x509', creds=creds, **self.vo)
 
-    @pytest.mark.noparallel(reason='fails when run in parallel')
     def testx509NonExistingCert(self):
         """ CLIENTS (BASECLIENT): authenticate with x509 with missing certificate."""
         creds = {'client_cert': '/opt/rucio/etc/web/notthere.crt'}


### PR DESCRIPTION
`testUserpassNoCACert` failed as well as `testx509NonExistingCert` in `TestBaseClient`.
This is actually strange and points to a real bug.
