### PR TITLE
Testing: make more tests parallel. #4134

### DIFF
--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 CERN
+# Copyright 2020-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #
 # Authors:
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -142,3 +143,33 @@ def auth_token(rest_client, vo):
     token = auth_response.headers.get('X-Rucio-Auth-Token')
     assert token
     return str(token)
+
+
+@pytest.fixture(scope='module')
+def mock_scope(vo):
+    from rucio.common.types import InternalScope
+
+    return InternalScope('mock', vo=vo)
+
+
+@pytest.fixture(scope='module')
+def root_account(vo):
+    from rucio.common.types import InternalAccount
+
+    return InternalAccount('root', vo=vo)
+
+
+@pytest.fixture
+def rse_factory(vo):
+    from rucio.tests.temp_factories import TemporaryRSEFactory
+
+    with TemporaryRSEFactory(vo=vo) as factory:
+        yield factory
+
+
+@pytest.fixture
+def file_factory(vo, mock_scope):
+    from rucio.tests.temp_factories import TemporaryFileFactory
+
+    with TemporaryFileFactory(vo=vo, default_scope=mock_scope) as factory:
+        yield factory

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
+
+import os
+
+from sqlalchemy import or_, and_
+
+from rucio.client.client import Client
+from rucio.client.uploadclient import UploadClient
+from rucio.common.types import InternalScope
+from rucio.common.utils import generate_uuid
+from rucio.core import replica as replica_core
+from rucio.core import rse as rse_core
+from rucio.core import rule as rule_core
+from rucio.db.sqla import models
+from rucio.db.sqla.session import transactional_session
+from rucio.tests.common import file_generator
+from rucio.tests.common import rse_name_generator
+
+
+class TemporaryRSEFactory:
+    """
+    Factory which keeps track of created RSEs and cleans up everything related to these RSEs at the end
+    """
+    def __init__(self, vo, **kwargs):
+        self.vo = vo
+
+        self.created_rses = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup()
+
+    @transactional_session
+    def cleanup(self, session=None):
+        if not self.created_rses:
+            return
+        # Cleanup Transfers
+        session.query(models.Source).filter(or_(models.Source.dest_rse_id.in_(self.created_rses),
+                                                models.Source.rse_id.in_(self.created_rses))).delete(synchronize_session=False)
+        session.query(models.Request).filter(or_(models.Request.dest_rse_id.in_(self.created_rses),
+                                                 models.Request.source_rse_id.in_(self.created_rses))).delete(synchronize_session=False)
+
+        # Cleanup Locks and Rules
+        query = session.query(models.ReplicationRule.id). \
+            join(models.ReplicaLock, models.ReplicationRule.id == models.ReplicaLock.rule_id). \
+            filter(models.ReplicaLock.rse_id.in_(self.created_rses)).distinct()
+        for rule_id, in query:
+            rule_core.delete_rule(rule_id, session=session)
+
+        # Cleanup Replicas and Parent Datasets
+        query = session.query(models.RSEFileAssociation.scope, models.RSEFileAssociation.name, models.RSEFileAssociation.rse_id). \
+            filter(models.RSEFileAssociation.rse_id.in_(self.created_rses))
+        dids_by_rse = {}
+        for scope, name, rse_id in query:
+            dids_by_rse.setdefault(rse_id, []).append({'scope': scope, 'name': name})
+        for rse_id, dids in dids_by_rse.items():
+            replica_core.delete_replicas(rse_id=rse_id, files=dids, session=session)
+
+        # Cleanup RSEs
+        for model in (models.RSEAttrAssociation, models.RSEProtocols, models.UpdatedRSECounter,
+                      models.RSEUsage, models.RSELimit, models.RSETransferLimit, models.RSEQoSAssociation):
+            session.query(model).filter(model.rse_id.in_(self.created_rses)).delete(synchronize_session=False)
+
+        session.query(models.Distance).filter(or_(models.Distance.src_rse_id.in_(self.created_rses),
+                                                  models.Distance.dest_rse_id.in_(self.created_rses))).delete(synchronize_session=False)
+        for rse_id in self.created_rses:
+            # Only archive RSE instead of deleting. Account handling code doesn't expect RSEs to ever be deleted.
+            # So running test in parallel results in some tests failing on foreign key errors.
+            rse_core.del_rse(rse_id, session=session)
+
+    def _make_rse(self, scheme, protocol_impl):
+        rse_name = rse_name_generator()
+        rse_id = rse_core.add_rse(rse_name, vo=self.vo)
+        rse_core.add_protocol(rse_id=rse_id, parameter={
+            'scheme': scheme,
+            'hostname': 'host%d' % len(self.created_rses),
+            'port': 0,
+            'prefix': '/test',
+            'impl': protocol_impl,
+            'domains': {
+                'wan': {
+                    'read': 1,
+                    'write': 1,
+                    'delete': 1,
+                    'third_party_copy': 1
+                }
+            }
+        })
+        self.created_rses.append(rse_id)
+        return rse_name, rse_id
+
+    def make_posix_rse(self):
+        return self._make_rse(scheme='file', protocol_impl='rucio.rse.protocols.posix.Default')
+
+    def make_mock_rse(self):
+        return self._make_rse(scheme='MOCK', protocol_impl='rucio.rse.protocols.mock.Default')
+
+    def make_xroot_rse(self):
+        return self._make_rse(scheme='root', protocol_impl='rucio.rse.protocols.xrootd.Default')
+
+
+class TemporaryFileFactory:
+    """
+    Factory which keeps track of uploaded files and cleans up everything related to these files at the end
+    """
+    def __init__(self, default_scope, vo):
+        self.default_scope = default_scope
+        self.vo = vo
+
+        self._client = None
+        self._upload_client = None
+
+        self.created_rses = []
+        self.created_dids = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup()
+
+    @property
+    def client(self):
+        if not self._client:
+            self._client = Client()
+        return self._client
+
+    @property
+    def upload_client(self):
+        if not self._upload_client:
+            self._upload_client = UploadClient(self.client)
+        return self._upload_client
+
+    @transactional_session
+    def cleanup(self, session=None):
+        if not self.created_dids:
+            return
+
+        # Cleanup Transfers
+        session.query(models.Source).filter(or_(and_(models.Source.scope == did['scope'],
+                                                     models.Source.name == did['name'])
+                                                for did in self.created_dids)).delete(synchronize_session=False)
+        session.query(models.Request).filter(or_(and_(models.Request.scope == did['scope'],
+                                                      models.Request.name == did['name'])
+                                                 for did in self.created_dids)).delete(synchronize_session=False)
+
+        # Cleanup Locks Rules
+        query = session.query(models.ReplicationRule.id).filter(or_(and_(models.ReplicationRule.scope == did['scope'],
+                                                                         models.ReplicationRule.name == did['name'])
+                                                                    for did in self.created_dids))
+        for rule_id, in query:
+            rule_core.delete_rule(rule_id, session=session)
+
+        # Cleanup Replicas and Parent Datasets
+        dids_by_rse = {}
+        replicas = list(replica_core.list_replicas(self.created_dids, all_states=True, session=session))
+        for replica in replicas:
+            for rse_id in replica['rses']:
+                dids_by_rse.setdefault(rse_id, []).append({'scope': replica['scope'], 'name': replica['name']})
+        for rse_id, dids in dids_by_rse.items():
+            replica_core.delete_replicas(rse_id=rse_id, files=dids, session=session)
+
+    def upload_test_file(self, rse_name, scope=None, name=None, path=None, return_full_item=False):
+        if not scope:
+            scope = self.default_scope
+        elif isinstance(scope, str):
+            scope = InternalScope(scope, vo=self.vo)
+        if not path:
+            path = file_generator()
+        if not name:
+            name = os.path.basename(path)
+        item = {
+            'path': path,
+            'rse': rse_name,
+            'did_scope': str(scope),
+            'did_name': name,
+            'guid': generate_uuid(),
+        }
+        self.upload_client.upload([item])
+        did = {'scope': scope, 'name': name}
+        self.created_dids.append(did)
+        return item if return_full_item else did

--- a/lib/rucio/tests/test_archive.py
+++ b/lib/rucio/tests/test_archive.py
@@ -1,4 +1,5 @@
-# Copyright 2017-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2017-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,169 +16,117 @@
 # Authors:
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2017-2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2017
-# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
-import unittest
-
-from rucio.client.didclient import DIDClient
-from rucio.client.replicaclient import ReplicaClient
-from rucio.common.config import config_get, config_get_bool
-from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.replica import add_replicas
-from rucio.core.rse import add_rse, add_protocol
-from rucio.tests.common import rse_name_generator
 
 
-class TestArchive(unittest.TestCase):
+def test_add_and_list_archive(rse_factory, replica_client, did_client, mock_scope):
+    """  ARCHIVE (CLIENT): Add files to archive and list the content """
+    rse, _ = rse_factory.make_mock_rse()
+    scope = mock_scope.external
+    archive_files = ['file_' + generate_uuid() + '.zip' for _ in range(2)]
+    files = []
+    for i in range(10):
+        files.append({'scope': scope, 'name': 'lfn.%s' % str(generate_uuid()),
+                      'bytes': 724963570,
+                      'adler32': '0cc737eb',
+                      'type': 'FILE',
+                      'meta': {'guid': str(generate_uuid())}})
+    for archive_file in archive_files:
 
-    def setUp(self):
-        self.dc = DIDClient()
-        self.rc = ReplicaClient()
+        replica_client.add_replicas(rse=rse, files=[{'scope': scope,
+                                                     'name': archive_file,
+                                                     'bytes': 1,
+                                                     'adler32': '0cc737eb'}])
 
-        if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
-        else:
-            self.vo = {}
+        did_client.add_files_to_archive(scope=scope, name=archive_file, files=files)
 
-    def test_add_and_list_archive(self):
-        """  ARCHIVE (CLIENT): Add files to archive and list the content """
-        scope, rse = 'mock', 'MOCK'
-        archive_files = ['file_' + generate_uuid() + '.zip' for _ in range(2)]
-        files = []
-        for i in range(10):
-            files.append({'scope': scope, 'name': 'lfn.%s' % str(generate_uuid()),
-                          'bytes': 724963570,
-                          'adler32': '0cc737eb',
-                          'type': 'FILE',
-                          'meta': {'guid': str(generate_uuid())}})
-        for archive_file in archive_files:
+        content = [f for f in did_client.list_archive_content(scope=scope, name=archive_file)]
 
-            self.rc.add_replicas(rse=rse, files=[{'scope': scope,
-                                                  'name': archive_file,
-                                                  'bytes': 1,
-                                                  'adler32': '0cc737eb'}])
+        assert len(content) == 10
 
-            self.dc.add_files_to_archive(scope=scope, name=archive_file, files=files)
 
-            content = [f for f in self.dc.list_archive_content(scope=scope, name=archive_file)]
+def test_list_archive_contents_transparently(rse_factory, replica_client, did_client, mock_scope, root_account):
+    """ ARCHIVE (CORE): Transparent archive listing """
 
-            assert len(content) == 10
+    rse, rse_id = rse_factory.make_xroot_rse()
 
-    def test_list_archive_contents_transparently(self):
-        """ ARCHIVE (CORE): Transparent archive listing """
+    # register archive
+    archive = {'scope': mock_scope, 'name': 'weighted.storage.cube.zip', 'type': 'FILE',
+               'bytes': 2596, 'adler32': 'beefdead'}
+    archive_client = archive.copy()
+    archive_client['scope'] = archive_client['scope'].external
 
-        scope = InternalScope('mock', **self.vo)
-        rse = 'APERTURE_%s' % rse_name_generator()
-        rse_id = add_rse(rse, **self.vo)
-        root = InternalAccount('root', **self.vo)
+    add_replicas(rse_id=rse_id, files=[archive], account=root_account)
 
-        add_protocol(rse_id, {'scheme': 'root',
-                              'hostname': 'root.aperture.com',
-                              'port': 1409,
-                              'prefix': '//test/chamber/',
-                              'impl': 'rucio.rse.protocols.xrootd.Default',
-                              'domains': {
-                                  'lan': {'read': 1, 'write': 1, 'delete': 1},
-                                  'wan': {'read': 1, 'write': 1, 'delete': 1}}})
+    # archived files with replicas
+    files_with_replicas = [{'scope': mock_scope, 'name': 'witrep-%i-%s' % (i, str(generate_uuid())), 'type': 'FILE',
+                            'bytes': 1234, 'adler32': 'deadbeef'} for i in range(2)]
+    files_with_replicas_client = []
+    for f in files_with_replicas:
+        new_file = f.copy()
+        new_file['scope'] = new_file['scope'].external
+        files_with_replicas_client.append(new_file)
 
-        # register archive
-        archive = {'scope': scope, 'name': 'weighted.storage.cube.zip', 'type': 'FILE',
-                   'bytes': 2596, 'adler32': 'beefdead'}
-        archive_client = archive.copy()
-        archive_client['scope'] = archive_client['scope'].external
+    add_replicas(rse_id=rse_id, files=files_with_replicas, account=root_account)
+    did_client.add_files_to_archive(scope=archive_client['scope'], name=archive_client['name'], files=files_with_replicas_client)
 
-        add_replicas(rse_id=rse_id, files=[archive], account=root)
+    res = [r['pfns'] for r in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files_with_replicas_client],
+                                                           resolve_archives=True)]
+    assert len(res) == 2
+    assert len(res[0]) == 2
+    assert len(res[1]) == 2
+    for r in res:
+        for p in r:
+            if r[p]['domain'] == 'zip':
+                assert 'weighted.storage.cube.zip?xrdcl.unzip=witrep-' in p
+            else:
+                assert 'weighted.storage.cube.zip?xrdcl.unzip=witrep-' not in p
 
-        # archived files with replicas
-        files_with_replicas = [{'scope': scope, 'name': 'witrep-%i-%s' % (i, str(generate_uuid())), 'type': 'FILE',
-                                'bytes': 1234, 'adler32': 'deadbeef'} for i in range(2)]
-        files_with_replicas_client = []
-        for f in files_with_replicas:
-            new_file = f.copy()
-            new_file['scope'] = new_file['scope'].external
-            files_with_replicas_client.append(new_file)
+    # archived files without replicas
+    files = [{'scope': mock_scope.external, 'name': 'norep-%i-%s' % (i, str(generate_uuid())), 'type': 'FILE',
+              'bytes': 1234, 'adler32': 'deadbeef'} for i in range(2)]
+    did_client.add_files_to_archive(scope=archive_client['scope'], name=archive_client['name'], files=files)
+    res = [r['pfns'] for r in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files],
+                                                           resolve_archives=True)]
+    assert len(res) == 2
+    for r in res:
+        assert 'weighted.storage.cube.zip?xrdcl.unzip=norep-' in list(r.keys())[0]
 
-        add_replicas(rse_id=rse_id, files=files_with_replicas, account=root)
-        self.dc.add_files_to_archive(scope=archive_client['scope'], name=archive_client['name'], files=files_with_replicas_client)
 
-        res = [r['pfns'] for r in self.rc.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files_with_replicas_client],
-                                                        resolve_archives=True)]
-        assert len(res) == 2
-        assert len(res[0]) == 2
-        assert len(res[1]) == 2
-        for r in res:
-            for p in r:
-                if r[p]['domain'] == 'zip':
-                    assert 'weighted.storage.cube.zip?xrdcl.unzip=witrep-' in p
-                else:
-                    assert 'weighted.storage.cube.zip?xrdcl.unzip=witrep-' not in p
+def test_list_archive_contents_at_rse(rse_factory, mock_scope, root_account, did_client, replica_client):
+    """ ARCHIVE (CORE): Transparent archive listing at RSE """
 
-        # archived files without replicas
-        files = [{'scope': scope.external, 'name': 'norep-%i-%s' % (i, str(generate_uuid())), 'type': 'FILE',
-                  'bytes': 1234, 'adler32': 'deadbeef'} for i in range(2)]
-        self.dc.add_files_to_archive(scope=archive_client['scope'], name=archive_client['name'], files=files)
-        res = [r['pfns'] for r in self.rc.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files],
-                                                        resolve_archives=True)]
-        assert len(res) == 2
-        for r in res:
-            assert 'weighted.storage.cube.zip?xrdcl.unzip=norep-' in list(r.keys())[0]
+    rse1, rse1_id = rse_factory.make_xroot_rse()
+    rse2, rse2_id = rse_factory.make_xroot_rse()
+    # register archive
+    archive1 = {'scope': mock_scope, 'name': 'cube.1.zip', 'type': 'FILE', 'bytes': 2596, 'adler32': 'beefdead'}
+    archive2 = {'scope': mock_scope, 'name': 'cube.2.zip', 'type': 'FILE', 'bytes': 5432, 'adler32': 'deadbeef'}
+    add_replicas(rse_id=rse1_id, files=[archive1], account=root_account)
+    add_replicas(rse_id=rse2_id, files=[archive2], account=root_account)
 
-    def test_list_archive_contents_at_rse(self):
-        """ ARCHIVE (CORE): Transparent archive listing at RSE """
+    # archived files with replicas
+    archived_file = [{'scope': mock_scope.external, 'name': 'zippedfile-%i-%s' % (i, str(generate_uuid())), 'type': 'FILE',
+                      'bytes': 4322, 'adler32': 'beefbeef'} for i in range(2)]
+    did_client.add_files_to_archive(scope=mock_scope.external, name=archive1['name'], files=archived_file)
+    did_client.add_files_to_archive(scope=mock_scope.external, name=archive2['name'], files=archived_file)
 
-        scope = InternalScope('mock', **self.vo)
-        root = InternalAccount('root', **self.vo)
+    res = [r['pfns'] for r in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file],
+                                                           rse_expression=rse1,
+                                                           resolve_archives=True)]
 
-        rse1 = 'APERTURE_%s' % rse_name_generator()
-        rse1_id = add_rse(rse1, **self.vo)
-        add_protocol(rse1_id, {'scheme': 'root',
-                               'hostname': 'root.aperture.com',
-                               'port': 1409,
-                               'prefix': '//test/chamber/',
-                               'impl': 'rucio.rse.protocols.xrootd.Default',
-                               'domains': {
-                                   'lan': {'read': 1, 'write': 1, 'delete': 1},
-                                   'wan': {'read': 1, 'write': 1, 'delete': 1}}})
+    res = replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file], metalink=True, rse_expression=rse1, resolve_archives=True)
+    assert rse1 in res
+    assert rse2 not in res
 
-        rse2 = 'BLACKMESA_%s' % rse_name_generator()
-        rse2_id = add_rse(rse2, **self.vo)
-        add_protocol(rse2_id, {'scheme': 'root',
-                               'hostname': 'root.blackmesa.com',
-                               'port': 1409,
-                               'prefix': '//lambda/complex/',
-                               'impl': 'rucio.rse.protocols.xrootd.Default',
-                               'domains': {
-                                   'lan': {'read': 1, 'write': 1, 'delete': 1},
-                                   'wan': {'read': 1, 'write': 1, 'delete': 1}}})
-
-        # register archive
-        archive1 = {'scope': scope, 'name': 'cube.1.zip', 'type': 'FILE', 'bytes': 2596, 'adler32': 'beefdead'}
-        archive2 = {'scope': scope, 'name': 'cube.2.zip', 'type': 'FILE', 'bytes': 5432, 'adler32': 'deadbeef'}
-        add_replicas(rse_id=rse1_id, files=[archive1], account=root)
-        add_replicas(rse_id=rse2_id, files=[archive2], account=root)
-
-        # archived files with replicas
-        archived_file = [{'scope': scope.external, 'name': 'zippedfile-%i-%s' % (i, str(generate_uuid())), 'type': 'FILE',
-                          'bytes': 4322, 'adler32': 'beefbeef'} for i in range(2)]
-        self.dc.add_files_to_archive(scope=scope.external, name=archive1['name'], files=archived_file)
-        self.dc.add_files_to_archive(scope=scope.external, name=archive2['name'], files=archived_file)
-
-        res = [r['pfns'] for r in self.rc.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file],
-                                                        rse_expression=rse1,
-                                                        resolve_archives=True)]
-
-        res = self.rc.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file], metalink=True, rse_expression=rse1, resolve_archives=True)
-        assert 'APERTURE' in res
-        assert 'BLACKMESA' not in res
-
-        res = self.rc.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file], metalink=True, rse_expression=rse2, resolve_archives=True)
-        assert 'BLACKMESA' in res
-        assert 'APERTURE' not in res
+    res = replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file], metalink=True, rse_expression=rse2, resolve_archives=True)
+    assert rse1 not in res
+    assert rse2 in res

--- a/lib/rucio/tests/test_download.py
+++ b/lib/rucio/tests/test_download.py
@@ -25,361 +25,348 @@
 
 import logging
 import shutil
-import unittest
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
 
 import pytest
 
-from rucio.client.client import Client
-from rucio.client.didclient import DIDClient
 from rucio.client.downloadclient import DownloadClient
-from rucio.client.uploadclient import UploadClient
-from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import InputValidationError, NoFilesDownloaded
 from rucio.common.utils import generate_uuid
 from rucio.rse import rsemanager as rsemgr
 from rucio.rse.protocols.posix import Default as PosixProtocol
-from rucio.tests.common import file_generator
 
 
-@pytest.mark.noparallel(reason='uses pre-defined RSEs, fails when run in parallel')
-class TestDownloadClient(unittest.TestCase):
-    def setUp(self):
-        if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
-        else:
-            self.vo = {}
+@pytest.fixture
+def download_client():
+    logger = logging.getLogger('dlul_client')
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.DEBUG)
+    return DownloadClient(logger=logger)
 
-        logger = logging.getLogger('dlul_client')
-        logger.addHandler(logging.StreamHandler())
-        logger.setLevel(logging.DEBUG)
-        self.client = Client()
-        self.did_client = DIDClient()
-        self.upload_client = UploadClient(_client=self.client, logger=logger)
-        self.download_client = DownloadClient(client=self.client, logger=logger)
 
-    def _upoad_test_file(self, rse, scope, name, path=None):
-        item = {
-            'path': path if path else file_generator(),
-            'rse': rse,
-            'did_scope': scope,
-            'did_name': name,
-            'guid': generate_uuid(),
-        }
-        assert self.upload_client.upload([item]) == 0
-        return item
+def _check_download_result(actual_result, expected_result):
+    assert len(expected_result) == len(actual_result)
+    expected_result = sorted(expected_result, key=lambda x: x['did'])
+    actual_result = sorted(actual_result, key=lambda x: x['did'])
+    for i, expected in enumerate(expected_result):
+        for param_name, expected_value in expected.items():
+            assert param_name and actual_result[i][param_name] == expected[param_name]
 
-    @staticmethod
-    def _check_download_result(actual_result, expected_result):
-        assert len(expected_result) == len(actual_result)
-        expected_result = sorted(expected_result, key=lambda x: x['did'])
-        actual_result = sorted(actual_result, key=lambda x: x['did'])
-        for i, expected in enumerate(expected_result):
-            for param_name, expected_value in expected.items():
-                assert param_name and actual_result[i][param_name] == expected[param_name]
 
-    def test_download_without_base_dir(self):
-        rse = 'MOCK4'
-        scope = 'mock'
-        item = self._upoad_test_file(rse, scope, 'testDownloadNoBasedir' + generate_uuid())
-        did = '%s:%s' % (scope, item['did_name'])
-        try:
-            # download to the default location, i.e. to ./
-            result = self.download_client.download_dids([{'did': did}])
-            self._check_download_result(
-                actual_result=result,
-                expected_result=[
-                    {
-                        'did': did,
-                        'clientState': 'DONE',
-                    }
-                ],
-            )
+def test_download_without_base_dir(rse_factory, file_factory, download_client):
+    scope = str(file_factory.default_scope)
+    rse, _ = rse_factory.make_posix_rse()
+    did = file_factory.upload_test_file(rse)
+    did_str = '%s:%s' % (did['scope'], did['name'])
+    try:
+        # download to the default location, i.e. to ./
+        result = download_client.download_dids([{'did': did_str}])
+        _check_download_result(
+            actual_result=result,
+            expected_result=[
+                {
+                    'did': did_str,
+                    'clientState': 'DONE',
+                }
+            ],
+        )
 
-            # re-downloading the same file again should not overwrite it
-            result = self.download_client.download_dids([{'did': did}])
-            self._check_download_result(
-                actual_result=result,
-                expected_result=[
-                    {
-                        'did': did,
-                        'clientState': 'ALREADY_DONE',
-                    }
-                ],
-            )
-        finally:
-            shutil.rmtree(scope)
+        # re-downloading the same file again should not overwrite it
+        result = download_client.download_dids([{'did': did_str}])
+        _check_download_result(
+            actual_result=result,
+            expected_result=[
+                {
+                    'did': did_str,
+                    'clientState': 'ALREADY_DONE',
+                }
+            ],
+        )
+    finally:
+        shutil.rmtree(scope)
 
-    def test_download_to_two_paths(self):
-        rse = 'MOCK4'
-        scope = 'mock'
-        base_name = 'testDownloadItem' + generate_uuid()
-        item000 = self._upoad_test_file(rse, scope, base_name + '.000')
-        item001 = self._upoad_test_file(rse, scope, base_name + '.001')
-        item100 = self._upoad_test_file(rse, scope, base_name + '.100')
 
-        with TemporaryDirectory() as tmp_dir1, TemporaryDirectory() as tmp_dir2:
-            # Download two overlapping wildcard dids to two separate paths.
-            # 000 will be in both paths. Other two files only in one of the two paths.
-            result = self.download_client.download_dids([{'did': '%s:%s.*0' % (scope, base_name), 'base_dir': tmp_dir1},
-                                                         {'did': '%s:%s.0*' % (scope, base_name), 'base_dir': tmp_dir2}])
-            paths000 = next(filter(lambda r: r['did'] == '%s:%s' % (scope, item000['did_name']), result))['dest_file_paths']
-            paths001 = next(filter(lambda r: r['did'] == '%s:%s' % (scope, item001['did_name']), result))['dest_file_paths']
-            paths100 = next(filter(lambda r: r['did'] == '%s:%s' % (scope, item100['did_name']), result))['dest_file_paths']
+def test_download_to_two_paths(rse_factory, file_factory, download_client):
+    scope = str(file_factory.default_scope)
+    rse, _ = rse_factory.make_posix_rse()
+    base_name = generate_uuid()
+    item000 = file_factory.upload_test_file(rse, name=base_name + '.000', return_full_item=True)
+    item001 = file_factory.upload_test_file(rse, name=base_name + '.001', return_full_item=True)
+    item100 = file_factory.upload_test_file(rse, name=base_name + '.100', return_full_item=True)
+    did000_str = '%s:%s' % (item000['did_scope'], item000['did_name'])
+    did001_str = '%s:%s' % (item001['did_scope'], item001['did_name'])
+    did100_str = '%s:%s' % (item100['did_scope'], item100['did_name'])
 
-            assert len(paths000) == 2
-            assert any(p.startswith(tmp_dir1) for p in paths000)
-            assert any(p.startswith(tmp_dir2) for p in paths000)
+    with TemporaryDirectory() as tmp_dir1, TemporaryDirectory() as tmp_dir2:
+        # Download two overlapping wildcard dids to two separate paths.
+        # 000 will be in both paths. Other two files only in one of the two paths.
+        result = download_client.download_dids([{'did': '%s:%s.*0' % (scope, base_name), 'base_dir': tmp_dir1},
+                                                {'did': '%s:%s.0*' % (scope, base_name), 'base_dir': tmp_dir2}])
+        paths000 = next(filter(lambda r: r['did'] == did000_str, result))['dest_file_paths']
+        paths001 = next(filter(lambda r: r['did'] == did001_str, result))['dest_file_paths']
+        paths100 = next(filter(lambda r: r['did'] == did100_str, result))['dest_file_paths']
 
-            assert len(paths001) == 1
-            assert paths001[0].startswith(tmp_dir2)
+        assert len(paths000) == 2
+        assert any(p.startswith(tmp_dir1) for p in paths000)
+        assert any(p.startswith(tmp_dir2) for p in paths000)
 
-            assert len(paths100) == 1
-            assert paths100[0].startswith(tmp_dir1)
+        assert len(paths001) == 1
+        assert paths001[0].startswith(tmp_dir2)
 
-    def test_download_multiple(self):
-        rse = 'MOCK4'
-        scope = 'mock'
-        base_name = 'testDownloadItem' + generate_uuid()
-        item000 = self._upoad_test_file(rse, scope, base_name + '.000')
-        item001 = self._upoad_test_file(rse, scope, base_name + '.001')
-        item100 = self._upoad_test_file(rse, scope, base_name + '.100')
+        assert len(paths100) == 1
+        assert paths100[0].startswith(tmp_dir1)
 
-        with TemporaryDirectory() as tmp_dir:
-            # Download specific DID
-            result = self.download_client.download_dids([{'did': '%s:%s' % (scope, item000['did_name']), 'base_dir': tmp_dir}])
-            self._check_download_result(
-                actual_result=result,
-                expected_result=[
-                    {
-                        'did': '%s:%s' % (scope, item000['did_name']),
-                        'clientState': 'DONE',
-                    }
-                ],
-            )
 
-            # Download multiple files with wildcard. One file already exists on the file system. Will not be re-downloaded.
-            result = self.download_client.download_dids([{'did': '%s:%s.0*' % (scope, base_name), 'base_dir': tmp_dir}])
-            self._check_download_result(
-                actual_result=result,
-                expected_result=[
-                    {
-                        'did': '%s:%s' % (scope, item000['did_name']),
-                        'clientState': 'ALREADY_DONE',
-                    },
-                    {
-                        'did': '%s:%s' % (scope, item001['did_name']),
-                        'clientState': 'DONE',
-                    },
-                ],
-            )
+def test_download_multiple(rse_factory, file_factory, download_client):
+    scope = str(file_factory.default_scope)
+    rse, _ = rse_factory.make_posix_rse()
+    base_name = generate_uuid()
+    item000 = file_factory.upload_test_file(rse, name=base_name + '.000', return_full_item=True)
+    item001 = file_factory.upload_test_file(rse, name=base_name + '.001', return_full_item=True)
+    item100 = file_factory.upload_test_file(rse, name=base_name + '.100', return_full_item=True)
+    did000_str = '%s:%s' % (item000['did_scope'], item000['did_name'])
+    did001_str = '%s:%s' % (item001['did_scope'], item001['did_name'])
+    did100_str = '%s:%s' % (item100['did_scope'], item100['did_name'])
 
-            # Download with filter
-            result = self.download_client.download_dids([{'filters': {'guid': item000['guid'], 'scope': scope}, 'base_dir': tmp_dir}])
-            self._check_download_result(
-                actual_result=result,
-                expected_result=[
-                    {
-                        'did': '%s:%s' % (scope, item000['did_name']),
-                    }
-                ],
-            )
+    with TemporaryDirectory() as tmp_dir:
+        # Download specific DID
+        result = download_client.download_dids([{'did': did000_str, 'base_dir': tmp_dir}])
+        _check_download_result(
+            actual_result=result,
+            expected_result=[
+                {
+                    'did': did000_str,
+                    'clientState': 'DONE',
+                }
+            ],
+        )
 
-            # Download with wildcard and name
-            result = self.download_client.download_dids([{'did': '%s:*' % scope, 'filters': {'guid': item100['guid']}, 'base_dir': tmp_dir}])
-            self._check_download_result(
-                actual_result=result,
-                expected_result=[
-                    {
-                        'did': '%s:%s' % (scope, item100['did_name']),
-                        'clientState': 'DONE',
-                    }
-                ],
-            )
+        # Download multiple files with wildcard. One file already exists on the file system. Will not be re-downloaded.
+        result = download_client.download_dids([{'did': '%s:%s.0*' % (scope, base_name), 'base_dir': tmp_dir}])
+        _check_download_result(
+            actual_result=result,
+            expected_result=[
+                {
+                    'did': did000_str,
+                    'clientState': 'ALREADY_DONE',
+                },
+                {
+                    'did': did001_str,
+                    'clientState': 'DONE',
+                },
+            ],
+        )
 
-            # Don't create subdirectories by scope
-            result = self.download_client.download_dids([{'did': '%s:%s.*' % (scope, base_name), 'base_dir': tmp_dir, 'no_subdir': True}])
-            self._check_download_result(
-                actual_result=result,
-                expected_result=[
-                    {
-                        'did': '%s:%s' % (scope, item000['did_name']),
-                        'clientState': 'DONE',
-                        'dest_file_paths': ['%s/%s' % (tmp_dir, item000['did_name'])],
-                    },
-                    {
-                        'did': '%s:%s' % (scope, item001['did_name']),
-                        'clientState': 'DONE',
-                        'dest_file_paths': ['%s/%s' % (tmp_dir, item001['did_name'])],
-                    },
-                    {
-                        'did': '%s:%s' % (scope, item100['did_name']),
-                        'clientState': 'DONE',
-                        'dest_file_paths': ['%s/%s' % (tmp_dir, item100['did_name'])],
-                    },
-                ],
-            )
+        # Download with filter
+        result = download_client.download_dids([{'filters': {'guid': item000['guid'], 'scope': scope}, 'base_dir': tmp_dir}])
+        _check_download_result(
+            actual_result=result,
+            expected_result=[
+                {
+                    'did': did000_str,
+                }
+            ],
+        )
 
-            # Re-download file existing on the file system with no-subdir set. It must be overwritten.
-            result = self.download_client.download_dids([{'did': '%s:%s' % (scope, item100['did_name']), 'base_dir': tmp_dir, 'no_subdir': True}])
-            self._check_download_result(
-                actual_result=result,
-                expected_result=[
-                    {
-                        'did': '%s:%s' % (scope, item100['did_name']),
-                        'clientState': 'ALREADY_DONE',
-                        'dest_file_paths': ['%s/%s' % (tmp_dir, item100['did_name'])],
-                    }
-                ],
-            )
+        # Download with wildcard and name
+        result = download_client.download_dids([{'did': '%s:*' % scope, 'filters': {'guid': item100['guid']}, 'base_dir': tmp_dir}])
+        _check_download_result(
+            actual_result=result,
+            expected_result=[
+                {
+                    'did': did100_str,
+                    'clientState': 'DONE',
+                }
+            ],
+        )
 
-    @pytest.mark.xfail(reason='XRD1 must be initialized https://github.com/rucio/rucio/pull/4165/')
-    def test_download_from_archive_on_xrd(self):
-        scope = 'test'
-        rse = 'XRD1'
-        base_name = 'testDownloadArchive' + generate_uuid()
-        with TemporaryDirectory() as tmp_dir:
-            # Create a zip archive with two files and upload it
-            name000 = base_name + '.000'
-            data000 = '000'
-            adler000 = '01230091'
-            name001 = base_name + '.001'
-            data001 = '001'
-            adler001 = '01240092'
-            zip_name = base_name + '.zip'
-            zip_path = '%s/%s' % (tmp_dir, zip_name)
-            with ZipFile(zip_path, 'w') as myzip:
-                myzip.writestr(name000, data=data000)
-                myzip.writestr(name001, data=data001)
-            self._upoad_test_file(rse, scope, zip_name, path=zip_path)
-            self.did_client.add_files_to_archive(
-                scope,
-                zip_name,
-                [
-                    {'scope': scope, 'name': name000, 'bytes': len(data000), 'type': 'FILE', 'adler32': adler000, 'meta': {'guid': str(generate_uuid())}},
-                    {'scope': scope, 'name': name001, 'bytes': len(data001), 'type': 'FILE', 'adler32': adler001, 'meta': {'guid': str(generate_uuid())}},
-                ],
-            )
+        # Don't create subdirectories by scope
+        result = download_client.download_dids([{'did': '%s:%s.*' % (scope, base_name), 'base_dir': tmp_dir, 'no_subdir': True}])
+        _check_download_result(
+            actual_result=result,
+            expected_result=[
+                {
+                    'did': did000_str,
+                    'clientState': 'DONE',
+                    'dest_file_paths': ['%s/%s' % (tmp_dir, item000['did_name'])],
+                },
+                {
+                    'did': did001_str,
+                    'clientState': 'DONE',
+                    'dest_file_paths': ['%s/%s' % (tmp_dir, item001['did_name'])],
+                },
+                {
+                    'did': did100_str,
+                    'clientState': 'DONE',
+                    'dest_file_paths': ['%s/%s' % (tmp_dir, item100['did_name'])],
+                },
+            ],
+        )
 
-            # Download one file from the archive
-            result = self.download_client.download_dids([{'did': '%s:%s' % (scope, name000), 'base_dir': tmp_dir}])
-            self._check_download_result(
-                actual_result=result,
-                expected_result=[
-                    {
-                        'did': '%s:%s' % (scope, name000),
-                        'clientState': 'DONE',
-                    },
-                ],
-            )
-            with open('%s/%s/%s' % (tmp_dir, scope, name000), 'r') as file:
-                assert file.read() == data000
+        # Re-download file existing on the file system with no-subdir set. It must be overwritten.
+        result = download_client.download_dids([{'did': did100_str, 'base_dir': tmp_dir, 'no_subdir': True}])
+        _check_download_result(
+            actual_result=result,
+            expected_result=[
+                {
+                    'did': did100_str,
+                    'clientState': 'ALREADY_DONE',
+                    'dest_file_paths': ['%s/%s' % (tmp_dir, item100['did_name'])],
+                }
+            ],
+        )
 
-            # Download both files from the archive
-            result = self.download_client.download_dids([{'did': '%s:%s.00*' % (scope, base_name), 'base_dir': tmp_dir}])
-            self._check_download_result(
-                actual_result=result,
-                expected_result=[
-                    {
-                        'did': '%s:%s' % (scope, name000),
-                        'clientState': 'ALREADY_DONE',
-                    },
-                    {
-                        'did': '%s:%s' % (scope, name001),
-                        'clientState': 'DONE',
-                    },
-                ],
-            )
-            with open('%s/%s/%s' % (tmp_dir, scope, name001), 'r') as file:
-                assert file.read() == data001
 
-            pfn = next(filter(lambda r: name001 in r['did'], result))['sources'][0]['pfn']
-            # Download by pfn from the archive
-            result = self.download_client.download_pfns([{'did': '%s:%s' % (scope, name001), 'pfn': pfn, 'rse': rse, 'base_dir': tmp_dir, 'no_subdir': True}])
-            self._check_download_result(
-                actual_result=result,
-                expected_result=[
-                    {
-                        'did': '%s:%s' % (scope, name001),
-                        'clientState': 'DONE',
-                    },
-                ],
-            )
+@pytest.mark.xfail(reason='XRD1 must be initialized https://github.com/rucio/rucio/pull/4165/')
+@pytest.mark.dirty
+@pytest.mark.noparallel(reason='uses pre-defined XRD1 RSE, may fails when run in parallel')  # TODO: verify if it really fails
+def test_download_from_archive_on_xrd(file_factory, download_client, did_client):
+    scope = 'test'
+    rse = 'XRD1'
+    base_name = 'testDownloadArchive' + generate_uuid()
+    with TemporaryDirectory() as tmp_dir:
+        # Create a zip archive with two files and upload it
+        name000 = base_name + '.000'
+        data000 = '000'
+        adler000 = '01230091'
+        name001 = base_name + '.001'
+        data001 = '001'
+        adler001 = '01240092'
+        zip_name = base_name + '.zip'
+        zip_path = '%s/%s' % (tmp_dir, zip_name)
+        with ZipFile(zip_path, 'w') as myzip:
+            myzip.writestr(name000, data=data000)
+            myzip.writestr(name001, data=data001)
+        file_factory.upload_test_file(rse, scope=scope, name=zip_name, path=zip_path)
+        did_client.add_files_to_archive(
+            scope,
+            zip_name,
+            [
+                {'scope': scope, 'name': name000, 'bytes': len(data000), 'type': 'FILE', 'adler32': adler000, 'meta': {'guid': str(generate_uuid())}},
+                {'scope': scope, 'name': name001, 'bytes': len(data001), 'type': 'FILE', 'adler32': adler001, 'meta': {'guid': str(generate_uuid())}},
+            ],
+        )
 
-    def test_trace_copy_out_and_checksum_validation(self):
-        rse = 'MOCK4'
-        scope = 'mock'
-        name = 'testDownloadTraces' + generate_uuid()
-        self._upoad_test_file(rse, scope, name)
+        # Download one file from the archive
+        result = download_client.download_dids([{'did': '%s:%s' % (scope, name000), 'base_dir': tmp_dir}])
+        _check_download_result(
+            actual_result=result,
+            expected_result=[
+                {
+                    'did': '%s:%s' % (scope, name000),
+                    'clientState': 'DONE',
+                },
+            ],
+        )
+        with open('%s/%s/%s' % (tmp_dir, scope, name000), 'r') as file:
+            assert file.read() == data000
 
-        with TemporaryDirectory() as tmp_dir:
-            # Try downloading non-existing did
-            traces = []
-            with pytest.raises(NoFilesDownloaded):
-                self.download_client.download_dids([{'did': 'some:randomNonExistingDid', 'base_dir': tmp_dir}], traces_copy_out=traces)
-            assert len(traces) == 1 and traces[0]['clientState'] == 'FILE_NOT_FOUND'
+        # Download both files from the archive
+        result = download_client.download_dids([{'did': '%s:%s.00*' % (scope, base_name), 'base_dir': tmp_dir}])
+        _check_download_result(
+            actual_result=result,
+            expected_result=[
+                {
+                    'did': '%s:%s' % (scope, name000),
+                    'clientState': 'ALREADY_DONE',
+                },
+                {
+                    'did': '%s:%s' % (scope, name001),
+                    'clientState': 'DONE',
+                },
+            ],
+        )
+        with open('%s/%s/%s' % (tmp_dir, scope, name001), 'r') as file:
+            assert file.read() == data001
 
-            # Download specific DID
-            traces = []
-            self.download_client.download_dids([{'did': '%s:%s' % (scope, name), 'base_dir': tmp_dir}], traces_copy_out=traces)
-            assert len(traces) == 1 and traces[0]['clientState'] == 'DONE'
+        pfn = next(filter(lambda r: name001 in r['did'], result))['sources'][0]['pfn']
+        # Download by pfn from the archive
+        result = download_client.download_pfns([{'did': '%s:%s' % (scope, name001), 'pfn': pfn, 'rse': rse, 'base_dir': tmp_dir, 'no_subdir': True}])
+        _check_download_result(
+            actual_result=result,
+            expected_result=[
+                {
+                    'did': '%s:%s' % (scope, name001),
+                    'clientState': 'DONE',
+                },
+            ],
+        )
 
-            # Download same DID again
-            traces = []
-            result = self.download_client.download_dids([{'did': '%s:%s' % (scope, name), 'base_dir': tmp_dir}], traces_copy_out=traces)
-            assert len(traces) == 1 and traces[0]['clientState'] == 'ALREADY_DONE'
 
-            # Change the local file and download the same file again. Checksum validation should fail and it must be re-downloaded
-            with open(result[0]['dest_file_paths'][0], 'a') as f:
-                f.write("more data")
-            traces = []
-            result = self.download_client.download_dids([{'did': '%s:%s' % (scope, name), 'base_dir': tmp_dir}], traces_copy_out=traces)
-            assert len(traces) == 1 and traces[0]['clientState'] == 'DONE'
+def test_trace_copy_out_and_checksum_validation(vo, rse_factory, file_factory, download_client):
+    rse, _ = rse_factory.make_posix_rse()
+    scope = str(file_factory.default_scope)
+    did = file_factory.upload_test_file(rse)
+    did_str = '%s:%s' % (did['scope'], did['name'])
 
-            pfn = result[0]['sources'][0]['pfn']
+    with TemporaryDirectory() as tmp_dir:
+        # Try downloading non-existing did
+        traces = []
+        with pytest.raises(NoFilesDownloaded):
+            download_client.download_dids([{'did': 'some:randomNonExistingDid', 'base_dir': tmp_dir}], traces_copy_out=traces)
+        assert len(traces) == 1 and traces[0]['clientState'] == 'FILE_NOT_FOUND'
 
-        # Switch to a new empty directory
-        with TemporaryDirectory() as tmp_dir:
-            # Wildcards in did name are not allowed on pfn downloads
-            traces = []
-            with pytest.raises(InputValidationError):
-                self.download_client.download_pfns([{'did': '%s:*' % scope, 'pfn': pfn, 'rse': rse, 'base_dir': tmp_dir}], traces_copy_out=traces)
-            assert not traces
+        # Download specific DID
+        traces = []
+        download_client.download_dids([{'did': did_str, 'base_dir': tmp_dir}], traces_copy_out=traces)
+        assert len(traces) == 1 and traces[0]['clientState'] == 'DONE'
 
-            # Same pfn, but without wildcard in the did should work
-            traces = []
-            self.download_client.download_pfns([{'did': '%s:%s' % (scope, name), 'pfn': pfn, 'rse': rse, 'base_dir': tmp_dir}], traces_copy_out=traces)
-            assert len(traces) == 1 and traces[0]['clientState'] == 'DONE'
+        # Download same DID again
+        traces = []
+        result = download_client.download_dids([{'did': did_str, 'base_dir': tmp_dir}], traces_copy_out=traces)
+        assert len(traces) == 1 and traces[0]['clientState'] == 'ALREADY_DONE'
 
-            # Same pfn. Local file already present. Shouldn't be overwritten.
-            traces = []
-            self.download_client.download_pfns([{'did': '%s:%s' % (scope, name), 'pfn': pfn, 'rse': rse, 'base_dir': tmp_dir}], traces_copy_out=traces)
-            assert len(traces) == 1 and traces[0]['clientState'] == 'ALREADY_DONE'
+        # Change the local file and download the same file again. Checksum validation should fail and it must be re-downloaded
+        with open(result[0]['dest_file_paths'][0], 'a') as f:
+            f.write("more data")
+        traces = []
+        result = download_client.download_dids([{'did': did_str, 'base_dir': tmp_dir}], traces_copy_out=traces)
+        assert len(traces) == 1 and traces[0]['clientState'] == 'DONE'
 
-            # Provide wrong checksum for validation, the file will be re-downloaded but checksum validation fails
-            traces = []
-            with pytest.raises(NoFilesDownloaded):
-                self.download_client.download_pfns([{'did': '%s:%s' % (scope, name), 'pfn': pfn, 'rse': rse, 'adler32': 'wrong', 'base_dir': tmp_dir}], traces_copy_out=traces)
-            assert len(traces) == 1 and traces[0]['clientState'] == 'FAIL_VALIDATE'
+        pfn = result[0]['sources'][0]['pfn']
 
-        # Switch to a new empty directory
-        with TemporaryDirectory() as tmp_dir:
-            # Simulate checksum corruption by changing the source file. We rely on the particularity
-            # that the MOCK4 rse uses the posix protocol: files are stored on the local file system
-            protocol = rsemgr.create_protocol(rsemgr.get_rse_info(rse, vo=self.client.vo), operation='read')
-            assert isinstance(protocol, PosixProtocol)
-            mock_rse_local_path = protocol.pfn2path(pfn)
-            with open(mock_rse_local_path, 'w') as f:
-                f.write('some completely other data')
+    # Switch to a new empty directory
+    with TemporaryDirectory() as tmp_dir:
+        # Wildcards in did name are not allowed on pfn downloads
+        traces = []
+        with pytest.raises(InputValidationError):
+            download_client.download_pfns([{'did': '%s:*' % scope, 'pfn': pfn, 'rse': rse, 'base_dir': tmp_dir}], traces_copy_out=traces)
+        assert not traces
 
-            # Download fails checksum validation
-            traces = []
-            with pytest.raises(NoFilesDownloaded):
-                self.download_client.download_dids([{'did': '%s:%s' % (scope, name), 'base_dir': tmp_dir}], traces_copy_out=traces)
-            assert len(traces) == 1 and traces[0]['clientState'] == 'FAIL_VALIDATE'
+        # Same pfn, but without wildcard in the did should work
+        traces = []
+        download_client.download_pfns([{'did': did_str, 'pfn': pfn, 'rse': rse, 'base_dir': tmp_dir}], traces_copy_out=traces)
+        assert len(traces) == 1 and traces[0]['clientState'] == 'DONE'
 
-            # Ignore_checksum set. Download works.
-            traces = []
-            self.download_client.download_dids([{'did': '%s:%s' % (scope, name), 'base_dir': tmp_dir, 'ignore_checksum': True}], traces_copy_out=traces)
-            assert len(traces) == 1 and traces[0]['clientState'] == 'DONE'
+        # Same pfn. Local file already present. Shouldn't be overwritten.
+        traces = []
+        download_client.download_pfns([{'did': did_str, 'pfn': pfn, 'rse': rse, 'base_dir': tmp_dir}], traces_copy_out=traces)
+        assert len(traces) == 1 and traces[0]['clientState'] == 'ALREADY_DONE'
+
+        # Provide wrong checksum for validation, the file will be re-downloaded but checksum validation fails
+        traces = []
+        with pytest.raises(NoFilesDownloaded):
+            download_client.download_pfns([{'did': did_str, 'pfn': pfn, 'rse': rse, 'adler32': 'wrong', 'base_dir': tmp_dir}], traces_copy_out=traces)
+        assert len(traces) == 1 and traces[0]['clientState'] == 'FAIL_VALIDATE'
+
+    # Switch to a new empty directory
+    with TemporaryDirectory() as tmp_dir:
+        # Simulate checksum corruption by changing the source file. We rely on the particularity
+        # that the MOCK4 rse uses the posix protocol: files are stored on the local file system
+        protocol = rsemgr.create_protocol(rsemgr.get_rse_info(rse, vo=vo), operation='read')
+        assert isinstance(protocol, PosixProtocol)
+        mock_rse_local_path = protocol.pfn2path(pfn)
+        with open(mock_rse_local_path, 'w') as f:
+            f.write('some completely other data')
+
+        # Download fails checksum validation
+        traces = []
+        with pytest.raises(NoFilesDownloaded):
+            download_client.download_dids([{'did': did_str, 'base_dir': tmp_dir}], traces_copy_out=traces)
+        assert len(traces) == 1 and traces[0]['clientState'] == 'FAIL_VALIDATE'
+
+        # Ignore_checksum set. Download works.
+        traces = []
+        download_client.download_dids([{'did': did_str, 'base_dir': tmp_dir, 'ignore_checksum': True}], traces_copy_out=traces)
+        assert len(traces) == 1 and traces[0]['clientState'] == 'DONE'


### PR DESCRIPTION
For multiple issues I'm working right now, I realize that I
copy-paste the same code for initializing rses, rules,
requests in test cases.

Add factory classes allowing to create RSEs and upload files
(implicitly creating replication rules, with correct checksums, etc).
Add an associated fixture to easily use it in multiple tests. 
Auto-cleanup created resources at the end of the test.

Migrate a couple of tests to using this fixture. This allows
to also remove some "noparallel" marks on download tests.
