### PR TITLE
Clients: Resolves adler32 mismatch Fix #4127

### DIFF
--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -913,7 +913,7 @@ class DownloadClient:
                     skip_check = item.get('ignore_checksum', False)
                     rucio_checksum = 0 if skip_check else item.get('adler32')
                     local_checksum = 0 if skip_check else adler32(temp_file_path)
-                    if rucio_checksum == local_checksum:
+                    if str(rucio_checksum).lstrip('0') == str(local_checksum).lstrip('0'):
                         item['clientState'] = 'DONE'
                         trace['clientState'] = 'DONE'
                         # remove .part ending

--- a/lib/rucio/client/dq2client.py
+++ b/lib/rucio/client/dq2client.py
@@ -1585,7 +1585,7 @@ class DQ2Client:
                     guid = '%s-%s-%s-%s-%s' % (guid[0:8], guid[8:12], guid[12:16], guid[16:20], guid[20:32])
                     if guid != did['meta']['guid']:
                         result[lfn] = {'status': False, 'error': FileConsistencyMismatch('guid mismatch DDM %s vs user %s' % (guid, did['meta']['guid']))}
-                    elif meta['adler32'] != did['adler32']:
+                    elif str(meta['adler32']).lstrip('0') != str(did['adler32']).lstrip('0'):
                         result[lfn] = {'status': False, 'error': FileConsistencyMismatch('adler32 mismatch DDM %s vs user %s' % (meta['adler32'], did['adler32']))}
                     elif meta['bytes'] != did['bytes']:
                         result[lfn] = {'status': False, 'error': FileConsistencyMismatch('filesize mismatch DDM %s vs user %s' % (meta['bytes'], did['bytes']))}

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -397,7 +397,7 @@ class UploadClient:
             logger(logging.INFO, 'File DID already exists')
             logger(logging.DEBUG, 'local checksum: %s, remote checksum: %s' % (file['adler32'], meta['adler32']))
 
-            if meta['adler32'] != file['adler32']:
+            if str(meta['adler32']).lstrip('0') != str(file['adler32']).lstrip('0'):
                 logger(logging.ERROR, 'Local checksum %s does not match remote checksum %s' % (file['adler32'], meta['adler32']))
 
                 raise DataIdentifierAlreadyExists
@@ -646,7 +646,7 @@ class UploadClient:
                 if rse_settings['verify_checksum'] is not False:
                     if ('adler32' in stats) and ('adler32' in lfn):
                         self.logger(logging.DEBUG, 'Checksum: Expected=%s Found=%s' % (lfn['adler32'], stats['adler32']))
-                        if stats['adler32'] != lfn['adler32']:
+                        if str(stats['adler32']).lstrip('0') != str(lfn['adler32']).lstrip('0'):
                             raise RucioException('Checksum mismatch. Source: %s Destination: %s' % (lfn['adler32'], stats['adler32']))
 
             except Exception as error:


### PR DESCRIPTION
Clients: Resolves adler32 mismatch Fix #4127
------------------
Normalizes the checksum while comparing adler32 values by removing leading zeroes using lstrip('0') in required places to ensure no discrepancies in values.
