### PR TITLE
Authentication: Added required padding for base64 decoder Fix #3115

### DIFF
--- a/lib/rucio/core/authentication.py
+++ b/lib/rucio/core/authentication.py
@@ -223,7 +223,9 @@ def get_auth_token_ssh(account, signature, appid, ip=None, session=None):
     # try all available SSH identities for the account with the provided signature
     match = False
     for identity in identities:
-        pub_k = paramiko.RSAKey(data=b64decode(identity['identity'].split()[1]))
+        data = identity['identity'].split()[1]
+        data += '=' * ((4 - len(data) % 4) % 4)  # adding required padding
+        pub_k = paramiko.RSAKey(data=b64decode(data))
         for challenge_token in active_challenge_tokens:
             if pub_k.verify_ssh_sig(str(challenge_token['token']).encode(),
                                     paramiko.Message(signature)):

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -735,6 +735,7 @@ class SSH(ErrorHandlingMethodView):
 
         # decode the signature which must come in base64 encoded
         try:
+            signature += '=' * ((4 - len(signature) % 4) % 4)  # adding required padding
             signature = base64.b64decode(signature)
         except TypeError:
             return generate_http_error_flask(


### PR DESCRIPTION
Authentication: Added required padding for base64 decoders Fix #3115

Extra padding (`=`) is added to the base64 encoded text to make its length a multiple of 4. 
base64.b64decoder raises invalid padding error when the padded "=" is removed for transmission by some keygens. 
However, removing the padding ("=" ) in base64 is lossless and can be simply added back before decoding.

There is a less verbose but awkward way of achieving the same.  i.e adding arbitrary length padding (>2) after the required data.

@bziemons  can you please review the changes.