### PR TITLE
Transfers: Changed Encoding of Updated Items Values Fix #4177

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -477,6 +477,8 @@ def set_request_state(request_id, new_state, transfer_id=None, transferred_at=No
         if err_msg:
             update_items['err_msg'] = err_msg
 
+        for attr in update_items.values():
+            attr = attr.encode('ascii', 'ignore')
         if transfer_id:
             rowcount = session.query(models.Request).filter_by(id=request_id, external_id=transfer_id).update(update_items, synchronize_session=False)
         else:


### PR DESCRIPTION
Fixing the encoding error in the Update_items dictionary for passing the filters in query
------------------

This PR aims to change the encoding of the passed parameters from the FTS to Poller during Transfer 
Thanks :)