### PR TITLE
Rules: added option to update comment in update_rule command Fix #4116

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -1279,6 +1279,8 @@ def update_rule(args):
             options['locked'] = True
         elif args.locked == "False":
             options['locked'] = False
+    if args.comment:
+        options['comment'] = args.comment
     if args.rule_account:
         options['account'] = args.rule_account
     if args.state_stuck:
@@ -2285,6 +2287,7 @@ You can filter by account::
     update_rule_parser.add_argument('--suspend', dest='state_suspended', action='store_true', help='Set state to SUSPENDED.')
     update_rule_parser.add_argument('--activity', dest='rule_activity', action='store', help='Activity of the rule.')
     update_rule_parser.add_argument('--source-replica-expression', dest='source_replica_expression', action='store', help='Source replica expression of the rule.')
+    update_rule_parser.add_argument('--comment', dest='comment', action='store', help="Update comment for the rule")
     update_rule_parser.add_argument('--cancel-requests', dest='cancel_requests', action='store_true', help='Cancel requests when setting rules to stuck.')
     update_rule_parser.add_argument('--priority', dest='priority', action='store', help='Priority of the requests of the rule.')
     update_rule_parser.add_argument('--child-rule-id', dest='child_rule_id', action='store', help='Child rule id of the rule.')

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -378,7 +378,8 @@ def add_rule(dids, account, copies, rse_expression, grouping, weight, lifetime, 
             insert_rule_history(rule=new_rule, recent=True, longterm=True, session=session)
 
             if use_new_rule_algorithm:
-                logger(logging.INFO, "Created rule %s [%d/%d/%d] with new algorithm for did %s:%s in state %s", str(new_rule.id), new_rule.locks_ok_cnt, new_rule.locks_replicating_cnt, new_rule.locks_stuck_cnt, new_rule.scope, new_rule.name, str(new_rule.state))
+                logger(logging.INFO, "Created rule %s [%d/%d/%d] with new algorithm for did %s:%s in state %s", str(new_rule.id), new_rule.locks_ok_cnt,
+                       new_rule.locks_replicating_cnt, new_rule.locks_stuck_cnt, new_rule.scope, new_rule.name, str(new_rule.state))
             else:
                 logger(logging.INFO, "Created rule %s [%d/%d/%d] for did %s:%s in state %s", str(new_rule.id), new_rule.locks_ok_cnt, new_rule.locks_replicating_cnt, new_rule.locks_stuck_cnt, new_rule.scope, new_rule.name, str(new_rule.state))
 
@@ -1282,7 +1283,7 @@ def update_rule(rule_id, options, session=None):
     :raises:            RuleNotFound if no Rule can be found, InputValidationError if invalid option is used, ScratchDiskLifetimeConflict if wrong ScratchDiskLifetime is used.
     """
 
-    valid_options = ['locked', 'lifetime', 'account', 'state', 'activity', 'source_replica_expression', 'cancel_requests', 'priority', 'child_rule_id', 'eol_at', 'meta', 'purge_replicas']
+    valid_options = ['comment', 'locked', 'lifetime', 'account', 'state', 'activity', 'source_replica_expression', 'cancel_requests', 'priority', 'child_rule_id', 'eol_at', 'meta', 'purge_replicas']
 
     for key in options:
         if key not in valid_options:
@@ -1302,6 +1303,9 @@ def update_rule(rule_id, options, session=None):
                 rule.expires_at = datetime.utcnow() + timedelta(seconds=lifetime) if lifetime is not None else None
             if key == 'source_replica_expression':
                 rule.source_replica_expression = options['source_replica_expression']
+
+            if key == 'comment':
+                rule.comments = options['comment']
 
             if key == 'activity':
                 validate_schema('activity', options['activity'], vo=rule.account.vo)


### PR DESCRIPTION
Rules: added option to update a comment in update_rule command Fix #4116 

Modified CLI to allow users to update comment for a rule, with the "--comment" option.  


![update comment](https://user-images.githubusercontent.com/69708588/111887131-004f6f80-89f9-11eb-8938-0f58ff56d942.JPG)

@nsmith- Kindly review, if this is the desired behaviour.