### PR TITLE
Clients: added new, consistent options for specifying rses Fix #1839

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -208,6 +208,10 @@ def exception_handler(function):
     return new_funct
 
 
+def option_deprecation_message(old_option, new_option, support_end_version='1.27'):
+    logger.warning(f'The use of {old_option} is deprecated in favour of {new_option} and will be removed in {support_end_version}')
+
+
 def get_client(args):
     """
     Returns a new client object.
@@ -376,9 +380,16 @@ def list_file_replicas(args):
         client.get_metadata(scope=scope, name=name)  # break with Exception before streaming replicas if DID does not exist
         dids.append({'scope': scope, 'name': name})
 
+    if args.rse_expression:  # TODO:remove-deprecated
+        args.rses = args.rse_expression
+        option_deprecation_message("--expression", "--rses")
+
+    if args.selected_rse:  # TODO:remove-deprecated
+        option_deprecation_message("--rse", "--rses")
+
     replicas = client.list_replicas(dids, schemes=protocols,
                                     all_states=args.all_states,
-                                    rse_expression=args.rse_expression,
+                                    rse_expression=args.rses,
                                     metalink=args.metalink,
                                     client_location=detect_client_location(),
                                     sort=args.sort, domain=args.domain,
@@ -969,6 +980,10 @@ def download(args):
         logger.error('Arguments dids and metalink cannot be used together.')
         return FAILURE
 
+    if args.rse:  # TODO:remove-deprecated
+        args.rses = args.rse
+        option_deprecation_message("--rse", "--rses")
+
     trace_pattern = {}
 
     if args.trace_appid:
@@ -992,7 +1007,7 @@ def download(args):
 
     result = None
     item_defaults = {}
-    item_defaults['rse'] = args.rse
+    item_defaults['rse'] = args.rses
     item_defaults['base_dir'] = args.dir
     item_defaults['no_subdir'] = args.no_subdir
     item_defaults['transfer_timeout'] = args.transfer_timeout
@@ -1233,13 +1248,18 @@ def delete_rule(args):
     Delete a rule.
     """
     client = get_client(args)
+
+    if args.rse_expression:  # TODO:remove-deprecated
+        args.rses = args.rse_expression
+        option_deprecation_message("--rse_expression", "--rses")
+
     try:
         # Test if the rule_id is a real rule_id
         uuid.UUID(args.rule_id)
         client.delete_replication_rule(rule_id=args.rule_id, purge_replicas=args.purge_replicas)
     except ValueError:
         # Otherwise, trying to extract the scope, name from args.rule_id
-        if not args.rse_expression:
+        if not args.rses:
             logger.error('A RSE expression must be specified if you do not provide a rule_id but a DID')
             return FAILURE
         scope, name = get_scope(args.rule_id, client)
@@ -1254,7 +1274,7 @@ def delete_rule(args):
                 account_checked = True
             else:
                 account_checked = rule['account'] == account
-            if rule['rse_expression'] == args.rse_expression and account_checked:
+            if rule['rse_expression'] == args.rses and account_checked:
                 client.delete_replication_rule(rule_id=rule['id'], purge_replicas=args.purge_replicas)
                 deletion_success = True
         if not deletion_success:
@@ -1484,8 +1504,14 @@ def list_rses(args):
     """
     client = get_client(args)
     rse_expression = None
-    if args.rse_expression:
-        rse_expression = args.rse_expression
+
+    if args.rse_expression:  # TODO:remove-deprecated
+        args.rses = args.rse_expression
+        option_deprecation_message("--expression", "--rses")
+
+    if args.rses:
+        rse_expression = args.rses
+
     rses = client.list_rses(rse_expression)
     for rse in rses:
         print('%(rse)s' % rse)
@@ -1798,13 +1824,15 @@ To list the missing replica of a dataset of a given RSE::
     list_file_replicas_parser.add_argument('--pfns', default=False, action='store_true', help='Show only the PFNs.', required=False)
     list_file_replicas_parser.add_argument('--domain', default=None, action='store', help='Force the networking domain. Available options: wan, lan, all.', required=False)
     list_file_replicas_parser.add_argument('--link', dest='link', default=None, action='store', help='Symlink PFNs with directory substitution.', required=False)
-    list_file_replicas_parser.add_argument('--rse', dest='selected_rse', default=False, action='store', help='Show only results for this RSE.', required=False).completer = rse_completer
+    list_file_replicas_parser.add_argument('--rse', dest='selected_rse', default=False, action='store', help='Show only results for this RSE.', required=False).completer = rse_completer  # TODO:remove-deprecated
     list_file_replicas_parser.add_argument('--missing', dest='missing', default=False, action='store_true', help='To list missing replicas at a RSE. Must be used with --rse option', required=False)
     list_file_replicas_parser.add_argument('--metalink', dest='metalink', default=False, action='store_true', help='Output available replicas as metalink.', required=False)
     list_file_replicas_parser.add_argument('--no-resolve-archives', dest='no_resolve_archives', default=False, action='store_true', help='Do not resolve archives which may contain the files.', required=False)
     list_file_replicas_parser.add_argument('--sort', dest='sort', default=None, action='store', help='Replica sort algorithm. Available options: geoip (default), random', required=False)
     list_file_replicas_parser.add_argument('--expression', dest='rse_expression', default=None, action='store', help='The RSE filter expression. A comprehensive help about RSE expressions\
-            can be found in ' + Color.BOLD + 'https://rucio.readthedocs.io/en/latest/rse_expressions.html' + Color.END)
+            can be found in ' + Color.BOLD + 'http://rucio.cern.ch/client_tutorial.html#adding-rules-for-replication' + Color.END)  # TODO:remove-deprecated
+    list_file_replicas_parser.add_argument('--rses', dest='rses', default=None, action='store', help='The RSE filter expression. A comprehensive help about RSE expressions\
+            can be found in ' + Color.BOLD + 'http://rucio.cern.ch/client_tutorial.html#adding-rules-for-replication' + Color.END)
 
     # The list-dataset-replicas command
     list_dataset_replicas_parser = subparsers.add_parser('list-dataset-replicas', help='List the dataset replicas.',
@@ -2141,7 +2169,8 @@ You can filter by key/value, e.g.::
         selected_parser.add_argument('--dir', dest='dir', default='.', action='store', help='The directory to store the downloaded file.')
         selected_parser.add_argument(dest='dids', nargs='*', action='store', help='List of space separated data identifiers.')
         selected_parser.add_argument('--allow-tape', action='store_true', default=False, help="Also consider tape endpoints as source of the download.")
-        selected_parser.add_argument('--rse', action='store', help='RSE Expression to specify allowed sources')
+        selected_parser.add_argument('--rse', action='store', help='RSE Expression to specify allowed sources')  # TODO:remove-deprecated
+        selected_parser.add_argument('--rses', action='store', help='RSE Expression to specify allowed sources')
         selected_parser.add_argument('--protocol', action='store', help='Force the protocol to use.')
         selected_parser.add_argument('--nrandom', type=int, action='store', help='Download N random files from the DID.')
         selected_parser.add_argument('--ndownloader', type=int, default=3, action='store', help='Choose the number of parallel processes for download.')
@@ -2226,7 +2255,8 @@ You can filter by key/value, e.g.::
     delete_rule_parser.add_argument(dest='rule_id', action='store', help='Rule id or DID. If DID, the RSE expression is mandatory.')
     delete_rule_parser.add_argument('--purge-replicas', dest='purge_replicas', action='store_true', help='Purge rule replicas')
     delete_rule_parser.add_argument('--all', dest='delete_all', action='store_true', default=False, help='Delete all the rules, even the ones that are not owned by the account')
-    delete_rule_parser.add_argument('--rse_expression', dest='rse_expression', action='store', help='The RSE expression. Must be specified if a DID is provided.')
+    delete_rule_parser.add_argument('--rse_expression', dest='rse_expression', action='store', help='The RSE expression. Must be specified if a DID is provided.')  # TODO:remove-deprecated
+    delete_rule_parser.add_argument('--rses', dest='rses', action='store', help='The RSE expression. Must be specified if a DID is provided.')
     delete_rule_parser.add_argument('--account', dest='rule_account', action='store', help='The account of the rule that must be deleted')
 
     # Info replication rule subparser
@@ -2298,7 +2328,9 @@ You can filter by account::
     list_rses_parser = subparsers.add_parser('list-rses', help='Show the list of all the registered Rucio Storage Elements (RSEs).')
     list_rses_parser.set_defaults(function=list_rses)
     list_rses_parser.add_argument('--expression', dest='rse_expression', action='store', help='The RSE filter expression. A comprehensive help about RSE expressions \
-can be found in ' + Color.BOLD + 'https://rucio.readthedocs.io/en/latest/rse_expressions.html' + Color.END)
+can be found in ' + Color.BOLD + 'http://rucio.cern.ch/client_tutorial.html#adding-rules-for-replication' + Color.END)  # TODO:remove-deprecated
+    list_rses_parser.add_argument('--rses', dest='rses', action='store', help='The RSE filter expression. A comprehensive help about RSE expressions \
+can be found in ' + Color.BOLD + 'http://rucio.cern.ch/client_tutorial.html#adding-rules-for-replication' + Color.END)
 
     # The list-suspicoius-replicas command
     list_suspicious_replicas_parser = subparsers.add_parser('list-suspicious-replicas', help='Show the list of all replicas marked "suspicious".')


### PR DESCRIPTION
Clients: added new, consistent options for specifying rses Fix #1839

Changes made: 
1. `--rse` is used where a single rse is accepted
2. `--rses` is used where a rse expression is accepted (Even though rses convey that they can be enumerated, the fact that composite rse expressions are the only way rucio accepts multiple rses, takes care of the case )
3.  Taking a cue from @mlassnig 's suggestion, removed multiple ways of accepting rses, i.e in list-file-replicas, which takes both a single rse and an expression, reduce the command to rses, since a single rse is also a valid rse expression. 
4. Added a deprecation warning for older commands.
5. The support for older commands can simply be removed by deleting the lines with the `TODO:remove-deprecated` comment

Here's a preview of the same:
![list-file-replicas](https://user-images.githubusercontent.com/69708588/111897629-1421c280-8a47-11eb-80fd-248d6499ca44.JPG)

![delete-rules](https://user-images.githubusercontent.com/69708588/111897634-1c79fd80-8a47-11eb-91bf-682825ca5877.JPG)
