### PR TITLE
Clients: retry on 502/503/504 errors. Closes #4444

### DIFF
--- a/lib/rucio/tests/test_clients.py
+++ b/lib/rucio/tests/test_clients.py
@@ -24,19 +24,67 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
 import unittest
+from datetime import datetime, timedelta
+try:
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
+except ImportError:
+    from http.server import SimpleHTTPRequestHandler
+try:
+    from SocketServer import TCPServer as HTTPServer
+except ImportError:
+    from http.server import HTTPServer
 from os import remove
+from threading import Thread
 
 import pytest
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.client import Client
 from rucio.common.config import config_get, config_get_bool
-from rucio.common.exception import CannotAuthenticate, ClientProtocolNotSupported
+from rucio.common.exception import CannotAuthenticate, ClientProtocolNotSupported, RucioException
 from rucio.common.utils import get_tmp_dir
+
+
+class MockServer:
+    """
+    Start A simple http server in a separate thread to serve as MOCK for testing the client
+    """
+
+    class Handler(SimpleHTTPRequestHandler):
+        def send_code_and_message(self, code, headers, message):
+            """
+            Helper which wraps the quite-low-level BaseHTTPRequestHandler primitives and is used to send reponses.
+            """
+            self.send_response(code)
+            self.send_header("Content-type", "text/plain")
+            for name, content in headers.items():
+                self.send_header(name, content)
+            self.end_headers()
+            self.wfile.write(message.encode())
+
+    def __init__(self, request_handler_cls):
+        self.server = HTTPServer(('localhost', 0), request_handler_cls)
+        self.thread = Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.server.shutdown()
+        self.thread.join()
+        self.server.server_close()
+
+    @property
+    def base_url(self):
+        name, port = self.server.server_address
+        return 'http://{}:{}'.format(name, port)
 
 
 @pytest.mark.noparallel(reason='fails when run in parallel')
@@ -98,6 +146,44 @@ class TestBaseClient(unittest.TestCase):
         creds = {'username': 'ddmlab', 'password': 'secret'}
         with pytest.raises(ClientProtocolNotSupported):
             BaseClient(rucio_host='localhost', auth_host='junk://localhost', account='root', auth_type='userpass', creds=creds, **self.vo)
+
+    def testRetryOn502AlwaysFail(self):
+        """ CLIENTS (BASECLIENT): Ensure client retries on 502 error codes, but fails on repeated errors"""
+
+        class AlwaysFailWith502(MockServer.Handler):
+            def do_GET(self):
+                self.send_code_and_message(502, {}, '')
+
+        with MockServer(AlwaysFailWith502) as server:
+            with pytest.raises(CannotAuthenticate):
+                creds = {'username': 'ddmlab', 'password': 'secret'}
+                BaseClient(rucio_host=server.base_url, auth_host=server.base_url, account='root', auth_type='userpass', creds=creds, **self.vo)
+            with pytest.raises(RucioException):
+                creds = {'client_cert': self.usercert,
+                         'client_key': self.userkey}
+                BaseClient(rucio_host=server.base_url, auth_host=server.base_url, account='root', ca_cert=self.cacert, auth_type='x509', creds=creds, **self.vo)
+
+    def testRetryOn502SucceedsEventually(self):
+        """ CLIENTS (BASECLIENT): Ensure client retries on 502 error codes"""
+        invocations = []
+
+        class FailTwiceWith502(MockServer.Handler):
+            def do_GET(self, invocations=invocations):
+                invocations.append(self.path)
+                if len(invocations) <= 2:
+                    self.send_code_and_message(502, {}, '')
+                else:
+                    self.send_code_and_message(200, {'x-rucio-auth-token': 'sometoken'}, '')
+
+        start_time = datetime.utcnow()
+        with MockServer(FailTwiceWith502) as server:
+            creds = {'username': 'ddmlab', 'password': 'secret'}
+            del invocations[:]
+            client = BaseClient(rucio_host=server.base_url, auth_host=server.base_url, account='root', auth_type='userpass', creds=creds, **self.vo)
+            del invocations[:]
+            client._send_request(server.base_url)  # noqa
+        # The client did back-off multiple times before succeeding: 2 * 0.25s (authentication) + 2 * 0.25s (request) = 1s
+        assert datetime.now() - start_time > timedelta(seconds=0.9)
 
 
 class TestRucioClients(unittest.TestCase):


### PR DESCRIPTION
Perform an exponential backoff when retrying.

Test it for password authentication and for get requests using a simple mock server 
which always returns 502. 