### PR TITLE
Deletion: handle archives in reaper. #1431 #2213

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1605,7 +1605,10 @@ def __cleanup_after_replica_deletion(rse_id, files, session=None):
                           models.DataIdentifier.availability == DIDAvailability.LOST)),
                  ~exists(select([1]).prefix_with("/*+ INDEX(REPLICAS REPLICAS_PK) */", dialect='oracle')).where(
                      and_(models.RSEFileAssociation.scope == file['scope'],
-                          models.RSEFileAssociation.name == file['name']))))
+                          models.RSEFileAssociation.name == file['name'])),
+                 ~exists(select([1]).prefix_with("/*+ INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_PK) */", dialect='oracle')).where(
+                     and_(models.ConstituentAssociation.child_scope == file['scope'],
+                          models.ConstituentAssociation.child_name == file['name']))))
 
         # 2) schedule removal of this file from the DID table
         did_condition.append(
@@ -1775,11 +1778,34 @@ def __cleanup_after_replica_deletion(rse_id, files, session=None):
                                              models.DidMeta.name == name))
 
     # Remove Archive Constituents
+    removed_constituents = []
     for chunk in chunks(archive_contents_condition, 30):
+        query = session.query(models.ConstituentAssociation). \
+            with_hint(models.ConstituentAssociation, "INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_CHILD_IDX)", 'oracle'). \
+            filter(or_(*chunk))
+        for constituent in query:
+            removed_constituents.append({'scope': constituent.child_scope, 'name': constituent.child_name})
+
+            models.ConstituentAssociationHistory(
+                child_scope=constituent.child_scope,
+                child_name=constituent.child_name,
+                scope=constituent.scope,
+                name=constituent.name,
+                bytes=constituent.bytes,
+                adler32=constituent.adler32,
+                md5=constituent.md5,
+                guid=constituent.guid,
+                length=constituent.length,
+                updated_at=constituent.updated_at,
+                created_at=constituent.created_at,
+            ).save(session=session, flush=False)
+
         session.query(models.ConstituentAssociation).\
             with_hint(models.ConstituentAssociation, "INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_CHILD_IDX)", 'oracle').\
             filter(or_(*chunk)).\
             delete(synchronize_session=False)
+    for chunk in chunks(removed_constituents, 200):
+        __cleanup_after_replica_deletion(rse_id=rse_id, files=chunk, session=session)
 
     # Remove rules in Waiting for approval or Suspended
     for chunk in chunks(deleted_rules, 100):

--- a/lib/rucio/daemons/reaper/reaper2.py
+++ b/lib/rucio/daemons/reaper/reaper2.py
@@ -246,7 +246,12 @@ def get_rses_to_hostname_mapping():
         result = {}
         all_rses = list_rses()
         for rse in all_rses:
-            rse_protocol = get_rse_protocols(rse_id=rse['id'])
+            try:
+                rse_protocol = get_rse_protocols(rse_id=rse['id'])
+            except RSENotFound:
+                logging.log(logging.WARNING, 'RSE deleted while constructing rse-to-hostname mapping. Skipping %s', rse['rse'])
+                continue
+
             for prot in rse_protocol['protocols']:
                 if prot['domains']['wan']['delete'] == 1:
                     result[rse['id']] = (prot['hostname'], rse_protocol)

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -178,6 +178,12 @@ class TemporaryFileFactory:
         for rse_id, dids in dids_by_rse.items():
             replica_core.delete_replicas(rse_id=rse_id, files=dids, session=session)
 
+    def register_dids(self, dids):
+        """
+        Register the provided dids to be cleaned up on teardown
+        """
+        self.created_dids.extend(dids)
+
     def _sanitize_or_set_scope(self, scope):
         if not scope:
             scope = self.default_scope


### PR DESCRIPTION
Ensure that replicas are removed from datasets only if they don't exists
in an archive.

When removing an archive, handle the removal of its constituents.
Only if:
- they don't exist in another archive
- they don't have replicas outside any archive

This is achieved by recursively calling the cleanup function after
removing the archive (and thus the constituent replicas).