### PR TITLE
Transfers: refactor get_transfer_requests_and_source_replicas. #4499

### DIFF
--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -791,6 +791,9 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
         if source_rse_id is None or rse is None:
             continue
 
+        if rses and dest_rse_id not in rses:
+            continue
+
         dest_rse_name = ctx.rse_name(dest_rse_id)
         source_rse_name = ctx.rse_name(source_rse_id)
 
@@ -856,9 +859,6 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
 
         allow_tape_source = True
         try:
-            if rses and dest_rse_id not in rses:
-                continue
-
             # Get source protocol
             source_protocol = ctx.protocol(source_rse_id, source_scheme, 'read')
 

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -627,13 +627,11 @@ def get_dsn(scope, name, dsn):
     return 'other'
 
 
-def __build_source_url(scope, name, path, protocol):
-    source_url = list(protocol.lfns2pfns(lfns={'scope': scope.external, 'name': name, 'path': path}).values())[0]
-    return source_url
-
-
 def __build_dest_url(scope, name, protocol, dest_rse_attrs, dest_is_deterministic, dest_is_tape, dict_attributes, retry_count, activity):
-    # I.3 - Compute the destination url
+    """
+    Private helper function to build destination URL when retrieving transfers to execute.
+    """
+
     if dest_is_deterministic:
         dest_url = list(protocol.lfns2pfns(lfns={'scope': scope.external, 'name': name}).values())[0]
     else:
@@ -653,6 +651,9 @@ def __build_dest_url(scope, name, protocol, dest_rse_attrs, dest_is_deterministi
 
 
 def __rewrite_source_url(source_url, source_sign_url, dest_sign_url, source_scheme):
+    """
+    Parametrize source url for some special cases of source and destination schemes
+    """
     if dest_sign_url == 'gcs':
         if source_scheme in ['davs', 'https']:
             source_url += '?copy_mode=push'
@@ -676,6 +677,9 @@ def __rewrite_source_url(source_url, source_sign_url, dest_sign_url, source_sche
 
 
 def __rewrite_dest_url(dest_url, dest_sign_url, dest_scheme):
+    """
+    Parametrize destination url for some special cases of destination schemes
+    """
     if dest_sign_url == 'gcs':
         dest_url = re.sub('davs', 'gclouds', dest_url)
         dest_url = re.sub('https', 'gclouds', dest_url)
@@ -866,7 +870,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
             dest_sign_url = ctx.rse_attrs(dest_rse_id).get('sign_url', None)
 
             # Compute the source URL
-            source_url = __build_source_url(scope=scope, name=name, path=path, protocol=source_protocol)
+            source_url = list(source_protocol.lfns2pfns(lfns={'scope': scope.external, 'name': name, 'path': path}).values())[0]
             source_url = __rewrite_source_url(source_url, source_sign_url=source_sign_url, dest_sign_url=dest_sign_url, source_scheme=source_scheme)
 
             # If the request_id is not already in the transfer dictionary, need to compute the destination URL

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -778,8 +778,8 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                 reqs_scheme_mismatch.append(req_id)
             continue
 
-        source_protocol = list_hops[0]['source_scheme']
-        destination_protocol = list_hops[-1]['dest_scheme']
+        source_scheme = list_hops[0]['source_scheme']
+        dest_scheme = list_hops[-1]['dest_scheme']
         dest_scheme_priority = list_hops[-1]['dest_scheme_priority']
 
         transfer_src_type = "DISK"
@@ -790,9 +790,9 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                 continue
 
             # Get source protocol
-            source_rse_id_key = 'read_%s_%s' % (source_rse_id, source_protocol)
+            source_rse_id_key = 'read_%s_%s' % (source_rse_id, source_scheme)
             if source_rse_id_key not in protocols:
-                protocols[source_rse_id_key] = rsemgr.create_protocol(ctx.rse_info(source_rse_id), 'third_party_copy', source_protocol)
+                protocols[source_rse_id_key] = rsemgr.create_protocol(ctx.rse_info(source_rse_id), 'third_party_copy', source_scheme)
 
             # If the request_id is not already in the transfer dictionary, need to compute the destination URL
             if req_id not in transfers:
@@ -803,9 +803,9 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
 
                 # I - Here we will compute the destination URL
                 # I.1 - Get destination protocol
-                dest_rse_id_key = 'write_%s_%s' % (dest_rse_id, destination_protocol)
+                dest_rse_id_key = 'write_%s_%s' % (dest_rse_id, dest_scheme)
                 if dest_rse_id_key not in protocols:
-                    protocols[dest_rse_id_key] = rsemgr.create_protocol(ctx.rse_info(dest_rse_id), 'third_party_copy', destination_protocol)
+                    protocols[dest_rse_id_key] = rsemgr.create_protocol(ctx.rse_info(dest_rse_id), 'third_party_copy', dest_scheme)
 
                 # I.2 - Get dest space token
                 dest_spacetoken = None
@@ -854,15 +854,15 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                 if sign_url == 'gcs':
                     dest_url = re.sub('davs', 'gclouds', dest_url)
                     dest_url = re.sub('https', 'gclouds', dest_url)
-                    if source_protocol in ['davs', 'https']:
+                    if source_scheme in ['davs', 'https']:
                         source_url += '?copy_mode=push'
                 elif sign_url == 's3':
                     dest_url = re.sub('davs', 's3s', dest_url)
                     dest_url = re.sub('https', 's3s', dest_url)
-                    if source_protocol in ['davs', 'https']:
+                    if source_scheme in ['davs', 'https']:
                         source_url += '?copy_mode=push'
                 elif WEBDAV_TRANSFER_MODE:
-                    if source_protocol in ['davs', 'https']:
+                    if source_scheme in ['davs', 'https']:
                         source_url += '?copy_mode=%s' % WEBDAV_TRANSFER_MODE
 
                 source_sign_url = ctx.rse_attrs(source_rse_id).get('sign_url', None)
@@ -950,7 +950,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                     file_metadata['previous_attempt_id'] = previous_attempt_id
 
                 transfers[req_id] = {'request_id': req_id,
-                                     'schemes': __add_compatible_schemes(schemes=[destination_protocol], allowed_schemes=SUPPORTED_PROTOCOLS),
+                                     'schemes': __add_compatible_schemes(schemes=[dest_scheme], allowed_schemes=SUPPORTED_PROTOCOLS),
                                      'account': account,
                                      # 'src_urls': [source_url],
                                      'sources': [(rse, source_url, source_rse_id, ranking if ranking is not None else 0, link_ranking)],
@@ -997,15 +997,15 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                 if sign_url == 'gcs':
                     dest_url = re.sub('davs', 'gclouds', dest_url)
                     dest_url = re.sub('https', 'gclouds', dest_url)
-                    if source_protocol in ['davs', 'https']:
+                    if source_scheme in ['davs', 'https']:
                         source_url += '?copy_mode=push'
                 elif sign_url == 's3':
                     dest_url = re.sub('davs', 's3s', dest_url)
                     dest_url = re.sub('https', 's3s', dest_url)
-                    if source_protocol in ['davs', 'https']:
+                    if source_scheme in ['davs', 'https']:
                         source_url += '?copy_mode=push'
                 elif WEBDAV_TRANSFER_MODE:
-                    if source_protocol in ['davs', 'https']:
+                    if source_scheme in ['davs', 'https']:
                         source_url += '?copy_mode=%s' % WEBDAV_TRANSFER_MODE
 
                 source_sign_url = ctx.rse_attrs(source_rse_id).get('sign_url', None)
@@ -1136,7 +1136,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
 
             for hop in list_multihop:
                 # hop = {'source_rse_id': source_rse_id, 'source_scheme': 'srm', 'source_scheme_priority': N, 'dest_rse_id': dest_rse_id, 'dest_scheme': 'srm', 'dest_scheme_priority': N}
-                source_protocol = hop['source_scheme']
+                source_scheme = hop['source_scheme']
                 source_rse_id = hop['source_rse_id']
                 dest_rse_id = hop['dest_rse_id']
                 source_rse_name = ctx.rse_name(source_rse_id)
@@ -1146,9 +1146,9 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                 transfer_dst_type = "DISK"
                 allow_tape_source = True
                 # Compute the source URL. We don't need to fill the rse_mapping and rse_attrs for the intermediate RSEs cause it has already been done before
-                source_rse_id_key = 'read_%s_%s' % (source_rse_id, source_protocol)
+                source_rse_id_key = 'read_%s_%s' % (source_rse_id, source_scheme)
                 if source_rse_id_key not in protocols:
-                    protocols[source_rse_id_key] = rsemgr.create_protocol(ctx.rse_info(source_rse_id), 'third_party_copy', source_protocol)
+                    protocols[source_rse_id_key] = rsemgr.create_protocol(ctx.rse_info(source_rse_id), 'third_party_copy', source_scheme)
                 source_url = list(protocols[source_rse_id_key].lfns2pfns(lfns={'scope': scope.external, 'name': name, 'path': None}).values())[0]
 
                 if transfers[req_id]['file_metadata']['dest_rse_id'] != hop['dest_rse_id']:
@@ -1209,10 +1209,10 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                     # I - Here we will compute the destination URL
                     # I.1 - Get destination protocol
                     dest_rse_id = hop['dest_rse_id']
-                    destination_protocol = hop['dest_scheme']
-                    dest_rse_id_key = 'write_%s_%s' % (dest_rse_id, destination_protocol)
+                    dest_scheme = hop['dest_scheme']
+                    dest_rse_id_key = 'write_%s_%s' % (dest_rse_id, dest_scheme)
                     if dest_rse_id_key not in protocols:
-                        protocols[dest_rse_id_key] = rsemgr.create_protocol(ctx.rse_info(dest_rse_id), 'third_party_copy', destination_protocol)
+                        protocols[dest_rse_id_key] = rsemgr.create_protocol(ctx.rse_info(dest_rse_id), 'third_party_copy', dest_scheme)
 
                     # I.2 - Get dest space token
                     dest_spacetoken = None
@@ -1274,7 +1274,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                                              'initial_request_id': req_id,
                                              'parent_request': parent_request,
                                              'account': InternalAccount('root'),
-                                             'schemes': __add_compatible_schemes(schemes=[destination_protocol], allowed_schemes=SUPPORTED_PROTOCOLS),
+                                             'schemes': __add_compatible_schemes(schemes=[dest_scheme], allowed_schemes=SUPPORTED_PROTOCOLS),
                                              # 'src_urls': [source_url],
                                              'sources': [(source_rse_name, source_url, source_rse_id, 0, 0)],
                                              'dest_urls': [dest_url],

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -777,6 +777,9 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
 
     for req_id, rule_id, scope, name, md5, adler32, bytes, activity, attributes, previous_attempt_id, dest_rse_id, account, source_rse_id, rse, deterministic, rse_type, path, retry_count, src_url, ranking, link_ranking in req_sources:
 
+        if ranking is None:
+            ranking = 0
+
         multihop = False
 
         # Add req to req_no_source list (Will be removed later if needed)
@@ -986,7 +989,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                                      'schemes': __add_compatible_schemes(schemes=[dest_scheme], allowed_schemes=SUPPORTED_PROTOCOLS),
                                      'account': account,
                                      # 'src_urls': [source_url],
-                                     'sources': [(rse, source_url, source_rse_id, ranking if ranking is not None else 0, link_ranking)],
+                                     'sources': [(rse, source_url, source_rse_id, ranking, link_ranking)],
                                      'dest_urls': [dest_url],
                                      'src_spacetoken': None,
                                      'dest_spacetoken': dest_spacetoken,
@@ -1026,9 +1029,6 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                 if transfers[req_id].get('multihop', False):
                     transfers[req_id].pop('multihop', None)
                     transfers[req_id]['sources'] = []
-
-                if ranking is None:
-                    ranking = 0
 
                 current_source_is_tape = transfers[req_id]['bring_online']
                 new_source_is_tape = ctx.is_tape_rse(source_rse_id) or ctx.rse_attrs(source_rse_id).get('staging_required', False)

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -876,7 +876,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                 # allow_tape_source = attr["allow_tape_source"] if (attr and "allow_tape_source" in attr) else True
                 allow_tape_source = True
 
-                # III - Extend the metadata dictionary with request attributes
+                # Extend the metadata dictionary with request attributes
                 transfer_src_type = "DISK"
                 transfer_dst_type = "DISK"
                 overwrite, bring_online = True, None
@@ -916,7 +916,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
 
                 use_ipv4 = ctx.rse_attrs(source_rse_id).get('use_ipv4', False) or ctx.rse_attrs(dest_rse_id).get('use_ipv4', False)
 
-                # IV - get external_host + strict_copy + archive timeout
+                # get external_host + strict_copy + archive timeout
                 strict_copy = ctx.rse_attrs(dest_rse_id).get('strict_copy', False)
                 fts_hosts = ctx.rse_attrs(dest_rse_id).get('fts', None)
                 archive_timeout = ctx.rse_attrs(dest_rse_id).get('archive_timeout', None)
@@ -941,7 +941,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                 if retry_other_fts:
                     external_host = fts_list[retry_count % len(fts_list)]
 
-                # V - Get the checksum validation strategy (none, source, destination or both)
+                # Get the checksum validation strategy (none, source, destination or both)
                 verify_checksum = 'both'
                 if not ctx.rse_attrs(dest_rse_id).get('verify_checksum', True):
                     if not ctx.rse_attrs(source_rse_id).get('verify_checksum', True):
@@ -963,7 +963,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                     logger(logging.INFO, 'No common checksum method. Verifying destination only.')
                     verify_checksum = 'destination'
 
-                # VI - Fill the transfer dictionary including file_metadata
+                # Fill the transfer dictionary including file_metadata
                 file_metadata = {'request_id': req_id,
                                  'scope': scope,
                                  'name': name,
@@ -1024,7 +1024,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                 if multihop:
                     continue
 
-                # III - The transfer queued previously is a multihop, but this one is direct.
+                # The transfer queued previously is a multihop, but this one is direct.
                 # Reset the sources, remove the multihop flag
                 if transfers[req_id].get('multihop', False):
                     transfers[req_id].pop('multihop', None)
@@ -1179,19 +1179,19 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                     set_requests_state(request_ids=[new_req_id, ], new_state=RequestState.QUEUED, session=session)
                     logger(logging.DEBUG, 'New request created for the transfer between %s and %s : %s', source_rse_name, dest_rse_name, new_req_id)
 
-                    # I - Here we will compute the destination URL
-                    # I.1 - Get destination protocol
+                    # Here we will compute the destination URL
+                    # Get destination protocol
                     dest_rse_id = hop['dest_rse_id']
                     dest_scheme = hop['dest_scheme']
                     dest_protocol = ctx.protocol(dest_rse_id, dest_scheme, 'write')
 
-                    # I.2 - Get dest space token
+                    # Get dest space token
                     dest_spacetoken = None
                     if dest_protocol.attributes and 'extended_attributes' in dest_protocol.attributes and \
                             dest_protocol.attributes['extended_attributes'] and 'space_token' in dest_protocol.attributes['extended_attributes']:
                         dest_spacetoken = dest_protocol.attributes['extended_attributes']['space_token']
 
-                    # I.3 - Compute the destination url
+                    # Compute the destination url
                     dest_url = __build_dest_url(scope=scope, name=name,
                                                 protocol=dest_protocol,
                                                 dest_rse_attrs=ctx.rse_attrs(dest_rse_id),
@@ -1201,7 +1201,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                                                 retry_count=retry_count,
                                                 activity=activity)
 
-                    # II - Extend the metadata dictionary with request attributes
+                    # Extend the metadata dictionary with request attributes
                     overwrite, bring_online = True, None
                     if ctx.is_tape_rse(source_rse_id):
                         bring_online = bring_online_local

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -98,9 +98,9 @@ class TemporaryRSEFactory:
             # So running test in parallel results in some tests failing on foreign key errors.
             rse_core.del_rse(rse_id)
 
-    def _make_rse(self, scheme, protocol_impl):
+    def _make_rse(self, scheme, protocol_impl, add_rse_kwargs):
         rse_name = rse_name_generator()
-        rse_id = rse_core.add_rse(rse_name, vo=self.vo)
+        rse_id = rse_core.add_rse(rse_name, vo=self.vo, **add_rse_kwargs)
         rse_core.add_protocol(rse_id=rse_id, parameter={
             'scheme': scheme,
             'hostname': 'host%d' % len(self.created_rses),
@@ -119,14 +119,14 @@ class TemporaryRSEFactory:
         self.created_rses.append(rse_id)
         return rse_name, rse_id
 
-    def make_posix_rse(self):
-        return self._make_rse(scheme='file', protocol_impl='rucio.rse.protocols.posix.Default')
+    def make_posix_rse(self, **kwargs):
+        return self._make_rse(scheme='file', protocol_impl='rucio.rse.protocols.posix.Default', add_rse_kwargs=kwargs)
 
-    def make_mock_rse(self):
-        return self._make_rse(scheme='MOCK', protocol_impl='rucio.rse.protocols.mock.Default')
+    def make_mock_rse(self, **kwargs):
+        return self._make_rse(scheme='MOCK', protocol_impl='rucio.rse.protocols.mock.Default', add_rse_kwargs=kwargs)
 
-    def make_xroot_rse(self):
-        return self._make_rse(scheme='root', protocol_impl='rucio.rse.protocols.xrootd.Default')
+    def make_xroot_rse(self, **kwargs):
+        return self._make_rse(scheme='root', protocol_impl='rucio.rse.protocols.xrootd.Default', add_rse_kwargs=kwargs)
 
 
 class TemporaryFileFactory:

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -51,10 +51,23 @@ class TemporaryRSEFactory:
     def cleanup(self):
         if not self.created_rses:
             return
+        rules_to_remove = self.__get_rules_to_remove()
         self.__cleanup_transfers()
-        self.__cleanup_locks_and_rules()
+        self.__cleanup_locks_and_rules(rules_to_remove)
         self.__cleanup_replicas()
         self.__cleanup_rse_attributes()
+
+    @transactional_session
+    def __get_rules_to_remove(self, session=None):
+        # Retrieve the list of rules to be cleaned up
+        rules_from_requests = session.query(models.ReplicationRule.id). \
+            join(models.Request, models.ReplicationRule.id == models.Request.rule_id). \
+            filter(or_(models.Request.dest_rse_id.in_(self.created_rses),
+                       models.Request.source_rse_id.in_(self.created_rses)))
+        rules_from_locks = session.query(models.ReplicationRule.id). \
+            join(models.ReplicaLock, models.ReplicationRule.id == models.ReplicaLock.rule_id). \
+            filter(models.ReplicaLock.rse_id.in_(self.created_rses))
+        return list(rules_from_requests.union(rules_from_locks).distinct())
 
     @transactional_session
     def __cleanup_transfers(self, session=None):
@@ -65,11 +78,8 @@ class TemporaryRSEFactory:
                                                  models.Request.source_rse_id.in_(self.created_rses))).delete(synchronize_session=False)
 
     @transactional_session
-    def __cleanup_locks_and_rules(self, session=None):
-        query = session.query(models.ReplicationRule.id). \
-            join(models.ReplicaLock, models.ReplicationRule.id == models.ReplicaLock.rule_id). \
-            filter(models.ReplicaLock.rse_id.in_(self.created_rses)).distinct()
-        for rule_id, in query:
+    def __cleanup_locks_and_rules(self, rules_to_remove, session=None):
+        for rule_id, in rules_to_remove:
             rule_core.delete_rule(rule_id, session=session)
 
     @transactional_session


### PR DESCRIPTION
Try to reduce the amount of duplicate code and reorganize over-complicated sections while keeping the same functional behavior. 

The merge request is split into multiple commits for easier review. But should be squashed into one on merge. 