### PR TITLE
Docker & Kubernetes: use python2 to run `fts-rest-delegate` #4525

### DIFF
--- a/tools/docker_activate_rses.sh
+++ b/tools/docker_activate_rses.sh
@@ -58,7 +58,7 @@ rucio-admin account set-limits root XRD3 -1
 rucio-admin scope add --account root --scope test
 
 # Delegate credentials to FTS
-fts-rest-delegate -vf -s https://fts:8446 -H 9999
+/usr/bin/python2.7 /usr/bin/fts-rest-delegate -vf -s https://fts:8446 -H 9999
 
 # Create initial transfer testing data
 dd if=/dev/urandom of=file1 bs=10M count=1


### PR DESCRIPTION
Fix #4525 
This PR works in conjunction with https://github.com/rucio/containers/pull/129 
