### PR TITLE
Clients: default to utf-8 encoding in execute(). #4503

### DIFF
--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -481,7 +481,7 @@ def execute(cmd, blocking=True):
         result = process.communicate()
         (out, err) = result
         exitcode = process.returncode
-        return exitcode, out.decode(), err.decode()
+        return exitcode, out.decode(encoding='utf-8'), err.decode(encoding='utf-8')
     return process
 
 


### PR DESCRIPTION
The default encoding in python27 is 'ascii', but 'utf-8' in python3.
Explicitly set it to 'utf-8'.