### PR TITLE
Transfers: further rework get transfer requests. #4499. Closes #4516.

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1614,7 +1614,9 @@ def __throttler_request_state(activity, source_rse_id, dest_rse_id, session: "Op
 
 
 def reduce_requests(
-    req_sources: "List[RequestWithSources]", sort_reduce_funcs: "List[ReduceFunction]", logger: "Callable",
+    req_sources: "List[RequestWithSources]",
+    sort_reduce_funcs: "List[ReduceFunction]",
+    logger: "Callable",
 ) -> "Iterator[RequestResultOrState]":
     """
     Reduces the passed requests & sources objects by using the sort-reduce

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1633,9 +1633,9 @@ def reduce_requests(
         result = [
             {
                 'request_id': rws.request_id,
-                'dest_rse_id': rws.dest_rse_id,
+                'dest_rse_id': rws.dest_rse.id,
                 'activity': rws.activity,
-                'src_rse_id': source.rse_id,
+                'src_rse_id': source.rse.id,
                 'distance_ranking': source.distance_ranking
             }
             for source in rws.sources

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1552,6 +1552,9 @@ def list_requests(src_rse_ids, dst_rse_ids, states=[RequestState.WAITING], sessi
 
 @transactional_session
 def preparer_update_requests(source_iter: "Iterable[RequestResultOrState]", session: "Optional[Session]" = None) -> int:
+    """
+    Update transfer requests according to preparer settings.
+    """
     count = 0
     for rws in source_iter:
         update_dict = dict()

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -17,7 +17,7 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2013-2021
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2013-2017
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2020
-# - Martin Barisits <martin.barisits@cern.ch>, 2014-2020
+# - Martin Barisits <martin.barisits@cern.ch>, 2014-2021
 # - Wen Guan <wen.guan@cern.ch>, 2014-2016
 # - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2015-2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2016-2021
@@ -28,16 +28,17 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
-# - Matt Snyder <msnyder@bnl.gov>, 2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Matt Snyder <msnyder@bnl.gov>, 2021
 
 import datetime
 import json
 import logging
 import time
 import traceback
+from collections import namedtuple
 from itertools import filterfalse
-from typing import TYPE_CHECKING, Set
+from typing import TYPE_CHECKING
 
 from six import string_types
 from sqlalchemy import and_, or_, func, update
@@ -58,11 +59,16 @@ from rucio.db.sqla.constants import RequestState, RequestType, ReplicaState, Loc
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
 from rucio.transfertool.fts3 import FTS3Transfertool
 
+RequestAndState = namedtuple('RequestAndState', ['request_id', 'request_state'])
+
 if TYPE_CHECKING:
-    from typing import List, Tuple, Iterable, Iterator, Optional, Callable, Sequence
+    from rucio.core.transfer import RequestWithSource
+    from typing import Any, Dict, Iterable, Iterator, List, Optional, Callable, Set, Union
     from sqlalchemy.orm import Session
 
-    RowIterator = Iterator[Sequence]
+    RequestResult = Dict[str, Any]
+    RequestResultOrState = Union[RequestResult, RequestAndState]
+    RowIterator = Iterator[RequestResult]
     ReduceFunction = Callable[[RowIterator], RowIterator]
 
 """
@@ -1544,38 +1550,30 @@ def list_requests(src_rse_ids, dst_rse_ids, states=[RequestState.WAITING], sessi
         yield request
 
 
-# important column indices from __list_transfer_requests_and_source_replicas
-request_id_col = 0
-activity_col = 7
-dest_rse_id_col = 10
-source_rse_id_col = 12
-distance_col = 20
-
-extra_transfertool_col = 21
-
-
 @transactional_session
-def preparer_update_requests(source_iter: "Iterable[Sequence]", session: "Optional[Session]" = None) -> int:
+def preparer_update_requests(source_iter: "Iterable[RequestResultOrState]", session: "Optional[Session]" = None) -> int:
     count = 0
-    for req_source in source_iter:
+    for rws in source_iter:
         update_dict = dict()
-        if len(req_source) == 2:
+        if isinstance(rws, RequestAndState):
             # special case where the first entry is the request id and the second is the new state
             # (see handling of RequestState.NO_SOURCES in reduce_requests)
-            update_dict[models.Request.state] = req_source[1]
+            request_id = rws.request_id
+            update_dict[models.Request.state] = rws.request_state
         else:
+            request_id = rws['request_id']
             update_dict[models.Request.state] = __throttler_request_state(
-                activity=req_source[activity_col],
-                source_rse_id=req_source[source_rse_id_col],
-                dest_rse_id=req_source[dest_rse_id_col],
+                activity=rws['activity'],
+                source_rse_id=rws['src_rse_id'],
+                dest_rse_id=rws['dest_rse_id'],
                 session=session,
             )
-            update_dict[models.Request.source_rse_id] = req_source[source_rse_id_col]
+            update_dict[models.Request.source_rse_id] = rws['src_rse_id']
 
-        if len(req_source) > extra_transfertool_col:
-            update_dict[models.Request.transfertool] = req_source[extra_transfertool_col]
+            if 'transfertool' in rws:
+                update_dict[models.Request.transfertool] = rws['transfertool']
 
-        session.query(models.Request).filter_by(id=req_source[request_id_col]).update(update_dict, synchronize_session=False)
+        session.query(models.Request).filter_by(id=request_id).update(update_dict, synchronize_session=False)
         count += 1
     return count
 
@@ -1615,19 +1613,22 @@ def __throttler_request_state(activity, source_rse_id, dest_rse_id, session: "Op
     return RequestState.WAITING if limit_found else RequestState.QUEUED
 
 
-def reduce_requests(req_sources: "List[Tuple]", sort_reduce_funcs: "List[ReduceFunction]", logger: "Callable") -> "RowIterator":
+def reduce_requests(
+    req_sources: "List[RequestWithSource]", sort_reduce_funcs: "List[ReduceFunction]", logger: "Callable",
+) -> "Iterator[RequestResultOrState]":
     """
-    Reduces the passed request sources tuples by using the sort-reduce functions,
-    returning the first of the remaining items or a simple
-    (request_id, RequestState.NO_SOURCES) tuple, if no sources were found.
+    Reduces the passed requests & sources objects by using the sort-reduce
+    functions, yielding the best RequestResult object or a RequestAndState
+    object. If all sources were filtered, a RequestAndState object with
+    RequestState.NO_SOURCES is yielded.
     """
     assert len(req_sources) != 0, 'parameter request sources must be non-empty'
 
     # sort by Request.id for partitioning later
-    req_sources.sort(key=lambda t: t[request_id_col])
+    req_sources.sort(key=lambda rws: rws.request_id)
 
-    def pick_result(items: "List[Sequence]") -> "Optional[Sequence]":
-        result = items
+    def pick_result(items: "List[RequestWithSource]") -> "Optional[RequestResult]":
+        result = [item._asdict() for item in items]
         debug_log = []
         for sort_reduce in sort_reduce_funcs:
             newresult = list(sort_reduce(result))
@@ -1635,25 +1636,25 @@ def reduce_requests(req_sources: "List[Tuple]", sort_reduce_funcs: "List[ReduceF
             result = newresult
 
         if len(result) == 0:
-            logger(logging.WARNING, 'all available sources were filtered for requests with id %s', items[0][request_id_col])
+            logger(logging.WARNING, 'all available sources were filtered for requests with id %s', items[0].request_id)
             logger(logging.DEBUG, 'the following filters ran:\n' + '\n'.join(debug_log))
         else:
             return result[0]
 
-    def result_or_no_sources(result: "Optional[Sequence]") -> "Sequence":
+    def result_or_no_sources(result: "Optional[RequestResult]") -> "RequestResultOrState":
         if result is None:
-            return (cur_request_id, RequestState.NO_SOURCES)
+            return RequestAndState(request_id=cur_request_id, request_state=RequestState.NO_SOURCES)
         else:
             return result
 
-    cur_request_id = req_sources[0][request_id_col]
+    cur_request_id = req_sources[0].request_id
 
     # partition the req_sources by request_id and yield the best result from each group
     current_items = [req_sources[0]]
     for idx in range(1, len(req_sources)):
-        if cur_request_id != req_sources[idx][request_id_col]:
+        if cur_request_id != req_sources[idx].request_id:
             yield result_or_no_sources(pick_result(current_items))
-            cur_request_id = req_sources[idx][request_id_col]
+            cur_request_id = req_sources[idx].request_id
             current_items.clear()
         current_items.append(req_sources[idx])
     yield result_or_no_sources(pick_result(current_items))
@@ -1675,37 +1676,38 @@ def get_supported_transfertools(rse_id: str, session=None) -> "Set[str]":
 
 
 def get_transfertool_filter(
-        get_transfertools: "Callable[[str], Set[str]]" = get_supported_transfertools
+    get_transfertools: "Callable[[str], Set[str]]" = get_supported_transfertools,
 ) -> "ReduceFunction":
     def filter_requests_for_transfertools(items: "RowIterator") -> "RowIterator":
         first = True
         first_request_id, first_dest_rse_id, dest_rse_transfertools = None, None, None
-        for t in items:
+        for rws_dict in items:
             if first:
                 first = False
-                first_request_id = t[request_id_col]
-                first_dest_rse_id = t[dest_rse_id_col]
+                first_request_id = rws_dict['request_id']
+                first_dest_rse_id = rws_dict['dest_rse_id']
                 dest_rse_transfertools = get_transfertools(first_dest_rse_id)
             else:
                 # same request id, same request destination rse in items per call
-                assert first_request_id == t[request_id_col]
-                assert first_dest_rse_id == t[dest_rse_id_col]
+                assert first_request_id == rws_dict['request_id']
+                assert first_dest_rse_id == rws_dict['dest_rse_id']
 
-            src_rse_transfertools = get_transfertools(t[source_rse_id_col])
+            src_rse_transfertools = get_transfertools(rws_dict['src_rse_id'])
             common_transfertools = dest_rse_transfertools.intersection(src_rse_transfertools)
             if common_transfertools:
                 if 'fts3' in common_transfertools and 'globus' in common_transfertools:
-                    transfertool = 'fts3'
+                    rws_dict['transfertool'] = 'fts3'
                 else:
-                    transfertool = common_transfertools.pop()
-                yield (*t, transfertool)
+                    rws_dict['transfertool'] = common_transfertools.pop()
+                yield rws_dict
 
     return filter_requests_for_transfertools
 
 
 def sort_requests_minimum_distance(items: "RowIterator") -> "RowIterator":
-    yield from sorted(items, key=lambda t: t[distance_col])
+    yield from sorted(items, key=lambda rws_dict: rws_dict['distance_ranking'])
 
 
 def rse_lookup_filter(items: "RowIterator") -> "RowIterator":
-    yield from filter(lambda row: row[source_rse_id_col] is not None and row[dest_rse_id_col] is not None, items)
+    yield from filter(lambda rws_dict: (rws_dict['src_rse_id'] is not None
+                                        and rws_dict['dest_rse_id'] is not None), items)

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1163,7 +1163,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
         # OIDC token will be requested for the account of this tranfer
         transfers[req_id]['use_oidc'] = use_oidc
 
-    for req_id in copy.deepcopy(transfers):
+    for req_id in list(transfers):
         # If the transfer is a multihop, need to create the intermediate replicas, intermediate requests and the transfers
         if transfers[req_id].get('multihop', False):
             parent_request = None

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -832,8 +832,7 @@ def __rewrite_dest_url(dest_url, dest_sign_url, dest_scheme):
 
 
 @transactional_session
-def __prepare_transfer_definition(ctx, rws, source, transfertool, retry_other_fts, list_hops, activity,
-                                  bring_online, logger, session=None):
+def __prepare_transfer_definition(ctx, rws, source, transfertool, retry_other_fts, list_hops, bring_online, logger, session=None):
     """
     Create a hop-by-hop transfer configuration.
     For each hop needed to replicate the file from source (source.rse_id) towards the request's destination (rws.dest_rse_id),
@@ -888,7 +887,7 @@ def __prepare_transfer_definition(ctx, rws, source, transfertool, retry_other_ft
                                     dest_is_tape=ctx.is_tape_rse(dest_rse_id),
                                     dict_attributes=rws.attributes,
                                     retry_count=rws.retry_count,
-                                    activity=activity)
+                                    activity=rws.activity)
         dest_url = __rewrite_dest_url(dest_url, dest_sign_url=dest_sign_url, dest_scheme=dest_scheme)
 
         # Get dest space token
@@ -950,7 +949,7 @@ def __prepare_transfer_definition(ctx, rws, source, transfertool, retry_other_ft
         file_metadata = {'request_id': rws.request_id,
                          'scope': rws.scope,
                          'name': rws.name,
-                         'activity': activity,
+                         'activity': rws.activity,
                          'request_type': RequestType.TRANSFER,
                          'src_type': transfer_src_type,
                          'dst_type': transfer_dst_type,
@@ -1167,7 +1166,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
 
             try:
                 transfer_path = __prepare_transfer_definition(ctx, rws=rws, source=source, transfertool=transfertool,
-                                                              retry_other_fts=retry_other_fts, list_hops=list_hops, activity=activity, logger=logger, session=session,
+                                                              retry_other_fts=retry_other_fts, list_hops=list_hops, logger=logger, session=session,
                                                               bring_online=bring_online)
                 if transfer_path:
                     candidate_paths.append(transfer_path)
@@ -1186,7 +1185,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
             for source, list_hops in __find_compatible_direct_sources(sources=additional_sources, scheme=best_path[0]['schemes'], dest_rse_id=rws.dest_rse_id, session=session):
                 try:
                     additional_path = __prepare_transfer_definition(ctx, rws=rws, source=source, transfertool=transfertool,
-                                                                    retry_other_fts=retry_other_fts, list_hops=list_hops, activity=activity, logger=logger, session=session,
+                                                                    retry_other_fts=retry_other_fts, list_hops=list_hops, logger=logger, session=session,
                                                                     bring_online=bring_online)
                 except Exception:
                     logger(logging.CRITICAL, "Exception happened when trying to add additional source to transfer of request %s:" % rws.request_id, exc_info=True)

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1103,9 +1103,6 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
         # Assume request doesn't have any sources. Will be removed later if sources are found.
         reqs_no_source.add(rws.request_id)
 
-        if rses and rws.dest_rse_id not in rses:
-            continue
-
         dest_rse_name = ctx.rse_name(rws.dest_rse_id)
         # Check if destination is blocked
         if rws.dest_rse_id in unavailable_write_rse_ids:

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1170,7 +1170,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                     candidate_paths.append(transfer_path)
             except Exception:
                 logger(logging.CRITICAL, "Exception happened when trying to get transfer for request %s:" % rws.request_id, exc_info=True)
-                break
+                continue
 
         best_path = __pick_best_transfer(candidate_paths)
         if best_path and len(best_path) == 1 and not ctx.is_tape_rse(best_path[0]['file_metadata']['src_rse_id']):

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -903,7 +903,6 @@ def __prepare_transfer_definition(ctx, rws, source, transfertool, retry_other_ft
     for hop in list_hops:
         source_scheme = hop['source_scheme']
         dest_scheme = hop['dest_scheme']
-        dest_scheme_priority = hop['dest_scheme_priority']
 
         source_rse = ctx.rse_data(hop['source_rse_id'])
         dest_rse = ctx.rse_data(hop['dest_rse_id'])
@@ -1034,8 +1033,7 @@ def __prepare_transfer_definition(ctx, rws, source, transfertool, retry_other_ft
                     'external_host': external_host,
                     'selection_strategy': 'auto',
                     'rule_id': rws.rule_id,
-                    'file_metadata': file_metadata,
-                    'dest_scheme_priority': dest_scheme_priority}
+                    'file_metadata': file_metadata}
         if len(list_hops) > 1:
             transfer['multihop'] = True
             transfer['initial_request_id'] = rws.request_id

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -191,7 +191,7 @@ class _RseLoaderContext:
         protocol_key = '%s_%s_%s' % (operation, rse_id, scheme)
         protocol = self.protocols.get(protocol_key)
         if not protocol:
-            protocol = rsemgr.create_protocol(self.rse_info(rse_id), 'third_party_copy', scheme)
+            protocol = rsemgr.create_protocol(self.rse_info(rse_id), operation, scheme)
             self.protocols[protocol_key] = protocol
         return protocol
 
@@ -803,7 +803,7 @@ def __prepare_transfer_definition(ctx, rws, source, computed_distance, dict_attr
             file_path = None
 
         # Get source protocol
-        source_protocol = ctx.protocol(source_rse_id, source_scheme, 'read')
+        source_protocol = ctx.protocol(source_rse_id, source_scheme, 'third_party_copy')
         source_sign_url = ctx.rse_attrs(source_rse_id).get('sign_url', None)
         dest_sign_url = ctx.rse_attrs(dest_rse_id).get('sign_url', None)
 
@@ -834,7 +834,7 @@ def __prepare_transfer_definition(ctx, rws, source, computed_distance, dict_attr
             transfer_dst_type = "TAPE"
 
         # Get destination protocol
-        dest_protocol = ctx.protocol(dest_rse_id, dest_scheme, 'write')
+        dest_protocol = ctx.protocol(dest_rse_id, dest_scheme, 'third_party_copy')
 
         # Compute the destination url
         dest_url = __build_dest_url(scope=rws.scope, name=rws.name,

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -842,119 +842,121 @@ def __prepare_source_dest_config(ctx, request_id, src_rse_id, dest_rse_id, sourc
 def __prepare_transfer_definition(ctx, rws, source, source_scheme, dest_scheme, computed_distance, dest_scheme_priority,
                                   dict_attributes, transfertool, retry_other_fts, multihop, activity,
                                   reqs_only_tape_source, reqs_no_source, bring_online_local, logger, session=None):
-    source_rse_name = ctx.rse_name(source.rse_id)
-    dest_rse_name = ctx.rse_name(rws.dest_rse_id)
-    source_sign_url = ctx.rse_attrs(source.rse_id).get('sign_url', None)
 
-    transfer_src_type, transfer_dst_type, source_url, dest_url, dest_spacetoken, overwrite, bring_online = __prepare_source_dest_config(
-        ctx, request_id=rws.request_id, src_rse_id=source.rse_id, dest_rse_id=rws.dest_rse_id, source_scheme=source_scheme,
-        dest_scheme=dest_scheme, dict_attributes=dict_attributes, activity=rws.activity, scope=rws.scope, name=rws.name,
-        file_path=source.file_path, retry_count=rws.retry_count, reqs_only_tape_source=reqs_only_tape_source, reqs_no_source=reqs_no_source,
-        bring_online_local=bring_online_local
-    )
+    if True:
+        source_rse_name = ctx.rse_name(source.rse_id)
+        dest_rse_name = ctx.rse_name(rws.dest_rse_id)
+        source_sign_url = ctx.rse_attrs(source.rse_id).get('sign_url', None)
 
-    use_ipv4 = ctx.rse_attrs(source.rse_id).get('use_ipv4', False) or ctx.rse_attrs(rws.dest_rse_id).get('use_ipv4', False)
+        transfer_src_type, transfer_dst_type, source_url, dest_url, dest_spacetoken, overwrite, bring_online = __prepare_source_dest_config(
+            ctx, request_id=rws.request_id, src_rse_id=source.rse_id, dest_rse_id=rws.dest_rse_id, source_scheme=source_scheme,
+            dest_scheme=dest_scheme, dict_attributes=dict_attributes, activity=rws.activity, scope=rws.scope, name=rws.name,
+            file_path=source.file_path, retry_count=rws.retry_count, reqs_only_tape_source=reqs_only_tape_source, reqs_no_source=reqs_no_source,
+            bring_online_local=bring_online_local
+        )
 
-    # get external_host + strict_copy + archive timeout
-    strict_copy = ctx.rse_attrs(rws.dest_rse_id).get('strict_copy', False)
-    fts_hosts = ctx.rse_attrs(rws.dest_rse_id).get('fts', None)
-    archive_timeout = ctx.rse_attrs(rws.dest_rse_id).get('archive_timeout', None)
-    if source_sign_url == 'gcs':
-        fts_hosts = ctx.rse_attrs(source.rse_id).get('fts', None)
-    source_globus_endpoint_id = ctx.rse_attrs(source.rse_id).get('globus_endpoint_id', None)
-    dest_globus_endpoint_id = ctx.rse_attrs(rws.dest_rse_id).get('globus_endpoint_id', None)
+        use_ipv4 = ctx.rse_attrs(source.rse_id).get('use_ipv4', False) or ctx.rse_attrs(rws.dest_rse_id).get('use_ipv4', False)
 
-    if transfertool == 'fts3' and not fts_hosts:
-        logger(logging.ERROR, 'Destination RSE %s FTS attribute not defined - SKIP REQUEST %s', dest_rse_name, rws.request_id)
-        return
-    if transfertool == 'globus' and (not dest_globus_endpoint_id or not source_globus_endpoint_id):
-        logger(logging.ERROR, 'Destination RSE %s Globus endpoint attributes not defined - SKIP REQUEST %s', dest_rse_name, rws.request_id)
-        return
-    if rws.retry_count is None:
-        rws.retry_count = 0
-    external_host = ''
-    if fts_hosts:
-        fts_list = fts_hosts.split(",")
-        external_host = fts_list[0]
+        # get external_host + strict_copy + archive timeout
+        strict_copy = ctx.rse_attrs(rws.dest_rse_id).get('strict_copy', False)
+        fts_hosts = ctx.rse_attrs(rws.dest_rse_id).get('fts', None)
+        archive_timeout = ctx.rse_attrs(rws.dest_rse_id).get('archive_timeout', None)
+        if source_sign_url == 'gcs':
+            fts_hosts = ctx.rse_attrs(source.rse_id).get('fts', None)
+        source_globus_endpoint_id = ctx.rse_attrs(source.rse_id).get('globus_endpoint_id', None)
+        dest_globus_endpoint_id = ctx.rse_attrs(rws.dest_rse_id).get('globus_endpoint_id', None)
 
-    if retry_other_fts:
-        external_host = fts_list[rws.retry_count % len(fts_list)]
+        if transfertool == 'fts3' and not fts_hosts:
+            logger(logging.ERROR, 'Destination RSE %s FTS attribute not defined - SKIP REQUEST %s', dest_rse_name, rws.request_id)
+            return
+        if transfertool == 'globus' and (not dest_globus_endpoint_id or not source_globus_endpoint_id):
+            logger(logging.ERROR, 'Destination RSE %s Globus endpoint attributes not defined - SKIP REQUEST %s', dest_rse_name, rws.request_id)
+            return
+        if rws.retry_count is None:
+            rws.retry_count = 0
+        external_host = ''
+        if fts_hosts:
+            fts_list = fts_hosts.split(",")
+            external_host = fts_list[0]
 
-    # Get the checksum validation strategy (none, source, destination or both)
-    verify_checksum = 'both'
-    if not ctx.rse_attrs(rws.dest_rse_id).get('verify_checksum', True):
-        if not ctx.rse_attrs(source.rse_id).get('verify_checksum', True):
-            verify_checksum = 'none'
+        if retry_other_fts:
+            external_host = fts_list[rws.retry_count % len(fts_list)]
+
+        # Get the checksum validation strategy (none, source, destination or both)
+        verify_checksum = 'both'
+        if not ctx.rse_attrs(rws.dest_rse_id).get('verify_checksum', True):
+            if not ctx.rse_attrs(source.rse_id).get('verify_checksum', True):
+                verify_checksum = 'none'
+            else:
+                verify_checksum = 'source'
         else:
-            verify_checksum = 'source'
-    else:
-        if not ctx.rse_attrs(source.rse_id).get('verify_checksum', True):
+            if not ctx.rse_attrs(source.rse_id).get('verify_checksum', True):
+                verify_checksum = 'destination'
+            else:
+                verify_checksum = 'both'
+
+        source_rse_checksums = get_rse_supported_checksums(source.rse_id, session=session)
+        dest_rse_checksums = get_rse_supported_checksums(rws.dest_rse_id, session=session)
+
+        common_checksum_names = set(source_rse_checksums).intersection(dest_rse_checksums)
+
+        if len(common_checksum_names) == 0:
+            logger(logging.INFO, 'No common checksum method. Verifying destination only.')
             verify_checksum = 'destination'
-        else:
-            verify_checksum = 'both'
 
-    source_rse_checksums = get_rse_supported_checksums(source.rse_id, session=session)
-    dest_rse_checksums = get_rse_supported_checksums(rws.dest_rse_id, session=session)
+        # Fill the transfer dictionary including file_metadata
+        file_metadata = {'request_id': rws.request_id,
+                         'scope': rws.scope,
+                         'name': rws.name,
+                         'activity': activity,
+                         'request_type': RequestType.TRANSFER,
+                         'src_type': transfer_src_type,
+                         'dst_type': transfer_dst_type,
+                         'src_rse': source_rse_name,
+                         'dst_rse': dest_rse_name,
+                         'src_rse_id': source.rse_id,
+                         'dest_rse_id': rws.dest_rse_id,
+                         'filesize': rws.byte_count,
+                         'md5': rws.md5,
+                         'adler32': rws.adler32,
+                         'verify_checksum': verify_checksum,
+                         'source_globus_endpoint_id': source_globus_endpoint_id,
+                         'dest_globus_endpoint_id': dest_globus_endpoint_id}
 
-    common_checksum_names = set(source_rse_checksums).intersection(dest_rse_checksums)
+        if rws.previous_attempt_id:
+            file_metadata['previous_attempt_id'] = rws.previous_attempt_id
 
-    if len(common_checksum_names) == 0:
-        logger(logging.INFO, 'No common checksum method. Verifying destination only.')
-        verify_checksum = 'destination'
-
-    # Fill the transfer dictionary including file_metadata
-    file_metadata = {'request_id': rws.request_id,
-                     'scope': rws.scope,
-                     'name': rws.name,
-                     'activity': activity,
-                     'request_type': RequestType.TRANSFER,
-                     'src_type': transfer_src_type,
-                     'dst_type': transfer_dst_type,
-                     'src_rse': source_rse_name,
-                     'dst_rse': dest_rse_name,
-                     'src_rse_id': source.rse_id,
-                     'dest_rse_id': rws.dest_rse_id,
-                     'filesize': rws.byte_count,
-                     'md5': rws.md5,
-                     'adler32': rws.adler32,
-                     'verify_checksum': verify_checksum,
-                     'source_globus_endpoint_id': source_globus_endpoint_id,
-                     'dest_globus_endpoint_id': dest_globus_endpoint_id}
-
-    if rws.previous_attempt_id:
-        file_metadata['previous_attempt_id'] = rws.previous_attempt_id
-
-    transfer = {'request_id': rws.request_id,
-                'schemes': __add_compatible_schemes(schemes=[dest_scheme], allowed_schemes=SUPPORTED_PROTOCOLS),
-                'account': rws.account,
-                # 'src_urls': [source_url],
-                'sources': [(source_rse_name, source_url, source.rse_id, source.source_ranking, computed_distance)],
-                'dest_urls': [dest_url],
-                'src_spacetoken': None,
-                'dest_spacetoken': dest_spacetoken,
-                'overwrite': overwrite,
-                'bring_online': bring_online,
-                'copy_pin_lifetime': dict_attributes.get('lifetime', 172800),
-                'external_host': external_host,
-                'selection_strategy': 'auto',
-                'rule_id': rws.rule_id,
-                'file_metadata': file_metadata,
-                'dest_scheme_priority': dest_scheme_priority}
-    if multihop:
-        transfer['multihop'] = True
-        transfer['initial_request_id'] = rws.request_id
-    if strict_copy:
-        transfer['strict_copy'] = strict_copy
-    if use_ipv4:
-        transfer['use_ipv4'] = True
-    if archive_timeout and ctx.is_tape_rse(rws.dest_rse_id):
-        try:
-            transfer['archive_timeout'] = int(archive_timeout)
-            logger(logging.DEBUG, 'Added archive timeout to transfer.')
-        except ValueError:
-            logger(logging.WARNING, 'Could not set archive_timeout for %s. Must be integer.', dest_url)
-            pass
-    return transfer
+        transfer = {'request_id': rws.request_id,
+                    'schemes': __add_compatible_schemes(schemes=[dest_scheme], allowed_schemes=SUPPORTED_PROTOCOLS),
+                    'account': rws.account,
+                    # 'src_urls': [source_url],
+                    'sources': [(source_rse_name, source_url, source.rse_id, source.source_ranking, computed_distance)],
+                    'dest_urls': [dest_url],
+                    'src_spacetoken': None,
+                    'dest_spacetoken': dest_spacetoken,
+                    'overwrite': overwrite,
+                    'bring_online': bring_online,
+                    'copy_pin_lifetime': dict_attributes.get('lifetime', 172800),
+                    'external_host': external_host,
+                    'selection_strategy': 'auto',
+                    'rule_id': rws.rule_id,
+                    'file_metadata': file_metadata,
+                    'dest_scheme_priority': dest_scheme_priority}
+        if multihop:
+            transfer['multihop'] = True
+            transfer['initial_request_id'] = rws.request_id
+        if strict_copy:
+            transfer['strict_copy'] = strict_copy
+        if use_ipv4:
+            transfer['use_ipv4'] = True
+        if archive_timeout and ctx.is_tape_rse(rws.dest_rse_id):
+            try:
+                transfer['archive_timeout'] = int(archive_timeout)
+                logger(logging.DEBUG, 'Added archive timeout to transfer.')
+            except ValueError:
+                logger(logging.WARNING, 'Could not set archive_timeout for %s. Must be integer.', dest_url)
+                pass
+        return transfer
 
 
 def __merge_or_discard_tranfer_definitions(candidate_transfers):

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -119,12 +119,21 @@ REQUEST_OIDC_AUDIENCE = config_get('conveyor', 'request_oidc_audience', False, '
 WEBDAV_TRANSFER_MODE = config_get('conveyor', 'webdav_transfer_mode', False, None)
 
 
-class RequestWithSource:
-    def __init__(self, request_id, rule_id, scope, name, md5, adler32, byte_count, activity, attributes,
-                 previous_attempt_id, dest_rse_id, account, src_rse_id, src_rse_name, src_rse_deterministic,
-                 src_rse_type, file_path, retry_count, src_url, source_ranking, distance_ranking):
-        self.request_id = request_id
-        self.rule_id  = rule_id
+class TransferSource:
+
+    def __init__(self, rse_id, rse_name, source_ranking, distance_ranking, file_path):
+        self.rse_name = rse_name
+        self.rse_id = rse_id
+        self.distance_ranking = distance_ranking
+        self.source_ranking = source_ranking if source_ranking is not None else 0
+        self.file_path = file_path
+
+
+class RequestWithSources:
+    def __init__(self, id, rule_id, scope, name, md5, adler32, byte_count, activity, attributes,
+                 previous_attempt_id, dest_rse_id, account, retry_count):
+        self.request_id = id
+        self.rule_id = rule_id
         self.scope = scope
         self.name = name
         self.md5 = md5
@@ -135,15 +144,9 @@ class RequestWithSource:
         self.previous_attempt_id = previous_attempt_id
         self.dest_rse_id = dest_rse_id
         self.account = account
-        self.src_rse_id = src_rse_id
-        self.src_rse_name = src_rse_name
-        self.src_rse_deterministic = src_rse_deterministic
-        self.src_rse_type = src_rse_type
-        self.file_path = file_path
         self.retry_count = retry_count
-        self.src_url = src_url
-        self.source_ranking = source_ranking
-        self.distance_ranking = distance_ranking
+
+        self.sources = []
 
 
 def submit_bulk_transfers(external_host, files, transfertool='fts3', job_params={}, timeout=None, user_transfer_job=False, logger=logging.log):
@@ -730,6 +733,168 @@ def __rewrite_dest_url(dest_url, dest_sign_url, dest_scheme):
 
 
 @transactional_session
+def __prepare_transfer(ctx, rws, source, source_scheme, dest_scheme, dest_scheme_priority, dict_attributes, transfertool, retry_other_fts, multihop, activity,
+                       reqs_only_tape_source, reqs_no_source, bring_online_local, logger, session=None):
+    source_rse_name = ctx.rse_name(source.rse_id)
+    dest_rse_name = ctx.rse_name(rws.dest_rse_id)
+
+    # Get source protocol
+    source_protocol = ctx.protocol(source.rse_id, source_scheme, 'read')
+    source_sign_url = ctx.rse_attrs(source.rse_id).get('sign_url', None)
+    dest_sign_url = ctx.rse_attrs(rws.dest_rse_id).get('sign_url', None)
+
+    # Compute the source URL
+    source_url = list(source_protocol.lfns2pfns(lfns={'scope': rws.scope.external, 'name': rws.name, 'path': source.file_path}).values())[0]
+    source_url = __rewrite_source_url(source_url, source_sign_url=source_sign_url, dest_sign_url=dest_sign_url, source_scheme=source_scheme)
+
+    # parse allow tape source expression, not finally version.
+    # allow_tape_source = attr["allow_tape_source"] if (attr and "allow_tape_source" in attr) else True
+    allow_tape_source = True
+
+    # Extend the metadata dictionary with request attributes
+    transfer_src_type = "DISK"
+    transfer_dst_type = "DISK"
+    overwrite, bring_online = True, None
+    if ctx.is_tape_rse(source.rse_id) or ctx.rse_attrs(source.rse_id).get('staging_required', False):
+        bring_online = bring_online_local
+        transfer_src_type = "TAPE"
+        if not allow_tape_source:
+            if rws.request_id not in reqs_only_tape_source:
+                reqs_only_tape_source.append(rws.request_id)
+            if rws.request_id in reqs_no_source:
+                reqs_no_source.remove(rws.request_id)
+            return
+
+    if ctx.is_tape_rse(rws.dest_rse_id):
+        overwrite = False
+        transfer_dst_type = "TAPE"
+
+    # Get destination protocol
+    dest_protocol = ctx.protocol(rws.dest_rse_id, dest_scheme, 'write')
+
+    # Compute the destination url
+    dest_url = __build_dest_url(scope=rws.scope, name=rws.name,
+                                protocol=dest_protocol,
+                                dest_rse_attrs=ctx.rse_attrs(rws.dest_rse_id),
+                                dest_is_deterministic=ctx.rse_info(rws.dest_rse_id)['deterministic'],
+                                dest_is_tape=ctx.is_tape_rse(rws.dest_rse_id),
+                                dict_attributes=dict_attributes,
+                                retry_count=rws.retry_count,
+                                activity=activity)
+    dest_url = __rewrite_dest_url(dest_url, dest_sign_url=dest_sign_url, dest_scheme=dest_scheme)
+
+    # Get dest space token
+    dest_spacetoken = None
+    if dest_protocol.attributes and 'extended_attributes' in dest_protocol.attributes and \
+            dest_protocol.attributes['extended_attributes'] and 'space_token' in dest_protocol.attributes['extended_attributes']:
+        dest_spacetoken = dest_protocol.attributes['extended_attributes']['space_token']
+
+    use_ipv4 = ctx.rse_attrs(source.rse_id).get('use_ipv4', False) or ctx.rse_attrs(rws.dest_rse_id).get('use_ipv4', False)
+
+    # get external_host + strict_copy + archive timeout
+    strict_copy = ctx.rse_attrs(rws.dest_rse_id).get('strict_copy', False)
+    fts_hosts = ctx.rse_attrs(rws.dest_rse_id).get('fts', None)
+    archive_timeout = ctx.rse_attrs(rws.dest_rse_id).get('archive_timeout', None)
+    if source_sign_url == 'gcs':
+        fts_hosts = ctx.rse_attrs(source.rse_id).get('fts', None)
+    source_globus_endpoint_id = ctx.rse_attrs(source.rse_id).get('globus_endpoint_id', None)
+    dest_globus_endpoint_id = ctx.rse_attrs(rws.dest_rse_id).get('globus_endpoint_id', None)
+
+    if transfertool == 'fts3' and not fts_hosts:
+        logger(logging.ERROR, 'Destination RSE %s FTS attribute not defined - SKIP REQUEST %s', dest_rse_name, rws.request_id)
+        return
+    if transfertool == 'globus' and (not dest_globus_endpoint_id or not source_globus_endpoint_id):
+        logger(logging.ERROR, 'Destination RSE %s Globus endpoint attributes not defined - SKIP REQUEST %s', dest_rse_name, rws.request_id)
+        return
+    if rws.retry_count is None:
+        rws.retry_count = 0
+    external_host = ''
+    if fts_hosts:
+        fts_list = fts_hosts.split(",")
+        external_host = fts_list[0]
+
+    if retry_other_fts:
+        external_host = fts_list[rws.retry_count % len(fts_list)]
+
+    # Get the checksum validation strategy (none, source, destination or both)
+    verify_checksum = 'both'
+    if not ctx.rse_attrs(rws.dest_rse_id).get('verify_checksum', True):
+        if not ctx.rse_attrs(source.rse_id).get('verify_checksum', True):
+            verify_checksum = 'none'
+        else:
+            verify_checksum = 'source'
+    else:
+        if not ctx.rse_attrs(source.rse_id).get('verify_checksum', True):
+            verify_checksum = 'destination'
+        else:
+            verify_checksum = 'both'
+
+    source_rse_checksums = get_rse_supported_checksums(source.rse_id, session=session)
+    dest_rse_checksums = get_rse_supported_checksums(rws.dest_rse_id, session=session)
+
+    common_checksum_names = set(source_rse_checksums).intersection(dest_rse_checksums)
+
+    if len(common_checksum_names) == 0:
+        logger(logging.INFO, 'No common checksum method. Verifying destination only.')
+        verify_checksum = 'destination'
+
+    # Fill the transfer dictionary including file_metadata
+    file_metadata = {'request_id': rws.request_id,
+                     'scope': rws.scope,
+                     'name': rws.name,
+                     'activity': activity,
+                     'request_type': RequestType.TRANSFER,
+                     'src_type': transfer_src_type,
+                     'dst_type': transfer_dst_type,
+                     'src_rse': source_rse_name,
+                     'dst_rse': dest_rse_name,
+                     'src_rse_id': source.rse_id,
+                     'dest_rse_id': rws.dest_rse_id,
+                     'filesize': rws.byte_count,
+                     'md5': rws.md5,
+                     'adler32': rws.adler32,
+                     'verify_checksum': verify_checksum,
+                     'source_globus_endpoint_id': source_globus_endpoint_id,
+                     'dest_globus_endpoint_id': dest_globus_endpoint_id}
+
+    if rws.previous_attempt_id:
+        file_metadata['previous_attempt_id'] = rws.previous_attempt_id
+
+    transfer = {'request_id': rws.request_id,
+                'schemes': __add_compatible_schemes(schemes=[dest_scheme], allowed_schemes=SUPPORTED_PROTOCOLS),
+                'account': rws.account,
+                # 'src_urls': [source_url],
+                'sources': [(source_rse_name, source_url, source.rse_id, source.source_ranking, source.distance_ranking)],
+                'dest_urls': [dest_url],
+                'src_spacetoken': None,
+                'dest_spacetoken': dest_spacetoken,
+                'overwrite': overwrite,
+                'bring_online': bring_online,
+                'copy_pin_lifetime': dict_attributes.get('lifetime', 172800),
+                'external_host': external_host,
+                'selection_strategy': 'auto',
+                'rule_id': rws.rule_id,
+                'file_metadata': file_metadata,
+                'dest_scheme_priority': dest_scheme_priority}
+    if multihop:
+        transfer['multihop'] = True
+        transfer['initial_request_id'] = rws.request_id
+    if strict_copy:
+        transfer['strict_copy'] = strict_copy
+    if use_ipv4:
+        transfer['use_ipv4'] = True
+    if archive_timeout and ctx.is_tape_rse(rws.dest_rse_id):
+        try:
+            transfer['archive_timeout'] = int(archive_timeout)
+            logger(logging.DEBUG, 'Added archive timeout to transfer.')
+        except ValueError:
+            logger(logging.WARNING, 'Could not set archive_timeout for %s. Must be integer.', dest_url)
+            pass
+    return transfer
+
+
+
+@transactional_session
 def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, limit=None, activity=None, older_than=None, rses=None, schemes=None,
                                               bring_online=43200, retry_other_fts=False, failover_schemes=None, transfertool=None, logger=logging.log, session=None):
     """
@@ -750,15 +915,17 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
     :returns:                     transfers, reqs_no_source, reqs_scheme_mismatch, reqs_only_tape_source
     """
 
-    req_sources = __list_transfer_requests_and_source_replicas(total_workers=total_workers,
-                                                               worker_number=worker_number,
-                                                               limit=limit,
-                                                               activity=activity,
-                                                               older_than=older_than,
-                                                               rses=rses,
-                                                               request_state=RequestState.QUEUED,
-                                                               transfertool=transfertool,
-                                                               session=session)
+    request_with_sources = __list_transfer_requests_and_source_replicas(
+        total_workers=total_workers,
+        worker_number=worker_number,
+        limit=limit,
+        activity=activity,
+        older_than=older_than,
+        rses=rses,
+        request_state=RequestState.QUEUED,
+        transfertool=transfertool,
+        session=session,
+    )
 
     class _LocalContext:
         def __init__(self, session):
@@ -817,39 +984,28 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
     except InvalidRSEExpression:
         multihop_rses = []
 
-    for rws in req_sources:
-
-        if rws.source_ranking is None:
-            rws.source_ranking = 0
-
-        multihop = False
-
+    for rws in request_with_sources:
         # Add req to req_no_source list (Will be removed later if needed)
         if rws.request_id not in reqs_no_source:
             reqs_no_source.append(rws.request_id)
-
-        # source_rse_id will be None if no source replicas
-        # rse will be None if rse is staging area
-        if rws.src_rse_id is None or rws.src_rse_name is None:
-            continue
 
         if rses and rws.dest_rse_id not in rses:
             continue
 
         dest_rse_name = ctx.rse_name(rws.dest_rse_id)
-        source_rse_name = ctx.rse_name(rws.src_rse_id)
-
-        dict_attributes = get_attributes(rws.attributes)
-
-        # Check if the source and destination are blocked
-        if rws.src_rse_id in unavailable_read_rse_ids:
-            continue
+        # Check if destination is blocked
         if rws.dest_rse_id in unavailable_write_rse_ids:
             logger(logging.WARNING, 'RSE %s is blocked for write. Will skip the submission of new jobs', dest_rse_name)
             continue
 
+        if not rws.sources:
+            continue
+
+        dict_attributes = get_attributes(rws.attributes)
+
         # parse source expression
         source_replica_expression = dict_attributes.get('source_replica_expression', None)
+        allowed_source_rses = None
         if source_replica_expression:
             try:
                 parsed_rses = parse_expression(source_replica_expression, session=session)
@@ -857,28 +1013,39 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                 logger(logging.ERROR, "Invalid RSE exception %s: %s", source_replica_expression, str(error))
                 continue
             else:
-                allowed_rses = [x['id'] for x in parsed_rses]
-                if rws.src_rse_id not in allowed_rses:
-                    continue
+                allowed_source_rses = [x['id'] for x in parsed_rses]
 
-        if True:
+        for source in rws.sources:
+            if allowed_source_rses is not None and source.rse_id not in allowed_source_rses:
+                continue
+
+            # rse_name will be None if rse is staging area
+            if source.rse_name is None:
+                continue
+
+            # Check if the source is blocked
+            if source.rse_id in unavailable_read_rse_ids:
+                continue
+
+            source_rse_name = ctx.rse_name(source.rse_id)
             # Call the get_hops function to create a list of RSEs used for the transfer
             # In case the source_rse and the dest_rse are connected, the list contains only the destination RSE
             # In case of non-connected, the list contains all the intermediary RSEs
-            list_hops = []
+
             include_multihop = False
             if transfertool in ['fts3', None]:
                 include_multihop = core_config_get('transfers', 'use_multihop', default=False, expiration_time=600, session=session)
 
             try:
-                list_hops = get_hops(rws.src_rse_id,
+                multihop = False
+                list_hops = get_hops(source.rse_id,
                                      rws.dest_rse_id,
                                      include_multihop=include_multihop,
                                      multihop_rses=multihop_rses,
                                      limit_dest_schemes=transfers.get(rws.request_id, {}).get('schemes', None),
                                      session=session)
                 if len(list_hops) > 1:
-                    logger(logging.DEBUG, 'From %s to %s requires multihop: %s', rws.src_rse_id, rws.dest_rse_id, list_hops)
+                    logger(logging.DEBUG, 'From %s to %s requires multihop: %s', source.rse_id, rws.dest_rse_id, list_hops)
                     multihop = True
                     multi_hop_dict[rws.request_id] = (list_hops, dict_attributes, rws.retry_count)
             except NoDistance:
@@ -900,165 +1067,26 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
             dest_scheme = list_hops[-1]['dest_scheme']
             dest_scheme_priority = list_hops[-1]['dest_scheme_priority']
 
-            allow_tape_source = True
             try:
-                # Get source protocol
-                source_protocol = ctx.protocol(rws.src_rse_id, source_scheme, 'read')
-
-                source_sign_url = ctx.rse_attrs(rws.src_rse_id).get('sign_url', None)
-                dest_sign_url = ctx.rse_attrs(rws.dest_rse_id).get('sign_url', None)
-
-                # Compute the source URL
-                source_url = list(source_protocol.lfns2pfns(lfns={'scope': rws.scope.external, 'name': rws.name, 'path': rws.file_path}).values())[0]
-                source_url = __rewrite_source_url(source_url, source_sign_url=source_sign_url, dest_sign_url=dest_sign_url, source_scheme=source_scheme)
-
                 # If the request_id is not already in the transfer dictionary, need to compute the destination URL
                 if rws.request_id not in transfers:
-
-                    # parse allow tape source expression, not finally version.
-                    # allow_tape_source = attr["allow_tape_source"] if (attr and "allow_tape_source" in attr) else True
-                    allow_tape_source = True
-
-                    # Extend the metadata dictionary with request attributes
-                    transfer_src_type = "DISK"
-                    transfer_dst_type = "DISK"
-                    overwrite, bring_online = True, None
-                    if ctx.is_tape_rse(rws.src_rse_id) or ctx.rse_attrs(rws.src_rse_id).get('staging_required', False):
-                        bring_online = bring_online_local
-                        transfer_src_type = "TAPE"
-                        if not allow_tape_source:
-                            if rws.request_id not in reqs_only_tape_source:
-                                reqs_only_tape_source.append(rws.request_id)
-                            if rws.request_id in reqs_no_source:
-                                reqs_no_source.remove(rws.request_id)
-                            continue
-
-                    if ctx.is_tape_rse(rws.dest_rse_id):
-                        overwrite = False
-                        transfer_dst_type = "TAPE"
-
-                    # Get destination protocol
-                    dest_protocol = ctx.protocol(rws.dest_rse_id, dest_scheme, 'write')
-
-                    # Compute the destination url
-                    dest_url = __build_dest_url(scope=rws.scope, name=rws.name,
-                                                protocol=dest_protocol,
-                                                dest_rse_attrs=ctx.rse_attrs(rws.dest_rse_id),
-                                                dest_is_deterministic=ctx.rse_info(rws.dest_rse_id)['deterministic'],
-                                                dest_is_tape=ctx.is_tape_rse(rws.dest_rse_id),
-                                                dict_attributes=dict_attributes,
-                                                retry_count=rws.retry_count,
-                                                activity=activity)
-                    dest_url = __rewrite_dest_url(dest_url, dest_sign_url=dest_sign_url, dest_scheme=dest_scheme)
-
-                    # Get dest space token
-                    dest_spacetoken = None
-                    if dest_protocol.attributes and 'extended_attributes' in dest_protocol.attributes and \
-                            dest_protocol.attributes['extended_attributes'] and 'space_token' in dest_protocol.attributes['extended_attributes']:
-                        dest_spacetoken = dest_protocol.attributes['extended_attributes']['space_token']
-
-                    use_ipv4 = ctx.rse_attrs(rws.src_rse_id).get('use_ipv4', False) or ctx.rse_attrs(rws.dest_rse_id).get('use_ipv4', False)
-
-                    # get external_host + strict_copy + archive timeout
-                    strict_copy = ctx.rse_attrs(rws.dest_rse_id).get('strict_copy', False)
-                    fts_hosts = ctx.rse_attrs(rws.dest_rse_id).get('fts', None)
-                    archive_timeout = ctx.rse_attrs(rws.dest_rse_id).get('archive_timeout', None)
-                    if source_sign_url == 'gcs':
-                        fts_hosts = ctx.rse_attrs(rws.src_rse_id).get('fts', None)
-                    source_globus_endpoint_id = ctx.rse_attrs(rws.src_rse_id).get('globus_endpoint_id', None)
-                    dest_globus_endpoint_id = ctx.rse_attrs(rws.dest_rse_id).get('globus_endpoint_id', None)
-
-                    if transfertool == 'fts3' and not fts_hosts:
-                        logger(logging.ERROR, 'Destination RSE %s FTS attribute not defined - SKIP REQUEST %s', dest_rse_name, rws.request_id)
-                        continue
-                    if transfertool == 'globus' and (not dest_globus_endpoint_id or not source_globus_endpoint_id):
-                        logger(logging.ERROR, 'Destination RSE %s Globus endpoint attributes not defined - SKIP REQUEST %s', dest_rse_name, rws.request_id)
-                        continue
-                    if rws.retry_count is None:
-                        rws.retry_count = 0
-                    external_host = ''
-                    if fts_hosts:
-                        fts_list = fts_hosts.split(",")
-                        external_host = fts_list[0]
-
-                    if retry_other_fts:
-                        external_host = fts_list[rws.retry_count % len(fts_list)]
-
-                    # Get the checksum validation strategy (none, source, destination or both)
-                    verify_checksum = 'both'
-                    if not ctx.rse_attrs(rws.dest_rse_id).get('verify_checksum', True):
-                        if not ctx.rse_attrs(rws.src_rse_id).get('verify_checksum', True):
-                            verify_checksum = 'none'
-                        else:
-                            verify_checksum = 'source'
-                    else:
-                        if not ctx.rse_attrs(rws.src_rse_id).get('verify_checksum', True):
-                            verify_checksum = 'destination'
-                        else:
-                            verify_checksum = 'both'
-
-                    source_rse_checksums = get_rse_supported_checksums(rws.src_rse_id, session=session)
-                    dest_rse_checksums = get_rse_supported_checksums(rws.dest_rse_id, session=session)
-
-                    common_checksum_names = set(source_rse_checksums).intersection(dest_rse_checksums)
-
-                    if len(common_checksum_names) == 0:
-                        logger(logging.INFO, 'No common checksum method. Verifying destination only.')
-                        verify_checksum = 'destination'
-
-                    # Fill the transfer dictionary including file_metadata
-                    file_metadata = {'request_id': rws.request_id,
-                                     'scope': rws.scope,
-                                     'name': rws.name,
-                                     'activity': activity,
-                                     'request_type': RequestType.TRANSFER,
-                                     'src_type': transfer_src_type,
-                                     'dst_type': transfer_dst_type,
-                                     'src_rse': source_rse_name,
-                                     'dst_rse': dest_rse_name,
-                                     'src_rse_id': rws.src_rse_id,
-                                     'dest_rse_id': rws.dest_rse_id,
-                                     'filesize': rws.byte_count,
-                                     'md5': rws.md5,
-                                     'adler32': rws.adler32,
-                                     'verify_checksum': verify_checksum,
-                                     'source_globus_endpoint_id': source_globus_endpoint_id,
-                                     'dest_globus_endpoint_id': dest_globus_endpoint_id}
-
-                    if rws.previous_attempt_id:
-                        file_metadata['previous_attempt_id'] = rws.previous_attempt_id
-
-                    transfers[rws.request_id] = {'request_id': rws.request_id,
-                                         'schemes': __add_compatible_schemes(schemes=[dest_scheme], allowed_schemes=SUPPORTED_PROTOCOLS),
-                                         'account': rws.account,
-                                         # 'src_urls': [source_url],
-                                         'sources': [(source_rse_name, source_url, rws.src_rse_id, rws.source_ranking, rws.distance_ranking)],
-                                         'dest_urls': [dest_url],
-                                         'src_spacetoken': None,
-                                         'dest_spacetoken': dest_spacetoken,
-                                         'overwrite': overwrite,
-                                         'bring_online': bring_online,
-                                         'copy_pin_lifetime': dict_attributes.get('lifetime', 172800),
-                                         'external_host': external_host,
-                                         'selection_strategy': 'auto',
-                                         'rule_id': rws.rule_id,
-                                         'file_metadata': file_metadata,
-                                         'dest_scheme_priority': dest_scheme_priority}
-                    if multihop:
-                        transfers[rws.request_id]['multihop'] = True
-                        transfers[rws.request_id]['initial_request_id'] = rws.request_id
-                    if strict_copy:
-                        transfers[rws.request_id]['strict_copy'] = strict_copy
-                    if use_ipv4:
-                        transfers[rws.request_id]['use_ipv4'] = True
-                    if archive_timeout and ctx.is_tape_rse(rws.dest_rse_id):
-                        try:
-                            transfers[rws.request_id]['archive_timeout'] = int(archive_timeout)
-                            logger(logging.DEBUG, 'Added archive timeout to transfer.')
-                        except ValueError:
-                            logger(logging.WARNING, 'Could not set archive_timeout for %s. Must be integer.', dest_url)
-                            pass
+                    transfer = __prepare_transfer(ctx, rws=rws, source=source, source_scheme=source_scheme, dest_scheme=dest_scheme,
+                                                  dest_scheme_priority=dest_scheme_priority, dict_attributes=dict_attributes, transfertool=transfertool,
+                                                  retry_other_fts=retry_other_fts, multihop=multihop, activity=activity, logger=logger, session=session,
+                                                  reqs_no_source=reqs_no_source, reqs_only_tape_source=reqs_only_tape_source, bring_online_local=bring_online_local)
+                    if transfer:
+                        transfers[rws.request_id] = transfer
                 else:
+                    # Get source protocol
+                    source_protocol = ctx.protocol(source.rse_id, source_scheme, 'read')
+
+                    source_sign_url = ctx.rse_attrs(source.rse_id).get('sign_url', None)
+                    dest_sign_url = ctx.rse_attrs(rws.dest_rse_id).get('sign_url', None)
+
+                    # Compute the source URL
+                    source_url = list(source_protocol.lfns2pfns(lfns={'scope': rws.scope.external, 'name': rws.name, 'path': source.file_path}).values())[0]
+                    source_url = __rewrite_source_url(source_url, source_sign_url=source_sign_url, dest_sign_url=dest_sign_url, source_scheme=source_scheme)
+
                     # parse allow tape source expression, not finally version.
                     allow_tape_source = dict_attributes.get('allow_tape_source', None)
 
@@ -1068,7 +1096,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                         continue
 
                     current_source_is_tape = transfers[rws.request_id]['bring_online']
-                    new_source_is_tape = ctx.is_tape_rse(rws.src_rse_id) or ctx.rse_attrs(rws.src_rse_id).get('staging_required', False)
+                    new_source_is_tape = ctx.is_tape_rse(source.rse_id) or ctx.rse_attrs(source.rse_id).get('staging_required', False)
 
                     if new_source_is_tape and not allow_tape_source:
                         continue
@@ -1089,12 +1117,12 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
 
                         # If ranking of the new source is better. On equal ranking, prefer Disk over Tape.
                         if avail_top_ranking is None or\
-                                (rws.source_ranking > avail_top_ranking) or\
-                                (rws.source_ranking >= avail_top_ranking and current_source_is_tape):
+                                (source.source_ranking > avail_top_ranking) or\
+                                (source.source_ranking >= avail_top_ranking and current_source_is_tape):
                             transfers[rws.request_id]['sources'] = []
                             transfers[rws.request_id]['bring_online'] = bring_online_local if new_source_is_tape else None
                             transfers[rws.request_id]['file_metadata']['src_type'] = 'TAPE' if new_source_is_tape else 'DISK'
-                            transfers[rws.request_id]['file_metadata']['src_rse'] = rws.src_rse_name
+                            transfers[rws.request_id]['file_metadata']['src_rse'] = source_rse_name
                         else:
                             continue
 
@@ -1102,12 +1130,12 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                         # multiple Tape source replicas are not allowed in FTS3.
                         # Either keep the old source. Or substitute it with the new one.
                         prev_is_multihop =  transfers[rws.request_id]['sources'][0][4] is None  # will be None if the previous transfer is multihop
-                        if rws.source_ranking > transfers[rws.request_id]['sources'][0][3] \
-                                or (rws.source_ranking == transfers[rws.request_id]['sources'][0][3] and (prev_is_multihop
-                                                                                                          or rws.distance_ranking < transfers[rws.request_id]['sources'][0][4])):
+                        if source.source_ranking > transfers[rws.request_id]['sources'][0][3] \
+                                or (source.source_ranking == transfers[rws.request_id]['sources'][0][3] and (prev_is_multihop
+                                                                                                             or source.distance_ranking < transfers[rws.request_id]['sources'][0][4])):
                             transfers[rws.request_id]['sources'] = []
                             transfers[rws.request_id]['bring_online'] = bring_online_local
-                            transfers[rws.request_id]['file_metadata']['src_rse'] = rws.src_rse_name
+                            transfers[rws.request_id]['file_metadata']['src_rse'] = source_rse_name
                         else:
                             continue
 
@@ -1117,9 +1145,9 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                         transfers[rws.request_id].pop('multihop', None)
                         transfers[rws.request_id]['sources'] = []
 
-                    transfers[rws.request_id]['sources'].append((rws.src_rse_name, source_url, rws.src_rse_id, rws.source_ranking, rws.distance_ranking))
+                    transfers[rws.request_id]['sources'].append((source_rse_name, source_url, source.rse_id, source.source_ranking, source.distance_ranking))
                     # if one source has force IPv4, force IPv4 for the whole job
-                    use_ipv4 = ctx.rse_attrs(rws.src_rse_id).get('use_ipv4', False)
+                    use_ipv4 = ctx.rse_attrs(source.rse_id).get('use_ipv4', False)
                     if use_ipv4:
                         transfers[rws.request_id]['use_ipv4'] = True
 
@@ -1331,7 +1359,7 @@ def __list_transfer_requests_and_source_replicas(
     request_state=None,
     transfertool=None,
     session=None,
-) -> "List[RequestWithSource]":
+) -> "List[RequestWithSources]":
     """
     List requests with source replicas
     :param total_workers:    Number of total workers.
@@ -1342,7 +1370,7 @@ def __list_transfer_requests_and_source_replicas(
     :param rses:             List of rse_id to select requests.
     :param transfertool:     The transfer tool as specified in rucio.cfg.
     :param session:          Database session to use.
-    :returns:                List of RequestWithSource objects.
+    :returns:                List of RequestWithSources objects.
     """
 
     if request_state is None:
@@ -1402,13 +1430,10 @@ def __list_transfer_requests_and_source_replicas(
                           sub_requests.c.previous_attempt_id,
                           sub_requests.c.dest_rse_id,
                           sub_requests.c.account,
+                          sub_requests.c.retry_count,
                           models.RSEFileAssociation.rse_id,
                           models.RSE.rse,
-                          models.RSE.deterministic,        # obsolete, remove?
-                          models.RSE.rse_type,             # obsolete, remove?
                           models.RSEFileAssociation.path,
-                          sub_requests.c.retry_count,
-                          models.Source.url,               # obsolete, remove?
                           models.Source.ranking.label("source_ranking"),
                           models.Distance.ranking.label("distance_ranking")) \
         .order_by(sub_requests.c.created_at) \
@@ -1434,11 +1459,25 @@ def __list_transfer_requests_and_source_replicas(
             .filter(models.RSEAttrAssociation.key == 'transfertool',
                     models.RSEAttrAssociation.value.like('%' + transfertool + '%'))
 
-    result = [RequestWithSource(*item) for item in query.all()]
-    if rses:
+    requests_by_id = {}
+    for (request_id, rule_id, scope, name, md5, adler32, byte_count, activity, attributes, previous_attempt_id, dest_rse_id, account, retry_count,
+         source_rse_id, source_rse_name, file_path, source_ranking, distance_ranking) in query:
+
         # rses (of unknown length) should be a temporary table to check against instead of this special case
-        result = list(filter(lambda req: req.dest_rse_id in rses, result))
-    return result
+        if rses and dest_rse_id not in rses:
+            continue
+
+        request = requests_by_id.get(request_id)
+        if not request:
+            request = RequestWithSources(id=request_id, rule_id=rule_id, scope=scope, name=name, md5=md5, adler32=adler32, byte_count=byte_count,
+                                         activity=activity, attributes=attributes, previous_attempt_id=previous_attempt_id, dest_rse_id=dest_rse_id,
+                                         account=account, retry_count=retry_count)
+            requests_by_id[request_id] = request
+
+        if source_rse_id is not None:
+            request.sources.append(TransferSource(rse_id=source_rse_id, rse_name=source_rse_name, file_path=file_path,
+                                                  source_ranking=source_ranking, distance_ranking=distance_ranking))
+    return list(requests_by_id.values())
 
 
 @transactional_session

--- a/lib/rucio/tests/test_transfer.py
+++ b/lib/rucio/tests/test_transfer.py
@@ -19,11 +19,12 @@
 import pytest
 
 from rucio.common.exception import NoDistance
-from rucio.core.distance import add_distance, update_distances
+from rucio.core.distance import add_distance
 from rucio.core.replica import add_replicas
 from rucio.core.transfer import get_hops, get_transfer_requests_and_source_replicas
 from rucio.core import rule as rule_core
 from rucio.core import request as request_core
+from rucio.core import rse as rse_core
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import RSEType
 from rucio.db.sqla.session import transactional_session
@@ -86,7 +87,7 @@ def test_get_hops(rse_factory):
         get_hops(source_rse_id=rse1_id, dest_rse_id=rse0_id, include_multihop=True, multihop_rses=all_rses)
 
     # A single hop path must be found between two directly connected RSE
-    [hop] = get_hops(source_rse_id=rse1_id, dest_rse_id=rse2_id)
+    [hop], _distance = get_hops(source_rse_id=rse1_id, dest_rse_id=rse2_id)
     assert hop['source_rse_id'] == rse1_id
     assert hop['dest_rse_id'] == rse2_id
 
@@ -99,46 +100,46 @@ def test_get_hops(rse_factory):
         get_hops(source_rse_id=rse3_id, dest_rse_id=rse2_id, include_multihop=True)
 
     # The shortest multihop path will be computed
-    [hop1, hop2] = get_hops(source_rse_id=rse3_id, dest_rse_id=rse2_id, include_multihop=True, multihop_rses=all_rses)
+    [hop1, hop2], _distance = get_hops(source_rse_id=rse3_id, dest_rse_id=rse2_id, include_multihop=True, multihop_rses=all_rses)
     assert hop1['source_rse_id'] == rse3_id
     assert hop1['dest_rse_id'] == rse4_id
     assert hop2['source_rse_id'] == rse4_id
     assert hop2['dest_rse_id'] == rse2_id
 
     # multihop_rses doesn't contain the RSE needed for the shortest path. Return a longer path
-    [hop1, hop2] = get_hops(source_rse_id=rse1_id, dest_rse_id=rse4_id, include_multihop=True, multihop_rses=[rse3_id])
+    [hop1, hop2], _distance = get_hops(source_rse_id=rse1_id, dest_rse_id=rse4_id, include_multihop=True, multihop_rses=[rse3_id])
     assert hop1['source_rse_id'] == rse1_id
     assert hop1['dest_rse_id'] == rse3_id
     assert hop2['source_rse_id'] == rse3_id
     assert hop2['dest_rse_id'] == rse4_id
 
     # A direct connection is preferred over a multihop one with smaller cost
-    [hop] = get_hops(source_rse_id=rse3_id, dest_rse_id=rse5_id, include_multihop=True, multihop_rses=all_rses)
+    [hop], _distance = get_hops(source_rse_id=rse3_id, dest_rse_id=rse5_id, include_multihop=True, multihop_rses=all_rses)
     assert hop['source_rse_id'] == rse3_id
     assert hop['dest_rse_id'] == rse5_id
 
     # A link with cost only in one direction will not be used in the opposite direction
     with pytest.raises(NoDistance):
         get_hops(source_rse_id=rse6_id, dest_rse_id=rse5_id, include_multihop=True, multihop_rses=all_rses)
-    [hop1, hop2] = get_hops(source_rse_id=rse4_id, dest_rse_id=rse3_id, include_multihop=True, multihop_rses=all_rses)
+    [hop1, hop2], _distance = get_hops(source_rse_id=rse4_id, dest_rse_id=rse3_id, include_multihop=True, multihop_rses=all_rses)
     assert hop1['source_rse_id'] == rse4_id
     assert hop2['source_rse_id'] == rse5_id
     assert hop2['dest_rse_id'] == rse3_id
 
     # A longer path is preferred over a shorter one with high intermediate cost
-    [hop1, hop2, hop3] = get_hops(source_rse_id=rse3_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
+    [hop1, hop2, hop3], _distance = get_hops(source_rse_id=rse3_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
     assert hop1['source_rse_id'] == rse3_id
     assert hop2['source_rse_id'] == rse4_id
     assert hop3['source_rse_id'] == rse5_id
     assert hop3['dest_rse_id'] == rse6_id
 
     # A link with no cost is ignored. Both for direct connection and multihop paths
-    [hop1, hop2, hop3] = get_hops(source_rse_id=rse2_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
+    [hop1, hop2, hop3], _distance = get_hops(source_rse_id=rse2_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
     assert hop1['source_rse_id'] == rse2_id
     assert hop2['source_rse_id'] == rse4_id
     assert hop3['source_rse_id'] == rse5_id
     assert hop3['dest_rse_id'] == rse6_id
-    [hop1, hop2, hop3, hop4] = get_hops(source_rse_id=rse1_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
+    [hop1, hop2, hop3, hop4], _distance = get_hops(source_rse_id=rse1_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
     assert hop1['source_rse_id'] == rse1_id
     assert hop2['source_rse_id'] == rse2_id
     assert hop3['source_rse_id'] == rse4_id
@@ -154,6 +155,10 @@ def test_disk_vs_tape_priority(rse_factory, root_account, mock_scope):
     dst_rse_name, dst_rse_id = rse_factory.make_posix_rse()
     source_rses = [tape1_rse_id, tape2_rse_id, disk1_rse_id, disk2_rse_id]
     all_rses = source_rses + [dst_rse_id]
+    add_distance(disk1_rse_id, dst_rse_id, ranking=15)
+    add_distance(disk2_rse_id, dst_rse_id, ranking=10)
+    add_distance(tape1_rse_id, dst_rse_id, ranking=15)
+    add_distance(tape2_rse_id, dst_rse_id, ranking=10)
 
     # add same file to all source RSEs
     file = {'scope': mock_scope, 'name': 'lfn.' + generate_uuid(), 'type': 'FILE', 'bytes': 1, 'adler32': 'beefdead'}
@@ -179,10 +184,6 @@ def test_disk_vs_tape_priority(rse_factory, root_account, mock_scope):
                           is_using=False). \
                 save(session=session, flush=False)
 
-    # Init all distances to the same value
-    for rse_id in source_rses:
-        add_distance(rse_id, dst_rse_id, ranking=10)
-
     # On equal priority and distance, disk should be preferred over tape. Both disk sources will be returned
     transfers, _reqs_no_source, _reqs_scheme_mismatch, _reqs_only_tape_source = get_transfer_requests_and_source_replicas(rses=all_rses)
     assert len(transfers) == 1
@@ -201,7 +202,6 @@ def test_disk_vs_tape_priority(rse_factory, root_account, mock_scope):
     assert transfer['sources'][0][0] in (tape1_rse_name, tape2_rse_name)
 
     # On equal source ranking, but different distance; the smaller distance is preferred
-    update_distances(tape1_rse_id, dst_rse_id, parameters={'ranking': 15})
     transfers, _reqs_no_source, _reqs_scheme_mismatch, _reqs_only_tape_source = get_transfer_requests_and_source_replicas(rses=all_rses)
     assert len(transfers) == 1
     transfer = next(iter(transfers.values()))
@@ -215,3 +215,96 @@ def test_disk_vs_tape_priority(rse_factory, root_account, mock_scope):
     transfer = next(iter(transfers.values()))
     assert len(transfer['sources']) == 1
     assert transfer['sources'][0][0] == tape1_rse_name
+
+
+@pytest.mark.parametrize("core_config_mock", [{"table_content": [
+    ('transfers', 'use_multihop', True)
+]}], indirect=True)
+@pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
+    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by an expression
+    'rucio.core.config',
+]}], indirect=True)
+def test_multihop_requests_created(rse_factory, did_factory, root_account, core_config_mock, caches_mock):
+    """
+    Ensure that multihop transfers are handled and intermediate request correctly created
+    """
+    rs0_name, src_rse_id = rse_factory.make_posix_rse()
+    _, intermediate_rse_id = rse_factory.make_posix_rse()
+    dst_rse_name, dst_rse_id = rse_factory.make_posix_rse()
+    rse_core.add_rse_attribute(intermediate_rse_id, 'available_for_multihop', True)
+
+    add_distance(src_rse_id, intermediate_rse_id, ranking=10)
+    add_distance(intermediate_rse_id, dst_rse_id, ranking=10)
+
+    did = did_factory.upload_test_file(rs0_name)
+    rule_core.add_rule(dids=[did], account=root_account, copies=1, rse_expression=dst_rse_name, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
+
+    transfers, _reqs_no_source, _reqs_scheme_mismatch, _reqs_only_tape_source = get_transfer_requests_and_source_replicas(rses=rse_factory.created_rses)
+    assert len(transfers) == 2
+    # ensure that one transfer is the parent of the other
+    assert any(t for t in transfers.values() if t.get('parent_request') in transfers)
+    # the intermediate request was correctly created
+    assert request_core.get_request_by_did(rse_id=intermediate_rse_id, **did)
+
+
+@pytest.mark.parametrize("core_config_mock", [{"table_content": [
+    ('transfers', 'use_multihop', True)
+]}], indirect=True)
+@pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
+    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by an expression
+    'rucio.core.config',
+]}], indirect=True)
+def test_singlehop_vs_multihop_priority(rse_factory, root_account, mock_scope, core_config_mock, caches_mock):
+    """
+    On small distance difference, singlehop is prioritized over multihop
+    due to HOP_PENALTY. On big difference, multihop is prioritized
+    """
+    # +------+    +------+
+    # |      | 10 |      |
+    # | RSE0 +--->| RSE1 |
+    # |      |    |      +-+ 10
+    # +------+    +------+ |  +------+       +------+
+    #                      +->|      |  200  |      |
+    # +------+                | RSE3 |<------| RSE4 |
+    # |      |   30      +--->|      |       |      |
+    # | RSE2 +-----------+    +------+       +------+
+    # |      |
+    # +------+
+    _, rse0_id = rse_factory.make_posix_rse()
+    _, rse1_id = rse_factory.make_posix_rse()
+    _, rse2_id = rse_factory.make_posix_rse()
+    rse3_name, rse3_id = rse_factory.make_posix_rse()
+    _, rse4_id = rse_factory.make_posix_rse()
+
+    add_distance(rse0_id, rse1_id, ranking=10)
+    add_distance(rse1_id, rse3_id, ranking=10)
+    add_distance(rse2_id, rse3_id, ranking=30)
+    add_distance(rse4_id, rse3_id, ranking=200)
+    rse_core.add_rse_attribute(rse1_id, 'available_for_multihop', True)
+
+    # add same file to two source RSEs
+    file = {'scope': mock_scope, 'name': 'lfn.' + generate_uuid(), 'type': 'FILE', 'bytes': 1, 'adler32': 'beefdead'}
+    did = {'scope': file['scope'], 'name': file['name']}
+    for rse_id in [rse0_id, rse2_id]:
+        add_replicas(rse_id=rse_id, files=[file], account=root_account)
+
+    rule_core.add_rule(dids=[did], account=root_account, copies=1, rse_expression=rse3_name, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
+
+    # The singlehop must be prioritized
+    transfers, _reqs_no_source, _reqs_scheme_mismatch, _reqs_only_tape_source = get_transfer_requests_and_source_replicas(rses=rse_factory.created_rses)
+    assert len(transfers) == 1
+    transfer = next(iter(transfers.values()))
+    assert transfer['file_metadata']['src_rse_id'] == rse2_id
+    assert transfer['file_metadata']['dest_rse_id'] == rse3_id
+
+    # add same file to two source RSEs
+    file = {'scope': mock_scope, 'name': 'lfn.' + generate_uuid(), 'type': 'FILE', 'bytes': 1, 'adler32': 'beefdead'}
+    did = {'scope': file['scope'], 'name': file['name']}
+    for rse_id in [rse0_id, rse4_id]:
+        add_replicas(rse_id=rse_id, files=[file], account=root_account)
+
+    rule_core.add_rule(dids=[did], account=root_account, copies=1, rse_expression=rse3_name, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
+
+    # The multihop must be prioritized
+    transfers, _reqs_no_source, _reqs_scheme_mismatch, _reqs_only_tape_source = get_transfer_requests_and_source_replicas(rses=rse_factory.created_rses)
+    assert len([t for t in transfers.values() if t['file_metadata']['name'] == did['name']]) == 2

--- a/lib/rucio/tests/test_transfer.py
+++ b/lib/rucio/tests/test_transfer.py
@@ -87,7 +87,7 @@ def test_get_hops(rse_factory):
         get_hops(source_rse_id=rse1_id, dest_rse_id=rse0_id, include_multihop=True, multihop_rses=all_rses)
 
     # A single hop path must be found between two directly connected RSE
-    [hop], _distance = get_hops(source_rse_id=rse1_id, dest_rse_id=rse2_id)
+    [hop] = get_hops(source_rse_id=rse1_id, dest_rse_id=rse2_id)
     assert hop['source_rse_id'] == rse1_id
     assert hop['dest_rse_id'] == rse2_id
 
@@ -100,46 +100,46 @@ def test_get_hops(rse_factory):
         get_hops(source_rse_id=rse3_id, dest_rse_id=rse2_id, include_multihop=True)
 
     # The shortest multihop path will be computed
-    [hop1, hop2], _distance = get_hops(source_rse_id=rse3_id, dest_rse_id=rse2_id, include_multihop=True, multihop_rses=all_rses)
+    [hop1, hop2] = get_hops(source_rse_id=rse3_id, dest_rse_id=rse2_id, include_multihop=True, multihop_rses=all_rses)
     assert hop1['source_rse_id'] == rse3_id
     assert hop1['dest_rse_id'] == rse4_id
     assert hop2['source_rse_id'] == rse4_id
     assert hop2['dest_rse_id'] == rse2_id
 
     # multihop_rses doesn't contain the RSE needed for the shortest path. Return a longer path
-    [hop1, hop2], _distance = get_hops(source_rse_id=rse1_id, dest_rse_id=rse4_id, include_multihop=True, multihop_rses=[rse3_id])
+    [hop1, hop2] = get_hops(source_rse_id=rse1_id, dest_rse_id=rse4_id, include_multihop=True, multihop_rses=[rse3_id])
     assert hop1['source_rse_id'] == rse1_id
     assert hop1['dest_rse_id'] == rse3_id
     assert hop2['source_rse_id'] == rse3_id
     assert hop2['dest_rse_id'] == rse4_id
 
     # A direct connection is preferred over a multihop one with smaller cost
-    [hop], _distance = get_hops(source_rse_id=rse3_id, dest_rse_id=rse5_id, include_multihop=True, multihop_rses=all_rses)
+    [hop] = get_hops(source_rse_id=rse3_id, dest_rse_id=rse5_id, include_multihop=True, multihop_rses=all_rses)
     assert hop['source_rse_id'] == rse3_id
     assert hop['dest_rse_id'] == rse5_id
 
     # A link with cost only in one direction will not be used in the opposite direction
     with pytest.raises(NoDistance):
         get_hops(source_rse_id=rse6_id, dest_rse_id=rse5_id, include_multihop=True, multihop_rses=all_rses)
-    [hop1, hop2], _distance = get_hops(source_rse_id=rse4_id, dest_rse_id=rse3_id, include_multihop=True, multihop_rses=all_rses)
+    [hop1, hop2] = get_hops(source_rse_id=rse4_id, dest_rse_id=rse3_id, include_multihop=True, multihop_rses=all_rses)
     assert hop1['source_rse_id'] == rse4_id
     assert hop2['source_rse_id'] == rse5_id
     assert hop2['dest_rse_id'] == rse3_id
 
     # A longer path is preferred over a shorter one with high intermediate cost
-    [hop1, hop2, hop3], _distance = get_hops(source_rse_id=rse3_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
+    [hop1, hop2, hop3] = get_hops(source_rse_id=rse3_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
     assert hop1['source_rse_id'] == rse3_id
     assert hop2['source_rse_id'] == rse4_id
     assert hop3['source_rse_id'] == rse5_id
     assert hop3['dest_rse_id'] == rse6_id
 
     # A link with no cost is ignored. Both for direct connection and multihop paths
-    [hop1, hop2, hop3], _distance = get_hops(source_rse_id=rse2_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
+    [hop1, hop2, hop3] = get_hops(source_rse_id=rse2_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
     assert hop1['source_rse_id'] == rse2_id
     assert hop2['source_rse_id'] == rse4_id
     assert hop3['source_rse_id'] == rse5_id
     assert hop3['dest_rse_id'] == rse6_id
-    [hop1, hop2, hop3, hop4], _distance = get_hops(source_rse_id=rse1_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
+    [hop1, hop2, hop3, hop4] = get_hops(source_rse_id=rse1_id, dest_rse_id=rse6_id, include_multihop=True, multihop_rses=all_rses)
     assert hop1['source_rse_id'] == rse1_id
     assert hop2['source_rse_id'] == rse2_id
     assert hop3['source_rse_id'] == rse4_id


### PR DESCRIPTION
Continue rework of transfers internal code. This PR has multiple functional changes: 

- there is no early binding when iterating over sources. All candidate transfers, including intermediate hops, are generated between possible sources and destination, followed by a merge operation. This should have a higher computational and memory cost: a small dict will be generated in memory for each hop, instead of one dict per transfer request. Also, generating this dict takes cpu time, but we mostly speak about string operations. The positive side is that this change should fix multiple issues with previous code. For example: impossibility to find the best source for multipath transfers; impossibility to correctly chose between mixed disk and tape sources; inconsistent transfer definition generated for intermediate jumps in multipaths; etc

- source and destination generation for multipath transfers now use common code path with singlepath ones. The common code  is capable to handle more cases than needed for multipath transfers. For example: it can correctly handle source and destination schemes which are not used for multipath today. However, it allows to reduce the amount of duplicate code.

- the OIDC support is activated after creating multihop transfers. Meaning it could be activated for each intermediate hop separately.

The PR is split into multiple commits for easier review, but it's probably better to squash them on merge. Some of them cannot be safely reverted individually. 

Resolves #4495