### PR TITLE
Clients: Improve handling of whitespace in bad replica declaration #4544

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -974,13 +974,9 @@ def declare_bad_file_replicas(args):
 
     """
     client = get_client(args)
-    bad_files = []
     if args.inputfile:
         with open(args.inputfile) as infile:
-            for line in infile:
-                bad_file = line.rstrip('\n')
-                if bad_file != '':
-                    bad_files.append(bad_file)
+            bad_files = list(filter(None, [line.strip() for line in infile]))
     else:
         bad_files = args.listbadfiles
 


### PR DESCRIPTION
This started with an observation that trying to declare a list of bad
replicas stored in a file that uses CRLF line terminators did not work.
When reading from a file on Python 2, each line would be terminated with
'\r\n'. Python 3 automatically translates them to '\n' (see universal
newlines).

This patch makes the handling more generic: all whitespace characters
either at the beginning or the end of the line are removed.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
