### PR TITLE
[WIP] Testing: rework test_replicas. #4491

### DIFF
--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -116,7 +116,7 @@ class TemporaryRSEFactory:
         if scheme and protocol_impl:
             rse_core.add_protocol(rse_id=rse_id, parameter={
                 'scheme': scheme,
-                'hostname': 'host%d' % len(self.created_rses),
+                'hostname': '%s.cern.ch' % rse_id,
                 'port': 0,
                 'prefix': '/test/',
                 'impl': protocol_impl,

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -111,23 +111,27 @@ class TemporaryRSEFactory:
     def _make_rse(self, scheme, protocol_impl, add_rse_kwargs):
         rse_name = rse_name_generator()
         rse_id = rse_core.add_rse(rse_name, vo=self.vo, **add_rse_kwargs)
-        rse_core.add_protocol(rse_id=rse_id, parameter={
-            'scheme': scheme,
-            'hostname': 'host%d' % len(self.created_rses),
-            'port': 0,
-            'prefix': '/test',
-            'impl': protocol_impl,
-            'domains': {
-                'wan': {
-                    'read': 1,
-                    'write': 1,
-                    'delete': 1,
-                    'third_party_copy': 1
+        if scheme and protocol_impl:
+            rse_core.add_protocol(rse_id=rse_id, parameter={
+                'scheme': scheme,
+                'hostname': 'host%d' % len(self.created_rses),
+                'port': 0,
+                'prefix': '/test',
+                'impl': protocol_impl,
+                'domains': {
+                    'wan': {
+                        'read': 1,
+                        'write': 1,
+                        'delete': 1,
+                        'third_party_copy': 1
+                    }
                 }
-            }
-        })
+            })
         self.created_rses.append(rse_id)
         return rse_name, rse_id
+
+    def make_rse(self, **kwargs):
+        return self._make_rse(scheme=None, protocol_impl=None, add_rse_kwargs=kwargs)
 
     def make_posix_rse(self, **kwargs):
         return self._make_rse(scheme='file', protocol_impl='rucio.rse.protocols.posix.Default', add_rse_kwargs=kwargs)

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -108,7 +108,7 @@ class TemporaryRSEFactory:
             # So running test in parallel results in some tests failing on foreign key errors.
             rse_core.del_rse(rse_id)
 
-    def _make_rse(self, scheme, protocol_impl, add_rse_kwargs):
+    def _make_rse(self, scheme, protocol_impl, parameters={}, add_rse_kwargs={}):
         rse_name = rse_name_generator()
         rse_id = rse_core.add_rse(rse_name, vo=self.vo, **add_rse_kwargs)
         if scheme and protocol_impl:
@@ -116,7 +116,7 @@ class TemporaryRSEFactory:
                 'scheme': scheme,
                 'hostname': 'host%d' % len(self.created_rses),
                 'port': 0,
-                'prefix': '/test',
+                'prefix': '/test/',
                 'impl': protocol_impl,
                 'domains': {
                     'wan': {
@@ -125,7 +125,8 @@ class TemporaryRSEFactory:
                         'delete': 1,
                         'third_party_copy': 1
                     }
-                }
+                },
+                **parameters
             })
         self.created_rses.append(rse_id)
         return rse_name, rse_id
@@ -141,6 +142,12 @@ class TemporaryRSEFactory:
 
     def make_xroot_rse(self, **kwargs):
         return self._make_rse(scheme='root', protocol_impl='rucio.rse.protocols.xrootd.Default', add_rse_kwargs=kwargs)
+
+    def make_srm_rse(self, **kwargs):
+        parameters = {
+            "extended_attributes": {"web_service_path": "/srm/managerv2?SFN=", "space_token": "RUCIODISK"},
+        }
+        return self._make_rse(scheme='srm', protocol_impl='rucio.rse.protocols.srm.Default', parameters=parameters, add_rse_kwargs=kwargs)
 
 
 class TemporaryFileFactory:

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -80,7 +80,7 @@ class TemporaryRSEFactory:
     @transactional_session
     def __cleanup_locks_and_rules(self, rules_to_remove, session=None):
         for rule_id, in rules_to_remove:
-            rule_core.delete_rule(rule_id, session=session)
+            rule_core.delete_rule(rule_id, session=session, ignore_rule_lock=True)
 
     @transactional_session
     def __cleanup_replicas(self, session=None):
@@ -199,7 +199,7 @@ class TemporaryFileFactory:
                                                                          models.ReplicationRule.name == did['name'])
                                                                     for did in self.created_dids))
         for rule_id, in query:
-            rule_core.delete_rule(rule_id, session=session)
+            rule_core.delete_rule(rule_id, session=session, ignore_rule_lock=True)
 
         # Cleanup Replicas and Parent Datasets
         dids_by_rse = {}

--- a/lib/rucio/tests/test_account.py
+++ b/lib/rucio/tests/test_account.py
@@ -51,6 +51,7 @@ class TestAccountCoreApi(unittest.TestCase):
         else:
             self.vo = {}
 
+    @pytest.mark.noparallel(reason='Acts on all RSEs, so creates deadlocks in tests')
     def test_create_and_check_for_user(self):
         """ ACCOUNT (CORE): Test the creation, query, and deletion of an account """
         usr = account_name_generator()
@@ -60,6 +61,7 @@ class TestAccountCoreApi(unittest.TestCase):
         assert not account_exists(invalid_usr, **self.vo)
         del_account(usr, 'root', **self.vo)
 
+    @pytest.mark.noparallel(reason='Acts on all RSEs, so creates deadlocks in tests')
     def test_update_account(self):
         """ ACCOUNT (CORE): Test changing and quering account parameters """
         usr = account_name_generator()
@@ -95,6 +97,7 @@ class TestAccountCoreApi(unittest.TestCase):
             add_account_attribute(account, key, value)
 
 
+@pytest.mark.noparallel(reason='Acts on all RSEs, so creates deadlocks in tests')
 def test_create_user_success(rest_client, auth_token):
     """ ACCOUNT (REST): send a POST to create a new user """
     acntusr = account_name_generator()
@@ -137,6 +140,7 @@ def test_create_user_not_json_dict(rest_client, auth_token):
     assert loads(response.get_data(as_text=True)) == {"ExceptionMessage": "body must be a json dictionary", "ExceptionClass": "TypeError"}
 
 
+@pytest.mark.noparallel(reason='Acts on all RSEs, so creates deadlocks in tests')
 def test_get_user_success(rest_client, auth_token):
     """ ACCOUNT (REST): send a GET to retrieve the infos of the new user """
     acntusr = account_name_generator()
@@ -156,6 +160,7 @@ def test_get_user_failure(rest_client, auth_token):
     assert reponse.status_code == 404
 
 
+@pytest.mark.noparallel(reason='Acts on all RSEs, so creates deadlocks in tests')
 def test_del_user_success(rest_client, auth_token):
     """ ACCOUNT (REST): send a DELETE to disable the new user """
     acntusr = account_name_generator()
@@ -184,6 +189,7 @@ def test_whoami_account(rest_client, auth_token):
     assert response.status_code == 303
 
 
+@pytest.mark.noparallel(reason='Acts on all RSEs, so creates deadlocks in tests')
 def test_add_attribute(rest_client, auth_token):
     """ ACCOUNT (REST): add/get/delete attribute."""
     acntusr = account_name_generator()
@@ -204,6 +210,7 @@ def test_add_attribute(rest_client, auth_token):
     assert response.status_code == 200
 
 
+@pytest.mark.noparallel(reason='Acts on all RSEs, so creates deadlocks in tests')
 def test_update_account(rest_client, auth_token):
     """ ACCOUNT (REST): send a PUT to update an account."""
     acntusr = account_name_generator()
@@ -222,6 +229,7 @@ def test_update_account(rest_client, auth_token):
     assert body['email'] == 'test'
 
 
+@pytest.mark.noparallel(reason='Acts on all RSEs, so creates deadlocks in tests')
 def test_delete_identity_of_account(vo, rest_client):
     """ ACCOUNT (REST): send a DELETE to remove an identity of an account."""
     account = account_name_generator()
@@ -248,6 +256,7 @@ def test_delete_identity_of_account(vo, rest_client):
     assert response.status_code == 401
 
 
+@pytest.mark.noparallel(reason='Acts on all RSEs, so creates deadlocks in tests')
 def test_add_identity_to_account(rest_client, auth_token):
     """ ACCOUNT (REST): send a POST to add an identity to an account."""
     identity = uuid()
@@ -273,6 +282,7 @@ class TestAccountClient(unittest.TestCase):
     def setUp(self):
         self.client = AccountClient()
 
+    @pytest.mark.noparallel(reason='Acts on all RSEs, so creates deadlocks in tests')
     def test_add_account_success(self):
         """ ACCOUNT (CLIENTS): create a new account and get information about account."""
         account = account_name_generator()
@@ -312,6 +322,7 @@ class TestAccountClient(unittest.TestCase):
         for account in acc_list:
             assert account in svr_list
 
+    @pytest.mark.noparallel(reason='Acts on all RSEs, so creates deadlocks in tests')
     def test_update_account(self):
         """ ACCOUNT (CLIENTS): create a new account and update it."""
         account = account_name_generator()

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -185,6 +185,7 @@ def test_core_update_replicas_paths(rse_factory, mock_scope, root_account):
         assert replica['rses'][rse_id][0] == 'srm://host0/srm/managerv2?SFN=/test/some/other/path'
 
 
+@pytest.mark.noparallel(reason='calls list_bad_replicas() which acts on all bad replicas without any filtering')
 def test_core_add_list_bad_replicas(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): Add bad replicas and list them"""
 
@@ -642,6 +643,7 @@ def test_core_get_RSE_coverage_of_dataset(rse_factory, mock_scope, root_account)
     assert cov[rse3_id] == 500
 
 
+@pytest.mark.noparallel(reason='calls list_bad_replicas() and runs necromancer. Both act on all bad replicas without any filtering')
 def test_client_add_list_bad_replicas(rse_factory, replica_client, did_client):
     """ REPLICA (CLIENT): Add bad replicas"""
     tmp_scope = 'mock'
@@ -745,7 +747,7 @@ def test_client_add_suspicious_replicas(rse_factory, replica_client):
     assert r == {rse2: output}
 
 
-@pytest.mark.noparallel(reason='fails when run in parallel')
+@pytest.mark.noparallel(reason='Lists bad replicas multiple times. If the list changes between calls, test fails.')
 def test_rest_bad_replica_methods_for_ui(rest_client, auth_token):
     __test_rest_bad_replica_methods_for_ui(rest_client, auth_token, list_pfns=False)
     __test_rest_bad_replica_methods_for_ui(rest_client, auth_token, list_pfns=True)
@@ -912,6 +914,8 @@ def test_client_access_denied_on_delete_replicas(rse_factory, mock_scope, replic
         assert len(replicas) == 1
 
 
+@pytest.mark.dirty
+@pytest.mark.noparallel(reason='runs minos, which acts on all bad pfns')
 def test_client_add_temporary_unavailable_pfns(rse_factory, mock_scope, replica_client):
     """ REPLICA (CLIENT): Add temporary unavailable PFNs"""
     rse, rse_id = rse_factory.make_posix_rse()

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -947,19 +947,18 @@ def test_add_replica_scope_not_found(replica_client):
         replica_client.add_replicas(rse='MOCK', files=files)
 
 
-@pytest.mark.dirty
-@pytest.mark.noparallel(reason='uses pre-defined RSE')
-def test_delete_replicas(replica_client):
-    """ REPLICA (CLIENT): Add and delete file replicas """
-    tmp_scope = 'mock'
+def test_access_denied_on_delete_replicas(rse_factory, mock_scope, replica_client):
+    """ REPLICA (CLIENT): Access denied on delete file replicas """
+    rse, _ = rse_factory.make_mock_rse()
     nbfiles = 5
-    files = [{'scope': tmp_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}} for _ in range(nbfiles)]
-    replica_client.add_replicas(rse='MOCK', files=files)
+    files = [{'scope': mock_scope.external, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}} for _ in range(nbfiles)]
+    replica_client.add_replicas(rse=rse, files=files)
     with pytest.raises(AccessDenied):
-        replica_client.delete_replicas(rse='MOCK', files=files)
+        replica_client.delete_replicas(rse=rse, files=files)
 
-    # replicas = [r for r in replica_client.list_replicas(dids=[{'scope': i['scope'], 'name': i['name']} for i in files])]
-    # assert len(replicas) == 0
+    for f in files:
+        replicas = list(replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']}]))
+        assert len(replicas) == 1
 
 
 def test_add_temporary_unavailable_pfns(rse_factory, mock_scope, replica_client):

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -331,27 +331,24 @@ class TestReplicaCore(unittest.TestCase):
 
         assert [f for f in list_files(scope=tmp_scope, name=tmp_dsn2)] == []
 
-    @pytest.mark.dirty
-    @pytest.mark.noparallel(reason='uses pre-defined RSE')
-    def test_update_lock_counter(self):
-        """ RSE (CORE): Test the update of a replica lock counter """
-        rse = 'MOCK'
-        rse_id = get_rse_id(rse=rse, **self.vo)
 
-        tmp_scope = InternalScope('mock', **self.vo)
-        tmp_file = 'file_%s' % generate_uuid()
-        add_replica(rse_id=rse_id, scope=tmp_scope, name=tmp_file, bytes=1, adler32='0cc737eb', account=InternalAccount('jdoe', **self.vo))
+def test_update_lock_counter(vo, rse_factory, mock_scope):
+    """ RSE (CORE): Test the update of a replica lock counter """
+    rse, rse_id = rse_factory.make_mock_rse()
 
-        values = (1, 1, 1, -1, -1, -1, 1, 1, -1)
-        tombstones = (True, True, True, True, True, False, True, True, True)
-        lock_counters = (1, 2, 3, 2, 1, 0, 1, 2, 1)
-        for value, tombstone, lock_counter in zip(values, tombstones, lock_counters):
-            status = update_replica_lock_counter(rse_id=rse_id, scope=tmp_scope, name=tmp_file, value=value)
-            assert status is True
-            replica = get_replica(rse_id=rse_id, scope=tmp_scope, name=tmp_file)
-            value = replica['tombstone'] is None
-            assert value is tombstone
-            assert lock_counter == replica['lock_cnt']
+    tmp_file = 'file_%s' % generate_uuid()
+    add_replica(rse_id=rse_id, scope=mock_scope, name=tmp_file, bytes=1, adler32='0cc737eb', account=InternalAccount('jdoe', vo=vo))
+
+    values = (1, 1, 1, -1, -1, -1, 1, 1, -1)
+    tombstones = (True, True, True, True, True, False, True, True, True)
+    lock_counters = (1, 2, 3, 2, 1, 0, 1, 2, 1)
+    for value, tombstone, lock_counter in zip(values, tombstones, lock_counters):
+        status = update_replica_lock_counter(rse_id=rse_id, scope=mock_scope, name=tmp_file, value=value)
+        assert status is True
+        replica = get_replica(rse_id=rse_id, scope=mock_scope, name=tmp_file)
+        value = replica['tombstone'] is None
+        assert value is tombstone
+        assert lock_counter == replica['lock_cnt']
 
 
 def test_touch_replicas(rse_factory, mock_scope, root_account):

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -631,41 +631,38 @@ class TestReplicaCore(unittest.TestCase):
         with pytest.raises(ReplicaNotFound):
             set_tombstone(rse_id, scope, name)
 
-    @pytest.mark.dirty
-    @pytest.mark.noparallel(reason='uses pre-defined RSE')
-    def test_list_replicas_with_updated_after(self):
-        """ REPLICA (CORE): Add and list file replicas with updated_after filter """
-        scope = InternalScope('mock', **self.vo)
-        root = InternalAccount('root', **self.vo)
-        mock = get_rse_id(rse='MOCK', **self.vo)
-        dsn = 'ds_ua_test_%s' % generate_uuid()
-        add_did(scope=scope, name=dsn, type='DATASET', account=root)
-        #
-        t0 = datetime.utcnow()
-        time.sleep(2)
-        lfn = '%s._%s.data' % (dsn, '0001')
-        add_replica(rse_id=mock, scope=scope, name=lfn, bytes=12345, account=root)
-        attach_dids(scope=scope, name=dsn, dids=[{'scope': scope, 'name': lfn}], account=root)
-        time.sleep(2)
-        t1 = datetime.utcnow()
-        time.sleep(2)
-        lfn = '%s._%s.data' % (dsn, '0002')
-        add_replica(rse_id=mock, scope=scope, name=lfn, bytes=12345, account=root)
-        attach_dids(scope=scope, name=dsn, dids=[{'scope': scope, 'name': lfn}], account=root)
-        time.sleep(2)
-        t2 = datetime.utcnow()
-        time.sleep(2)
-        lfn = '%s._%s.data' % (dsn, '0003')
-        add_replica(rse_id=mock, scope=scope, name=lfn, bytes=12345, account=root)
-        attach_dids(scope=scope, name=dsn, dids=[{'scope': scope, 'name': lfn}], account=root)
-        time.sleep(2)
-        t3 = datetime.utcnow()
-        #
-        assert len(list(list_replicas([{'scope': scope, 'name': dsn}], updated_after=None))) == 3
-        assert len(list(list_replicas([{'scope': scope, 'name': dsn}], updated_after=t0))) == 3
-        assert len(list(list_replicas([{'scope': scope, 'name': dsn}], updated_after=t1))) == 2
-        assert len(list(list_replicas([{'scope': scope, 'name': dsn}], updated_after=t2))) == 1
-        assert len(list(list_replicas([{'scope': scope, 'name': dsn}], updated_after=t3))) == 0
+
+def test_list_replicas_with_updated_after(rse_factory, mock_scope, root_account):
+    """ REPLICA (CORE): Add and list file replicas with updated_after filter """
+    _, rse_id = rse_factory.make_mock_rse()
+    dsn = 'ds_ua_test_%s' % generate_uuid()
+    add_did(scope=mock_scope, name=dsn, type='DATASET', account=root_account)
+    #
+    t0 = datetime.utcnow()
+    time.sleep(2)
+    lfn = '%s._%s.data' % (dsn, '0001')
+    add_replica(rse_id=rse_id, scope=mock_scope, name=lfn, bytes=12345, account=root_account)
+    attach_dids(scope=mock_scope, name=dsn, dids=[{'scope': mock_scope, 'name': lfn}], account=root_account)
+    time.sleep(2)
+    t1 = datetime.utcnow()
+    time.sleep(2)
+    lfn = '%s._%s.data' % (dsn, '0002')
+    add_replica(rse_id=rse_id, scope=mock_scope, name=lfn, bytes=12345, account=root_account)
+    attach_dids(scope=mock_scope, name=dsn, dids=[{'scope': mock_scope, 'name': lfn}], account=root_account)
+    time.sleep(2)
+    t2 = datetime.utcnow()
+    time.sleep(2)
+    lfn = '%s._%s.data' % (dsn, '0003')
+    add_replica(rse_id=rse_id, scope=mock_scope, name=lfn, bytes=12345, account=root_account)
+    attach_dids(scope=mock_scope, name=dsn, dids=[{'scope': mock_scope, 'name': lfn}], account=root_account)
+    time.sleep(2)
+    t3 = datetime.utcnow()
+    #
+    assert len(list(list_replicas([{'scope': mock_scope, 'name': dsn}], updated_after=None))) == 3
+    assert len(list(list_replicas([{'scope': mock_scope, 'name': dsn}], updated_after=t0))) == 3
+    assert len(list(list_replicas([{'scope': mock_scope, 'name': dsn}], updated_after=t1))) == 2
+    assert len(list(list_replicas([{'scope': mock_scope, 'name': dsn}], updated_after=t2))) == 1
+    assert len(list(list_replicas([{'scope': mock_scope, 'name': dsn}], updated_after=t3))) == 0
 
 
 def test_get_RSE_coverage_of_dataset(rse_factory, mock_scope, root_account):

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -865,14 +865,13 @@ def test_bad_replica_methods_for_UI(rest_client, auth_token):
     assert nb_tot_bad_files1 == nb_tot_bad_files2
 
 
-@pytest.mark.dirty
-@pytest.mark.noparallel(reason='uses pre-defined RSE')
-def test_list_replicas_content_type(replica_client, rest_client, auth_token):
+def test_list_replicas_content_type(rse_factory, mock_scope, replica_client, rest_client, auth_token):
     """ REPLICA (REST): send a GET to list replicas with specific ACCEPT header."""
-    scope = 'mock'
+    rse, _ = rse_factory.make_mock_rse()
+    scope = mock_scope.external
     name = 'file_%s' % generate_uuid()
     files1 = [{'scope': scope, 'name': name, 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}}]
-    replica_client.add_replicas(rse='MOCK', files=files1)
+    replica_client.add_replicas(rse=rse, files=files1)
 
     # unsupported requested content type
     response = rest_client.get('/replicas/%s/%s' % (scope, name), headers=headers(auth(auth_token), accept('application/unsupported')))

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -107,71 +107,59 @@ def mocked_VP_requests_get(*args, **kwargs):
     return MockResponse(None, 404)
 
 
-class TestReplicaCore(unittest.TestCase):
+@mock.patch('rucio.core.replica.requests.get', side_effect=mocked_VP_requests_get)
+def test_cache_replicas(mock_get, rse_factory, mock_scope, root_account):
+    """ REPLICA (CORE): Test listing replicas with cached root protocol """
 
-    def setUp(self):
-        if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
-        else:
-            self.vo = {}
+    rse, rse_id = rse_factory.make_rse()
 
-    @mock.patch('rucio.core.replica.requests.get', side_effect=mocked_VP_requests_get)
-    def test_cache_replicas(self, mock_get):
-        """ REPLICA (CORE): Test listing replicas with cached root protocol """
+    add_protocol(rse_id, {'scheme': 'root',
+                          'hostname': 'root.aperture.com',
+                          'port': 1409,
+                          'prefix': '//test/chamber/',
+                          'impl': 'rucio.rse.protocols.xrootd.Default',
+                          'domains': {
+                              'lan': {'read': 1, 'write': 1, 'delete': 1},
+                              'wan': {'read': 1, 'write': 1, 'delete': 1}}})
+    add_protocol(rse_id, {'scheme': 'http',
+                          'hostname': 'root.aperture.com',
+                          'port': 1409,
+                          'prefix': '//test/chamber/',
+                          'impl': 'rucio.rse.protocols.xrootd.Default',
+                          'domains': {
+                              'lan': {'read': 1, 'write': 1, 'delete': 1},
+                              'wan': {'read': 1, 'write': 1, 'delete': 1}}})
 
-        rse = 'APERTURE_%s' % rse_name_generator()
-        rse_id = add_rse(rse, **self.vo)
+    files = []
 
-        add_protocol(rse_id, {'scheme': 'root',
-                              'hostname': 'root.aperture.com',
-                              'port': 1409,
-                              'prefix': '//test/chamber/',
-                              'impl': 'rucio.rse.protocols.xrootd.Default',
-                              'domains': {
-                                  'lan': {'read': 1, 'write': 1, 'delete': 1},
-                                  'wan': {'read': 1, 'write': 1, 'delete': 1}}})
-        add_protocol(rse_id, {'scheme': 'http',
-                              'hostname': 'root.aperture.com',
-                              'port': 1409,
-                              'prefix': '//test/chamber/',
-                              'impl': 'rucio.rse.protocols.xrootd.Default',
-                              'domains': {
-                                  'lan': {'read': 1, 'write': 1, 'delete': 1},
-                                  'wan': {'read': 1, 'write': 1, 'delete': 1}}})
+    name = 'file_%s' % generate_uuid()
+    hstr = hashlib.md5(('%s:%s' % (mock_scope, name)).encode('utf-8')).hexdigest()
+    pfn = 'root://root.aperture.com:1409//test/chamber/mock/%s/%s/%s' % (hstr[0:2], hstr[2:4], name)
+    files.append({'scope': mock_scope, 'name': name, 'bytes': 1234, 'adler32': 'deadbeef', 'pfn': pfn})
 
-        tmp_scope = InternalScope('mock', **self.vo)
-        root = InternalAccount('root', **self.vo)
+    name = 'element_%s' % generate_uuid()
+    hstr = hashlib.md5(('%s:%s' % (mock_scope, name)).encode('utf-8')).hexdigest()
+    pfn = 'http://root.aperture.com:1409//test/chamber/mock/%s/%s/%s' % (hstr[0:2], hstr[2:4], name)
+    files.append({'scope': mock_scope, 'name': name, 'bytes': 1234, 'adler32': 'deadbeef', 'pfn': pfn})
 
-        files = []
+    add_replicas(rse_id=rse_id, files=files, account=root_account)
 
-        name = 'file_%s' % generate_uuid()
-        hstr = hashlib.md5(('%s:%s' % (tmp_scope, name)).encode('utf-8')).hexdigest()
-        pfn = 'root://root.aperture.com:1409//test/chamber/mock/%s/%s/%s' % (hstr[0:2], hstr[2:4], name)
-        files.append({'scope': tmp_scope, 'name': name, 'bytes': 1234, 'adler32': 'deadbeef', 'pfn': pfn})
+    cconfig_set('clientcachemap', 'BLACKMESA', 'AGLT2')
+    cconfig_set('virtual_placement', 'vp_endpoint', 'https://vps-mock.cern.ch')
 
-        name = 'element_%s' % generate_uuid()
-        hstr = hashlib.md5(('%s:%s' % (tmp_scope, name)).encode('utf-8')).hexdigest()
-        pfn = 'http://root.aperture.com:1409//test/chamber/mock/%s/%s/%s' % (hstr[0:2], hstr[2:4], name)
-        files.append({'scope': tmp_scope, 'name': name, 'bytes': 1234, 'adler32': 'deadbeef', 'pfn': pfn})
+    for rep in list_replicas(
+            dids=[{'scope': f['scope'], 'name': f['name'], 'type': DIDType.FILE} for f in files],
+            schemes=['root'],
+            domain='wan',
+            client_location={'site': 'BLACKMESA'}):
+        assert list(rep['pfns'].keys())[0].count('root://') == 2
 
-        add_replicas(rse_id=rse_id, files=files, account=root)
-
-        cconfig_set('clientcachemap', 'BLACKMESA', 'AGLT2')
-        cconfig_set('virtual_placement', 'vp_endpoint', 'https://vps-mock.cern.ch')
-
-        for rep in list_replicas(
-                dids=[{'scope': f['scope'], 'name': f['name'], 'type': DIDType.FILE} for f in files],
-                schemes=['root'],
-                domain='wan',
-                client_location={'site': 'BLACKMESA'}):
-            assert list(rep['pfns'].keys())[0].count('root://') == 2
-
-        for rep in list_replicas(
-                dids=[{'scope': f['scope'], 'name': f['name'], 'type': DIDType.FILE} for f in files],
-                schemes=['root'],
-                domain='wan',
-                client_location={'site': rse}):
-            assert list(rep['pfns'].keys())[0].count('root://') == 1
+    for rep in list_replicas(
+            dids=[{'scope': f['scope'], 'name': f['name'], 'type': DIDType.FILE} for f in files],
+            schemes=['root'],
+            domain='wan',
+            client_location={'site': rse}):
+        assert list(rep['pfns'].keys())[0].count('root://') == 1
 
 
 def test_update_replicas_paths(rse_factory, mock_scope, root_account):

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -563,46 +563,42 @@ class TestReplicaCore(unittest.TestCase):
                                                 client_location={'site': 'SOMEWHERE'})]
         assert 'root://' in list(replicas[0]['pfns'].keys())[0]
 
-    @pytest.mark.dirty
-    def test_replica_mixed_protocols(self):
-        """ REPLICA (CORE): Test adding replicas with mixed protocol """
 
-        rse = 'APERTURE_%s' % rse_name_generator()
-        rse_id = add_rse(rse, **self.vo)
+def test_replica_mixed_protocols(rse_factory, mock_scope, root_account):
+    """ REPLICA (CORE): Test adding replicas with mixed protocol """
 
-        add_protocol(rse_id, {'scheme': 'root',
-                              'hostname': 'root.aperture.com',
-                              'port': 1409,
-                              'prefix': '//test/chamber/',
-                              'impl': 'rucio.rse.protocols.xrootd.Default',
-                              'domains': {
-                                  'lan': {'read': 1, 'write': 1, 'delete': 1},
-                                  'wan': {'read': 1, 'write': 1, 'delete': 1}}})
-        add_protocol(rse_id, {'scheme': 'http',
-                              'hostname': 'root.aperture.com',
-                              'port': 1409,
-                              'prefix': '//test/chamber/',
-                              'impl': 'rucio.rse.protocols.xrootd.Default',
-                              'domains': {
-                                  'lan': {'read': 1, 'write': 1, 'delete': 1},
-                                  'wan': {'read': 1, 'write': 1, 'delete': 1}}})
+    rse, rse_id = rse_factory.make_rse()
 
-        tmp_scope = InternalScope('mock', **self.vo)
-        root = InternalAccount('root', **self.vo)
+    add_protocol(rse_id, {'scheme': 'root',
+                          'hostname': 'root.aperture.com',
+                          'port': 1409,
+                          'prefix': '//test/chamber/',
+                          'impl': 'rucio.rse.protocols.xrootd.Default',
+                          'domains': {
+                              'lan': {'read': 1, 'write': 1, 'delete': 1},
+                              'wan': {'read': 1, 'write': 1, 'delete': 1}}})
+    add_protocol(rse_id, {'scheme': 'http',
+                          'hostname': 'root.aperture.com',
+                          'port': 1409,
+                          'prefix': '//test/chamber/',
+                          'impl': 'rucio.rse.protocols.xrootd.Default',
+                          'domains': {
+                              'lan': {'read': 1, 'write': 1, 'delete': 1},
+                              'wan': {'read': 1, 'write': 1, 'delete': 1}}})
 
-        files = []
+    files = []
 
-        name = 'element_%s' % generate_uuid()
-        hstr = hashlib.md5(('%s:%s' % (tmp_scope, name)).encode('utf-8')).hexdigest()
-        pfn = 'root://root.aperture.com:1409//test/chamber/mock/%s/%s/%s' % (hstr[0:2], hstr[2:4], name)
-        files.append({'scope': tmp_scope, 'name': name, 'bytes': 1234, 'adler32': 'deadbeef', 'pfn': pfn})
+    name = 'element_%s' % generate_uuid()
+    hstr = hashlib.md5(('%s:%s' % (mock_scope, name)).encode('utf-8')).hexdigest()
+    pfn = 'root://root.aperture.com:1409//test/chamber/mock/%s/%s/%s' % (hstr[0:2], hstr[2:4], name)
+    files.append({'scope': mock_scope, 'name': name, 'bytes': 1234, 'adler32': 'deadbeef', 'pfn': pfn})
 
-        name = 'element_%s' % generate_uuid()
-        hstr = hashlib.md5(('%s:%s' % (tmp_scope, name)).encode('utf-8')).hexdigest()
-        pfn = 'http://root.aperture.com:1409//test/chamber/mock/%s/%s/%s' % (hstr[0:2], hstr[2:4], name)
-        files.append({'scope': tmp_scope, 'name': name, 'bytes': 1234, 'adler32': 'deadbeef', 'pfn': pfn})
+    name = 'element_%s' % generate_uuid()
+    hstr = hashlib.md5(('%s:%s' % (mock_scope, name)).encode('utf-8')).hexdigest()
+    pfn = 'http://root.aperture.com:1409//test/chamber/mock/%s/%s/%s' % (hstr[0:2], hstr[2:4], name)
+    files.append({'scope': mock_scope, 'name': name, 'bytes': 1234, 'adler32': 'deadbeef', 'pfn': pfn})
 
-        add_replicas(rse_id=rse_id, files=files, account=root)
+    add_replicas(rse_id=rse_id, files=files, account=root_account)
 
 
 def test_set_tombstone_via_core(rse_factory, mock_scope, root_account):

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -353,39 +353,38 @@ class TestReplicaCore(unittest.TestCase):
             assert value is tombstone
             assert lock_counter == replica['lock_cnt']
 
-    @pytest.mark.dirty
-    @pytest.mark.noparallel(reason='uses pre-defined RSE')
-    def test_touch_replicas(self):
-        """ REPLICA (CORE): Touch replicas accessed_at timestamp"""
-        tmp_scope = InternalScope('mock', **self.vo)
-        root = InternalAccount('root', **self.vo)
-        nbfiles = 5
-        files1 = [{'scope': tmp_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}} for _ in range(nbfiles)]
-        files2 = [{'scope': tmp_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}} for _ in range(nbfiles)]
-        files2.append(files1[0])
-        rse_id = get_rse_id(rse='MOCK', **self.vo)
 
-        add_replicas(rse_id=rse_id, files=files1, account=root, ignore_availability=True)
-        add_replicas(rse_id=rse_id, files=files2, account=root, ignore_availability=True)
+def test_touch_replicas(rse_factory, mock_scope, root_account):
+    """ REPLICA (CORE): Touch replicas accessed_at timestamp"""
 
-        now = datetime.utcnow()
+    _, rse_id = rse_factory.make_mock_rse()
 
-        now -= timedelta(microseconds=now.microsecond)
+    nbfiles = 5
+    files1 = [{'scope': mock_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}} for _ in range(nbfiles)]
+    files2 = [{'scope': mock_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}} for _ in range(nbfiles)]
+    files2.append(files1[0])
 
-        assert get_replica_atime({'scope': files1[0]['scope'], 'name': files1[0]['name'], 'rse_id': rse_id}) is None
-        assert get_did_atime(scope=tmp_scope, name=files1[0]['name']) is None
+    add_replicas(rse_id=rse_id, files=files1, account=root_account, ignore_availability=True)
+    add_replicas(rse_id=rse_id, files=files2, account=root_account, ignore_availability=True)
 
-        for r in [{'scope': files1[0]['scope'], 'name': files1[0]['name'], 'rse_id': rse_id, 'accessed_at': now}]:
-            touch_replica(r)
+    now = datetime.utcnow()
 
-        assert now == get_replica_atime({'scope': files1[0]['scope'], 'name': files1[0]['name'], 'rse_id': rse_id})
-        assert now == get_did_atime(scope=tmp_scope, name=files1[0]['name'])
+    now -= timedelta(microseconds=now.microsecond)
 
-        for i in range(1, nbfiles):
-            assert get_replica_atime({'scope': files1[i]['scope'], 'name': files1[i]['name'], 'rse_id': rse_id}) is None
+    assert get_replica_atime({'scope': files1[0]['scope'], 'name': files1[0]['name'], 'rse_id': rse_id}) is None
+    assert get_did_atime(scope=mock_scope, name=files1[0]['name']) is None
 
-        for i in range(0, nbfiles - 1):
-            assert get_replica_atime({'scope': files2[i]['scope'], 'name': files2[i]['name'], 'rse_id': rse_id}) is None
+    for r in [{'scope': files1[0]['scope'], 'name': files1[0]['name'], 'rse_id': rse_id, 'accessed_at': now}]:
+        touch_replica(r)
+
+    assert now == get_replica_atime({'scope': files1[0]['scope'], 'name': files1[0]['name'], 'rse_id': rse_id})
+    assert now == get_did_atime(scope=mock_scope, name=files1[0]['name'])
+
+    for i in range(1, nbfiles):
+        assert get_replica_atime({'scope': files1[i]['scope'], 'name': files1[i]['name'], 'rse_id': rse_id}) is None
+
+    for i in range(0, nbfiles - 1):
+        assert get_replica_atime({'scope': files2[i]['scope'], 'name': files2[i]['name'], 'rse_id': rse_id}) is None
 
 
 def test_list_replicas_all_states(rse_factory, mock_scope, root_account):

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -36,23 +36,18 @@ import hashlib
 import os
 import sys
 import time
-import unittest
 from datetime import datetime, timedelta
 from json import dumps, loads
 from xml.etree import ElementTree
 import pytest
 import xmltodict
 from werkzeug.datastructures import MultiDict
-from rucio.client.baseclient import BaseClient
-from rucio.client.didclient import DIDClient
-from rucio.client.replicaclient import ReplicaClient
 from rucio.client.ruleclient import RuleClient
 from rucio.core.config import set as cconfig_set
-from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import (DataIdentifierNotFound, AccessDenied, UnsupportedOperation,
                                     RucioException, ReplicaIsLocked, ReplicaNotFound, ScopeNotFound,
                                     DatabaseException)
-from rucio.common.types import InternalAccount, InternalScope
+from rucio.common.types import InternalAccount
 from rucio.common.utils import generate_uuid, clean_surls, parse_response
 from rucio.core.did import add_did, attach_dids, get_did, set_status, list_files, get_did_atime
 from rucio.core.replica import (add_replica, add_replicas, delete_replicas, get_replicas_state,
@@ -60,13 +55,13 @@ from rucio.core.replica import (add_replica, add_replicas, delete_replicas, get_
                                 declare_bad_file_replicas, list_bad_replicas,
                                 update_replicas_paths, update_replica_state, get_RSEcoverage_of_dataset,
                                 get_replica_atime, touch_replica, get_bad_pfns, set_tombstone)
-from rucio.core.rse import add_rse, add_protocol, add_rse_attribute, del_rse_attribute, get_rse_id
+from rucio.core.rse import add_protocol, add_rse_attribute, del_rse_attribute
 from rucio.daemons.badreplicas.minos import run as minos_run
 from rucio.daemons.badreplicas.minos_temporary_expiration import run as minos_temp_run
 from rucio.daemons.badreplicas.necromancer import run as necromancer_run
 from rucio.db.sqla.constants import DIDType, ReplicaState, BadPFNStatus, OBSOLETE
 from rucio.rse import rsemanager as rsemgr
-from rucio.tests.common import execute, rse_name_generator, headers, auth, Mime, accept
+from rucio.tests.common import execute, headers, auth, Mime, accept
 
 
 if sys.version_info >= (3, 3):

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -257,24 +257,22 @@ class TestReplicaCore(unittest.TestCase):
         output = ['%s Unknown replica' % rep for rep in files]
         assert r == {rse_id2: output}
 
-    @pytest.mark.dirty
-    @pytest.mark.noparallel(reason='uses pre-defined RSE')
-    def test_add_list_replicas(self):
-        """ REPLICA (CORE): Add and list file replicas """
-        tmp_scope = InternalScope('mock', **self.vo)
-        root = InternalAccount('root', **self.vo)
-        nbfiles = 13
-        files = [{'scope': tmp_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}} for _ in range(nbfiles)]
-        rses = ['MOCK', 'MOCK3']
-        for rse in rses:
-            rse_id = get_rse_id(rse=rse, **self.vo)
-            add_replicas(rse_id=rse_id, files=files, account=root, ignore_availability=True)
 
-        replica_cpt = 0
-        for _ in list_replicas(dids=[{'scope': f['scope'], 'name': f['name'], 'type': DIDType.FILE} for f in files], schemes=['srm']):
-            replica_cpt += 1
+def test_add_list_replicas_via_core(rse_factory, mock_scope, root_account):
+    """ REPLICA (CORE): Add and list file replicas """
+    _, rse1_id = rse_factory.make_mock_rse()
+    _, rse2_id = rse_factory.make_mock_rse()
 
-        assert nbfiles == replica_cpt
+    nbfiles = 13
+    files = [{'scope': mock_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}} for _ in range(nbfiles)]
+    for rse_id in [rse1_id, rse2_id]:
+        add_replicas(rse_id=rse_id, files=files, account=root_account, ignore_availability=True)
+
+    replica_cpt = 0
+    for _ in list_replicas(dids=[{'scope': f['scope'], 'name': f['name'], 'type': DIDType.FILE} for f in files], schemes=['srm']):
+        replica_cpt += 1
+
+    assert nbfiles == replica_cpt
 
 
 def test_delete_replicas(rse_factory, mock_scope, root_account):

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -1051,27 +1051,25 @@ class TestReplicaMetalink(unittest.TestCase):
             pfn = list(result.keys())[0]
             assert input[pfn] == list(result.values())[0]
 
-    def test_get_did_from_pfns_deterministic(self):
-        """ REPLICA (CLIENT): Get list of DIDs associated to PFNs for deterministic sites"""
-        tmp_scope = InternalScope('mock', **self.vo)
-        root = InternalAccount('root', **self.vo)
-        rse = 'MOCK3'
-        rse_id = get_rse_id(rse=rse, **self.vo)
-        nbfiles = 3
-        pfns = []
-        input = {}
-        rse_info = rsemgr.get_rse_info(rse=rse, **self.vo)
-        assert rse_info['deterministic'] is True
-        files = [{'scope': tmp_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}} for _ in range(nbfiles)]
-        p = rsemgr.create_protocol(rse_info, 'read', scheme='srm')
-        for f in files:
-            pfn = list(p.lfns2pfns(lfns={'scope': f['scope'].external, 'name': f['name']}).values())[0]
-            pfns.append(pfn)
-            input[pfn] = {'scope': f['scope'].external, 'name': f['name']}
-        add_replicas(rse_id=rse_id, files=files, account=root, ignore_availability=True)
-        for result in self.replica_client.get_did_from_pfns(pfns, rse):
-            pfn = list(result.keys())[0]
-            assert input[pfn] == list(result.values())[0]
+
+def test_get_did_from_pfns_deterministic(vo, rse_factory, mock_scope, root_account, replica_client):
+    """ REPLICA (CLIENT): Get list of DIDs associated to PFNs for deterministic sites"""
+    rse, rse_id = rse_factory.make_srm_rse()
+    nbfiles = 3
+    pfns = []
+    input = {}
+    rse_info = rsemgr.get_rse_info(rse=rse, vo=vo)
+    assert rse_info['deterministic'] is True
+    files = [{'scope': mock_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}} for _ in range(nbfiles)]
+    p = rsemgr.create_protocol(rse_info, 'read', scheme='srm')
+    for f in files:
+        pfn = list(p.lfns2pfns(lfns={'scope': f['scope'].external, 'name': f['name']}).values())[0]
+        pfns.append(pfn)
+        input[pfn] = {'scope': f['scope'].external, 'name': f['name']}
+    add_replicas(rse_id=rse_id, files=files, account=root_account, ignore_availability=True)
+    for result in replica_client.get_did_from_pfns(pfns, rse):
+        pfn = list(result.keys())[0]
+        assert input[pfn] == list(result.values())[0]
 
 
 @pytest.mark.parametrize("content_type", [Mime.METALINK, Mime.JSON_STREAM])

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -667,36 +667,34 @@ class TestReplicaCore(unittest.TestCase):
         assert len(list(list_replicas([{'scope': scope, 'name': dsn}], updated_after=t2))) == 1
         assert len(list(list_replicas([{'scope': scope, 'name': dsn}], updated_after=t3))) == 0
 
-    @pytest.mark.dirty
-    @pytest.mark.noparallel(reason='uses pre-defined RSE')
-    def test_get_RSE_coverage_of_dataset(self):
-        """ REPLICA (CORE): test RSE coverage retrieval """
-        scope = InternalScope('mock', **self.vo)
-        root = InternalAccount('root', **self.vo)
-        mock1 = get_rse_id(rse='MOCK', **self.vo)
-        mock3 = get_rse_id(rse='MOCK3', **self.vo)
-        mock4 = get_rse_id(rse='MOCK4', **self.vo)
-        dsn = 'ds_cov_test_%s' % generate_uuid()
-        add_did(scope=scope, name=dsn, type='DATASET', account=root)
 
-        # test empty dataset
-        cov = get_RSEcoverage_of_dataset(scope=scope, name=dsn)
-        print(cov)
-        assert cov == {}
-        # add files/replicas
-        for i in range(1, 8):
-            add_replica(rse_id=mock1, scope=scope, name=dsn + '_%06d.data' % i, bytes=100, account=root)
-        for i in range(8, 11):
-            add_replica(rse_id=mock3, scope=scope, name=dsn + '_%06d.data' % i, bytes=100, account=root)
-        for i in range(11, 16):
-            add_replica(rse_id=mock4, scope=scope, name=dsn + '_%06d.data' % i, bytes=100, account=root)
+def test_get_RSE_coverage_of_dataset(rse_factory, mock_scope, root_account):
+    """ REPLICA (CORE): test RSE coverage retrieval """
+    _, rse1_id = rse_factory.make_mock_rse()
+    _, rse2_id = rse_factory.make_mock_rse()
+    _, rse3_id = rse_factory.make_mock_rse()
 
-        attach_dids(scope=scope, name=dsn, dids=[{'scope': scope, 'name': dsn + '_%06d.data' % i} for i in range(1, 16)], account=root)
-        cov = get_RSEcoverage_of_dataset(scope=scope, name=dsn)
-        print(cov)
-        assert cov[mock1] == 700
-        assert cov[mock3] == 300
-        assert cov[mock4] == 500
+    dsn = 'ds_cov_test_%s' % generate_uuid()
+    add_did(scope=mock_scope, name=dsn, type='DATASET', account=root_account)
+
+    # test empty dataset
+    cov = get_RSEcoverage_of_dataset(scope=mock_scope, name=dsn)
+    print(cov)
+    assert cov == {}
+    # add files/replicas
+    for i in range(1, 8):
+        add_replica(rse_id=rse1_id, scope=mock_scope, name=dsn + '_%06d.data' % i, bytes=100, account=root_account)
+    for i in range(8, 11):
+        add_replica(rse_id=rse2_id, scope=mock_scope, name=dsn + '_%06d.data' % i, bytes=100, account=root_account)
+    for i in range(11, 16):
+        add_replica(rse_id=rse3_id, scope=mock_scope, name=dsn + '_%06d.data' % i, bytes=100, account=root_account)
+
+    attach_dids(scope=mock_scope, name=dsn, dids=[{'scope': mock_scope, 'name': dsn + '_%06d.data' % i} for i in range(1, 16)], account=root_account)
+    cov = get_RSEcoverage_of_dataset(scope=mock_scope, name=dsn)
+    print(cov)
+    assert cov[rse1_id] == 700
+    assert cov[rse2_id] == 300
+    assert cov[rse3_id] == 500
 
 
 @pytest.mark.dirty

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -108,7 +108,7 @@ def mocked_VP_requests_get(*args, **kwargs):
 
 
 @mock.patch('rucio.core.replica.requests.get', side_effect=mocked_VP_requests_get)
-def test_cache_replicas(mock_get, rse_factory, mock_scope, root_account):
+def test_core_cache_replicas(mock_get, rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): Test listing replicas with cached root protocol """
 
     rse, rse_id = rse_factory.make_rse()
@@ -162,7 +162,7 @@ def test_cache_replicas(mock_get, rse_factory, mock_scope, root_account):
         assert list(rep['pfns'].keys())[0].count('root://') == 1
 
 
-def test_update_replicas_paths(rse_factory, mock_scope, root_account):
+def test_core_update_replicas_paths(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): Force update the replica path """
     _, rse_id = rse_factory.make_srm_rse(deterministic=False)
 
@@ -246,7 +246,7 @@ def test_core_add_list_bad_replicas(rse_factory, mock_scope, root_account):
     assert r == {rse2_id: output}
 
 
-def test_add_list_replicas_via_core(rse_factory, mock_scope, root_account):
+def test_core_add_list_replicas(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): Add and list file replicas """
     _, rse1_id = rse_factory.make_mock_rse()
     _, rse2_id = rse_factory.make_mock_rse()
@@ -263,7 +263,7 @@ def test_add_list_replicas_via_core(rse_factory, mock_scope, root_account):
     assert nbfiles == replica_cpt
 
 
-def test_delete_replicas(rse_factory, mock_scope, root_account):
+def test_core_delete_replicas(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): Delete replicas """
     _, rse1_id = rse_factory.make_mock_rse()
     _, rse2_id = rse_factory.make_mock_rse()
@@ -287,7 +287,7 @@ def test_delete_replicas(rse_factory, mock_scope, root_account):
         get_did(scope=file['scope'], name=file['name'])
 
 
-def test_delete_replicas_from_datasets(rse_factory, mock_scope, root_account):
+def test_core_delete_replicas_from_datasets(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): Delete replicas from dataset """
     _, rse_id = rse_factory.make_mock_rse()
 
@@ -314,7 +314,7 @@ def test_delete_replicas_from_datasets(rse_factory, mock_scope, root_account):
     assert [f for f in list_files(scope=mock_scope, name=tmp_dsn2)] == []
 
 
-def test_update_lock_counter(vo, rse_factory, mock_scope):
+def test_core_update_lock_counter(vo, rse_factory, mock_scope):
     """ RSE (CORE): Test the update of a replica lock counter """
     rse, rse_id = rse_factory.make_mock_rse()
 
@@ -333,7 +333,7 @@ def test_update_lock_counter(vo, rse_factory, mock_scope):
         assert lock_counter == replica['lock_cnt']
 
 
-def test_touch_replicas(rse_factory, mock_scope, root_account):
+def test_core_touch_replicas(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): Touch replicas accessed_at timestamp"""
 
     _, rse_id = rse_factory.make_mock_rse()
@@ -366,7 +366,7 @@ def test_touch_replicas(rse_factory, mock_scope, root_account):
         assert get_replica_atime({'scope': files2[i]['scope'], 'name': files2[i]['name'], 'rse_id': rse_id}) is None
 
 
-def test_list_replicas_all_states(rse_factory, mock_scope, root_account):
+def test_core_list_replicas_all_states(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): list file replicas with all_states"""
     _, rse1_id = rse_factory.make_mock_rse()
     _, rse2_id = rse_factory.make_mock_rse()
@@ -389,7 +389,7 @@ def test_list_replicas_all_states(rse_factory, mock_scope, root_account):
     assert nbfiles == replica_cpt
 
 
-def test_list_replica_with_domain(rse_factory, mock_scope, root_account):
+def test_core_list_replica_with_domain(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): Add and list file replicas forcing domain"""
 
     rse, rse_id = rse_factory.make_rse()
@@ -468,7 +468,7 @@ def test_list_replica_with_domain(rse_factory, mock_scope, root_account):
         assert '/i/prefer/the/lan' in stdout
 
 
-def test_list_replica_with_schemes(rse_factory, mock_scope, root_account, replica_client):
+def test_core_list_replica_with_schemes(rse_factory, mock_scope, root_account, replica_client):
     """ REPLICA (CORE): Add and list file replicas forcing schemes"""
 
     rse, rse_id = rse_factory.make_rse()
@@ -491,7 +491,7 @@ def test_list_replica_with_schemes(rse_factory, mock_scope, root_account, replic
     assert 'http://' in list(replicas[0]['pfns'].keys())[0]
 
 
-def test_replica_no_site(rse_factory, mock_scope, root_account, replica_client):
+def test_client_replica_no_site(rse_factory, mock_scope, root_account, replica_client):
     """ REPLICA (CORE): Test listing replicas without site attribute """
 
     rse, rse_id = rse_factory.make_rse()
@@ -525,7 +525,7 @@ def test_replica_no_site(rse_factory, mock_scope, root_account, replica_client):
     assert 'root://' in list(replicas[0]['pfns'].keys())[0]
 
 
-def test_replica_mixed_protocols(rse_factory, mock_scope, root_account):
+def test_core_replica_mixed_protocols(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): Test adding replicas with mixed protocol """
 
     rse, rse_id = rse_factory.make_rse()
@@ -562,7 +562,7 @@ def test_replica_mixed_protocols(rse_factory, mock_scope, root_account):
     add_replicas(rse_id=rse_id, files=files, account=root_account)
 
 
-def test_set_tombstone_via_core(rse_factory, mock_scope, root_account):
+def test_core_set_tombstone(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): set tombstone on replica """
     # Set tombstone on one replica
     rse, rse_id = rse_factory.make_mock_rse()
@@ -585,7 +585,7 @@ def test_set_tombstone_via_core(rse_factory, mock_scope, root_account):
         set_tombstone(rse_id, mock_scope, name)
 
 
-def test_list_replicas_with_updated_after(rse_factory, mock_scope, root_account):
+def test_core_list_replicas_with_updated_after(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): Add and list file replicas with updated_after filter """
     _, rse_id = rse_factory.make_mock_rse()
     dsn = 'ds_ua_test_%s' % generate_uuid()
@@ -618,7 +618,7 @@ def test_list_replicas_with_updated_after(rse_factory, mock_scope, root_account)
     assert len(list(list_replicas([{'scope': mock_scope, 'name': dsn}], updated_after=t3))) == 0
 
 
-def test_get_RSE_coverage_of_dataset(rse_factory, mock_scope, root_account):
+def test_core_get_RSE_coverage_of_dataset(rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): test RSE coverage retrieval """
     _, rse1_id = rse_factory.make_mock_rse()
     _, rse2_id = rse_factory.make_mock_rse()
@@ -751,7 +751,7 @@ def test_client_add_suspicious_replicas(rse_factory, replica_client):
 
 
 @pytest.mark.noparallel(reason='fails when run in parallel')
-def test_bad_replica_methods_for_UI(rest_client, auth_token):
+def test_rest_bad_replica_methods_for_UI(rest_client, auth_token):
     """ REPLICA (REST): Test the listing of bad and suspicious replicas """
     response = rest_client.get('/replicas/bad/states', headers=headers(auth(auth_token)))
     assert response.status_code == 200
@@ -811,7 +811,7 @@ def test_bad_replica_methods_for_UI(rest_client, auth_token):
     assert nb_tot_bad_files1 == nb_tot_bad_files2
 
 
-def test_list_replicas_content_type(rse_factory, mock_scope, replica_client, rest_client, auth_token):
+def test_rest_list_replicas_content_type(rse_factory, mock_scope, replica_client, rest_client, auth_token):
     """ REPLICA (REST): send a GET to list replicas with specific ACCEPT header."""
     rse, _ = rse_factory.make_mock_rse()
     scope = mock_scope.external
@@ -847,7 +847,7 @@ def test_list_replicas_content_type(rse_factory, mock_scope, replica_client, res
     assert [header[1] for header in response.headers if header[0] == 'Content-Type'][0] == Mime.JSON_STREAM
 
 
-def test_add_list_replicas_via_client(rse_factory, replica_client, mock_scope):
+def test_client_add_list_replicas(rse_factory, replica_client, mock_scope):
     """ REPLICA (CLIENT): Add, change state and list file replicas """
     rse1, _ = rse_factory.make_posix_rse()
     rse2, _ = rse_factory.make_posix_rse()
@@ -884,14 +884,14 @@ def test_add_list_replicas_via_client(rse_factory, replica_client, mock_scope):
         assert rse2 in replicas[i]['rses']
 
 
-def test_add_replica_scope_not_found(replica_client):
+def test_client_add_replica_scope_not_found(replica_client):
     """ REPLICA (CLIENT): Add replica with missing scope """
     files = [{'scope': 'nonexistingscope', 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb'}]
     with pytest.raises(ScopeNotFound):
         replica_client.add_replicas(rse='MOCK', files=files)
 
 
-def test_access_denied_on_delete_replicas(rse_factory, mock_scope, replica_client):
+def test_client_access_denied_on_delete_replicas(rse_factory, mock_scope, replica_client):
     """ REPLICA (CLIENT): Access denied on delete file replicas """
     rse, _ = rse_factory.make_mock_rse()
     nbfiles = 5
@@ -905,7 +905,7 @@ def test_access_denied_on_delete_replicas(rse_factory, mock_scope, replica_clien
         assert len(replicas) == 1
 
 
-def test_add_temporary_unavailable_pfns(rse_factory, mock_scope, replica_client):
+def test_client_add_temporary_unavailable_pfns(rse_factory, mock_scope, replica_client):
     """ REPLICA (CLIENT): Add temporary unavailable PFNs"""
     rse, rse_id = rse_factory.make_posix_rse()
     nbfiles = 5
@@ -966,7 +966,7 @@ def test_add_temporary_unavailable_pfns(rse_factory, mock_scope, replica_client)
         assert list(rep.keys())[0] == ReplicaState.AVAILABLE
 
 
-def test_set_tombstone_via_client(rse_factory, mock_scope, root_account, replica_client):
+def test_client_set_tombstone(rse_factory, mock_scope, root_account, replica_client):
     """ REPLICA (CLIENT): set tombstone on replica """
     # Set tombstone on one replica
     rse, rse_id = rse_factory.make_mock_rse()
@@ -991,7 +991,7 @@ def test_set_tombstone_via_client(rse_factory, mock_scope, root_account, replica
 
 @pytest.mark.dirty
 @pytest.mark.noparallel(reason='uses pre-defined RSE')
-def test_list_replicas_metalink_4(did_client, replica_client):
+def test_client_list_replicas_metalink_4(did_client, replica_client):
     """ REPLICA (METALINK): List replicas as metalink version 4 """
     fname = generate_uuid()
 
@@ -1012,7 +1012,7 @@ def test_list_replicas_metalink_4(did_client, replica_client):
     assert 3 == len(ml['metalink']['file']['url'])
 
 
-def test_get_did_from_pfns_nondeterministic(vo, rse_factory, mock_scope, root_account, replica_client):
+def test_client_get_did_from_pfns_nondeterministic(vo, rse_factory, mock_scope, root_account, replica_client):
     """ REPLICA (CLIENT): Get list of DIDs associated to PFNs for non-deterministic sites"""
     rse, rse_id = rse_factory.make_srm_rse(deterministic=False)
     nbfiles = 3
@@ -1033,7 +1033,7 @@ def test_get_did_from_pfns_nondeterministic(vo, rse_factory, mock_scope, root_ac
         assert input[pfn] == list(result.values())[0]
 
 
-def test_get_did_from_pfns_deterministic(vo, rse_factory, mock_scope, root_account, replica_client):
+def test_client_get_did_from_pfns_deterministic(vo, rse_factory, mock_scope, root_account, replica_client):
     """ REPLICA (CLIENT): Get list of DIDs associated to PFNs for deterministic sites"""
     rse, rse_id = rse_factory.make_srm_rse()
     nbfiles = 3
@@ -1054,7 +1054,7 @@ def test_get_did_from_pfns_deterministic(vo, rse_factory, mock_scope, root_accou
 
 
 @pytest.mark.parametrize("content_type", [Mime.METALINK, Mime.JSON_STREAM])
-def test_list_replicas_streaming_error(content_type, vo, did_client, replica_client):
+def test_client_list_replicas_streaming_error(content_type, vo, did_client, replica_client):
     """
     REPLICA (CLIENT): List replicas and test for behavior when an error occurs while streaming.
     Complicated test ahead! Mocking the wsgi frameworks, because the

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -1025,32 +1025,27 @@ def test_add_temporary_unavailable_pfns(vo, replica_client):
         assert list(rep.keys())[0] == ReplicaState.AVAILABLE
 
 
-@pytest.mark.dirty
-@pytest.mark.noparallel(reason='uses pre-defined RSE')
-def test_set_tombstone2(vo, replica_client):
+def test_set_tombstone_via_client(rse_factory, mock_scope, root_account, replica_client):
     """ REPLICA (CLIENT): set tombstone on replica """
     # Set tombstone on one replica
-    rse = 'MOCK4'
-    rse_id = get_rse_id(rse=rse, vo=vo)
-    scope = InternalScope('mock', vo=vo)
-    user = InternalAccount('root', vo=vo)
+    rse, rse_id = rse_factory.make_mock_rse()
     name = generate_uuid()
-    add_replica(rse_id, scope, name, 4, user)
-    assert get_replica(rse_id, scope, name)['tombstone'] is None
-    replica_client.set_tombstone([{'rse': rse, 'scope': scope.external, 'name': name}])
-    assert get_replica(rse_id, scope, name)['tombstone'] == OBSOLETE
+    add_replica(rse_id, mock_scope, name, 4, root_account)
+    assert get_replica(rse_id, mock_scope, name)['tombstone'] is None
+    replica_client.set_tombstone([{'rse': rse, 'scope': mock_scope.external, 'name': name}])
+    assert get_replica(rse_id, mock_scope, name)['tombstone'] == OBSOLETE
 
     # Set tombstone on locked replica
     name = generate_uuid()
-    add_replica(rse_id, scope, name, 4, user)
-    RuleClient().add_replication_rule([{'name': name, 'scope': scope.external}], 1, rse, locked=True)
+    add_replica(rse_id, mock_scope, name, 4, root_account)
+    RuleClient().add_replication_rule([{'name': name, 'scope': mock_scope.external}], 1, rse, locked=True)
     with pytest.raises(ReplicaIsLocked):
-        replica_client.set_tombstone([{'rse': rse, 'scope': scope.external, 'name': name}])
+        replica_client.set_tombstone([{'rse': rse, 'scope': mock_scope.external, 'name': name}])
 
     # Set tombstone on not found replica
     name = generate_uuid()
     with pytest.raises(ReplicaNotFound):
-        replica_client.set_tombstone([{'rse': rse, 'scope': scope.external, 'name': name}])
+        replica_client.set_tombstone([{'rse': rse, 'scope': mock_scope.external, 'name': name}])
 
 
 @pytest.mark.dirty


### PR DESCRIPTION
Until now, almost entire test_replicas was marked noparallel, which is unfortunate, because it contains 30 different tests; many not very fast. Rework the entire file and remove the noparallel mark when possible. 

Add minor changes to temp factories to cleanup bad replicas and allow to easily create 'srm' rses which are used all-over this test. 
The usage of rse_factory also allows to remove the dirty flag from most tests, because it takes care of cleanup after the test ends.

The patch is split into multiple commits for easier review. Otherwise github just shows that "everything" changed in test_replicas.py, 
but a squash is definitely needed when merging. 