### PR TITLE
Testing: TPC + UploadClient

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -95,7 +95,7 @@ jobs:
         shell: bash
         run: |
           FTS_LOG_FILE=${{ steps.tpc.outputs.fts3log }}
-          if grep -Fq "3rd pull" $FTS_LOG_FILE
+          if docker exec -t dev_fts_1 grep -Fq "3rd pull" $FTS_LOG_FILE
           then
             echo "TPC verified"
           else

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -77,8 +77,8 @@ jobs:
           docker exec -t dev_rucio_1 tools/run_tests_docker.sh -ir
       - name: File Upload/Download Test
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_rucio_server.py
-      - name: UploadClient Test
-        run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_upload.py
+      # - name: UploadClient Test
+      #   run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_upload.py
       - name: Test Protocol XrootD
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_rse_protocol_xrootd.py
       - name: Test Conveyor

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -77,18 +77,17 @@ jobs:
           docker exec -t dev_rucio_1 tools/run_tests_docker.sh -ir
       - name: File Upload/Download Test
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_rucio_server.py
-      # - name: UploadClient Test
-      #   run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_upload.py
+      - name: UploadClient Test
+        run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_upload.py
       - name: Test Protocol XrootD
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_rse_protocol_xrootd.py
       - name: Test Conveyor
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_conveyor.py::test_multihop_intermediate_replica_lifecycle
-      - name: Test TPC with artifacts
+      - name: Execute transfer and export FTS transfer details
         id: tpc
         shell: bash
         run: |
-          docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short --save-artifacts-from="test_tpc" test_tpc.py
-          echo "Fetch artifact created by test_tpc.py"
+          docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short --export-artifacts-from="test_tpc" test_tpc.py
           FTS_LOG_FILE=$(docker exec -t dev_rucio_1 cat /tmp/test_tpc.artifact)
           echo "::set-output name=fts3log::$FTS_LOG_FILE"
       - name: Verify TPC transfers from FTS logs
@@ -97,7 +96,7 @@ jobs:
           FTS_LOG_FILE=${{ steps.tpc.outputs.fts3log }}
           if docker exec -t dev_fts_1 /bin/bash -c "grep -Fq \"3rd pull\" $FTS_LOG_FILE"
           then
-            echo "TPC verified"
+            echo "TPC 3rd party pull verified"
           else
             echo "TPC failed"
             exit 1

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -79,6 +79,8 @@ jobs:
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_rucio_server.py
       - name: Archive Upload/Download Test
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_download.py::test_download_from_archive_on_xrd
+      - name: UploadClient Test
+        run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_upload.py
       - name: Test Protocol XrootD
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_rse_protocol_xrootd.py
       - name: Test Conveyor

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -77,8 +77,6 @@ jobs:
           docker exec -t dev_rucio_1 tools/run_tests_docker.sh -ir
       - name: File Upload/Download Test
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_rucio_server.py
-      - name: Archive Upload/Download Test
-        run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_download.py::test_download_from_archive_on_xrd
       - name: UploadClient Test
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_upload.py
       - name: Test Protocol XrootD
@@ -104,5 +102,7 @@ jobs:
             echo "TPC failed"
             exit 1
           fi
+      - name: Archive Upload/Download Test
+        run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_download.py::test_download_from_archive_on_xrd
       - name: Stop containers
         run: docker-compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose-storage.yml down

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -85,5 +85,24 @@ jobs:
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_rse_protocol_xrootd.py
       - name: Test Conveyor
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_conveyor.py::test_multihop_intermediate_replica_lifecycle
+      - name: Test TPC with artifacts
+        id: tpc
+        shell: bash
+        run: |
+          docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short --save-artifacts-from="test_tpc" test_tpc.py
+          echo "Fetch artifact created by test_tpc.py"
+          FTS_LOG_FILE=$(docker exec -t dev_rucio_1 cat /tmp/test_tpc.artifact)
+          echo "::set-output name=fts3log::$FTS_LOG_FILE"
+      - name: Verify TPC transfers from FTS logs
+        shell: bash
+        run: |
+          FTS_LOG_FILE=${{ steps.tpc.outputs.fts3log }}
+          if grep -Fq "3rd pull" $FTS_LOG_FILE
+          then
+            echo "TPC verified"
+          else
+            echo "TPC failed"
+            exit 1
+          fi
       - name: Stop containers
         run: docker-compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose-storage.yml down

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -95,7 +95,7 @@ jobs:
         shell: bash
         run: |
           FTS_LOG_FILE=${{ steps.tpc.outputs.fts3log }}
-          if docker exec -t dev_fts_1 grep -Fq "3rd pull" $FTS_LOG_FILE
+          if docker exec -t dev_fts_1 /bin/bash -c "grep -Fq \"3rd pull\" $FTS_LOG_FILE"
           then
             echo "TPC verified"
           else

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ tools/test.file.1G
 # autotest logs/data
 /.autotest
 
+.idea
+.vscode
+.virtualenv

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ tools/test.file.1G
 
 # autotest logs/data
 /.autotest
+

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,3 @@ tools/test.file.1G
 
 # autotest logs/data
 /.autotest
-
-.idea
-.virtualenv
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,3 @@ tools/test.file.1G
 
 # autotest logs/data
 /.autotest
-
-.idea
-.vscode
-.virtualenv

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,3 @@ tools/test.file.1G
 # autotest logs/data
 /.autotest
 
-.idea
-.vscode
-.virtualenv

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ tools/test.file.1G
 
 # autotest logs/data
 /.autotest
+
+.idea
+.vscode
+.virtualenv

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ tools/test.file.1G
 # autotest logs/data
 /.autotest
 
+.idea
+.virtualenv
+.vscode

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -77,7 +77,7 @@ from uuid import uuid4 as uuid
 from xml.etree import ElementTree
 
 import requests
-from six import string_types, text_type, PY3
+from six import string_types, text_type, binary_type, ensure_text, PY3
 
 from rucio.common.config import config_get
 from rucio.common.exception import MissingModuleException, InvalidType, InputValidationError, MetalinkJsonParsingError, RucioException
@@ -1242,9 +1242,9 @@ def run_cmd_process(cmd, timeout=3600):
         process.kill()
 
     stdout, stderr = process.communicate()
-    if isinstance(stdout, bytes):
-        stdout = stdout.decode()
-        stderr = stderr.decode()
+    if isinstance(stdout, binary_type):
+        stdout = ensure_text(stdout, errors='replace')
+        stderr = ensure_text(stderr, errors='replace')
     if not stderr:
         stderr = ''
     if not stdout:

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1241,6 +1241,9 @@ def run_cmd_process(cmd, timeout=3600):
         process.kill()
 
     stdout, stderr = process.communicate()
+    if isinstance(stdout, bytes):
+        stdout = stdout.decode()
+        stderr = stderr.decode()
     if not stderr:
         stderr = ''
     if not stdout:

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -38,6 +38,7 @@
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Anil Panta <47672624+panta-123@users.noreply.github.com>, 2021
 
+
 from __future__ import absolute_import, print_function
 
 try:

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -123,11 +123,18 @@ def root_account(vo):
 def containerized_rses(rucio_client):
     """
     Detects if containerized rses for xrootd are available in the testing environment.
-    :return: An array of (rse_name, rse_id) tuples.
+    :return: A list of (rse_name, rse_id) tuples.
     """
-    rses = rucio_client.list_rses()
-    available_xrd_containerized_rses = [(rse_obj['rse'], rse_obj['id']) for rse_obj in rses if "xrd" in rse_obj['rse'].lower()]
-    return available_xrd_containerized_rses
+    rses = []
+    try:
+        xrd_rses = [x['rse'] for x in rucio_client.list_rses(rse_expression='test_container_xrd=True')]
+        xrd_rses = [rucio_client.get_rse(rse) for rse in xrd_rses]
+        xrd_containerized_rses = [(rse_obj['rse'], rse_obj['id']) for rse_obj in xrd_rses if "xrd" in rse_obj['rse'].lower()]
+        xrd_containerized_rses.sort()
+        rses.extend(xrd_containerized_rses)
+    except Exception:
+        traceback.print_exc()
+    return rses
 
 
 @pytest.fixture

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -46,6 +46,12 @@ def replica_client():
 
 
 @pytest.fixture(scope='module')
+def rucio_client():
+    from rucio.client import Client
+    return Client()
+
+
+@pytest.fixture(scope='module')
 def did_client():
     from rucio.client.didclient import DIDClient
 
@@ -111,6 +117,17 @@ def root_account(vo):
     from rucio.common.types import InternalAccount
 
     return InternalAccount('root', vo=vo)
+
+
+@pytest.fixture(scope="module")
+def containerized_rses(rucio_client):
+    """
+    Detects if containerized rses for xrootd are available in the testing environment.
+    :return: An array of (rse_name, rse_id) tuples.
+    """
+    rses = rucio_client.list_rses()
+    available_xrd_containerized_rses = [(rse_obj['rse'], rse_obj['id']) for rse_obj in rses if "xrd" in rse_obj['rse'].lower()]
+    return available_xrd_containerized_rses
 
 
 @pytest.fixture

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -16,7 +16,7 @@
 # Authors:
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
-# - Mayank Sharma <mayank.sharma@cern.ch> 2021
+# - Mayank Sharma <mayank.sharma@cern.ch>, 2021
 
 from __future__ import print_function
 

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -23,8 +23,6 @@ from __future__ import print_function
 import traceback
 import pytest
 
-from rucio.common.exception import InvalidRSEExpression
-
 # local imports in the fixtures to make this file loadable in e.g. client tests
 
 
@@ -125,6 +123,8 @@ def containerized_rses(rucio_client):
     Detects if containerized rses for xrootd are available in the testing environment.
     :return: A list of (rse_name, rse_id) tuples.
     """
+    from rucio.common.exception import InvalidRSEExpression
+
     rses = []
     try:
         xrd_rses = [x['rse'] for x in rucio_client.list_rses(rse_expression='test_container_xrd=True')]
@@ -152,6 +152,14 @@ def did_factory(vo, mock_scope):
     from rucio.tests.temp_factories import TemporaryDidFactory
 
     with TemporaryDidFactory(vo=vo, default_scope=mock_scope) as factory:
+        yield factory
+
+
+@pytest.fixture
+def file_factory(tmp_path_factory):
+    from rucio.tests.temp_factories import TemporaryFileFactory
+
+    with TemporaryFileFactory(pytest_path_factory=tmp_path_factory) as factory:
         yield factory
 
 

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -132,8 +132,9 @@ def containerized_rses(rucio_client):
         xrd_containerized_rses = [(rse_obj['rse'], rse_obj['id']) for rse_obj in xrd_rses if "xrd" in rse_obj['rse'].lower()]
         xrd_containerized_rses.sort()
         rses.extend(xrd_containerized_rses)
-    except InvalidRSEExpression as ex:
-        # containerized RSEs will not be available in non-containerized test environments
+    except InvalidRSEExpression as invalid_rse_expression:
+        print("{ex}. Note that containerized RSEs will not be available in non-containerized test environments"
+              .format(ex=invalid_rse_expression))
         traceback.print_exc()
     return rses
 

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -16,6 +16,7 @@
 # Authors:
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Mayank Sharma <mayank.sharma@cern.ch> 2021
 
 from __future__ import print_function
 
@@ -96,6 +97,13 @@ def mock_scope(vo):
     from rucio.common.types import InternalScope
 
     return InternalScope('mock', vo=vo)
+
+
+@pytest.fixture(scope='module')
+def test_scope(vo):
+    from rucio.common.types import InternalScope
+
+    return InternalScope('test', vo=vo)
 
 
 @pytest.fixture(scope='module')

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -21,9 +21,9 @@
 from __future__ import print_function
 
 import traceback
-
 import pytest
 
+from rucio.common.exception import InvalidRSEExpression
 
 # local imports in the fixtures to make this file loadable in e.g. client tests
 
@@ -126,14 +126,15 @@ def containerized_rses(rucio_client):
     :return: A list of (rse_name, rse_id) tuples.
     """
     rses = []
-    # try:
-    xrd_rses = [x['rse'] for x in rucio_client.list_rses(rse_expression='test_container_xrd=True')]
-    xrd_rses = [rucio_client.get_rse(rse) for rse in xrd_rses]
-    xrd_containerized_rses = [(rse_obj['rse'], rse_obj['id']) for rse_obj in xrd_rses if "xrd" in rse_obj['rse'].lower()]
-    xrd_containerized_rses.sort()
-    rses.extend(xrd_containerized_rses)
-    # except Exception:
-    #     traceback.print_exc()
+    try:
+        xrd_rses = [x['rse'] for x in rucio_client.list_rses(rse_expression='test_container_xrd=True')]
+        xrd_rses = [rucio_client.get_rse(rse) for rse in xrd_rses]
+        xrd_containerized_rses = [(rse_obj['rse'], rse_obj['id']) for rse_obj in xrd_rses if "xrd" in rse_obj['rse'].lower()]
+        xrd_containerized_rses.sort()
+        rses.extend(xrd_containerized_rses)
+    except InvalidRSEExpression as ex:
+        # containerized RSEs will not be available in non-containerized test environments
+        traceback.print_exc()
     return rses
 
 

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -126,14 +126,14 @@ def containerized_rses(rucio_client):
     :return: A list of (rse_name, rse_id) tuples.
     """
     rses = []
-    try:
-        xrd_rses = [x['rse'] for x in rucio_client.list_rses(rse_expression='test_container_xrd=True')]
-        xrd_rses = [rucio_client.get_rse(rse) for rse in xrd_rses]
-        xrd_containerized_rses = [(rse_obj['rse'], rse_obj['id']) for rse_obj in xrd_rses if "xrd" in rse_obj['rse'].lower()]
-        xrd_containerized_rses.sort()
-        rses.extend(xrd_containerized_rses)
-    except Exception:
-        traceback.print_exc()
+    # try:
+    xrd_rses = [x['rse'] for x in rucio_client.list_rses(rse_expression='test_container_xrd=True')]
+    xrd_rses = [rucio_client.get_rse(rse) for rse in xrd_rses]
+    xrd_containerized_rses = [(rse_obj['rse'], rse_obj['id']) for rse_obj in xrd_rses if "xrd" in rse_obj['rse'].lower()]
+    xrd_containerized_rses.sort()
+    rses.extend(xrd_containerized_rses)
+    # except Exception:
+    #     traceback.print_exc()
     return rses
 
 

--- a/lib/rucio/tests/ruciopytest/plugin.py
+++ b/lib/rucio/tests/ruciopytest/plugin.py
@@ -48,9 +48,10 @@ if sys.version_info >= (3, 6):
 
             if not option_appended:
                 raise pytest.UsageError('rucio pytest plugin must be loaded after xdist plugin')
+
         # Initialization hook to add --artifacts option, used by integration or TPC tests
         parser.addoption(
-            "--save-artifacts-from",
+            "--export-artifacts-from",
             action="append",
             dest="artifacts",
             default=[],
@@ -60,7 +61,7 @@ if sys.version_info >= (3, 6):
     def pytest_generate_tests(metafunc):
         tests_with_artifacts = metafunc.config.getoption('artifacts')
         if len(tests_with_artifacts) > 1:
-            raise pytest.UsageError('--save-artifacts-from must be used only one. It should contain a CSV string of test names that can manage artifacts.')
+            raise pytest.UsageError('--export-artifacts-from must be used only once. It should contain a CSV string of test names that can manage artifacts.')
         elif len(tests_with_artifacts) == 1:
             tests_with_artifacts = tests_with_artifacts[0].split(',')
             test_function_name = metafunc.function.__name__

--- a/lib/rucio/tests/ruciopytest/plugin.py
+++ b/lib/rucio/tests/ruciopytest/plugin.py
@@ -15,6 +15,7 @@
 #
 # Authors:
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
+# - Mayank Sharma <mayank.sharma@cern.ch>, 2021
 
 import os
 import sys
@@ -32,14 +33,6 @@ def pytest_configure(config):
         from rucio.tests.ruciopytest.rucioxdist import NoParallelXDist
 
         config.pluginmanager.register(NoParallelXDist(config))
-    # set env variables
-
-
-def set_test_environment():
-    """
-    Sets additional environment variables for testing environment, depending on where tests are executed (containerized, standalone, GH_Actions)
-    """
-    pass
 
 
 if sys.version_info >= (3, 6):

--- a/lib/rucio/tests/ruciopytest/plugin.py
+++ b/lib/rucio/tests/ruciopytest/plugin.py
@@ -32,6 +32,14 @@ def pytest_configure(config):
         from rucio.tests.ruciopytest.rucioxdist import NoParallelXDist
 
         config.pluginmanager.register(NoParallelXDist(config))
+    # set env variables
+
+
+def set_test_environment():
+    """
+    Sets additional environment variables for testing environment, depending on where tests are executed (containerized, standalone, GH_Actions)
+    """
+    pass
 
 
 if sys.version_info >= (3, 6):
@@ -49,7 +57,7 @@ if sys.version_info >= (3, 6):
             if not option_appended:
                 raise pytest.UsageError('rucio pytest plugin must be loaded after xdist plugin')
 
-        # Initialization hook to add --artifacts option, used by integration or TPC tests
+        # Initialization hook to add --artifacts option, can be used by integration or TPC tests to further check non-dev container states
         parser.addoption(
             "--export-artifacts-from",
             action="append",
@@ -62,7 +70,8 @@ if sys.version_info >= (3, 6):
         tests_with_artifacts = metafunc.config.getoption('artifacts')
         if len(tests_with_artifacts) > 1:
             raise pytest.UsageError('--export-artifacts-from must be used only once. It should contain a CSV string of test names that can manage artifacts.')
-        elif len(tests_with_artifacts) == 1:
+
+        if len(tests_with_artifacts) == 1:
             tests_with_artifacts = tests_with_artifacts[0].split(',')
             test_function_name = metafunc.function.__name__
             if "artifact" in metafunc.fixturenames:
@@ -73,6 +82,9 @@ if sys.version_info >= (3, 6):
                     )
                 else:
                     metafunc.parametrize("artifact", [None])
+        else:
+            if "artifact" in metafunc.fixturenames:
+                metafunc.parametrize("artifact", [None])
 
 
 def pytest_cmdline_main(config):

--- a/lib/rucio/tests/ruciopytest/plugin.py
+++ b/lib/rucio/tests/ruciopytest/plugin.py
@@ -53,18 +53,21 @@ if sys.version_info >= (3, 6):
             "--save-artifacts-from",
             action="append",
             dest="artifacts",
-            default = [],
+            default=[],
             help="A csv string with test names that should persist their artifacts"
         )
 
     def pytest_generate_tests(metafunc):
         tests_with_artifacts = metafunc.config.getoption('artifacts')
         if len(tests_with_artifacts) > 1:
-                raise pytest.UsageError('--save-artifacts-from must be used only one. It should contain a CSV string of test names that can manage artifacts.')
+            raise pytest.UsageError('--save-artifacts-from must be used only one. It should contain a CSV string of test names that can manage artifacts.')
         tests_with_artifacts = tests_with_artifacts[0].split(',')
         test_function_name = metafunc.function.__name__
-        if "artifact" in metafunc.fixturenames and test_function_name in tests_with_artifacts:
-            metafunc.parametrize("artifact", [f'/tmp/{test_function_name}.artifact'])
+        if "artifact" in metafunc.fixturenames:
+            if test_function_name in tests_with_artifacts:
+                metafunc.parametrize("artifact", [f'/tmp/{test_function_name}.artifact'])
+            else:
+                metafunc.parametrize("artifact", [None])
 
 
 def pytest_cmdline_main(config):

--- a/lib/rucio/tests/ruciopytest/plugin.py
+++ b/lib/rucio/tests/ruciopytest/plugin.py
@@ -61,13 +61,14 @@ if sys.version_info >= (3, 6):
         tests_with_artifacts = metafunc.config.getoption('artifacts')
         if len(tests_with_artifacts) > 1:
             raise pytest.UsageError('--save-artifacts-from must be used only one. It should contain a CSV string of test names that can manage artifacts.')
-        tests_with_artifacts = tests_with_artifacts[0].split(',')
-        test_function_name = metafunc.function.__name__
-        if "artifact" in metafunc.fixturenames:
-            if test_function_name in tests_with_artifacts:
-                metafunc.parametrize("artifact", [f'/tmp/{test_function_name}.artifact'])
-            else:
-                metafunc.parametrize("artifact", [None])
+        elif len(tests_with_artifacts) == 1:
+            tests_with_artifacts = tests_with_artifacts[0].split(',')
+            test_function_name = metafunc.function.__name__
+            if "artifact" in metafunc.fixturenames:
+                if test_function_name in tests_with_artifacts:
+                    metafunc.parametrize("artifact", [f'/tmp/{test_function_name}.artifact'])
+                else:
+                    metafunc.parametrize("artifact", [None])
 
 
 def pytest_cmdline_main(config):

--- a/lib/rucio/tests/ruciopytest/plugin.py
+++ b/lib/rucio/tests/ruciopytest/plugin.py
@@ -66,7 +66,10 @@ if sys.version_info >= (3, 6):
             test_function_name = metafunc.function.__name__
             if "artifact" in metafunc.fixturenames:
                 if test_function_name in tests_with_artifacts:
-                    metafunc.parametrize("artifact", [f'/tmp/{test_function_name}.artifact'])
+                    metafunc.parametrize(
+                        "artifact",
+                        ['/tmp/{function}.artifact'.format(function=test_function_name)]
+                    )
                 else:
                     metafunc.parametrize("artifact", [None])
 

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -25,13 +25,6 @@ from pathlib import Path
 from random import choice
 from string import ascii_uppercase
 
-import os
-import shutil
-import tempfile
-from pathlib import Path
-from random import choice
-from string import ascii_uppercase
-
 from rucio.client.client import Client
 from rucio.client.uploadclient import UploadClient
 from rucio.common.types import InternalScope

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -15,6 +15,7 @@
 #
 # Authors:
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Mayank Sharma <mayank.sharma@cern.ch> 2020-2021
 
 import os
 
@@ -32,6 +33,7 @@ from rucio.db.sqla.session import transactional_session
 from rucio.tests.common import file_generator
 from rucio.tests.common import rse_name_generator
 from rucio.db.sqla.constants import DIDType
+from rucio.common.utils import execute
 
 
 class TemporaryRSEFactory:
@@ -42,6 +44,7 @@ class TemporaryRSEFactory:
         self.vo = vo
 
         self.created_rses = []
+        self.containerized_rses = []
 
     def __enter__(self):
         return self
@@ -151,6 +154,27 @@ class TemporaryRSEFactory:
             "extended_attributes": {"web_service_path": "/srm/managerv2?SFN=", "space_token": "RUCIODISK"},
         }
         return self._make_rse(scheme='srm', protocol_impl='rucio.rse.protocols.srm.Default', parameters=parameters, add_rse_kwargs=kwargs)
+
+    def fetch_containerized_rse(self, rse):
+        """
+        Detects if containerized rses for xrootd are available in the testing environment.
+        :param rse: rse_id of containerzed rse to be used for lookup
+        :return: rse_id if containerized rse was found else None
+        """
+        # return rse if already cached
+        if rse in self.containerized_rses:
+            return rse
+
+        # lookup rse
+        cmd = "rucio list-rses --expression 'test_container_xrd=True'"
+        exitcode, out, err = execute(cmd)
+        rses = out.split()
+
+        if len(rses) != 0 and rse in rses:
+            self.containerized_rses.append(rse)
+            return rse
+        else:
+            return None
 
 
 class TemporaryDidFactory:

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -15,7 +15,6 @@
 #
 # Authors:
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
-# - Mayank Sharma <mayank.sharma@cern.ch> 2021
 
 import os
 
@@ -33,7 +32,6 @@ from rucio.db.sqla.session import transactional_session
 from rucio.tests.common import file_generator
 from rucio.tests.common import rse_name_generator
 from rucio.db.sqla.constants import DIDType
-from rucio.client.rseclient import RSEClient
 
 
 class TemporaryRSEFactory:
@@ -43,9 +41,7 @@ class TemporaryRSEFactory:
 
     def __init__(self, vo, **kwargs):
         self.vo = vo
-        self._rse_client = RSEClient()
         self.created_rses = []
-        self.containerized_rses = []
 
     def __enter__(self):
         return self
@@ -162,7 +158,6 @@ class TemporaryDidFactory:
     Factory which keeps track of created dids and cleans up everything related to these dids at the end.
     All files related to the same test will have the same uuid in the name for easier debugging.
     """
-
     def __init__(self, default_scope, vo):
         self.default_scope = default_scope
         self.vo = vo

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -28,12 +28,10 @@ from string import ascii_uppercase
 import os
 import shutil
 import tempfile
-from logging import setLogRecordFactory
 from pathlib import Path
 from random import choice
 from string import ascii_uppercase
 
-import py
 from rucio.client.client import Client
 from rucio.client.uploadclient import UploadClient
 from rucio.common.types import InternalScope

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -33,7 +33,6 @@ from rucio.db.sqla.session import transactional_session
 from rucio.tests.common import file_generator
 from rucio.tests.common import rse_name_generator
 from rucio.db.sqla.constants import DIDType
-from rucio.common.utils import execute
 from rucio.client.rseclient import RSEClient
 
 
@@ -41,6 +40,7 @@ class TemporaryRSEFactory:
     """
     Factory which keeps track of created RSEs and cleans up everything related to these RSEs at the end
     """
+
     def __init__(self, vo, **kwargs):
         self.vo = vo
         self._rse_client = RSEClient()
@@ -156,25 +156,13 @@ class TemporaryRSEFactory:
         }
         return self._make_rse(scheme='srm', protocol_impl='rucio.rse.protocols.srm.Default', parameters=parameters, add_rse_kwargs=kwargs)
 
-    def fetch_containerized_rse(self, rse_name):
-        """
-        Detects if containerized rses for xrootd are available in the testing environment.
-        :param rse: rse_id of containerzed rse to be used for lookup
-        :return: rse_id if containerized rse was found else None
-        """
-        rse = self._rse_client.get_rse(rse_name)
-        rse_id = rse['id']
-        if rse is not None:
-            return rse_name, rse_id
-        else:
-            return None, None
-
 
 class TemporaryDidFactory:
     """
     Factory which keeps track of created dids and cleans up everything related to these dids at the end.
     All files related to the same test will have the same uuid in the name for easier debugging.
     """
+
     def __init__(self, default_scope, vo):
         self.default_scope = default_scope
         self.vo = vo

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -15,23 +15,29 @@
 #
 # Authors:
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Mayank Sharma <mayank.sharma@cern.ch>, 2021
+
 
 import os
-
-from sqlalchemy import or_, and_
+import shutil
+import tempfile
+from pathlib import Path
+from random import choice
+from string import ascii_uppercase
 
 from rucio.client.client import Client
 from rucio.client.uploadclient import UploadClient
 from rucio.common.types import InternalScope
-from rucio.common.utils import generate_uuid
+from rucio.common.utils import execute, generate_uuid
 from rucio.core import replica as replica_core
 from rucio.core import rse as rse_core
 from rucio.core import rule as rule_core
 from rucio.db.sqla import models
-from rucio.db.sqla.session import transactional_session
-from rucio.tests.common import file_generator
-from rucio.tests.common import rse_name_generator
 from rucio.db.sqla.constants import DIDType
+from rucio.db.sqla.session import transactional_session
+from rucio.tests.common import file_generator, rse_name_generator
+from six import PY3
+from sqlalchemy import and_, or_
 
 
 class TemporaryRSEFactory:
@@ -283,3 +289,72 @@ class TemporaryDidFactory:
         did = {'scope': scope, 'name': name}
         self.created_dids.append(did)
         return item if return_full_item else did
+
+
+class TemporaryFileFactory:
+    """
+    Factory which keeps track of creation and cleanup of created local test files and directories.
+    If initialized with tmp_path_factory fixture, the basedir is managed by pytest.
+    Otherwise, the basedir is handled by this factory itself.
+    """
+
+    def __init__(self, pytest_path_factory=None) -> None:
+        self.pytest_path_factory = pytest_path_factory
+        self.base_uuid = generate_uuid()
+        self._base_dir = None
+        self.non_basedir_files = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.pytest_path_factory is None:
+            shutil.rmtree(self.base_dir)
+        self.cleanup()
+
+    @property
+    def base_dir(self):
+        if not self._base_dir:
+            if self.pytest_path_factory is not None:
+                self._base_dir = self.pytest_path_factory.mktemp(basename=self.base_uuid, numbered=True)
+            else:
+                tmp_dir = tempfile.mkdtemp(prefix=self.base_uuid)
+                self._base_dir = Path(tmp_dir)
+
+        return self._base_dir
+
+    def _make_temp_file(self, data, size, namelen, use_basedir):
+        fn = ''.join(choice(ascii_uppercase) for x in range(namelen))
+        if use_basedir:
+            fp = self.base_dir / fn
+        else:
+            fp = Path(tempfile.gettempdir(), fn)
+            self.non_basedir_files.append(fp)
+
+        if data is not None:
+            if PY3:
+                with open(fp, 'w', encoding='utf-8') as f:
+                    f.write(data)
+            else:
+                with open(fp, 'w') as f:
+                    f.write(data)
+        else:
+            execute('dd if=/dev/urandom of={0} count={1} bs=1'.format(fp, size))
+
+        return fp
+
+    def file_generator(self, data=None, size=2, namelen=10, use_basedir=False):
+        """
+        Creates a temporary file
+        :param data        : The content to be written in the file. If provided, the size parameter is ignored.
+        :param size        : The size of random bytes to be written in the file
+        :param namelen     : The length of filename
+        :param use_basedir : If True, the file is created under the base_dir for this TemporaryFileFactory instance.
+        :returns: The absolute path of the generated file
+        """
+        return self._make_temp_file(data, size, namelen, use_basedir)
+
+    def cleanup(self):
+        for fp in self.non_basedir_files:
+            if os.path.isfile(fp):
+                os.remove(fp)

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -25,6 +25,15 @@ from pathlib import Path
 from random import choice
 from string import ascii_uppercase
 
+import os
+import shutil
+import tempfile
+from logging import setLogRecordFactory
+from pathlib import Path
+from random import choice
+from string import ascii_uppercase
+
+import py
 from rucio.client.client import Client
 from rucio.client.uploadclient import UploadClient
 from rucio.common.types import InternalScope

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -41,6 +41,7 @@ class TemporaryRSEFactory:
 
     def __init__(self, vo, **kwargs):
         self.vo = vo
+
         self.created_rses = []
 
     def __enter__(self):
@@ -158,6 +159,7 @@ class TemporaryDidFactory:
     Factory which keeps track of created dids and cleans up everything related to these dids at the end.
     All files related to the same test will have the same uuid in the name for easier debugging.
     """
+
     def __init__(self, default_scope, vo):
         self.default_scope = default_scope
         self.vo = vo

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -139,5 +139,5 @@ def test_tpc(rse1, rse2, root_account, test_scope, did_factory, rse_client, rule
         date = datetime.date.today().strftime("%Y-%m-%d")
         with open(artifact, 'w') as artifact_file:
             artifact_file.write(
-                f"/var/log/fts3/{date}/{rse1['rse_name']}__{rse2['rse_name']}/*__{fts_transfer_id}"
+                f"/var/log/fts3/{date}/{rse1['rse_name'].lower()}__{rse2['rse_name'].lower()}/*__{fts_transfer_id}"
             )

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -14,10 +14,10 @@ from rucio.common.utils import run_cmd_process
 
 
 @pytest.fixture
-def file_factory(vo, test_scope):
-    from rucio.tests.temp_factories import TemporaryFileFactory
+def did_factory(vo, test_scope):
+    from rucio.tests.temp_factories import TemporaryDidFactory
 
-    with TemporaryFileFactory(vo=vo, default_scope=test_scope) as factory:
+    with TemporaryDidFactory(vo=vo, default_scope=test_scope) as factory:
         yield factory
 
 
@@ -84,9 +84,9 @@ def poll_fts_transfer_status(request_id, timeout=30):
     return transfer_status
 
 
-def test_tpc(rse1, rse2, root_account, test_scope, file_factory, rse_client, rule_client, artifact):
+def test_tpc(rse1, rse2, root_account, test_scope, did_factory, rse_client, rule_client, artifact):
     base_file_name = generate_uuid()
-    test_file = file_factory.upload_test_file(rse1['rse_name'], name=base_file_name + '.000', return_full_item=True)
+    test_file = did_factory.upload_test_file(rse1['rse_name'], name=base_file_name + '.000', return_full_item=True)
     test_file_did_str = '%s:%s' % (test_file['did_scope'], test_file['did_name'])
     test_file_did = {
         'scope': test_scope,

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -136,5 +136,8 @@ def test_tpc(rse1, rse2, root_account, test_scope, did_factory, rse_client, rule
     assert rule['locks_replicating_cnt'] == 0
 
     if artifact is not None:
+        date = datetime.date.today().strftime("%Y-%m-%d")
         with open(artifact, 'w') as artifact_file:
-            artifact_file.write(fts_transfer_id)
+            artifact_file.write(
+                f"/var/log/fts3/{date}/{rse1['rse_name']}__{rse2['rse_name']}/*__{fts_transfer_id}"
+            )

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -1,0 +1,135 @@
+import datetime
+import pytest
+import hashlib
+import re
+
+from rucio.core.rule import add_rule
+from rucio.core.transfer import get_transfer_requests_and_source_replicas
+from rucio.common.utils import generate_uuid
+from rucio.daemons.judge.evaluator import re_evaluator
+from rucio.daemons.conveyor import submitter, poller, finisher
+from rucio.client.rseclient import RSEClient
+from rucio.client.ruleclient import RuleClient
+from rucio.common.utils import run_cmd_process
+
+
+@pytest.fixture
+def file_factory(vo, test_scope):
+    from rucio.tests.temp_factories import TemporaryFileFactory
+
+    with TemporaryFileFactory(vo=vo, default_scope=test_scope) as factory:
+        yield factory
+
+@pytest.fixture
+def rse_client():
+    return RSEClient()
+
+
+@pytest.fixture
+def rule_client():
+    return RuleClient()
+
+
+@pytest.fixture
+def rse1(rse_factory):
+    xrd1, xrd1_id = rse_factory.fetch_containerized_rse('XRD1')
+    if xrd1 is not None:
+        return {
+            'rse_name': xrd1,
+            'rse_id': xrd1_id,
+        }
+    rse, _ = rse_factory.make_posix_rse()
+    return rse
+
+
+@pytest.fixture
+def rse2(rse_factory):
+    xrd2, xrd2_id = rse_factory.fetch_containerized_rse('XRD2')
+    if xrd2 is not None:
+        return {
+            'rse_name': xrd2,
+            'rse_id': xrd2_id
+        }
+    rse, _ = rse_factory.make_posix_rse()
+    return rse
+
+
+def check_url(pfn, hostname, path):
+    assert hostname in pfn
+    assert path in pfn
+
+
+def list_fts_transfer(timeout=30):
+    time_start = datetime.datetime.now().second
+    running_time = 0
+    request_id = None
+    request_status = None
+    while running_time < timeout:
+        rcode, out = run_cmd_process("/usr/bin/python2 /usr/bin/fts-rest-transfer-list -v -s https://fts:8446", timeout=10)
+        if "Request ID" in out:
+            request_id = re.search("Request ID: (.*)", out).group(1)
+            request_status = re.search("Status: (.*)", out).group(1)
+            break
+        time_now = datetime.datetime.now().second
+        running_time = int(time_now - time_start)
+    return request_id, request_status
+
+
+def poll_fts_transfer_status(request_id, timeout=30):
+    rcode, out = run_cmd_process(f"/usr/bin/python2 /usr/bin/fts-rest-transfer-status -v -s https://fts:8446 {request_id}", timeout=timeout)
+    transfer_status = None
+    if rcode == 0:
+        transfer_status = re.search("Status: (.*)", out).group(1)
+    return transfer_status
+
+
+def test_tpc(rse1, rse2, root_account, test_scope, file_factory, rse_client, rule_client):
+    base_file_name = generate_uuid()
+    test_file = file_factory.upload_test_file(rse1['rse_name'], name=base_file_name + '.000', return_full_item=True)
+    test_file_did_str = '%s:%s' % (test_file['did_scope'], test_file['did_name'])
+    test_file_did = {
+        'scope': test_scope,
+        'name': test_file['did_name']
+    }
+    test_file_name_hash = hashlib.md5(test_file_did_str.encode('utf-8')).hexdigest()
+    test_file_expected_pfn = '%s/%s/%s/%s' % (test_file_did['scope'], test_file_name_hash[0:2], test_file_name_hash[2:4], test_file_did['name'])
+
+    rse1_hostname = rse_client.get_protocols(rse1['rse_name'])[0]['hostname']
+    rse2_hostname = rse_client.get_protocols(rse2['rse_name'])[0]['hostname']
+
+    rule_id = add_rule(dids=[test_file_did], account=root_account, copies=1, rse_expression=rse2['rse_name'],
+                       grouping='NONE', weight=None, lifetime=None, locked=False, subscription_id=None)
+    rule = rule_client.get_replication_rule(rule_id[0])
+
+    re_evaluator(once=True)
+
+    assert rule['locks_ok_cnt'] == 0
+    assert rule['locks_replicating_cnt'] == 1
+
+    requestss = get_transfer_requests_and_source_replicas(rses=[rse1['rse_id'], rse2['rse_id']])
+    for requests in requestss:
+        for request in requests:
+            if requests[request]['rule_id'] == rule_id[0]:
+                src_url = requests[request]['sources'][0][1]
+                dest_url = requests[request]['dest_urls'][0]
+                check_url(src_url, rse1_hostname, test_file_expected_pfn)
+                check_url(dest_url, rse2_hostname, test_file_expected_pfn)
+
+    # Run Submitter
+    submitter.run(once=True)
+
+    # Get FTS transfer job info
+    fts_transfer_id, fts_transfer_status = list_fts_transfer(timeout=30)
+
+    # Check FTS transfer job
+    assert fts_transfer_id is not None and fts_transfer_status is not None
+    assert fts_transfer_status in ['SUBMITTED', 'ACTIVE']
+
+    fts_transfer_status = poll_fts_transfer_status(fts_transfer_id)
+    assert fts_transfer_status == 'FINISHED'
+
+    poller.run(once=True, older_than=0)
+    finisher.run(once=True)
+    rule = rule_client.get_replication_rule(rule_id[0])
+    assert rule['locks_ok_cnt'] == 1
+    assert rule['locks_replicating_cnt'] == 0

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -16,6 +16,7 @@
 # Authors:
 # - Mayank Sharma <mayank.sharma@cern.ch>, 2021
 
+import time
 import datetime
 import pytest
 import hashlib
@@ -29,8 +30,6 @@ from rucio.daemons.conveyor import submitter, poller, finisher
 from rucio.client.rseclient import RSEClient
 from rucio.client.ruleclient import RuleClient
 from rucio.common.utils import run_cmd_process
-
-# Fixtures
 
 
 @pytest.fixture
@@ -72,8 +71,6 @@ def rse2(containerized_rses):
         }
     return None
 
-# Utility functions
-
 
 def check_url(pfn, hostname, path):
     assert hostname in pfn
@@ -81,7 +78,7 @@ def check_url(pfn, hostname, path):
 
 
 def list_fts_transfer(timeout=30):
-    time_start = datetime.datetime.now().second
+    time_start = time.time()
     running_time = 0
     request_id = None
     request_status = None
@@ -91,7 +88,7 @@ def list_fts_transfer(timeout=30):
             request_id = re.search("Request ID: (.*)", out).group(1)
             request_status = re.search("Status: (.*)", out).group(1)
             break
-        time_now = datetime.datetime.now().second
+        time_now = time.time()
         running_time = int(time_now - time_start)
     return request_id, request_status
 
@@ -102,8 +99,6 @@ def poll_fts_transfer_status(request_id, timeout=30):
     if rcode == 0:
         transfer_status = re.search("Status: (.*)", out).group(1)
     return transfer_status
-
-# TPC tests
 
 
 @pytest.mark.dirty(reason="Creates artifact /tmp/test_tpc.artifact in dev_rucio_1 container")

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -50,28 +50,6 @@ def rule_client():
     return RuleClient()
 
 
-@pytest.fixture
-def rse1(containerized_rses):
-    if len(containerized_rses) > 1:
-        rse, rse_id = containerized_rses[0]
-        return {
-            'rse_name': rse,
-            'rse_id': rse_id,
-        }
-    return None
-
-
-@pytest.fixture
-def rse2(containerized_rses):
-    if len(containerized_rses) > 1:
-        rse, rse_id = containerized_rses[1]
-        return {
-            'rse_name': rse,
-            'rse_id': rse_id,
-        }
-    return None
-
-
 def check_url(pfn, hostname, path):
     assert hostname in pfn
     assert path in pfn
@@ -102,11 +80,14 @@ def poll_fts_transfer_status(request_id, timeout=30):
 
 
 @pytest.mark.dirty(reason="Creates artifact /tmp/test_tpc.artifact in dev_rucio_1 container")
-def test_tpc(rse1, rse2, root_account, test_scope, did_factory, rse_client, rule_client, artifact):
-    if rse1 is None or rse2 is None:
+def test_tpc(containerized_rses, root_account, test_scope, did_factory, rse_client, rule_client, artifact):
+    if len(containerized_rses) < 2:
         pytest.skip("TPC tests need at least 2 containerized rse's for execution}")
+    rse1_name, rse1_id = containerized_rses[0]
+    rse2_name, rse2_id = containerized_rses[1]
+
     base_file_name = generate_uuid()
-    test_file = did_factory.upload_test_file(rse1['rse_name'], name=base_file_name + '.000', return_full_item=True)
+    test_file = did_factory.upload_test_file(rse1_name, name=base_file_name + '.000', return_full_item=True)
     test_file_did_str = '%s:%s' % (test_file['did_scope'], test_file['did_name'])
     test_file_did = {
         'scope': test_scope,
@@ -115,10 +96,10 @@ def test_tpc(rse1, rse2, root_account, test_scope, did_factory, rse_client, rule
     test_file_name_hash = hashlib.md5(test_file_did_str.encode('utf-8')).hexdigest()
     test_file_expected_pfn = '%s/%s/%s/%s' % (test_file_did['scope'], test_file_name_hash[0:2], test_file_name_hash[2:4], test_file_did['name'])
 
-    rse1_hostname = rse_client.get_protocols(rse1['rse_name'])[0]['hostname']
-    rse2_hostname = rse_client.get_protocols(rse2['rse_name'])[0]['hostname']
+    rse1_hostname = rse_client.get_protocols(rse1_name)[0]['hostname']
+    rse2_hostname = rse_client.get_protocols(rse2_name)[0]['hostname']
 
-    rule_id = add_rule(dids=[test_file_did], account=root_account, copies=1, rse_expression=rse2['rse_name'],
+    rule_id = add_rule(dids=[test_file_did], account=root_account, copies=1, rse_expression=rse2_name,
                        grouping='NONE', weight=None, lifetime=None, locked=False, subscription_id=None)
     rule = rule_client.get_replication_rule(rule_id[0])
 
@@ -127,7 +108,7 @@ def test_tpc(rse1, rse2, root_account, test_scope, did_factory, rse_client, rule
     assert rule['locks_ok_cnt'] == 0
     assert rule['locks_replicating_cnt'] == 1
 
-    transfer_requestss = get_transfer_requests_and_source_replicas(rses=[rse1['rse_id'], rse2['rse_id']])
+    transfer_requestss = get_transfer_requests_and_source_replicas(rses=[rse1_id, rse2_id])
     for transfer_requests in transfer_requestss:
         for transfer_request in transfer_requests:
             if transfer_requests[transfer_request]['rule_id'] == rule_id[0]:
@@ -159,5 +140,5 @@ def test_tpc(rse1, rse2, root_account, test_scope, did_factory, rse_client, rule
         date = datetime.date.today().strftime("%Y-%m-%d")
         with open(artifact, 'w') as artifact_file:
             artifact_file.write(
-                f"/var/log/fts3/{date}/{rse1['rse_name'].lower()}__{rse2['rse_name'].lower()}/*__{fts_transfer_id}"
+                f"/var/log/fts3/{date}/{rse1_name.lower()}__{rse2_name.lower()}/*__{fts_transfer_id}"
             )

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -12,7 +12,7 @@ from rucio.client.rseclient import RSEClient
 from rucio.client.ruleclient import RuleClient
 from rucio.common.utils import run_cmd_process
 
-
+# Fixtures
 @pytest.fixture
 def did_factory(vo, test_scope):
     from rucio.tests.temp_factories import TemporaryDidFactory
@@ -33,28 +33,26 @@ def rule_client():
 
 @pytest.fixture
 def rse1(rse_factory):
-    xrd1, xrd1_id = rse_factory.fetch_containerized_rse('XRD1')
-    if xrd1 is not None:
-        return {
-            'rse_name': xrd1,
-            'rse_id': xrd1_id,
+    rse, rse_id = rse_factory.fetch_containerized_rse('XRD1')
+    if rse is None:
+        rse, rse_id = rse_factory.make_posix_rse()
+    return {
+            'rse_name': rse,
+            'rse_id': rse_id,
         }
-    rse, _ = rse_factory.make_posix_rse()
-    return rse
 
 
 @pytest.fixture
 def rse2(rse_factory):
-    xrd2, xrd2_id = rse_factory.fetch_containerized_rse('XRD2')
-    if xrd2 is not None:
-        return {
-            'rse_name': xrd2,
-            'rse_id': xrd2_id
+    rse, rse_id = rse_factory.fetch_containerized_rse('XRD2')
+    if rse is None:
+        rse, rse_id = rse_factory.make_posix_rse()
+    return {
+            'rse_name': rse,
+            'rse_id': rse_id,
         }
-    rse, _ = rse_factory.make_posix_rse()
-    return rse
 
-
+# Utility functions
 def check_url(pfn, hostname, path):
     assert hostname in pfn
     assert path in pfn
@@ -83,7 +81,8 @@ def poll_fts_transfer_status(request_id, timeout=30):
         transfer_status = re.search("Status: (.*)", out).group(1)
     return transfer_status
 
-
+# TPC tests
+@pytest.mark.integration_test_only
 def test_tpc(rse1, rse2, root_account, test_scope, did_factory, rse_client, rule_client, artifact):
     base_file_name = generate_uuid()
     test_file = did_factory.upload_test_file(rse1['rse_name'], name=base_file_name + '.000', return_full_item=True)

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -55,7 +55,7 @@ def check_url(pfn, hostname, path):
     assert path in pfn
 
 
-def list_fts_transfer(timeout=30, max_attempts=10):
+def list_fts_transfer(timeout=60, max_attempts=10):
     running_time = 0
     request_id = None
     request_status = None

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2021 CERN
+# Copyright 2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -79,6 +79,7 @@ def poll_fts_transfer_status(request_id, timeout=30):
     return transfer_status
 
 
+@pytest.mark.noparallel(reason="multiple submitters cannot be run in parallel due to partial job assignment by hash")
 @pytest.mark.dirty(reason="Creates artifact /tmp/test_tpc.artifact in dev_rucio_1 container")
 def test_tpc(containerized_rses, root_account, test_scope, did_factory, rse_client, rule_client, artifact):
     if len(containerized_rses) < 2:

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -106,10 +106,10 @@ def poll_fts_transfer_status(request_id, timeout=30):
 # TPC tests
 
 
-@pytest.mark.skipif(rse1 is None or rse2 is None, reason="TPC tests need at least 2 containerized xrd rse's for execution")
+@pytest.mark.dirty(reason="Creates artifact /tmp/test_tpc.artifact in dev_rucio_1 container")
 def test_tpc(rse1, rse2, root_account, test_scope, did_factory, rse_client, rule_client, artifact):
     if rse1 is None or rse2 is None:
-        pytest.skip("TPC tests need at least 2 containerized xrd rse's for execution. Found {rse1} {rse2}")
+        pytest.skip("TPC tests need at least 2 containerized rse's for execution}")
     base_file_name = generate_uuid()
     test_file = did_factory.upload_test_file(rse1['rse_name'], name=base_file_name + '.000', return_full_item=True)
     test_file_did_str = '%s:%s' % (test_file['did_scope'], test_file['did_name'])

--- a/lib/rucio/tests/test_upload.py
+++ b/lib/rucio/tests/test_upload.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 CERN
+# Copyright 2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # Authors:
-# - Mayank Sharma <mayank.sharma@cern.ch>, 2020-2021
+# - Mayank Sharma <mayank.sharma@cern.ch>, 2021
 
 import logging
 import pytest

--- a/lib/rucio/tests/test_upload.py
+++ b/lib/rucio/tests/test_upload.py
@@ -18,10 +18,8 @@
 import logging
 import pytest
 import os
-import shutil
 from rucio.client.downloadclient import DownloadClient
 from rucio.client.uploadclient import UploadClient
-from rucio.tests.common import file_generator
 from rucio.common.exception import NotAllFilesUploaded, NoFilesUploaded, InputValidationError
 from rucio.common.utils import generate_uuid
 from rucio.common.utils import adler32
@@ -57,8 +55,9 @@ def scope(vo, containerized_rses, test_scope, mock_scope):
         return str(mock_scope)
 
 
-def test_upload_single(rse, scope, upload_client, download_client):
-    local_file = file_generator()
+def test_upload_single(rse, scope, upload_client, download_client, file_factory):
+    local_file = file_factory.file_generator()
+    download_dir = file_factory.base_dir
     fn = os.path.basename(local_file)
 
     # upload a file
@@ -70,110 +69,100 @@ def test_upload_single(rse, scope, upload_client, download_client):
         'guid': generate_uuid()
     }])
     assert status == 0
-    try:
-        # download the file
-        did = f"{scope}:{fn}"
-        download_client.download_dids([{'did': did}])
 
-        # match checksums
-        downloaded_file = f"./{scope}/{fn}"
-        assert adler32(local_file) == adler32(downloaded_file)
+    # download the file
+    did = f"{scope}:{fn}"
+    download_client.download_dids([{'did': did, 'base_dir': download_dir}])
 
-    finally:
-        os.remove(local_file)
-        shutil.rmtree(scope)
+    # match checksums
+    downloaded_file = f"{download_dir}/{scope}/{fn}"
+    assert adler32(local_file) == adler32(downloaded_file)
 
 
-@pytest.mark.noparallel(reason="Fails when run in parallel")
-def test_upload_multi(rse, scope, upload_client, download_client):
-    local_file1 = file_generator()
-    local_file2 = file_generator()
+def test_upload_multi(rse, scope, upload_client, download_client, file_factory):
+    local_file1 = file_factory.file_generator(use_basedir=True)
+    local_file2 = file_factory.file_generator(use_basedir=True)
+    download_dir = file_factory.base_dir
+
     fn1 = os.path.basename(local_file1)
     fn2 = os.path.basename(local_file2)
-    try:
-        items = [
-            {
-                'path': local_file1,
-                'rse': rse,
-                'did_scope': scope,
-                'did_name': fn1,
-                'guid': generate_uuid()
-            },
-            {
-                'path': local_file2,
-                'rse': rse,
-                'did_scope': scope,
-                'did_name': fn2,
-                'guid': generate_uuid()
-            }
-        ]
 
-        status = upload_client.upload(items)
-        assert status == 0
-        # download the files
-        did1 = f"{scope}:{fn1}"
-        did2 = f"{scope}:{fn2}"
-        download_client.download_dids([{'did': did1}, {'did': did2}])
+    items = [
+        {
+            'path': local_file1,
+            'rse': rse,
+            'did_scope': scope,
+            'did_name': fn1,
+            'guid': generate_uuid()
+        },
+        {
+            'path': local_file2,
+            'rse': rse,
+            'did_scope': scope,
+            'did_name': fn2,
+            'guid': generate_uuid()
+        }
+    ]
 
-        # match checksums
-        downloaded_file1 = f"./{scope}/{fn1}"
-        assert adler32(local_file1) == adler32(downloaded_file1)
+    status = upload_client.upload(items)
+    assert status == 0
+    # download the files
+    did1 = f"{scope}:{fn1}"
+    did2 = f"{scope}:{fn2}"
+    download_client.download_dids([
+        {'did': did1, 'base_dir': download_dir},
+        {'did': did2, 'base_dir': download_dir}
+    ])
 
-        downloaded_file2 = f"./{scope}/{fn2}"
-        assert adler32(local_file2) == adler32(downloaded_file2)
+    # match checksums
+    downloaded_file1 = f"{download_dir}/{scope}/{fn1}"
+    assert adler32(local_file1) == adler32(downloaded_file1)
 
-    finally:
-        os.remove(local_file1)
-        os.remove(local_file2)
-        shutil.rmtree(scope)
+    downloaded_file2 = f"{download_dir}/{scope}/{fn2}"
+    assert adler32(local_file2) == adler32(downloaded_file2)
 
 
-def test_upload_file_already_exists_single(rse, scope, upload_client):
+def test_upload_file_already_exists_single(rse, scope, upload_client, file_factory):
     traces = []
-    local_file = file_generator()
-    try:
-        item = [
-            {
-                'path': local_file,
-                'rse': rse,
-                'did_scope': scope,
-            }
-        ]
-        # upload the file
-        upload_client.upload(item)
-        # re_upload the file
-        with pytest.raises(NoFilesUploaded):
-            upload_client.upload(item, traces_copy_out=traces)
-        assert len(traces) == 1 and traces[0]['stateReason'] == 'File already exists'
-    finally:
-        os.remove(local_file)
+    local_file = file_factory.file_generator()
+
+    item = [
+        {
+            'path': local_file,
+            'rse': rse,
+            'did_scope': scope,
+        }
+    ]
+    # upload the file
+    upload_client.upload(item)
+    # re_upload the file
+    with pytest.raises(NoFilesUploaded):
+        upload_client.upload(item, traces_copy_out=traces)
+    assert len(traces) == 1 and traces[0]['stateReason'] == 'File already exists'
 
 
-@pytest.mark.noparallel(reason="Fails when run in parallel")
-def test_upload_file_already_exists_multi(rse, scope, upload_client):
+def test_upload_file_already_exists_multi(rse, scope, upload_client, file_factory):
     traces = []
-    local_file = file_generator()
-    try:
-        items = [
-            {
-                'path': local_file,
-                'rse': rse,
-                'did_scope': scope,
-            },
-            {
-                'path': local_file,
-                'rse': rse,
-                'did_scope': scope,
-            }
-        ]
+    local_file = file_factory.file_generator()
 
-        # upload the file twice in the same upload command
-        with pytest.raises(NotAllFilesUploaded):
-            upload_client.upload(items, traces_copy_out=traces)
+    items = [
+        {
+            'path': local_file,
+            'rse': rse,
+            'did_scope': scope,
+        },
+        {
+            'path': local_file,
+            'rse': rse,
+            'did_scope': scope,
+        }
+    ]
 
-        assert len(traces) == 2 and traces[1]['stateReason'] == 'File already exists'
-    finally:
-        os.remove(local_file)
+    # upload the file twice in the same upload command
+    with pytest.raises(NotAllFilesUploaded):
+        upload_client.upload(items, traces_copy_out=traces)
+
+    assert len(traces) == 2 and traces[1]['stateReason'] == 'File already exists'
 
 
 def test_upload_source_not_found(rse, scope, upload_client):

--- a/lib/rucio/tests/test_upload.py
+++ b/lib/rucio/tests/test_upload.py
@@ -84,6 +84,7 @@ def test_upload_single(rse, scope, upload_client, download_client):
         shutil.rmtree(scope)
 
 
+@pytest.mark.noparallel(reason="Fails when run in parallel")
 def test_upload_multi(rse, scope, upload_client, download_client):
     local_file1 = file_generator()
     local_file2 = file_generator()
@@ -148,6 +149,7 @@ def test_upload_file_already_exists_single(rse, scope, upload_client):
         os.remove(local_file)
 
 
+@pytest.mark.noparallel(reason="Fails when run in parallel")
 def test_upload_file_already_exists_multi(rse, scope, upload_client):
     traces = []
     local_file = file_generator()

--- a/lib/rucio/tests/test_upload.py
+++ b/lib/rucio/tests/test_upload.py
@@ -1,0 +1,187 @@
+# Copyright 2018-2021 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Mayank Sharma <mayank.sharma@cern.ch>, 2020-2021
+
+import logging
+import pytest
+import os
+import shutil
+from rucio.client.downloadclient import DownloadClient
+from rucio.client.uploadclient import UploadClient
+from rucio.tests.common import file_generator
+from rucio.common.exception import NotAllFilesUploaded, NoFilesUploaded, InputValidationError
+from rucio.common.utils import generate_uuid
+from rucio.common.utils import adler32
+
+
+@pytest.fixture
+def upload_client():
+    logger = logging.getLogger('upload_client')
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.DEBUG)
+    return UploadClient(logger=logger)
+
+
+@pytest.fixture
+def download_client():
+    return DownloadClient()
+
+
+@pytest.fixture
+def rse(rse_factory):
+    xrd1 = rse_factory.fetch_containerized_rse('XRD1')
+    if xrd1 is not None:
+        return xrd1
+    rse, _ = rse_factory.make_posix_rse()
+    return rse
+
+
+@pytest.fixture
+def scope(vo, rse_factory, test_scope, mock_scope):
+    xrd1 = rse_factory.fetch_containerized_rse('XRD1')
+    if xrd1 is not None:
+        return str(test_scope)
+    else:
+        return str(mock_scope)
+
+
+def test_upload_single(rse, scope, upload_client, download_client):
+    local_file = file_generator()
+    fn = os.path.basename(local_file)
+
+    # upload a file
+    status = upload_client.upload([{
+        'path': local_file,
+        'rse': rse,
+        'did_scope': str(scope),
+        'did_name': fn,
+        'guid': generate_uuid()
+    }])
+    assert status == 0
+    try:
+        # download the file
+        did = f"{scope}:{fn}"
+        download_client.download_dids([{'did': did}])
+
+        # match checksums
+        downloaded_file = f"./{scope}/{fn}"
+        assert adler32(local_file) == adler32(downloaded_file)
+
+    finally:
+        os.remove(local_file)
+        shutil.rmtree(scope)
+
+
+def test_upload_multi(rse, scope, upload_client, download_client):
+    local_file1 = file_generator()
+    local_file2 = file_generator()
+    fn1 = os.path.basename(local_file1)
+    fn2 = os.path.basename(local_file2)
+    try:
+        items = [
+            {
+                'path': local_file1,
+                'rse': rse,
+                'did_scope': scope,
+                'did_name': fn1,
+                'guid': generate_uuid()
+            },
+            {
+                'path': local_file2,
+                'rse': rse,
+                'did_scope': scope,
+                'did_name': fn2,
+                'guid': generate_uuid()
+            }
+        ]
+
+        status = upload_client.upload(items)
+        assert status == 0
+        # download the files
+        did1 = f"{scope}:{fn1}"
+        did2 = f"{scope}:{fn2}"
+        download_client.download_dids([{'did': did1}, {'did': did2}])
+
+        # match checksums
+        downloaded_file1 = f"./{scope}/{fn1}"
+        assert adler32(local_file1) == adler32(downloaded_file1)
+
+        downloaded_file2 = f"./{scope}/{fn2}"
+        assert adler32(local_file2) == adler32(downloaded_file2)
+
+    finally:
+        os.remove(local_file1)
+        os.remove(local_file2)
+        shutil.rmtree(scope)
+
+
+def test_upload_file_already_exists_single(rse, scope, upload_client):
+    traces = []
+    local_file = file_generator()
+    try:
+        item = [
+            {
+                'path': local_file,
+                'rse': rse,
+                'did_scope': scope,
+            }
+        ]
+        # upload the file
+        upload_client.upload(item)
+        # re_upload the file
+        with pytest.raises(NoFilesUploaded):
+            upload_client.upload(item, traces_copy_out=traces)
+        assert len(traces) == 1 and traces[0]['stateReason'] == 'File already exists'
+    finally:
+        os.remove(local_file)
+
+
+def test_upload_file_already_exists_multi(rse, scope, upload_client):
+    traces = []
+    local_file = file_generator()
+    try:
+        items = [
+            {
+                'path': local_file,
+                'rse': rse,
+                'did_scope': scope,
+            },
+            {
+                'path': local_file,
+                'rse': rse,
+                'did_scope': scope,
+            }
+        ]
+
+        # upload the file twice in the same upload command
+        with pytest.raises(NotAllFilesUploaded):
+            upload_client.upload(items, traces_copy_out=traces)
+
+        assert len(traces) == 2 and traces[1]['stateReason'] == 'File already exists'
+    finally:
+        os.remove(local_file)
+
+
+def test_upload_source_not_found(rse, scope, upload_client):
+    items = [
+        {
+            'path': 'non_existant_local_file',
+            'rse': rse,
+            'did_scope': scope,
+        }
+    ]
+    with pytest.raises(InputValidationError):
+        upload_client.upload(items)

--- a/lib/rucio/tests/test_upload.py
+++ b/lib/rucio/tests/test_upload.py
@@ -41,19 +41,17 @@ def download_client():
 
 
 @pytest.fixture
-def rse(rse_factory):
-    xrd1, xrd1_id = rse_factory.fetch_containerized_rse('XRD1')
-    if xrd1 is not None:
-        return xrd1
+def rse(containerized_rses, rse_factory):
+    if len(containerized_rses) > 0:
+        rse, _ = containerized_rses[0]
     else:
         rse, _ = rse_factory.make_posix_rse()
-        return rse
+    return rse
 
 
 @pytest.fixture
-def scope(vo, rse_factory, test_scope, mock_scope):
-    xrd1, xrd1_id = rse_factory.fetch_containerized_rse('XRD1')
-    if xrd1 is not None:
+def scope(vo, containerized_rses, test_scope, mock_scope):
+    if len(containerized_rses) > 0:
         return str(test_scope)
     else:
         return str(mock_scope)

--- a/lib/rucio/tests/test_upload.py
+++ b/lib/rucio/tests/test_upload.py
@@ -42,16 +42,17 @@ def download_client():
 
 @pytest.fixture
 def rse(rse_factory):
-    xrd1 = rse_factory.fetch_containerized_rse('XRD1')
+    xrd1, xrd1_id = rse_factory.fetch_containerized_rse('XRD1')
     if xrd1 is not None:
         return xrd1
-    rse, _ = rse_factory.make_posix_rse()
-    return rse
+    else:
+        rse, _ = rse_factory.make_posix_rse()
+        return rse
 
 
 @pytest.fixture
 def scope(vo, rse_factory, test_scope, mock_scope):
-    xrd1 = rse_factory.fetch_containerized_rse('XRD1')
+    xrd1, xrd1_id = rse_factory.fetch_containerized_rse('XRD1')
     if xrd1 is not None:
         return str(test_scope)
     else:
@@ -66,7 +67,7 @@ def test_upload_single(rse, scope, upload_client, download_client):
     status = upload_client.upload([{
         'path': local_file,
         'rse': rse,
-        'did_scope': str(scope),
+        'did_scope': scope,
         'did_name': fn,
         'guid': generate_uuid()
     }])

--- a/lib/rucio/tests/test_upload.py
+++ b/lib/rucio/tests/test_upload.py
@@ -16,13 +16,12 @@
 # Authors:
 # - Mayank Sharma <mayank.sharma@cern.ch>, 2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
-from rucio.core.rse import add_protocol, add_rse_attribute
-from rucio.tests.common import file_generator
 import json
 import logging
 import pytest
 import os
 from rucio.client.downloadclient import DownloadClient
+from rucio.core.rse import add_protocol, add_rse_attribute
 from rucio.client.uploadclient import UploadClient
 from rucio.common.exception import NotAllFilesUploaded, NoFilesUploaded, InputValidationError
 from rucio.common.utils import generate_uuid


### PR DESCRIPTION

----- Comments below have been Addressed ---- 
1. The TPC workflow uses fts-rest-cli to validate the functions performed by rucio-daemons.
For the fts-rest-cli to work correctly inside the rucio-dev container, we still need the following PR to be merged:
https://github.com/rucio/containers/pull/129

2. Remaining task: The TPC workflow needs to create an artefact for the fts_transfer's request-id (fts job id). The job-id will be used to validate that the transfer was actually TPC. This validation will be done by checking the fts transfer logs in the fts container. To realize this feature, I'll add a new GH Action workflow for TPC that shares and cleans up the artefacts. Converting this PR to a draft.