### PR TITLE
rse/protocols: fixed a missing line necessary to implement the xenon filesystem

### DIFF
--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -228,6 +228,7 @@ class RSEDeterministicTranslation(object):
         cls.register(cls.__identity, "identity")
         cls.register(cls.__ligo, "ligo")
         cls.register(cls.__belleii, "belleii")
+        cls.register(cls.__xenon, "xenon")
         policy_module = None
         try:
             policy_module = config.config_get('policy', 'lfn2pfn_module')


### PR DESCRIPTION
A missing line prevented the new __xenon protocol to work. This patch fixes this issue