### PR TITLE
Testing: rework test_replica

### DIFF
--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -117,7 +117,7 @@ class TemporaryRSEFactory:
         if scheme and protocol_impl:
             rse_core.add_protocol(rse_id=rse_id, parameter={
                 'scheme': scheme,
-                'hostname': 'host%d' % len(self.created_rses),
+                'hostname': '%s.cern.ch' % rse_id,
                 'port': 0,
                 'prefix': '/test/',
                 'impl': protocol_impl,


### PR DESCRIPTION
Stop using the predefined RSEs in most tests. Remove the noparallel
and the dirty flag whenever possible. Change the 'reason' of the flag
to the correct reason when the test cannot be done in parallel.

Fixes to particular tests:
- completely rework test_delete_replicas: the content of the test
didn't correspond to its name.

- fix test_update_replicas_paths: It wasn't actually testing anything
because it tried to update a path to the _same_ path and than checked
if the "new" path was correct.

- rework bad_replicas_for_ui. This test cannot work because it mixes
calls to list bad replicas with and without 'list_pfns' set.
When it set to true, list_replicas is performed on bad replicas,
which does additional filtering. Mixing this parameter as true
and as false in the same test doesn't work as expected.
In particular, because list_replicas ignores deleted rses.

make protocol hostnames uniques in rse_factory:
- Otherwise multiple factories instantiated in parallel will re-use
the same hostnames. Retrieving the rses by pfn can fail with
'ERROR, multiple matches'.

Also some cosmetic refactoring: move code, reword local variables
to be consistent with other functions.