### PR TITLE
Testing: Re-activate integration tests. #2311

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -74,6 +74,8 @@ jobs:
           docker exec -t dev_rucio_1 tools/run_tests_docker.sh -ir
       - name: File Upload/Download Test
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_rucio_server.py
+      - name: Archive Upload/Download Test
+        run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_download.py::test_download_from_archive_on_xrd
       - name: Test Protocol XrootD
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short test_rse_protocol_xrootd.py
       - name: Stop containers

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2020 CERN
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,9 +24,11 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
+import json
 import contextlib
 import itertools
 import os
@@ -38,8 +40,10 @@ import pytest
 from six import PY3
 
 from rucio.common.utils import generate_uuid as uuid, execute
+from rucio.common.config import get_config_dirs
 
-skip_rse_tests_with_accounts = pytest.mark.skipif(not os.path.exists('etc/rse-accounts.cfg'), reason='fails if no rse-accounts.cfg found')
+skip_rse_tests_with_accounts = pytest.mark.skipif(not any(os.path.exists(os.path.join(d, 'rse-accounts.cfg')) for d in get_config_dirs()),
+                                                  reason='fails if no rse-accounts.cfg found')
 skiplimitedsql = pytest.mark.skipif('RDBMS' in os.environ and (os.environ['RDBMS'] == 'sqlite' or os.environ['RDBMS'] == 'mysql5'),
                                     reason="does not work in SQLite or MySQL 5, because of missing features")
 
@@ -164,3 +168,9 @@ class Mime:
     JSON = 'application/json'
     JSON_STREAM = 'application/x-json-stream'
     BINARY = 'application/octet-stream'
+
+
+def load_test_conf_file(file_name):
+    config_dir = next(filter(lambda d: os.path.exists(os.path.join(d, file_name)), get_config_dirs()))
+    with open(os.path.join(config_dir, file_name)) as f:
+        return json.load(f)

--- a/lib/rucio/tests/rsemgr_api_test.py
+++ b/lib/rucio/tests/rsemgr_api_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,17 +22,18 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Mayank Sharma <mayank.sharma@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
-import json
 import os
 import os.path
 import tempfile
 
 from rucio.common.utils import adler32
 from rucio.rse import rsemanager as mgr
-from rucio.tests.common import skip_rse_tests_with_accounts
+from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 
 try:
     from exceptions import NotImplementedError
@@ -55,8 +56,7 @@ class MgrTestCases:
     def __init__(self, tmpdir, rse_tag, user, static_file, vo='def'):
         self.rse_settings = mgr.get_rse_info(rse=rse_tag, vo=vo)
         try:
-            with open('etc/rse-accounts.cfg') as f:
-                data = json.load(f)
+            data = load_test_conf_file('rse-accounts.cfg')
             self.rse_settings['credentials'] = data[rse_tag]
         except KeyError:
             print('No credentials found for this RSE.')

--- a/lib/rucio/tests/test_download.py
+++ b/lib/rucio/tests/test_download.py
@@ -37,6 +37,7 @@ from rucio.common.utils import generate_uuid
 from rucio.core import did as did_core
 from rucio.rse import rsemanager as rsemgr
 from rucio.rse.protocols.posix import Default as PosixProtocol
+from rucio.tests.common import skip_rse_tests_with_accounts
 
 
 @pytest.fixture
@@ -220,9 +221,9 @@ def test_download_multiple(rse_factory, did_factory, download_client):
         )
 
 
-@pytest.mark.xfail(reason='XRD1 must be initialized https://github.com/rucio/rucio/pull/4165/')
 @pytest.mark.dirty
 @pytest.mark.noparallel(reason='uses pre-defined XRD1 RSE, may fails when run in parallel')  # TODO: verify if it really fails
+@skip_rse_tests_with_accounts
 def test_download_from_archive_on_xrd(did_factory, download_client, did_client):
     scope = 'test'
     rse = 'XRD1'

--- a/lib/rucio/tests/test_rse_protocol_gfal2.py
+++ b/lib/rucio/tests/test_rse_protocol_gfal2.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2014-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 # - Wen Guan <wen.guan@cern.ch>, 2014
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2015
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
-import json
 import os
 import shutil
 import tempfile
@@ -30,7 +30,7 @@ import pytest
 from rucio.common import exception
 from rucio.common.utils import execute
 from rucio.rse import rsemanager as mgr
-from rucio.tests.common import skip_rse_tests_with_accounts
+from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 from rucio.tests.rsemgr_api_test import MgrTestCases
 
 
@@ -52,8 +52,7 @@ class TestRseGFAL2(unittest.TestCase):
         for f in MgrTestCases.files_local:
             shutil.copy('%s/data.raw' % cls.tmpdir, '%s/%s' % (cls.tmpdir, f))
 
-        with open('etc/rse_repository.json') as f:
-            data = json.load(f)
+        data = load_test_conf_file('rse_repository.json')
         prefix = data['FZK-LCG2_SCRATCHDISK']['protocols']['supported']['srm']['prefix']
         hostname = data['FZK-LCG2_SCRATCHDISK']['protocols']['supported']['srm']['hostname']
         if hostname.count("://"):
@@ -90,8 +89,7 @@ class TestRseGFAL2(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """GFAL2 (RSE/PROTOCOLS): Removing created directorie s and files"""
-        with open('etc/rse_repository.json') as f:
-            data = json.load(f)
+        data = load_test_conf_file('rse_repository.json')
         prefix = data['FZK-LCG2_SCRATCHDISK']['protocols']['supported']['srm']['prefix']
         hostname = data['FZK-LCG2_SCRATCHDISK']['protocols']['supported']['srm']['hostname']
         if hostname.count("://"):

--- a/lib/rucio/tests/test_rse_protocol_posix.py
+++ b/lib/rucio/tests/test_rse_protocol_posix.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2017
 # - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
-import json
 import os
 import shutil
 import tempfile
@@ -33,7 +33,7 @@ import pytest
 
 from rucio.common import exception
 from rucio.rse import rsemanager as mgr
-from rucio.tests.common import skip_rse_tests_with_accounts
+from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 from rucio.tests.rsemgr_api_test import MgrTestCases
 
 
@@ -59,8 +59,7 @@ class TestRsePOSIX(unittest.TestCase):
         for f in MgrTestCases.files_local:
             shutil.copy('%s/data.raw' % cls.tmpdir, '%s/%s' % (cls.tmpdir, f))
 
-        with open('etc/rse_repository.json') as f:
-            data = json.load(f)
+        data = load_test_conf_file('rse_repository.json')
         prefix = data['MOCK-POSIX']['protocols']['supported']['file']['prefix']
         try:
             os.mkdir(prefix)
@@ -80,8 +79,7 @@ class TestRsePOSIX(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """POSIX (RSE/PROTOCOLS): Removing created directorie s and files """
-        with open('etc/rse_repository.json') as f:
-            data = json.load(f)
+        data = load_test_conf_file('rse_repository.json')
         prefix = data['MOCK-POSIX']['protocols']['supported']['file']['prefix']
         shutil.rmtree(prefix)
         shutil.rmtree(cls.tmpdir)

--- a/lib/rucio/tests/test_rse_protocol_s3boto.py
+++ b/lib/rucio/tests/test_rse_protocol_s3boto.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2014-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,12 +19,10 @@
 # - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
-import json
 import os
 import tempfile
 import unittest
@@ -37,7 +35,7 @@ from boto.s3.key import Key
 
 from rucio.common import exception
 from rucio.rse import rsemanager as mgr
-from rucio.tests.common import skip_rse_tests_with_accounts
+from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 from rucio.tests.rsemgr_api_test import MgrTestCases
 
 try:
@@ -92,8 +90,7 @@ class TestRseS3(unittest.TestCase):
         rse_tag = 'BNL-BOTO'
         rse_settings = mgr.get_rse_info(rse_tag)
         try:
-            with open('etc/rse-accounts.cfg') as f:
-                data = json.load(f)
+            data = load_test_conf_file('rse-accounts.cfg')
             rse_settings['credentials'] = data[rse_tag]
         except KeyError:
             print('No credentials found for this RSE.')
@@ -131,8 +128,7 @@ class TestRseS3(unittest.TestCase):
         rse_tag = 'BNL-BOTO'
         rse_settings = mgr.get_rse_info(rse_tag)
         try:
-            with open('etc/rse-accounts.cfg') as f:
-                data = json.load(f)
+            data = load_test_conf_file('rse-accounts.cfg')
             rse_settings['credentials'] = data[rse_tag]
         except KeyError:
             print('No credentials found for this RSE.')

--- a/lib/rucio/tests/test_rse_protocol_sftp.py
+++ b/lib/rucio/tests/test_rse_protocol_sftp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012
 # - Martin Barisits <martin.barisits@cern.ch>, 2017
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
-import json
 import os
 import shutil
 import tempfile
@@ -33,7 +33,7 @@ import pytest
 
 from rucio.common import exception
 from rucio.rse import rsemanager as mgr
-from rucio.tests.common import skip_rse_tests_with_accounts
+from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 from rucio.tests.rsemgr_api_test import MgrTestCases
 
 
@@ -56,12 +56,10 @@ class TestRseSFTP(unittest.TestCase):
             os.symlink('%s/data.raw' % cls.tmpdir, '%s/%s' % (cls.tmpdir, fil))
 
         # Load local credentials from file
-        with open('etc/rse-accounts.cfg') as fil:
-            data = json.load(fil)
+        data = load_test_conf_file('rse-accounts.cfg')
         credentials = data['LXPLUS']
         lxplus = pysftp.Connection(**credentials)
-        with open('etc/rse_repository.json') as fil:
-            prefix = json.load(fil)['LXPLUS']['protocols']['supported']['sftp']['prefix']
+        prefix = load_test_conf_file('rse_repository.json')['LXPLUS']['protocols']['supported']['sftp']['prefix']
         lxplus.execute('mkdir %s' % prefix)
         lxplus.execute('dd if=/dev/urandom of=%s/data.raw bs=1024 count=1024' % prefix)
         cls.static_file = 'sftp://lxplus.cern.ch:22%sdata.raw' % prefix
@@ -77,12 +75,10 @@ class TestRseSFTP(unittest.TestCase):
         """SFTP (RSE/PROTOCOLS): Removing created directorie s and files """
         # Load local creditentials from file
         credentials = {}
-        with open('etc/rse-accounts.cfg') as fil:
-            data = json.load(fil)
+        data = load_test_conf_file('rse-accounts.cfg')
         credentials = data['LXPLUS']
         lxplus = pysftp.Connection(**credentials)
-        with open('etc/rse_repository.json') as fil:
-            prefix = json.load(fil)['LXPLUS']['protocols']['supported']['sftp']['prefix']
+        prefix = load_test_conf_file('rse_repository.json')['LXPLUS']['protocols']['supported']['sftp']['prefix']
         lxplus.execute('rm -rf %s' % prefix)
         lxplus.close()
         shutil.rmtree(cls.tmpdir)

--- a/lib/rucio/tests/test_rse_protocol_srm.py
+++ b/lib/rucio/tests/test_rse_protocol_srm.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2014-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 # - Wen Guan <wen.guan@cern.ch>, 2014
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2014
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
-import json
 import os
 import shutil
 import tempfile
@@ -30,7 +30,7 @@ import pytest
 from rucio.common import exception
 from rucio.common.utils import execute
 from rucio.rse import rsemanager as mgr
-from rucio.tests.common import skip_rse_tests_with_accounts
+from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 from rucio.tests.rsemgr_api_test import MgrTestCases
 
 
@@ -52,8 +52,7 @@ class TestRseSRM(unittest.TestCase):
         for f in MgrTestCases.files_local:
             shutil.copy('%s/data.raw' % cls.tmpdir, '%s/%s' % (cls.tmpdir, f))
 
-        with open('etc/rse_repository.json') as f:
-            data = json.load(f)
+        data = load_test_conf_file('rse_repository.json')
         prefix = data['FZK-LCG2_SCRATCHDISK']['protocols']['supported']['srm']['prefix']
         hostname = data['FZK-LCG2_SCRATCHDISK']['protocols']['supported']['srm']['hostname']
         if hostname.count("://"):
@@ -83,8 +82,7 @@ class TestRseSRM(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """SRM (RSE/PROTOCOLS): Removing created directorie s and files"""
-        with open('etc/rse_repository.json') as f:
-            data = json.load(f)
+        data = load_test_conf_file('rse_repository.json')
         prefix = data['FZK-LCG2_SCRATCHDISK']['protocols']['supported']['srm']['prefix']
         hostname = data['FZK-LCG2_SCRATCHDISK']['protocols']['supported']['srm']['hostname']
         if hostname.count("://"):

--- a/lib/rucio/tests/test_rse_protocol_webdav.py
+++ b/lib/rucio/tests/test_rse_protocol_webdav.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2017
 # - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
-import json
 import os
 import tempfile
 import unittest
@@ -34,7 +34,7 @@ import requests
 from rucio.common import exception
 from rucio.common.exception import FileReplicaAlreadyExists
 from rucio.rse import rsemanager
-from rucio.tests.common import skip_rse_tests_with_accounts
+from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 from rucio.tests.rsemgr_api_test import MgrTestCases
 
 
@@ -59,8 +59,7 @@ class TestRseWebDAV(unittest.TestCase):
         # Creating local files
         cls.tmpdir = tempfile.mkdtemp()
         cls.user = 'jdoe'
-        with open('etc/rse_repository.json') as f:
-            data = json.load(f)
+        data = load_test_conf_file('rse_repository.json')
         scheme = data[cls.site]['protocols']['supported']['https']['scheme']
         prefix = data[cls.site]['protocols']['supported']['https']['prefix']
         hostname = data[cls.site]['protocols']['supported']['https']['hostname']
@@ -91,8 +90,7 @@ class TestRseWebDAV(unittest.TestCase):
     def tearDownClass(cls):
         """WebDAV (RSE/PROTOCOLS): Removing created directories and files """
         rse_settings = rsemanager.get_rse_info(cls.site)
-        with open('etc/rse_repository.json') as f:
-            data = json.load(f)
+        data = load_test_conf_file('rse_repository.json')
         scheme = data[cls.site]['protocols']['supported']['https']['scheme']
         prefix = data[cls.site]['protocols']['supported']['https']['prefix']
         hostname = data[cls.site]['protocols']['supported']['https']['hostname']

--- a/lib/rucio/tests/test_rse_protocol_xrootd.py
+++ b/lib/rucio/tests/test_rse_protocol_xrootd.py
@@ -40,6 +40,7 @@ from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 from rucio.tests.rsemgr_api_test import MgrTestCases
 
 
+@pytest.mark.noparallel(reason='creates and removes a test directory with a fixed name')
 @skip_rse_tests_with_accounts
 class TestRseXROOTD(unittest.TestCase):
     tmpdir = None

--- a/lib/rucio/tests/test_rse_protocol_xrootd.py
+++ b/lib/rucio/tests/test_rse_protocol_xrootd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2013-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,10 +20,11 @@
 # - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2018
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Mayank Sharma <mayank.sharma@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import print_function
 
-import json
 import os
 import shutil
 import tempfile
@@ -35,7 +36,7 @@ import pytest
 from rucio.common import exception
 from rucio.common.utils import execute
 from rucio.rse import rsemanager
-from rucio.tests.common import skip_rse_tests_with_accounts
+from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 from rucio.tests.rsemgr_api_test import MgrTestCases
 
 
@@ -56,8 +57,7 @@ class TestRseXROOTD(unittest.TestCase):
         print(out, err)
         rses = out.split()
 
-        with open('etc/rse_repository.json') as f:
-            data = json.load(f)
+        data = load_test_conf_file('rse_repository.json')
         prefix = data['WJ-XROOTD']['protocols']['supported']['xroot']['prefix']
         port = data['WJ-XROOTD']['protocols']['supported']['xroot']['port']
 


### PR DESCRIPTION
This PR was already submitted once (#4370). The previous PR got automatically closed because I removed by error the branch from my fork repository. However, the PR is still relevant.

All integration tests got silently disabled by some previous commit because they are skipped if a particular file doesn't exist. Due to 
a change in the current directory from which pytest is called, the relative path isn't correctly constructed anymore and the integration tests are skipped. 