### PR TITLE
Core & Internals: Replace isAlive with is_alive; Fix #4585

### DIFF
--- a/lib/rucio/daemons/atropos/atropos.py
+++ b/lib/rucio/daemons/atropos/atropos.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2020 CERN
+# Copyright 2016-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 import datetime
 import logging
@@ -226,7 +226,7 @@ def run(threads=1, bulk=100, date_check=None, dry_run=True, grace_period=86400,
 
     # Interruptible joins require a timeout.
     while thread_list:
-        thread_list = [t.join(timeout=3.14) for t in thread_list if t and t.isAlive()]
+        thread_list = [t.join(timeout=3.14) for t in thread_list if t and t.is_alive()]
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/badreplicas/minos.py
+++ b/lib/rucio/daemons/badreplicas/minos.py
@@ -15,13 +15,13 @@
 #
 # Authors:
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2018-2019
-# - Martin Barisits <martin.barisits@cern.ch>, 2018-2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2018-2021
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2021
 
 from __future__ import division
@@ -276,7 +276,7 @@ def run(threads=1, bulk=100, once=False, sleep_time=60):
         logging.info('waiting for interrupts')
         # Interruptible joins require a timeout.
         while thread_list:
-            thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.isAlive()]
+            thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.is_alive()]
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
+++ b/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 CERN
+# Copyright 2018-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 from __future__ import division
 
@@ -178,7 +178,7 @@ def run(threads=1, bulk=100, once=False, sleep_time=60):
         logging.info('Waiting for interrupts')
         # Interruptible joins require a timeout.
         while thread_list:
-            thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.isAlive()]
+            thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.is_alive()]
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/badreplicas/necromancer.py
+++ b/lib/rucio/daemons/badreplicas/necromancer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 CERN
+# Copyright 2014-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 from __future__ import division
 
@@ -163,7 +163,7 @@ def run(threads=1, bulk=100, once=False):
 
         # Interruptible joins require a timeout.
         while thread_list:
-            thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.isAlive()]
+            thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.is_alive()]
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/c3po/c3po.py
+++ b/lib/rucio/daemons/c3po/c3po.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2020 CERN
+# Copyright 2015-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 '''
 Dynamic data placement daemon.
@@ -327,6 +327,6 @@ def run(once=False,
         logging.info('waiting for interrupts')
 
         while len(thread_list) > 0:
-            [t.join(timeout=3) for t in thread_list if t and t.isAlive()]
+            [t.join(timeout=3) for t in thread_list if t and t.is_alive()]
     except Exception as error:
         logging.critical(error)

--- a/lib/rucio/daemons/cache/consumer.py
+++ b/lib/rucio/daemons/cache/consumer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2020 CERN
+# Copyright 2014-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 # - Robert Illingworth <illingwo@fnal.gov>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
 
 """
@@ -185,5 +185,5 @@ def run(num_thread=1):
     logging.info('waiting for interrupts')
 
     # Interruptible joins require a timeout.
-    while threads[0].isAlive():
+    while threads[0].is_alive():
         [t.join(timeout=3.14) for t in threads]

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2020 CERN
+# Copyright 2015-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,8 +25,9 @@
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Matt Snyder <msnyder@bnl.gov>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Conveyor finisher is a daemon to update replicas and rules based on requests.
@@ -205,7 +206,7 @@ def run(once=False, total_threads=1, sleep_time=60, activities=None, bulk=100, d
 
         # Interruptible joins require a timeout.
         while threads:
-            threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.isAlive()]
+            threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.is_alive()]
 
 
 def __handle_requests(reqs, suspicious_patterns, retry_protocol_mismatches, logger=logging.log):

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -24,7 +24,8 @@
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Nick Smith <nick.smith@cern.ch>, 2020
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Conveyor is a daemon to manage file transfers.
@@ -227,7 +228,7 @@ def run(once=False, sleep_time=60, activities=None,
 
         # Interruptible joins require a timeout.
         while threads:
-            threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.isAlive()]
+            threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.is_alive()]
 
 
 def poll_transfers(external_host, xfers, request_ids=None, timeout=None, logger=logging.log):

--- a/lib/rucio/daemons/conveyor/poller_latest.py
+++ b/lib/rucio/daemons/conveyor/poller_latest.py
@@ -19,8 +19,9 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2016-2017
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2018
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2021
+# - Sahan Dilshan <32576163+sahandilshan@users.noreply.github.com>, 2021
 
 """
 Conveyor is a daemon to manage file transfers.
@@ -158,4 +159,4 @@ def run(once=False, last_nhours=1, external_hosts=None, fts_wait=1800, total_thr
 
         # Interruptible joins require a timeout.
         while threads:
-            threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.isAlive()]
+            threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.is_alive()]

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2020 CERN
+# Copyright 2015-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@
 # Authors:
 # - Wen Guan <wen.guan@cern.ch>, 2015-2016
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2015-2021
-# - Martin Barisits <martin.barisits@cern.ch>, 2015-2018
+# - Martin Barisits <martin.barisits@cern.ch>, 2015-2021
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2015-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2018
 # - Robert Illingworth <illingwo@fnal.gov>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Sahan Dilshan <32576163+sahandilshan@users.noreply.github.com>, 2021
 
 """
 Conveyor is a daemon to manage file transfers.
@@ -301,4 +302,4 @@ def run(once=False, total_threads=1, full_mode=False):
 
     # Interruptible joins require a timeout.
     while threads:
-        threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.isAlive()]
+        threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.is_alive()]

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2020 CERN
+# Copyright 2015-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 """
 Conveyor stager is a daemon to manage stagein file transfers.
@@ -242,7 +242,7 @@ def run(once=False, total_threads=1, group_bulk=1, group_policy='rule', mock=Fal
 
         # Interruptible joins require a timeout.
         while threads:
-            threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.isAlive()]
+            threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.is_alive()]
 
 
 def __get_stagein_transfers(total_workers=0, worker_number=0, failover_schemes=None, limit=None, activity=None, older_than=None,

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -30,7 +30,7 @@
 # - Nick Smith <nick.smith@cern.ch>, 2020
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
@@ -313,7 +313,7 @@ def run(once=False, group_bulk=1, group_policy='rule', mock=False,
 
     # Interruptible joins require a timeout.
     while threads:
-        threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.isAlive()]
+        threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.is_alive()]
 
 
 def __get_transfers(total_workers=0, worker_number=0, failover_schemes=None, limit=None, activity=None, older_than=None,

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -137,7 +137,7 @@ def run(once=False, sleep_time=600):
 
         # Interruptible joins require a timeout.
         while threads:
-            threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.isAlive()]
+            threads = [thread.join(timeout=3.14) for thread in threads if thread and thread.is_alive()]
 
 
 def __get_request_stats(all_activities=False, direction='destination'):

--- a/lib/rucio/daemons/hermes/hermes.py
+++ b/lib/rucio/daemons/hermes/hermes.py
@@ -18,11 +18,11 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2014-2021
 # - Wen Guan <wen.guan@cern.ch>, 2014-2015
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2015-2018
-# - Martin Barisits <martin.barisits@cern.ch>, 2016-2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2016-2021
 # - Robert Illingworth <illingwo@fnal.gov>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
 # - Eric Vaandering <ewv@fnal.gov>, 2019-2021
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 '''
    Hermes is a daemon to deliver messages: to a messagebroker via STOMP, or emails via SMTP.
@@ -449,4 +449,4 @@ def run(once=False, send_email=True, threads=1, bulk=1000, delay=10, broker_time
 
         # Interruptible joins require a timeout.
         while thread_list:
-            thread_list = [t.join(timeout=3.14) for t in thread_list if t and t.isAlive()]
+            thread_list = [t.join(timeout=3.14) for t in thread_list if t and t.is_alive()]

--- a/lib/rucio/daemons/hermes/hermes2.py
+++ b/lib/rucio/daemons/hermes/hermes2.py
@@ -15,10 +15,12 @@
 #
 # Authors:
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2020-2021
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020-2021
-# - Eric Vaandering <ewv@fnal.gov>, 2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
+# - Eric Vaandering <ewv@fnal.gov>, 2021
+# - Martin Barisits <martin.barisits@cern.ch>, 2021
+# - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
 
 '''
    Hermes2 is a daemon that get the messages and sends them to external services (influxDB, ES, ActiveMQ).
@@ -579,4 +581,4 @@ def run(once=False, threads=1, bulk=1000, sleep_time=10, broker_timeout=3):
     logging.debug(thread_list)
     # Interruptible joins require a timeout.
     while thread_list:
-        thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.isAlive()]
+        thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.is_alive()]

--- a/lib/rucio/daemons/reaper/reaper2.py
+++ b/lib/rucio/daemons/reaper/reaper2.py
@@ -15,7 +15,7 @@
 #
 # Authors:
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2016-2018
-# - Martin Barisits <martin.barisits@cern.ch>, 2016-2020
+# - Martin Barisits <martin.barisits@cern.ch>, 2016-2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2016-2021
 # - Wen Guan <wguan.icedew@gmail.com>, 2016
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
@@ -26,8 +26,9 @@
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 '''
 Reaper is a daemon to manage file deletion.
@@ -687,4 +688,4 @@ def run(threads=1, chunk_size=100, once=False, greedy=False, rses=None, scheme=N
 
     # Interruptible joins require a timeout.
     while threads_list:
-        threads_list = [thread.join(timeout=3.14) for thread in threads_list if thread and thread.isAlive()]
+        threads_list = [thread.join(timeout=3.14) for thread in threads_list if thread and thread.is_alive()]

--- a/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
+++ b/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 CERN
+# Copyright 2018-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
 
 """
@@ -262,7 +262,7 @@ def run(once=False, younger_than=3, nattempts=10, rse_expression='MOCK', vos=Non
         logging.info('waiting for interrupts')
 
         # Interruptible joins require a timeout.
-        while t.isAlive():
+        while t.is_alive():
             t.join(timeout=3.14)
 
 

--- a/lib/rucio/daemons/sonar/distribution/distribution_daemon.py
+++ b/lib/rucio/daemons/sonar/distribution/distribution_daemon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2020 CERN
+# Copyright 2017-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 # - Vincent Garonne <vgaronne@gmail.com>, 2017-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Eric Vaandering <ewv@fnal.gov>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
 
 """
@@ -137,7 +137,7 @@ def run():
 
     thread = threading.Thread(target=run_distribution, kwargs={})
     thread.start()
-    while thread and thread.isAlive():
+    while thread and thread.is_alive():
         thread.join(timeout=3.14)
 
 

--- a/lib/rucio/daemons/tracer/kronos.py
+++ b/lib/rucio/daemons/tracer/kronos.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2020 CERN
+# Copyright 2014-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 """
 This daemon consumes tracer messages from ActiveMQ and updates the atime for replicas.
@@ -567,4 +567,4 @@ def run(threads=1, sleep_time_datasets=60, sleep_time_files=60):
     logging.info('waiting for interrupts')
 
     while len(thread_list) > 0:
-        thread_list = [thread.join(timeout=3) for thread in thread_list if thread and thread.isAlive()]
+        thread_list = [thread.join(timeout=3) for thread in thread_list if thread and thread.is_alive()]

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -23,7 +23,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Eric Vaandering <ewv@fnal.gov>, 2020
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
@@ -485,7 +485,7 @@ def run(threads=1, bulk=100, once=False, sleep_time=60):
         logging.info('waiting for interrupts')
         # Interruptible joins require a timeout.
         while thread_list:
-            thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.isAlive()]
+            thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.is_alive()]
 
 
 def stop(signum=None, frame=None):


### PR DESCRIPTION
`Thread.isAlive` has been deprecated in Python 3.8 and removed in Python 3.9 in favor of using `Thread.is_alive` (which is available since Python 2.6[ ¹ ]).

[ ¹ ]: https://docs.python.org/2.7/library/threading.html?highlight=thread%20is_alive#threading.Thread.is_alive