### PR TITLE
Core: Change prerequisites for move_rule() #4222

### DIFF
--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -1493,8 +1493,8 @@ def move_rule(rule_id, rse_expression, session=None):
     try:
         rule = session.query(models.ReplicationRule).filter_by(id=rule_id).one()
 
-        if rule.state != RuleState.OK:
-            raise RuleReplaceFailed('The source rule must be in state OK.')
+        if rule.child_rule_id:
+            raise RuleReplaceFailed('The rule must not have a child rule.')
 
         grouping = {RuleGrouping.ALL: 'ALL', RuleGrouping.NONE: 'NONE'}.get(rule.grouping, 'DATASET')
 

--- a/lib/rucio/tests/test_rule.py
+++ b/lib/rucio/tests/test_rule.py
@@ -909,6 +909,8 @@ class TestReplicationRuleCore(unittest.TestCase):
         assert(get_rule(rule_id2)['state'] == RuleState.REPLICATING)
         assert(get_rule(rule_id)['child_rule_id'] == rule_id2)
 
+        pytest.raises(RuleReplaceFailed, move_rule, rule_id, self.rse4)
+
     def test_add_rule_with_scratchdisk(self):
         """ REPLICATION RULE (CORE): Add a replication rule for scratchdisk"""
         if get_policy() != 'atlas':


### PR DESCRIPTION
> There does not seem to be a legitimate reason for restricting this
> operation to rules in OK state. Instead, it is important that there is
> no child rule, otherwise the relation would be silently overridden.

I have been using this patch already to aid RSE decommissioning.