### PR TITLE
Core & Internals: rework tombstone handling. Closes #4491, #4436 and #4188

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1988,7 +1988,7 @@ def list_and_mark_unlocked_replicas(limit, bytes=None, rse_id=None, delay_second
     for chunk in chunks(replica_clause, 100):
         session.query(models.RSEFileAssociation).filter(or_(*chunk)).\
             with_hint(models.RSEFileAssociation, text="INDEX(REPLICAS REPLICAS_PK)", dialect_name='oracle').\
-            update({'updated_at': datetime.utcnow(), 'state': ReplicaState.BEING_DELETED, 'tombstone': datetime(1970, 1, 1)}, synchronize_session=False)
+            update({'updated_at': datetime.utcnow(), 'state': ReplicaState.BEING_DELETED, 'tombstone': OBSOLETE}, synchronize_session=False)
 
     return rows
 

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1899,55 +1899,6 @@ def get_replica(rse_id, scope, name, session=None):
         raise exception.ReplicaNotFound("No row found for scope: %s name: %s rse: %s" % (scope, name, get_rse_name(rse_id=rse_id, session=session)))
 
 
-@read_session
-def list_unlocked_replicas(rse_id, limit, bytes=None, worker_number=None, total_workers=None, delay_seconds=0, session=None):
-    """
-    List RSE File replicas with no locks.
-
-    :param rse_id: the rse id.
-    :param bytes: the amount of needed bytes.
-    :param session: The database session in use.
-
-    :returns: a list of dictionary replica.
-    """
-
-    # filter(models.RSEFileAssociation.state != ReplicaState.BEING_DELETED).\
-    none_value = None  # Hack to get pep8 happy...
-    query = session.query(models.RSEFileAssociation.scope, models.RSEFileAssociation.name, models.RSEFileAssociation.path, models.RSEFileAssociation.bytes, models.RSEFileAssociation.tombstone, models.RSEFileAssociation.state).\
-        with_hint(models.RSEFileAssociation, "INDEX_RS_ASC(replicas REPLICAS_TOMBSTONE_IDX)  NO_INDEX_FFS(replicas REPLICAS_TOMBSTONE_IDX)", 'oracle').\
-        filter(models.RSEFileAssociation.tombstone < datetime.utcnow()).\
-        filter(models.RSEFileAssociation.lock_cnt == 0).\
-        filter(case([(models.RSEFileAssociation.tombstone != none_value, models.RSEFileAssociation.rse_id), ]) == rse_id).\
-        filter(or_(models.RSEFileAssociation.state.in_((ReplicaState.AVAILABLE, ReplicaState.UNAVAILABLE, ReplicaState.BAD)),
-                   and_(models.RSEFileAssociation.state == ReplicaState.BEING_DELETED, models.RSEFileAssociation.updated_at < datetime.utcnow() - timedelta(seconds=delay_seconds)))).\
-        order_by(models.RSEFileAssociation.tombstone)
-
-    # do no delete files used as sources
-    stmt = exists(select([1]).prefix_with("/*+ INDEX(requests REQUESTS_SCOPE_NAME_RSE_IDX) */", dialect='oracle')).\
-        where(and_(models.RSEFileAssociation.scope == models.Request.scope,
-                   models.RSEFileAssociation.name == models.Request.name))
-    query = query.filter(not_(stmt))
-    query = filter_thread_work(session=session, query=query, total_threads=total_workers, thread_id=worker_number, hash_variable='name')
-    needed_space = bytes
-    total_bytes, total_files = 0, 0
-    rows = []
-    for (scope, name, path, bytes, tombstone, state) in query.yield_per(1000):
-        if state != ReplicaState.UNAVAILABLE:
-
-            if tombstone != OBSOLETE and needed_space is not None and total_bytes > needed_space:
-                break
-            total_bytes += bytes
-
-            total_files += 1
-            if total_files > limit:
-                break
-
-        rows.append({'scope': scope, 'name': name, 'path': path,
-                     'bytes': bytes, 'tombstone': tombstone,
-                     'state': state})
-    return rows
-
-
 @transactional_session
 def list_and_mark_unlocked_replicas(limit, bytes=None, rse_id=None, delay_seconds=600, only_delete_obsolete=False, session=None):
     """
@@ -2040,23 +1991,6 @@ def list_and_mark_unlocked_replicas(limit, bytes=None, rse_id=None, delay_second
             update({'updated_at': datetime.utcnow(), 'state': ReplicaState.BEING_DELETED, 'tombstone': datetime(1970, 1, 1)}, synchronize_session=False)
 
     return rows
-
-
-@read_session
-def get_sum_count_being_deleted(rse_id, session=None):
-    """
-
-    :param rse_id: The id of the RSE.
-    :param session: The database session in use.
-
-    :returns: A dictionary with total and bytes.
-    """
-    none_value = None
-    total, bytes = session.query(func.count(models.RSEFileAssociation.tombstone), func.sum(models.RSEFileAssociation.bytes)).filter_by(rse_id=rse_id).\
-        filter(models.RSEFileAssociation.tombstone != none_value).\
-        filter(models.RSEFileAssociation.state == ReplicaState.BEING_DELETED).\
-        one()
-    return {'bytes': bytes or 0, 'total': total or 0}
 
 
 @transactional_session
@@ -2180,42 +2114,6 @@ def update_replica_state(rse_id, scope, name, state, session=None):
     :param session: The database session in use.
     """
     return update_replicas_states(replicas=[{'scope': scope, 'name': name, 'state': state, 'rse_id': rse_id}], session=session)
-
-
-@transactional_session
-def update_replica_lock_counter(rse_id, scope, name, value, session=None):
-    """
-    Update File replica lock counters.
-
-    :param rse_id: The id of the RSE.
-    :param scope: the tag name.
-    :param name: The data identifier name.
-    :param value: The number of created/deleted locks.
-    :param session: The database session in use.
-
-    :returns: True or False.
-    """
-
-    # WTF BUG in the mysql-driver: lock_cnt uses the already updated value! ACID? Never heard of it!
-
-    if session.bind.dialect.name == 'mysql':
-        rowcount = session.query(models.RSEFileAssociation).\
-            filter_by(rse_id=rse_id, scope=scope, name=name).\
-            update({'lock_cnt': models.RSEFileAssociation.lock_cnt + value,
-                    'tombstone': case([(models.RSEFileAssociation.lock_cnt + value < 0,
-                                        datetime.utcnow()), ],
-                                      else_=None)},
-                   synchronize_session=False)
-    else:
-        rowcount = session.query(models.RSEFileAssociation).\
-            filter_by(rse_id=rse_id, scope=scope, name=name).\
-            update({'lock_cnt': models.RSEFileAssociation.lock_cnt + value,
-                    'tombstone': case([(models.RSEFileAssociation.lock_cnt + value == 0,
-                                        datetime.utcnow()), ],
-                                      else_=None)},
-                   synchronize_session=False)
-
-    return bool(rowcount)
 
 
 @transactional_session
@@ -2470,23 +2368,6 @@ def get_source_replicas_for_dataset(scope, name, source_rses=None,
                 replicas[(child_scope, child_name)].append(rse_id)
 
     return replicas
-
-
-@transactional_session
-def update_replicas_paths(replicas, session=None):
-    """
-    Update the path for the given replicas.
-    Primarily useful for nondeterministic replicas.
-
-    :param replicas: List of dictionaries {scope, name, rse_id, path}
-    :param session: Database session to use.
-    """
-
-    for replica in replicas:
-        session.query(models.RSEFileAssociation).filter_by(scope=replica['scope'],
-                                                           name=replica['name'],
-                                                           rse_id=replica['rse_id']).update({'path': replica['path']},
-                                                                                            synchronize_session=False)
 
 
 @read_session
@@ -2826,49 +2707,6 @@ def list_datasets_per_rse(rse_id, filters=None, limit=None, session=None):
 
     for row in query:
         yield row._asdict()
-
-
-@transactional_session
-def mark_unlocked_replicas(rse_id, bytes, session=None):
-    """
-    Mark unlocked replicas as obsolete to release space quickly.
-
-    :param rse_id: the rse id.
-    :param bytes: the amount of needed bytes.
-    :param session: The database session in use.
-
-    :returns: The list of marked replicas.
-    """
-    none_value = None  # Hack to get pep8 happy...
-#    query = session.query( func.count(), func.sum(models.RSEFileAssociation.bytes)).\
-    query = session.query(models.RSEFileAssociation.scope, models.RSEFileAssociation.name, models.RSEFileAssociation.bytes).\
-        with_hint(models.RSEFileAssociation, "INDEX_RS_ASC(replicas REPLICAS_TOMBSTONE_IDX)  NO_INDEX_FFS(replicas REPLICAS_TOMBSTONE_IDX)", 'oracle').\
-        filter(models.RSEFileAssociation.tombstone < datetime.utcnow()).\
-        filter(models.RSEFileAssociation.lock_cnt == 0).\
-        filter(models.RSEFileAssociation.tombstone != OBSOLETE).\
-        filter(case([(models.RSEFileAssociation.tombstone != none_value, models.RSEFileAssociation.rse_id), ]) == rse_id).\
-        filter(models.RSEFileAssociation.state.in_((ReplicaState.AVAILABLE, ReplicaState.UNAVAILABLE, ReplicaState.BAD))).\
-        order_by(models.RSEFileAssociation.bytes.desc())
-
-    rows = []
-    needed_space, total_bytes = bytes, 0
-    for (scope, name, bytes) in query.yield_per(1000):
-
-        if total_bytes > needed_space:
-            break
-
-        rowcount = session.query(models.RSEFileAssociation).\
-            filter_by(rse_id=rse_id, scope=scope, name=name).\
-            with_hint(models.RSEFileAssociation,
-                      "index(REPLICAS REPLICAS_PK)",
-                      'oracle').\
-            filter(models.RSEFileAssociation.tombstone != none_value).\
-            update({'tombstone': OBSOLETE}, synchronize_session=False)
-
-        if rowcount:
-            total_bytes += bytes
-            rows.append({'scope': scope, 'name': name})
-    return rows
 
 
 @transactional_session

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -65,12 +65,12 @@ from rucio.core import did, message as message_core, request as request_core
 from rucio.core.config import get as core_config_get
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core.oidc import get_token_for_account_operation
-from rucio.core.replica import add_replicas
+from rucio.core.replica import add_replicas, tombstone_from_delay
 from rucio.core.request import queue_requests, set_requests_state
 from rucio.core.rse import get_rse_name, get_rse_vo, list_rses, get_rse_supported_checksums
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla import models, filter_thread_work
-from rucio.db.sqla.constants import DIDType, RequestState, RSEType, RequestType, ReplicaState
+from rucio.db.sqla.constants import DIDType, RequestState, RSEType, RequestType, ReplicaState, OBSOLETE
 from rucio.db.sqla.session import read_session, transactional_session
 from rucio.rse import rsemanager as rsemgr
 from rucio.transfertool.fts3 import FTS3Transfertool
@@ -1135,6 +1135,7 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
                               'bytes': transfers[req_id]['file_metadata']['filesize'],
                               'adler32': transfers[req_id]['file_metadata']['adler32'],
                               'md5': transfers[req_id]['file_metadata']['md5'],
+                              'tombstone': tombstone_from_delay(ctx.rse_attrs(dest_rse_id).get('multihop_tombstone_delay')) or OBSOLETE,
                               'state': 'C'}]
                     try:
                         add_replicas(rse_id=hop['dest_rse_id'],

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -414,7 +414,7 @@ def __update_bulk_replicas(replicas, session=None, logger=logging.log):
     :returns commit_or_rollback:  Boolean.
     """
     try:
-        replica_core.update_replicas_states(replicas, nowait=True, add_tombstone=True, session=session)
+        replica_core.update_replicas_states(replicas, nowait=True, session=session)
     except ReplicaNotFound as error:
         logger(logging.WARNING, 'Failed to bulk update replicas, will do it one by one: %s', str(error))
         raise ReplicaNotFound(error)
@@ -438,7 +438,7 @@ def __update_replica(replica, session=None, logger=logging.log):
     """
 
     try:
-        replica_core.update_replicas_states([replica], nowait=True, add_tombstone=True, session=session)
+        replica_core.update_replicas_states([replica], nowait=True, session=session)
         if not replica['archived']:
             request_core.archive_request(replica['request_id'], session=session)
         logger(logging.INFO, "HANDLED REQUEST %s DID %s:%s AT RSE %s STATE %s", replica['request_id'], replica['scope'], replica['name'], replica['rse_id'], str(replica['state']))

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -215,8 +215,8 @@ class TemporaryDidFactory:
     @transactional_session
     def __cleanup_replicas(self, session=None):
         query = session.query(models.RSEFileAssociation.scope, models.RSEFileAssociation.name, models.RSEFileAssociation.rse_id). \
-            filter(or_(and_(models.ReplicationRule.scope == did['scope'],
-                            models.ReplicationRule.name == did['name'])
+            filter(or_(and_(models.RSEFileAssociation.scope == did['scope'],
+                            models.RSEFileAssociation.name == did['name'])
                        for did in self.created_dids))
         dids_by_rse = {}
         for scope, name, rse_id in query:

--- a/lib/rucio/tests/test_conveyor.py
+++ b/lib/rucio/tests/test_conveyor.py
@@ -16,10 +16,12 @@
 # Authors:
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 import time
+from datetime import datetime
 
 import pytest
 
 import rucio.daemons.reaper.reaper2
+from rucio.common.exception import ReplicaNotFound
 from rucio.core import replica as replica_core
 from rucio.core import request as request_core
 from rucio.core import rse as rse_core
@@ -91,11 +93,12 @@ def test_multihop_intermediate_replica_lifecycle(vo, did_factory, root_account, 
         rule_core.add_rule(dids=[did], account=root_account, copies=1, rse_expression=dst_rse_name, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
 
         # Submit transfers to FTS
-        # Ensure a replica was created on the intermediary host
+        # Ensure a replica was created on the intermediary host with epoch tombstone
         submitter(once=True, rses=[{'id': rse_id} for rse_id in all_rses], partition_wait_time=None, transfertype='single', filter_transfertool=None)
         request = request_core.get_request_by_did(rse_id=jump_rse_id, **did)
         assert request['state'] == RequestState.SUBMITTED
         replica = replica_core.get_replica(rse_id=jump_rse_id, **did)
+        assert replica['tombstone'] == datetime(year=1970, month=1, day=1)
         assert replica['state'] == ReplicaState.COPYING
 
         # The intermediate replica is protected by its state (Copying)
@@ -110,12 +113,10 @@ def test_multihop_intermediate_replica_lifecycle(vo, did_factory, root_account, 
 
         # The intermediate replica is protected by an entry in the sources table
         # Reaper must not remove this replica, even if it has an obsolete tombstone
-        #
-        # TODO: Uncomment following lines
-        # rucio.daemons.reaper.reaper2.REGION.invalidate()
-        # reaper(once=True, rses=[], include_rses=jump_rse_name, exclude_rses=None)
-        # replica = replica_core.get_replica(rse_id=jump_rse_id, **did)
-        # assert replica
+        rucio.daemons.reaper.reaper2.REGION.invalidate()
+        reaper(once=True, rses=[], include_rses=jump_rse_name, exclude_rses=None)
+        replica = replica_core.get_replica(rse_id=jump_rse_id, **did)
+        assert replica
 
         # FTS fails the second transfer, so run submitter again to copy from jump rse to destination rse
         submitter(once=True, rses=[{'id': rse_id} for rse_id in all_rses], partition_wait_time=None, transfertype='single', filter_transfertool=None)
@@ -127,8 +128,8 @@ def test_multihop_intermediate_replica_lifecycle(vo, did_factory, root_account, 
         rucio.daemons.reaper.reaper2.REGION.invalidate()
         reaper(once=True, rses=[], include_rses='test_container_xrd=True', exclude_rses=None)
 
-        # TODO: reaper must delete this replica. It is not a source anymore.
-        replica_core.get_replica(rse_id=jump_rse_id, **did)
+        with pytest.raises(ReplicaNotFound):
+            replica_core.get_replica(rse_id=jump_rse_id, **did)
     finally:
 
         @transactional_session

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -25,6 +25,7 @@ from unittest.mock import patch
 from rucio.core import distance as distance_core
 from rucio.core import request as request_core
 from rucio.core import rse as rse_core
+from rucio.core import replica as replica_core
 from rucio.core import rule as rule_core
 from rucio.daemons.conveyor.submitter import submitter
 from rucio.db.sqla.models import Request, Source
@@ -114,6 +115,16 @@ def test_multihop_sources_created(rse_factory, did_factory, root_account, core_c
     for rse_id in jump_rses:
         rse_core.add_rse_attribute(rse_id, 'available_for_multihop', True)
 
+    rse_tombstone_delay = 3600
+    rse_multihop_tombstone_delay = 12 * 3600
+
+    # if both attributes are set, the multihop one will take precedence
+    rse_core.add_rse_attribute(jump_rse1_id, 'tombstone_delay', rse_tombstone_delay)
+    rse_core.add_rse_attribute(jump_rse1_id, 'multihop_tombstone_delay', rse_multihop_tombstone_delay)
+
+    # if multihop delay not set, it's the default multihop takes precedence. Not normal tombstone delay.
+    rse_core.add_rse_attribute(jump_rse2_id, 'tombstone_delay', rse_tombstone_delay)
+
     distance_core.add_distance(src_rse_id, jump_rse1_id, ranking=10)
     distance_core.add_distance(jump_rse1_id, jump_rse2_id, ranking=10)
     distance_core.add_distance(jump_rse2_id, jump_rse3_id, ranking=10)
@@ -139,3 +150,14 @@ def test_multihop_sources_created(rse_factory, did_factory, root_account, core_c
     # Ensure that sources where created for transfers
     for rse_id in jump_rses + [src_rse_id]:
         __ensure_source_exists(rse_id, **did)
+
+    # Ensure the tombstone is correctly set on intermediate replicas
+    replica = replica_core.get_replica(jump_rse1_id, **did)
+    expected_tombstone = datetime.utcnow() + timedelta(seconds=rse_multihop_tombstone_delay)
+    assert expected_tombstone - timedelta(minutes=5) < replica['tombstone'] < expected_tombstone + timedelta(minutes=5)
+
+    replica = replica_core.get_replica(jump_rse2_id, **did)
+    assert replica['tombstone'] == datetime(year=1970, month=1, day=1)
+
+    replica = replica_core.get_replica(jump_rse3_id, **did)
+    assert replica['tombstone'] == datetime(year=1970, month=1, day=1)

--- a/tools/add_header
+++ b/tools/add_header
@@ -67,6 +67,7 @@ author_map = {
     ("maatthias", "<maatthias@gmail.com>"): ("Matt Snyder", "<msnyder@bnl.gov>"),
     ("maatthias", "<msnyder@bnl.gov>"): ("Matt Snyder", "<msnyder@bnl.gov>"),
     ("Mario Lassnig", "<mlassnig@users.noreply.github.com>"): ("Mario Lassnig", "<mario.lassnig@cern.ch>"),
+    ("rcarpa", "<2905943+rcarpa@users.noreply.github.com>"): ("Radu Carpa", "<radu.carpa@cern.ch>"),
 }
 
 


### PR DESCRIPTION
Always set a default tombstone on any replica creation. Introduce two
rse attributes which allow to customize the behavior per rse:
- One allows to define the normal replica creation tombstone
- The other used to configure the multihop temporary replica tombstone

As a tombstone will now be added when the intermediate multihop replica
is created, remove the redundant protection which was touching the
tombstone in the finisher.
Add a submitter test which ensures that multihop sources are created;
and that the multihop request are created with a tombstone.