### PR TITLE
Core & Internals: rework tombstone handling. Closes #4491, #4436 and #4188

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1406,6 +1406,26 @@ def __bulk_add_file_dids(files, account, dataset_meta=None, session=None):
     return new_files + available_files
 
 
+def tombstone_from_delay(tombstone_delay):
+    # Tolerate None for tombstone_delay
+    if not tombstone_delay:
+        return None
+
+    if not isinstance(tombstone_delay, timedelta):
+        try:
+            tombstone_delay = timedelta(seconds=int(tombstone_delay))
+        except ValueError:
+            return None
+
+    if not tombstone_delay:
+        return None
+
+    if tombstone_delay < timedelta(0):
+        return datetime(1970, 1, 1)
+
+    return datetime.utcnow() + tombstone_delay
+
+
 @transactional_session
 def __bulk_add_replicas(rse_id, files, account, session=None):
     """
@@ -1428,6 +1448,9 @@ def __bulk_add_replicas(rse_id, files, account, session=None):
         filter(condition)
     available_replicas = [dict([(column, getattr(row, column)) for column in row._fields]) for row in query]
 
+    default_tombstone_delay = next(iter(get_rse_attribute('tombstone_delay', rse_id=rse_id, session=session)), None)
+    default_tombstone = tombstone_from_delay(default_tombstone_delay)
+
     new_replicas = []
     for file in files:
         found = False
@@ -1444,7 +1467,7 @@ def __bulk_add_replicas(rse_id, files, account, session=None):
                                  'state': ReplicaState(file.get('state', 'A')),
                                  'md5': file.get('md5'), 'adler32': file.get('adler32'),
                                  'lock_cnt': file.get('lock_cnt', 0),
-                                 'tombstone': file.get('tombstone')})
+                                 'tombstone': file.get('tombstone') or default_tombstone})
     try:
         new_replicas and session.bulk_insert_mappings(models.RSEFileAssociation,
                                                       new_replicas)
@@ -1996,6 +2019,10 @@ def list_and_mark_unlocked_replicas(limit, bytes=None, rse_id=None, delay_second
         filter(case([(models.RSEFileAssociation.tombstone != none_value, models.RSEFileAssociation.rse_id), ]) == rse_id).\
         filter(or_(models.RSEFileAssociation.state.in_((ReplicaState.AVAILABLE, ReplicaState.UNAVAILABLE, ReplicaState.BAD)),
                    and_(models.RSEFileAssociation.state == ReplicaState.BEING_DELETED, models.RSEFileAssociation.updated_at < datetime.utcnow() - timedelta(seconds=delay_seconds)))).\
+        filter(~exists(select([1]).prefix_with("/*+ INDEX(SOURCES SOURCES_SC_NM_DST_IDX) */", dialect='oracle')
+                       .where(and_(models.RSEFileAssociation.scope == models.Source.scope,
+                                   models.RSEFileAssociation.name == models.Source.name,
+                                   models.RSEFileAssociation.rse_id == models.Source.rse_id)))).\
         with_for_update(skip_locked=True).\
         order_by(models.RSEFileAssociation.tombstone)
 
@@ -2063,25 +2090,20 @@ def list_and_mark_unlocked_replicas(limit, bytes=None, rse_id=None, delay_second
 
 
 @transactional_session
-def update_replicas_states(replicas, nowait=False, add_tombstone=False, session=None):
+def update_replicas_states(replicas, nowait=False, session=None):
     """
     Update File replica information and state.
 
     :param replicas:        The list of replicas.
     :param nowait:          Nowait parameter for the for_update queries.
-    :param add_tombstone:   To set a tombstone in case there is no lock on the replica.
     :param session:         The database session in use.
     """
 
     for replica in replicas:
         query = session.query(models.RSEFileAssociation).filter_by(rse_id=replica['rse_id'], scope=replica['scope'], name=replica['name'])
-        lock_cnt = 0
         try:
             if nowait:
-                rep = query.with_for_update(nowait=True).one()
-            else:
-                rep = query.one()
-            lock_cnt = rep.lock_cnt
+                query.with_for_update(nowait=True).one()
         except NoResultFound:
             # remember scope, name and rse
             raise exception.ReplicaNotFound("No row found for scope: %s name: %s rse: %s" % (replica['scope'], replica['name'], get_rse_name(replica['rse_id'], session=session)))
@@ -2100,19 +2122,12 @@ def update_replicas_states(replicas, nowait=False, add_tombstone=False, session=
             values['tombstone'] = OBSOLETE
         elif replica['state'] == ReplicaState.AVAILABLE:
             rucio.core.lock.successful_transfer(scope=replica['scope'], name=replica['name'], rse_id=replica['rse_id'], nowait=nowait, session=session)
-            # If No locks we set a tombstone in the future
-            if add_tombstone and lock_cnt == 0:
-                set_tombstone(rse_id=replica['rse_id'], scope=replica['scope'], name=replica['name'], tombstone=datetime.utcnow() + timedelta(hours=2), session=session)
-
         elif replica['state'] == ReplicaState.UNAVAILABLE:
             rucio.core.lock.failed_transfer(scope=replica['scope'], name=replica['name'], rse_id=replica['rse_id'],
                                             error_message=replica.get('error_message', None),
                                             broken_rule_id=replica.get('broken_rule_id', None),
                                             broken_message=replica.get('broken_message', None),
                                             nowait=nowait, session=session)
-            # If No locks we set a tombstone in the future
-            if add_tombstone and lock_cnt == 0:
-                set_tombstone(rse_id=replica['rse_id'], scope=replica['scope'], name=replica['name'], tombstone=datetime.utcnow() + timedelta(hours=2), session=session)
         elif replica['state'] == ReplicaState.TEMPORARY_UNAVAILABLE:
             query = query.filter(or_(models.RSEFileAssociation.state == ReplicaState.AVAILABLE, models.RSEFileAssociation.state == ReplicaState.TEMPORARY_UNAVAILABLE))
 

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -415,7 +415,7 @@ def __update_bulk_replicas(replicas, session=None, logger=logging.log):
     :returns commit_or_rollback:  Boolean.
     """
     try:
-        replica_core.update_replicas_states(replicas, nowait=True, add_tombstone=True, session=session)
+        replica_core.update_replicas_states(replicas, nowait=True, session=session)
     except ReplicaNotFound as error:
         logger(logging.WARNING, 'Failed to bulk update replicas, will do it one by one: %s', str(error))
         raise ReplicaNotFound(error)
@@ -439,7 +439,7 @@ def __update_replica(replica, session=None, logger=logging.log):
     """
 
     try:
-        replica_core.update_replicas_states([replica], nowait=True, add_tombstone=True, session=session)
+        replica_core.update_replicas_states([replica], nowait=True, session=session)
         if not replica['archived']:
             request_core.archive_request(replica['request_id'], session=session)
         logger(logging.INFO, "HANDLED REQUEST %s DID %s:%s AT RSE %s STATE %s", replica['request_id'], replica['scope'], replica['name'], replica['rse_id'], str(replica['state']))


### PR DESCRIPTION
Allow setting a default tombstone on any replica creation. Introduce two
rse attributes which allow to customize the behavior per rse:
- One allows to define the normal replica creation tombstone
(defaults to 0: "no tombstone")
- The other used to configure the multihop temporary replica tombstone
(defaults to 2 hours in the future)
Use a negative value to set the epoch tombstone. Or 0 to explicitly
set a null tombstone.

Protect replicas which are used as sources from deletion even if their
tombstone is set to epoch. Add an integration test which verifies this
behavior.
Add a submitter test ensuring that multihop sources are created;
and that the temp multihop replicas are created with a tombstone.

Remove the redundant behavior which touches the tombstone in the
finisher. The 2 remaining protections for intermediate multihop replicas
are now: 1) entries in the source table; 2) the default multihop
tombstone delay of 2 hours into the future.