### PR TITLE
Clients: ignore broken pipe. Closes #4482

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -47,6 +47,7 @@
 from __future__ import print_function
 
 import argparse
+import errno
 import logging
 import math
 import os
@@ -195,6 +196,15 @@ def exception_handler(function):
             logger.error(error)
             return error.error_code
         except Exception as error:
+            if isinstance(error, IOError) and getattr(error, 'errno', None) == errno.EPIPE:
+                # Ignore Broken Pipe
+                # While in python3 we can directly catch 'BrokenPipeError', in python2 it doesn't exist.
+
+                # Python flushes standard streams on exit; redirect remaining output
+                # to devnull to avoid another BrokenPipeError at shutdown
+                devnull = os.open(os.devnull, os.O_WRONLY)
+                os.dup2(devnull, sys.stdout.fileno())
+                return SUCCESS
             logger.debug(traceback.format_exc())
             logger.error(error)
             contact = config_get('policy', 'support', raise_exception=False)

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -37,12 +37,14 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Rob Barnsley <robbarnsley@users.noreply.github.com>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import division
 from __future__ import print_function
 
 import argparse
 import datetime
+import errno
 import json
 import logging
 import math
@@ -181,6 +183,15 @@ def exception_handler(function):
             logger.error('This means that no scopes were found for the specified account ID.')
             return FAILURE
         except Exception as error:
+            if isinstance(error, IOError) and getattr(error, 'errno', None) == errno.EPIPE:
+                # Ignore Broken Pipe
+                # While in python3 we can directly catch 'BrokenPipeError', in python2 it doesn't exist.
+
+                # Python flushes standard streams on exit; redirect remaining output
+                # to devnull to avoid another BrokenPipeError at shutdown
+                devnull = os.open(os.devnull, os.O_WRONLY)
+                os.dup2(devnull, sys.stdout.fileno())
+                return SUCCESS
             logger.error(error)
             logger.error('Rucio exited with an unexpected/unknown error, please provide the traceback below to the developers.')
             logger.debug(traceback.format_exc())


### PR DESCRIPTION
The second except block is probably only for the print at line 2403. 