### PR TITLE
Clients: bring python 2.7 support back to bin/rucio

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -22,9 +22,9 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2020
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2013
 # - David Cameron <david.cameron@cern.ch>, 2014-2020
-# - Tomáš Kouba <tomas.kouba@cern.ch>, 2014
+# - Tomas Kouba <tomas.kouba@cern.ch>, 2014
 # - Wen Guan <wen.guan@cern.ch>, 2014
-# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2014-2018
+# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2014-2018
 # - Evangelia Liotiri <evangelia.liotiri@cern.ch>, 2015
 # - Tobias Wegner <twegner@cern.ch>, 2017-2019
 # - Brian Bockelman <bbockelm@cse.unl.edu>, 2017-2018
@@ -209,7 +209,7 @@ def exception_handler(function):
 
 
 def option_deprecation_message(old_option, new_option, support_end_version='1.27'):
-    logger.warning(f'The use of {old_option} is deprecated in favour of {new_option} and will be removed in {support_end_version}')
+    logger.warning('The use of {} is deprecated in favour of {} and will be removed in {}'.format(old_option, new_option, support_end_version))
 
 
 def get_client(args):

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -24,7 +24,7 @@
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2014
 # - David Cameron <david.cameron@cern.ch>, 2014-2015
 # - Cheng-Hsi Chao <cheng-hsi.chao@cern.ch>, 2014
-# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2014-2019
+# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2014-2019
 # - Brian Bockelman <bbockelm@cse.unl.edu>, 2017-2018
 # - Tomas Javurek <tomas.javurek@cern.ch>, 2018
 # - Nicolo Magini <nicolo.magini@cern.ch>, 2018


### PR DESCRIPTION
fixes following two errors:
- File "bin/rucio", line 212
  SyntaxError: invalid syntax
- File "bin/rucio", line 25
  SyntaxError: Non-ASCII character '\xc3' in file bin/rucio on line 25