### PR TITLE
Configs: also ignore RuntimeError if raise_exception=False. Closes #1911

### DIFF
--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -54,7 +54,7 @@ def config_get(section, option, raise_exception=True, default=None, clean_cached
     global __CONFIG
     try:
         return get_config().get(section, option)
-    except (ConfigParser.NoOptionError, ConfigParser.NoSectionError) as err:
+    except (ConfigParser.NoOptionError, ConfigParser.NoSectionError, RuntimeError) as err:
         if raise_exception and default is None:
             raise err
         if clean_cached:


### PR DESCRIPTION
When the config file doesn't exist at all, this exception is raised.
In cases when config_get was explicitly requested to not raise an
exception on missing values, it's probably safe to ignore a missing
config file.