### PR TITLE
Clients + Api + Core & Internals: ignore_availability for list_replicas. #4603

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -388,6 +388,7 @@ def list_file_replicas(args):
         option_deprecation_message("--rse", "--rses")
 
     replicas = client.list_replicas(dids, schemes=protocols,
+                                    ignore_availability=True,
                                     all_states=args.all_states,
                                     rse_expression=args.rses,
                                     metalink=args.metalink,

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1130,6 +1130,7 @@ class DownloadClient:
 
             metalink_str = self.client.list_replicas(item['dids'],
                                                      schemes=schemes,
+                                                     ignore_availability=False,
                                                      rse_expression=rse_expression,
                                                      client_location=self.client_location,
                                                      resolve_archives=resolve_archives,

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -118,7 +118,7 @@ class ReplicaClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def list_replicas(self, dids, schemes=None, unavailable=False,
+    def list_replicas(self, dids, schemes=None, unavailable=False, ignore_availability=True,
                       all_states=False, metalink=False, rse_expression=None,
                       client_location=None, sort=None, domain=None,
                       signature_lifetime=None,
@@ -130,7 +130,8 @@ class ReplicaClient(BaseClient):
         :param dids: The list of data identifiers (DIDs) like :
             [{'scope': <scope1>, 'name': <name1>}, {'scope': <scope2>, 'name': <name2>}, ...]
         :param schemes: A list of schemes to filter the replicas. (e.g. file, http, ...)
-        :param unavailable: Also include unavailable replicas in the list.
+        :param unavailable: Also include unavailable replicas in the list (deprecated)
+        :param ignore_availability: Also include blacklisted replicas into the list
         :param metalink: ``False`` (default) retrieves as JSON,
                          ``True`` retrieves as metalink4+xml.
         :param rse_expression: The RSE expression to restrict replicas on a set of RSEs.
@@ -154,6 +155,8 @@ class ReplicaClient(BaseClient):
             data['schemes'] = schemes
         if unavailable:
             data['unavailable'] = True
+        if ignore_availability is not None:
+            data['ignore_availability'] = ignore_availability
         data['all_states'] = all_states
 
         if rse_expression:

--- a/lib/rucio/tests/test_archive.py
+++ b/lib/rucio/tests/test_archive.py
@@ -137,10 +137,11 @@ def test_list_archive_contents_at_rse(rse_factory, mock_scope, root_account, did
     both_rses = rse1 + '|' + rse2
     update_rse(rse1_id, {'availability_read': False})
     update_rse(rse2_id, {'availability_read': False})
-    res = replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file], metalink=True, rse_expression=both_rses, resolve_archives=True)
+    res = replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file],
+                                       metalink=True, rse_expression=both_rses, resolve_archives=True, ignore_availability=False)
     assert rse1 not in res
     assert rse2 not in res
-    res = replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file], metalink=True, rse_expression=both_rses, resolve_archives=True, unavailable=True)
+    res = replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in archived_file], metalink=True, rse_expression=both_rses, resolve_archives=True)
     assert rse1 in res
     assert rse2 in res
 

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -896,6 +896,61 @@ class TestBinRucio(unittest.TestCase):
         search = '{0} successfully downloaded'.format(tmp_file1[5:])  # triming '/tmp/' from filename
         assert re.search(search, err) is not None
 
+    def test_list_blacklisted_replicas(self):
+        """CLIENT(USER): Rucio list replicas"""
+        # add rse
+        tmp_rse = rse_name_generator()
+        cmd = 'rucio-admin rse add {0}'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        cmd = 'rucio-admin rse add-protocol --hostname blacklistreplica --scheme file --prefix /rucio --port 0 --impl rucio.rse.protocols.posix.Default ' \
+              '--domain-json \'{"wan": {"read": 1, "write": 1, "delete": 1, "third_party_copy": 1}}\' %s' % tmp_rse
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+
+        # add files
+        tmp_file1 = file_generator()
+        file_name = tmp_file1[5:]  # triming '/tmp/' from filename
+        cmd = 'rucio upload --rse {0} --scope {1} {2}'.format(tmp_rse, self.user, tmp_file1)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+
+        # create dataset
+        tmp_dataset = self.user + ':DSet' + rse_name_generator()
+        cmd = 'rucio add-dataset ' + tmp_dataset
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add files to dataset
+        cmd = 'rucio attach {0} {1}:{2}'.format(tmp_dataset, self.user, file_name)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+
+        # Listing the replica should work before blacklisting the RSE
+        cmd = 'rucio list-file-replicas {}'.format(tmp_dataset)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        assert tmp_rse in out
+
+        # Blacklist the rse
+        cmd = 'rucio-admin rse update --rse {} --setting availability_read --value False'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        assert not err
+
+        # list-file-replicas should, by default, list replicas from blacklisted rses
+        cmd = 'rucio list-file-replicas {}'.format(tmp_dataset)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        assert tmp_rse in out
+
     def test_create_rule(self):
         """CLIENT(USER): Rucio add rule"""
         tmp_file1 = file_generator()

--- a/lib/rucio/tests/test_download.py
+++ b/lib/rucio/tests/test_download.py
@@ -395,6 +395,18 @@ def test_norandom_respected(rse_factory, did_factory, download_client, root_acco
         assert len(result) == nrandom
 
 
+def test_download_blacklisted_replicas(rse_factory, did_factory, download_client):
+    rse, _ = rse_factory.make_posix_rse()
+    did = did_factory.upload_test_file(rse)
+    did_str = '%s:%s' % (did['scope'], did['name'])
+
+    did_factory.client.update_rse(rse, {'availability_read': False})
+
+    with TemporaryDirectory() as tmp_dir:
+        with pytest.raises(NoFilesDownloaded):
+            download_client.download_dids([{'did': did_str, 'base_dir': tmp_dir}])
+
+
 def test_transfer_timeout(rse_factory, did_factory, download_client):
     rse, _ = rse_factory.make_posix_rse()
     did = did_factory.upload_test_file(rse)

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -874,15 +874,15 @@ def test_client_list_blacklisted_replicas(rse_factory, did_factory, replica_clie
 
     # if availability_read is set to false, the replicas from the given rse will not be listed
     did_factory.client.update_rse(rse, {'availability_read': False})
-    replicas = list(replica_client.list_replicas(dids=[file]))
+    replicas = list(replica_client.list_replicas(dids=[file], ignore_availability=False))
     assert len(replicas) == 1
     assert not replicas[0]['rses'] and not replicas[0]['pfns']
     for did in (dataset, container):
-        replicas = list(replica_client.list_replicas(dids=[did]))
+        replicas = list(replica_client.list_replicas(dids=[did], ignore_availability=False))
         assert len(replicas) == 0
-    # Explicitly requesting unavailable replicas will return them
+    # By default unavailable replicas will be returned
     for did in (file, dataset, container):
-        replicas = list(replica_client.list_replicas(dids=[did], unavailable=True))
+        replicas = list(replica_client.list_replicas(dids=[did]))
         assert len(replicas) == 1
         assert len(replicas[0]['rses']) == 1
 

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -301,7 +301,7 @@ class ListReplicas(ErrorHandlingMethodView):
         schemes = param_get(parameters, 'schemes', default=None)
         select = param_get(parameters, 'sort', default=None)
         unavailable = param_get(parameters, 'unavailable', default=False)
-        ignore_availability = 'unavailable' in parameters
+        ignore_availability = param_get(parameters, 'ignore_availability', default='unavailable' in parameters)
         rse_expression = param_get(parameters, 'rse_expression', default=None)
         all_states = param_get(parameters, 'all_states', default=False)
         domain = param_get(parameters, 'domain', default=None)

--- a/lib/rucio/web/ui/static/rucio.js
+++ b/lib/rucio/web/ui/static/rucio.js
@@ -865,7 +865,7 @@ RucioClient.prototype.list_replicas = function(options) {
     check_token();
     var url = this.url + '/replicas/list/';
     if (options.async == null) { options.async = true; }
-    data = {'dids': [{'scope': options.scope, 'name': options.name}], 'unavailable': true, 'all_states': true }
+    data = {'dids': [{'scope': options.scope, 'name': options.name}], 'unavailable': true, 'all_states': true, 'ignore_availability': true}
     if (options.schemes != null) {
         data['schemes'] = options.schemes;
     }


### PR DESCRIPTION
To be consistent with other API and client parameters,
ignore_availability is default to True. Also update the Web
ui and the rucio client to explicitly set it how needed.

Add a test to ensure that bin/rucio list-file-replicas does
indeed show blacklisted replicas.

Add test to ensure that download fails if only a blacklisted
replica exists.