### PR TITLE
Testing: Pin dev containers in integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Checkout rucio containers repository
         uses: actions/checkout@v2
         with:
+          ref: a51596415bf19027a9a22930b046c443917caa2c
           repository: rucio/containers
       - uses: actions/checkout@v2
         name: Checkout rucio source

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Use rucio/containers Dockerfile for integration tests
         shell: bash
         run: |
-          sed -i "s/RUN git clone .*/COPY .\/rucio \/tmp\/rucio/" $GITHUB_WORKSPACE/dev/Dockerfile
+          sed -i 's;RUN git clone .*;COPY ./rucio /tmp/rucio;' $GITHUB_WORKSPACE/dev/Dockerfile
       - name: Build rucio-dev images
         id: images
         shell: bash
@@ -62,7 +62,8 @@ jobs:
         shell: bash
         run: |
           docker image ls
-          sed -i "s;image: rucio/rucio-dev.*;image: docker\.pkg\.github\.com/${{ github.repository }}/rucio-integration-test:centos7-python3.6;" $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose-storage.yml
+          sed -i 's;image: docker.io/rucio/rucio-dev.*;image: docker\.pkg\.github\.com/${{ github.repository }}/rucio-integration-test:centos7-python3.6;' \
+              $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose-storage.yml
       - name: Start containers
         run: |
           docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pin dev containers in integration tests to older rucio/containers revision to work with web.py. Should fix errors for integration tests in release branch.