### PR TITLE
Deletion: change constituent removal batch handling

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1814,12 +1814,18 @@ def __cleanup_after_replica_deletion(rse_id, files, session=None):
 
     # Remove Archive Constituents
     removed_constituents = []
+    constituents_to_delete_condition = []
     for chunk in chunks(archive_contents_condition, 30):
         query = session.query(models.ConstituentAssociation). \
             with_hint(models.ConstituentAssociation, "INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_CHILD_IDX)", 'oracle'). \
             filter(or_(*chunk))
         for constituent in query:
             removed_constituents.append({'scope': constituent.child_scope, 'name': constituent.child_name})
+            constituents_to_delete_condition.append(
+                and_(models.ConstituentAssociation.scope == constituent.scope,
+                     models.ConstituentAssociation.name == constituent.name,
+                     models.ConstituentAssociation.child_scope == constituent.child_scope,
+                     models.ConstituentAssociation.child_name == constituent.child_name))
 
             models.ConstituentAssociationHistory(
                 child_scope=constituent.child_scope,
@@ -1835,12 +1841,21 @@ def __cleanup_after_replica_deletion(rse_id, files, session=None):
                 created_at=constituent.created_at,
             ).save(session=session, flush=False)
 
-        session.query(models.ConstituentAssociation).\
-            with_hint(models.ConstituentAssociation, "INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_CHILD_IDX)", 'oracle').\
-            filter(or_(*chunk)).\
+            if len(constituents_to_delete_condition) > 200:
+                session.query(models.ConstituentAssociation).\
+                    with_hint(models.ConstituentAssociation, "INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_PK)", 'oracle').\
+                    filter(or_(*constituents_to_delete_condition)).\
+                    delete(synchronize_session=False)
+                constituents_to_delete_condition.clear()
+
+                __cleanup_after_replica_deletion(rse_id=rse_id, files=removed_constituents, session=session)
+                removed_constituents.clear()
+    if constituents_to_delete_condition:
+        session.query(models.ConstituentAssociation). \
+            with_hint(models.ConstituentAssociation, "INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_PK)", 'oracle'). \
+            filter(or_(*constituents_to_delete_condition)). \
             delete(synchronize_session=False)
-    for chunk in chunks(removed_constituents, 200):
-        __cleanup_after_replica_deletion(rse_id=rse_id, files=chunk, session=session)
+        __cleanup_after_replica_deletion(rse_id=rse_id, files=removed_constituents, session=session)
 
     # Remove rules in Waiting for approval or Suspended
     for chunk in chunks(deleted_rules, 100):


### PR DESCRIPTION
Instead of constructing the list of all constituents, which can
grow very big, delete them as soon as it reaches the batch size.