### PR TITLE
Testing: Create image cache for release branches

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -13,10 +13,14 @@ jobs:
         run: python3 -m pip install -U pip setuptools
       - name: Install python requirements for matrix_parser.py
         run: python3 -m pip install -U PyYAML
+      - name: Identify branch
+        id: branch
+        run: python3 -c 'from os import environ as env; print("::set-output name=branch::" + (env.get("GITHUB_BASE_REF", None) if env.get("GITHUB_BASE_REF", None) else env.get("GITHUB_REF", "master")))'
       - name: Identify Matrix
         id: matrix
         run: echo "::set-output name=matrix::$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix.yml)"
     outputs:
+      branch: ${{ steps.branch.outputs.branch }}
       matrix: ${{ steps.matrix.outputs.matrix }}
   test:
     needs: setup
@@ -34,7 +38,8 @@ jobs:
           docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           i=0; until [ "$i" -ge 3 ]; do
             IMAGES=$(echo '${{ toJson(matrix.cfg) }}' | ./tools/test/build_images.py \
-                --cache-repo docker.pkg.github.com/${{ github.repository }} ./etc/docker/test || echo "")
+                --cache-repo docker.pkg.github.com/${{ github.repository }} \
+                --branch "${{ needs.setup.outputs.branch }}" ./etc/docker/test || echo "")
             if [[ -n $IMAGES ]]; then break;
             else
               i=$((i+1)); sleep 5;
@@ -42,7 +47,7 @@ jobs:
             fi
           done
           docker logout https://docker.pkg.github.com
-          if [[ -z $IMAGES ]]; then exit 1; fi
+          if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
           echo "::set-output name=images::$IMAGES"
       - name: Run test with cfg
         run: 'echo ''{"matrix": ${{ toJson(matrix.cfg) }}, "images": ${{ steps.images.outputs.images }} }'' | ./tools/test/run_tests.py'
@@ -106,7 +111,8 @@ jobs:
           docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           i=0; until [ "$i" -ge 3 ]; do
             IMAGES=$(echo '${{ toJson(matrix.cfg) }}' | ./tools/test/build_images.py \
-                --cache-repo docker.pkg.github.com/${{ github.repository }} ./etc/docker/test || echo "")
+                --cache-repo docker.pkg.github.com/${{ github.repository }} \
+                --branch "${{ needs.release-patch-setup.outputs.release_branch }}" ./etc/docker/test || echo "")
             if [[ -n $IMAGES ]]; then break;
             else
               i=$((i+1)); sleep 5;
@@ -114,7 +120,7 @@ jobs:
             fi
           done
           docker logout https://docker.pkg.github.com
-          if [[ -z $IMAGES ]]; then exit 1; fi
+          if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
           echo "::set-output name=images::$IMAGES"
       - name: Run test with cfg
         run: 'echo ''{"matrix": ${{ toJson(matrix.cfg) }}, "images": ${{ steps.images.outputs.images }} }'' | ./tools/test/run_tests.py'

--- a/.github/workflows/imagecache.yml
+++ b/.github/workflows/imagecache.yml
@@ -6,36 +6,89 @@ on:
     - cron: '0 3 * * 1-5'
 
 jobs:
-  build_autotests:
+  setup:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Update pip
-        run: python3 -m pip install -U pip setuptools
-      - name: Install python requirements for matrix_parser.py
-        run: python3 -m pip install -U PyYAML
+      - name: Identify branches
+        id: branches
+        run: |
+          BRANCHES="$(echo "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/branches{/branch}" | \
+              ./tools/github/workflow/grabrelease.py --all --json --add master)"
+          echo "Will build image cache for branches: ${BRANCHES}"
+          echo "::set-output name=branches::${BRANCHES}"
+    outputs:
+      branches: ${{ steps.branches.outputs.branches }}
+  build_autotests:
+    runs-on: ubuntu-latest
+    needs:
+      - setup
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.setup.outputs.branches) }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branch }}
+      - name: Check and get files
+        id: files
+        shell: bash
+        run: |
+          MATRIX_PARSER_PY="${{ github.workspace }}/tools/test/matrix_parser.py"
+          MATRIX_CONF="${{ github.workspace }}/etc/docker/test/matrix.yml"
+          BUILD_IMAGES_PY="${{ github.workspace }}/tools/test/build_images.py"
+          echo "::set-output name=requirements_met::$(if [[ -r "$MATRIX_CONF" && -x "$MATRIX_PARSER_PY" && -x "$BUILD_IMAGES_PY" ]]; then echo "true"; else echo "false"; fi)"
+          echo "::set-output name=matrix_parser::$MATRIX_PARSER_PY"
+          echo "::set-output name=matrix_configuration::$MATRIX_CONF"
+          echo "::set-output name=build_images::$BUILD_IMAGES_PY"
+      - name: Update pip, install python requirements for matrix parser
+        if: ${{ steps.files.outputs.requirements_met == 'true' }}
+        run: |
+          python3 -m pip install -U pip setuptools
+          python3 -m pip install -U PyYAML
       - name: Identify Matrix
+        if: ${{ steps.files.outputs.requirements_met == 'true' }}
         id: matrix
-        run: echo "::set-output name=matrix::$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix.yml)"
+        run: echo "::set-output name=matrix::$(${{ steps.files.outputs.matrix_parser }} < ${{ steps.files.outputs.matrix_configuration }})"
       - name: Build and upload images
+        if: ${{ steps.files.outputs.requirements_met == 'true' }}
         id: images
         shell: bash
         run: |
+          BUILD_ARGS=("--output" "list" "--cache-repo" "docker.pkg.github.com/${{ github.repository }}" "--push-cache")
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            # only build without cache on schedule (to update distro packages)
+            BUILD_ARGS=("${BUILD_ARGS[@]}" "--build-no-cache")
+          fi
+
+          # the {} input for build_images.py is necessary until version 2
+          if echo '{}' | "${{ steps.files.outputs.build_images }}" --version-test 2; then
+            # new --branch option not available in older build_images.py revisions
+            BUILD_ARGS=("${BUILD_ARGS[@]}" "--branch" "${{ matrix.branch }}")
+          elif [[ "${{ matrix.branch }}" != "master" ]]; then
+            echo "::warning::Not building image for branch ${{ matrix.branch }}, because it would overwrite master"
+            exit 0
+          fi
           docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           i=0; until [ "$i" -ge 3 ]; do
-            IMAGES=$(echo '${{ steps.matrix.outputs.matrix }}' | ./tools/test/build_images.py --output list \
-                --build-no-cache --cache-repo docker.pkg.github.com/${{ github.repository }} --push-cache \
-                ./etc/docker/test || echo "")
-            if [[ -n $IMAGES ]]; then break;
+            IMAGES="$(echo '${{ steps.matrix.outputs.matrix }}' | "${{ steps.files.outputs.build_images }}" ${BUILD_ARGS[@]} ./etc/docker/test || echo "")"
+            if [[ -n "$IMAGES" ]]; then break;
             else
               i=$((i+1)); sleep 5;
               echo "::warning::Building images failed, retrying…"
             fi
           done
           docker logout https://docker.pkg.github.com
-          if [[ -z $IMAGES ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
+          if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
   build_integration_tests:
     runs-on: ubuntu-latest
+    needs:
+      - setup
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.setup.outputs.branches) }}
     steps:
       - name: Checkout rucio containers repository
         uses: actions/checkout@v2
@@ -45,27 +98,55 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: dev/rucio
-      - name: Update pip
-        run: python3 -m pip install -U pip setuptools
-      - name: Install python requirements for matrix_parser.py
-        run: python3 -m pip install -U PyYAML
+          ref: ${{ matrix.branch }}
+      - name: Check and get files
+        id: files
+        shell: bash
+        run: |
+          MATRIX_PARSER_PY="${{ github.workspace }}/dev/rucio/tools/test/matrix_parser.py"
+          MATRIX_CONF="${{ github.workspace }}/dev/rucio/etc/docker/test/matrix_integration_tests.yml"
+          BUILD_IMAGES_PY="${{ github.workspace }}/dev/rucio/tools/test/build_images.py"
+          echo "::set-output name=requirements_met::$(if [[ -r "$MATRIX_CONF" && -x "$MATRIX_PARSER_PY" && -x "$BUILD_IMAGES_PY" ]]; then echo "true"; else echo "false"; fi)"
+          echo "::set-output name=matrix_parser::$MATRIX_PARSER_PY"
+          echo "::set-output name=matrix_configuration::$MATRIX_CONF"
+          echo "::set-output name=build_images::$BUILD_IMAGES_PY"
+      - name: Update pip, install python requirements for matrix parser
+        if: ${{ steps.files.outputs.requirements_met == 'true' }}
+        run: |
+          python3 -m pip install -U pip setuptools
+          python3 -m pip install -U PyYAML
       - name: Identify Matrix
+        if: ${{ steps.files.outputs.requirements_met == 'true' }}
         id: matrix
-        run: echo "::set-output name=matrix::$(${{ github.workspace }}/dev/rucio/tools/test/matrix_parser.py < ${{ github.workspace }}/dev/rucio/etc/docker/test/matrix_integration_tests.yml)"
+        run: echo "::set-output name=matrix::$(${{ steps.files.outputs.matrix_parser }} < ${{ steps.files.outputs.matrix_configuration }})"
       - name: Build and upload images
+        if: ${{ steps.files.outputs.requirements_met == 'true' }}
         id: images
         shell: bash
         run: |
+          BUILD_ARGS=("--output" "list" "--cache-repo" "docker.pkg.github.com/${{ github.repository }}" "--push-cache")
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            # only build without cache on schedule (to update distro packages)
+            BUILD_ARGS=("${BUILD_ARGS[@]}" "--build-no-cache")
+          fi
+
+          # the {} input for build_images.py is necessary until version 2
+          if echo '{}' | "${{ steps.files.outputs.build_images }}" --version-test 2; then
+            # new --branch option not available in older build_images.py revisions
+            BUILD_ARGS=("${BUILD_ARGS[@]}" "--branch" "${{ matrix.branch }}")
+          elif [[ "${{ matrix.branch }}" != "master" ]]; then
+            echo "::warning::Not building image for branch ${{ matrix.branch }}, because it would overwrite master"
+            exit 0
+          fi
           docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           i=0; until [ "$i" -ge 3 ]; do
-            IMAGES=$(echo '${{ steps.matrix.outputs.matrix }}' | ${{ github.workspace }}/dev/rucio/tools/test/build_images.py --output list \
-                --build-no-cache --cache-repo docker.pkg.github.com/${{ github.repository }} --push-cache \
-                ${{ github.workspace }}/dev || echo "")
-            if [[ -n $IMAGES ]]; then break;
+            IMAGES="$(echo '${{ steps.matrix.outputs.matrix }}' | "${{ steps.files.outputs.build_images }}" ${BUILD_ARGS[@]} \
+                ${{ github.workspace }}/dev || echo "")"
+            if [[ -n "$IMAGES" ]]; then break;
             else
               i=$((i+1)); sleep 5;
               echo "::warning::Building images failed, retrying…"
             fi
           done
           docker logout https://docker.pkg.github.com
-          if [[ -z $IMAGES ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
+          if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -13,12 +13,14 @@ jobs:
         run: python3 -m pip install -U pip setuptools
       - name: Install python requirements for matrix_parser.py
         run: python3 -m pip install -U PyYAML
+      - name: Identify branch
+        id: branch
+        run: python3 -c 'from os import environ as env; print("::set-output name=branch::" + (env.get("GITHUB_BASE_REF", None) if env.get("GITHUB_BASE_REF", None) else env.get("GITHUB_REF", "master")))'
       - name: Identify Matrix
         id: matrix
         run: echo "::set-output name=matrix::$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix_integration_tests.yml)"
-      - name: test output
-        run: echo "${{ steps.matrix.outputs.matrix }}"
     outputs:
+      branch: ${{ steps.branch.outputs.branch }}
       matrix: ${{ steps.matrix.outputs.matrix }}
 
   integration-tests:
@@ -46,9 +48,11 @@ jobs:
         shell: bash
         run: |
           docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          docker-compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose-storage.yml pull
           i=0; until [ "$i" -ge 3 ]; do
-            IMAGES=$(echo '${{ toJson(matrix.cfg) }}' | $GITHUB_WORKSPACE/dev/rucio/tools/test/build_images.py \
-                --cache-repo docker.pkg.github.com/${{ github.repository }} $GITHUB_WORKSPACE/dev || echo "")
+            IMAGES=$(echo '${{ toJson(matrix.cfg) }}' | $GITHUB_WORKSPACE/dev/rucio/tools/test/build_images.py --output list \
+                --cache-repo docker.pkg.github.com/${{ github.repository }} --branch "${{ needs.setup.outputs.branch }}" \
+                $GITHUB_WORKSPACE/dev || echo "")
             if [[ -n $IMAGES ]]; then break;
             else
               i=$((i+1)); sleep 5;
@@ -56,18 +60,16 @@ jobs:
             fi
           done
           docker logout https://docker.pkg.github.com
-          if [[ -z $IMAGES ]]; then exit 1; fi
+          if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
           echo "::set-output name=images::$IMAGES"
       - name: Prepare Docker Compose
         shell: bash
         run: |
           docker image ls
-          sed -i 's;image: docker.io/rucio/rucio-dev.*;image: docker\.pkg\.github\.com/${{ github.repository }}/rucio-integration-test:centos7-python3.6;' \
+          sed -i 's;image: docker.io/rucio/rucio-dev.*;image: ${{ fromJSON(steps.images.outputs.images)[0] }};' \
               $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose-storage.yml
       - name: Start containers
-        run: |
-          docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
-          docker-compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose-storage.yml up -d
+        run: docker-compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose-storage.yml up -d
       - name: Initialize tests
         shell: bash
         run: |

--- a/tools/github/workflow/util.py
+++ b/tools/github/workflow/util.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-# Copyright 2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2020-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +15,9 @@
 # limitations under the License.
 #
 # Authors:
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
+import json
 import sys
 import urllib.request
 
@@ -35,3 +37,12 @@ def get_next_link(answer):
             if 'rel="next"' in parts:
                 return parts[0][1:-1]
     return False
+
+
+def all_branches(branches_url: str):
+    while branches_url:
+        with urllib.request.urlopen(req_json(branches_url)) as answer:
+            branches = json.load(answer)
+            branches = map(lambda b: b["name"], branches)
+            branches_url = get_next_link(answer)
+        yield from branches


### PR DESCRIPTION
Reduces the `patch-*` branches testing time when the latest release branch and master diverted.

Must be applied to `release-1.25` as well to actually work at this time :)