### PR TITLE
Transfers: skip missing request on state update in submitter. #4625

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -445,7 +445,7 @@ def query_request_details(request_id, transfertool='fts3', session=None, logger=
 @transactional_session
 def set_request_state(request_id, new_state, transfer_id=None, transferred_at=None, started_at=None, staging_started_at=None, staging_finished_at=None, src_rse_id=None, err_msg=None, session=None, logger=logging.log):
     """
-    Update the state of a request. Fails silently if the request_id does not exist.
+    Update the state of a request.
 
     :param request_id:           Request-ID as a 32 character hex string.
     :param new_state:            New state as string.
@@ -495,7 +495,7 @@ def set_request_state(request_id, new_state, transfer_id=None, transferred_at=No
 @transactional_session
 def set_requests_state(request_ids, new_state, session=None, logger=logging.log):
     """
-    Bulk update the state of requests. Fails silently if the request_id does not exist.
+    Bulk update the state of requests.
 
     :param request_ids:  List of (Request-ID as a 32 character hex string).
     :param new_state:    New state as string.
@@ -508,6 +508,29 @@ def set_requests_state(request_ids, new_state, session=None, logger=logging.log)
     try:
         for request_id in request_ids:
             set_request_state(request_id, new_state, session=session, logger=logger)
+    except IntegrityError as error:
+        raise RucioException(error.args)
+
+
+@transactional_session
+def set_requests_state_if_possible(request_ids, new_state, session=None, logger=logging.log):
+    """
+    Bulk update the state of requests. Skips silently if the request_id does not exist.
+
+    :param request_ids:  List of (Request-ID as a 32 character hex string).
+    :param new_state:    New state as string.
+    :param session:      Database session to use.
+    :param logger:       Optional decorated logger that can be passed from the calling daemons or servers.
+    """
+
+    record_counter('core.request.set_requests_state_if_possible')
+
+    try:
+        for request_id in request_ids:
+            try:
+                set_request_state(request_id, new_state, session=session, logger=logger)
+            except UnsupportedOperation:
+                continue
     except IntegrityError as error:
         raise RucioException(error.args)
 

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -349,9 +349,9 @@ def __get_transfers(total_workers=0, worker_number=0, failover_schemes=None, lim
                                                                                                                                      retry_other_fts=retry_other_fts,
                                                                                                                                      failover_schemes=failover_schemes,
                                                                                                                                      transfertool=transfertool)
-    request_core.set_requests_state(reqs_no_source, RequestState.NO_SOURCES, logger=logger)
-    request_core.set_requests_state(reqs_only_tape_source, RequestState.ONLY_TAPE_SOURCES, logger=logger)
-    request_core.set_requests_state(reqs_scheme_mismatch, RequestState.MISMATCH_SCHEME, logger=logger)
+    request_core.set_requests_state_if_possible(reqs_no_source, RequestState.NO_SOURCES, logger=logger)
+    request_core.set_requests_state_if_possible(reqs_only_tape_source, RequestState.ONLY_TAPE_SOURCES, logger=logger)
+    request_core.set_requests_state_if_possible(reqs_scheme_mismatch, RequestState.MISMATCH_SCHEME, logger=logger)
 
     for request_id in transfers:
         sources = transfers[request_id]['sources']


### PR DESCRIPTION
The submitter fails when trying to update the request state of missing
requests. I verified 5 requests manually on which the operation failed
and all of them where from the "Functional Tests" activity.
I assume some job creates and removes requests for testing. These
requests are queued in submitter. In the meantime they get deleted.
This crashes the submitter, which must restart all activities.

The docstring of the set_request_state function actually says that
missing requests will be ignored, but it's not what the function did.
It is used in multiple places in the code, some rely on the fact that
it will fail on missing requests. So fix the docstring and add a
version of this function which does actually skip missing requests.
