### PR TITLE
Core & Internals, API, Clients: nrandom for list_replicas. #4626

### DIFF
--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -24,8 +24,8 @@
 # - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Eric Vaandering <ewv@fnal.gov>, 2020
-#
-# PY3K COMPATIBLE
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from rucio.api import permission
 from rucio.db.sqla.constants import BadFilesStatus
@@ -143,7 +143,7 @@ def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
                   ignore_availability=True, all_states=False, rse_expression=None,
                   client_location=None, domain=None, signature_lifetime=None,
                   resolve_archives=True, resolve_parents=False,
-                  updated_after=None,
+                  nrandom=None, updated_after=None,
                   issuer=None, vo='def'):
     """
     List file replicas for a list of data identifiers.
@@ -181,7 +181,7 @@ def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
                                      client_location=client_location, domain=domain,
                                      sign_urls=sign_urls, signature_lifetime=signature_lifetime,
                                      resolve_archives=resolve_archives, resolve_parents=resolve_parents,
-                                     updated_after=updated_after)
+                                     nrandom=nrandom, updated_after=updated_after)
 
     for rep in replicas:
         # 'rses' and 'states' use rse_id as the key. This needs updating to be rse.

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1128,6 +1128,7 @@ class DownloadClient:
             # get PFNs of files and datasets
             logger(logging.DEBUG, 'num DIDs for list_replicas call: %d' % len(item['dids']))
 
+            nrandom = item.get('nrandom')
             metalink_str = self.client.list_replicas(item['dids'],
                                                      schemes=schemes,
                                                      ignore_availability=False,
@@ -1135,6 +1136,7 @@ class DownloadClient:
                                                      client_location=self.client_location,
                                                      resolve_archives=resolve_archives,
                                                      resolve_parents=True,
+                                                     nrandom=nrandom,
                                                      metalink=True)
             file_items = parse_replicas_from_string(metalink_str)
 
@@ -1161,7 +1163,6 @@ class DownloadClient:
                         logger(logging.WARNING, 'The requested DID {} only has replicas on tape. Direct download from tape is prohibited. '
                                                 'Please request a transfer to a non-tape endpoint.'.format(file_item['did']))
 
-            nrandom = item.get('nrandom')
             if nrandom:
                 logger(logging.INFO, 'Selecting %d random replicas from DID(s): %s' % (nrandom, item['dids']))
                 random.shuffle(file_items)

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -121,7 +121,7 @@ class ReplicaClient(BaseClient):
     def list_replicas(self, dids, schemes=None, unavailable=False, ignore_availability=True,
                       all_states=False, metalink=False, rse_expression=None,
                       client_location=None, sort=None, domain=None,
-                      signature_lifetime=None,
+                      signature_lifetime=None, nrandom=None,
                       resolve_archives=True, resolve_parents=False,
                       updated_after=None):
         """
@@ -141,6 +141,7 @@ class ReplicaClient(BaseClient):
                                         ``dynamic`` - Rucio Dynamic Smart Sort (tm)
         :param domain: Define the domain. None is fallback to 'wan', otherwise 'wan, 'lan', or 'all'
         :param signature_lifetime: If supported, in seconds, restrict the lifetime of the signed PFN.
+        :param nrandom: pick N random replicas. If the initial number of replicas is smaller than N, returns all replicas.
         :param resolve_archives: When set to True, find archives which contain the replicas.
         :param resolve_parents: When set to True, find all parent datasets which contain the replicas.
         :param updated_after: epoch timestamp or datetime object (UTC time), only return replicas updated after this time
@@ -177,6 +178,9 @@ class ReplicaClient(BaseClient):
 
         if signature_lifetime:
             data['signature_lifetime'] = signature_lifetime
+
+        if nrandom:
+            data['nrandom'] = nrandom
 
         data['resolve_archives'] = resolve_archives
 

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -978,6 +978,28 @@ def test_client_set_tombstone(rse_factory, mock_scope, root_account, replica_cli
         replica_client.set_tombstone([{'rse': rse, 'scope': mock_scope.external, 'name': name}])
 
 
+def test_client_get_nrandom(rse_factory, did_factory, did_client, replica_client):
+    """ REPLICA (CLIENT): get N random replicas from a dataset"""
+    rse, _ = rse_factory.make_posix_rse()
+
+    dataset = did_factory.make_dataset()
+    dataset = {'scope': dataset['scope'].external, 'name': dataset['name']}
+
+    files = []
+    for _ in range(10):
+        file = did_factory.upload_test_file(rse)
+        file = {'scope': file['scope'].external, 'name': file['name']}
+        files.append(file)
+    did_client.add_files_to_dataset(files=files, **dataset)
+
+    replicas = list(replica_client.list_replicas(dids=[dataset], nrandom=5))
+    assert len(replicas) == 5
+
+    # Requesting more files than actually exist in the dataset, will return all files
+    replicas = list(replica_client.list_replicas(dids=[dataset], nrandom=15))
+    assert len(replicas) == 10
+
+
 class TestReplicaMetalink:
 
     @pytest.mark.dirty

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -23,6 +23,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Eric Vaandering <ewv@fnal.gov>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from datetime import datetime
 from json import dumps, loads
@@ -320,6 +321,9 @@ class ListReplicas(ErrorHandlingMethodView):
             else:
                 # attempt UTC format '%Y-%m-%dT%H:%M:%S' conversion
                 updated_after = datetime.strptime(updated_after, '%Y-%m-%dT%H:%M:%S')
+        nrandom = param_get(parameters, 'nrandom', default=None)
+        if nrandom:
+            nrandom = int(nrandom)
 
         limit = request.args.get('limit', default=None)
         select = request.args.get('select', default=select)
@@ -347,6 +351,7 @@ class ListReplicas(ErrorHandlingMethodView):
                                            domain=domain, signature_lifetime=signature_lifetime,
                                            resolve_archives=resolve_archives,
                                            resolve_parents=resolve_parents,
+                                           nrandom=nrandom,
                                            updated_after=updated_after,
                                            issuer=issuer,
                                            vo=vo):

--- a/lib/rucio/web/rest/webpy/v1/replica.py
+++ b/lib/rucio/web/rest/webpy/v1/replica.py
@@ -335,7 +335,7 @@ class ListReplicas(RucioController):
         dids, schemes, select, unavailable, limit = [], None, None, False, None
         ignore_availability, rse_expression, all_states, domain = False, None, False, None
         signature_lifetime, resolve_archives, resolve_parents = None, True, False
-        updated_after = None
+        nrandom, updated_after = None, None
 
         client_location = {'ip': client_ip,
                            'fqdn': None,
@@ -367,7 +367,8 @@ class ListReplicas(RucioController):
                 resolve_archives = params['resolve_archives']
             if 'resolve_parents' in params:
                 resolve_parents = params['resolve_parents']
-
+            if 'nrandom' in params:
+                nrandom = params['nrandom']
             if 'signature_lifetime' in params:
                 signature_lifetime = params['signature_lifetime']
             else:
@@ -416,6 +417,7 @@ class ListReplicas(RucioController):
                                        domain=domain, signature_lifetime=signature_lifetime,
                                        resolve_archives=resolve_archives,
                                        resolve_parents=resolve_parents,
+                                       nrandom=nrandom,
                                        updated_after=updated_after,
                                        issuer=ctx.env.get('issuer'),
                                        vo=ctx.env.get('vo')):


### PR DESCRIPTION
Introduce the nrandom filter for list_replicas. It is applied before
sending replicas to the client: all replicas are retrieved from the
database, processed; and then the filtering is applied. This is
sub-optimal, because a lot of processing is performed for replicas
which will be dropped afterwards, but is the only safe way to implement
it right now.

The reason is the following: some existing filters are only applied
in python processing logic. For example the "schemes" filter. Meaning
that "nrandom" can only be applied after these filters and cannot be
done during the SQL call.

This change still results in some optimisation, because less data will
be serialized to json and sent to clients.

