### PR TITLE
 Multi VO: Add long VO name mapping feature. Fix #4548 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -52,6 +52,7 @@ Individual contributors to the source code
 - Ian Johnson, <ian.johnson@stfc.ac.uk>, 2021
 - Radu Carpa <radu.carpa@cern.ch>, 2021
 - Dhruv Sondhi <dhruvsondhi05@gmail.com>, 2021
+- Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 
 Organisations employing contributors
@@ -77,3 +78,4 @@ Organisations employing contributors
 - Science and Technology Facilities Council (UK)
 - Brookhaven National Laboratory (USA)
 - Institut Teknologi Bandung (Indonesia)
+- Imperial College London (UK)

--- a/etc/docker/test/extra/rucio_multi_vo_ts2_postgres12.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_ts2_postgres12.cfg
@@ -16,7 +16,8 @@ client_key = /opt/rucio/etc/ruciouser.key.pem
 client_x509_proxy = $X509_USER_PROXY
 account = root
 request_retries = 3
-vo = ts2
+# Relies on mapping created by bootstrap_tests.py
+vo = testvo2
 
 [database]
 default = postgresql://postgres:secret@postgres12/postgres

--- a/etc/docker/test/extra/rucio_multi_vo_tst_postgres12.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_tst_postgres12.cfg
@@ -16,7 +16,8 @@ client_key = /opt/rucio/etc/ruciouser.key.pem
 client_x509_proxy = $X509_USER_PROXY
 account = root
 request_retries = 3
-vo = tst
+# Relies on mapping created by bootstrap_tests.py
+vo = testvo1
 
 [database]
 default = postgresql://postgres:secret@postgres12/postgres

--- a/lib/rucio/api/vo.py
+++ b/lib/rucio/api/vo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019-2020 CERN
+# Copyright 2019-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 # Authors:
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from rucio.api.permission import has_permission
 from rucio.common import exception
@@ -38,6 +40,7 @@ def add_vo(new_vo, issuer, description=None, email=None, vo='def'):
     :param vo: The vo of the user issuing the command.
     '''
 
+    new_vo = vo_core.map_vo(new_vo)
     validate_schema('vo', new_vo, vo=vo)
 
     kwargs = {}
@@ -75,6 +78,7 @@ def recover_vo_root_identity(root_vo, identity_key, id_type, email, issuer, defa
     :param vo: the VO to act on.
     """
     kwargs = {}
+    root_vo = vo_core.map_vo(root_vo)
     if not has_permission(issuer=issuer, vo=vo, action='recover_vo_root_identity', kwargs=kwargs):
         raise exception.AccessDenied('Account %s can not recover root identity' % (issuer))
 
@@ -93,6 +97,7 @@ def update_vo(updated_vo, parameters, issuer, vo='def'):
     :param vo: The VO of the user issusing the command.
     """
     kwargs = {}
+    updated_vo = vo_core.map_vo(updated_vo)
     if not has_permission(issuer=issuer, action='update_vo', kwargs=kwargs, vo=vo):
         raise exception.AccessDenied('Account {} cannot update VO'.format(issuer))
 

--- a/lib/rucio/rse/__init__.py
+++ b/lib/rucio/rse/__init__.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2019 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,15 +14,15 @@
 # limitations under the License.
 #
 # Authors:
-# - Ralph Vigne, <ralph.vigne@cern.ch>, 2013 - 2014
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013-2017
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2017-2019
-# - James Perry, <j.perry@epcc.ed.ac.uk>, 2019
-# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
-# - Brandon White, <bjwhite@fnal.gov>, 2019
-# - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
-#
-# PY3K COMPATIBLE
+# - Ralph Vigne <ralph.vigne@cern.ch>, 2012-2013
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2017
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2013
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2017-2019
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Brandon White <bjwhite@fnal.gov>, 2019
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from dogpile.cache import make_region
 
@@ -93,10 +94,15 @@ if rsemanager.CLIENT_MODE:   # pylint:disable=no-member
 
 if rsemanager.SERVER_MODE:   # pylint:disable=no-member
     from rucio.core.rse import get_rse_protocols, get_rse_id
+    from rucio.core.vo import map_vo
 
     def tmp_rse_info(rse=None, vo='def', rse_id=None, session=None):
         if rse_id is None:
-            rse_id = get_rse_id(rse=rse, vo=vo)
+            # This can be called directly by client tools if they're co-located on a server
+            # i.e. running rucio cli on a server and during the test suite.
+            # We have to map to VO name here for this situations, despite this nominally
+            # not being a client interface.
+            rse_id = get_rse_id(rse=rse, vo=map_vo(vo))
         return get_rse_protocols(rse_id=rse_id, session=session)
 
     setattr(rsemanager, '__request_rse_info', tmp_rse_info)

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -25,12 +25,13 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from __future__ import print_function
 
-import json
 import contextlib
 import itertools
+import json
 import os
 import tempfile
 from random import choice
@@ -39,13 +40,24 @@ from string import ascii_uppercase
 import pytest
 from six import PY3
 
+from rucio.common.config import config_get, config_get_bool, get_config_dirs
 from rucio.common.utils import generate_uuid as uuid, execute
-from rucio.common.config import get_config_dirs
 
 skip_rse_tests_with_accounts = pytest.mark.skipif(not any(os.path.exists(os.path.join(d, 'rse-accounts.cfg')) for d in get_config_dirs()),
                                                   reason='fails if no rse-accounts.cfg found')
 skiplimitedsql = pytest.mark.skipif('RDBMS' in os.environ and (os.environ['RDBMS'] == 'sqlite' or os.environ['RDBMS'] == 'mysql5'),
                                     reason="does not work in SQLite or MySQL 5, because of missing features")
+
+
+def get_long_vo():
+    """ Get the VO name from the config file for testing.
+    Don't map the name to a short version.
+    :returns: VO name string.
+    """
+    vo_name = 'def'
+    if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
+        vo_name = config_get('client', 'vo', raise_exception=False, default=None)
+    return vo_name
 
 
 def account_name_generator():

--- a/lib/rucio/tests/common_server.py
+++ b/lib/rucio/tests/common_server.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
+
+from rucio.core import config as config_db
+from rucio.core.vo import map_vo
+from rucio.db.sqla import session, models
+from rucio.tests.common import get_long_vo
+
+
+# Functions containing server-only includes that can't be included in client tests
+
+
+def reset_config_table():
+    """ Clear the config table and install any default entires needed for the tests.
+    """
+    db_session = session.get_session()
+    db_session.query(models.Config).delete()
+    db_session.commit()
+    config_db.set("vo-map", "testvo1", "tst")
+    config_db.set("vo-map", "testvo2", "ts2")
+
+
+def get_vo():
+    """ Gets the current short/mapped VO name for testing.
+    Maps the vo name to the short name, if configured.
+    :returns: VO name string.
+    """
+    return map_vo(get_long_vo())

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -17,23 +17,28 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Mayank Sharma <mayank.sharma@cern.ch>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from __future__ import print_function
 
 import traceback
+
 import pytest
+
 
 # local imports in the fixtures to make this file loadable in e.g. client tests
 
 
 @pytest.fixture(scope='session')
 def vo():
-    from rucio.common.config import config_get_bool, config_get
+    from rucio.tests.common_server import get_vo
+    return get_vo()
 
-    if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-        return config_get('client', 'vo', raise_exception=False, default='tst')
-    else:
-        return 'def'
+
+@pytest.fixture(scope='session')
+def long_vo():
+    from rucio.tests.common import get_long_vo
+    return get_long_vo()
 
 
 @pytest.fixture(scope='module')
@@ -86,10 +91,10 @@ def rest_client():
 
 
 @pytest.fixture
-def auth_token(rest_client, vo):
+def auth_token(rest_client, long_vo):
     from rucio.tests.common import vohdr, headers, loginhdr
 
-    auth_response = rest_client.get('/auth/userpass', headers=headers(loginhdr('root', 'ddmlab', 'secret'), vohdr(vo)))
+    auth_response = rest_client.get('/auth/userpass', headers=headers(loginhdr('root', 'ddmlab', 'secret'), vohdr(long_vo)))
     assert auth_response.status_code == 200
     token = auth_response.headers.get('X-Rucio-Auth-Token')
     assert token

--- a/lib/rucio/tests/test_abacus_account.py
+++ b/lib/rucio/tests/test_abacus_account.py
@@ -21,6 +21,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import os
 import unittest
@@ -29,7 +30,7 @@ import pytest
 
 from rucio.client.accountclient import AccountClient
 from rucio.client.uploadclient import UploadClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.account import get_usage_history
@@ -43,6 +44,7 @@ from rucio.daemons.undertaker import undertaker
 from rucio.db.sqla import models
 from rucio.db.sqla.session import get_session
 from rucio.tests.common import file_generator
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.noparallel(reason='uses daemon, failing in parallel to other tests, updates account')
@@ -58,7 +60,7 @@ class TestAbacusAccount(unittest.TestCase):
         cls.session = get_session()
 
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
 
         cls.account = InternalAccount('root', **cls.vo)
         cls.scope = InternalScope('mock', **cls.vo)

--- a/lib/rucio/tests/test_abacus_collection_replica.py
+++ b/lib/rucio/tests/test_abacus_collection_replica.py
@@ -21,6 +21,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2020-2021
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import os
 import unittest
@@ -31,7 +32,7 @@ from rucio.client.didclient import DIDClient
 from rucio.client.replicaclient import ReplicaClient
 from rucio.client.ruleclient import RuleClient
 from rucio.client.uploadclient import UploadClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalScope, InternalAccount
 from rucio.common.utils import generate_uuid
 from rucio.core.did import add_did
@@ -44,6 +45,7 @@ from rucio.daemons.undertaker import undertaker
 from rucio.db.sqla import models, session
 from rucio.db.sqla.constants import DIDType, ReplicaState
 from rucio.tests.common import file_generator, rse_name_generator
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.noparallel(reason='uses pre-defined RSE, fails when run in parallel')
@@ -64,7 +66,7 @@ class TestAbacusCollectionReplica(unittest.TestCase):
         cls.upload_client = UploadClient()
 
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
 
         cls.rse_id = get_rse_id(rse=cls.rse, **cls.vo)
 

--- a/lib/rucio/tests/test_abacus_rse.py
+++ b/lib/rucio/tests/test_abacus_rse.py
@@ -20,6 +20,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import os
 import unittest
@@ -27,7 +28,7 @@ import unittest
 import pytest
 
 from rucio.client.uploadclient import UploadClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.utils import generate_uuid
 from rucio.core.rse import get_rse_id, get_rse_usage
 from rucio.daemons.abacus import rse
@@ -37,6 +38,7 @@ from rucio.daemons.undertaker import undertaker
 from rucio.db.sqla import models
 from rucio.db.sqla.session import get_session
 from rucio.tests.common import file_generator
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.noparallel(reason='uses daemon, failing in parallel to other tests, updates account')
@@ -53,7 +55,7 @@ class TestAbacusRSE(unittest.TestCase):
         cls.session = get_session()
 
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
 
         cls.rse_id = get_rse_id(cls.rse, session=cls.session, **cls.vo)
 

--- a/lib/rucio/tests/test_account.py
+++ b/lib/rucio/tests/test_account.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2020 CERN
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 from json import loads
@@ -42,12 +43,13 @@ from rucio.core.account import list_identities, add_account_attribute, list_acco
 from rucio.core.identity import add_account_identity, add_identity
 from rucio.db.sqla.constants import AccountStatus, IdentityType
 from rucio.tests.common import account_name_generator, headers, auth, vohdr, loginhdr
+from rucio.tests.common_server import get_vo
 
 
 class TestAccountCoreApi(unittest.TestCase):
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_account_limits.py
+++ b/lib/rucio/tests/test_account_limits.py
@@ -21,6 +21,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import random
 import string
@@ -30,13 +31,14 @@ import pytest
 
 from rucio.client.accountclient import AccountClient
 from rucio.client.accountlimitclient import AccountLimitClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount
 from rucio.core import account_limit
 from rucio.core.account import add_account
 from rucio.core.rse import get_rse_id
 from rucio.db.sqla import session, models
 from rucio.db.sqla.constants import AccountType
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.dirty
@@ -46,7 +48,7 @@ class TestCoreAccountLimits(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
             cls.multi_vo = True
         else:
             cls.vo = {}
@@ -144,7 +146,7 @@ class TestAccountClient(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
             cls.multi_vo = True
         else:
             cls.vo = {}

--- a/lib/rucio/tests/test_api_external_representation.py
+++ b/lib/rucio/tests/test_api_external_representation.py
@@ -19,6 +19,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import random
 import string
@@ -41,7 +42,7 @@ from rucio.api.rule import add_replication_rule
 from rucio.api.scope import add_scope, list_scopes, get_scopes
 from rucio.api.subscription import add_subscription, list_subscriptions, list_subscription_rule_states, \
     get_subscription_by_id
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import api_update_return_dict, generate_uuid
 from rucio.core.rse import get_rse_id
@@ -51,6 +52,7 @@ from rucio.daemons.judge import cleaner
 from rucio.daemons.reaper import reaper
 from rucio.db.sqla import constants
 from rucio.tests.common import rse_name_generator
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.noparallel(reason='uses pre-defined RSE, fails when run in parallel')
@@ -59,7 +61,7 @@ class TestApiExternalRepresentation(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
             cls.new_vo = {'vo': 'new'}
             cls.multi_vo = True
             if not vo_exists(**cls.new_vo):

--- a/lib/rucio/tests/test_authentication.py
+++ b/lib/rucio/tests/test_authentication.py
@@ -25,6 +25,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import base64
 import unittest
@@ -34,13 +35,14 @@ from requests import session
 
 from rucio.api.authentication import get_auth_token_user_pass, get_auth_token_ssh, get_ssh_challenge_token, \
     get_auth_token_saml
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import Duplicate, AccessDenied
 from rucio.common.types import InternalAccount
 from rucio.common.utils import ssh_sign
 from rucio.core.identity import add_account_identity, del_account_identity
 from rucio.db.sqla.constants import IdentityType
 from rucio.tests.common import headers, hdrdict, loginhdr, vohdr
+from rucio.tests.common_server import get_vo
 
 PUBLIC_KEY = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq5LySllrQFpPL"\
              "614sulXQ7wnIr1aGhGtl8b+HCB/0FhMSMTHwSjX78UbfqEorZ"\
@@ -97,7 +99,7 @@ class TestAuthCoreApi(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_bb8.py
+++ b/lib/rucio/tests/test_bb8.py
@@ -21,13 +21,14 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 from datetime import datetime
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import RuleNotFound, UnsupportedOperation
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid
@@ -39,6 +40,7 @@ from rucio.core.rule import add_rule, get_rule, delete_rule
 from rucio.daemons.bb8.common import rebalance_rule
 from rucio.daemons.judge.cleaner import rule_cleaner
 from rucio.db.sqla.constants import DIDType, RuleState
+from rucio.tests.common_server import get_vo
 from rucio.tests.test_rule import create_files, tag_generator
 
 
@@ -48,7 +50,7 @@ class TestJudgeCleaner(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 

--- a/lib/rucio/tests/test_clients.py
+++ b/lib/rucio/tests/test_clients.py
@@ -25,11 +25,13 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from __future__ import print_function
 
 import unittest
 from datetime import datetime, timedelta
+
 try:
     from SimpleHTTPServer import SimpleHTTPRequestHandler
 except ImportError:
@@ -48,6 +50,7 @@ from rucio.client.client import Client
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import CannotAuthenticate, ClientProtocolNotSupported, RucioException
 from rucio.common.utils import get_tmp_dir
+from rucio.tests.common import get_long_vo
 
 
 class MockServer:
@@ -93,7 +96,7 @@ class TestBaseClient(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_long_vo()}
             try:
                 remove(get_tmp_dir() + '/.rucio_root@%s/auth_token_root' % self.vo['vo'])
             except OSError as error:
@@ -191,7 +194,7 @@ class TestRucioClients(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_long_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_common_types.py
+++ b/lib/rucio/tests/test_common_types.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2019-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +17,13 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalScope, InternalAccount, InternalType
+from rucio.tests.common_server import get_vo
 
 
 class TestInternalType(unittest.TestCase):
@@ -29,7 +32,7 @@ class TestInternalType(unittest.TestCase):
     def setUp(self):
         ''' INTERNAL TYPES: Setup the tests '''
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_counter.py
+++ b/lib/rucio/tests/test_counter.py
@@ -23,12 +23,13 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount
 from rucio.core import account_counter, rse_counter
 from rucio.core.account import get_usage
@@ -36,13 +37,14 @@ from rucio.core.rse import get_rse_id
 from rucio.daemons.abacus.account import account_update
 from rucio.daemons.abacus.rse import rse_update
 from rucio.db.sqla import session, models
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.noparallel(reason='uses pre-defined RSE, fails when run in parallel')
 class TestCoreRSECounter(unittest.TestCase):
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 
@@ -109,7 +111,7 @@ class TestCoreRSECounter(unittest.TestCase):
 class TestCoreAccountCounter(unittest.TestCase):
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_credential.py
+++ b/lib/rucio/tests/test_credential.py
@@ -1,4 +1,5 @@
-# Copyright 2018-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,26 +21,28 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
 import pytest
 
 from rucio.client import client
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import UnsupportedOperation
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.credential import get_signed_url
 from rucio.core.replica import add_replicas, delete_replicas
 from rucio.core.rse import add_rse, del_rse, add_protocol, add_rse_attribute
 from rucio.tests.common import rse_name_generator
+from rucio.tests.common_server import get_vo
 
 
 class TestCredential(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_curl.py
+++ b/lib/rucio/tests/test_curl.py
@@ -23,6 +23,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from __future__ import print_function
 
@@ -33,7 +34,7 @@ import unittest
 import pytest
 
 from rucio.common.config import config_get, config_get_bool
-from rucio.tests.common import account_name_generator, rse_name_generator, execute
+from rucio.tests.common import account_name_generator, rse_name_generator, execute, get_long_vo
 
 
 class TestCurlRucio(unittest.TestCase):
@@ -43,7 +44,7 @@ class TestCurlRucio(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo_header = '-H "X-Rucio-VO: %s"' % config_get('client', 'vo', raise_exception=False, default='tst')
+            self.vo_header = '-H "X-Rucio-VO: %s"' % get_long_vo()
         else:
             self.vo_header = ''
 

--- a/lib/rucio/tests/test_dataset_replicas.py
+++ b/lib/rucio/tests/test_dataset_replicas.py
@@ -22,6 +22,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
@@ -30,7 +31,7 @@ import pytest
 from rucio.client.didclient import DIDClient
 from rucio.client.replicaclient import ReplicaClient
 from rucio.client.ruleclient import RuleClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import InvalidObject
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
@@ -41,13 +42,14 @@ from rucio.core.rse import add_rse, del_rse, add_protocol, get_rse_id
 from rucio.db.sqla import session, models, constants
 from rucio.db.sqla.constants import ReplicaState
 from rucio.tests.common import rse_name_generator
+from rucio.tests.common_server import get_vo
 
 
 class TestDatasetReplicaClient(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 
@@ -181,7 +183,7 @@ class TestDatasetReplicaUpdate(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_did.py
+++ b/lib/rucio/tests/test_did.py
@@ -29,6 +29,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from __future__ import print_function
 
@@ -46,7 +47,7 @@ from rucio.client.replicaclient import ReplicaClient
 from rucio.client.rseclient import RSEClient
 from rucio.client.scopeclient import ScopeClient
 from rucio.common import exception
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import (DataIdentifierNotFound, DataIdentifierAlreadyExists,
                                     InvalidPath, KeyNotFound, UnsupportedOperation,
                                     UnsupportedStatus, ScopeNotFound, FileAlreadyExists, FileConsistencyMismatch)
@@ -60,13 +61,14 @@ from rucio.core.replica import add_replica
 from rucio.core.rse import get_rse_id
 from rucio.db.sqla.constants import DIDType
 from rucio.tests.common import rse_name_generator, scope_name_generator
+from rucio.tests.common_server import get_vo
 
 
 class TestDIDCore(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 
@@ -259,7 +261,7 @@ class TestDIDCore(unittest.TestCase):
 class TestDIDApi(unittest.TestCase):
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 
@@ -300,7 +302,7 @@ class TestDIDClients(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_did_meta_plugins.py
+++ b/lib/rucio/tests/test_did_meta_plugins.py
@@ -16,13 +16,14 @@
 # Authors:
 # - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
 import pytest
 
 from rucio.client.didclient import DIDClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import KeyNotFound
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
@@ -30,6 +31,7 @@ from rucio.core.did import add_did, delete_dids, set_metadata_bulk
 from rucio.core.did_meta_plugins import list_dids, get_metadata, set_metadata
 from rucio.db.sqla.session import get_session
 from rucio.db.sqla.util import json_implemented
+from rucio.tests.common_server import get_vo
 
 
 def skip_without_json():
@@ -41,7 +43,7 @@ class TestDidMetaDidColumn(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
         self.tmp_scope = InternalScope('mock', **self.vo)
@@ -124,7 +126,7 @@ class TestDidMetaJSON(unittest.TestCase):
     def setUp(self):
         self.session = get_session()
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
         self.tmp_scope = InternalScope('mock', **self.vo)

--- a/lib/rucio/tests/test_identity.py
+++ b/lib/rucio/tests/test_identity.py
@@ -22,18 +22,20 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account import add_account, del_account
 from rucio.core.identity import add_identity, del_identity, add_account_identity, del_account_identity, list_identities
 from rucio.db.sqla.constants import AccountType, IdentityType
 from rucio.tests.common import account_name_generator, headers, hdrdict, auth
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.noparallel(reason='adds/removes entities with non-unique names')
@@ -45,7 +47,7 @@ class TestIdentity(unittest.TestCase):
     def setUp(self):
         """ Setup the Test Case """
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_import_export.py
+++ b/lib/rucio/tests/test_import_export.py
@@ -21,6 +21,8 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from __future__ import print_function
 
@@ -31,7 +33,7 @@ import pytest
 
 from rucio.client.exportclient import ExportClient
 from rucio.client.importclient import ImportClient
-from rucio.common.config import config_set, config_add_section, config_has_section, config_get, config_get_bool
+from rucio.common.config import config_set, config_add_section, config_has_section, config_get_bool
 from rucio.common.exception import RSENotFound
 from rucio.common.types import InternalAccount
 from rucio.common.utils import render_json, parse_response
@@ -46,6 +48,7 @@ from rucio.core.rse import get_rse_id, get_rse_name, add_rse, get_rse, add_proto
 from rucio.db.sqla import session, models
 from rucio.db.sqla.constants import RSEType, AccountType, IdentityType, AccountStatus
 from rucio.tests.common import rse_name_generator, headers, auth, hdrdict
+from rucio.tests.common_server import get_vo
 
 
 def check_rse(rse_name, test_data, vo='def'):
@@ -475,7 +478,7 @@ class TestImporterSyncModes(unittest.TestCase):
     def setUp(self):
         # Since test config scenarios are complicated moved the setup inside the individual tests
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_judge_cleaner.py
+++ b/lib/rucio/tests/test_judge_cleaner.py
@@ -21,12 +21,13 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account_limit import set_local_account_limit
@@ -36,6 +37,7 @@ from rucio.core.rse import add_rse_attribute, get_rse_id
 from rucio.core.rule import add_rule, update_rule
 from rucio.daemons.judge.cleaner import rule_cleaner
 from rucio.db.sqla.constants import DIDType
+from rucio.tests.common_server import get_vo
 from rucio.tests.test_rule import create_files, tag_generator
 
 
@@ -45,7 +47,7 @@ class TestJudgeCleaner(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 

--- a/lib/rucio/tests/test_judge_evaluator.py
+++ b/lib/rucio/tests/test_judge_evaluator.py
@@ -22,12 +22,13 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account import get_usage
@@ -39,6 +40,7 @@ from rucio.core.rule import add_rule, get_rule
 from rucio.daemons.abacus.account import account_update
 from rucio.daemons.judge.evaluator import re_evaluator
 from rucio.db.sqla.constants import DIDType
+from rucio.tests.common_server import get_vo
 from rucio.tests.test_rule import create_files, tag_generator
 
 
@@ -48,7 +50,7 @@ class TestJudgeEvaluator(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 

--- a/lib/rucio/tests/test_judge_injector.py
+++ b/lib/rucio/tests/test_judge_injector.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # Authors:
-# - Martin Barisits <martin.barisits@cern.ch>, 2015-2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2015-2021
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2015
 # - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
@@ -23,13 +23,14 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 from datetime import datetime, timedelta
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import RuleNotFound
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid
@@ -42,6 +43,7 @@ from rucio.daemons.judge.injector import rule_injector
 from rucio.db.sqla.constants import DIDType, RuleState
 from rucio.db.sqla.models import ReplicationRule
 from rucio.db.sqla.session import transactional_session
+from rucio.tests.common_server import get_vo
 from rucio.tests.test_rule import create_files, tag_generator
 
 
@@ -51,7 +53,7 @@ class TestJudgeEvaluator(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 

--- a/lib/rucio/tests/test_judge_repairer.py
+++ b/lib/rucio/tests/test_judge_repairer.py
@@ -22,6 +22,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 from hashlib import sha256
@@ -46,6 +47,7 @@ from rucio.db.sqla import models
 from rucio.db.sqla.constants import DIDType, RuleState, ReplicaState
 from rucio.db.sqla.session import get_session
 from rucio.tests.common import rse_name_generator
+from rucio.tests.common_server import get_vo
 from rucio.tests.test_rule import create_files, tag_generator
 
 
@@ -56,7 +58,7 @@ class TestJudgeRepairer(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 

--- a/lib/rucio/tests/test_naming_convention.py
+++ b/lib/rucio/tests/test_naming_convention.py
@@ -1,4 +1,5 @@
-# Copyright 2015-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2015-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,15 +19,14 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
 import pytest
 
 from rucio.client.didclient import DIDClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import InvalidObject
 from rucio.common.types import InternalScope
 from rucio.common.utils import generate_uuid
@@ -35,6 +35,7 @@ from rucio.core.naming_convention import (add_naming_convention,
                                           list_naming_conventions,
                                           delete_naming_convention)
 from rucio.db.sqla.constants import KeyType
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.noparallel(reason='changes global naming conventions, breaks other tests')
@@ -46,7 +47,7 @@ class TestNamingConventionCore(unittest.TestCase):
     def setUp(self):
         """ Constructor."""
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_oauthmanager.py
+++ b/lib/rucio/tests/test_oauthmanager.py
@@ -17,6 +17,7 @@
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import datetime
 import json
@@ -30,12 +31,13 @@ from sqlalchemy import and_, or_
 from sqlalchemy.sql.expression import true
 
 from rucio.api.account import add_account, del_account
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import Duplicate
 from rucio.common.types import InternalAccount
 from rucio.daemons.oauthmanager.oauthmanager import run, stop
 from rucio.db.sqla import models
 from rucio.db.sqla.session import get_session
+from rucio.tests.common_server import get_vo
 
 new_token_dict = {'access_token': '',
                   'expires_in': 3599,
@@ -185,7 +187,7 @@ class TestOAuthManager(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_oidc.py
+++ b/lib/rucio/tests/test_oidc.py
@@ -19,6 +19,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import time
 import traceback
@@ -30,7 +31,7 @@ from urllib.parse import urlparse, parse_qs
 import pytest
 from oic import rndstr
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import (CannotAuthenticate, DatabaseException)
 from rucio.common.exception import Duplicate
 from rucio.common.types import InternalAccount
@@ -43,6 +44,7 @@ from rucio.db.sqla import models
 from rucio.db.sqla.constants import AccountType
 from rucio.db.sqla.constants import IdentityType
 from rucio.db.sqla.session import get_session
+from rucio.tests.common_server import get_vo
 
 NEW_TOKEN_DICT = {'access_token': 'eyJ3bG...',
                   'expires_in': 3599,
@@ -277,7 +279,7 @@ class TestAuthCoreAPIoidc(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_permission.py
+++ b/lib/rucio/tests/test_permission.py
@@ -1,4 +1,5 @@
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +20,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
@@ -27,6 +29,7 @@ from rucio.common.config import config_get, config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.scope import add_scope
 from rucio.tests.common import scope_name_generator
+from rucio.tests.common_server import get_vo
 
 
 class TestPermissionCoreApi(unittest.TestCase):
@@ -37,7 +40,7 @@ class TestPermissionCoreApi(unittest.TestCase):
     def setUp(self):
         """ Setup Test Case """
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_pfns.py
+++ b/lib/rucio/tests/test_pfns.py
@@ -1,4 +1,5 @@
-# Copyright 2017-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2017-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,18 +18,20 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.rse import rsemanager as rsemgr
+from rucio.tests.common_server import get_vo
 
 
 class TestPFNs(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_qos.py
+++ b/lib/rucio/tests/test_qos.py
@@ -1,4 +1,5 @@
-# Copyright 2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2020-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,15 +16,15 @@
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
 from rucio.client.rseclient import RSEClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.core.rse import update_rse, get_rse
 from rucio.tests.common import rse_name_generator
+from rucio.tests.common_server import get_vo
 
 
 class TestQoS(unittest.TestCase):
@@ -31,7 +32,7 @@ class TestQoS(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 

--- a/lib/rucio/tests/test_quarantined_replica.py
+++ b/lib/rucio/tests/test_quarantined_replica.py
@@ -20,21 +20,23 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.utils import generate_uuid
 from rucio.core.quarantined_replica import add_quarantined_replicas, list_quarantined_replicas, \
     delete_quarantined_replicas
 from rucio.core.rse import get_rse_id
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.noparallel(reason='uses pre-defined rses')
 def test_quarantined_replicas():
     """ QUARANTINED REPLICA (CORE): Add, List and Delete quarantined replicas """
     if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-        vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+        vo = {'vo': get_vo()}
     else:
         vo = {}
 

--- a/lib/rucio/tests/test_redirect.py
+++ b/lib/rucio/tests/test_redirect.py
@@ -20,6 +20,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
@@ -29,7 +30,7 @@ from rucio.client.baseclient import BaseClient
 from rucio.client.replicaclient import ReplicaClient
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.utils import generate_uuid
-from rucio.tests.common import execute
+from rucio.tests.common import execute, get_long_vo
 
 
 @pytest.mark.dirty
@@ -38,7 +39,7 @@ class TestReplicaHeaderRedirection(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo_header = '-H "X-Rucio-VO: %s"' % config_get('client', 'vo', raise_exception=False, default='tst')
+            self.vo_header = '-H "X-Rucio-VO: %s"' % get_long_vo()
         else:
             self.vo_header = ''
 
@@ -82,7 +83,7 @@ class TestReplicaMetalinkRedirection(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo_header = '-H "X-Rucio-VO: %s"' % config_get('client', 'vo', raise_exception=False, default='tst')
+            self.vo_header = '-H "X-Rucio-VO: %s"' % get_long_vo()
         else:
             self.vo_header = ''
 

--- a/lib/rucio/tests/test_replica_recoverer.py
+++ b/lib/rucio/tests/test_replica_recoverer.py
@@ -18,6 +18,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from __future__ import print_function
 
@@ -29,13 +30,14 @@ from time import sleep
 import pytest
 
 from rucio.client.replicaclient import ReplicaClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalScope
 from rucio.core.replica import (update_replica_state, list_replicas, list_bad_replicas_status)
 from rucio.core.rse import get_rse_id
 from rucio.daemons.replicarecoverer.suspicious_replica_recoverer import run, stop
 from rucio.db.sqla.constants import DIDType, BadFilesStatus, ReplicaState
 from rucio.tests.common import execute, file_generator
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.dirty
@@ -44,7 +46,7 @@ class TestReplicaRecoverer(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_request.py
+++ b/lib/rucio/tests/test_request.py
@@ -20,13 +20,14 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 from datetime import datetime
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool, config_set, config_remove_option
+from rucio.common.config import config_get_bool, config_set, config_remove_option
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid, parse_response
 from rucio.core.replica import add_replica
@@ -35,6 +36,7 @@ from rucio.core.rse import get_rse_id, set_rse_transfer_limits, add_rse_attribut
 from rucio.db.sqla import session, models, constants
 from rucio.db.sqla.constants import RequestType, RequestState
 from rucio.tests.common import vohdr, hdrdict, headers, auth
+from rucio.tests.common_server import get_vo, reset_config_table
 
 
 @pytest.mark.dirty
@@ -141,8 +143,8 @@ def test_queue_requests_state(vo, use_preparer):
         db_session.query(models.Request).delete()
         db_session.query(models.RSETransferLimit).delete()
         db_session.query(models.Distance).delete()
-        db_session.query(models.Config).delete()
         db_session.commit()
+        reset_config_table()
 
 
 @pytest.mark.dirty
@@ -152,7 +154,7 @@ class TestRequestCoreList(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 
@@ -171,8 +173,8 @@ class TestRequestCoreList(unittest.TestCase):
         self.db_session.query(models.Request).delete()
         self.db_session.query(models.RSETransferLimit).delete()
         self.db_session.query(models.Distance).delete()
-        self.db_session.query(models.Config).delete()
         self.db_session.commit()
+        reset_config_table()
 
     def tearDown(self):
         self.db_session.commit()

--- a/lib/rucio/tests/test_rse.py
+++ b/lib/rucio/tests/test_rse.py
@@ -29,6 +29,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from __future__ import print_function
 
@@ -39,7 +40,7 @@ import pytest
 from rucio.client.replicaclient import ReplicaClient
 from rucio.client.rseclient import RSEClient
 from rucio.common import exception
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import (Duplicate, RSENotFound, RSEProtocolNotSupported,
                                     InvalidObject, ResourceTemporaryUnavailable,
                                     RSEAttributeNotFound, RSEOperationNotSupported)
@@ -53,13 +54,14 @@ from rucio.db.sqla import session, models
 from rucio.db.sqla.constants import RSEType
 from rucio.rse import rsemanager as mgr
 from rucio.tests.common import rse_name_generator, hdrdict, auth, headers
+from rucio.tests.common_server import get_vo
 
 
 class TestRSECoreApi(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 
@@ -364,7 +366,7 @@ class TestRSEClient(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_rse_expression_parser.py
+++ b/lib/rucio/tests/test_rse_expression_parser.py
@@ -21,6 +21,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 from random import choice
@@ -29,10 +30,11 @@ from string import ascii_uppercase, digits, ascii_lowercase
 import pytest
 
 from rucio.client.rseclient import RSEClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import InvalidRSEExpression, RSEWriteBlocked
 from rucio.core import rse
 from rucio.core import rse_expression_parser
+from rucio.tests.common_server import get_vo
 
 
 def rse_name_generator(size=10):
@@ -52,7 +54,7 @@ class TestRSEExpressionParserCore(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
             self.filter = {'filter': self.vo}
         else:
             self.vo = {}
@@ -235,7 +237,7 @@ class TestRSEExpressionParserClient(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_rse_selector.py
+++ b/lib/rucio/tests/test_rse_selector.py
@@ -18,12 +18,13 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import InsufficientAccountLimit, InsufficientTargetRSEs
 from rucio.common.types import InternalAccount
 from rucio.core.account_counter import update_account_counter, increase
@@ -31,6 +32,7 @@ from rucio.core.account_limit import set_local_account_limit, set_global_account
 from rucio.core.rse import get_rse_id
 from rucio.core.rse_selector import RSESelector
 from rucio.db.sqla import session, models
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.dirty
@@ -40,7 +42,7 @@ class TestRSESelectorInit(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 
@@ -141,7 +143,7 @@ class TestRSESelectorDynamic(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 

--- a/lib/rucio/tests/test_rule.py
+++ b/lib/rucio/tests/test_rule.py
@@ -29,6 +29,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import json
 import random
@@ -45,7 +46,7 @@ from rucio.client.didclient import DIDClient
 from rucio.client.lockclient import LockClient
 from rucio.client.ruleclient import RuleClient
 from rucio.client.subscriptionclient import SubscriptionClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import (RuleNotFound, AccessDenied, InsufficientAccountLimit, DuplicateRule, RSEWriteBlocked,
                                     RSEOverQuota,
                                     RuleReplaceFailed, ManualRuleApprovalBlocked, InputValidationError,
@@ -70,6 +71,7 @@ from rucio.db.sqla import models, session
 from rucio.db.sqla.constants import DIDType, OBSOLETE, RuleState, LockState
 from rucio.db.sqla.session import transactional_session
 from rucio.tests.common import rse_name_generator, account_name_generator
+from rucio.tests.common_server import get_vo
 
 LOG = getLogger(__name__)
 
@@ -85,7 +87,7 @@ def create_files(nrfiles, scope, rse_id, bytes=1):
     :returns:        List of dict
     """
     if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-        vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+        vo = {'vo': get_vo()}
     else:
         vo = {}
 
@@ -145,7 +147,7 @@ class TestReplicationRuleCore(unittest.TestCase):
         cls.db_session = session.get_session()
 
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 
@@ -1193,7 +1195,7 @@ class TestReplicationRuleClient(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 

--- a/lib/rucio/tests/test_s3.py
+++ b/lib/rucio/tests/test_s3.py
@@ -16,13 +16,14 @@
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 
 import pytest
 
 from rucio.client import client
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.distance import add_distance
 from rucio.core.replica import add_replicas, delete_replicas
@@ -30,6 +31,7 @@ from rucio.core.rse import add_rse, del_rse, add_protocol, add_rse_attribute
 from rucio.core.rule import add_rule
 from rucio.core.transfer import get_transfer_requests_and_source_replicas
 from rucio.tests.common import rse_name_generator
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.noparallel(reason='fails when run in parallel')
@@ -37,7 +39,7 @@ class TestS3(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_scope.py
+++ b/lib/rucio/tests/test_scope.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2020 CERN
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 from json import loads
@@ -31,19 +32,20 @@ import pytest
 
 from rucio.client.accountclient import AccountClient
 from rucio.client.scopeclient import ScopeClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import AccountNotFound, Duplicate, ScopeNotFound, InvalidObject
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.scope import get_scopes, add_scope, is_scope_owner
 from rucio.tests.common import account_name_generator, scope_name_generator, headers, auth, hdrdict
+from rucio.tests.common_server import get_vo
 
 
 class TestScopeCoreApi(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/tests/test_subscription.py
+++ b/lib/rucio/tests/test_subscription.py
@@ -25,6 +25,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from __future__ import print_function
 
@@ -37,7 +38,7 @@ from rucio.api.subscription import list_subscriptions, add_subscription, update_
     list_subscription_rule_states, get_subscription_by_id
 from rucio.client.didclient import DIDClient
 from rucio.client.subscriptionclient import SubscriptionClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.exception import InvalidObject, SubscriptionNotFound, SubscriptionDuplicate
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid
@@ -50,6 +51,7 @@ from rucio.core.scope import add_scope
 from rucio.daemons.transmogrifier.transmogrifier import run
 from rucio.db.sqla.constants import AccountType, DIDType
 from rucio.tests.common import headers, auth
+from rucio.tests.common_server import get_vo
 
 
 class TestSubscriptionCoreApi(unittest.TestCase):
@@ -57,7 +59,7 @@ class TestSubscriptionCoreApi(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 
@@ -318,7 +320,7 @@ class TestSubscriptionClient(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 

--- a/lib/rucio/tests/test_temporary_did.py
+++ b/lib/rucio/tests/test_temporary_did.py
@@ -19,16 +19,18 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import pytest
 
 from rucio.client.didclient import DIDClient
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.rse import get_rse_id
 from rucio.core.temporary_did import (add_temporary_dids, compose, delete_temporary_dids,
                                       list_expired_temporary_dids)
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.noparallel(reason='uses pre-defined RSE')
@@ -36,7 +38,7 @@ def test_core_temporary_dids():
     """ TMP DATA IDENTIFIERS (CORE): """
 
     if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-        vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+        vo = {'vo': get_vo()}
     else:
         vo = {}
     scope = InternalScope('mock', **vo)

--- a/lib/rucio/tests/test_throttler.py
+++ b/lib/rucio/tests/test_throttler.py
@@ -19,13 +19,15 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 from datetime import datetime, timedelta
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool, config_set, config_remove_option
+from rucio.common.config import config_get_bool, config_set, config_remove_option
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.did import attach_dids, add_did
@@ -36,6 +38,7 @@ from rucio.daemons.conveyor import throttler, preparer
 from rucio.db.sqla import session, models
 from rucio.db.sqla.constants import DIDType, RequestType, RequestState
 from rucio.tests.common import skiplimitedsql
+from rucio.tests.common_server import get_vo
 
 
 @pytest.mark.dirty
@@ -53,7 +56,7 @@ class TestThrottlerGroupedFIFO(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 
@@ -426,7 +429,7 @@ class TestThrottlerFIFO(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 
@@ -679,7 +682,7 @@ class TestThrottlerFIFOSRCACT(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 
@@ -808,7 +811,7 @@ class TestThrottlerFIFOSRCALLACT(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 
@@ -909,7 +912,7 @@ class TestThrottlerFIFODESTALLACT(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 
@@ -1040,7 +1043,7 @@ class TestThrottlerGroupedFIFOSRCALLACT(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 
@@ -1203,7 +1206,7 @@ class TestRequestCoreRelease(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            cls.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
 

--- a/lib/rucio/tests/test_undertaker.py
+++ b/lib/rucio/tests/test_undertaker.py
@@ -24,6 +24,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import unittest
 from datetime import datetime, timedelta
@@ -31,7 +32,7 @@ from logging import getLogger
 
 import pytest
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get_bool
 from rucio.common.policy import get_policy
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
@@ -43,6 +44,7 @@ from rucio.core.rule import add_rules, list_rules
 from rucio.daemons.undertaker.undertaker import undertaker
 from rucio.db.sqla.util import json_implemented
 from rucio.tests.common import rse_name_generator
+from rucio.tests.common_server import get_vo
 
 LOG = getLogger(__name__)
 
@@ -53,7 +55,7 @@ class TestUndertaker(unittest.TestCase):
 
     def setUp(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            self.vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+            self.vo = {'vo': get_vo()}
         else:
             self.vo = {}
 

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -21,6 +21,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from __future__ import print_function
 
@@ -42,7 +43,7 @@ from rucio.common.exception import AccessDenied, IdentityError, CannotAuthentica
 from rucio.common.extra import import_extras
 from rucio.common.utils import date_to_str
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, error_headers, \
-    generate_http_error_flask, ErrorHandlingMethodView
+    extract_vo, generate_http_error_flask, ErrorHandlingMethodView
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -111,7 +112,7 @@ class UserPass(ErrorHandlingMethodView):
         headers.add('Cache-Control', 'post-check=0, pre-check=0')
         headers['Pragma'] = 'no-cache'
 
-        vo = request.headers.get('X-Rucio-VO', default='def')
+        vo = extract_vo(request.headers)
         account = request.headers.get('X-Rucio-Account', default=None)
         username = request.headers.get('X-Rucio-Username', default=None)
         password = request.headers.get('X-Rucio-Password', default=None)
@@ -174,7 +175,7 @@ class OIDC(ErrorHandlingMethodView):
         headers.add('Cache-Control', 'post-check=0, pre-check=0')
         headers.set('Pragma', 'no-cache')
 
-        vo = request.headers.get('X-Rucio-VO', default='def')
+        vo = extract_vo(request.headers)
         account = request.environ.get('HTTP_X_RUCIO_ACCOUNT', 'webui')
         auth_scope = request.environ.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_SCOPE', "")
         audience = request.environ.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_AUDIENCE', "")
@@ -465,7 +466,7 @@ class RefreshOIDC(ErrorHandlingMethodView):
         headers.add('Cache-Control', 'post-check=0, pre-check=0')
         headers.set('Pragma', 'no-cache')
 
-        vo = request.headers.get('X-Rucio-VO', default='def')
+        vo = extract_vo(request.headers)
         account = request.headers.get('X-Rucio-Account', default=None)
         token = request.headers.get('X-Rucio-Auth-Token', default=None)
         if token is None or account is None:
@@ -536,7 +537,7 @@ class GSS(ErrorHandlingMethodView):
         headers.add('Cache-Control', 'post-check=0, pre-check=0')
         headers['Pragma'] = 'no-cache'
 
-        vo = request.headers.get('X-Rucio-VO', default='def')
+        vo = extract_vo(request.headers)
         account = request.headers.get('X-Rucio-Account', default=None)
         gsscred = request.environ.get('REMOTE_USER')
         appid = request.headers.get('X-Rucio-AppID', default='unknown')
@@ -615,7 +616,7 @@ class x509(ErrorHandlingMethodView):
         headers.add('Cache-Control', 'post-check=0, pre-check=0')
         headers['Pragma'] = 'no-cache'
 
-        vo = request.headers.get('X-Rucio-VO', default='def')
+        vo = extract_vo(request.headers)
         account = request.headers.get('X-Rucio-Account', default=None)
         dn = request.environ.get('SSL_CLIENT_S_DN')
         if not dn:
@@ -721,7 +722,7 @@ class SSH(ErrorHandlingMethodView):
         headers.add('Cache-Control', 'post-check=0, pre-check=0')
         headers['Pragma'] = 'no-cache'
 
-        vo = request.headers.get('X-Rucio-VO', default='def')
+        vo = extract_vo(request.headers)
         account = request.headers.get('X-Rucio-Account', default=None)
         signature = request.headers.get('X-Rucio-SSH-Signature', default=None)
         appid = request.headers.get('X-Rucio-AppID', default='unknown')
@@ -812,7 +813,7 @@ class SSHChallengeToken(ErrorHandlingMethodView):
         headers.add('Cache-Control', 'post-check=0, pre-check=0')
         headers['Pragma'] = 'no-cache'
 
-        vo = request.headers.get('X-Rucio-VO', default='def')
+        vo = extract_vo(request.headers)
         account = request.headers.get('X-Rucio-Account', default=None)
         appid = request.headers.get('X-Rucio-AppID', default='unknown')
         ip = request.headers.get('X-Forwarded-For', default=request.remote_addr)
@@ -879,7 +880,7 @@ class SAML(ErrorHandlingMethodView):
             return "SAML not configured on the server side.", 400, headers
 
         saml_nameid = request.cookies.get('saml-nameid', default=None)
-        vo = request.headers.get('X-Rucio-VO', default='def')
+        vo = extract_vo(request.headers)
         account = request.headers.get('X-Rucio-Account', default=None)
         appid = request.headers.get('X-Rucio-AppID', default='unknown')
         ip = request.headers.get('X-Forwarded-For', default=request.remote_addr)

--- a/lib/rucio/web/rest/flaskapi/v1/credentials.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credentials.py
@@ -20,6 +20,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 from typing import TYPE_CHECKING
 
@@ -28,8 +29,8 @@ from werkzeug.datastructures import Headers
 
 from rucio.api.credential import get_signed_url
 from rucio.common.exception import CannotAuthenticate
-from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, generate_http_error_flask, \
-    ErrorHandlingMethodView
+from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, extract_vo, \
+    generate_http_error_flask, ErrorHandlingMethodView
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -77,7 +78,7 @@ class SignURL(ErrorHandlingMethodView):
         :status 406: Not Acceptable
         """
         headers = self.get_headers()
-        vo = request.headers.get('X-Rucio-VO', default='def')
+        vo = extract_vo(request.headers)
         account = request.headers.get('X-Rucio-Account', default=None)
         appid = request.headers.get('X-Rucio-AppID', default='unknown')
         ip = request.headers.get('X-Forwarded-For', default=request.remote_addr)

--- a/tools/bootstrap_tests.py
+++ b/tools/bootstrap_tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2013-2020 CERN
+# Copyright 2013-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,14 +18,15 @@
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2013-2015
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2014-2020
 # - Evangelia Liotiri <evangelia.liotiri@cern.ch>, 2014
-# - Martin Barisits <martin.barisits@cern.ch>, 2014-2017
+# - Martin Barisits <martin.barisits@cern.ch>, 2014-2020
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2017
 # - Stefan Prenner <stefan.prenner@cern.ch>, 2017-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-# - Gabriele Gaetano Fronze' <gabriele.fronze@to.infn.it>, 2020
+# - Gabriele Fronze' <gfronze@cern.ch>, 2020
+# - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 
 import os.path
 import sys
@@ -40,12 +41,16 @@ from rucio.client import Client  # noqa: E402
 from rucio.common.config import config_get, config_get_bool  # noqa: E402
 from rucio.common.exception import Duplicate, RucioException  # noqa: E402
 from rucio.core.account import add_account_attribute  # noqa: E402
+from rucio.core.vo import map_vo  # noqa: E402
 from rucio.common.types import InternalAccount  # noqa: E402
+from rucio.tests.common_server import reset_config_table  # noqa: E402
 
 
 if __name__ == '__main__':
+    # Create config table including the long VO mappings
+    reset_config_table()
     if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-        vo = {'vo': config_get('client', 'vo', raise_exception=False, default='tst')}
+        vo = {'vo': map_vo(config_get('client', 'vo', raise_exception=False, default='tst'))}
         try:
             add_vo(new_vo=vo['vo'], issuer='super_root', description='A VO to test multi-vo features', email='N/A', vo='def')
         except Duplicate:


### PR DESCRIPTION
Hi,

This adds support for mapping long VO names to the internal three-character tags at client interfaces as discussed in ticket #4548. It also updates the multi VO tests to use the long names to ensure that all interfaces are properly covered.

Regards,
Simon
