### PR TITLE
Rest & API: always setup logger

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/main.py
+++ b/lib/rucio/web/rest/flaskapi/v1/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2020 CERN
+# Copyright 2020-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,10 @@
 # limitations under the License.
 #
 # Authors:
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Thomas Beermann <thomas.beermann@cern.ch>, 2021
+# - Martin Barisits <martin.barisits@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 import importlib
 
@@ -73,10 +76,10 @@ except RuntimeError:
 if not endpoints:
     endpoints = DEFAULT_ENDPOINTS
 
+setup_logging()
 application = Flask(__name__)
 apply_endpoints(application, endpoints)
 
 
 if __name__ == '__main__':
-    setup_logging()
     application.run()

--- a/lib/rucio/web/rest/main.py
+++ b/lib/rucio/web/rest/main.py
@@ -16,10 +16,9 @@
 # Authors:
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
-from rucio.common.logging import setup_logging
 from rucio.web.rest.flaskapi.v1.main import application
 
 if __name__ == '__main__':
-    setup_logging()
     application.run()

--- a/lib/rucio/web/ui/flask/main.py
+++ b/lib/rucio/web/ui/flask/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright 2014-2020 CERN
+# Copyright 2020-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,18 +16,19 @@
 #
 # Authors:
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020
-
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from flask import Flask
 
 from rucio.common.logging import setup_logging
 from rucio.web.ui.flask import bp
 
+setup_logging()
 application = Flask(__name__)
 
 application.register_blueprint(bp.blueprint())
 
 
 if __name__ == '__main__':
-    setup_logging()
     application.run()

--- a/lib/rucio/web/ui/main.py
+++ b/lib/rucio/web/ui/main.py
@@ -26,10 +26,9 @@
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
-from rucio.common.logging import setup_logging
 from rucio.web.ui.flask.main import application
 
 if __name__ == '__main__':
-    setup_logging()
     application.run()


### PR DESCRIPTION
WSGI doesn't run applications via __main__, so the logger is not setup in production.