### PR TITLE
Exporter : Broken distance option in Flask API : Closes #4657

### DIFF
--- a/lib/rucio/tests/test_import_export.py
+++ b/lib/rucio/tests/test_import_export.py
@@ -1252,6 +1252,8 @@ def test_export_client(vo, distances_data):
         }
     }
     assert parse_response(render_json(**distances_cmp)) == data['distances']
+    data = export_client.export_data(distance=False)
+    assert 'distances' not in data
 
 
 @pytest.mark.noparallel(reason='modifies distance on pre-defined RSE')

--- a/lib/rucio/web/rest/flaskapi/v1/export.py
+++ b/lib/rucio/web/rest/flaskapi/v1/export.py
@@ -56,7 +56,7 @@ class Export(ErrorHandlingMethodView):
         :status 406: Not Acceptable
         :returns: dictionary with rucio data
         """
-        distance = request.args.get('distance', default=True)
+        distance = request.args.get('distance', default='True') == 'True'
         return Response(render_json(**export_data(issuer=request.environ.get('issuer'), distance=distance, vo=request.environ.get('vo'))), content_type='application/json')
 
 


### PR DESCRIPTION
Exporter : Broken distance option in Flask API : Closes #4657