### PR TITLE
Core & Internals: Make Rucio query policy package for surl and lfn2pfn algorithms #4624

### DIFF
--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -579,7 +579,7 @@ def _register_policy_package_surl_algorithms():
                 _SURL_ALGORITHMS.update(module.get_surl_algorithms())
         except (NoOptionError, NoSectionError, ImportError):
             pass
-        
+
     from rucio.common import config
     from rucio.core.vo import list_vos
     try:

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -571,6 +571,7 @@ register_surl_algorithm(construct_surl_BelleII, 'BelleII')
 
 def _register_policy_package_surl_algorithms():
     def try_importing_policy(vo=None):
+        import importlib
         try:
             package = config.config_get('policy', 'package' + ('' if not vo else '-' + vo['vo']))
             module = importlib.import_module(package)
@@ -581,7 +582,6 @@ def _register_policy_package_surl_algorithms():
         
     from rucio.common import config
     from rucio.core.vo import list_vos
-    import importlib
     try:
         multivo = config.config_get_bool('common', 'multi_vo')
     except (NoOptionError, NoSectionError):

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -554,6 +554,7 @@ def construct_surl_BelleII(dsn, filename):
 
 _SURL_ALGORITHMS = {}
 _DEFAULT_SURL = 'DQ2'
+_loaded_policy_modules = False
 
 
 def register_surl_algorithm(surl_callable, name=None):
@@ -567,9 +568,42 @@ register_surl_algorithm(construct_surl_DQ2, 'DQ2')
 register_surl_algorithm(construct_surl_BelleII, 'BelleII')
 
 
+def _register_policy_package_surl_algorithms():
+    from rucio.common import config
+    from rucio.core.vo import list_vos
+    import importlib
+    try:
+        multivo = config.config_get_bool('common', 'multi_vo')
+    except (NoOptionError, NoSectionError):
+        multivo = False
+    if not multivo:
+        # single policy package
+        try:
+            package = config.config_get('policy', 'package')
+            module = importlib.import_module(package)
+            if hasattr(module, 'get_surl_algorithms'):
+                _SURL_ALGORITHMS.update(module.get_surl_algorithms())
+        except (NoOptionError, NoSectionError, ImportError):
+            pass
+    else:
+        # policy package per VO
+        vos = list_vos()
+        for vo in vos:
+            try:
+                package = config.config_get('policy', 'package-' + vo['vo'])
+                module = importlib.import_module(package)
+                if hasattr(module, 'get_surl_algorithms'):
+                    _SURL_ALGORITHMS.update(module.get_surl_algorithms())
+            except (NoOptionError, NoSectionError, ImportError):
+                pass
+
+
 def construct_surl(dsn, filename, naming_convention=None):
-    # ensure that policy package is loaded in case it registers its own algorithms
-    import rucio.common.schema  # noqa: F401
+    global _loaded_policy_modules
+    if not _loaded_policy_modules:
+        # on first call, register any SURL functions from the policy packages
+        _register_policy_package_surl_algorithms()
+        _loaded_policy_modules = True
 
     if naming_convention is None or naming_convention not in _SURL_ALGORITHMS:
         naming_convention = _DEFAULT_SURL

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -245,6 +245,7 @@ class RSEDeterministicTranslation(object):
         cls._DEFAULT_LFN2PFN = config.get_lfn2pfn_algorithm_default()
 
     def try_importing_policy(self, vo=None):
+        import importlib
         try:
             package = config.config_get('policy', 'package' + ('' if not vo else '-' + vo['vo']))
             module = importlib.import_module(package)
@@ -255,7 +256,6 @@ class RSEDeterministicTranslation(object):
 
     def query_policy_packages(self):
         from rucio.core.vo import list_vos
-        import importlib
         try:
             multivo = config.config_get_bool('common', 'multi_vo')
         except (NoOptionError, NoSectionError):


### PR DESCRIPTION
This pull request changes the policy package code so that Rucio will query the policy package(s) for any lfn2pfn and surl algorithms that should be registered. This avoids the import loops that can happen if the policy package does the registration when it loads. I will submit another PR to update the documentation accordingly.