### PR TITLE
Core & Internals: Add import_extras; Fix #4168

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -60,6 +60,7 @@ import unittest
 import uuid
 from functools import wraps
 
+from six.moves.configparser import NoOptionError, NoSectionError
 from tabulate import tabulate
 
 # rucio module has the same name as this executable module, so this rule fails. pylint: disable=no-name-in-module
@@ -70,14 +71,15 @@ from rucio.common.exception import (DataIdentifierAlreadyExists, AccessDenied, D
                                     RSENotFound, InvalidRSEExpression, InputValidationError, DuplicateContent,
                                     RuleNotFound, CannotAuthenticate, MissingDependency, UnsupportedOperation,
                                     RucioException, DuplicateRule, InvalidType)
+from rucio.common.extra import import_extras
 from rucio.common.test_rucio_server import TestRucioServer
 from rucio.common.utils import sizefmt, Color, detect_client_location, chunks, parse_did_filter_from_string, \
     extract_scope, setup_logger
 
-try:
-    from ConfigParser import NoOptionError, NoSectionError
-except ImportError:
-    from configparser import NoOptionError, NoSectionError
+EXTRA_MODULES = import_extras(['argcomplete'])
+
+if EXTRA_MODULES['argcomplete']:
+    import argcomplete  # pylint: disable=E0401
 
 SUCCESS = 0
 FAILURE = 1
@@ -2390,11 +2392,8 @@ if __name__ == '__main__':
             os.environ['RUCIO_CONFIG'] = arguments[argi + 1]
 
     oparser = get_parser()
-    try:
-        import argcomplete
+    if EXTRA_MODULES['argcomplete']:
         argcomplete.autocomplete(oparser)
-    except ImportError:
-        pass
 
     if len(sys.argv) == 1:
         oparser.print_help()

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -55,6 +55,7 @@ import time
 import traceback
 from functools import wraps
 
+from six.moves.configparser import NoOptionError, NoSectionError
 from tabulate import tabulate
 
 from rucio import version
@@ -65,15 +66,15 @@ from rucio.common.exception import (AccountNotFound, DataIdentifierAlreadyExists
                                     RSENotFound, RSEOperationNotSupported, InvalidRSEExpression,
                                     DuplicateContent, RuleNotFound, CannotAuthenticate,
                                     Duplicate, ReplicaIsLocked, ConfigNotFound, ScopeNotFound)
+from rucio.common.extra import import_extras
 from rucio.common.utils import (chunks, construct_surl, sizefmt, get_bytes_value_from_string,
                                 render_json, parse_response, extract_scope, clean_surls)
 from rucio.rse import rsemanager as rsemgr
 
-try:
-    from ConfigParser import NoOptionError, NoSectionError
-except ImportError:
-    from configparser import NoOptionError, NoSectionError
+EXTRA_MODULES = import_extras(['argcomplete'])
 
+if EXTRA_MODULES['argcomplete']:
+    import argcomplete  # pylint: disable=E0401
 
 possible_topdir = os.path.normpath(os.path.join(os.path.abspath(sys.argv[0]),
                                                 os.pardir, os.pardir))
@@ -2195,11 +2196,8 @@ def get_parser():
 
 if __name__ == '__main__':
     oparser = get_parser()
-    try:
-        import argcomplete
+    if EXTRA_MODULES['argcomplete']:
         argcomplete.autocomplete(oparser)
-    except ImportError:
-        pass
 
     if len(sys.argv) == 1:
         oparser.print_help()

--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -1,4 +1,5 @@
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,27 +15,25 @@
 #
 # Authors:
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2012-2013
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2013
 # - Yun-Pin Sun <winter0128@gmail.com>, 2013
-# - Martin Barisits <martin.barisits@cern.ch>, 2013-2018
+# - Martin Barisits <martin.barisits@cern.ch>, 2013-2020
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2019
 # - Cheng-Hsi Chao <cheng-hsi.chao@cern.ch>, 2014
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
-# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2015
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2015
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Eric Vaandering <ewv@fnal.gov>, 2020
+# - Brandon White <bjwhite@fnal.gov>, 2020
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
-
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 
 from json import dumps
+
 from requests.status_codes import codes
+from six.moves.urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/accountlimitclient.py
+++ b/lib/rucio/client/accountlimitclient.py
@@ -1,4 +1,5 @@
-# Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2014-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,20 +16,18 @@
 # Authors:
 # - Martin Barisits <martin.barisits@cern.ch>, 2014-2020
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014
-# - Vincent Garonne <vgaronne@gmail.com>, 2014-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2018
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Brandon White <bjwhite@fnal.gov>, 2020
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-#
-# PY3K COMPATIBLE
-
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 from json import dumps
+
 from requests.status_codes import codes
+from six.moves.urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2020 CERN
+# Copyright 2013-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,17 +30,14 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
 # - Alan Malta Rodrigues <alan.malta@cern.ch>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
 from __future__ import print_function
 
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
-
 from json import dumps, loads
+
 from requests.status_codes import codes
+from six.moves.urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/fileclient.py
+++ b/lib/rucio/client/fileclient.py
@@ -1,4 +1,5 @@
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,24 +14,22 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
 # - Brian Bockelman <bbockelm@cse.unl.edu>, 2018
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 from __future__ import print_function
 
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
 from json import loads
+
 from requests.status_codes import codes
+from six.moves.urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/lockclient.py
+++ b/lib/rucio/client/lockclient.py
@@ -1,4 +1,5 @@
-# Copyright 2014-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2014-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,19 +15,15 @@
 #
 # Authors:
 # - Martin Barisits <martin.barisits@cern.ch>, 2014-2018
-# - Vincent Garonne <vgaronne@gmail.com>, 2014-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014-2018
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
 # - Brian Bockelman <bbockelm@cse.unl.edu>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-#
-# PY3K COMPATIBLE
-
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 from requests.status_codes import codes
+from six.moves.urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/metaclient.py
+++ b/lib/rucio/client/metaclient.py
@@ -1,4 +1,5 @@
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,23 +14,20 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
 # - Brian Bockelman <bbockelm@cse.unl.edu>, 2018
+# - asket <asket.agarwal96@gmail.com>, 2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-#
-# PY3K COMPATIBLE
-
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 from json import dumps, loads
 
 from requests.status_codes import codes
+from six.moves.urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -25,19 +25,15 @@
 # - Ilija Vukotic <ivukotic@cern.ch>, 2020
 # - Luc Goossens <luc.goossens@cern.ch>, 2020
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Eric Vaandering <ewv@fnal.gov>, 2020
-# - Christoph Ames <christoph.ames@cern.ch>, 2021
-
-
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from datetime import datetime
 from json import dumps, loads
+
 from requests.status_codes import codes
+from six.moves.urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,15 +14,12 @@
 # limitations under the License.
 #
 # Authors:
-# - Diego Ciangottini <diego.ciangottini@gmail.com>, 2018
+# - dciangot <diego.ciangottini@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 from requests.status_codes import codes
+from six.moves.urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -1,4 +1,5 @@
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,24 +14,25 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2012
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2020
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2013-2015
 # - Martin Barisits <martin.barisits@cern.ch>, 2013-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014
-# - Wen Guan <wguan.icedew@gmail.com>, 2014
+# - Wen Guan <wen.guan@cern.ch>, 2014
+# - Brian Bockelman <bbockelm@cse.unl.edu>, 2018
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-#
-# PY3K COMPATIBLE
+# - Tomas Javurek <tomas.javurek@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 from json import dumps, loads
+
 from requests.status_codes import codes
-try:
-    from urllib import quote
-except ImportError:
-    from urllib.parse import quote
+from six.moves.urllib.parse import quote
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2013-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,22 +15,23 @@
 #
 # Authors:
 # - Martin Barisits <martin.barisits@cern.ch>, 2013-2018
-# - Vincent Garonne <vgaronne@gmail.com>, 2013-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2013-2018
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2015
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
-# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2018
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - dciangot <diego.ciangottini@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Eric Vaandering <ewv@fnal.gov>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
-#
-# PY3K COMPATIBLE
-
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 from json import dumps, loads
+
 from requests.status_codes import codes
+from six.moves.urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/scopeclient.py
+++ b/lib/rucio/client/scopeclient.py
@@ -1,4 +1,5 @@
-# Copyright 2012-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,23 +15,20 @@
 #
 # Authors:
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2012
-# - Vincent Garonne <vgaronne@gmail.com>, 2012-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2014
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
 # - Brian Bockelman <bbockelm@cse.unl.edu>, 2018
 # - Martin Barisits <martin.barisits@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-#
-# PY3K COMPATIBLE
-
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 from json import loads
+
 from requests.status_codes import codes
+from six.moves.urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/common/extra.py
+++ b/lib/rucio/common/extra.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import List, Dict, Any
+
+
+def import_extras(module_list):
+    # type: (List[str]) -> Dict[str, Any]
+    out = dict()
+    for mod in module_list:
+        out[mod] = None
+        try:
+            out[mod] = importlib.import_module(mod)
+        except ImportError:
+            pass
+    return out

--- a/lib/rucio/common/pcache.py
+++ b/lib/rucio/common/pcache.py
@@ -19,26 +19,21 @@
 # - Boris Bauermeister <boris.bauermeister@fysik.su.se>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2019-2021
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 
-import sys
-import os
 import errno
 import fcntl
-import time
 import getopt
+import os
 import re
-import subprocess
 import signal
-
-try:
-    # Python 2
-    from urllib import urlencode, urlopen
-except ImportError:
-    # Python 3
-    from urllib.parse import urlencode
-    from urllib.request import urlopen
+import subprocess
+import sys
+import time
 from socket import gethostname
+
+from six.moves.urllib.parse import urlencode
+from six.moves.urllib.request import urlopen
 
 # The pCache Version
 pcacheversion = "4.2.3"

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -38,21 +38,7 @@
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Anil Panta <47672624+panta-123@users.noreply.github.com>, 2021
 
-
 from __future__ import absolute_import, print_function
-
-try:
-    import importlib
-    importlib.util.find_spec('')
-except AttributeError:
-    pass
-
-# Fallback until Python <3.9
-# Must be removed with Python 3.9
-try:
-    import imp
-except AttributeError:
-    pass
 
 import base64
 import copy
@@ -67,7 +53,6 @@ import os.path
 import re
 import socket
 import subprocess
-import sys
 import tempfile
 import threading
 import time
@@ -78,51 +63,15 @@ from xml.etree import ElementTree
 
 import requests
 from six import string_types, text_type, binary_type, ensure_text, PY3
+from six.moves import StringIO, zip_longest as izip_longest
+from six.moves.urllib.parse import urlparse, urlencode, quote, parse_qsl, urlunparse
 
 from rucio.common.config import config_get
 from rucio.common.exception import MissingModuleException, InvalidType, InputValidationError, MetalinkJsonParsingError, RucioException
+from rucio.common.extra import import_extras
 from rucio.common.types import InternalAccount, InternalScope
 
-try:
-    # Python 2
-    from itertools import izip_longest
-except ImportError:
-    # Python 3
-    from itertools import zip_longest as izip_longest
-try:
-    # Python 2
-    from urllib import urlencode, quote
-except ImportError:
-    # Python 3
-    from urllib.parse import urlencode, quote
-try:
-    # Python 2
-    from StringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
-try:
-    # Python 2
-    import urlparse
-except ImportError:
-    # Python 3
-    import urllib.parse as urlparse
-
-# Extra modules: Only imported if available
-EXTRA_MODULES = {'paramiko': False}
-
-for extra_module in EXTRA_MODULES:
-    if 'imp' in sys.modules:
-        try:
-            imp.find_module(extra_module)
-            EXTRA_MODULES[extra_module] = True
-        except ImportError:
-            EXTRA_MODULES[extra_module] = False
-    else:
-        if importlib.util.find_spec(extra_module):
-            EXTRA_MODULES[extra_module] = True
-        else:
-            EXTRA_MODULES[extra_module] = False
+EXTRA_MODULES = import_extras(['paramiko'])
 
 if EXTRA_MODULES['paramiko']:
     try:
@@ -1005,11 +954,11 @@ def add_url_query(url, query):
     :return: The expanded URL with the new query parameters
     """
 
-    url_parts = list(urlparse.urlparse(url))
-    mod_query = dict(urlparse.parse_qsl(url_parts[4]))
+    url_parts = list(urlparse(url))
+    mod_query = dict(parse_qsl(url_parts[4]))
     mod_query.update(query)
     url_parts[4] = urlencode(mod_query)
-    return urlparse.urlunparse(url_parts)
+    return urlunparse(url_parts)
 
 
 def get_bytes_value_from_string(input_string):

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -1,4 +1,5 @@
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2018-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,35 +17,25 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018-2020
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2019
-#
-# PY3K COMPATIBLE
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 import base64
 import datetime
-import time
 import hmac
+import time
 from hashlib import sha1
 
+import boto3
+from botocore.client import Config
+from dogpile.cache import make_region
+from dogpile.cache.api import NO_VALUE
+from oauth2client.service_account import ServiceAccountCredentials
 from six import integer_types
-try:
-    # Python 2
-    from urlparse import urlparse
-    from urllib import urlencode
-except ImportError:
-    # Python 3
-    from urllib.parse import urlparse, urlencode
+from six.moves.urllib.parse import urlparse, urlencode
 
 from rucio.common.config import config_get, get_rse_credentials
 from rucio.common.exception import UnsupportedOperation
 from rucio.core.monitor import record_timer_block
-
-from oauth2client.service_account import ServiceAccountCredentials
-
-import boto3
-from botocore.client import Config
-
-from dogpile.cache import make_region
-from dogpile.cache.api import NO_VALUE
 
 CREDS_GCS = None
 

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -42,7 +42,6 @@ import datetime
 import json
 import logging
 import re
-import sys
 import time
 from typing import TYPE_CHECKING
 
@@ -58,6 +57,7 @@ from rucio.common.constants import SUPPORTED_PROTOCOLS, FTS_STATE
 from rucio.common.exception import (InvalidRSEExpression, NoDistance,
                                     RequestNotFound, RSEProtocolNotSupported,
                                     RucioException, UnsupportedOperation)
+from rucio.common.extra import import_extras
 from rucio.common.rse_attributes import get_rse_attributes
 from rucio.common.types import InternalAccount
 from rucio.common.utils import construct_surl
@@ -79,25 +79,7 @@ from rucio.transfertool.mock import MockTransfertool
 if TYPE_CHECKING:
     from typing import List, Tuple
 
-# Extra modules: Only imported if available
-EXTRA_MODULES = {'globus_sdk': False}
-
-for extra_module in EXTRA_MODULES:
-    if sys.version_info < (3, 5):
-        try:
-            import imp
-            imp.find_module(extra_module)
-            EXTRA_MODULES[extra_module] = True
-        except ImportError:
-            EXTRA_MODULES[extra_module] = False
-
-    else:
-        try:
-            import importlib
-            importlib.util.find_spec(extra_module)
-            EXTRA_MODULES[extra_module] = True
-        except ModuleNotFoundError:
-            EXTRA_MODULES[extra_module] = False
+EXTRA_MODULES = import_extras(['globus_sdk'])
 
 if EXTRA_MODULES['globus_sdk']:
     from rucio.transfertool.globus import GlobusTransferTool  # pylint: disable=import-error

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -44,6 +44,7 @@ import time
 from collections import defaultdict
 
 from requests.exceptions import RequestException
+from six.moves.configparser import NoOptionError
 from sqlalchemy.exc import DatabaseError
 
 import rucio.db.sqla.util
@@ -54,11 +55,6 @@ from rucio.common.utils import chunks
 from rucio.core import heartbeat, transfer as transfer_core, request as request_core
 from rucio.core.monitor import record_timer, record_counter
 from rucio.db.sqla.constants import RequestState, RequestType
-
-try:
-    from ConfigParser import NoOptionError  # py2
-except Exception:
-    from configparser import NoOptionError  # py3
 
 graceful_stop = threading.Event()
 

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -37,6 +37,8 @@ import threading
 import time
 from collections import defaultdict
 
+from six.moves.configparser import NoOptionError
+
 import rucio.db.sqla.util
 from rucio.common import exception
 from rucio.common.config import config_get, config_get_bool
@@ -47,11 +49,6 @@ from rucio.core.request import set_requests_state
 from rucio.core.staging import get_stagein_requests_and_source_replicas
 from rucio.daemons.conveyor.common import submit_transfer, bulk_group_transfer, get_conveyor_rses
 from rucio.db.sqla.constants import RequestState
-
-try:
-    from ConfigParser import NoOptionError  # py2
-except Exception:
-    from configparser import NoOptionError  # py3
 
 graceful_stop = threading.Event()
 

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -49,6 +49,7 @@ from collections import defaultdict
 
 from prometheus_client import Counter
 from six import iteritems
+from six.moves.configparser import NoOptionError
 
 import rucio.db.sqla.util
 from rucio.common import exception
@@ -59,11 +60,6 @@ from rucio.core import heartbeat, request as request_core, transfer as transfer_
 from rucio.core.monitor import record_counter, record_timer
 from rucio.daemons.conveyor.common import submit_transfer, bulk_group_transfer, get_conveyor_rses, USER_ACTIVITY
 from rucio.db.sqla.constants import RequestState
-
-try:
-    from ConfigParser import NoOptionError  # py2
-except Exception:
-    from configparser import NoOptionError  # py3
 
 graceful_stop = threading.Event()
 

--- a/lib/rucio/rse/protocols/globus.py
+++ b/lib/rucio/rse/protocols/globus.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2019 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2019-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,38 +14,26 @@
 # limitations under the License.
 #
 # Authors:
-# - Matt Snyder <msnyder@rcf.rhic.bnl.gov>, 2019
+# - Matt Snyder <msnyder@bnl.gov>, 2019-2020
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
+# - Tomas Javurek <tomas.javurek@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 from __future__ import print_function
 
-import imp
-
 from six import string_types
+from six.moves.urllib.parse import urlparse
+
 from rucio.common import exception
+from rucio.common.extra import import_extras
 from rucio.core.rse import get_rse_attribute
 from rucio.rse.protocols.protocol import RSEProtocol
 from rucio.transfertool.globusLibrary import getTransferClient, send_delete_task
 
-# Extra modules: Only imported if available
-EXTRA_MODULES = {'globus_sdk': False}
-
-for extra_module in EXTRA_MODULES:
-    try:
-        imp.find_module(extra_module)
-        EXTRA_MODULES[extra_module] = True
-    except ImportError:
-        EXTRA_MODULES[extra_module] = False
+EXTRA_MODULES = import_extras(['globus_sdk'])
 
 if EXTRA_MODULES['globus_sdk']:
     from globus_sdk import TransferAPIError  # pylint: disable=import-error
-
-try:
-    # PY2
-    from urlparse import urlparse
-except ImportError:
-    # PY3
-    from urllib.parse import urlparse
 
 
 class GlobusRSEProtocol(RSEProtocol):

--- a/lib/rucio/transfertool/globusLibrary.py
+++ b/lib/rucio/transfertool/globusLibrary.py
@@ -16,23 +16,15 @@
 # - Matt Snyder <msnyder@rcf.rhic.bnl.gov>, 2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2019-2020
 
-import imp
+import datetime
 import logging
 import os
 
 from rucio.common.config import config_get, config_get_int, get_config_dirs
+from rucio.common.extra import import_extras
 from rucio.core.monitor import record_counter
-import datetime
 
-# Extra modules: Only imported if available
-EXTRA_MODULES = {'globus_sdk': False}
-
-for extra_module in EXTRA_MODULES:
-    try:
-        imp.find_module(extra_module)
-        EXTRA_MODULES[extra_module] = True
-    except ImportError:
-        EXTRA_MODULES[extra_module] = False
+EXTRA_MODULES = import_extras(['globus_sdk'])
 
 if EXTRA_MODULES['globus_sdk']:
     from globus_sdk import NativeAppAuthClient, RefreshTokenAuthorizer, TransferClient, TransferData, DeleteData  # pylint: disable=import-error

--- a/lib/rucio/web/ui/flask/common/utils.py
+++ b/lib/rucio/web/ui/flask/common/utils.py
@@ -19,6 +19,7 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
+# - Dhruv Sondhi <dhruvsondhi05@gmail.com>, 2021
 
 import re
 import sys
@@ -27,18 +28,14 @@ from os.path import dirname, join
 from time import time
 
 from flask import request, render_template, redirect, make_response
+from six.moves.urllib.parse import quote, unquote
 
 from rucio.api import authentication as auth, identity
 from rucio.api.account import account_exists, get_account_info, list_account_attributes
 from rucio.common.config import config_get, config_get_bool
+from rucio.common.extra import import_extras
 from rucio.core import identity as identity_core, vo as vo_core
 from rucio.db.sqla.constants import AccountType, IdentityType
-
-try:
-    from urllib import unquote, quote
-except ImportError:
-    from urllib.parse import unquote, quote
-
 
 if sys.version_info > (3, 0):
     long = int
@@ -55,10 +52,13 @@ else:
     def html_escape(s, quote=True):
         return cgi.escape(s, quote)  # pylint: disable-msg=E1101
 
-try:
-    from onelogin.saml2.auth import OneLogin_Saml2_Auth
+
+EXTRA_MODULES = import_extras(['onelogin'])
+
+if EXTRA_MODULES['onelogin']:
+    from onelogin.saml2.auth import OneLogin_Saml2_Auth  # pylint: disable=import-error
     SAML_SUPPORT = True
-except:
+else:
     SAML_SUPPORT = False
 
 # check if there is preferred server side config for webui authentication

--- a/pylintrc
+++ b/pylintrc
@@ -553,7 +553,7 @@ allow-wildcard-with-all=no
 # Analyse import fallback blocks. This can be used to support both Python 2 and
 # 3 compatible code, which means that the block might have code that exists
 # only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks=no
+analyse-fallback-blocks=yes
 
 # Deprecated modules which should not be used, separated by a comma.
 deprecated-modules=optparse,tkinter.tix

--- a/tools/add_header
+++ b/tools/add_header
@@ -68,6 +68,7 @@ author_map = {
     ("maatthias", "<msnyder@bnl.gov>"): ("Matt Snyder", "<msnyder@bnl.gov>"),
     ("Mario Lassnig", "<mlassnig@users.noreply.github.com>"): ("Mario Lassnig", "<mario.lassnig@cern.ch>"),
     ("rcarpa", "<2905943+rcarpa@users.noreply.github.com>"): ("Radu Carpa", "<radu.carpa@cern.ch>"),
+    ("Dhruv Sondhi", "<66117751+DhruvSondhi@users.noreply.github.com>"): ("Dhruv Sondhi", "<dhruvsondhi05@gmail.com>"),
 }
 
 


### PR DESCRIPTION
Add `import_extras` function in common to import optional modules by using importlib and remove all usages of imp.

Fixes #4168 