### PR TITLE
Documentation: Fix escaping toc anchors in doc gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ examples/whip/results/
 lib/rucio.egg-info/
 cache/
 changed_files.txt
+docs/
 
 # Backup and temp files
 *.log

--- a/tools/generate_doc.py
+++ b/tools/generate_doc.py
@@ -16,17 +16,69 @@
 # Authors:
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
+import itertools
 import os
 import pathlib
+import re
 import sys
 import typing
 from collections import namedtuple
+from typing import TYPE_CHECKING
 
 import sh
 
+if TYPE_CHECKING:
+    from typing import List
+
+ANCHOR_PATTERN = re.compile(r"<a[^>]*>[^<]*</a>")
+
+
+class CommandErrorWrapper:
+    def __init__(self, procs: "List[sh.RunningCommand]"):
+        self.procs = procs
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if isinstance(exc_val, sh.ErrorReturnCode):
+            print(
+                "Error running:",
+                exc_val.full_cmd,
+                "\nExit Code:",
+                exc_val.exit_code,
+                file=sys.stderr
+            )
+            print(
+                "  STDOUT:\n",
+                exc_val.stdout.decode(errors='replace'),
+                "\n",
+                file=sys.stderr
+            )
+            print(
+                "  STDERR:\n",
+                exc_val.stderr.decode(errors='replace'),
+                "\n",
+                file=sys.stderr
+            )
+            for proc in self.procs:
+                try:
+                    proc.process.terminate()
+                except ProcessLookupError:
+                    pass
+            sys.exit(1)
+
+
+def escape_doc_line(line: str):
+    # there are anchor lines produced by the table of contents option, ignore these
+    if ANCHOR_PATTERN.match(line):
+        return line
+    else:
+        return line.replace('<', r'\<').replace('>', r'\>')
+
 
 def render_pydoc_markdown(rucio_src: str):
-    RenderParams = namedtuple("RenderParams", ["title", "fh", "in_path", "out_file"])
+    RenderParams = namedtuple("RenderParams", ["title", "fh", "args", "out_file"])
 
     def render_done(par: RenderParams):
         def inner(cmd, success, exit_code):
@@ -39,7 +91,7 @@ def render_pydoc_markdown(rucio_src: str):
 
     def print_line(par: RenderParams):
         def inner(line: str):
-            print(line.replace('<', r'\<').replace('>', r'\>'), end="", file=par.fh)
+            print(escape_doc_line(line), end="", file=par.fh)
 
         return inner
 
@@ -61,8 +113,7 @@ def render_pydoc_markdown(rucio_src: str):
                 python(
                     "-m",
                     "pydoc_markdown.main",
-                    "-I",
-                    par.in_path,
+                    *par.args,
                     "--render-toc",
                     _out=print_line(par),
                     _bg=True,
@@ -71,7 +122,8 @@ def render_pydoc_markdown(rucio_src: str):
             )
 
         for handle in procs:
-            handle.wait(timeout=60)
+            with CommandErrorWrapper(procs):
+                handle.wait(timeout=60)
 
     def create_parent_directory(file: str):
         directory = os.path.dirname(file)
@@ -81,11 +133,19 @@ def render_pydoc_markdown(rucio_src: str):
             except FileExistsError:
                 pass  # ignore existing
 
-    client_api_path = os.path.join(rucio_src, "lib/rucio/client/")
+    lib_path = os.path.join(rucio_src, "lib")
+    client_module_path = pathlib.Path(lib_path, "rucio/client")
+    client_module_excludes = {"__pycache__", "__init__", "dq2client"}
+    client_modules = [
+        module_path.with_suffix("").name
+        for module_path in client_module_path.iterdir()
+        if module_path.with_suffix("").name not in client_module_excludes
+    ]
+    client_modules_args = list(itertools.chain(*(("--module", "rucio.client." + mod) for mod in client_modules)))
     client_api_output_file = os.environ.get("RUCIO_CLIENT_API_OUTPUT", default="docs/rucio_client_api.md")
     create_parent_directory(client_api_output_file)
 
-    rest_api_path = os.path.join(rucio_src, "lib/rucio/web/rest/flaskapi/v1/")
+    rest_api_path = os.path.join(lib_path, "rucio/web/rest/flaskapi/v1/")
     rest_api_output_file = os.environ.get("RUCIO_REST_API_OUTPUT", default="docs/rucio_rest_api.md")
     create_parent_directory(rest_api_output_file)
 
@@ -95,13 +155,13 @@ def render_pydoc_markdown(rucio_src: str):
                 RenderParams(
                     title="Rucio client API",
                     fh=client_api_fh,
-                    in_path=client_api_path,
+                    args=("--search-path", lib_path, *client_modules_args),
                     out_file=client_api_output_file,
                 ),
                 RenderParams(
                     title="Rucio REST API",
                     fh=rest_api_fh,
-                    in_path=rest_api_path,
+                    args=("--search-path", rest_api_path),
                     out_file=rest_api_output_file,
                 ),
             ]
@@ -132,20 +192,23 @@ def render_bin_help_pages(rucio_src: str):
     bin_help_output_path = os.environ.get("RUCIO_BIN_HELP_OUTPUT", default="docs/bin")
     bin_help_output_path = pathlib.Path(bin_help_output_path)
     bin_help_output_path.mkdir(parents=True, exist_ok=True)
+    excludes = {"rucio-sonar", "rucio-sonar-distribution"}
+    os.environ["PYTHONPATH"] = os.path.join(rucio_src, "lib")
 
     def generate_procs():
         for runnable_path in bin_path.iterdir():
-            out_file = str((bin_help_output_path / runnable_path.name).with_suffix(".md"))
-            file_handles[runnable_path] = open(out_file, 'w')
-            print("Adding header for", runnable_path.name)
-            print("---", file=file_handles[runnable_path])
-            print("title: Running", runnable_path.name, file=file_handles[runnable_path])
-            print("---", file=file_handles[runnable_path])
-            print(file=file_handles[runnable_path])
-            print("```", file=file_handles[runnable_path])
-            out_files[runnable_path] = out_file
-            runnable = sh.Command(str(runnable_path))
-            yield runnable("--help", _out=print_line(runnable_path), _bg=True, _done=render_done(runnable_path))
+            if runnable_path.name not in excludes:
+                out_file = str((bin_help_output_path / runnable_path.name).with_suffix(".md"))
+                file_handles[runnable_path] = open(out_file, 'w')
+                print("Adding header for", runnable_path.name)
+                print("---", file=file_handles[runnable_path])
+                print("title: Running", runnable_path.name, file=file_handles[runnable_path])
+                print("---", file=file_handles[runnable_path])
+                print(file=file_handles[runnable_path])
+                print("```", file=file_handles[runnable_path])
+                out_files[runnable_path] = out_file
+                runnable = sh.Command(str(runnable_path))
+                yield runnable("--help", _out=print_line(runnable_path), _bg=True, _done=render_done(runnable_path))
 
     procgen = generate_procs()
     procs = []
@@ -157,7 +220,8 @@ def render_bin_help_pages(rucio_src: str):
 
     try:
         while len(procs) > 0:
-            procs.pop(0).wait(timeout=10)
+            with CommandErrorWrapper(procs):
+                procs.pop(0).wait(timeout=10)
             proc = next(procgen, None)
             if proc is not None:
                 procs.append(proc)


### PR DESCRIPTION
Fix escaping toc anchors in doc generation, improve error output and exclude certain modules in client/bin.