### PR TITLE
Deletion: allow bulk deletion of files transferred by globus #4575

### DIFF
--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -29,6 +29,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Matt Snyder <msnyder@bnl.gov>, 2021
 
 '''
 Reaper is a daemon to manage file deletion.
@@ -151,6 +152,8 @@ def delete_from_storage(replicas, prot, rse_info, staging_areas, auto_exclude_th
     rse_name = rse_info['rse']
     rse_id = rse_info['id']
     noaccess_attempts = 0
+    if prot.attributes['scheme'] == 'globus':
+        pfns_to_bulk_delete = []
     try:
         prot.connect()
         for replica in replicas:
@@ -178,7 +181,10 @@ def delete_from_storage(replicas, prot, rse_info, staging_areas, auto_exclude_th
                     # sign the URL if necessary
                     if prot.attributes['scheme'] == 'https' and rse_info['sign_url'] is not None:
                         pfn = get_signed_url(rse_id, rse_info['sign_url'], 'delete', pfn)
-                    prot.delete(pfn)
+                    if prot.attributes['scheme'] == 'globus':
+                        pfns_to_bulk_delete.append(replica['pfn'])
+                    else:
+                        prot.delete(pfn)
                 else:
                     logger(logging.WARNING, 'Deletion UNAVAILABLE of %s:%s as %s on %s', replica['scope'], replica['name'], replica['pfn'], rse_name)
 
@@ -212,6 +218,10 @@ def delete_from_storage(replicas, prot, rse_info, staging_areas, auto_exclude_th
                 logger(logging.CRITICAL, 'Deletion CRITICAL of %s:%s as %s on %s: %s', replica['scope'], replica['name'], replica['pfn'], rse_name, str(traceback.format_exc()))
                 deletion_dict['reason'] = str(error)
                 add_message('deletion-failed', deletion_dict)
+
+        if pfns_to_bulk_delete and prot.attributes['scheme'] == 'globus':
+            logger(logging.DEBUG, 'Attempting bulk delete on RSE %s for scheme %s', rse_name, prot.attributes['scheme'])
+            prot.bulk_delete(pfns_to_bulk_delete)
 
     except (ServiceUnavailable, RSEAccessDenied, ResourceTemporaryUnavailable) as error:
         for replica in replicas:
@@ -571,7 +581,7 @@ def reaper(rses, include_rses, exclude_rses, vos=None, chunk_size=100, once=Fals
                 # Physical  deletion will take place there
                 try:
                     prot = rsemgr.create_protocol(rse_info, 'delete', scheme=scheme, logger=logger)
-                    for file_replicas in chunks(replicas, 100):
+                    for file_replicas in chunks(replicas, chunk_size):
                         # Refresh heartbeat
                         live(executable, hostname, pid, hb_thread, older_than=600, hash_executable=None, payload=rse_hostname_key, session=None)
                         del_start_time = time.time()

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -152,8 +152,7 @@ def delete_from_storage(replicas, prot, rse_info, staging_areas, auto_exclude_th
     rse_name = rse_info['rse']
     rse_id = rse_info['id']
     noaccess_attempts = 0
-    if prot.attributes['scheme'] == 'globus':
-        pfns_to_bulk_delete = []
+    pfns_to_bulk_delete = []
     try:
         prot.connect()
         for replica in replicas:

--- a/lib/rucio/rse/protocols/globus.py
+++ b/lib/rucio/rse/protocols/globus.py
@@ -13,18 +13,19 @@
 # limitations under the License.
 #
 # Authors:
-# - Matt Snyder <msnyder@rcf.rhic.bnl.gov>, 2019
+# - Matt Snyder <msnyder@bnl.gov>, 2019-2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
 
 from __future__ import print_function
 
 import imp
+import logging
 
 from six import string_types
 from rucio.common import exception
 from rucio.core.rse import get_rse_attribute
 from rucio.rse.protocols.protocol import RSEProtocol
-from rucio.transfertool.globusLibrary import getTransferClient, send_delete_task
+from rucio.transfertool.globus_library import get_transfer_client, send_delete_task, send_bulk_delete_task
 
 # Extra modules: Only imported if available
 EXTRA_MODULES = {'globus_sdk': False}
@@ -50,13 +51,14 @@ except ImportError:
 class GlobusRSEProtocol(RSEProtocol):
     """ This class is to support Globus as a Rucio RSE protocol.  Inherits from abstract base class RSEProtocol."""
 
-    def __init__(self, protocol_attr, rse_settings, logger=None):
+    def __init__(self, protocol_attr, rse_settings, logger=logging.log):
         """ Initializes the object with information about the referred RSE.
 
             :param props: Properties of the requested protocol
         """
         super(GlobusRSEProtocol, self).__init__(protocol_attr, rse_settings, logger=logger)
         self.globus_endpoint_id = get_rse_attribute(key='globus_endpoint_id', rse_id=self.rse.get('id'))
+        self.logger = logger
 
     def lfns2pfns(self, lfns):
         """
@@ -163,7 +165,7 @@ class GlobusRSEProtocol(RSEProtocol):
         filepath = '/'.join(path.split('/')[0:-1]) + '/'
         filename = path.split('/')[-1]
 
-        transfer_client = getTransferClient()
+        transfer_client = get_transfer_client()
         exists = False
 
         if self.globus_endpoint_id:
@@ -188,7 +190,7 @@ class GlobusRSEProtocol(RSEProtocol):
 
         """
 
-        transfer_client = getTransferClient()
+        transfer_client = get_transfer_client()
         items = []
 
         if self.globus_endpoint_id:
@@ -223,6 +225,38 @@ class GlobusRSEProtocol(RSEProtocol):
             print('delete_task not accepted by Globus')
             print('delete_response: %s' % delete_response)
 
+    def bulk_delete(self, pfns):
+        """
+            Submits an async task to bulk delete files on globus endpoint.
+
+            :param replicas: list of file replicas to delete
+
+            :raises TransferAPIError: if unexpected response from the service.
+        """
+        if self.globus_endpoint_id:
+            try:
+                bulk_delete_response = send_bulk_delete_task(endpoint_id=self.globus_endpoint_id[0], pfns=pfns)
+            except TransferAPIError as err:
+                self.logger(logging.WARNING, str(err))
+        else:
+            self.logger(logging.WARNING, 'No rse attribute found for globus endpoint id.')
+
+        if bulk_delete_response['code'] != 'Accepted':
+            self.logger(logging.WARNING, 'delete_task not accepted by Globus')
+            self.logger(logging.WARNING, 'delete_response: %s' % bulk_delete_response)
+
+    def connect(self):
+        """
+            Establishes the actual connection to the referred RSE.
+
+            reaper2 daemon requires implementation of protocol.connect
+        """
+        pass
+
     def close(self):
-        """ Closes the connection to RSE."""
-        raise NotImplementedError
+        """
+            Closes the connection to RSE.
+
+            reaper2 daemon requires implementation of protocol.close
+        """
+        pass

--- a/lib/rucio/rse/protocols/globus.py
+++ b/lib/rucio/rse/protocols/globus.py
@@ -229,7 +229,7 @@ class GlobusRSEProtocol(RSEProtocol):
         """
             Submits an async task to bulk delete files on globus endpoint.
 
-            :param replicas: list of file replicas to delete
+            :param pfns: list of pfns to delete
 
             :raises TransferAPIError: if unexpected response from the service.
         """

--- a/lib/rucio/rse/protocols/mock.py
+++ b/lib/rucio/rse/protocols/mock.py
@@ -101,6 +101,16 @@ class Default(protocol.RSEProtocol):
         """
         pass
 
+    def bulk_delete(self, pfns):
+        """
+            Submits an async task to bulk delete files.
+
+            :param pfns: list of pfns to delete
+
+            :raises TransferAPIError: if unexpected response from the service.
+        """
+        pass
+
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 

--- a/lib/rucio/tests/test_reaper.py
+++ b/lib/rucio/tests/test_reaper.py
@@ -136,14 +136,14 @@ def test_reaper_bulk_delete(vo):
     # Check first if the reaper does not delete anything if no space is needed
     REGION.invalidate()
     rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=323000000000)
-    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None, chunk_size=1000, scheme='globus')
+    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None, chunk_size=1000, scheme='MOCK')
     assert len(list(replica_core.list_replicas(dids=dids, rse_expression=rse_name))) == nb_files
 
     # Now put it over threshold and delete
     REGION.invalidate()
     rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=1)
-    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None, chunk_size=1000, scheme='globus')
-    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None, chunk_size=1000, scheme='globus')
+    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None, chunk_size=1000, scheme='MOCK')
+    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None, chunk_size=1000, scheme='MOCK')
     assert len(list(replica_core.list_replicas(dids, rse_expression=rse_name))) == 200
 
 

--- a/lib/rucio/tests/test_reaper.py
+++ b/lib/rucio/tests/test_reaper.py
@@ -19,6 +19,7 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Matt Snyder <msnyder@bnl.gov>, 2021
 
 from datetime import datetime, timedelta
 

--- a/lib/rucio/tests/test_reaper.py
+++ b/lib/rucio/tests/test_reaper.py
@@ -121,6 +121,33 @@ def test_reaper(vo):
 
 
 @pytest.mark.noparallel(reason='fails when run in parallel. It resets some memcached values.')
+def test_reaper_bulk_delete(vo):
+    """ REAPER (DAEMON): Mock test the reaper daemon on async bulk delete request."""
+    scope = InternalScope('data13_hip', vo=vo)
+
+    nb_files = 250
+    file_size = 200  # 2G
+    rse_name, rse_id, dids = __add_test_rse_and_replicas(vo=vo, scope=scope, rse_name=rse_name_generator(),
+                                                         names=['lfn' + generate_uuid() for _ in range(nb_files)], file_size=file_size)
+
+    rse_core.set_rse_limits(rse_id=rse_id, name='MinFreeSpace', value=50 * file_size)
+    assert len(list(replica_core.list_replicas(dids=dids, rse_expression=rse_name))) == nb_files
+
+    # Check first if the reaper does not delete anything if no space is needed
+    REGION.invalidate()
+    rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=323000000000)
+    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None, chunk_size=1000, scheme='globus')
+    assert len(list(replica_core.list_replicas(dids=dids, rse_expression=rse_name))) == nb_files
+
+    # Now put it over threshold and delete
+    REGION.invalidate()
+    rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=1)
+    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None, chunk_size=1000, scheme='globus')
+    reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None, chunk_size=1000, scheme='globus')
+    assert len(list(replica_core.list_replicas(dids, rse_expression=rse_name))) == 200
+
+
+@pytest.mark.noparallel(reason='fails when run in parallel. It resets some memcached values.')
 def test_reaper_multi_vo_via_run(vo):
     """ MULTI VO (DAEMON): Test that reaper runs on the specified VO(s) """
     new_vo = __setup_new_vo()

--- a/lib/rucio/transfertool/globus.py
+++ b/lib/rucio/transfertool/globus.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # Authors:
-# - Matt Snyder <msnyder@rcf.rhic.bnl.gov>, 2019
+# - Matt Snyder <msnyder@rcf.rhic.bnl.gov>, 2019-2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 

--- a/lib/rucio/transfertool/globus.py
+++ b/lib/rucio/transfertool/globus.py
@@ -20,7 +20,7 @@
 import logging
 
 from rucio.transfertool.transfertool import Transfertool
-from .globusLibrary import bulk_submit_xfer, submit_xfer, bulk_check_xfers
+from .globus_library import bulk_submit_xfer, submit_xfer, bulk_check_xfers
 
 
 class GlobusTransferTool(Transfertool):

--- a/lib/rucio/transfertool/globus_library.py
+++ b/lib/rucio/transfertool/globus_library.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # Authors:
-# - Matt Snyder <msnyder@rcf.rhic.bnl.gov>, 2019
+# - Matt Snyder <msnyder@bnl.gov>, 2019-2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2019-2020
 
 import imp
@@ -52,7 +52,7 @@ def load_config(cfg_file='globus-config.yml'):
     return yaml.safe_load(open(config).read())
 
 
-def getTransferClient():
+def get_transfer_client():
     cfg = load_config()
     # cfg = yaml.safe_load(open("/opt/rucio/lib/rucio/transfertool/config.yml"))
     client_id = cfg['globus']['apps'][GLOBUS_AUTH_APP]['client_id']
@@ -81,7 +81,7 @@ def auto_activate_endpoint(tc, ep_id):
 
 def submit_xfer(source_endpoint_id, destination_endpoint_id, source_path, dest_path, job_label, recursive=False):
 
-    tc = getTransferClient()
+    tc = get_transfer_client()
     # as both endpoints are expected to be Globus Server endpoints, send auto-activate commands for both globus endpoints
     auto_activate_endpoint(tc, source_endpoint_id)
     auto_activate_endpoint(tc, destination_endpoint_id)
@@ -138,20 +138,20 @@ def bulk_submit_xfer(submitjob, recursive=False):
 
     # logging.info('submitting transfer...')
     transfer_result = tc.submit_transfer(tdata)
-    # logging.info("task_id =", transfer_result["task_id"])
+    logging.info("transfer_result: %s" % transfer_result)
 
     return transfer_result["task_id"]
 
 
 def check_xfer(task_id):
-    tc = getTransferClient()
+    tc = get_transfer_client()
     transfer = tc.get_task(task_id)
     status = str(transfer["status"])
     return status
 
 
 def bulk_check_xfers(task_ids):
-    tc = getTransferClient()
+    tc = get_transfer_client()
 
     logging.debug('task_ids: %s' % task_ids)
 
@@ -172,9 +172,20 @@ def bulk_check_xfers(task_ids):
 
 
 def send_delete_task(endpoint_id=None, path=None):
-    tc = getTransferClient()
+    tc = get_transfer_client()
     ddata = DeleteData(tc, endpoint_id, recursive=True)
     ddata.add_item(path)
     delete_result = tc.submit_delete(ddata)
 
     return delete_result
+
+
+def send_bulk_delete_task(endpoint_id=None, pfns=None):
+    tc = get_transfer_client()
+    ddata = DeleteData(tc, endpoint_id, recursive=True)
+    for pfn in pfns:
+        logging.debug('pfn: %s' % pfn)
+        ddata.add_item(pfn)
+    bulk_delete_result = tc.submit_delete(ddata)
+
+    return bulk_delete_result


### PR DESCRIPTION
- added feature to reaper2 daemon to submit a bulk delete job to globus
- uses --chunk-size argument to bundle multiple files into async delete request
- renamed transfertool/globusLibrary.py -> transfertool/globus_library.py
- added mock test test_reaper_bulk_delete(vo) to test_reaper

