### PR TITLE
Transfers: prepare transfertool specifics removal from transfer core. #857

### DIFF
--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -602,24 +602,35 @@ def get_rse_attribute(key, rse_id=None, value=None, use_cache=True, session=None
 
 
 @read_session
-def get_rse_supported_checksums(rse_id=None, session=None):
+def get_rse_supported_checksums(rse_id, session=None):
     """
-    Retrieve RSE attribute value.
+    Retrieve from the DB and parse the RSE attribute defining the checksum supported by the RSE
+    """
+    return parse_checksum_support_attribute(get_rse_attribute(key=CHECKSUM_KEY, rse_id=rse_id, session=session))
 
-    :param rse_id: The RSE id.
-    :param session: The database session in use.
+
+def get_rse_supported_checksums_from_attributes(rse_attributes):
+    """
+    Parse the RSE attribute defining the checksum supported by the RSE
+    :param rse_attributes: attributes retrieved using list_rse_attributes
+    """
+    return parse_checksum_support_attribute(rse_attributes.get(CHECKSUM_KEY))
+
+
+def parse_checksum_support_attribute(checksum_attribute):
+    """
+    Parse the checksum support RSE attribute.
+    :param checksum_attribute: The value of the RSE attribute storing the checksum value
 
     :returns: The list of checksums supported by the selected RSE.
               If the list is empty (aka attribute is not set) it returns all the default checksums.
               Use 'none' to explicitly tell the RSE does not support any checksum algorithm.
     """
 
-    checksum_support_attribute_list = get_rse_attribute(key=CHECKSUM_KEY, rse_id=rse_id, session=session)
-
-    if not checksum_support_attribute_list:
+    if not checksum_attribute:
         return GLOBALLY_SUPPORTED_CHECKSUMS
     else:
-        supported_checksum_list = checksum_support_attribute_list[0].split(',')
+        supported_checksum_list = checksum_attribute[0].split(',')
         if 'none' in supported_checksum_list:
             return []
         return supported_checksum_list

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1205,10 +1205,10 @@ def __filter_unwanted_paths(candidate_paths):
 
     # Discard multihop transfers which contain other candidate as part of itself For example:
     # if A->B->C and B->C are both candidates, discard A->B->C because it includes B->C. Doing B->C is enough.
-    source_rses = {path[0]['file_metadata']['src_rse_id'] for path in candidate_paths}
+    source_rses = {path[0].src.rse.id for path in candidate_paths}
     filtered_candidate_paths = []
     for path in candidate_paths:
-        if any(transfer['file_metadata']['src_rse_id'] in source_rses for transfer in path[1:]):
+        if any(hop.src.rse.id in source_rses for hop in path[1:]):
             continue
         filtered_candidate_paths.append(path)
     candidate_paths = filtered_candidate_paths

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -936,6 +936,7 @@ def __search_shortest_paths(source_rse_ids, dest_rse_id, include_multihop, multi
     return paths
 
 
+@read_session
 def __create_transfer_definitions(ctx, protocol_factory, rws, sources, include_multihop, multihop_rses, limit_dest_schemes, session=None):
     """
     Find the all paths from sources towards the destination of the given transfer request.

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1131,7 +1131,7 @@ def __add_legacy_transfer_definitions(protocol_factory, rws, source, transfertoo
                          'source_globus_endpoint_id': source_globus_endpoint_id,
                          'dest_globus_endpoint_id': dest_globus_endpoint_id}
         transfer = {'request_id': rws.request_id,
-                    'account': InternalAccount('root'),
+                    'account': rws.account,
                     'src_spacetoken': None,
                     'dest_spacetoken': dest_spacetoken,
                     'overwrite': overwrite,
@@ -1154,7 +1154,6 @@ def __add_legacy_transfer_definitions(protocol_factory, rws, source, transfertoo
                 logger(logging.WARNING, 'Could not set archive_timeout for %s. Must be integer.', hop)
                 pass
         if hop is transfer_path[-1]:
-            transfer['account'] = rws.account
             if rws.previous_attempt_id:
                 file_metadata['previous_attempt_id'] = rws.previous_attempt_id
 
@@ -1433,7 +1432,6 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
             transfers[new_req_id]['request_id'] = new_req_id
             transfers[new_req_id]['initial_request_id'] = rws.request_id
             transfers[new_req_id]['parent_request'] = parent_request
-            transfers[new_req_id]['account'] = InternalAccount('root')
 
             parent_request = new_req_id
         if len(transfer_path) > 1 and not multihop_cancelled:

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1087,7 +1087,6 @@ def __prepare_transfer_definition(ctx, protocol_factory, rws, source, transferto
                          'source_globus_endpoint_id': source_globus_endpoint_id,
                          'dest_globus_endpoint_id': dest_globus_endpoint_id}
         transfer = {'request_id': rws.request_id,
-                    'schemes': __add_compatible_schemes(schemes=[dst.scheme], allowed_schemes=SUPPORTED_PROTOCOLS),
                     'account': InternalAccount('root'),
                     'src_spacetoken': None,
                     'dest_spacetoken': dest_spacetoken,
@@ -1304,7 +1303,10 @@ def get_transfer_requests_and_source_replicas(total_workers=0, worker_number=0, 
             additional_sources = [s for s in filtered_sources
                                   if s.rse != best_path[0].src.rse and not s.rse.is_tape()]
 
-            for source, hop in islice(__find_compatible_direct_sources(sources=additional_sources, scheme=best_path[0]['schemes'], dest_rse_id=rws.dest_rse.id, session=session),
+            for source, hop in islice(__find_compatible_direct_sources(sources=additional_sources,
+                                                                       scheme=__add_compatible_schemes(schemes=[best_path[0].dst.scheme], allowed_schemes=SUPPORTED_PROTOCOLS),
+                                                                       dest_rse_id=rws.dest_rse.id,
+                                                                       session=session),
                                       5):
                 best_path[0].sources.append(TransferSource(
                     rse_data=source.rse,

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -51,7 +51,7 @@ from rucio.common.utils import chunks, set_checksum_value
 from rucio.core import request, transfer as transfer_core
 from rucio.core.config import get
 from rucio.core.monitor import record_counter, record_timer
-from rucio.core.rse import list_rses, get_rse_supported_checksums
+from rucio.core.rse import list_rses
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.vo import list_vos
 from rucio.db.sqla.session import read_session
@@ -262,34 +262,8 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
 
     for request_id in transfers:
         transfer = transfers[request_id]
-        verify_checksum = transfer['file_metadata'].get('verify_checksum', 'both')
 
-        dest_rse_id = transfer['file_metadata']['dest_rse_id']
-        source_rse_id = transfer['file_metadata']['src_rse_id']
-
-        dest_supported_checksums = get_rse_supported_checksums(rse_id=dest_rse_id, session=session)
-        source_supported_checksums = get_rse_supported_checksums(rse_id=source_rse_id, session=session)
-        common_checksum_names = set(source_supported_checksums).intersection(dest_supported_checksums)
-
-        if source_supported_checksums == ['none']:
-            if dest_supported_checksums == ['none']:
-                # both endpoints support none
-                verify_checksum = 'none'
-            else:
-                # src supports none but dst does
-                verify_checksum = 'destination'
-        else:
-            if dest_supported_checksums == ['none']:
-                # source supports some but destination does not
-                verify_checksum = 'source'
-            else:
-                if len(common_checksum_names) == 0:
-                    # source and dst support some bot none in common (dst priority)
-                    verify_checksum = 'destination'
-                else:
-                    # Don't override the value in the file_metadata
-                    pass
-
+        verify_checksum, checksums_to_use = transfer_core.checksum_validation_strategy(transfer.src.rse.attributes, transfer.dst.rse.attributes, logger=logger)
         t_file = {'sources': transfer['sources'],
                   'destinations': transfer['dest_urls'],
                   'metadata': transfer['file_metadata'],
@@ -301,12 +275,7 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
                   'activity': str(transfer['file_metadata']['activity'])}
 
         if verify_checksum != 'none':
-            if verify_checksum == 'both':
-                set_checksum_value(t_file, common_checksum_names)
-            if verify_checksum == 'source':
-                set_checksum_value(t_file, source_supported_checksums)
-            if verify_checksum == 'destination':
-                set_checksum_value(t_file, dest_supported_checksums)
+            set_checksum_value(t_file, checksums_to_use)
 
         multihop = transfer.get('multihop', False)
         strict_copy = transfer.get('strict_copy', False)

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -332,7 +332,7 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
         current_jobs_group = grouped_jobs[external_host][scope_str]
 
         job_params = {'account': transfer['account'],
-                      'use_oidc': transfer.get('use_oidc', False),
+                      'use_oidc': transfer_core.oidc_supported(transfer),
                       'verify_checksum': verify_checksum,
                       'copy_pin_lifetime': transfer['copy_pin_lifetime'] if transfer['copy_pin_lifetime'] else -1,
                       'bring_online': transfer['bring_online'] if transfer['bring_online'] else None,

--- a/lib/rucio/tests/test_transfer.py
+++ b/lib/rucio/tests/test_transfer.py
@@ -113,11 +113,6 @@ def test_get_hops(rse_factory):
     assert hop2['source_rse_id'] == rse3_id
     assert hop2['dest_rse_id'] == rse4_id
 
-    # A direct connection is preferred over a multihop one with smaller cost
-    [hop] = get_hops(source_rse_id=rse3_id, dest_rse_id=rse5_id, include_multihop=True, multihop_rses=all_rses)
-    assert hop['source_rse_id'] == rse3_id
-    assert hop['dest_rse_id'] == rse5_id
-
     # A link with cost only in one direction will not be used in the opposite direction
     with pytest.raises(NoDistance):
         get_hops(source_rse_id=rse6_id, dest_rse_id=rse5_id, include_multihop=True, multihop_rses=all_rses)


### PR DESCRIPTION
Gradual refactoring with the goal to move transfertool-specifics closer to those transfertools. One of the big goals is to construct all possible paths, but delay the generation of FTS API arguments until after selecting the best path. With each commit from this PR, the paths encapsulate in them more and more raw information which we'll use later to generate the actual FTS API arguments. 

Transfertool-specific filtering (content of the "fts" attribute on the rse; or existence of globus ids) can now also be done at a later stage to select among all candidates.

The PR doesn't yet try to move anything into FTS/Globus Transfertool drivers because [bulk_group_transfer](https://github.com/rucio/rucio/blob/6ed8844217f2ef91f317d1238a78be3844a715ae/lib/rucio/daemons/conveyor/common.py#L230) lays in between. Most of this function is FTS-specific; but it was forcefully introduced into the globus code-path too. Refactoring it here would make this PR much too big.