### PR TITLE
Clients: deprecate unavailable argument for list-replicas. Closes #4603

### DIFF
--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -152,7 +152,7 @@ def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
 
     :param dids: The list of data identifiers (DIDs).
     :param schemes: A list of schemes to filter the replicas. (e.g. file, http, ...)
-    :param unavailable: Also include unavailable replicas in the list.
+    :param unavailable: (deprecated) Also include unavailable replicas in the list.
     :param request_id: ID associated with the request for debugging.
     :param all_states: Return all replicas whatever state they are in. Adds an extra 'states' entry in the result dictionary.
     :param rse_expression: The RSE expression to restrict replicas on a set of RSEs.

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -114,7 +114,7 @@ class ReplicaClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def list_replicas(self, dids, schemes=None, unavailable=False, ignore_availability=True,
+    def list_replicas(self, dids, schemes=None, ignore_availability=True,
                       all_states=False, metalink=False, rse_expression=None,
                       client_location=None, sort=None, domain=None,
                       signature_lifetime=None, nrandom=None,
@@ -126,7 +126,6 @@ class ReplicaClient(BaseClient):
         :param dids: The list of data identifiers (DIDs) like :
             [{'scope': <scope1>, 'name': <name1>}, {'scope': <scope2>, 'name': <name2>}, ...]
         :param schemes: A list of schemes to filter the replicas. (e.g. file, http, ...)
-        :param unavailable: Also include unavailable replicas in the list (deprecated)
         :param ignore_availability: Also include replicas from blocked RSEs into the list
         :param metalink: ``False`` (default) retrieves as JSON,
                          ``True`` retrieves as metalink4+xml.
@@ -150,8 +149,6 @@ class ReplicaClient(BaseClient):
 
         if schemes:
             data['schemes'] = schemes
-        if unavailable:
-            data['unavailable'] = True
         if ignore_availability is not None:
             data['ignore_availability'] = ignore_availability
         data['all_states'] = all_states

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -635,7 +635,7 @@ def _resolve_dids(dids, unavailable, ignore_availability, all_states, resolve_ar
     Resolve list of DIDs into a list of conditions.
 
     :param dids: The list of data identifiers (DIDs).
-    :param unavailable: Also include unavailable replicas in the list.
+    :param unavailable: (deprecated) Also include unavailable replicas in the list.
     :param ignore_availability: Ignore the RSE blocklisting.
     :param all_states: Return all replicas whatever state they are in. Adds an extra 'states' entry in the result dictionary.
     :param resolve_archives: When set to true, find archives which contain the replicas.
@@ -1277,7 +1277,7 @@ def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
 
     :param dids: The list of data identifiers (DIDs).
     :param schemes: A list of schemes to filter the replicas. (e.g. file, http, ...)
-    :param unavailable: Also include unavailable replicas in the list.
+    :param unavailable: (deprecated) Also include unavailable replicas in the list.
     :param request_id: ID associated with the request for debugging.
     :param ignore_availability: Ignore the RSE blocklisting.
     :param all_states: Return all replicas whatever state they are in. Adds an extra 'states' entry in the result dictionary.

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -620,7 +620,7 @@ def test_client_add_list_bad_replicas(rse_factory, replica_client, did_client):
 
     # Listing replicas on deterministic RSE
     replicas, list_rep = [], []
-    for replica in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files], schemes=['srm'], unavailable=True):
+    for replica in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files], schemes=['srm'], all_states=True):
         replicas.extend(replica['rses'][rse1])
         list_rep.append(replica)
     r = replica_client.declare_bad_file_replicas(replicas, 'This is a good reason')
@@ -651,7 +651,7 @@ def test_client_add_list_bad_replicas(rse_factory, replica_client, did_client):
 
     # Listing replicas on non-deterministic RSE
     replicas, list_rep = [], []
-    for replica in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files], schemes=['srm'], unavailable=True):
+    for replica in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files], schemes=['srm'], all_states=True):
         replicas.extend(replica['rses'][rse2])
         list_rep.append(replica)
     print(replicas, list_rep)
@@ -686,7 +686,7 @@ def test_client_add_suspicious_replicas(rse_factory, replica_client):
     # Listing replicas on deterministic RSE
     replicas = []
     list_rep = []
-    for replica in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files], schemes=['srm'], unavailable=True):
+    for replica in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files], schemes=['srm'], all_states=True):
         replicas.extend(replica['rses'][rse1])
         list_rep.append(replica)
     r = replica_client.declare_suspicious_file_replicas(replicas, 'This is a good reason')
@@ -701,7 +701,7 @@ def test_client_add_suspicious_replicas(rse_factory, replica_client):
     # Listing replicas on non-deterministic RSE
     replicas = []
     list_rep = []
-    for replica in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files], schemes=['srm'], unavailable=True):
+    for replica in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files], schemes=['srm'], all_states=True):
         replicas.extend(replica['rses'][rse2])
         list_rep.append(replica)
     r = replica_client.declare_suspicious_file_replicas(replicas, 'This is a good reason')
@@ -853,7 +853,7 @@ def test_client_add_list_replicas(rse_factory, replica_client, mock_scope):
         file['state'] = 'A'
         files4.append(file)
     replica_client.update_replicas_states(rse2, files=files4)
-    replicas = [r for r in replica_client.list_replicas(dids=[{'scope': i['scope'], 'name': i['name']} for i in files3], schemes=['file'], unavailable=True)]
+    replicas = [r for r in replica_client.list_replicas(dids=[{'scope': i['scope'], 'name': i['name']} for i in files3], schemes=['file'], all_states=True)]
     assert len(replicas) == 5
     for i in range(nbfiles):
         assert rse2 in replicas[i]['rses']
@@ -956,7 +956,7 @@ def test_client_add_temporary_unavailable_pfns(rse_factory, mock_scope, replica_
 
     # Listing replicas on deterministic RSE
     list_rep = []
-    for replica in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files], schemes=['file'], unavailable=True):
+    for replica in replica_client.list_replicas(dids=[{'scope': f['scope'], 'name': f['name']} for f in files], schemes=['file'], all_states=True):
         pfn = list(replica['pfns'].keys())[0]
         list_rep.append(pfn)
 
@@ -1071,7 +1071,7 @@ class TestReplicaMetalink:
 
         ml = xmltodict.parse(replica_client.list_replicas(files,
                                                           metalink=4,
-                                                          unavailable=True,
+                                                          all_states=True,
                                                           schemes=['https', 'sftp', 'file']),
                              xml_attribs=False)
         assert 3 == len(ml['metalink']['file']['url'])

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -265,7 +265,7 @@ class ListReplicas(ErrorHandlingMethodView):
         :query sort: Requested sorting of the result, e.g., 'geoip', 'closeness', 'dynamic', 'ranking', 'random'.
         :<json list dids: list of DIDs.
         :<json list schemes: A list of schemes to filter the replicas.
-        :<json bool unavailable: Also include unavailable replicas.
+        :<json bool unavailable: (deprecated) Also include unavailable replicas.
         :<json bool all_states: Return all replicas whatever state they are in. Adds an extra 'states' entry in the result dictionary.
         :<json string rse_expression: The RSE expression to restrict on a list of RSEs.
         :<json dict client_location: Client location dictionary for PFN modification {'ip', 'fqdn', 'site', 'latitude', 'longitude'}.


### PR DESCRIPTION
unavailable has very similar behavior to all_states: it lists replicas
in following 3 states: Available/Unavailable/Copying. The argument
is confusing because it makes you think it ignores rse availability.
Remove the argument from clients, but leave it on the API side to keep
it compatible with older clients.

There are no references to `unavailable` in bin/rucio
