### PR TITLE
Clients: recursive upload of a folder into collections #4616

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -43,6 +43,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -947,7 +948,8 @@ def upload(args):
                       'lifetime': args.lifetime,
                       'register_after_upload': args.register_after_upload,
                       'transfer_timeout': args.transfer_timeout,
-                      'guid': args.guid})
+                      'guid': args.guid,
+                      'recursive': args.recursive})
 
     if len(items) < 1:
         raise InputValidationError('No files could be extracted from the given arguments')
@@ -959,6 +961,11 @@ def upload(args):
     if len(items) > 1 and args.name:
         logger.error("A single LFN was specified on the command line, but there are multiple files to upload.")
         logger.error("If LFN auto-detection is not used, only one file may be uploaded at a time")
+        raise InputValidationError('Invalid input argument composition')
+
+    if args.recursive and args.pfn:
+        logger.error("It is not possible to create the folder structure into collections with a non-deterministic way.")
+        logger.error("If PFN is specified, you cannot use --recursive")
         raise InputValidationError('Invalid input argument composition')
 
     client = get_client(args)
@@ -2178,6 +2185,7 @@ You can filter by key/value, e.g.::
     upload_parser.add_argument('--name', dest='name', action='store', help='Specify the exact LFN for the upload.')
     upload_parser.add_argument('--transfer-timeout', dest='transfer_timeout', type=float, action='store', default=config_get('upload', 'transfer_timeout', False, 360), help='Transfer timeout (in seconds).')
     upload_parser.add_argument(dest='args', action='store', nargs='+', help='files and datasets.')
+    upload_parser.add_argument('--recursive', dest='recursive', action='store_true', default=False, help='Convert recursively the folder structure into collections')
 
     # The download and get subparser
     get_parser = subparsers.add_parser('get', help='Download method (synonym for download)')

--- a/bin/rucio
+++ b/bin/rucio
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Copyright 2012-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,9 +23,9 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2020
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2013
 # - David Cameron <david.cameron@cern.ch>, 2014-2020
-# - Tomas Kouba <tomas.kouba@cern.ch>, 2014
+# - Tomáš Kouba <tomas.kouba@cern.ch>, 2014
 # - Wen Guan <wen.guan@cern.ch>, 2014
-# - Joaquin Bogado <jbogado@linti.unlp.edu.ar>, 2014-2018
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2014-2018
 # - Evangelia Liotiri <evangelia.liotiri@cern.ch>, 2015
 # - Tobias Wegner <twegner@cern.ch>, 2017-2019
 # - Brian Bockelman <bbockelm@cse.unl.edu>, 2017-2018
@@ -43,6 +44,9 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
+# - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
+# - Christoph Ames <christoph.ames@physik.uni-muenchen.de>, 2021
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from __future__ import print_function

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -111,6 +111,7 @@ class UploadClient:
             lifetime              - Optional: the lifetime of the file after it was uploaded
             transfer_timeout      - Optional: time after the upload will be aborted
             guid                  - Optional: guid of the file
+            recursive             - Optional: if set, parses the folder structure recursively into collections
         :param summary_file_path: Optional: a path where a summary in form of a json file will be stored
         :param traces_copy_out: reference to an external list, where the traces should be uploaded
 
@@ -490,6 +491,7 @@ class UploadClient:
         for item in items:
             path = item.get('path')
             pfn = item.get('pfn')
+            recursive = item.get('recursive')
             if not path:
                 logger(logging.WARNING, 'Skipping source entry because the key "path" is missing')
                 continue
@@ -498,7 +500,7 @@ class UploadClient:
                 continue
             if pfn:
                 item['force_scheme'] = pfn.split(':')[0]
-            if os.path.isdir(path):
+            if os.path.isdir(path) and not recursive:
                 dname, subdirs, fnames = next(os.walk(path))
                 for fname in fnames:
                     file = self._collect_file_info(os.path.join(dname, fname), item)
@@ -507,9 +509,13 @@ class UploadClient:
                     logger(logging.WARNING, 'Skipping %s because it is empty.' % dname)
                 elif not len(fnames):
                     logger(logging.WARNING, 'Skipping %s because it has no files in it. Subdirectories are not supported.' % dname)
-            elif os.path.isfile(path):
+            elif os.path.isdir(path) and recursive:
+                files.extend(self._recursive(item))
+            elif os.path.isfile(path) and not recursive:
                 file = self._collect_file_info(path, item)
                 files.append(file)
+            elif os.path.isfile(path) and recursive:
+                logger(logging.WARNING, 'Skipping %s because of --recursive flag' % path)
             else:
                 logger(logging.WARNING, 'No such file or directory: %s' % path)
 
@@ -721,3 +727,80 @@ class UploadClient:
         """
         if self.tracing:
             send_trace(trace, self.client.trace_host, self.client.user_agent)
+
+    def _recursive(self, item):
+        """
+        If the --recursive flag is set, it replicates the folder structure recursively into collections
+        A folder only can have either other folders inside or files, but not both of them
+            - If it has folders, the root folder will be a container
+            - If it has files, the root folder will be a dataset
+            - If it is empty, it does not create anything
+
+        :param: item        dictionary containing all descriptions of the files to upload
+        """
+        logger = self.logger
+        files = []
+        datasets = []
+        containers = []
+        attach = []
+        scope = item.get('did_scope') if item.get('did_scope') is not None else self.default_file_scope
+        rse = item.get('rse')
+        path = item.get('path')
+        if path[-1] == '/':
+            path = path[0:-1]
+        for root, dirs, fnames in os.walk(path):
+            if len(dirs) > 0 and len(fnames) > 0:
+                logger(logging.ERROR, 'A container can only have either collections or files, not both')
+                raise InputValidationError('Invalid input folder structure')
+            if path == root:
+                root2 = root.split('/')[-1] if root.__contains__('/') else root
+                if len(fnames) > 0:
+                    datasets.append({'scope': scope, 'name': root2, 'rse': rse})
+                    logger(logging.DEBUG, 'Appended dataset with DID %s:%s' % (scope, path))
+                elif len(dirs) > 0:
+                    containers.append({'scope': scope, 'name': root2})
+                    logger(logging.DEBUG, 'Appended container with DID %s:%s' % (scope, path))
+                else:
+                    logger(logging.WARNING, 'The folder %s is empty, skipping' % root)
+            if len(dirs) > 0:
+                for directory in dirs:
+                    root_dir, dir_dir, fnames_dir = next(os.walk(os.path.join(root, directory)))
+                    if len(dir_dir) > 0:
+                        containers.append({'scope': scope, 'name': directory})
+                        logger(logging.DEBUG, 'Appended container with DID %s:%s' % (scope, directory))
+                    elif len(fnames_dir) > 0:
+                        datasets.append({'scope': scope, 'name': directory, 'rse': rse})
+                        logger(logging.DEBUG, 'Appended dataset with DID %s:%s' % (scope, directory))
+                    else:
+                        logger(logging.WARNING, 'The folder %s is empty, skipping' % root_dir)
+                        continue
+                    attach.append({'scope': scope, 'name': root.split('/')[-1], 'rse': rse, 'dids': {'scope': scope, 'name': directory}})
+            else:
+                for fname in fnames:
+                    file = self._collect_file_info(os.path.join(root, fname), item)
+                    file['dataset_scope'] = scope
+                    file['dataset_name'] = root.split('/')[-1]
+                    files.append(file)
+        # if everything went ok, replicate the folder structure in Rucio storage
+        for dataset in datasets:
+            try:
+                self.client.add_dataset(scope=dataset['scope'], name=dataset['name'], rse=dataset['rse'])
+                logger(logging.INFO, 'Created dataset with DID %s:%s' % (dataset['scope'], dataset['name']))
+            except RucioException as error:
+                logger(logging.ERROR, error)
+                logger(logging.ERROR, 'It was not possible to create dataset with DID %s:%s' % (dataset['scope'], dataset['name']))
+        for container in containers:
+            try:
+                self.client.add_container(scope=container['scope'], name=container['name'])
+                logger(logging.INFO, 'Created container with DID %s:%s' % (container['scope'], container['name']))
+            except RucioException as error:
+                logger(logging.ERROR, error)
+                logger(logging.ERROR, 'It was not possible to create dataset with DID %s:%s' % (container['scope'], container['name']))
+        for att in attach:
+            try:
+                self.client.attach_dids(scope=att['scope'], name=att['name'], dids=[att['dids']])
+                logger(logging.INFO, 'DIDs attached to collection %s:%s' % (att['scope'], att['name']))
+            except RucioException as error:
+                logger(logging.ERROR, error)
+                logger(logging.ERROR, 'It was not possible to attach to collection with DID %s:%s' % (att['scope'], att['name']))
+        return files

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -16,7 +16,7 @@
 # Authors:
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Mayank Sharma <mayank.sharma@cern.ch>, 2021
-
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 import os
 import shutil
@@ -323,12 +323,12 @@ class TemporaryFileFactory:
 
         return self._base_dir
 
-    def _make_temp_file(self, data, size, namelen, use_basedir):
+    def _make_temp_file(self, data, size, namelen, use_basedir, path):
         fn = ''.join(choice(ascii_uppercase) for x in range(namelen))
         if use_basedir:
-            fp = self.base_dir / fn
+            fp = self.base_dir / path / fn if path is not None else self.base_dir / fn
         else:
-            fp = Path(tempfile.gettempdir(), fn)
+            fp = Path(tempfile.gettempdir()) / path / fn if path is not None else Path(tempfile.gettempdir()) / fn
             self.non_basedir_files.append(fp)
 
         if data is not None:
@@ -343,16 +343,39 @@ class TemporaryFileFactory:
 
         return fp
 
-    def file_generator(self, data=None, size=2, namelen=10, use_basedir=False):
+    def _make_temp_folder(self, namelen, use_basedir, path):
+        fn = ''.join(choice(ascii_uppercase) for x in range(namelen))
+        if use_basedir:
+            fp = self.base_dir / path / fn if path is not None else self.base_dir / fn
+        else:
+            fp = Path(tempfile.gettempdir()) / path / fn if path is not None else Path(tempfile.gettempdir()) / fn
+            self.non_basedir_files.append(fp)
+
+        os.makedirs(fp, exist_ok=True)
+
+        return fp
+
+    def file_generator(self, data=None, size=2, namelen=10, use_basedir=False, path=None):
         """
         Creates a temporary file
         :param data        : The content to be written in the file. If provided, the size parameter is ignored.
         :param size        : The size of random bytes to be written in the file
         :param namelen     : The length of filename
         :param use_basedir : If True, the file is created under the base_dir for this TemporaryFileFactory instance.
+        :param path        : Relative path of the file, can be under basedir (if use_basedir True) or from the temp dir
         :returns: The absolute path of the generated file
         """
-        return self._make_temp_file(data, size, namelen, use_basedir)
+        return self._make_temp_file(data, size, namelen, use_basedir, path)
+
+    def folder_generator(self, namelen=10, use_basedir=False, path=None):
+        """
+        Creates an empty temporary folder
+        :param namelen     : The length of folder. Only used if path is None.
+        :param use_basedir : If True, the folder is created under the base_dir for this TemporaryFileFactory instance.
+        :param path        : Relative path of the folder, can be under basedir (if use_basedir True).
+        :returns: The absolute path of the generated folder
+        """
+        return self._make_temp_folder(namelen, use_basedir, path)
 
     def cleanup(self):
         for fp in self.non_basedir_files:

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -56,6 +56,7 @@ from rucio.common.types import InternalScope, InternalAccount
 from rucio.common.utils import generate_uuid, get_tmp_dir, md5, render_json
 from rucio.rse import rsemanager as rsemgr
 from rucio.tests.common import execute, account_name_generator, rse_name_generator, file_generator, scope_name_generator, get_long_vo
+from rucio.tests.temp_factories import TemporaryFileFactory
 
 
 class TestBinRucio(unittest.TestCase):
@@ -1578,113 +1579,76 @@ class TestBinRucio(unittest.TestCase):
 
     def test_upload_recursive_ok(self):
         """CLIENT(USER): Upload and preserve folder structure"""
-        folder = 'folder_' + generate_uuid()
-        folder1 = '%s/folder_%s' % (folder, generate_uuid())
-        folder2 = '%s/folder_%s' % (folder, generate_uuid())
-        folder3 = '%s/folder_%s' % (folder, generate_uuid())
-        folder11 = '%s/folder_%s' % (folder1, generate_uuid())
-        folder12 = '%s/folder_%s' % (folder1, generate_uuid())
-        folder13 = '%s/folder_%s' % (folder1, generate_uuid())
-        file1 = 'file_%s' % generate_uuid()
-        file2 = 'file_%s' % generate_uuid()
-        cmd = 'mkdir %s' % folder
-        execute(cmd)
-        cmd = 'mkdir %s && mkdir %s && mkdir %s' % (folder1, folder2, folder3)
-        execute(cmd)
-        cmd = 'mkdir %s && mkdir %s && mkdir %s' % (folder11, folder12, folder13)
-        execute(cmd)
-        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder11, file1)
-        execute(cmd)
-        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder2, file2)
-        execute(cmd)
-        cmd = 'rucio upload --scope %s --rse %s --recursive %s/' % (self.user, self.def_rse, folder)
-        execute(cmd)
-        cmd = 'rucio list-content %s:%s' % (self.user, folder)
-        exitcode, out, err = execute(cmd)
-        assert re.search("{0}:{1}".format(self.user, folder1.split('/')[-1]), out) is not None
-        assert re.search("{0}:{1}".format(self.user, folder2.split('/')[-1]), out) is not None
-        assert re.search("{0}:{1}".format(self.user, folder3.split('/')[-1]), out) is None
-        cmd = 'rucio list-content %s:%s' % (self.user, folder1.split('/')[-1])
-        exitcode, out, err = execute(cmd)
-        assert re.search("{0}:{1}".format(self.user, folder11.split('/')[-1]), out) is not None
-        assert re.search("{0}:{1}".format(self.user, folder12.split('/')[-1]), out) is None
-        assert re.search("{0}:{1}".format(self.user, folder13.split('/')[-1]), out) is None
-        cmd = 'rucio list-content %s:%s' % (self.user, folder11.split('/')[-1])
-        exitcode, out, err = execute(cmd)
-        assert re.search("{0}:{1}".format(self.user, file1), out) is not None
-        cmd = 'rucio list-content %s:%s' % (self.user, folder2.split('/')[-1])
-        exitcode, out, err = execute(cmd)
-        assert re.search("{0}:{1}".format(self.user, file2), out) is not None
-        cmd = 'rm -rf %s' % folder
-        execute(cmd)
+        with TemporaryFileFactory() as file_factory:
+            folder = file_factory.base_dir
+            folder1 = file_factory.folder_generator(use_basedir=True)
+            folder2 = file_factory.folder_generator(use_basedir=True)
+            folder3 = file_factory.folder_generator(use_basedir=True)
+            folder11 = file_factory.folder_generator(use_basedir=True, path=str(folder1).split('/')[-1])
+            folder12 = file_factory.folder_generator(use_basedir=True, path=str(folder1).split('/')[-1])
+            folder13 = file_factory.folder_generator(use_basedir=True, path=str(folder1).split('/')[-1])
+            file1 = str(file_factory.file_generator(path=folder11)).split('/')[-1]
+            file2 = str(file_factory.file_generator(path=folder2)).split('/')[-1]
+
+            exitcode, out, err = execute('rucio upload --scope %s --rse %s --recursive %s' % (self.user, self.def_rse, folder))
+            print(err)
+            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder).split('/')[-1]))
+            assert re.search("{0}:{1}".format(self.user, str(folder1).split('/')[-1]), out) is not None
+            assert re.search("{0}:{1}".format(self.user, str(folder2).split('/')[-1]), out) is not None
+            assert re.search("{0}:{1}".format(self.user, str(folder3).split('/')[-1]), out) is None
+
+            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder1).split('/')[-1]))
+            assert re.search("{0}:{1}".format(self.user, str(folder11).split('/')[-1]), out) is not None
+            assert re.search("{0}:{1}".format(self.user, str(folder12).split('/')[-1]), out) is None
+            assert re.search("{0}:{1}".format(self.user, str(folder13).split('/')[-1]), out) is None
+
+            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder11).split('/')[-1]))
+            assert re.search("{0}:{1}".format(self.user, file1), out) is not None
+
+            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder2).split('/')[-1]))
+            assert re.search("{0}:{1}".format(self.user, file2), out) is not None
 
     def test_upload_recursive_subfolder(self):
         """CLIENT(USER): Upload and preserve folder structure in a subfolder"""
-        folder = 'folder_' + generate_uuid()
-        folder1 = '%s/folder_%s' % (folder, generate_uuid())
-        folder11 = '%s/folder_%s' % (folder1, generate_uuid())
-        file1 = 'file_%s' % generate_uuid()
-        cmd = 'mkdir %s' % (folder)
-        execute(cmd)
-        cmd = 'mkdir %s' % (folder1)
-        execute(cmd)
-        cmd = 'mkdir %s' % (folder11)
-        execute(cmd)
-        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder11, file1)
-        execute(cmd)
-        cmd = 'rucio upload --scope %s --rse %s --recursive %s/' % (self.user, self.def_rse, folder1)
-        execute(cmd)
-        cmd = 'rucio list-content %s:%s' % (self.user, folder)
-        exitcode, out, err = execute(cmd)
-        assert re.search("{0}:{1}".format(self.user, folder1.split('/')[-1]), out) is None
-        cmd = 'rucio list-content %s:%s' % (self.user, folder1.split('/')[-1])
-        exitcode, out, err = execute(cmd)
-        assert re.search("{0}:{1}".format(self.user, folder11.split('/')[-1]), out) is not None
-        cmd = 'rucio list-content %s:%s' % (self.user, folder11.split('/')[-1])
-        exitcode, out, err = execute(cmd)
-        assert re.search("{0}:{1}".format(self.user, file1), out) is not None
-        cmd = 'rm -rf %s' % folder
-        execute(cmd)
+        with TemporaryFileFactory() as file_factory:
+            folder = file_factory.base_dir
+            folder1 = file_factory.folder_generator(use_basedir=True)
+            folder11 = file_factory.folder_generator(use_basedir=True, path=str(folder1).split('/')[-1])
+            file1 = str(file_factory.file_generator(path=folder11)).split('/')[-1]
+
+            execute('rucio upload --scope %s --rse %s --recursive %s' % (self.user, self.def_rse, folder1))
+            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder).split('/')[-1]))
+            assert re.search("{0}:{1}".format(self.user, str(folder1).split('/')[-1]), out) is None
+
+            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder1).split('/')[-1]))
+            assert re.search("{0}:{1}".format(self.user, str(folder11).split('/')[-1]), out) is not None
+
+            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder11).split('/')[-1]))
+            assert re.search("{0}:{1}".format(self.user, file1), out) is not None
 
     def test_recursive_empty(self):
         """CLIENT(USER): Upload and preserve folder structure with an empty folder"""
-        folder = 'folder_' + generate_uuid()
-        folder1 = '%s/folder_%s' % (folder, generate_uuid())
-        cmd = 'mkdir %s' % (folder)
-        execute(cmd)
-        cmd = 'mkdir %s' % (folder1)
-        execute(cmd)
-        cmd = 'rucio upload --scope %s --rse %s --recursive %s/' % (self.user, self.def_rse, folder)
-        execute(cmd)
-        cmd = 'rucio list-content %s:%s' % (self.user, folder)
-        exitcode, out, err = execute(cmd)
-        assert re.search("{0}:{1}".format(self.user, folder1.split('/')[-1]), out) is None
-        cmd = 'rm -rf %s' % folder
-        execute(cmd)
+        with TemporaryFileFactory() as file_factory:
+            folder = file_factory.base_dir
+            folder1 = file_factory.folder_generator(use_basedir=True)
+
+            execute('rucio upload --scope %s --rse %s --recursive %s' % (self.user, self.def_rse, folder))
+            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder).split('/')[-1]))
+            assert re.search("{0}:{1}".format(self.user, str(folder1).split('/')[-1]), out) is None
 
     def test_upload_recursive_only_files(self):
         """CLIENT(USER): Upload and preserve folder structure only with files"""
-        folder = 'folder_' + generate_uuid()
-        file1 = 'file_%s' % generate_uuid()
-        file2 = 'file_%s' % generate_uuid()
-        file3 = 'file_%s' % generate_uuid()
-        cmd = 'mkdir %s' % folder
-        execute(cmd)
-        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder, file1)
-        execute(cmd)
-        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder, file2)
-        execute(cmd)
-        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder, file3)
-        execute(cmd)
-        cmd = 'rucio upload --scope %s --rse %s --recursive %s/' % (self.user, self.def_rse, folder)
-        execute(cmd)
-        cmd = 'rucio list-content %s:%s' % (self.user, folder)
-        exitcode, out, err = execute(cmd)
-        assert re.search("{0}:{1}".format(self.user, file1), out) is not None
-        assert re.search("{0}:{1}".format(self.user, file2), out) is not None
-        assert re.search("{0}:{1}".format(self.user, file3), out) is not None
-        cmd = 'rucio ls %s:%s' % (self.user, folder)
-        exitcode, out, err = execute(cmd)
-        assert re.search("DATASET", out) is not None
-        cmd = 'rm -rf %s' % folder
-        execute(cmd)
+        with TemporaryFileFactory() as file_factory:
+            folder = file_factory.base_dir
+            file1 = str(file_factory.file_generator(use_basedir=True)).split('/')[-1]
+            file2 = str(file_factory.file_generator(use_basedir=True)).split('/')[-1]
+            file3 = str(file_factory.file_generator(use_basedir=True)).split('/')[-1]
+
+            execute('rucio upload --scope %s --rse %s --recursive %s' % (self.user, self.def_rse, folder))
+            exitcode, out, err = execute('rucio ls %s:%s' % (self.user, str(folder).split('/')[-1]))
+            assert re.search("DATASET", out) is not None
+
+            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder).split('/')[-1]))
+            assert re.search("{0}:{1}".format(self.user, file1), out) is not None
+            assert re.search("{0}:{1}".format(self.user, file2), out) is not None
+            assert re.search("{0}:{1}".format(self.user, file3), out) is not None


### PR DESCRIPTION
### Clients: recursive upload of a folder into collections. Closes #4616 
The changes allow to replicate the folder structure (recursively) into collections.

Add a new flag in rucio CLI client: `--recursive`. It needs at least one argument and it should be a folder.
It is not possible to create the folder structure into collections with a non-deterministic way.
A folder only can have either other folders inside or files, but not both of them:
- If it has folders, the root folder will be a container
- If it has files, the root folder will be a dataset
- If it is empty, it does not create anything

Add some tests.