### PR TITLE
Clients: remove un-needed try-except blocks. Closes #3911

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -2401,15 +2401,10 @@ if __name__ == '__main__':
 
     args = oparser.parse_args(arguments)
 
-    logger = None
-    try:
-        logger = setup_logger(module_name=__name__, logger_name='user', verbose=args.verbose)
-        start_time = time.time()
-        result = args.function(args)
-        end_time = time.time()
-        if args.verbose:
-            print("Completed in %-0.4f sec." % (end_time - start_time))
-        sys.exit(result)
-    except Exception as error:
-        logging.log(logging.ERROR, "Strange error: {0}".format(error))
-        sys.exit(FAILURE)
+    logger = setup_logger(module_name=__name__, logger_name='user', verbose=args.verbose)
+    start_time = time.time()
+    result = args.function(args)
+    end_time = time.time()
+    if args.verbose:
+        print("Completed in %-0.4f sec." % (end_time - start_time))
+    sys.exit(result)

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -2258,16 +2258,12 @@ if __name__ == '__main__':
                 'set_tombstone': set_tombstone
                 }
 
-    try:
-        if args.verbose:
-            logger.setLevel(logging.DEBUG)
-        start_time = time.time()
-        command = commands.get(args.which)
-        result = command(args)
-        end_time = time.time()
-        if args.verbose:
-            print("Completed in %-0.4f sec." % (end_time - start_time))
-        sys.exit(result)
-    except Exception:
-        logger.exception("Uncaught exception")
-        sys.exit(FAILURE)
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+    start_time = time.time()
+    command = commands.get(args.which)
+    result = command(args)
+    end_time = time.time()
+    if args.verbose:
+        print("Completed in %-0.4f sec." % (end_time - start_time))
+    sys.exit(result)


### PR DESCRIPTION
All rucio commands are wrapped by an exception_handler functions.
As a consequence, the removed excepts should not occur in any normal
program flow or on expected error. It's more beneficial to have a full
trace in such cases. So let the exception propagate.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
