### PR TITLE
Clients: expose RSE limits in rucio-admin. Closes #4073

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -54,7 +54,6 @@ Individual contributors to the source code
 - Dhruv Sondhi <dhruvsondhi05@gmail.com>, 2021
 - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 - Ilija Vukotic <ivukotic@uchicago.edu>, 2020-2021
-- David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 
 Organisations employing contributors

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -54,6 +54,7 @@ Individual contributors to the source code
 - Dhruv Sondhi <dhruvsondhi05@gmail.com>, 2021
 - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 - Ilija Vukotic <ivukotic@uchicago.edu>, 2020-2021
+- David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 
 Organisations employing contributors

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -580,7 +580,7 @@ def info_rse(args):
     print('RSE limits:')
     print('===========')
     for limit in rse_limits:
-        print('  ' + limit + ': ' + str(rse_limits[limit]))
+        print('  ' + limit + ': ' + str(rse_limits[limit]) + ' B')
 
     return SUCCESS
 
@@ -777,8 +777,12 @@ def set_limit_rse(args):
     Set the RSE limit given the rse name and the name and value of the limit
     """
     client = get_client(args)
-    if client.set_rse_limits(args.rse, args.name, args.value):
-        logger.info('Set RSE limit successfully for %s: %s = %s' % (args.rse, args.name, args.value))
+    try:
+        args.value = int(args.value)
+        if client.set_rse_limits(args.rse, args.name, args.value):
+            logger.info('Set RSE limit successfully for %s: %s = %s' % (args.rse, args.name, args.value))
+    except ValueError:
+        logger.error('The RSE limit value must be an integer')
 
     return SUCCESS
 

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -1965,12 +1965,12 @@ def get_parser():
 
     # The set_limit_rse command
     set_limit_rse_parser = rse_subparser.add_parser('set-limit',
-                                               help='Set a RSE limit',
-                                               formatter_class=argparse.RawDescriptionHelpFormatter,
-                                               epilog='Usage example\n'
-                                                      '"""""""""""""\n'
-                                                      '\n'
-                                                      '  $ rucio-admin rse set-limit XRD1 MinFreeSpace 10000')
+                                                    help='Set a RSE limit',
+                                                    formatter_class=argparse.RawDescriptionHelpFormatter,
+                                                    epilog='Usage example\n'
+                                                           '"""""""""""""\n'
+                                                           '\n'
+                                                           '  $ rucio-admin rse set-limit XRD1 MinFreeSpace 10000')
     set_limit_rse_parser.set_defaults(which='set_limit_rse')
     set_limit_rse_parser.add_argument('rse', action='store', help='RSE name')
     set_limit_rse_parser.add_argument('name', action='store', help='Name of the limit')

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -38,6 +38,7 @@
 # - Rob Barnsley <robbarnsley@users.noreply.github.com>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from __future__ import division
 from __future__ import print_function
@@ -551,6 +552,7 @@ def info_rse(args):
     rseinfo = client.get_rse(rse=args.rse)
     attributes = client.list_rse_attributes(rse=args.rse)
     usage = client.get_rse_usage(rse=args.rse)
+    accounts = client.list_accounts()
     print('Settings:')
     print('=========')
     for key in sorted(rseinfo):
@@ -575,7 +577,12 @@ def info_rse(args):
         print('  ' + elem['source'])
         for item in sorted(elem):
             print('    ' + item + ': ' + str(elem[item]))
-
+    print("Account limits:")
+    print("===============")
+    for account in accounts:
+        print('  ' + account['account'])
+        print('    local_limit: %s' % sizefmt(client.get_account_limits(account=account['account'], rse_expression=args.rse, locality='local')[args.rse], True))
+        print('    global_limit: %s' % sizefmt(client.get_account_limits(account=account['account'], rse_expression=args.rse, locality='global')[args.rse], True))
     return SUCCESS
 
 

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -38,6 +38,7 @@
 # - Rob Barnsley <robbarnsley@users.noreply.github.com>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from __future__ import division
 from __future__ import print_function
@@ -551,6 +552,7 @@ def info_rse(args):
     rseinfo = client.get_rse(rse=args.rse)
     attributes = client.list_rse_attributes(rse=args.rse)
     usage = client.get_rse_usage(rse=args.rse)
+    rse_limits = client.get_rse_limits(args.rse)
     print('Settings:')
     print('=========')
     for key in sorted(rseinfo):
@@ -575,6 +577,10 @@ def info_rse(args):
         print('  ' + elem['source'])
         for item in sorted(elem):
             print('    ' + item + ': ' + str(elem[item]))
+    print('RSE limits:')
+    print('===========')
+    for limit in rse_limits:
+        print('  ' + limit + ': ' + str(rse_limits[limit]))
 
     return SUCCESS
 
@@ -760,6 +766,38 @@ def list_qos_policies(args):
     qos_policies = client.list_qos_policies(args.rse)
     for qos_policy in sorted(qos_policies):
         print(qos_policy)
+    return SUCCESS
+
+
+@exception_handler
+def set_limit_rse(args):
+    """
+    %(prog)s set-limit <rse> <name> <value>
+
+    Set the RSE limit given the rse name and the name and value of the limit
+    """
+    client = get_client(args)
+    if client.set_rse_limits(args.rse, args.name, args.value):
+        logger.info('Set RSE limit successfully for %s: %s = %s' % (args.rse, args.name, args.value))
+
+    return SUCCESS
+
+
+@exception_handler
+def delete_limit_rse(args):
+    """
+    %(prog)s delete-limit <rse> <name>
+
+    Delete the RSE limit given the rse name and the name of the limit
+    """
+    client = get_client(args)
+    limits = client.get_rse_limits(args.rse)
+    if args.name not in limits.keys():
+        logger.error('Limit %s not defined in RSE %s' % (args.name, args.rse))
+    else:
+        if client.delete_rse_limits(args.rse, args.name):
+            logger.info('Deleted RSE limit successfully for %s: %s' % (args.rse, args.name))
+
     return SUCCESS
 
 
@@ -1925,6 +1963,31 @@ def get_parser():
     list_qos_policies_parser.set_defaults(which='list_qos_policies')
     list_qos_policies_parser.add_argument('rse', action='store', help='RSE name')
 
+    # The set_limit_rse command
+    set_limit_rse_parser = rse_subparser.add_parser('set-limit',
+                                               help='Set a RSE limit',
+                                               formatter_class=argparse.RawDescriptionHelpFormatter,
+                                               epilog='Usage example\n'
+                                                      '"""""""""""""\n'
+                                                      '\n'
+                                                      '  $ rucio-admin rse set-limit XRD1 MinFreeSpace 10000')
+    set_limit_rse_parser.set_defaults(which='set_limit_rse')
+    set_limit_rse_parser.add_argument('rse', action='store', help='RSE name')
+    set_limit_rse_parser.add_argument('name', action='store', help='Name of the limit')
+    set_limit_rse_parser.add_argument('value', action='store', help='Value of the limit')
+
+    # The delete_limit_rse command
+    set_limit_rse_parser = rse_subparser.add_parser('delete-limit',
+                                                    help='Delete a RSE limit',
+                                                    formatter_class=argparse.RawDescriptionHelpFormatter,
+                                                    epilog='Usage example\n'
+                                                           '"""""""""""""\n'
+                                                           '\n'
+                                                           '  $ rucio-admin rse delete-limit XRD3 MaxBeingDeletedFiles')
+    set_limit_rse_parser.set_defaults(which='delete_limit_rse')
+    set_limit_rse_parser.add_argument('rse', action='store', help='RSE name')
+    set_limit_rse_parser.add_argument('name', action='store', help='Name of the limit')
+
     # The scope subparser
     scope_parser = subparsers.add_parser('scope', help='Scope methods')
     scope_subparser = scope_parser.add_subparsers(dest='scope_subcommand', **required_arg)
@@ -2255,7 +2318,9 @@ if __name__ == '__main__':
                 'list_pfns': list_pfns,
                 'import': import_data,
                 'export': export_data,
-                'set_tombstone': set_tombstone
+                'set_tombstone': set_tombstone,
+                'set_limit_rse': set_limit_rse,
+                'delete_limit_rse': delete_limit_rse,
                 }
 
     try:

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -38,7 +38,6 @@
 # - Rob Barnsley <robbarnsley@users.noreply.github.com>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
-# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from __future__ import division
 from __future__ import print_function
@@ -552,7 +551,6 @@ def info_rse(args):
     rseinfo = client.get_rse(rse=args.rse)
     attributes = client.list_rse_attributes(rse=args.rse)
     usage = client.get_rse_usage(rse=args.rse)
-    accounts = client.list_accounts()
     print('Settings:')
     print('=========')
     for key in sorted(rseinfo):
@@ -577,12 +575,7 @@ def info_rse(args):
         print('  ' + elem['source'])
         for item in sorted(elem):
             print('    ' + item + ': ' + str(elem[item]))
-    print("Account limits:")
-    print("===============")
-    for account in accounts:
-        print('  ' + account['account'])
-        print('    local_limit: %s' % sizefmt(client.get_account_limits(account=account['account'], rse_expression=args.rse, locality='local')[args.rse], True))
-        print('    global_limit: %s' % sizefmt(client.get_account_limits(account=account['account'], rse_expression=args.rse, locality='global')[args.rse], True))
+
     return SUCCESS
 
 

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -33,10 +33,12 @@
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from __future__ import print_function
 
 import os
+import random
 import re
 import unittest
 from datetime import datetime, timedelta
@@ -1532,3 +1534,44 @@ class TestBinRucio(unittest.TestCase):
         assert re.search('.*{0}.*{1}.*{2}.*{3}'.format(rse_exp, usage, global_limit, global_left), out) is not None
         self.account_client.set_local_account_limit(account, rse, -1)
         self.account_client.set_global_account_limit(account, rse_exp, -1)
+
+    def test_get_set_delete_limits_rse(self):
+        """CLIENT(ADMIN): Get, set and delete RSE limits"""
+        name = generate_uuid()
+        value = random.randint(0, 100000)
+        name2 = generate_uuid()
+        value2 = random.randint(0, 100000)
+        name3 = generate_uuid()
+        value3 = account_name_generator()
+        cmd = 'rucio-admin rse set-limit %s %s %s' % (self.def_rse, name, value)
+        execute(cmd)
+        cmd = 'rucio-admin rse set-limit %s %s %s' % (self.def_rse, name2, value2)
+        execute(cmd)
+        cmd = 'rucio-admin rse info %s' % self.def_rse
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}: {1}".format(name, value), out) is not None
+        assert re.search("{0}: {1}".format(name2, value2), out) is not None
+        new_value = random.randint(100001, 999999999)
+        cmd = 'rucio-admin rse set-limit %s %s %s' % (self.def_rse, name, new_value)
+        execute(cmd)
+        cmd = 'rucio-admin rse info %s' % self.def_rse
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}: {1}".format(name, new_value), out) is not None
+        assert re.search("{0}: {1}".format(name, value), out) is None
+        assert re.search("{0}: {1}".format(name2, value2), out) is not None
+        cmd = 'rucio-admin rse delete-limit %s %s' % (self.def_rse, name)
+        execute(cmd)
+        cmd = 'rucio-admin rse info %s' % self.def_rse
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}: {1}".format(name, new_value), out) is None
+        assert re.search("{0}: {1}".format(name2, value2), out) is not None
+        cmd = 'rucio-admin rse delete-limit %s %s' % (self.def_rse, name)
+        exitcode, out, err = execute(cmd)
+        assert re.search('Limit {0} not defined in RSE {1}'.format(name, self.def_rse), err) is not None
+        cmd = 'rucio-admin rse set-limit %s %s %s' % (self.def_rse, name3, value3)
+        exitcode, out, err = execute(cmd)
+        assert re.search('Database exception.', err) is not None
+        cmd = 'rucio-admin rse info %s' % self.def_rse
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}: {1}".format(name3, value3), out) is None
+        assert re.search("{0}: {1}".format(name2, value2), out) is not None

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -1569,7 +1569,8 @@ class TestBinRucio(unittest.TestCase):
         exitcode, out, err = execute(cmd)
         assert re.search('Limit {0} not defined in RSE {1}'.format(name, self.def_rse), err) is not None
         cmd = 'rucio-admin rse set-limit %s %s %s' % (self.def_rse, name3, value3)
-        execute(cmd)
+        exitcode, out, err = execute(cmd)
+        assert re.search('The RSE limit value must be an integer', err) is not None
         cmd = 'rucio-admin rse info %s' % self.def_rse
         exitcode, out, err = execute(cmd)
         assert re.search("{0}: {1}".format(name3, value3), out) is None

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -1569,8 +1569,7 @@ class TestBinRucio(unittest.TestCase):
         exitcode, out, err = execute(cmd)
         assert re.search('Limit {0} not defined in RSE {1}'.format(name, self.def_rse), err) is not None
         cmd = 'rucio-admin rse set-limit %s %s %s' % (self.def_rse, name3, value3)
-        exitcode, out, err = execute(cmd)
-        assert re.search('Database exception.', err) is not None
+        execute(cmd)
         cmd = 'rucio-admin rse info %s' % self.def_rse
         exitcode, out, err = execute(cmd)
         assert re.search("{0}: {1}".format(name3, value3), out) is None

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -21,6 +21,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from json import dumps
 
@@ -875,7 +876,7 @@ def blueprint():
     usage_history_view = UsageHistory.as_view('usage_history')
     bp.add_url_rule('/<rse>/usage/history', view_func=usage_history_view, methods=['get', ])
     limits_view = Limits.as_view('limits')
-    bp.add_url_rule('/<rse>/limits', view_func=limits_view, methods=['get', 'put'])
+    bp.add_url_rule('/<rse>/limits', view_func=limits_view, methods=['get', 'put', 'delete'])
     qos_policy_view = QoSPolicy.as_view('qos_policy')
     bp.add_url_rule('/<rse>/qos_policy', view_func=qos_policy_view, methods=['get', ])
     bp.add_url_rule('/<rse>/qos_policy/<policy>', view_func=qos_policy_view, methods=['post', 'delete'])


### PR DESCRIPTION
### Clients: expose RSE limits in rucio-admin. Closes #4073

When running `rucio-admin rse info RSE`, now it prints the quota for each account, both the local and global scopes.

Example: `rucio-admin rse info XRD1`
Output:
```
[...]
Account limits:
===============
  jdoe
    local_limit: 512.000 B
    global_limit: 0.0 B
  panda
    local_limit: 0.0 B
    global_limit: 1.024 kB
  root
    local_limit: Inf
    global_limit: 0.0 B
```