### PR TITLE
Release Management: Fix pip install; #4456

### DIFF
--- a/setup_rucio.py
+++ b/setup_rucio.py
@@ -31,11 +31,15 @@ import sys
 
 from setuptools import setup, find_packages
 
-from setuputil import server_requirements_table, match_define_requirements, get_rucio_version
-
 if sys.version_info < (3, 6):
     print('ERROR: Rucio Server requires at least Python 3.6 to run.')
     sys.exit(1)
+
+try:
+    from setuputil import server_requirements_table, match_define_requirements, get_rucio_version
+except ImportError:
+    sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+    from setuputil import server_requirements_table, match_define_requirements, get_rucio_version
 
 install_requires, extras_require = match_define_requirements(server_requirements_table)
 

--- a/setup_rucio_client.py
+++ b/setup_rucio_client.py
@@ -28,12 +28,15 @@ import sys
 
 from setuptools import setup
 
-from setuputil import clients_requirements_table, get_rucio_version, match_define_requirements
-
 if sys.version_info < (2, 7):
     print('ERROR: Rucio Client requires at least Python 2.7 to run.')
     sys.exit(1)
 
+try:
+    from setuputil import clients_requirements_table, get_rucio_version, match_define_requirements
+except ImportError:
+    sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+    from setuputil import clients_requirements_table, get_rucio_version, match_define_requirements
 
 install_requires, extras_require = match_define_requirements(clients_requirements_table)
 

--- a/setup_webui.py
+++ b/setup_webui.py
@@ -22,11 +22,16 @@ import sys
 
 from setuptools import setup
 
-from setuputil import get_rucio_version
 
 if sys.version_info < (3, 6):
     print('ERROR: Rucio WebUI requires at least Python 3.6 to run.')
     sys.exit(1)
+
+try:
+    from setuputil import get_rucio_version
+except ImportError:
+    sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+    from setuputil import get_rucio_version
 
 name = 'rucio-webui'
 packages = ['rucio', 'rucio.web', 'rucio.web.ui', 'rucio.web.ui.common']


### PR DESCRIPTION
Change sys.path if necessary.

With the patch, installing via a tarball from GitHub also works:
`pip install https://github.com/bziemons/rucio/archive/refs/heads/feature-4456-fix_pip_install_import_setuputil.tar.gz`
