### PR TITLE
Testing: Use new registry for image building; Fix #4154

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -35,10 +35,10 @@ jobs:
         id: images
         shell: bash
         run: |
-          docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          docker login https://ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           i=0; until [ "$i" -ge 3 ]; do
             IMAGES=$(echo '${{ toJson(matrix.cfg) }}' | ./tools/test/build_images.py \
-                --cache-repo docker.pkg.github.com/${{ github.repository }} \
+                --cache-repo ghcr.io/${{ github.repository }} \
                 --branch "${{ needs.setup.outputs.branch }}" ./etc/docker/test || echo "")
             if [[ -n $IMAGES ]]; then break;
             else
@@ -46,7 +46,7 @@ jobs:
               echo "::warning::Building images failed, retrying…"
             fi
           done
-          docker logout https://docker.pkg.github.com
+          docker logout https://ghcr.io
           if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
           echo "::set-output name=images::$IMAGES"
       - name: Run test with cfg
@@ -108,10 +108,10 @@ jobs:
         id: images
         shell: bash
         run: |
-          docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          docker login https://ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           i=0; until [ "$i" -ge 3 ]; do
             IMAGES=$(echo '${{ toJson(matrix.cfg) }}' | ./tools/test/build_images.py \
-                --cache-repo docker.pkg.github.com/${{ github.repository }} \
+                --cache-repo ghcr.io/${{ github.repository }} \
                 --branch "${{ needs.release-patch-setup.outputs.release_branch }}" ./etc/docker/test || echo "")
             if [[ -n $IMAGES ]]; then break;
             else
@@ -119,7 +119,7 @@ jobs:
               echo "::warning::Building images failed, retrying…"
             fi
           done
-          docker logout https://docker.pkg.github.com
+          docker logout https://ghcr.io
           if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
           echo "::set-output name=images::$IMAGES"
       - name: Run test with cfg

--- a/.github/workflows/imagecache.yml
+++ b/.github/workflows/imagecache.yml
@@ -56,7 +56,7 @@ jobs:
         id: images
         shell: bash
         run: |
-          BUILD_ARGS=("--output" "list" "--cache-repo" "docker.pkg.github.com/${{ github.repository }}" "--push-cache")
+          BUILD_ARGS=("--output" "list" "--cache-repo" "ghcr.io/${{ github.repository }}" "--push-cache")
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             # only build without cache on schedule (to update distro packages)
             BUILD_ARGS=("${BUILD_ARGS[@]}" "--build-no-cache")
@@ -70,7 +70,7 @@ jobs:
             echo "::warning::Not building image for branch ${{ matrix.branch }}, because it would overwrite master"
             exit 0
           fi
-          docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          docker login https://ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           i=0; until [ "$i" -ge 3 ]; do
             IMAGES="$(echo '${{ steps.matrix.outputs.matrix }}' | "${{ steps.files.outputs.build_images }}" ${BUILD_ARGS[@]} ./etc/docker/test || echo "")"
             if [[ -n "$IMAGES" ]]; then break;
@@ -79,7 +79,7 @@ jobs:
               echo "::warning::Building images failed, retrying…"
             fi
           done
-          docker logout https://docker.pkg.github.com
+          docker logout https://ghcr.io
           if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
   build_integration_tests:
     runs-on: ubuntu-latest
@@ -124,7 +124,7 @@ jobs:
         id: images
         shell: bash
         run: |
-          BUILD_ARGS=("--output" "list" "--cache-repo" "docker.pkg.github.com/${{ github.repository }}" "--push-cache")
+          BUILD_ARGS=("--output" "list" "--cache-repo" "ghcr.io/${{ github.repository }}" "--push-cache")
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             # only build without cache on schedule (to update distro packages)
             BUILD_ARGS=("${BUILD_ARGS[@]}" "--build-no-cache")
@@ -138,7 +138,7 @@ jobs:
             echo "::warning::Not building image for branch ${{ matrix.branch }}, because it would overwrite master"
             exit 0
           fi
-          docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          docker login https://ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           i=0; until [ "$i" -ge 3 ]; do
             IMAGES="$(echo '${{ steps.matrix.outputs.matrix }}' | "${{ steps.files.outputs.build_images }}" ${BUILD_ARGS[@]} \
                 ${{ github.workspace }}/dev || echo "")"
@@ -148,5 +148,5 @@ jobs:
               echo "::warning::Building images failed, retrying…"
             fi
           done
-          docker logout https://docker.pkg.github.com
+          docker logout https://ghcr.io
           if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,11 +47,11 @@ jobs:
         id: images
         shell: bash
         run: |
-          docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          docker login https://ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           docker-compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose-storage.yml pull
           i=0; until [ "$i" -ge 3 ]; do
             IMAGES=$(echo '${{ toJson(matrix.cfg) }}' | $GITHUB_WORKSPACE/dev/rucio/tools/test/build_images.py --output list \
-                --cache-repo docker.pkg.github.com/${{ github.repository }} --branch "${{ needs.setup.outputs.branch }}" \
+                --cache-repo ghcr.io/${{ github.repository }} --branch "${{ needs.setup.outputs.branch }}" \
                 $GITHUB_WORKSPACE/dev || echo "")
             if [[ -n $IMAGES ]]; then break;
             else
@@ -59,7 +59,7 @@ jobs:
               echo "::warning::Building images failed, retrying…"
             fi
           done
-          docker logout https://docker.pkg.github.com
+          docker logout https://ghcr.io
           if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
           echo "::set-output name=images::$IMAGES"
       - name: Prepare Docker Compose

--- a/tools/test/build_images.py
+++ b/tools/test/build_images.py
@@ -152,8 +152,8 @@ def main():
                         help='the output of this command')
     parser.add_argument('-n', '--build-no-cache', dest='build_no_cache', action='store_true',
                         help='build images without cache')
-    parser.add_argument('-r', '--cache-repo', dest='cache_repo', type=str, default='docker.pkg.github.com/rucio/rucio',
-                        help='use the following cache repository, like docker.pkg.github.com/USER/REPO')
+    parser.add_argument('-r', '--cache-repo', dest='cache_repo', type=str, default='ghcr.io/rucio/rucio',
+                        help='use the following cache repository, like ghcr.io/USER/REPO')
     parser.add_argument('-p', '--push-cache', dest='push_cache', action='store_true',
                         help='push the images to the cache repo')
     parser.add_argument('-b', '--branch', dest='branch', type=str, default='master',


### PR DESCRIPTION
Fix #4154
Details on the migration: https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry
Other than the new registry is said to be more stable, this is also interesting: _Access public container images anonymously_. In theory it will allow using the test container image cache locally without using `docker login`, making it much faster to run tests on a developer machine.