### PR TITLE
Fix typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ urllib3>=1.24.2,<=1.26.5                                    # HTTP library with 
 dogpile.cache>=0.6.5,<0.7.0; python_version < '3.0'         # Caching API plugins (0.7.0 only Py3 compatible)
 dogpile.cache>=0.6.5,<=1.1.1; python_version >= '3.0'       # Caching API plugins
 tabulate>=0.8.0,<0.9.0                                      # Pretty-print tabular data
-six>=1.12.0<1.16.0                                          # Python 2 and 3 compatibility utilities
+six>=1.12.0,<1.16.0                                         # Python 2 and 3 compatibility utilities
 jsonschema>=3.2.0                                           # For JSON schema validation (Policy modules)
 
 # All dependencies needed in extras for rucio client (and server/daemons) should be defined here


### PR DESCRIPTION
On a related note, do the client dependencies (below) need to have such restrictive upper pins?

```yaml
    - dogpile.cache <=1.1.1,>=0.6.5
    - jsonschema >=3.2.0
    - requests <=2.25.0,>=2.20.0
    - six >=1.12.0,<1.16.0
    - tabulate <0.9.0,>=0.8.0
    - urllib3 <=1.26.5,>=1.24.2
```