### PR TITLE
Database: Update drop_everything method; Fix #4212

### DIFF
--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -167,7 +167,7 @@ def my_on_connect(dbapi_con, connection_record):
     dbapi_con.action = caller
 
 
-def get_engine(echo=True):
+def get_engine():
     """ Creates a engine to a specific database.
         :returns: engine
     """


### PR DESCRIPTION
Update drop_everything method according to the [wiki site](https://github.com/sqlalchemy/sqlalchemy/wiki/DropEverything).
Also drop schema when dropping everything (will be re-created anyway) and enum types for postgres. Fix #4212
Removing the echo parameter on `get_engine` since it wasn't working anyway. Use the echo config variable in the database section.