### PR TITLE
Allow override of srv/client mode via RUCIO_CLIENT_MODE envvar

### DIFF
--- a/lib/rucio/rse/__init__.py
+++ b/lib/rucio/rse/__init__.py
@@ -28,18 +28,25 @@ from dogpile.cache import make_region
 
 from rucio.rse import rsemanager
 from rucio.common import config
+from os import environ
 
-
-if config.config_has_section('database'):
-    setattr(rsemanager, 'CLIENT_MODE', False)
-    setattr(rsemanager, 'SERVER_MODE', True)
-elif config.config_has_section('client'):
-    setattr(rsemanager, 'CLIENT_MODE', True)
-    setattr(rsemanager, 'SERVER_MODE', False)
+if 'RUCIO_CLIENT_MODE' not in environ:
+    if config.config_has_section('database'):
+        setattr(rsemanager, 'CLIENT_MODE', False)
+        setattr(rsemanager, 'SERVER_MODE', True)
+    elif config.config_has_section('client'):
+        setattr(rsemanager, 'CLIENT_MODE', True)
+        setattr(rsemanager, 'SERVER_MODE', False)
+    else:
+        setattr(rsemanager, 'CLIENT_MODE', False)
+        setattr(rsemanager, 'SERVER_MODE', True)
 else:
-    setattr(rsemanager, 'CLIENT_MODE', False)
-    setattr(rsemanager, 'SERVER_MODE', True)
-
+    if environ['RUCIO_CLIENT_MODE']:
+        setattr(rsemanager, 'CLIENT_MODE', True)
+        setattr(rsemanager, 'SERVER_MODE', False)
+    else:
+        setattr(rsemanager, 'CLIENT_MODE', False)
+        setattr(rsemanager, 'SERVER_MODE', True)
 
 def get_rse_client(rse, vo='def', **kwarg):
     '''

--- a/lib/rucio/rse/__init__.py
+++ b/lib/rucio/rse/__init__.py
@@ -48,6 +48,7 @@ else:
         setattr(rsemanager, 'CLIENT_MODE', False)
         setattr(rsemanager, 'SERVER_MODE', True)
 
+
 def get_rse_client(rse, vo='def', **kwarg):
     '''
     get_rse_client

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -56,8 +56,12 @@ from rucio.rse.protocols import protocol
 try:
     import gfal2  # pylint: disable=import-error
 except:
-    if not config.config_has_section('database'):
-        raise exception.MissingDependency('Missing dependency : gfal2')
+    if 'RUCIO_CLIENT_MODE' not in os.environ:
+        if not config.config_has_section('database'):
+            raise exception.MissingDependency('Missing dependency : gfal2')
+    else:
+        if os.environ['RUCIO_CLIENT_MODE']:
+            raise exception.MissingDependency('Missing dependency : gfal2')
 
 
 class Default(protocol.RSEProtocol):


### PR DESCRIPTION

Fixing #4725 via introducing an override based on the presence and value of the RUCIO_CLIENT_MODE environment variable.

Default behavior is not changed.

For example this will allow the deployment of dockerized setups were all containers can rely on the same `rucio.cfg` without minding for the presence of the database section, therefore allowing the client to use the same `rucio.cfg` and setting `RUCIO_CLIENT_MODE=True` in `docker run` or `docker-compose.yaml`.