### PR TITLE
Transfers: return RSE.id instead of replicas.rse_id on sources query

### DIFF
--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1509,7 +1509,7 @@ def __list_transfer_requests_and_source_replicas(
                           sub_requests.c.dest_rse_id,
                           sub_requests.c.account,
                           sub_requests.c.retry_count,
-                          models.RSEFileAssociation.rse_id,
+                          models.RSE.id,
                           models.RSE.rse,
                           models.RSEFileAssociation.path,
                           models.Source.ranking.label("source_ranking"),


### PR DESCRIPTION
In most cases they are equal, but not in the following scenario:
- the rse_id field was populated for the row in the replicas table
- the corresponding RSE was marked as deleted = 1
In this case, replicas.rse_id will return the id of the deleted rse,
while RSE.id will be NULL because of deleted = 0 filtering in the
outer join condition.

Fixes the following exception:
  File "lib/daemons/conveyor/submitter.py", line 174, in submitter
    logger=logger)
  File "lib/daemons/conveyor/submitter.py", line 346, in __get_transfers
    transfertool=transfertool)
  File "lib/db/sqla/session.py", line 374, in new_funct
    result = function(*args, **kwargs)
  File "lib/core/transfer.py", line 1217, in get_transfer_requests_and_source_replicas
    ctx.ensure_fully_loaded(source.rse)
  File "lib/core/transfer.py", line 242, in ensure_fully_loaded
  ......................................

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
