### PR TITLE
Clients: add the possibility to point to a different host. Closes #4700

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -54,6 +54,7 @@ Individual contributors to the source code
 - Dhruv Sondhi <dhruvsondhi05@gmail.com>, 2021
 - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 - Ilija Vukotic <ivukotic@uchicago.edu>, 2020-2021
+- David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 
 Organisations employing contributors

--- a/etc/rucio.cfg.template
+++ b/etc/rucio.cfg.template
@@ -117,6 +117,7 @@ port=61013
 username = _________
 password = _________
 topic = /topic/rucio.tracer
+trace_host = https://rucio-server-prod.cern.ch:443
 
 [tracer-kronos]
 brokers=atlas-test-mb.cern.ch

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -152,9 +152,9 @@ class BaseClient(object):
 
         try:
             self.trace_host = config_get('trace', 'trace_host')
-        except (NoOptionError, NoSectionError) as error:
+        except (NoOptionError, NoSectionError):
             self.trace_host = self.host
-            LOG.warning('No trace_host passed. Using rucio_host instead')
+            LOG.debug('No trace_host passed. Using rucio_host instead')
 
         self.account = account
         self.vo = vo

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -36,6 +36,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 '''
  Client class for callers of the Rucio system
@@ -148,6 +149,12 @@ class BaseClient(object):
                 self.auth_host = config_get('client', 'auth_host')
         except (NoOptionError, NoSectionError) as error:
             raise MissingClientParameter('Section client and Option \'%s\' cannot be found in config file' % error.args[0])
+
+        try:
+            self.trace_host = config_get('trace', 'trace_host')
+        except (NoOptionError, NoSectionError) as error:
+            self.trace_host = self.host
+            LOG.warning('No trace_host passed. Using rucio_host instead')
 
         self.account = account
         self.vo = vo

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -23,6 +23,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 
@@ -1508,7 +1509,7 @@ class DownloadClient:
         :param trace: the trace
         """
         if self.tracing:
-            send_trace(trace, self.client.host, self.client.user_agent)
+            send_trace(trace, self.client.trace_host, self.client.user_agent)
 
 
 def _verify_checksum(item, path):

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -38,6 +38,7 @@
 # - Eric Vaandering <ewv@fnal.gov>, 2020
 # - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 import copy
 import json
@@ -719,4 +720,4 @@ class UploadClient:
         :param trace: the trace
         """
         if self.tracing:
-            send_trace(trace, self.client.host, self.client.user_agent)
+            send_trace(trace, self.client.trace_host, self.client.user_agent)


### PR DESCRIPTION
Clients: add the possibility to point to a different host. Closes #4700

Add a new parameter in rucio.cfg called `trace_host` (`trace` section). If it is not specified, use `rucio_host` instead.