### PR TITLE
Clients: show did length estimation in downloadclient. Closes #3824

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -1110,15 +1110,12 @@ def download(args):
 
     summary = {}
     for item in result:
-        scope = item.get('dataset_scope', item['scope'])
-        name = item.get('dataset_name', item['name'])
-        summary_key = '%s:%s' % (scope, name)
-
-        summary.setdefault(summary_key, {'DONE': 0, 'ALREADY_DONE': 0, '_total': 0})
-        summary[summary_key]['_total'] += 1
-        state = item['clientState'].upper()
-        if state in summary[summary_key]:
-            summary[summary_key][state] += 1
+        for did, did_stats in item.get('input_dids').items():
+            did_summary = summary.setdefault(did, {'length': did_stats.get('length'), 'DONE': 0, 'ALREADY_DONE': 0, '_total': 0})
+            did_summary['_total'] += 1
+            state = item['clientState'].upper()
+            if state in did_summary:
+                did_summary[state] += 1
 
     print('----------------------------------')
     print('Download summary')
@@ -1126,14 +1123,20 @@ def download(args):
         print('-' * 40)
         print('No DID matching the pattern')
 
-    for summary_key in summary:
+    for summary_key, did_summary in summary.items():
         print('-' * 40)
-        print('DID %s' % (summary_key))
-        ds_total = summary[summary_key]['_total']
-        downloaded_files = summary[summary_key]['DONE']
-        local_files = summary[summary_key]['ALREADY_DONE']
+        print('DID %s' % summary_key)
+        length = did_summary['length']
+        ds_total = did_summary['_total']
+        downloaded_files = did_summary['DONE']
+        local_files = did_summary['ALREADY_DONE']
         not_downloaded_files = ds_total - downloaded_files - local_files
-        print('{0:40} {1:6d}'.format('Total files: ', ds_total))
+
+        if length:
+            print('{0:40} {1:6d}'.format('Total files (DID): ', length))
+            print('{0:40} {1:6d}'.format('Total files (filtered):   ', ds_total))
+        else:
+            print('{0:40} {1:6d}'.format('Total files:   ', ds_total))
         print('{0:40} {1:6d}'.format('Downloaded files: ', downloaded_files))
         print('{0:40} {1:6d}'.format('Files already found locally: ', local_files))
         print('{0:40} {1:6d}'.format('Files that cannot be downloaded: ', not_downloaded_files))

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1051,7 +1051,7 @@ class DownloadClient:
                     logger(logging.DEBUG, item)
                     raise InputValidationError('Item without did and filter/scope')
 
-        distinct_keys = ['rse', 'force_scheme', 'nrandom']
+        distinct_keys = ['rse', 'force_scheme']
         all_resolved_did_strs = set()
 
         did_to_options = {}
@@ -1098,11 +1098,14 @@ class DownloadClient:
                 continue
 
             was_merged = False
-            for merged_item in merged_items:
-                if all(item.get(k) == merged_item.get(k) for k in distinct_keys):
-                    merged_item['dids'].extend(resolved_dids)
-                    was_merged = True
-                    break
+            if not item.get('nrandom'):
+                # Don't merge items if nrandom is set. Otherwise two items with the same nrandom will be merged into one
+                # and we'll effectively download only half of the desired replicas for each item.
+                for merged_item in merged_items:
+                    if all(item.get(k) == merged_item.get(k) for k in distinct_keys):
+                        merged_item['dids'].extend(resolved_dids)
+                        was_merged = True
+                        break
             if not was_merged:
                 item['dids'] = resolved_dids
                 merged_items.append(item)

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1089,6 +1089,11 @@ class DownloadClient:
             for did in resolved_dids:
                 did_to_input_items.setdefault(DIDType(did), []).append(item)
 
+                if 'length' in did and not did['length']:
+                    did_with_size = self.client.get_did(scope=did['scope'], name=did['name'], dynamic=True)
+                    did['length'] = did_with_size['length']
+                    did['bytes'] = did_with_size['bytes']
+
         # group input items by common options to reduce the number of calls to list_replicas
         distinct_keys = ['rse', 'force_scheme', 'no_resolve_archives']
         item_groups = []

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -833,6 +833,8 @@ class TestBinRucio(unittest.TestCase):
         cmd = 'rucio download --dir /tmp --metalink {0}'.format(metalink_file_path)
         exitcode, out, err = execute(cmd)
         print(out, err)
+        assert '{} successfully downloaded'.format(tmp_file_name) in err
+        assert re.search('Total files.*1', out) is not None
         remove(metalink_file_path)
         cmd = 'ls /tmp/{0}'.format(scope)
         exitcode, out, err = execute(cmd)

--- a/lib/rucio/tests/test_download.py
+++ b/lib/rucio/tests/test_download.py
@@ -409,22 +409,32 @@ def test_trace_copy_out_and_checksum_validation(vo, rse_factory, did_factory, do
         assert len(traces) == 1 and traces[0]['clientState'] == 'DONE'
 
 
-def test_norandom_respected(rse_factory, did_factory, download_client, root_account):
+def test_nrandom_respected(rse_factory, did_factory, download_client, root_account):
     rse, _ = rse_factory.make_posix_rse()
     did1 = did_factory.upload_test_file(rse)
     did2 = did_factory.upload_test_file(rse)
-    dataset = did_factory.make_dataset()
-    did_core.attach_dids(dids=[did1, did2], account=root_account, **dataset)
+    did3 = did_factory.upload_test_file(rse)
+    did4 = did_factory.upload_test_file(rse)
+    dataset1 = did_factory.make_dataset()
+    dataset2 = did_factory.make_dataset()
+    did_core.attach_dids(dids=[did1, did2], account=root_account, **dataset1)
+    did_core.attach_dids(dids=[did3, did4], account=root_account, **dataset2)
 
-    dataset_did_str = '%s:%s' % (dataset['scope'], dataset['name'])
+    dataset1_did_str = '%s:%s' % (dataset1['scope'], dataset1['name'])
+    dataset2_did_str = '%s:%s' % (dataset2['scope'], dataset2['name'])
 
     with TemporaryDirectory() as tmp_dir:
         nrandom = 1
-        result = download_client.download_dids([{'did': dataset_did_str, 'nrandom': nrandom, 'base_dir': tmp_dir}])
+        result = download_client.download_dids([{'did': dataset1_did_str, 'nrandom': nrandom, 'base_dir': tmp_dir}])
         assert len(result) == nrandom
 
+        nrandom = 1
+        result = download_client.download_dids([{'did': dataset1_did_str, 'nrandom': nrandom, 'base_dir': tmp_dir},
+                                                {'did': dataset2_did_str, 'nrandom': nrandom, 'base_dir': tmp_dir}])
+        assert len(result) == 2 * nrandom
+
         nrandom = 2
-        result = download_client.download_dids([{'did': dataset_did_str, 'nrandom': nrandom, 'base_dir': tmp_dir}])
+        result = download_client.download_dids([{'did': dataset1_did_str, 'nrandom': nrandom, 'base_dir': tmp_dir}])
         assert len(result) == nrandom
 
 

--- a/lib/rucio/tests/test_judge_evaluator.py
+++ b/lib/rucio/tests/test_judge_evaluator.py
@@ -40,6 +40,8 @@ from rucio.core.rule import add_rule, get_rule
 from rucio.daemons.abacus.account import account_update
 from rucio.daemons.judge.evaluator import re_evaluator
 from rucio.db.sqla.constants import DIDType
+from rucio.db.sqla.models import UpdatedDID
+from rucio.db.sqla.session import transactional_session
 from rucio.tests.common_server import get_vo
 from rucio.tests.test_rule import create_files, tag_generator
 
@@ -53,6 +55,12 @@ class TestJudgeEvaluator(unittest.TestCase):
             cls.vo = {'vo': get_vo()}
         else:
             cls.vo = {}
+
+        @transactional_session
+        def __cleanup_updated_dids(session=None):
+            session.query(UpdatedDID).delete()
+
+        __cleanup_updated_dids()
 
         # Add test RSE
         cls.rse1 = 'MOCK'


### PR DESCRIPTION
Some refactoring was needed to make it possible. see individual commits for details. 
I would keep the commits separated on merge instead of squashing them.