### PR TITLE
Core & Internals: fix internal types comparison

### DIFF
--- a/lib/rucio/common/types.py
+++ b/lib/rucio/common/types.py
@@ -62,13 +62,13 @@ class InternalType(object):
         val = self.external <= other.external
         if val is NotImplemented:
             return NotImplemented
-        return not val
+        return val
 
     def __lt__(self, other):
         val = self.external < other.external
         if val is NotImplemented:
             return NotImplemented
-        return not val
+        return val
 
     def __hash__(self):
         return hash(self.internal)


### PR DESCRIPTION
we suspect a copy-paste from __ne__.
It started to be visible now because of #4620, which introduced
sorting by scope/name.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
