### PR TITLE
Daemons: record counters to both prometheus and graphite #3416

### DIFF
--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -716,7 +716,7 @@ def delete_dids(dids, account, expire_rules=False, session=None, logger=logging.
         with record_timer_block('undertaker.content'):
             rowcount = session.query(models.DataIdentifierAssociation).filter(or_(*content_clause)).\
                 delete(synchronize_session=False)
-        record_counter(counters='undertaker.content.rowcount', delta=rowcount)
+        record_counter(name='undertaker.content.rowcount', delta=rowcount)
 
     # Remove CollectionReplica
     if collection_replica_clause:

--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -1,18 +1,25 @@
-# Copyright European Organization for Nuclear Research (CERN)
+# -*- coding: utf-8 -*-
+# Copyright 2013-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
 # - Luis Rodrigues <lfrodrigues@gmail.com>, 2013
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2013
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2017-2020
-# - Vincent Garonne vgaronne@gmail.com, 2018
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
-#
-# PY3K COMPATIBLE
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Graphite counters
@@ -112,8 +119,7 @@ def record_counter(name, delta=1, labels=None):
     if not counter:
         COUNTERS[name] = counter = MultiCounter(statsd=name, labelnames=labels.keys() if labels else ())
 
-    if delta < 0:
-        delta = -delta
+    delta = abs(delta)
 
     if labels:
         counter.labels(**labels).inc(delta)

--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -20,9 +20,11 @@ Graphite counters
 
 from __future__ import division
 
+import string
 import time
+from abc import abstractmethod
 
-from prometheus_client import start_http_server
+from prometheus_client import start_http_server, Counter, REGISTRY
 from statsd import StatsClient
 
 from rucio.common.config import config_get, config_get_bool, config_get_int
@@ -35,27 +37,88 @@ CLIENT = StatsClient(host=SERVER, port=PORT, prefix=SCOPE)
 ENABLE_METRICS = config_get_bool('monitor', 'enable_metrics', raise_exception=False, default=False)
 if ENABLE_METRICS:
     METRICS_PORT = config_get_int('monitor', 'metrics_port', raise_exception=False, default=8080)
-    start_http_server(METRICS_PORT)
+    start_http_server(METRICS_PORT, registry=REGISTRY)
+
+COUNTERS = {}
 
 
-def record_counter(counters, delta=1):
+class MultiMetric:
+    """
+    Thin wrapper class allowing to record both prometheus and statsd metrics.
+
+    Inspired by the prometheus metric behavior: uses labels to parametrize metrics.
+    In case of statsd, metrics are formatted using str.format(**labels). The prometheus
+    ones using metric.labels(**labels) calls.
+
+    If the prometheus metric string is not provided, it is derived from the statsd one.
+    """
+
+    def __init__(self, statsd, prom=None, documentation=None, labelnames=(), labelvalues=None, registry=None):
+        """
+        :param statsd: a string, eventually with keyword placeholders for the str.format(**labels) call
+        :param prom: a string or a prometheus metric object
+        """
+        self._registry = registry or REGISTRY
+        self._documentation = documentation or ''
+        self._statsd = statsd
+        if not prom:
+            # automatically generate a prometheus metric name
+            #
+            # remove '.{label}' from the string for each `label`
+            stats_without_labels = ''.join(tup[0].rstrip('.') for tup in string.Formatter().parse(self._statsd))
+            prom = 'rucio_{}'.format(stats_without_labels).replace('.', '_')
+        if isinstance(prom, str):
+            self._prom = self.init_prometheus_metric(prom, self._documentation, labelnames=labelnames, labelvalues=labelvalues)
+        else:
+            self._prom = prom
+        self._labelnames = labelnames
+        self._labelvalues = labelvalues
+
+    @abstractmethod
+    def init_prometheus_metric(self, name, documentation, labelnames=(), labelvalues=None):
+        pass
+
+    def labels(self, **labelvalues):
+        return self.__class__(
+            prom=self._prom.labels(**labelvalues),
+            statsd=self._statsd.format(**labelvalues),
+            documentation=self._documentation,
+            labelnames=self._labelnames,
+            labelvalues=labelvalues,
+            registry=self._registry,
+        )
+
+
+class MultiCounter(MultiMetric):
+
+    def inc(self, delta=1):
+        self._prom.inc(delta)
+        CLIENT.incr(self._statsd, delta)
+
+    def init_prometheus_metric(self, name, documentation, labelnames=(), labelvalues=None):
+        return Counter(name, documentation, labelnames=labelnames, labelvalues=labelvalues, registry=self._registry)
+
+
+def record_counter(name, delta=1, labels=None):
     """
     Log one or more counters by arbitrary amounts
 
-    :param counters: The counter or a list of counters to be updated.
+    :param name: The counter to be updated.
     :param delta: The increment for the counter, by default increment by 1.
+    :param labels: labels used to parametrize the metric
     """
-    if isinstance(counters, list):
-        for counter in counters:
-            if delta > 0:
-                CLIENT.incr(counter, delta)
-            else:
-                CLIENT.decr(counter, delta)
+
+    counter = COUNTERS.get(name)
+    if not counter:
+        COUNTERS[name] = counter = MultiCounter(statsd=name, labelnames=labels.keys() if labels else ())
+
+    if delta < 0:
+        delta = -delta
+
+    if labels:
+        counter.labels(**labels).inc(delta)
     else:
-        if delta > 0:
-            CLIENT.incr(counters, delta)
-        else:
-            CLIENT.decr(counters, delta)
+        counter.inc(delta)
 
 
 def record_gauge(stat, value):

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -309,7 +309,7 @@ def get_auth_oidc(account, session=None, **kwargs):
             auth_url = build_url('https://' + auth_server.netloc,
                                  path='auth/oidc_redirect', params=access_msg)
 
-        record_counter(counters='IdP_authentication.request')
+        record_counter(name='IdP_authentication.request')
         record_timer(stat='IdP_authentication.request', time=time.time() - start)
         return auth_url
 
@@ -349,7 +349,7 @@ def get_token_oidc(auth_query_string, ip=None, session=None):
             req_params[key] = val_to_space_sep_str(req_params[key])
 
         oidc_client = __get_init_oidc_client(issuer=issuer, code=code, **req_params)['client']
-        record_counter(counters='IdP_authentication.code_granted')
+        record_counter(name='IdP_authentication.code_granted')
         # exchange access code for a access token
         oidc_tokens = oidc_client.do_access_token_request(state=state,
                                                           request_args={"code": code},
@@ -378,7 +378,7 @@ def get_token_oidc(auth_query_string, ip=None, session=None):
         if not exist_identity_account(jwt_row_dict['identity'], IdentityType.OIDC, jwt_row_dict['account'], session=session):
             raise CannotAuthenticate("OIDC identity '%s' of the '%s' account is unknown to Rucio."
                                      % (jwt_row_dict['identity'], str(jwt_row_dict['account'])))
-        record_counter(counters='IdP_authentication.success')
+        record_counter(name='IdP_authentication.success')
         # get access token expiry timestamp
         jwt_row_dict['lifetime'] = datetime.utcnow() + timedelta(seconds=oidc_tokens['expires_in'])
         # get audience and scope info from the token
@@ -419,9 +419,9 @@ def get_token_oidc(auth_query_string, ip=None, session=None):
                 extra_dict['refresh_expired_at'] = datetime.utcnow() + timedelta(hours=REFRESH_LIFETIME_H)
 
         new_token = __save_validated_token(oidc_tokens['access_token'], jwt_row_dict, extra_dict=extra_dict, session=session)
-        record_counter(counters='IdP_authorization.access_token.saved')
+        record_counter(name='IdP_authorization.access_token.saved')
         if 'refresh_token' in oidc_tokens:
-            record_counter(counters='IdP_authorization.refresh_token.saved')
+            record_counter(name='IdP_authorization.refresh_token.saved')
         # In case authentication via browser was requested,
         # we save the token in the oauth_requests table
         if oauth_req_params.access_msg:
@@ -451,7 +451,7 @@ def get_token_oidc(auth_query_string, ip=None, session=None):
 
     except Exception:
         # TO-DO catch different exceptions - InvalidGrant etc. ...
-        record_counter(counters='IdP_authorization.access_token.exception')
+        record_counter(name='IdP_authorization.access_token.exception')
         return None
         # raise CannotAuthenticate(traceback.format_exc())
 
@@ -483,14 +483,14 @@ def __get_admin_token_oidc(account, req_scope, req_audience, issuer, session=Non
                                          response=AccessTokenResponse)
         if 'error' in oidc_tokens:
             raise CannotAuthorize(oidc_tokens['error'])
-        record_counter(counters='IdP_authentication.rucio_admin_token_granted')
+        record_counter(name='IdP_authentication.rucio_admin_token_granted')
         # save the access token in the Rucio DB
         if 'access_token' in oidc_tokens:
             validate_dict = __get_rucio_jwt_dict(oidc_tokens['access_token'], account=account, session=session)
             if validate_dict:
-                record_counter(counters='IdP_authentication.success')
+                record_counter(name='IdP_authentication.success')
                 new_token = __save_validated_token(oidc_tokens['access_token'], validate_dict, extra_dict={}, session=session)
-                record_counter(counters='IdP_authorization.access_token.saved')
+                record_counter(name='IdP_authorization.access_token.saved')
                 return new_token
             return None
             # raise RucioException("Rucio could not get a valid admin token from the Identity Provider.")
@@ -499,7 +499,7 @@ def __get_admin_token_oidc(account, req_scope, req_audience, issuer, session=Non
 
     except Exception:
         # TO-DO catch different exceptions - InvalidGrant etc. ...
-        record_counter(counters='IdP_authorization.access_token.exception')
+        record_counter(name='IdP_authorization.access_token.exception')
         return None
         # raise CannotAuthenticate(traceback.format_exc())
 
@@ -703,7 +703,7 @@ def __exchange_token_oidc(subject_token_object, session=None, **kwargs):
     try:
         start = time.time()
 
-        record_counter(counters='IdP_authentication.code_granted')
+        record_counter(name='IdP_authentication.code_granted')
         oidc_dict = __get_init_oidc_client(token_object=subject_token_object, token_type="subject_token")
         oidc_client = oidc_dict['client']
         args = {"subject_token": subject_token_object.token,
@@ -742,9 +742,9 @@ def __exchange_token_oidc(subject_token_object, session=None, **kwargs):
                 extra_dict['refresh_expired_at'] = datetime.utcnow() + timedelta(hours=REFRESH_LIFETIME_H)
 
         new_token = __save_validated_token(oidc_tokens['access_token'], jwt_row_dict, extra_dict=extra_dict, session=session)
-        record_counter(counters='IdP_authorization.access_token.saved')
+        record_counter(name='IdP_authorization.access_token.saved')
         if 'refresh_token' in oidc_tokens:
-            record_counter(counters='IdP_authorization.refresh_token.saved')
+            record_counter(name='IdP_authorization.refresh_token.saved')
         record_timer(stat='IdP_authorization.token_exchange', time=time.time() - start)
         return new_token
 
@@ -900,7 +900,7 @@ def __refresh_token_oidc(token_object, session=None):
     """
     try:
         start = time.time()
-        record_counter(counters='IdP_authorization.refresh_token.request')
+        record_counter(name='IdP_authorization.refresh_token.request')
         jwt_row_dict, extra_dict = {}, {}
         jwt_row_dict['account'] = token_object.account
         jwt_row_dict['identity'] = token_object.identity
@@ -925,7 +925,7 @@ def __refresh_token_oidc(token_object, session=None):
         oidc_tokens = oidc_client.do_access_token_refresh(state=state)
         if 'error' in oidc_tokens:
             raise CannotAuthorize(oidc_tokens['error'])
-        record_counter(counters='IdP_authorization.refresh_token.refreshed')
+        record_counter(name='IdP_authorization.refresh_token.refreshed')
         # get audience and scope information
         if 'scope' in oidc_tokens and 'audience' in oidc_tokens:
             jwt_row_dict['authz_scope'] = val_to_space_sep_str(oidc_tokens['scope'])
@@ -951,8 +951,8 @@ def __refresh_token_oidc(token_object, session=None):
                 # 4 day expiry period by default
                 extra_dict['refresh_expired_at'] = datetime.utcnow() + timedelta(hours=REFRESH_LIFETIME_H)
             new_token = __save_validated_token(oidc_tokens['access_token'], jwt_row_dict, extra_dict=extra_dict, session=session)
-            record_counter(counters='IdP_authorization.access_token.saved')
-            record_counter(counters='IdP_authorization.refresh_token.saved')
+            record_counter(name='IdP_authorization.access_token.saved')
+            record_counter(name='IdP_authorization.refresh_token.saved')
         else:
             raise CannotAuthorize("OIDC identity '%s' of the '%s' account is did not " % (token_object.identity, token_object.account)
                                   + "succeed requesting a new access and refresh tokens.")  # NOQA: W503
@@ -960,7 +960,7 @@ def __refresh_token_oidc(token_object, session=None):
         return new_token
 
     except Exception:
-        record_counter(counters='IdP_authorization.refresh_token.exception')
+        record_counter(name='IdP_authorization.refresh_token.exception')
         raise CannotAuthorize(traceback.format_exc())
 
 
@@ -1139,7 +1139,7 @@ def validate_jwt(json_web_token, session=None):
                 token_dict['authz_scope'] = inspect_claims['scope']
             except:
                 pass
-        record_counter(counters='JSONWebToken.valid')
+        record_counter(name='JSONWebToken.valid')
         # if token is valid and coming from known issuer --> check aud and scope and save it if unknown
         if token_dict['authz_scope'] and token_dict['audience']:
             if all_oidc_req_claims_present(token_dict['authz_scope'], token_dict['audience'], EXPECTED_OIDC_SCOPE, EXPECTED_OIDC_AUDIENCE):
@@ -1149,10 +1149,10 @@ def validate_jwt(json_web_token, session=None):
                 return None
         else:
             return None
-        record_counter(counters='JSONWebToken.saved')
+        record_counter(name='JSONWebToken.saved')
         return token_dict
     except Exception:
-        record_counter(counters='JSONWebToken.invalid')
+        record_counter(name='JSONWebToken.invalid')
         return None
 
 

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -17,6 +17,7 @@
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 import json
 import random

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -303,7 +303,7 @@ def get_next(request_type, state, limit=100, older_than=None, rse_id=None, activ
     :returns:                 Request as a dictionary.
     """
 
-    record_counter('core.request.get_next.%s-%s' % (request_type, state))
+    record_counter('core.request.get_next.{request_type}.{state}', labels={'request_type': request_type, 'state': state})
 
     # lists of one element are not allowed by SQLA, so just duplicate the item
     if type(request_type) is not list:

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -33,6 +33,7 @@
 # - Sahan Dilshan <32576163+sahandilshan@users.noreply.github.com>, 2021
 # - Nick Smith <nick.smith@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Nick Smith <nick.smith@cern.ch>, 2021
 
 import datetime
 import json

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -261,8 +261,8 @@ def automatix(sites, inputfile, sleep_time, account, worker_number=1, total_work
                     remove(physical_fname)
                 rmdir(tmpdir)
                 if status:
-                    monitor.record_counter(counters='automatix.addnewdataset.done', delta=1)
-                    monitor.record_counter(counters='automatix.addnewfile.done', delta=nbfiles)
+                    monitor.record_counter(name='automatix.addnewdataset.done', delta=1)
+                    monitor.record_counter(name='automatix.addnewfile.done', delta=nbfiles)
                     monitor.record_timer('automatix.datasetinjection', (time() - start_time) * 1000)
                     break
                 else:

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -24,6 +24,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import division
 

--- a/lib/rucio/daemons/badreplicas/necromancer.py
+++ b/lib/rucio/daemons/badreplicas/necromancer.py
@@ -20,6 +20,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 from __future__ import division
 

--- a/lib/rucio/daemons/badreplicas/necromancer.py
+++ b/lib/rucio/daemons/badreplicas/necromancer.py
@@ -84,7 +84,7 @@ def necromancer(thread=0, bulk=5, once=False, sleep_time=60):
                     logging.info(prepend_str + 'File %s:%s has no other available or temporary available replicas, it will be marked as lost' % (scope, name))
                     try:
                         update_rules_for_lost_replica(scope=scope, name=name, rse_id=rse_id, nowait=True)
-                        monitor.record_counter(counters='necromancer.badfiles.lostfile', delta=1)
+                        monitor.record_counter(name='necromancer.badfiles.lostfile')
                     except DatabaseException as error:
                         logging.info(prepend_str + '%s' % (str(error)))
 
@@ -94,7 +94,7 @@ def necromancer(thread=0, bulk=5, once=False, sleep_time=60):
                     logging.info(prepend_str + 'File %s:%s can be recovered. Available sources : %s + Unavailable sources : %s' % (scope, name, str(rep), str(unavailable_rep)))
                     try:
                         update_rules_for_bad_replica(scope=scope, name=name, rse_id=rse_id, nowait=True)
-                        monitor.record_counter(counters='necromancer.badfiles.recovering', delta=1)
+                        monitor.record_counter(name='necromancer.badfiles.recovering')
                     except DatabaseException as error:
                         logging.info(prepend_str + '%s' % (str(error)))
 

--- a/lib/rucio/daemons/cache/consumer.py
+++ b/lib/rucio/daemons/cache/consumer.py
@@ -22,6 +22,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Fax consumer is a daemon to retrieve rucio cache operation information to synchronize rucio catalog.

--- a/lib/rucio/daemons/cache/consumer.py
+++ b/lib/rucio/daemons/cache/consumer.py
@@ -139,7 +139,7 @@ def consumer(id_, num_thread=1):
 
             if not conn.is_connected():
                 logging.info('connecting to %s' % conn.transport._Transport__host_and_ports[0][0])
-                record_counter('daemons.messaging.cache.reconnect.%s' % conn.transport._Transport__host_and_ports[0][0].split('.')[0])
+                record_counter('daemons.messaging.cache.reconnect.{}', labels={'host': conn.transport._Transport__host_and_ports[0][0].split('.')[0]})
 
                 conn.set_listener('rucio-cache-messaging', conns[conn])
                 conn.connect()

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -129,7 +129,7 @@ def _submit_transfers(external_host, transfers, job_params, submitter='submitter
         duration = time.time() - start_time
         logger(logging.INFO, 'Submit job %s to %s in %s seconds' % (eid, external_host, duration))
         record_timer('daemons.conveyor.%s.submit_bulk_transfer.per_file' % submitter, (time.time() - start_time) * 1000 / len(transfers) or 1)
-        record_counter('daemons.conveyor.%s.submit_bulk_transfer' % submitter, len(transfers))
+        record_counter('daemons.conveyor.{submitter}.submit_bulk_transfer', delta=len(transfers), labels={'submitter': submitter})
         record_timer('daemons.conveyor.%s.submit_bulk_transfer.files' % submitter, len(transfers))
 
     if state_to_set:

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -142,7 +142,7 @@ def finisher(once=False, sleep_time=60, activities=None, bulk=100, db_bulk=1000,
                         time3 = time.time()
                         __handle_requests(chunk, suspicious_patterns, retry_protocol_mismatches, logger=logger)
                         record_timer('daemons.conveyor.finisher.handle_requests', (time.time() - time3) * 1000 / (len(chunk) if chunk else 1))
-                        record_counter('daemons.conveyor.finisher.handle_requests', len(chunk))
+                        record_counter('daemons.conveyor.finisher.handle_requests', delta=len(chunk))
                     except Exception as error:
                         logger(logging.WARNING, '%s', str(error))
                 if reqs:

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -243,7 +243,7 @@ def poll_transfers(external_host, xfers, request_ids=None, timeout=None, logger=
             logger(logging.DEBUG, 'Setting %s transfer requests status to DONE per mock tool' % (len(xfers)))
             for task_id in xfers:
                 ret = transfer_core.update_transfer_state(external_host=None, transfer_id=task_id, state=RequestState.DONE)
-                record_counter('daemons.conveyor.poller.update_request_state.%s' % ret)
+                record_counter('daemons.conveyor.poller.update_request_state.{updated}', labels={'updated': ret})
             return
         try:
             tss = time.time()
@@ -281,7 +281,7 @@ def poll_transfers(external_host, xfers, request_ids=None, timeout=None, logger=
         if TRANSFER_TOOL == 'globus':
             for task_id in resps:
                 ret = transfer_core.update_transfer_state(external_host=None, transfer_id=task_id, state=resps[task_id])
-                record_counter('daemons.conveyor.poller.update_request_state.%s' % ret)
+                record_counter('daemons.conveyor.poller.update_request_state.{updated}', labels={'updated': ret})
         else:
             for transfer_id in resps:
                 try:
@@ -303,7 +303,7 @@ def poll_transfers(external_host, xfers, request_ids=None, timeout=None, logger=
                                 # if True, really update request content; if False, only touch request
                                 if ret:
                                     cnt += 1
-                                record_counter('daemons.conveyor.poller.update_request_state.%s' % ret)
+                                record_counter('daemons.conveyor.poller.update_request_state.{updated}', labels={'updated': ret})
 
                     # should touch transfers.
                     # Otherwise if one bulk transfer includes many requests and one is not terminated, the transfer will be poll again.

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -135,7 +135,7 @@ class Receiver(object):
 
                         if self.__full_mode:
                             ret = request.update_request_state(response)
-                            record_counter('daemons.conveyor.receiver.update_request_state.%s' % ret)
+                            record_counter('daemons.conveyor.receiver.update_request_state.{updated}', labels={'updated': ret})
                         else:
                             try:
                                 logging.debug("Update request %s update time" % response['request_id'])
@@ -221,7 +221,7 @@ def receiver(id_, total_threads=1, full_mode=False, all_vos=False):
 
             if not conn.is_connected():
                 logging.info('connecting to %s' % conn.transport._Transport__host_and_ports[0][0])
-                record_counter('daemons.messaging.fts3.reconnect.%s' % conn.transport._Transport__host_and_ports[0][0].split('.')[0])
+                record_counter('daemons.messaging.fts3.reconnect.{host}', labels={'host': conn.transport._Transport__host_and_ports[0][0].split('.')[0]})
 
                 conn.set_listener('rucio-messaging-fts3', Receiver(broker=conn.transport._Transport__host_and_ports[0],
                                                                    id_=id_, total_threads=total_threads,

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -25,6 +25,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Sahan Dilshan <32576163+sahandilshan@users.noreply.github.com>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Conveyor is a daemon to manage file transfers.

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -46,7 +46,6 @@ import threading
 import time
 from collections import defaultdict
 
-from prometheus_client import Counter
 from six.moves.configparser import NoOptionError
 
 import rucio.db.sqla.util
@@ -55,7 +54,7 @@ from rucio.common.config import config_get, config_get_bool
 from rucio.common.logging import formatted_logger, setup_logging
 from rucio.common.schema import get_schema_value
 from rucio.core import heartbeat, transfer as transfer_core
-from rucio.core.monitor import record_counter, record_timer
+from rucio.core.monitor import MultiCounter, record_timer
 from rucio.daemons.conveyor.common import submit_transfer, bulk_group_transfers_for_fts, bulk_group_transfers_for_globus, get_conveyor_rses
 from rucio.db.sqla.constants import RequestType
 
@@ -65,7 +64,8 @@ TRANSFER_TOOL = config_get('conveyor', 'transfertool', False, None)  # NOTE: Thi
 FILTER_TRANSFERTOOL = config_get('conveyor', 'filter_transfertool', False, None)  # NOTE: TRANSFERTOOL to filter requests on
 TRANSFER_TYPE = config_get('conveyor', 'transfertype', False, 'single')
 
-GET_TRANSFERS_COUNTER = Counter('rucio_daemons_conveyor_submitter_get_transfers', 'Number of transfers retrieved')
+GET_TRANSFERS_COUNTER = MultiCounter(prom='rucio_daemons_conveyor_submitter_get_transfers', statsd='daemons.conveyor.transfer_submitter.get_transfers',
+                                     documentation='Number of transfers retrieved')
 
 
 def submitter(once=False, rses=None, partition_wait_time=10,
@@ -170,7 +170,6 @@ def submitter(once=False, rses=None, partition_wait_time=10,
                 total_transfers = len(list(hop for paths in transfers.values() for path in paths for hop in path))
 
                 record_timer('daemons.conveyor.transfer_submitter.get_transfers.per_transfer', (time.time() - start_time) * 1000 / (total_transfers or 1))
-                record_counter('daemons.conveyor.transfer_submitter.get_transfers', total_transfers)
                 GET_TRANSFERS_COUNTER.inc(total_transfers)
                 record_timer('daemons.conveyor.transfer_submitter.get_transfers.transfers', total_transfers)
                 logger(logging.INFO, 'Got %s transfers for %s in %s seconds', total_transfers, activity, time.time() - start_time)

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -262,7 +262,7 @@ def __release_all_activities(stats, direction, rse_name, rse_id, logger, session
         logger(logging.DEBUG, "Throttler remove limits(threshold: %s) and release all waiting requests, rse %s" % (threshold, rse_name))
         delete_rse_transfer_limits(rse_id, activity='all_activities', session=session)
         release_all_waiting_requests(rse_id, direction=direction, session=session)
-        record_counter('daemons.conveyor.throttler.delete_rse_transfer_limits.%s' % (rse_name))
+        record_counter('daemons.conveyor.throttler.delete_rse_transfer_limits.{activity}.{rse}', labels={'activity': 'all_activities', 'rse': rse_name})
 
 
 def __release_per_activity(stats, direction, rse_name, rse_id, logger, session):
@@ -285,7 +285,7 @@ def __release_per_activity(stats, direction, rse_name, rse_id, logger, session):
                 logger(logging.DEBUG, "Throttler remove limits(threshold: %s) and release all waiting requests for activity %s, rse_id %s" % (threshold, activity, rse_id))
                 delete_rse_transfer_limits(rse_id, activity=activity, session=session)
                 release_all_waiting_requests(rse_id, activity=activity, direction=direction, session=session)
-                record_counter('daemons.conveyor.throttler.delete_rse_transfer_limits.%s.%s' % (activity, rse_name))
+                record_counter('daemons.conveyor.throttler.delete_rse_transfer_limits.{activity}.{rse}', labels={'activity': activity, 'rse': rse_name})
             elif transfer + waiting > threshold:
                 logger(logging.DEBUG, "Throttler set limits for activity %s, rse %s" % (activity, rse_name))
                 set_rse_transfer_limits(rse_id, activity=activity, max_transfers=threshold, transfers=transfer, waitings=waiting, session=session)
@@ -330,4 +330,4 @@ def __release_per_activity(stats, direction, rse_name, rse_id, logger, session):
                 logger(logging.DEBUG, "Throttler remove limits(threshold: %s) and release all waiting requests for activity %s, rse %s" % (threshold, activity, rse_name))
                 delete_rse_transfer_limits(rse_id, activity=activity, session=session)
                 release_all_waiting_requests(rse_id, activity=activity, direction=direction, session=session)
-                record_counter('daemons.conveyor.throttler.delete_rse_transfer_limits.%s.%s' % (activity, rse_name))
+                record_counter('daemons.conveyor.throttler.delete_rse_transfer_limits.{activity}.{rse}', labels={'activity': activity, 'rse': rse_name})

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -23,6 +23,7 @@
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Conveyor throttler is a daemon to manage rucio internal queue.

--- a/lib/rucio/daemons/hermes/hermes.py
+++ b/lib/rucio/daemons/hermes/hermes.py
@@ -24,6 +24,7 @@
 # - Eric Vaandering <ewv@fnal.gov>, 2019-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 '''
    Hermes is a daemon to deliver messages: to a messagebroker via STOMP, or emails via SMTP.

--- a/lib/rucio/daemons/hermes/hermes2.py
+++ b/lib/rucio/daemons/hermes/hermes2.py
@@ -44,7 +44,6 @@ from email.mime.text import MIMEText
 
 import requests
 import stomp
-from prometheus_client import Counter
 from six import PY2
 
 import rucio.db.sqla.util
@@ -55,13 +54,14 @@ from rucio.common.utils import daemon_sleep
 from rucio.core import heartbeat
 from rucio.core.config import get
 from rucio.core.message import retrieve_messages, delete_messages, update_messages_services
-from rucio.core.monitor import record_counter
+from rucio.core.monitor import MultiCounter
 
 logging.getLogger('requests').setLevel(logging.CRITICAL)
 
 GRACEFUL_STOP = threading.Event()
 
-RECONNECT_COUNTER = Counter('rucio_daemons_hermes2_reconnect', 'Counts Hermes2 reconnects to different ActiveMQ brokers', labelnames=('host',))
+RECONNECT_COUNTER = MultiCounter(prom='rucio_daemons_hermes2_reconnect', statsd='daemons.hermes.reconnect.{host}',
+                                 documentation='Counts Hermes2 reconnects to different ActiveMQ brokers', labelnames=('host',))
 
 
 def default(datetype):
@@ -180,9 +180,7 @@ def deliver_to_activemq(messages, conns, destination, username, password, use_ss
             conn = random.sample(conns, 1)[0]
             if not conn.is_connected():
                 host_and_ports = conn.transport._Transport__host_and_ports[0][0]
-                record_counter('daemons.hermes.reconnect.%s' % host_and_ports.split('.')[0])
-                labels = {'host': host_and_ports.split('.')[0]}
-                RECONNECT_COUNTER.labels(**labels).inc()
+                RECONNECT_COUNTER.labels(host=host_and_ports.split('.')[0]).inc()
                 if not use_ssl:
                     logger(logging.INFO,
                            '[broker] - connecting with USERPASS to %s',

--- a/lib/rucio/daemons/hermes/hermes2.py
+++ b/lib/rucio/daemons/hermes/hermes2.py
@@ -22,6 +22,7 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 '''
    Hermes2 is a daemon that get the messages and sends them to external services (influxDB, ES, ActiveMQ).

--- a/lib/rucio/daemons/judge/cleaner.py
+++ b/lib/rucio/daemons/judge/cleaner.py
@@ -109,32 +109,32 @@ def rule_cleaner(once=False, sleep_time=60):
                     except (DatabaseException, DatabaseError, UnsupportedOperation) as e:
                         if match('.*ORA-00054.*', str(e.args[0])):
                             paused_rules[rule_id] = datetime.utcnow() + timedelta(seconds=randint(600, 2400))
-                            record_counter('rule.judge.exceptions.LocksDetected')
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': 'LocksDetected'})
                             logger(logging.WARNING, 'Locks detected for %s' % rule_id)
                         elif match('.*QueuePool.*', str(e.args[0])):
                             logger(logging.WARNING, 'DatabaseException', exc_info=True)
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                         elif match('.*ORA-03135.*', str(e.args[0])):
                             logger(logging.WARNING, 'DatabaseException', exc_info=True)
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                         else:
                             logger(logging.ERROR, 'DatabaseException', exc_info=True)
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                     except RuleNotFound:
                         pass
         except (DatabaseException, DatabaseError) as e:
             if match('.*QueuePool.*', str(e.args[0])):
                 logger(logging.WARNING, 'DatabaseException', exc_info=True)
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
             elif match('.*ORA-03135.*', str(e.args[0])):
                 logger(logging.WARNING, 'DatabaseException', exc_info=True)
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
             else:
                 logger(logging.CRITICAL, 'DatabaseException', exc_info=True)
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
         except Exception as e:
             logger(logging.CRITICAL, 'DatabaseException', exc_info=True)
-            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
         if once:
             break
 

--- a/lib/rucio/daemons/judge/cleaner.py
+++ b/lib/rucio/daemons/judge/cleaner.py
@@ -23,6 +23,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Judge-Cleaner is a daemon to clean expired replication rules.

--- a/lib/rucio/daemons/judge/evaluator.py
+++ b/lib/rucio/daemons/judge/evaluator.py
@@ -24,6 +24,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Judge-Evaluator is a daemon to re-evaluate and execute replication rules.

--- a/lib/rucio/daemons/judge/evaluator.py
+++ b/lib/rucio/daemons/judge/evaluator.py
@@ -128,35 +128,35 @@ def re_evaluator(once=False, sleep_time=30, did_limit=100):
                         if match('.*ORA-00054.*', str(e.args[0])):
                             paused_dids[(did.scope.internal, did.name)] = datetime.utcnow() + timedelta(seconds=randint(60, 600))
                             logging.warning('re_evaluator[%s/%s]: Locks detected for %s:%s' % (heartbeat['assign_thread'], heartbeat['nr_threads'], did.scope, did.name))
-                            record_counter('rule.judge.exceptions.LocksDetected')
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': 'LocksDetected'})
                         elif match('.*QueuePool.*', str(e.args[0])):
                             logging.warning(traceback.format_exc())
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                         elif match('.*ORA-03135.*', str(e.args[0])):
                             logging.warning(traceback.format_exc())
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                         else:
                             logging.error(traceback.format_exc())
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                     except ReplicationRuleCreationTemporaryFailed as e:
-                        record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                        record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                         logging.warning('re_evaluator[%s/%s]: Replica Creation temporary failed, retrying later for %s:%s' % (heartbeat['assign_thread'], heartbeat['nr_threads'], did.scope, did.name))
                     except FlushError as e:
-                        record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                        record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                         logging.warning('re_evaluator[%s/%s]: Flush error for %s:%s' % (heartbeat['assign_thread'], heartbeat['nr_threads'], did.scope, did.name))
         except (DatabaseException, DatabaseError) as e:
             if match('.*QueuePool.*', str(e.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
             elif match('.*ORA-03135.*', str(e.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
             else:
                 logging.critical(traceback.format_exc())
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
         except Exception as e:
             logging.critical(traceback.format_exc())
-            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
 
         if once:
             break

--- a/lib/rucio/daemons/judge/injector.py
+++ b/lib/rucio/daemons/judge/injector.py
@@ -22,6 +22,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Eric Vaandering <ewv@fnal.gov>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Judge-Injector is a daemon to asynchronously create replication rules

--- a/lib/rucio/daemons/judge/injector.py
+++ b/lib/rucio/daemons/judge/injector.py
@@ -106,25 +106,25 @@ def rule_injector(once=False, sleep_time=60):
                     except (DatabaseException, DatabaseError) as e:
                         if match('.*ORA-00054.*', str(e.args[0])):
                             paused_rules[rule_id] = datetime.utcnow() + timedelta(seconds=randint(60, 600))
-                            record_counter('rule.judge.exceptions.LocksDetected')
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': 'LocksDetected'})
                             logger(logging.WARNING, 'Locks detected for %s' % rule_id)
                         elif match('.*QueuePool.*', str(e.args[0])):
                             logger(logging.WARNING, 'DatabaseException', exc_info=True)
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                         elif match('.*ORA-03135.*', str(e.args[0])):
                             logger(logging.WARNING, 'DatabaseException', exc_info=True)
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                         else:
                             logger(logging.ERROR, 'DatabaseException', exc_info=True)
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                     except (RSEWriteBlocked) as e:
                         paused_rules[rule_id] = datetime.utcnow() + timedelta(seconds=randint(60, 600))
                         logger(logging.WARNING, 'RSEWriteBlocked for rule %s' % rule_id)
-                        record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                        record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                     except ReplicationRuleCreationTemporaryFailed as e:
                         paused_rules[rule_id] = datetime.utcnow() + timedelta(seconds=randint(60, 600))
                         logger(logging.WARNING, 'ReplicationRuleCreationTemporaryFailed for rule %s' % rule_id)
-                        record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                        record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                     except RuleNotFound:
                         pass
                     except InsufficientAccountLimit:
@@ -136,16 +136,16 @@ def rule_injector(once=False, sleep_time=60):
         except (DatabaseException, DatabaseError) as e:
             if match('.*QueuePool.*', str(e.args[0])):
                 logger(logging.WARNING, 'DatabaseException', exc_info=True)
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
             elif match('.*ORA-03135.*', str(e.args[0])):
                 logger(logging.WARNING, 'DatabaseException', exc_info=True)
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
             else:
                 logger(logging.CRITICAL, 'DatabaseException', exc_info=True)
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
         except Exception as e:
             logger(logging.CRITICAL, 'Exception', exc_info=True)
-            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
         if once:
             break
 

--- a/lib/rucio/daemons/judge/repairer.py
+++ b/lib/rucio/daemons/judge/repairer.py
@@ -107,30 +107,30 @@ def rule_repairer(once=False, sleep_time=60):
                         if match('.*ORA-00054.*', str(e.args[0])):
                             paused_rules[rule_id] = datetime.utcnow() + timedelta(seconds=randint(600, 2400))
                             logging.warning('rule_repairer[%s/%s]: Locks detected for %s' % (heartbeat['assign_thread'], heartbeat['nr_threads'], rule_id))
-                            record_counter('rule.judge.exceptions.LocksDetected')
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': 'LocksDetected'})
                         elif match('.*QueuePool.*', str(e.args[0])):
                             logging.warning(traceback.format_exc())
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                         elif match('.*ORA-03135.*', str(e.args[0])):
                             logging.warning(traceback.format_exc())
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
                         else:
                             logging.error(traceback.format_exc())
-                            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
 
         except (DatabaseException, DatabaseError) as e:
             if match('.*QueuePool.*', str(e.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
             elif match('.*ORA-03135.*', str(e.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
             else:
                 logging.critical(traceback.format_exc())
-                record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+                record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
         except Exception as e:
             logging.critical(traceback.format_exc())
-            record_counter('rule.judge.exceptions.%s' % e.__class__.__name__)
+            record_counter('rule.judge.exceptions.{exception}', labels={'exception': e.__class__.__name__})
         if once:
             break
 

--- a/lib/rucio/daemons/judge/repairer.py
+++ b/lib/rucio/daemons/judge/repairer.py
@@ -22,6 +22,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Judge-Repairer is a daemon to repair stuck replication rules.

--- a/lib/rucio/daemons/oauthmanager/oauthmanager.py
+++ b/lib/rucio/daemons/oauthmanager/oauthmanager.py
@@ -101,21 +101,21 @@ def OAuthManager(once=False, loop_rate=300, max_rows=100, sleep_time=300):
             nrefreshed = refresh_jwt_tokens(total_workers, worker_number, refreshrate=int(sleep_time), limit=max_rows)
             logging.info('oauth_manager[%i/%i]: successfully refreshed %i tokens', worker_number, total_workers, nrefreshed)
             logging.info('oauth_manager[%i/%i]: ----- END ----- ACCESS TOKEN REFRESH ----- ', worker_number, total_workers)
-            record_counter(counters='oauth_manager.tokens.refreshed', delta=nrefreshed)
+            record_counter(name='oauth_manager.tokens.refreshed', delta=nrefreshed)
 
         except (DatabaseException, DatabaseError) as err:
             if match('.*QueuePool.*', str(err.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+                record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
             elif match('.*ORA-03135.*', str(err.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+                record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
             else:
                 logging.critical(traceback.format_exc())
-                record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+                record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
         except Exception as err:
             logging.critical(traceback.format_exc())
-            record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+            record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
 
         try:
             # waiting 1 sec as DBs does not store milisecond and tokens
@@ -127,21 +127,21 @@ def OAuthManager(once=False, loop_rate=300, max_rows=100, sleep_time=300):
             ndeleted += delete_expired_tokens(total_workers, worker_number, limit=max_rows)
             logging.info('oauth_manager[%i/%i]: deleted %i expired tokens', worker_number, total_workers, ndeleted)
             logging.info('oauth_manager[%i/%i]: ----- END ----- DELETION OF EXPIRED TOKENS ----- ', worker_number, total_workers)
-            record_counter(counters='oauth_manager.tokens.deleted', delta=ndeleted)
+            record_counter(name='oauth_manager.tokens.deleted', delta=ndeleted)
 
         except (DatabaseException, DatabaseError) as err:
             if match('.*QueuePool.*', str(err.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+                record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
             elif match('.*ORA-03135.*', str(err.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+                record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
             else:
                 logging.critical(traceback.format_exc())
-                record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+                record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
         except Exception as err:
             logging.critical(traceback.format_exc())
-            record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+            record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
 
         try:
             # DELETING EXPIRED OAUTH SESSION PARAMETERS
@@ -150,21 +150,21 @@ def OAuthManager(once=False, loop_rate=300, max_rows=100, sleep_time=300):
             ndeletedreq += delete_expired_oauthrequests(total_workers, worker_number, limit=max_rows)
             logging.info('oauth_manager[%i/%i]: expired parameters of %i authentication requests were deleted', worker_number, total_workers, ndeletedreq)
             logging.info('oauth_manager[%i/%i]: ----- END ----- DELETION OF EXPIRED OAUTH SESSION REQUESTS ----- ', worker_number, total_workers)
-            record_counter(counters='oauth_manager.oauthreq.deleted', delta=ndeletedreq)
+            record_counter(name='oauth_manager.oauthreq.deleted', delta=ndeletedreq)
 
         except (DatabaseException, DatabaseError) as err:
             if match('.*QueuePool.*', str(err.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+                record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
             elif match('.*ORA-03135.*', str(err.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+                record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
             else:
                 logging.critical(traceback.format_exc())
-                record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+                record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
         except Exception as err:
             logging.critical(traceback.format_exc())
-            record_counter('oauth_manager.exceptions.' + err.__class__.__name__)
+            record_counter('oauth_manager.exceptions.{exception}', labels={'exception': err.__class__.__name__})
 
         tottime = time.time() - start
         logging.info('oauth_manager[%i/%i]: took %f seconds to delete %i tokens, %i session parameters and refreshed %i tokens', worker_number, total_workers, tottime, ndeleted, ndeletedreq, nrefreshed)

--- a/lib/rucio/daemons/oauthmanager/oauthmanager.py
+++ b/lib/rucio/daemons/oauthmanager/oauthmanager.py
@@ -18,6 +18,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 OAuth Manager is a daemon which is reponsible for:

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -19,7 +19,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2016-2021
 # - Wen Guan <wen.guan@cern.ch>, 2016
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2019
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2019-2021
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
@@ -27,6 +27,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Matt Snyder <msnyder@bnl.gov>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 '''
 Reaper is a daemon to manage file deletion.

--- a/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
+++ b/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
@@ -218,16 +218,16 @@ def declare_suspicious_replicas_bad(once=False, younger_than=3, nattempts=10, rs
         except (DatabaseException, DatabaseError) as err:
             if match('.*QueuePool.*', str(err.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('replica.recoverer.exceptions.' + err.__class__.__name__)
+                record_counter('replica.recoverer.exceptions.{exception}', labels={'exception': err.__class__.__name__})
             elif match('.*ORA-03135.*', str(err.args[0])):
                 logging.warning(traceback.format_exc())
-                record_counter('replica.recoverer.exceptions.' + err.__class__.__name__)
+                record_counter('replica.recoverer.exceptions.{exception}', labels={'exception': err.__class__.__name__})
             else:
                 logging.critical(traceback.format_exc())
-                record_counter('replica.recoverer.exceptions.' + err.__class__.__name__)
+                record_counter('replica.recoverer.exceptions.{exception}', labels={'exception': err.__class__.__name__})
         except Exception as err:
             logging.critical(traceback.format_exc())
-            record_counter('replica.recoverer.exceptions.' + err.__class__.__name__)
+            record_counter('replica.recoverer.exceptions.{exception}', labels={'exception': err.__class__.__name__})
         if once:
             break
 

--- a/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
+++ b/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
@@ -22,6 +22,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 Suspicious-Replica-Recoverer is a daemon that declares suspicious replicas as bad if they are found available on other RSE.

--- a/lib/rucio/daemons/tracer/kronos.py
+++ b/lib/rucio/daemons/tracer/kronos.py
@@ -26,6 +26,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 """
 This daemon consumes tracer messages from ActiveMQ and updates the atime for replicas.

--- a/lib/rucio/daemons/tracer/kronos.py
+++ b/lib/rucio/daemons/tracer/kronos.py
@@ -407,7 +407,7 @@ def kronos_file(thread=0, dataset_queue=None, sleep_time=60):
         for conn in conns:
             if not conn.is_connected():
                 logger(logging.INFO, 'connecting to %s' % str(conn.transport._Transport__host_and_ports[0]))
-                record_counter('daemons.tracer.kronos.reconnect.%s' % conn.transport._Transport__host_and_ports[0][0])
+                record_counter('daemons.tracer.kronos.reconnect.{host}', labels={'host': conn.transport._Transport__host_and_ports[0][0]})
                 conn.set_listener('rucio-tracer-kronos', AMQConsumer(broker=conn.transport._Transport__host_and_ports[0],
                                                                      conn=conn,
                                                                      queue=config_get('tracer-kronos', 'queue'),

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -28,6 +28,7 @@
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 import logging
 import os

--- a/lib/rucio/daemons/undertaker/undertaker.py
+++ b/lib/rucio/daemons/undertaker/undertaker.py
@@ -96,14 +96,14 @@ def undertaker(worker_number=1, total_workers=1, chunk_size=5, once=False, sleep
                     logging.info('Undertaker(%s): Receive %s dids to delete', worker_number, len(chunk))
                     delete_dids(dids=chunk, account=InternalAccount('root', vo='def'), expire_rules=True)
                     logging.info('Undertaker(%s): Delete %s dids', worker_number, len(chunk))
-                    record_counter(counters='undertaker.delete_dids', delta=len(chunk))
+                    record_counter(name='undertaker.delete_dids', delta=len(chunk))
                 except RuleNotFound as error:
                     logging.error(error)
                 except (DatabaseException, DatabaseError, UnsupportedOperation) as e:
                     if match('.*ORA-00054.*', str(e.args[0])) or match('.*55P03.*', str(e.args[0])) or match('.*3572.*', str(e.args[0])):
                         for did in chunk:
                             paused_dids[(did['scope'], did['name'])] = datetime.utcnow() + timedelta(seconds=randint(600, 2400))
-                        record_counter('undertaker.delete_dids.exceptions.LocksDetected')
+                        record_counter('undertaker.delete_dids.exceptions.{exception}', labels={'exception': 'LocksDetected'})
                         logging.warning('undertaker[%s/%s]: Locks detected for chunk', heartbeat['assign_thread'], heartbeat['nr_threads'])
                     else:
                         logging.error('Undertaker(%s): Got database error %s.', worker_number, str(e))

--- a/lib/rucio/daemons/undertaker/undertaker.py
+++ b/lib/rucio/daemons/undertaker/undertaker.py
@@ -23,6 +23,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 '''
 Undertaker is a daemon to manage expired did.

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # Authors:
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Mayank Sharma <mayank.sharma@cern.ch>, 2021
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -295,3 +295,17 @@ def caches_mock(request):
             stack.enter_context(mock.patch('{}.{}'.format(module, 'REGION'), new=region))
 
         yield
+
+
+@pytest.fixture
+def metrics_mock():
+    """
+    Overrides the prometheus metric registry and allows to verify if the desired
+    prometheus metrics were correctly recorded.
+    """
+
+    from unittest import mock
+    from prometheus_client import CollectorRegistry
+
+    with mock.patch('rucio.core.monitor.REGISTRY', new=CollectorRegistry()) as registry, mock.patch('rucio.core.monitor.COUNTERS', new={}):
+        yield registry

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -101,7 +101,7 @@ def test_request_submitted_in_order(rse_factory, did_factory, root_account):
     'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by rse expression
     'rucio.core.config',
 ]}], indirect=True)
-def test_multihop_sources_created(rse_factory, did_factory, root_account, core_config_mock, caches_mock):
+def test_multihop_sources_created(rse_factory, did_factory, root_account, core_config_mock, caches_mock, metrics_mock):
     """
     Ensure that multihop transfers are handled and intermediate request correctly created
     """
@@ -169,6 +169,9 @@ def test_multihop_sources_created(rse_factory, did_factory, root_account, core_c
 
     replica = replica_core.get_replica(jump_rse3_id, **did)
     assert replica['tombstone'] is None
+
+    # Ensure that prometheus metrics were correctly registered. One submission for each transfer hop
+    assert metrics_mock.get_sample_value('rucio_core_request_submit_transfer_total') == 4
 
 
 @pytest.mark.noparallel(reason="multiple submitters cannot be run in parallel due to partial job assignment by hash")


### PR DESCRIPTION
Introduce a MultiCounter class which takes care of registering
both statsd and prometheus Counters. Use it in all places where
both prometheus and statsd metrics where collected.

Update the record_counter function to also record both counters
as drop-in replacement. I didn't find any place where it would be
called with multiple counters, so remove this capability.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
