### PR TITLE
Transfers: disable overwrite for multihop transfers towards tape. #4447 

### DIFF
--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -378,6 +378,10 @@ def bulk_group_transfer(transfers, policy='rule', group_bulk=200, source_strateg
             if policy_key not in current_transfers_group[job_key]:
                 current_transfers_group[job_key][policy_key] = {'files': [], 'job_params': job_params}
             current_transfers_policy = current_transfers_group[job_key][policy_key]
+
+            # Only allow overwrite if all transfers grouped together allow it
+            current_transfers_policy['job_params']['overwrite'] = current_transfers_policy['job_params']['overwrite'] and job_params['overwrite']
+
             if multihop:
                 # The parent transfer should be the first of the list
                 # TODO : Only work for a single hop now, need to be able to handle multiple hops

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -122,7 +122,7 @@ class TemporaryRSEFactory:
         rse_name = rse_name_generator()
         rse_id = rse_core.add_rse(rse_name, vo=self.vo, **(add_rse_kwargs or {}))
         if scheme and protocol_impl:
-            rse_core.add_protocol(rse_id=rse_id, parameter={
+            protocol_parameters = {
                 'scheme': scheme,
                 'hostname': '%s.cern.ch' % rse_id,
                 'port': 0,
@@ -135,14 +135,15 @@ class TemporaryRSEFactory:
                         'delete': 1,
                         'third_party_copy': 1
                     }
-                },
-                **(parameters or {})
-            })
+                }
+            }
+            protocol_parameters.update(parameters or {})
+            rse_core.add_protocol(rse_id=rse_id, parameter=protocol_parameters)
         self.created_rses.append(rse_id)
         return rse_name, rse_id
 
-    def make_rse(self, **kwargs):
-        return self._make_rse(scheme=None, protocol_impl=None, add_rse_kwargs=kwargs)
+    def make_rse(self, scheme=None, protocol_impl=None, **kwargs):
+        return self._make_rse(scheme=scheme, protocol_impl=protocol_impl, add_rse_kwargs=kwargs)
 
     def make_posix_rse(self, **kwargs):
         return self._make_rse(scheme='file', protocol_impl='rucio.rse.protocols.posix.Default', add_rse_kwargs=kwargs)


### PR DESCRIPTION
Bulk_group_transfer takes the overwrite parameter from the first
transfer of the group. In the multihop case, it is the first hop,
which is not the desired behavior when we transfer towards a tape.

Ensure that overwrite is disabled as soon as any transfer in the
group desires it disabled.

Add a test to ensure this parameter is correctly passed to FTS and
it acts accordingly. Rely on the "mock" gfal plugin for this.