### PR TITLE
Tests: don't import temp factories in test_bin_rucio.py

### DIFF
--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -56,7 +56,6 @@ from rucio.common.types import InternalScope, InternalAccount
 from rucio.common.utils import generate_uuid, get_tmp_dir, md5, render_json
 from rucio.rse import rsemanager as rsemgr
 from rucio.tests.common import execute, account_name_generator, rse_name_generator, file_generator, scope_name_generator, get_long_vo
-from rucio.tests.temp_factories import TemporaryFileFactory
 
 
 class TestBinRucio(unittest.TestCase):
@@ -1613,76 +1612,113 @@ class TestBinRucio(unittest.TestCase):
 
     def test_upload_recursive_ok(self):
         """CLIENT(USER): Upload and preserve folder structure"""
-        with TemporaryFileFactory() as file_factory:
-            folder = file_factory.base_dir
-            folder1 = file_factory.folder_generator(use_basedir=True)
-            folder2 = file_factory.folder_generator(use_basedir=True)
-            folder3 = file_factory.folder_generator(use_basedir=True)
-            folder11 = file_factory.folder_generator(use_basedir=True, path=str(folder1).split('/')[-1])
-            folder12 = file_factory.folder_generator(use_basedir=True, path=str(folder1).split('/')[-1])
-            folder13 = file_factory.folder_generator(use_basedir=True, path=str(folder1).split('/')[-1])
-            file1 = str(file_factory.file_generator(path=folder11)).split('/')[-1]
-            file2 = str(file_factory.file_generator(path=folder2)).split('/')[-1]
-
-            exitcode, out, err = execute('rucio upload --scope %s --rse %s --recursive %s' % (self.user, self.def_rse, folder))
-            print(err)
-            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder).split('/')[-1]))
-            assert re.search("{0}:{1}".format(self.user, str(folder1).split('/')[-1]), out) is not None
-            assert re.search("{0}:{1}".format(self.user, str(folder2).split('/')[-1]), out) is not None
-            assert re.search("{0}:{1}".format(self.user, str(folder3).split('/')[-1]), out) is None
-
-            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder1).split('/')[-1]))
-            assert re.search("{0}:{1}".format(self.user, str(folder11).split('/')[-1]), out) is not None
-            assert re.search("{0}:{1}".format(self.user, str(folder12).split('/')[-1]), out) is None
-            assert re.search("{0}:{1}".format(self.user, str(folder13).split('/')[-1]), out) is None
-
-            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder11).split('/')[-1]))
-            assert re.search("{0}:{1}".format(self.user, file1), out) is not None
-
-            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder2).split('/')[-1]))
-            assert re.search("{0}:{1}".format(self.user, file2), out) is not None
+        folder = 'folder_' + generate_uuid()
+        folder1 = '%s/folder_%s' % (folder, generate_uuid())
+        folder2 = '%s/folder_%s' % (folder, generate_uuid())
+        folder3 = '%s/folder_%s' % (folder, generate_uuid())
+        folder11 = '%s/folder_%s' % (folder1, generate_uuid())
+        folder12 = '%s/folder_%s' % (folder1, generate_uuid())
+        folder13 = '%s/folder_%s' % (folder1, generate_uuid())
+        file1 = 'file_%s' % generate_uuid()
+        file2 = 'file_%s' % generate_uuid()
+        cmd = 'mkdir %s' % folder
+        execute(cmd)
+        cmd = 'mkdir %s && mkdir %s && mkdir %s' % (folder1, folder2, folder3)
+        execute(cmd)
+        cmd = 'mkdir %s && mkdir %s && mkdir %s' % (folder11, folder12, folder13)
+        execute(cmd)
+        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder11, file1)
+        execute(cmd)
+        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder2, file2)
+        execute(cmd)
+        cmd = 'rucio upload --scope %s --rse %s --recursive %s/' % (self.user, self.def_rse, folder)
+        execute(cmd)
+        cmd = 'rucio list-content %s:%s' % (self.user, folder)
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}:{1}".format(self.user, folder1.split('/')[-1]), out) is not None
+        assert re.search("{0}:{1}".format(self.user, folder2.split('/')[-1]), out) is not None
+        assert re.search("{0}:{1}".format(self.user, folder3.split('/')[-1]), out) is None
+        cmd = 'rucio list-content %s:%s' % (self.user, folder1.split('/')[-1])
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}:{1}".format(self.user, folder11.split('/')[-1]), out) is not None
+        assert re.search("{0}:{1}".format(self.user, folder12.split('/')[-1]), out) is None
+        assert re.search("{0}:{1}".format(self.user, folder13.split('/')[-1]), out) is None
+        cmd = 'rucio list-content %s:%s' % (self.user, folder11.split('/')[-1])
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}:{1}".format(self.user, file1), out) is not None
+        cmd = 'rucio list-content %s:%s' % (self.user, folder2.split('/')[-1])
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}:{1}".format(self.user, file2), out) is not None
+        cmd = 'rm -rf %s' % folder
+        execute(cmd)
 
     def test_upload_recursive_subfolder(self):
         """CLIENT(USER): Upload and preserve folder structure in a subfolder"""
-        with TemporaryFileFactory() as file_factory:
-            folder = file_factory.base_dir
-            folder1 = file_factory.folder_generator(use_basedir=True)
-            folder11 = file_factory.folder_generator(use_basedir=True, path=str(folder1).split('/')[-1])
-            file1 = str(file_factory.file_generator(path=folder11)).split('/')[-1]
-
-            execute('rucio upload --scope %s --rse %s --recursive %s' % (self.user, self.def_rse, folder1))
-            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder).split('/')[-1]))
-            assert re.search("{0}:{1}".format(self.user, str(folder1).split('/')[-1]), out) is None
-
-            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder1).split('/')[-1]))
-            assert re.search("{0}:{1}".format(self.user, str(folder11).split('/')[-1]), out) is not None
-
-            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder11).split('/')[-1]))
-            assert re.search("{0}:{1}".format(self.user, file1), out) is not None
+        folder = 'folder_' + generate_uuid()
+        folder1 = '%s/folder_%s' % (folder, generate_uuid())
+        folder11 = '%s/folder_%s' % (folder1, generate_uuid())
+        file1 = 'file_%s' % generate_uuid()
+        cmd = 'mkdir %s' % (folder)
+        execute(cmd)
+        cmd = 'mkdir %s' % (folder1)
+        execute(cmd)
+        cmd = 'mkdir %s' % (folder11)
+        execute(cmd)
+        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder11, file1)
+        execute(cmd)
+        cmd = 'rucio upload --scope %s --rse %s --recursive %s/' % (self.user, self.def_rse, folder1)
+        execute(cmd)
+        cmd = 'rucio list-content %s:%s' % (self.user, folder)
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}:{1}".format(self.user, folder1.split('/')[-1]), out) is None
+        cmd = 'rucio list-content %s:%s' % (self.user, folder1.split('/')[-1])
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}:{1}".format(self.user, folder11.split('/')[-1]), out) is not None
+        cmd = 'rucio list-content %s:%s' % (self.user, folder11.split('/')[-1])
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}:{1}".format(self.user, file1), out) is not None
+        cmd = 'rm -rf %s' % folder
+        execute(cmd)
 
     def test_recursive_empty(self):
         """CLIENT(USER): Upload and preserve folder structure with an empty folder"""
-        with TemporaryFileFactory() as file_factory:
-            folder = file_factory.base_dir
-            folder1 = file_factory.folder_generator(use_basedir=True)
-
-            execute('rucio upload --scope %s --rse %s --recursive %s' % (self.user, self.def_rse, folder))
-            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder).split('/')[-1]))
-            assert re.search("{0}:{1}".format(self.user, str(folder1).split('/')[-1]), out) is None
+        folder = 'folder_' + generate_uuid()
+        folder1 = '%s/folder_%s' % (folder, generate_uuid())
+        cmd = 'mkdir %s' % (folder)
+        execute(cmd)
+        cmd = 'mkdir %s' % (folder1)
+        execute(cmd)
+        cmd = 'rucio upload --scope %s --rse %s --recursive %s/' % (self.user, self.def_rse, folder)
+        execute(cmd)
+        cmd = 'rucio list-content %s:%s' % (self.user, folder)
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}:{1}".format(self.user, folder1.split('/')[-1]), out) is None
+        cmd = 'rm -rf %s' % folder
+        execute(cmd)
 
     def test_upload_recursive_only_files(self):
         """CLIENT(USER): Upload and preserve folder structure only with files"""
-        with TemporaryFileFactory() as file_factory:
-            folder = file_factory.base_dir
-            file1 = str(file_factory.file_generator(use_basedir=True)).split('/')[-1]
-            file2 = str(file_factory.file_generator(use_basedir=True)).split('/')[-1]
-            file3 = str(file_factory.file_generator(use_basedir=True)).split('/')[-1]
-
-            execute('rucio upload --scope %s --rse %s --recursive %s' % (self.user, self.def_rse, folder))
-            exitcode, out, err = execute('rucio ls %s:%s' % (self.user, str(folder).split('/')[-1]))
-            assert re.search("DATASET", out) is not None
-
-            exitcode, out, err = execute('rucio list-content %s:%s' % (self.user, str(folder).split('/')[-1]))
-            assert re.search("{0}:{1}".format(self.user, file1), out) is not None
-            assert re.search("{0}:{1}".format(self.user, file2), out) is not None
-            assert re.search("{0}:{1}".format(self.user, file3), out) is not None
+        folder = 'folder_' + generate_uuid()
+        file1 = 'file_%s' % generate_uuid()
+        file2 = 'file_%s' % generate_uuid()
+        file3 = 'file_%s' % generate_uuid()
+        cmd = 'mkdir %s' % folder
+        execute(cmd)
+        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder, file1)
+        execute(cmd)
+        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder, file2)
+        execute(cmd)
+        cmd = 'echo "%s" > %s/%s.txt' % (generate_uuid(), folder, file3)
+        execute(cmd)
+        cmd = 'rucio upload --scope %s --rse %s --recursive %s/' % (self.user, self.def_rse, folder)
+        execute(cmd)
+        cmd = 'rucio list-content %s:%s' % (self.user, folder)
+        exitcode, out, err = execute(cmd)
+        assert re.search("{0}:{1}".format(self.user, file1), out) is not None
+        assert re.search("{0}:{1}".format(self.user, file2), out) is not None
+        assert re.search("{0}:{1}".format(self.user, file3), out) is not None
+        cmd = 'rucio ls %s:%s' % (self.user, folder)
+        exitcode, out, err = execute(cmd)
+        assert re.search("DATASET", out) is not None
+        cmd = 'rm -rf %s' % folder
+        execute(cmd)


### PR DESCRIPTION
temp factories cannot be used in python2.7 env because of
calling directly some core functions which are python3 only.
