### PR TITLE
Core & Internals: Remove typing import; Fix #4777

### DIFF
--- a/lib/rucio/common/extra.py
+++ b/lib/rucio/common/extra.py
@@ -17,14 +17,9 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 import importlib
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import List, Dict, Any
 
 
 def import_extras(module_list):
-    # type: (List[str]) -> Dict[str, Any]
     out = dict()
     for mod in module_list:
         out[mod] = None


### PR DESCRIPTION
Hotfix for Python 2.7 compatibility, fixes #4777 
