### PR TITLE
Core & Internals: Add typing dependency; Fix #4777

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ dogpile.cache>=0.6.5,<=1.1.1; python_version >= '3.0'       # Caching API plugin
 tabulate>=0.8.0,<0.9.0                                      # Pretty-print tabular data
 six>=1.12.0,<1.16.0                                         # Python 2 and 3 compatibility utilities
 jsonschema>=3.2.0                                           # For JSON schema validation (Policy modules)
+typing; python_version < '3.5'                              # typing package support for older Python versions
 
 # All dependencies needed in extras for rucio client (and server/daemons) should be defined here
 paramiko==2.7.2                                             # ssh_extras; SSH2 protocol library (also needed in the server)

--- a/setuputil.py
+++ b/setuputil.py
@@ -34,6 +34,7 @@ clients_requirements_table = {
         'tabulate',
         'six',
         'jsonschema',
+        'typing',
     ],
     'ssh': ['paramiko'],
     'kerberos': [


### PR DESCRIPTION
For Python versions smaller than 3.5 (so only Python 2.7). Fixes #4777 on master for 1.27
Related to #4778