### PR TITLE
Core: config_get search in cfg and in config table. Closes #2630

### DIFF
--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -33,7 +33,7 @@ import os
 import json
 import sys
 
-from rucio.common.exception import ConfigNotFound
+from rucio.common.exception import ConfigNotFound, DatabaseException
 
 try:
     import ConfigParser
@@ -80,7 +80,7 @@ def config_get(section, option, raise_exception=True, default=None, clean_cached
                 return __config_get_table(section=section, option=option, raise_exception=raise_exception,
                                           default=default, clean_cached=clean_cached, session=session,
                                           use_cache=use_cache, expiration_time=expiration_time)
-            except ConfigNotFound:
+            except (ConfigNotFound, DatabaseException):
                 raise err
         else:
             if raise_exception and default is None:
@@ -144,7 +144,7 @@ def config_get_int(section, option, raise_exception=True, default=None, check_co
                 return int(__config_get_table(section=section, option=option, raise_exception=raise_exception,
                                               default=default, session=session, use_cache=use_cache,
                                               expiration_time=expiration_time))
-            except ConfigNotFound:
+            except (ConfigNotFound, DatabaseException):
                 raise err
             except ValueError as err_:
                 raise err_
@@ -191,7 +191,7 @@ def config_get_float(section, option, raise_exception=True, default=None, check_
                 return float(__config_get_table(section=section, option=option, raise_exception=raise_exception,
                                                 default=default, session=session, use_cache=use_cache,
                                                 expiration_time=expiration_time))
-            except ConfigNotFound:
+            except (ConfigNotFound, DatabaseException):
                 raise err
             except ValueError as err_:
                 raise err_
@@ -238,7 +238,7 @@ def config_get_bool(section, option, raise_exception=True, default=None, check_c
                 return bool(__config_get_table(section=section, option=option, raise_exception=raise_exception,
                                                default=default, session=session, use_cache=use_cache,
                                                expiration_time=expiration_time))
-            except ConfigNotFound:
+            except (ConfigNotFound, DatabaseException):
                 raise err
             except ValueError as err_:
                 raise err_
@@ -267,13 +267,14 @@ def __config_get_table(section, option, raise_exception=True, default=None, clea
     :returns: the configuration value from the config table.
 
     :raises ConfigNotFound
+    :raises DatabaseException
     """
-    from rucio.core.config import get as core_config_get
     global __CONFIG
     try:
+        from rucio.core.config import get as core_config_get
         return core_config_get(section, option, default=default, session=session, use_cache=use_cache,
                                expiration_time=expiration_time)
-    except ConfigNotFound as err:
+    except (ConfigNotFound, DatabaseException) as err:
         if raise_exception and default is None:
             raise err
         if clean_cached:

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -80,7 +80,7 @@ def config_get(section, option, raise_exception=True, default=None, clean_cached
                 return __config_get_table(section=section, option=option, raise_exception=raise_exception,
                                           default=default, clean_cached=clean_cached, session=session,
                                           use_cache=use_cache, expiration_time=expiration_time)
-            except (ConfigNotFound, DatabaseException):
+            except (ConfigNotFound, DatabaseException, ImportError):
                 raise err
         else:
             if raise_exception and default is None:
@@ -144,7 +144,7 @@ def config_get_int(section, option, raise_exception=True, default=None, check_co
                 return int(__config_get_table(section=section, option=option, raise_exception=raise_exception,
                                               default=default, session=session, use_cache=use_cache,
                                               expiration_time=expiration_time))
-            except (ConfigNotFound, DatabaseException):
+            except (ConfigNotFound, DatabaseException, ImportError):
                 raise err
             except ValueError as err_:
                 raise err_
@@ -191,7 +191,7 @@ def config_get_float(section, option, raise_exception=True, default=None, check_
                 return float(__config_get_table(section=section, option=option, raise_exception=raise_exception,
                                                 default=default, session=session, use_cache=use_cache,
                                                 expiration_time=expiration_time))
-            except (ConfigNotFound, DatabaseException):
+            except (ConfigNotFound, DatabaseException, ImportError):
                 raise err
             except ValueError as err_:
                 raise err_
@@ -238,7 +238,7 @@ def config_get_bool(section, option, raise_exception=True, default=None, check_c
                 return bool(__config_get_table(section=section, option=option, raise_exception=raise_exception,
                                                default=default, session=session, use_cache=use_cache,
                                                expiration_time=expiration_time))
-            except (ConfigNotFound, DatabaseException):
+            except (ConfigNotFound, DatabaseException, ImportError):
                 raise err
             except ValueError as err_:
                 raise err_
@@ -274,7 +274,7 @@ def __config_get_table(section, option, raise_exception=True, default=None, clea
         from rucio.core.config import get as core_config_get
         return core_config_get(section, option, default=default, session=session, use_cache=use_cache,
                                expiration_time=expiration_time)
-    except (ConfigNotFound, DatabaseException) as err:
+    except (ConfigNotFound, DatabaseException, ImportError) as err:
         if raise_exception and default is None:
             raise err
         if clean_cached:

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -22,15 +22,18 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Tobias Wegner <twegner@cern.ch>, 2019
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Tomas Javurek <tomas.javurek@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 """Provides functions to access the local configuration. The configuration locations are provided by get_config_dirs."""
 
 import os
 import json
 import sys
+
+from rucio.common.exception import ConfigNotFound
 
 try:
     import ConfigParser
@@ -40,26 +43,51 @@ except ImportError:
 from rucio.common import exception
 
 
-def config_get(section, option, raise_exception=True, default=None, clean_cached=False):
+def config_get(section, option, raise_exception=True, default=None, clean_cached=False, check_config_table=True,
+               session=None, use_cache=True, expiration_time=3600):
     """
     Return the string value for a given option in a section
 
+    First it looks at the configuration file and, if it is not found, check in the config table only if it is called
+    from a server/daemon (and if check_config_table is set).
+
     :param section: the named section.
     :param option: the named option.
-    :param raise_exception: Boolean to raise or not NoOptionError or NoSectionError.
+    :param raise_exception: Boolean to raise or not NoOptionError, NoSectionError or RuntimeError.
     :param default: the default value if not found.
-.
+    :param check_config_table: if not set, avoid looking at config table even if it is called from server/daemon
+    :param session: The database session in use. Only used if not found in config file and if it is called from
+                    server/daemon
+    :param use_cache: Boolean if the cache should be used. Only used if not found in config file and if it is called
+                      from server/daemon
+    :param expiration_time: Time after that the cached value gets ignored. Only used if not found in config file and if
+                            it is called from server/daemon
+
     :returns: the configuration value.
+
+    :raises NoOptionError
+    :raises NoSectionError
+    :raises RuntimeError
     """
     global __CONFIG
+    from rucio.common.utils import is_client
+    client_mode = is_client()
     try:
         return get_config().get(section, option)
     except (ConfigParser.NoOptionError, ConfigParser.NoSectionError, RuntimeError) as err:
-        if raise_exception and default is None:
-            raise err
-        if clean_cached:
-            __CONFIG = None
-        return default
+        if not client_mode and check_config_table:
+            try:
+                return __config_get_table(section=section, option=option, raise_exception=raise_exception,
+                                          default=default, clean_cached=clean_cached, session=session,
+                                          use_cache=use_cache, expiration_time=expiration_time)
+            except ConfigNotFound:
+                raise err
+        else:
+            if raise_exception and default is None:
+                raise err
+            if clean_cached:
+                __CONFIG = None
+            return default
 
 
 def config_has_section(section):
@@ -82,45 +110,175 @@ def config_add_section(section):
     return get_config().add_section(section)
 
 
-def config_get_int(section, option, raise_exception=True, default=None):
-    """Return the integer value for a given option in a section"""
+def config_get_int(section, option, raise_exception=True, default=None, check_config_table=True, session=None,
+                   use_cache=True, expiration_time=3600):
+    """
+    Return the integer value for a given option in a section
+
+    :param section: the named section.
+    :param option: the named option.
+    :param raise_exception: Boolean to raise or not NoOptionError, NoSectionError or RuntimeError.
+    :param default: the default value if not found.
+    :param check_config_table: if not set, avoid looking at config table even if it is called from server/daemon
+    :param session: The database session in use. Only used if not found in config file and if it is called from
+                    server/daemon
+    :param use_cache: Boolean if the cache should be used. Only used if not found in config file and if it is called
+                      from server/daemon
+    :param expiration_time: Time after that the cached value gets ignored. Only used if not found in config file and if
+                            it is called from server/daemon
+
+    :returns: the configuration value.
+
+    :raises NoOptionError
+    :raises NoSectionError
+    :raises RuntimeError
+    :raises ValueError
+    """
+    from rucio.common.utils import is_client
+    client_mode = is_client()
     try:
         return get_config().getint(section, option)
     except (ConfigParser.NoOptionError, ConfigParser.NoSectionError) as err:
-        if raise_exception and default is None:
-            raise err
-        return default
+        if not client_mode and check_config_table:
+            try:
+                return int(__config_get_table(section=section, option=option, raise_exception=raise_exception,
+                                              default=default, session=session, use_cache=use_cache,
+                                              expiration_time=expiration_time))
+            except ConfigNotFound:
+                raise err
+            except ValueError as err_:
+                raise err_
+        else:
+            if raise_exception and default is None:
+                raise err
+            try:
+                return int(default)
+            except ValueError as err_:
+                raise err_
 
 
-def config_get_float(section, option, raise_exception=True, default=None):
-    """Return the floating point value for a given option in a section"""
+def config_get_float(section, option, raise_exception=True, default=None, check_config_table=True, session=None,
+                     use_cache=True, expiration_time=3600):
+    """
+    Return the floating point value for a given option in a section
+
+    :param section: the named section.
+    :param option: the named option.
+    :param raise_exception: Boolean to raise or not NoOptionError, NoSectionError or RuntimeError.
+    :param default: the default value if not found.
+    :param check_config_table: if not set, avoid looking at config table even if it is called from server/daemon
+    :param session: The database session in use. Only used if not found in config file and if it is called from
+                    server/daemon
+    :param use_cache: Boolean if the cache should be used. Only used if not found in config file and if it is called
+                      from server/daemon
+    :param expiration_time: Time after that the cached value gets ignored. Only used if not found in config file and if
+                            it is called from server/daemon
+
+    :returns: the configuration value.
+
+    :raises NoOptionError
+    :raises NoSectionError
+    :raises RuntimeError
+    :raises ValueError
+    """
+    from rucio.common.utils import is_client
+    client_mode = is_client()
     try:
         return get_config().getfloat(section, option)
     except (ConfigParser.NoOptionError, ConfigParser.NoSectionError) as err:
-        if raise_exception and default is None:
-            raise err
-        return default
+        if not client_mode and check_config_table:
+            try:
+                return float(__config_get_table(section=section, option=option, raise_exception=raise_exception,
+                                                default=default, session=session, use_cache=use_cache,
+                                                expiration_time=expiration_time))
+            except ConfigNotFound:
+                raise err
+            except ValueError as err_:
+                raise err_
+        else:
+            if raise_exception and default is None:
+                raise err
+            try:
+                return float(default)
+            except ValueError as err_:
+                raise err_
 
 
-def config_get_bool(section, option, raise_exception=True, default=None):
+def config_get_bool(section, option, raise_exception=True, default=None, check_config_table=True, session=None,
+                    use_cache=True, expiration_time=3600):
     """
     Return the boolean value for a given option in a section
 
     :param section: the named section.
     :param option: the named option.
-    :param raise_exception: Boolean to raise or not NoOptionError or NoSectionError.
+    :param raise_exception: Boolean to raise or not NoOptionError, NoSectionError or RuntimeError.
     :param default: the default value if not found.
+    :param check_config_table: if not set, avoid looking at config table even if it is called from server/daemon
+    :param session: The database session in use. Only used if not found in config file and if it is called from
+                    server/daemon
+    :param use_cache: Boolean if the cache should be used. Only used if not found in config file and if it is called
+                      from server/daemon
+    :param expiration_time: Time after that the cached value gets ignored. Only used if not found in config file and if
+                            it is called from server/daemon
 .
     :returns: the configuration value.
+
+    :raises NoOptionError
+    :raises NoSectionError
+    :raises RuntimeError
+    :raises ValueError
     """
+    from rucio.common.utils import is_client
+    client_mode = is_client()
     try:
         return get_config().getboolean(section, option)
     except (ConfigParser.NoOptionError, ConfigParser.NoSectionError) as err:
-        if raise_exception:
+        if not client_mode and check_config_table:
+            try:
+                return bool(__config_get_table(section=section, option=option, raise_exception=raise_exception,
+                                               default=default, session=session, use_cache=use_cache,
+                                               expiration_time=expiration_time))
+            except ConfigNotFound:
+                raise err
+            except ValueError as err_:
+                raise err_
+        else:
+            if raise_exception and default is None:
+                raise err
+            try:
+                return bool(default)
+            except ValueError as err_:
+                raise err_
+
+
+def __config_get_table(section, option, raise_exception=True, default=None, clean_cached=False, session=None,
+                       use_cache=True, expiration_time=3600):
+    """
+    Search for a section-option configuration parameter in the configuration table
+
+    :param section: the named section.
+    :param option: the named option.
+    :param raise_exception: Boolean to raise or not ConfigNotFound.
+    :param default: the default value if not found.
+    :param session: The database session in use.
+    :param use_cache: Boolean if the cache should be used.
+    :param expiration_time: Time after that the cached value gets ignored.
+
+    :returns: the configuration value from the config table.
+
+    :raises ConfigNotFound
+    """
+    from rucio.core.config import get as core_config_get
+    global __CONFIG
+    try:
+        return core_config_get(section, option, default=default, session=session, use_cache=use_cache,
+                               expiration_time=expiration_time)
+    except ConfigNotFound as err:
+        if raise_exception and default is None:
             raise err
-        if default is None:
-            return default
-        return bool(default)
+        if clean_cached:
+            __CONFIG = None
+        return default
 
 
 def config_get_options(section):

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -52,7 +52,7 @@ if not multivo:
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             try:
-                POLICY = config.config_get('policy', 'schema')
+                POLICY = config.config_get('policy', 'schema', check_config_table=False)
             except (NoOptionError, NoSectionError):
                 POLICY = GENERIC_FALLBACK
             POLICY = 'rucio.common.schema.' + POLICY.lower()
@@ -72,11 +72,11 @@ def load_schema_for_vo(vo):
     GENERIC_FALLBACK = 'generic_multi_vo'
     if config.config_has_section('policy'):
         try:
-            POLICY = config.config_get('policy', 'package-' + vo) + ".schema"
+            POLICY = config.config_get('policy', 'package-' + vo, check_config_table=False) + ".schema"
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             try:
-                POLICY = config.config_get('policy', 'schema')
+                POLICY = config.config_get('policy', 'schema', check_config_table=False)
             except (NoOptionError, NoSectionError):
                 POLICY = GENERIC_FALLBACK
             POLICY = 'rucio.common.schema.' + POLICY.lower()

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -36,7 +36,7 @@ schema_modules = {}
 scope_name_regexps = []
 
 try:
-    multivo = config.config_get_bool('common', 'multi_vo')
+    multivo = config.config_get_bool('common', 'multi_vo', check_config_table=False)
 except (NoOptionError, NoSectionError):
     multivo = False
 
@@ -48,7 +48,7 @@ if not multivo:
 
     if config.config_has_section('policy'):
         try:
-            POLICY = config.config_get('policy', 'package') + ".schema"
+            POLICY = config.config_get('policy', 'package', check_config_table=False) + ".schema"
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             try:

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1390,7 +1390,7 @@ def is_client():
     """"
     Checks if the function is called from a client or from a server/daemon
 
-    :returns client: True if is called from a client, False if it is called from a server/daemon
+    :returns client_mode: True if is called from a client, False if it is called from a server/daemon
     """
     if 'RUCIO_CLIENT_MODE' not in os.environ:
         if config_has_section('database'):

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -26,7 +26,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Tomas Javurek <tomas.javurek@cern.ch>, 2019-2020
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - James Perry <j.perry@epcc.ed.ac.uk>, 2019
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019-2021
 # - Gabriele Fronze' <gfronze@cern.ch>, 2019
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
@@ -68,7 +68,7 @@ from six.moves import StringIO, zip_longest as izip_longest
 from six.moves.urllib.parse import urlparse, urlencode, quote, parse_qsl, urlunparse
 from six.moves.configparser import NoOptionError, NoSectionError
 
-from rucio.common.config import config_get
+from rucio.common.config import config_get, config_has_section
 from rucio.common.exception import MissingModuleException, InvalidType, InputValidationError, MetalinkJsonParsingError, RucioException
 from rucio.common.extra import import_extras
 from rucio.common.types import InternalAccount, InternalScope
@@ -1308,7 +1308,8 @@ def setup_logger(module_name=None, logger_name=None, logger_level=None, verbose=
     '''
     # helper method for cfg check
     def _force_cfg_log_level(cfg_option):
-        cfg_forced_modules = config_get('logging', cfg_option, raise_exception=False, default=None, clean_cached=True)
+        cfg_forced_modules = config_get('logging', cfg_option, raise_exception=False, default=None, clean_cached=True,
+                                        check_config_table=False)
         if cfg_forced_modules:
             if re.match(str(cfg_forced_modules), module_name):
                 return True
@@ -1383,6 +1384,28 @@ def daemon_sleep(start_time, sleep_time, graceful_stop, logger=logging.log):
     if time_diff < sleep_time:
         logger(logging.INFO, 'Sleeping for a while :  %s seconds', (sleep_time - time_diff))
         graceful_stop.wait(sleep_time - time_diff)
+
+
+def is_client():
+    """"
+    Checks if the function is called from a client or from a server/daemon
+
+    :returns client: True if is called from a client, False if it is called from a server/daemon
+    """
+    if 'RUCIO_CLIENT_MODE' not in os.environ:
+        if config_has_section('database'):
+            client_mode = False
+        elif config_has_section('client'):
+            client_mode = True
+        else:
+            client_mode = False
+    else:
+        if os.environ['RUCIO_CLIENT_MODE']:
+            client_mode = True
+        else:
+            client_mode = False
+
+    return client_mode
 
 
 class retry:

--- a/lib/rucio/core/config.py
+++ b/lib/rucio/core/config.py
@@ -26,16 +26,16 @@ from dogpile.cache import make_region
 from dogpile.cache.api import NoValue
 from sqlalchemy import func
 
-from rucio.common.exception import ConfigNotFound
 from rucio.common.config import config_get
+from rucio.common.exception import ConfigNotFound
 from rucio.db.sqla import models
 from rucio.db.sqla.session import read_session, transactional_session
 
 
 REGION = make_region().configure('dogpile.cache.memcached',
                                  expiration_time=3600,
-                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
-
+                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211',
+                                                              check_config_table=False), 'distributed_lock': True})
 SECTIONS_CACHE_KEY = 'sections'
 
 

--- a/lib/rucio/core/lifetime_exception.py
+++ b/lib/rucio/core/lifetime_exception.py
@@ -32,10 +32,10 @@ from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
+from rucio.common.config import config_get
 from rucio.common.exception import RucioException, LifetimeExceptionDuplicate, LifetimeExceptionNotFound, UnsupportedOperation
 from rucio.common.utils import generate_uuid, str_to_date
 import rucio.common.policy
-from rucio.core.config import get
 from rucio.core.message import add_message
 from rucio.core.rse import list_rse_attributes
 
@@ -136,7 +136,7 @@ def add_exception(dids, account, pattern, comments, expires_at, session=None):
     text += '\n'
     text += 'Approve:   https://rucio-ui.cern.ch/lifetime_exception?id=%s&action=approve\n' % str(exception_id)
     text += 'Deny:      https://rucio-ui.cern.ch/lifetime_exception?id=%s&action=deny\n' % str(exception_id)
-    approvers_email = get('lifetime_model', 'approvers_email', default=[], session=session)
+    approvers_email = config_get('lifetime_model', 'approvers_email', default=[], session=session)
     if approvers_email:
         approvers_email = approvers_email.split(',')  # pylint: disable=no-member
 

--- a/lib/rucio/core/message.py
+++ b/lib/rucio/core/message.py
@@ -25,6 +25,7 @@
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 import json
+from configparser import NoOptionError, NoSectionError
 
 from sqlalchemy import or_, delete, update
 from sqlalchemy.exc import IntegrityError
@@ -33,9 +34,8 @@ from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 
 from rucio.common.config import config_get
-from rucio.common.exception import InvalidObject, RucioException, ConfigNotFound
+from rucio.common.exception import InvalidObject, RucioException
 from rucio.common.utils import APIEncoder
-from rucio.core.config import get
 from rucio.db.sqla import filter_thread_work
 from rucio.db.sqla.models import Message, MessageHistory
 from rucio.db.sqla.session import transactional_session
@@ -62,8 +62,8 @@ def add_message(event_type, payload, session=None):
     services_list = REGION.get('services_list')
     if services_list == NO_VALUE:
         try:
-            services_list = get('hermes', 'services_list')
-        except ConfigNotFound:
+            services_list = config_get('hermes', 'services_list')
+        except (NoOptionError, NoSectionError, RuntimeError):
             services_list = None
         REGION.set('services_list', services_list)
 

--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -57,7 +57,7 @@ if not multivo:
 
     if config.config_has_section('policy'):
         try:
-            POLICY = config.config_get('policy', 'package') + ".permission"
+            POLICY = config.config_get('policy', 'package', check_config_table=False) + ".permission"
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             POLICY = 'rucio.core.permission.' + FALLBACK_POLICY.lower()

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -69,9 +69,9 @@ from sqlalchemy.sql.expression import case, select, text, false, true
 import rucio.core.did
 import rucio.core.lock
 from rucio.common import exception
+from rucio.common.config import config_get
 from rucio.common.types import InternalScope
 from rucio.common.utils import chunks, clean_surls, str_to_date, add_url_query
-from rucio.core.config import get as config_get
 from rucio.core.credential import get_signed_url
 from rucio.core.rse import get_rse, get_rse_name, get_rse_attribute, get_rse_vo, list_rses
 from rucio.core.rse_counter import decrease, increase

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -41,6 +41,7 @@ import logging
 import time
 import traceback
 from collections import namedtuple
+from configparser import NoOptionError, NoSectionError
 from itertools import filterfalse
 from typing import TYPE_CHECKING
 
@@ -49,12 +50,11 @@ from sqlalchemy import and_, or_, func, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import asc, true
 
-from rucio.common.config import config_get_bool
+from rucio.common.config import config_get_bool, config_get
 from rucio.common.constants import FTS_STATE
-from rucio.common.exception import RequestNotFound, RucioException, UnsupportedOperation, ConfigNotFound
+from rucio.common.exception import RequestNotFound, RucioException, UnsupportedOperation
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid, chunks, get_parsed_throttler_mode
-from rucio.core.config import get
 from rucio.core.message import add_message
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core.rse import get_rse_name, get_rse_vo, get_rse_transfer_limits, get_rse_attribute
@@ -1508,8 +1508,8 @@ def __throttler_request_state(activity, source_rse_id, dest_rse_id, session: "Op
     if the throttler mode is not set.
     """
     try:
-        throttler_mode = get('throttler', 'mode', default=None, use_cache=False, session=session)
-    except ConfigNotFound:
+        throttler_mode = config_get('throttler', 'mode', default=None, use_cache=False, session=session)
+    except (NoOptionError, NoSectionError, RuntimeError):
         throttler_mode = None
 
     limit_found = False

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -68,7 +68,8 @@ if TYPE_CHECKING:
 
 REGION = make_region().configure('dogpile.cache.memcached',
                                  expiration_time=3600,
-                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'),
+                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211',
+                                                              check_config_table=False),
                                             'distributed_lock': True})
 
 

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -61,7 +61,6 @@ from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import and_, or_, text, true, null, tuple_, false
 
 from rucio.core.account import has_account_attribute
-from rucio.core.config import get as core_config_get
 import rucio.core.did
 import rucio.core.lock  # import get_replica_locks, get_files_and_replica_locks_of_dataset
 import rucio.core.replica  # import get_and_lock_file_replicas, get_and_lock_file_replicas_for_dataset
@@ -148,7 +147,7 @@ def add_rule(dids, account, copies, rse_expression, grouping, weight, lifetime, 
     if USE_NEW_RULE_ALGORITHM:
         use_new_rule_algorithm = True
     else:
-        use_new_rule_algorithm = core_config_get('rules', 'use_new_rule_algorithm', default=False, session=session)
+        use_new_rule_algorithm = config_get('rules', 'use_new_rule_algorithm', default=False, session=session)
 
     with record_timer_block('rule.add_rule'):
         # 1. Resolve the rse_expression into a list of RSE-ids
@@ -661,7 +660,7 @@ def inject_rule(rule_id, session=None, logger=logging.log):
     if USE_NEW_RULE_ALGORITHM:
         use_new_rule_algorithm = True
     else:
-        use_new_rule_algorithm = core_config_get('rules', 'use_new_rule_algorithm', default=False, session=session)
+        use_new_rule_algorithm = config_get('rules', 'use_new_rule_algorithm', default=False, session=session)
 
     try:
         rule = session.query(models.ReplicationRule).filter(models.ReplicationRule.id == rule_id).with_for_update(nowait=True).one()
@@ -2481,7 +2480,7 @@ def __evaluate_did_detach(eval_did, session=None, logger=logging.log):
     """
 
     logger(logging.INFO, "Re-Evaluating did %s:%s for DETACH", eval_did.scope, eval_did.name)
-    force_epoch = core_config_get('rules', 'force_epoch_when_detach', default=False, session=session)
+    force_epoch = config_get('rules', 'force_epoch_when_detach', default=False, session=session)
 
     with record_timer_block('rule.evaluate_did_detach'):
         # Get all parent DID's

--- a/lib/rucio/core/rule_grouping.py
+++ b/lib/rucio/core/rule_grouping.py
@@ -32,9 +32,9 @@ from datetime import datetime
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy import func
 
+from rucio.common.config import config_get
 from rucio.common.exception import InsufficientTargetRSEs
 from rucio.core import account_counter, rse_counter, request as request_core
-from rucio.core.config import get as core_config_get
 import rucio.core.did
 import rucio.core.lock
 import rucio.core.replica
@@ -1152,7 +1152,7 @@ def apply_rule(did, rule, rses, source_rses, rseselector, session=None, logger=l
     :param session:      the database session in use
     """
 
-    max_partition_size = core_config_get('rules', 'apply_rule_max_partition_size', default=2000, session=session)  # process dataset files in bunches of max this size
+    max_partition_size = config_get('rules', 'apply_rule_max_partition_size', default=2000, session=session)  # process dataset files in bunches of max this size
 
     # accounting counters
     rse_counters_files = {}

--- a/lib/rucio/core/subscription.py
+++ b/lib/rucio/core/subscription.py
@@ -27,6 +27,7 @@
 import datetime
 import logging
 import re
+from configparser import NoOptionError, NoSectionError
 
 from json import dumps
 
@@ -35,8 +36,8 @@ from sqlalchemy.exc import IntegrityError, StatementError
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.exc import NoResultFound
 
-from rucio.common.exception import SubscriptionNotFound, SubscriptionDuplicate, RucioException, ConfigNotFound
-from rucio.core.config import get
+from rucio.common.config import config_get
+from rucio.common.exception import SubscriptionNotFound, SubscriptionDuplicate, RucioException
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import SubscriptionState
 from rucio.db.sqla.session import transactional_session, stream_session, read_session
@@ -71,8 +72,8 @@ def add_subscription(name, account, filter_, replication_rules, comments, lifeti
     :returns:                  The subscriptionid
     """
     try:
-        keep_history = get('subscriptions', 'keep_history')
-    except ConfigNotFound:
+        keep_history = config_get('subscriptions', 'keep_history')
+    except (NoOptionError, NoSectionError, RuntimeError):
         keep_history = False
 
     SubscriptionHistory = models.SubscriptionHistory
@@ -135,8 +136,8 @@ def update_subscription(name, account, metadata=None, session=None):
     :raises: SubscriptionNotFound if subscription is not found
     """
     try:
-        keep_history = get('subscriptions', 'keep_history')
-    except ConfigNotFound:
+        keep_history = config_get('subscriptions', 'keep_history')
+    except (NoOptionError, NoSectionError, RuntimeError):
         keep_history = False
     values = {'state': SubscriptionState.UPDATED}
     if 'filter' in metadata and metadata['filter']:

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -66,7 +66,6 @@ from rucio.common.extra import import_extras
 from rucio.common.rse_attributes import get_rse_attributes
 from rucio.common.utils import construct_surl
 from rucio.core import did, message as message_core, request as request_core
-from rucio.core.config import get as core_config_get
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core.oidc import get_token_for_account_operation
 from rucio.core.replica import add_replicas, tombstone_from_delay
@@ -939,7 +938,7 @@ def __search_shortest_paths(
     The inbound links retrieved from the database can be accumulated into the inbound_links_by_node, passed
     from the calling context. To be able to reuse them.
     """
-    HOP_PENALTY = core_config_get('transfers', 'hop_penalty', default=10, session=session)  # Penalty to be applied to each further hop
+    HOP_PENALTY = config_get('transfers', 'hop_penalty', default=10, session=session)  # Penalty to be applied to each further hop
 
     if multihop_rses:
         # Filter out island source RSEs

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -66,6 +66,7 @@ from rucio.common.extra import import_extras
 from rucio.common.rse_attributes import get_rse_attributes
 from rucio.common.utils import construct_surl
 from rucio.core import did, message as message_core, request as request_core
+from rucio.core.config import get as core_config_get
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core.oidc import get_token_for_account_operation
 from rucio.core.replica import add_replicas, tombstone_from_delay

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -33,6 +33,7 @@ import random
 import socket
 import tempfile
 import threading
+from configparser import NoOptionError, NoSectionError
 from datetime import datetime
 from json import load
 from math import exp
@@ -42,13 +43,13 @@ from time import sleep, time
 import rucio.db.sqla.util
 from rucio.client import Client
 from rucio.common import exception
-from rucio.common.exception import FileReplicaAlreadyExists, ConfigNotFound
+from rucio.common.config import config_get
+from rucio.common.exception import FileReplicaAlreadyExists
 from rucio.common.logging import formatted_logger, setup_logging
 from rucio.common.types import InternalScope
 from rucio.common.utils import adler32, daemon_sleep
 from rucio.common.utils import execute, generate_uuid
 from rucio.core import monitor, heartbeat
-from rucio.core.config import get
 from rucio.core.scope import list_scopes
 from rucio.rse import rsemanager as rsemgr
 
@@ -174,13 +175,13 @@ def generate_file(fname, size, logger=logging.log):
 
 def generate_didname(metadata, dsn, did_type):
     try:
-        did_prefix = get('automatix', 'did_prefix')
-    except ConfigNotFound:
+        did_prefix = config_get('automatix', 'did_prefix')
+    except (NoOptionError, NoSectionError, RuntimeError):
         did_prefix = ''
     try:
-        pattern = get('automatix', '%s_pattern' % did_type)
-        separator = get('automatix', 'separator')
-    except ConfigNotFound:
+        pattern = config_get('automatix', '%s_pattern' % did_type)
+        separator = config_get('automatix', 'separator')
+    except (NoOptionError, NoSectionError, RuntimeError):
         return generate_uuid()
     fields = pattern.split(separator)
     file_name = ''
@@ -292,31 +293,31 @@ def run(total_workers=1, once=False, inputfile=None, sleep_time=-1):
         raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     try:
-        sites = [s.strip() for s in get('automatix', 'sites').split(',')]
-    except Exception:
+        sites = [s.strip() for s in config_get('automatix', 'sites').split(',')]
+    except (NoOptionError, NoSectionError, RuntimeError):
         raise Exception('Could not load sites from configuration')
     if not inputfile:
         inputfile = '/opt/rucio/etc/automatix.json'
     if sleep_time == -1:
         try:
-            sleep_time = get('automatix', 'sleep_time')
-        except Exception:
+            sleep_time = config_get('automatix', 'sleep_time')
+        except (NoOptionError, NoSectionError, RuntimeError):
             sleep_time = 30
     try:
-        account = get('automatix', 'account')
-    except Exception:
+        account = config_get('automatix', 'account')
+    except (NoOptionError, NoSectionError, RuntimeError):
         account = 'root'
     try:
-        dataset_lifetime = get('automatix', 'dataset_lifetime')
-    except Exception:
+        dataset_lifetime = config_get('automatix', 'dataset_lifetime')
+    except (NoOptionError, NoSectionError, RuntimeError):
         dataset_lifetime = None
     try:
-        set_metadata = get('automatix', 'set_metadata')
-    except Exception:
+        set_metadata = config_get('automatix', 'set_metadata')
+    except (NoOptionError, NoSectionError, RuntimeError):
         set_metadata = False
 
     try:
-        scope = get('automatix', 'scope')
+        scope = config_get('automatix', 'scope')
         client = Client()
         filters = {'scope': InternalScope('*', vo=client.vo)}
         if InternalScope(scope, vo=client.vo) not in list_scopes(filter_=filters):

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -41,6 +41,8 @@ Methods common to different conveyor submitter daemons.
 
 from __future__ import division
 
+from configparser import NoOptionError, NoSectionError
+from json import loads
 import datetime
 import functools
 import logging
@@ -49,10 +51,9 @@ from json import loads
 
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import (InvalidRSEExpression, TransferToolTimeout, TransferToolWrongAnswer, RequestNotFound,
-                                    ConfigNotFound, DuplicateFileTransferSubmission, VONotFound)
-from rucio.common.utils import chunks
+                                    DuplicateFileTransferSubmission, VONotFound)
+from rucio.common.utils import chunks, set_checksum_value
 from rucio.core import request, transfer as transfer_core
-from rucio.core.config import get
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core.rse import list_rses
 from rucio.core.rse_expression_parser import parse_expression
@@ -262,14 +263,14 @@ def bulk_group_transfers_for_fts(transfers, policy='rule', group_bulk=200, sourc
     grouped_jobs = []
 
     try:
-        default_source_strategy = get(section='conveyor', option='default-source-strategy')
-    except ConfigNotFound:
+        default_source_strategy = config_get(section='conveyor', option='default-source-strategy')
+    except (NoOptionError, NoSectionError, RuntimeError):
         default_source_strategy = 'orderly'
 
     try:
-        activity_source_strategy = get(section='conveyor', option='activity-source-strategy')
+        activity_source_strategy = config_get(section='conveyor', option='activity-source-strategy')
         activity_source_strategy = loads(activity_source_strategy)
-    except ConfigNotFound:
+    except (NoOptionError, NoSectionError, RuntimeError):
         activity_source_strategy = {}
     except ValueError:
         logger(logging.WARNING, 'activity_source_strategy not properly defined')

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -42,17 +42,16 @@ Methods common to different conveyor submitter daemons.
 from __future__ import division
 
 from configparser import NoOptionError, NoSectionError
-from json import loads
 import datetime
 import functools
 import logging
 import time
 from json import loads
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get
 from rucio.common.exception import (InvalidRSEExpression, TransferToolTimeout, TransferToolWrongAnswer, RequestNotFound,
                                     DuplicateFileTransferSubmission, VONotFound)
-from rucio.common.utils import chunks, set_checksum_value
+from rucio.common.utils import chunks
 from rucio.core import request, transfer as transfer_core
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core.rse import list_rses
@@ -360,7 +359,7 @@ def get_conveyor_rses(rses=None, include_rses=None, exclude_rses=None, vos=None,
     :param logger:        Optional decorated logger that can be passed from the calling daemons or servers.
     :return:              List of working rses
     """
-    multi_vo = config_get_bool('common', 'multi_vo', raise_exception=False, default=False)
+    multi_vo = config_get('common', 'multi_vo', raise_exception=False, default=False)
     if not multi_vo:
         if vos:
             logger(logging.WARNING, 'Ignoring argument vos, this is only applicable in a multi-VO setup.')

--- a/lib/rucio/daemons/hermes/hermes2.py
+++ b/lib/rucio/daemons/hermes/hermes2.py
@@ -41,6 +41,7 @@ import socket
 import sys
 import threading
 import time
+from configparser import NoOptionError, NoSectionError
 from email.mime.text import MIMEText
 
 import requests
@@ -49,11 +50,10 @@ from six import PY2
 
 import rucio.db.sqla.util
 from rucio.common.config import config_get, config_get_int, config_get_bool
-from rucio.common.exception import ConfigNotFound, DatabaseException
+from rucio.common.exception import DatabaseException
 from rucio.common.logging import setup_logging, formatted_logger
 from rucio.common.utils import daemon_sleep
 from rucio.core import heartbeat
-from rucio.core.config import get
 from rucio.core.message import retrieve_messages, delete_messages, update_messages_services
 from rucio.core.monitor import MultiCounter
 
@@ -427,9 +427,9 @@ def hermes2(once=False, thread=0, bulk=1000, sleep_time=10):
     logger = formatted_logger(logging.log, prepend_str + '%s')
 
     try:
-        services_list = get('hermes', 'services_list')
+        services_list = config_get('hermes', 'services_list')
         services_list = services_list.split(',')
-    except ConfigNotFound:
+    except (NoOptionError, NoSectionError, RuntimeError):
         logger(logging.DEBUG, 'No services found, exiting')
         sys.exit(1)
     if 'influx' in services_list:

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -43,6 +43,7 @@ import threading
 import time
 import traceback
 from collections import OrderedDict
+from configparser import NoOptionError, NoSectionError
 from datetime import datetime, timedelta
 from math import ceil
 from typing import TYPE_CHECKING
@@ -54,14 +55,13 @@ from sqlalchemy.exc import DatabaseError, IntegrityError
 
 import rucio.db.sqla.util
 from rucio.common.config import config_get, config_get_bool
-from rucio.common.exception import (DatabaseException, RSENotFound, ConfigNotFound,
+from rucio.common.exception import (DatabaseException, RSENotFound,
                                     ReplicaUnAvailable, ReplicaNotFound, ServiceUnavailable,
                                     RSEAccessDenied, ResourceTemporaryUnavailable, SourceNotFound,
                                     VONotFound)
 from rucio.common.logging import formatted_logger, setup_logging
 from rucio.common.utils import chunks, daemon_sleep
 from rucio.core import monitor
-from rucio.core.config import get
 from rucio.core.credential import get_signed_url
 from rucio.core.heartbeat import live, die, sanity_check, list_payload_counts
 from rucio.core.message import add_message
@@ -289,11 +289,11 @@ def get_max_deletion_threads_by_hostname(hostname):
     result = REGION.get('max_deletion_threads_%s' % hostname)
     if result is NO_VALUE:
         try:
-            max_deletion_thread = get('reaper', 'max_deletion_threads_%s' % hostname)
-        except ConfigNotFound:
+            max_deletion_thread = config_get('reaper', 'max_deletion_threads_%s' % hostname)
+        except (NoOptionError, NoSectionError, RuntimeError):
             try:
-                max_deletion_thread = get('reaper', 'nb_workers_by_hostname')
-            except ConfigNotFound:
+                max_deletion_thread = config_get('reaper', 'nb_workers_by_hostname')
+            except (NoOptionError, NoSectionError, RuntimeError):
                 max_deletion_thread = 5
         REGION.set('max_deletion_threads_%s' % hostname, max_deletion_thread)
         result = max_deletion_thread
@@ -424,19 +424,19 @@ def reaper(rses, include_rses, exclude_rses, vos=None, chunk_size=100, once=Fals
     while not GRACEFUL_STOP.is_set():
         # try to get auto exclude parameters from the config table. Otherwise use CLI parameters.
         try:
-            auto_exclude_threshold = get('reaper', 'auto_exclude_threshold', default=auto_exclude_threshold)
-            auto_exclude_timeout = get('reaper', 'auto_exclude_timeout', default=auto_exclude_timeout)
-        except ConfigNotFound:
+            auto_exclude_threshold = config_get('reaper', 'auto_exclude_threshold', default=auto_exclude_threshold)
+            auto_exclude_timeout = config_get('reaper', 'auto_exclude_timeout', default=auto_exclude_timeout)
+        except (NoOptionError, NoSectionError, RuntimeError):
             pass
 
         # Check if there is a Judge Evaluator backlog
         try:
-            max_evaluator_backlog_count = get('reaper', 'max_evaluator_backlog_count')
-        except ConfigNotFound:
+            max_evaluator_backlog_count = config_get('reaper', 'max_evaluator_backlog_count')
+        except (NoOptionError, NoSectionError, RuntimeError):
             max_evaluator_backlog_count = None
         try:
-            max_evaluator_backlog_duration = get('reaper', 'max_evaluator_backlog_duration')
-        except ConfigNotFound:
+            max_evaluator_backlog_duration = config_get('reaper', 'max_evaluator_backlog_duration')
+        except (NoOptionError, NoSectionError, RuntimeError):
             max_evaluator_backlog_duration = None
         if max_evaluator_backlog_count or max_evaluator_backlog_duration:
             backlog = get_evaluation_backlog()

--- a/lib/rucio/daemons/tracer/kronos.py
+++ b/lib/rucio/daemons/tracer/kronos.py
@@ -35,6 +35,7 @@ This daemon consumes tracer messages from ActiveMQ and updates the atime for rep
 import logging
 import re
 import socket
+from configparser import NoOptionError, NoSectionError
 from datetime import datetime
 from json import loads as jloads, dumps as jdumps
 from os import getpid
@@ -45,11 +46,10 @@ from stomp import Connection
 
 import rucio.db.sqla.util
 from rucio.common.config import config_get, config_get_bool, config_get_int
-from rucio.common.exception import ConfigNotFound, RSENotFound, DatabaseException
+from rucio.common.exception import RSENotFound, DatabaseException
 from rucio.common.logging import setup_logging, formatted_logger
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import daemon_sleep
-from rucio.core.config import get
 from rucio.core.did import touch_dids, list_parent_dids
 from rucio.core.heartbeat import live, die, sanity_check
 from rucio.core.lock import touch_dataset_locks
@@ -360,12 +360,12 @@ def kronos_file(thread=0, dataset_queue=None, sleep_time=60):
     subscription_id = config_get('tracer-kronos', 'subscription_id')
     try:
         bad_files_patterns = []
-        pattern = get(section='kronos', option='bad_files_patterns', session=None)
+        pattern = config_get(section='kronos', option='bad_files_patterns', session=None)
         pattern = str(pattern)
         patterns = pattern.split(",")
         for pat in patterns:
             bad_files_patterns.append(re.compile(pat.strip()))
-    except ConfigNotFound:
+    except (NoOptionError, NoSectionError, RuntimeError):
         bad_files_patterns = []
     except Exception as error:
         logging.log(logging.ERROR, 'kronos_file[%i/?] Failed to get bad_file_patterns %s', thread, str(error))

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -53,7 +53,7 @@ except:
 DATABASE_SECTION = 'database'
 try:
     if CURRENT_COMPONENT:
-        sql_connection = config_get('%s-database' % CURRENT_COMPONENT, 'default').strip()
+        sql_connection = config_get('%s-database' % CURRENT_COMPONENT, 'default', check_config_table=False).strip()
         if sql_connection and len(sql_connection):
             DATABASE_SECTION = '%s-database' % CURRENT_COMPONENT
 except:
@@ -61,7 +61,7 @@ except:
 
 BASE = declarative_base()
 DEFAULT_SCHEMA_NAME = config_get(DATABASE_SECTION, 'schema',
-                                 raise_exception=False, default=None)
+                                 raise_exception=False, default=None, check_config_table=False)
 if DEFAULT_SCHEMA_NAME:
     BASE.metadata.schema = DEFAULT_SCHEMA_NAME
 

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -183,7 +183,7 @@ def get_engine():
             params['connect_args'] = {'conv': conv}
         for param, param_type in config_params:
             try:
-                params[param] = param_type(config_get(DATABASE_SECTION, param))
+                params[param] = param_type(config_get(DATABASE_SECTION, param, check_config_table=False))
             except:
                 pass
         _ENGINE = create_engine(sql_connection, **params)
@@ -219,7 +219,7 @@ def get_dump_engine(echo=False):
             print(statement.replace(')', ');\n'))
         else:
             print(statement)
-    sql_connection = config_get(DATABASE_SECTION, 'default')
+    sql_connection = config_get(DATABASE_SECTION, 'default', check_config_table=False)
 
     engine = create_engine(sql_connection, echo=echo, strategy='mock', executor=dump)
     return engine

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -173,7 +173,7 @@ def get_engine():
     """
     global _ENGINE
     if not _ENGINE:
-        sql_connection = config_get(DATABASE_SECTION, 'default')
+        sql_connection = config_get(DATABASE_SECTION, 'default', check_config_table=False)
         config_params = [('pool_size', int), ('max_overflow', int), ('pool_timeout', int),
                          ('pool_recycle', int), ('echo', int), ('echo_pool', str),
                          ('pool_reset_on_return', str), ('use_threadlocal', int)]

--- a/lib/rucio/db/sqla/util.py
+++ b/lib/rucio/db/sqla/util.py
@@ -60,7 +60,7 @@ def build_database():
     """ Applies the schema to the database. Run this command once to build the database. """
     engine = get_engine()
 
-    schema = config_get('database', 'schema', raise_exception=False)
+    schema = config_get('database', 'schema', raise_exception=False, check_config_table=False)
     if schema:
         print('Schema set in config, trying to create schema:', schema)
         try:

--- a/lib/rucio/rse/__init__.py
+++ b/lib/rucio/rse/__init__.py
@@ -23,30 +23,21 @@
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
+# - Gabriele Fronzé <sucre.91@hotmail.it>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from dogpile.cache import make_region
 
+from rucio.common.utils import is_client
 from rucio.rse import rsemanager
 from rucio.common import config
-from os import environ
 
-if 'RUCIO_CLIENT_MODE' not in environ:
-    if config.config_has_section('database'):
-        setattr(rsemanager, 'CLIENT_MODE', False)
-        setattr(rsemanager, 'SERVER_MODE', True)
-    elif config.config_has_section('client'):
-        setattr(rsemanager, 'CLIENT_MODE', True)
-        setattr(rsemanager, 'SERVER_MODE', False)
-    else:
-        setattr(rsemanager, 'CLIENT_MODE', False)
-        setattr(rsemanager, 'SERVER_MODE', True)
+if is_client():
+    setattr(rsemanager, 'CLIENT_MODE', True)
+    setattr(rsemanager, 'SERVER_MODE', False)
 else:
-    if environ['RUCIO_CLIENT_MODE']:
-        setattr(rsemanager, 'CLIENT_MODE', True)
-        setattr(rsemanager, 'SERVER_MODE', False)
-    else:
-        setattr(rsemanager, 'CLIENT_MODE', False)
-        setattr(rsemanager, 'SERVER_MODE', True)
+    setattr(rsemanager, 'CLIENT_MODE', False)
+    setattr(rsemanager, 'SERVER_MODE', True)
 
 
 def get_rse_client(rse, vo='def', **kwarg):


### PR DESCRIPTION
**Core: config_get search in cfg and in config table. Closes #2630**

The ticket description is outdated. The changes that this PR covers are:
- There is only one `config_get` (in `rucio.common`) method to retrieve all the configuration (both from config file and from config table).
- The method first checks in the configuration file (cfg) and, if the `(section, option)` pair is not found, looks in the configuration table only for server/daemon. Even if it is called from server/daemon, it is possible to avoid looking at the config table with the `check_config_table` argument in order to avoid circular imports and other issues such as trying to get config from the DB if the DB is not created yet (the section _database_ cannot be retrieved from config table).
- Created new method (`is_client`) in `rucio.common.utils` to check if it is called from a client or from a server/daemon. Code from: https://github.com/rucio/rucio/blob/900b555970e25d7e6b7137d4c725ebc9f0027a08/lib/rucio/rse/__init__.py#L33-L49
- Refactor all the calls to `rucio.core.get` to use the new method.

