### PR TITLE
Remove client_cert and client_key from cfg templates. Closes #4787

### DIFF
--- a/etc/rucio.cfg.atlas.client.template
+++ b/etc/rucio.cfg.atlas.client.template
@@ -1,25 +1,32 @@
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2014-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2018
-# - Nicolo Magini, <nicolo.magini@cern.ch>, 2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2014
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2018
+# - Nicolo Magini <nicolo.magini@cern.ch>, 2018
+# - Tomas Javurek <tomas.javurek@cern.ch>, 2019
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 [common]
 
 [client]
 rucio_host = https://voatlasrucio-server-prod.cern.ch:443
 auth_host = https://voatlasrucio-auth-prod.cern.ch:443
-ca_cert =
-client_cert = $X509_USER_PROXY
-client_key = $X509_USER_PROXY
 client_x509_proxy = $X509_USER_PROXY
 request_retries = 3
-auth_type = x509
+auth_type = x509_proxy
 
 [policy]
 permission = atlas

--- a/etc/rucio.cfg.template
+++ b/etc/rucio.cfg.template
@@ -1,3 +1,37 @@
+# Copyright 2012-2021 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2020
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2017
+# - Thomas Beermann <thomas.beermann@cern.ch>, 2012-2021
+# - Luis Rodrigues <lfrodrigues@gmail.com>, 2013
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2013
+# - Wen Guan <wen.guan@cern.ch>, 2014
+# - Fernando López <felopez@cern.ch>, 2015
+# - Martin Barisits <martin.barisits@cern.ch>, 2015-2017
+# - Vitjan Zavrtanik <vitjan.zavrtanik@cern.ch>, 2017
+# - Stefan Prenner <stefan.prenner@cern.ch>, 2018
+# - Nicolo Magini <nicolo.magini@cern.ch>, 2018
+# - Frank Berghaus <berghaus@cern.ch>, 2019
+# - Dilaksun Bavarajan <dilaksun.bavarajan@cern.ch>, 2019
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019
+# - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+
 [common]
 logdir = /var/log/rucio
 loglevel = DEBUG
@@ -14,10 +48,10 @@ auth_type = userpass
 username = ddmlab
 password = secret
 ca_cert = /opt/rucio/etc/web/ca.crt
-client_cert = /opt/rucio/etc/web/client.crt
-client_key = /opt/rucio/etc/web/client.key
-client_x509_proxy = $X509_USER_PROXY
-ssh_private_key = $HOME/.ssh/id_rsa
+#client_cert = /opt/rucio/etc/web/client.crt
+#client_key = /opt/rucio/etc/web/client.key
+#client_x509_proxy = $X509_USER_PROXY
+#ssh_private_key = $HOME/.ssh/id_rsa
 account = root
 request_retries = 3
 protocol_stat_retries = 6

--- a/etc/rucio_multi_vo.cfg.template
+++ b/etc/rucio_multi_vo.cfg.template
@@ -1,17 +1,21 @@
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright 2020-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2012-2018
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2012, 2015-2016
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2013
-# - Nicolo Magini, <nicolo.magini@cern.ch>, 2018
-# - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
-# - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
-# - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 [common]
 logdir = /var/log/rucio
@@ -29,10 +33,10 @@ auth_type = userpass
 username = ddmlab
 password = secret
 ca_cert = /opt/rucio/etc/web/ca.crt
-client_cert = /opt/rucio/etc/web/client.crt
-client_key = /opt/rucio/etc/web/client.key
-client_x509_proxy = $X509_USER_PROXY
-ssh_private_key = $HOME/.ssh/id_rsa
+#client_cert = /opt/rucio/etc/web/client.crt
+#client_key = /opt/rucio/etc/web/client.key
+#client_x509_proxy = $X509_USER_PROXY
+#ssh_private_key = $HOME/.ssh/id_rsa
 account = root
 vo = tst
 request_retries = 3


### PR DESCRIPTION
Remove client_cert and client_key from cfg templates. Closes #4787
