### PR TITLE
Authentication: X509 auth in the WebUI fails multiple accounts. Closes #4810

### DIFF
--- a/lib/rucio/web/ui/flask/common/utils.py
+++ b/lib/rucio/web/ui/flask/common/utils.py
@@ -20,7 +20,6 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
 # - Dhruv Sondhi <dhruvsondhi05@gmail.com>, 2021
-# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 import re
 import sys
@@ -188,6 +187,9 @@ def select_account_name(identitystr, identity_type, vo=None):
             if account_info.account_type == AccountType.USER:
                 def_account = account
                 break
+        selected_account = request.cookies.get('rucio-selected-account')
+        if (selected_account):
+            def_account = selected_account
         ui_account = def_account
     return ui_account, vo
 

--- a/lib/rucio/web/ui/flask/common/utils.py
+++ b/lib/rucio/web/ui/flask/common/utils.py
@@ -20,6 +20,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
 # - Dhruv Sondhi <dhruvsondhi05@gmail.com>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 import re
 import sys
@@ -187,9 +188,6 @@ def select_account_name(identitystr, identity_type, vo=None):
             if account_info.account_type == AccountType.USER:
                 def_account = account
                 break
-        selected_account = request.cookies.get('rucio-selected-account')
-        if (selected_account):
-            def_account = selected_account
         ui_account = def_account
     return ui_account, vo
 

--- a/lib/rucio/web/ui/flask/common/utils.py
+++ b/lib/rucio/web/ui/flask/common/utils.py
@@ -20,6 +20,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
 # - Dhruv Sondhi <dhruvsondhi05@gmail.com>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 import re
 import sys
@@ -188,7 +189,7 @@ def select_account_name(identitystr, identity_type, vo=None):
                 def_account = account
                 break
         selected_account = request.cookies.get('rucio-selected-account')
-        if (selected_account):
+        if selected_account in accounts:
             def_account = selected_account
         ui_account = def_account
     return ui_account, vo


### PR DESCRIPTION
**Authentication: X509 auth in the WebUI fails multiple accounts. Closes #4810**

When logging in the first time with a certificate, it saves a cookie that Rucio retrieves in following sessions. If later try to log in with another certificate (mapped with another account than the first one), the cookie will still have the first account and the log in fails with the following error:
```html
<br><br>Your certificate (/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=Alice) is not mapped to (possibly any) rucio account: ana.
```
