### PR TITLE
Clients: --all-states show the states. Closes #3431

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -80,7 +80,7 @@ from rucio.common.extra import import_extras
 from rucio.common.test_rucio_server import TestRucioServer
 from rucio.common.utils import sizefmt, Color, detect_client_location, chunks, parse_did_filter_from_string, \
     extract_scope, setup_logger
-from rucio.db.sqla.constants import ReplicaState
+from rucio.common.constants import ReplicaState
 
 EXTRA_MODULES = import_extras(['argcomplete'])
 

--- a/bin/rucio
+++ b/bin/rucio
@@ -454,7 +454,7 @@ def list_file_replicas(args):
                     for rse in replica['rses']:
                         for pfn in replica['rses'][rse]:
                             if args.all_states:
-                                rse_string = '({2}) {0} {1}'.format(rse, pfn, ReplicaState[replica['states'][rse]].value)
+                                rse_string = '({2}) {0}: {1}'.format(rse, pfn, ReplicaState[replica['states'][rse]].value)
                             else:
                                 rse_string = '{0}: {1}'.format(rse, pfn)
                             if args.selected_rse:

--- a/bin/rucio
+++ b/bin/rucio
@@ -80,6 +80,7 @@ from rucio.common.extra import import_extras
 from rucio.common.test_rucio_server import TestRucioServer
 from rucio.common.utils import sizefmt, Color, detect_client_location, chunks, parse_did_filter_from_string, \
     extract_scope, setup_logger
+from rucio.db.sqla.constants import ReplicaState
 
 EXTRA_MODULES = import_extras(['argcomplete'])
 
@@ -444,16 +445,24 @@ def list_file_replicas(args):
                             for pfn in replica['rses'][rse]:
                                 print(pfn)
         else:
+            if args.all_states:
+                header = ['SCOPE', 'NAME', 'FILESIZE', 'ADLER32', '(STATE) RSE: REPLICA']
+            else:
+                header = ['SCOPE', 'NAME', 'FILESIZE', 'ADLER32', 'RSE: REPLICA']
             for replica in replicas:
                 if 'bytes' in replica:
                     for rse in replica['rses']:
                         for pfn in replica['rses'][rse]:
+                            if args.all_states:
+                                rse_string = '({2}) {0} {1}'.format(rse, pfn, ReplicaState[replica['states'][rse]].value)
+                            else:
+                                rse_string = '{0}: {1}'.format(rse, pfn)
                             if args.selected_rse:
                                 if rse == args.selected_rse:
-                                    table.append([replica['scope'], replica['name'], sizefmt(replica['bytes'], args.human), replica['adler32'], '{0}: {1}'.format(rse, pfn)])
+                                    table.append([replica['scope'], replica['name'], sizefmt(replica['bytes'], args.human), replica['adler32'], rse_string])
                             else:
-                                table.append([replica['scope'], replica['name'], sizefmt(replica['bytes'], args.human), replica['adler32'], '{0}: {1}'.format(rse, pfn)])
-            print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE', 'NAME', 'FILESIZE', 'ADLER32', 'RSE: REPLICA'], disable_numparse=True))
+                                table.append([replica['scope'], replica['name'], sizefmt(replica['bytes'], args.human), replica['adler32'], rse_string])
+            print(tabulate(table, tablefmt=tablefmt, headers=header, disable_numparse=True))
 
     return SUCCESS
 
@@ -1848,7 +1857,9 @@ To list the missing replica of a dataset of a given RSE::
     ''')
     list_file_replicas_parser.set_defaults(function=list_file_replicas)
     list_file_replicas_parser.add_argument('--protocols', dest='protocols', action='store', help='List of comma separated protocols. (i.e. https, root, srm).', required=False)
-    list_file_replicas_parser.add_argument('--all-states', dest='all_states', action='store_true', default=False, help='To select all replicas (including unavailable ones).', required=False)
+    list_file_replicas_parser.add_argument('--all-states', dest='all_states', action='store_true', default=False, help='To select all replicas (including unavailable ones).\
+            Also gets information about the current state of a DID in each RSE.\
+            Legend: ' + ', '.join(["{0} = {1}".format(state.value, state.name) for state in ReplicaState]), required=False)
     list_file_replicas_parser.add_argument(dest='dids', nargs='+', action='store', help='List of space separated data identifiers.')
     list_file_replicas_parser.add_argument('--pfns', default=False, action='store_true', help='Show only the PFNs.', required=False)
     list_file_replicas_parser.add_argument('--domain', default=None, action='store', help='Force the networking domain. Available options: wan, lan, all.', required=False)

--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -20,8 +20,10 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018-2021
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Sahan Dilshan <32576163+sahandilshan@users.noreply.github.com>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from collections import namedtuple
+from enum import Enum
 
 """
 Constants.
@@ -52,3 +54,13 @@ FTS_STATE = namedtuple('FTS_STATE', ['SUBMITTED', 'READY', 'ACTIVE', 'FAILED', '
                                                   'CANCELED')
 
 FTS_COMPLETE_STATE = namedtuple('FTS_COMPLETE_STATE', ['OK', 'ERROR'])('Ok', 'Error')
+
+
+class ReplicaState(Enum):
+    # From rucio.db.sqla.constants, update that file at the same time than this
+    AVAILABLE = 'A'
+    UNAVAILABLE = 'U'
+    COPYING = 'C'
+    BEING_DELETED = 'B'
+    BAD = 'D'
+    TEMPORARY_UNAVAILABLE = 'T'

--- a/lib/rucio/db/sqla/constants.py
+++ b/lib/rucio/db/sqla/constants.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2020 CERN
+# Copyright 2015-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - Sahan Dilshan <32576163+sahandilshan@users.noreply.github.com>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from datetime import datetime
 from enum import Enum
@@ -116,6 +118,7 @@ class LockState(Enum):
 
 
 class ReplicaState(Enum):
+    # Update rucio.common.constants at the same time than this
     AVAILABLE = 'A'
     UNAVAILABLE = 'U'
     COPYING = 'C'


### PR DESCRIPTION
**Clients: --all-states show the states. Closes #3431**
 Show the states when executing `rucio list-file-replicas` with `--all-states` flag. Example:
```
[root@904674d3c00a rucio]# rucio list-file-replicas --all-states test:container
+---------+--------+------------+-----------+---------------------------------------------------+
| SCOPE   | NAME   | FILESIZE   | ADLER32   | (STATE) RSE: REPLICA                              |
|---------+--------+------------+-----------+---------------------------------------------------|
| test    | file1  | 10.486 MB  | 8017409e  | (A) XRD1 root://xrd1:1094//rucio/test/80/25/file1 |
| test    | file1  | 10.486 MB  | 8017409e  | (C) XRD3 root://xrd3:1096//rucio/test/80/25/file1 |
| test    | file2  | 10.486 MB  | 6b9b1453  | (A) XRD1 root://xrd1:1094//rucio/test/f3/14/file2 |
| test    | file2  | 10.486 MB  | 6b9b1453  | (C) XRD3 root://xrd3:1096//rucio/test/f3/14/file2 |
| test    | file3  | 10.486 MB  | f0896aea  | (A) XRD2 root://xrd2:1095//rucio/test/a9/23/file3 |
| test    | file3  | 10.486 MB  | f0896aea  | (C) XRD3 root://xrd3:1096//rucio/test/a9/23/file3 |
| test    | file4  | 10.486 MB  | f11f5845  | (A) XRD2 root://xrd2:1095//rucio/test/2b/c2/file4 |
| test    | file4  | 10.486 MB  | f11f5845  | (C) XRD3 root://xrd3:1096//rucio/test/2b/c2/file4 |
+---------+--------+------------+-----------+---------------------------------------------------+


```
Update the help with the legend extracted from: https://github.com/rucio/rucio/blob/7c8f6ae1adfa0d41e533da572997bdfed6c555e1/lib/rucio/db/sqla/constants.py#L118-L124