### PR TITLE
client: make account optional

### DIFF
--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -71,7 +71,8 @@ class TestBinRucio(unittest.TestCase):
                 # Client-only test, only use config with no DB config
                 self.vo = {'vo': get_long_vo()}
             try:
-                remove(get_tmp_dir() + '/.rucio_root@%s/auth_token_root' % self.vo['vo'])
+                remove(get_tmp_dir()
+                       + '/.rucio_root@%s/auth_token_for_account_root' % self.vo['vo'])
             except OSError as error:
                 if error.args[0] != 2:
                     raise error
@@ -79,7 +80,7 @@ class TestBinRucio(unittest.TestCase):
     def setUp(self):
         self.conf_vo()
         try:
-            remove(get_tmp_dir() + '/.rucio_root/auth_token_root')
+            remove(get_tmp_dir() + '/.rucio_root/auth_token_for_account_root')
         except OSError as e:
             if e.args[0] != 2:
                 raise e

--- a/lib/rucio/tests/test_clients.py
+++ b/lib/rucio/tests/test_clients.py
@@ -98,7 +98,8 @@ class TestBaseClient(unittest.TestCase):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
             self.vo = {'vo': get_long_vo()}
             try:
-                remove(get_tmp_dir() + '/.rucio_root@%s/auth_token_root' % self.vo['vo'])
+                remove(get_tmp_dir()
+                       + '/.rucio_root@%s/auth_token_for_account_root' % self.vo['vo'])
             except OSError as error:
                 if error.args[0] != 2:
                     raise error
@@ -110,7 +111,7 @@ class TestBaseClient(unittest.TestCase):
         self.usercert = config_get('test', 'usercert')
         self.userkey = config_get('test', 'userkey')
         try:
-            remove(get_tmp_dir() + '/.rucio_root/auth_token_root')
+            remove(get_tmp_dir() + '/.rucio_root/auth_token_for_account_root')
         except OSError as error:
             if error.args[0] != 2:
                 raise error

--- a/lib/rucio/tests/test_multi_vo.py
+++ b/lib/rucio/tests/test_multi_vo.py
@@ -986,12 +986,14 @@ class TestMultiVOBinRucio(unittest.TestCase):
             add_rse(cls.rse_new, 'root', **cls.new_vo)
 
             try:
-                remove(get_tmp_dir() + '/.rucio_root@%s/auth_token_root' % cls.vo['vo'])
+                remove(get_tmp_dir()
+                       + '/.rucio_root@%s/auth_token_for_account_root' % cls.vo['vo'])
             except OSError as e:
                 if e.args[0] != 2:
                     raise e
             try:
-                remove(get_tmp_dir() + '/.rucio_root@%s/auth_token_root' % cls.new_vo['vo'])
+                remove(get_tmp_dir()
+                       + '/.rucio_root@%s/auth_token_for_account_root' % cls.new_vo['vo'])
             except OSError as e:
                 if e.args[0] != 2:
                     raise e


### PR DESCRIPTION
Motivation:

Rucio supports the concept of a default account: the authentication
credentials may indicate an account that is used if the client provides
no account information.

However, the rucio client currently requires an explicit account is
supplied.

Modification:

Make account optional: do not fail if one cannot be found.

Update token storage to reflect whether the account is known or whether
the default account is being used.

Result:

The Rucio 'account' is no longer required by the client.

Closes: #4802

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
