### PR TITLE
Clients: support default accounts. Closes #4802

### DIFF
--- a/lib/rucio/api/authentication.py
+++ b/lib/rucio/api/authentication.py
@@ -24,6 +24,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from rucio.api import permission
 from rucio.common import exception
@@ -137,6 +138,11 @@ def get_auth_token_user_pass(account, username, password, appid, ip=None, vo='de
 
     :returns: A dict with token and expires_at entries.
     """
+    if account is None:
+        account = identity.get_default_account(username, IdentityType.USERPASS).external
+        if account is None:
+            raise exception.AccountNotFound('Cannot find a default account for (%s, %s)' %
+                                            (username, IdentityType.USERPASS))
 
     kwargs = {'account': account, 'username': username, 'password': password}
     if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_user_pass', kwargs=kwargs):
@@ -161,6 +167,10 @@ def get_auth_token_gss(account, gsscred, appid, ip=None, vo='def'):
 
     :returns: A dict with token and expires_at entries.
     """
+    if account is None:
+        account = identity.get_default_account(gsscred, IdentityType.GSS).external
+        if account is None:
+            raise exception.AccountNotFound('Cannot find a default account for (%s, %s)' % (gsscred, IdentityType.GSS))
 
     kwargs = {'account': account, 'gsscred': gsscred}
     if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_gss', kwargs=kwargs):
@@ -188,6 +198,8 @@ def get_auth_token_x509(account, dn, appid, ip=None, vo='def'):
 
     if account is None:
         account = identity.get_default_account(dn, IdentityType.X509).external
+        if account is None:
+            raise exception.AccountNotFound('Cannot find a default account for (%s, %s)' % (dn, IdentityType.X509))
 
     kwargs = {'account': account, 'dn': dn}
     if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_x509', kwargs=kwargs):
@@ -212,6 +224,11 @@ def get_auth_token_ssh(account, signature, appid, ip=None, vo='def'):
 
     :returns: A dict with token and expires_at entries.
     """
+    if account is None:
+        account = identity.get_default_account(signature, IdentityType.SSH).external
+        if account is None:
+            raise exception.AccountNotFound('Cannot find a default account for (%s, %s)' %
+                                            (signature, IdentityType.SSH))
 
     kwargs = {'account': account, 'signature': signature}
     if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_ssh', kwargs=kwargs):
@@ -258,6 +275,11 @@ def get_auth_token_saml(account, saml_nameid, appid, ip=None, vo='def'):
 
     :returns: A dict with token and expires_at entries.
     """
+    if account is None:
+        account = identity.get_default_account(saml_nameid, IdentityType.SAML).external
+        if account is None:
+            raise exception.AccountNotFound('Cannot find a default account for (%s, %s)' %
+                                            (saml_nameid, IdentityType.SAML))
 
     kwargs = {'account': account, 'saml_nameid': saml_nameid}
     if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_saml', kwargs=kwargs):

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -655,7 +655,6 @@ class BaseClient(object):
         client_cert = None
         client_key = None
         if self.auth_type == 'x509':
-            LOG.info("X509")
             url = build_url(self.auth_host, path='auth/x509')
             client_cert = self.creds['client_cert']
             if 'client_key' in self.creds:

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -276,7 +276,7 @@ class BaseClient(object):
                 try:
                     self.account = config_get('client', 'account')
                 except (NoOptionError, NoSectionError):
-                    raise MissingClientParameter('Option \'account\' cannot be found in config file and RUCIO_ACCOUNT is not set.')
+                    LOG.debug("No account in config file, trying to use default account.")
 
         if vo is None:
             LOG.debug('No VO passed. Trying to get it from environment variable RUCIO_VO.')
@@ -294,13 +294,13 @@ class BaseClient(object):
         if self.auth_token_file_path:
             self.token_file = self.auth_token_file_path
             self.token_path = '/'.join(self.token_file.split('/')[:-1])
-            self.token_exp_epoch_file = self.token_path + '/' + self.TOKEN_EXP_PREFIX + self.account
+            self.token_exp_epoch_file = self.token_path + '/' + self.TOKEN_EXP_PREFIX + str(self.account)
         else:
-            self.token_path = self.TOKEN_PATH_PREFIX + self.account
+            self.token_path = self.TOKEN_PATH_PREFIX + str(self.account)
             if self.vo != 'def':
                 self.token_path += '@%s' % self.vo
-            self.token_file = self.token_path + '/' + self.TOKEN_PREFIX + self.account
-            self.token_exp_epoch_file = self.token_path + '/' + self.TOKEN_EXP_PREFIX + self.account
+            self.token_file = self.token_path + '/' + self.TOKEN_PREFIX + str(self.account)
+            self.token_exp_epoch_file = self.token_path + '/' + self.TOKEN_EXP_PREFIX + str(self.account)
 
         self.__authenticate()
 
@@ -655,6 +655,7 @@ class BaseClient(object):
         client_cert = None
         client_key = None
         if self.auth_type == 'x509':
+            LOG.info("X509")
             url = build_url(self.auth_host, path='auth/x509')
             client_cert = self.creds['client_cert']
             if 'client_key' in self.creds:

--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2018 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2013-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +17,13 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2013-2018
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2015
-# - Vincent Garonne <vgaronne@gmail.com>, 2015-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2015-2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
-#
-# PY3K COMPATIBLE
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
+import logging
 from json import dumps
 from requests.status_codes import codes
 
@@ -135,8 +137,15 @@ class SubscriptionClient(BaseClient):
         :type priority: Integer
         :raises: exception.NotFound if subscription is not found
         """
+        from rucio.client import Client
+        client = Client()
         if not account:
             account = self.account
+        if not account:
+            account = client.whoami()['account']
+        if not account:
+            logging.error("Cannot found default account with given identity. Please supply a Rucio account to authenticate")
+
         if retroactive:
             raise NotImplementedError('Retroactive mode is not implemented')
         path = self.SUB_BASEURL + '/' + account + '/' + name

--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -137,14 +137,14 @@ class SubscriptionClient(BaseClient):
         :type priority: Integer
         :raises: exception.NotFound if subscription is not found
         """
-        from rucio.client import Client
-        client = Client()
+        from rucio.client.accountclient import AccountClient
+        client = AccountClient()
         if not account:
             account = self.account
         if not account:
             account = client.whoami()['account']
         if not account:
-            logging.error("Cannot found default account with given identity. Please supply a Rucio account to authenticate")
+            logging.error("Cannot find default account with given identity. Please supply a Rucio account to authenticate")
 
         if retroactive:
             raise NotImplementedError('Retroactive mode is not implemented')

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -89,7 +89,6 @@ class UploadClient:
             self.account = self.client.whoami()['account']
         if not self.account:
             logger(logging.ERROR, "Cannot found default account with given identity. Please supply a Rucio account to authenticate")
-        print(self.account)
         self.default_file_scope = 'user.' + self.account
         self.rses = {}
         self.rse_expressions = {}

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -124,7 +124,7 @@ class UserPass(ErrorHandlingMethodView):
         except AccessDenied:
             return generate_http_error_flask(401, CannotAuthenticate.__name__, f'Cannot authenticate to account {account} with given credentials', headers=headers)
         except AccountNotFound:
-            return generate_http_error_flask(401, CannotAuthenticate.__name__, f'Cannot found default account with given identity. Please supply a Rucio account to authenticate', headers=headers)
+            return generate_http_error_flask(401, CannotAuthenticate.__name__, 'Cannot found default account with given identity. Please supply a Rucio account to authenticate', headers=headers)
 
         if not result:
             return generate_http_error_flask(401, CannotAuthenticate.__name__, f'Cannot authenticate to account {account} with given credentials', headers=headers)
@@ -555,7 +555,7 @@ class GSS(ErrorHandlingMethodView):
             return generate_http_error_flask(
                 status_code=401,
                 exc=CannotAuthenticate.__name__,
-                exc_msg=f'Cannot found default account with given identity. Please supply a Rucio account to authenticate',
+                exc_msg='Cannot found default account with given identity. Please supply a Rucio account to authenticate',
                 headers=headers
             )
 
@@ -668,7 +668,7 @@ class x509(ErrorHandlingMethodView):
             return generate_http_error_flask(
                 status_code=401,
                 exc=CannotAuthenticate.__name__,
-                exc_msg=f'Cannot found default account with given identity. Please supply a Rucio account to authenticate',
+                exc_msg='Cannot found default account with given identity. Please supply a Rucio account to authenticate',
                 headers=headers
             )
 
@@ -766,10 +766,9 @@ class SSH(ErrorHandlingMethodView):
             return generate_http_error_flask(
                 status_code=401,
                 exc=CannotAuthenticate.__name__,
-                exc_msg=f'Cannot found default account with given identity. Please supply a Rucio account to authenticate',
+                exc_msg='Cannot found default account with given identity. Please supply a Rucio account to authenticate',
                 headers=headers
             )
-
 
         if not result:
             return generate_http_error_flask(
@@ -920,7 +919,7 @@ class SAML(ErrorHandlingMethodView):
                 return generate_http_error_flask(
                     status_code=401,
                     exc=CannotAuthenticate.__name__,
-                    exc_msg=f'Cannot found default account with given identity. Please supply a Rucio account to authenticate',
+                    exc_msg='Cannot found default account with given identity. Please supply a Rucio account to authenticate',
                     headers=headers
                 )
 


### PR DESCRIPTION
**Clients: support default accounts. Closes #4802**
Tested with _userpass_ and _X509_ login methods.
Maybe default accounts do not work with _OIDC_, I was not able to find if the identity string (`SUB=sub, ISS=issuer`) can be retrieved from [get_auth_oidc in rucio.api.authentication](https://github.com/rucio/rucio/blob/b6092bcd78f8cfac079e5b3cc25a92b4163960ed/lib/rucio/api/authentication.py#L68) in order to call [get_default_account](https://github.com/rucio/rucio/blob/b6092bcd78f8cfac079e5b3cc25a92b4163960ed/lib/rucio/api/identity.py#L115) (*identity_key* argument is missing)