### PR TITLE
Recovery: Expanding the daemon suspicious_replica_recoverer #4565

### DIFF
--- a/bin/rucio-replica-recoverer
+++ b/bin/rucio-replica-recoverer
@@ -15,11 +15,14 @@
 # limitations under the License.
 #
 # Authors:
+# - Cedric Serfon, <cedric.serfon@cern.ch>, 2018
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Christoph Ames <cames@cern.ch>, 2021
+# PY3K COMPATIBLE
 
 """
 Replica-Recoverer is a daemon that declares suspicious replicas as bad if they are found available on other RSE.
@@ -207,10 +210,11 @@ $$ from rucio.core.replica import get_suspicious_files
 $$ from datetime import datetime, timedelta
 $$ from_date = datetime.now() - timedelta(days=3)
 $$ from rucio.core.replica import list_bad_replicas_status
+$$ from rucio.common.constants import SuspiciousAvailability
 
-$$ get_suspicious_files('MOCK_SUSPICIOUS',younger_than=from_date, nattempts=10, is_suspicious=True, available_elsewhere=True)
+$$ get_suspicious_files('MOCK_SUSPICIOUS',younger_than=from_date, nattempts=10, is_suspicious=True, available_elsewhere=SuspiciousAvailability["EXIST_COPIES"].value)
 
->>> get_suspicious_files('MOCK_SUSPICIOUS',younger_than=from_date, nattempts=10, is_suspicious=True, available_elsewhere=True)
+>>> get_suspicious_files('MOCK_SUSPICIOUS',younger_than=from_date, nattempts=10, is_suspicious=True, available_elsewhere=SuspiciousAvailability["EXIST_COPIES"].value)
 []
 
 $$ list_bad_replicas_status(rse='MOCK_SUSPICIOUS', younger_than=from_date)
@@ -235,13 +239,12 @@ Note that attempting the use the ``--vos`` argument when in single-VO mode will 
   $ rucio-replica-recoverer --run-once --vos abc xyz
   2020-07-28 15:21:33,349 5488    WARNING Ignoring argument vos, this is only applicable in a multi-VO setup.
 ''')  # NOQA: E501
-    parser.add_argument("--nattempts", action="store", default=10, help='Minimum count of suspicious file replica appearance in bad_replicas table.Default value is 10.')
-    parser.add_argument("--younger-than", action="store", default=3, help='Consider all file replicas logged in bad_replicas table since speicified number of younger-than. Default value is 3.')
-    parser.add_argument("--rse-expression", action="store", default='MOCK', help='The RSE on which the recovery should be happening.')
+    parser.add_argument("--nattempts", action="store", default=10, help='Minimum count of suspicious file replica appearance in bad_replicas table. Default value is 10.')
+    parser.add_argument("--younger-than", action="store", default=3, help='Consider all file replicas logged in bad_replicas table since speicified number of younger-than days. Default value is 3.')
     parser.add_argument('--vos', nargs='+', type=str, help='Optional list of VOs to consider. Only used in multi-VO mode.')
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only.')
-    parser.add_argument("--max-replicas-per-rse", action="store", default=100, help='The maximum number of suspicious replicas found on an RSE which may be declared bad. If a higher count is found, no action is be taken.')
-    parser.add_argument('--sleep-time', action="store", default=60, type=int, help='Concurrency control: thread sleep time after each chunk of work')
+    parser.add_argument("--limit-suspicious-files-on-rse", action="store", default=5, help='Maximum number of suspicious replicas on an RSE before that RSE is considered problematic and the suspicious replicas on that RSE are declared "TEMPORARY_UNAVAILABLE". Default value is 5.')
+    parser.add_argument('--sleep-time', action="store", default=300, type=int, help='Concurrency control: thread sleep time after each chunk of work')
     return parser
 
 
@@ -250,6 +253,6 @@ if __name__ == "__main__":
     PARSER = get_parser()
     ARGS = PARSER.parse_args()
     try:
-        run(once=ARGS.run_once, younger_than=ARGS.younger_than, nattempts=ARGS.nattempts, rse_expression=ARGS.rse_expression, vos=ARGS.vos, max_replicas_per_rse=ARGS.max_replicas_per_rse, sleep_time=ARGS.sleep_time)
+        run(once=ARGS.run_once, younger_than=ARGS.younger_than, nattempts=ARGS.nattempts, vos=ARGS.vos, limit_suspicious_files_on_rse=ARGS.limit_suspicious_files_on_rse)
     except KeyboardInterrupt:
         stop()

--- a/etc/suspicious_replica_recoverer.json
+++ b/etc/suspicious_replica_recoverer.json
@@ -1,0 +1,10 @@
+[
+    {
+        "datatype": "RAW",
+        "action": "ignore"
+    },
+    {
+        "datatype": "testtypedeclarebad",
+        "action": "declare bad"
+    }
+]

--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -30,6 +30,7 @@
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
+# - Christoph Ames <christoph.ames@cern.ch>, 2021
 
 import datetime
 
@@ -41,6 +42,7 @@ from rucio.common import exception
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import api_update_return_dict
+from rucio.common.constants import SuspiciousAvailability
 
 
 def get_bad_replicas_summary(rse_expression=None, from_date=None, to_date=None, vo='def'):
@@ -442,7 +444,7 @@ def get_suspicious_files(rse_expression, younger_than=None, nattempts=None, vo='
     :param nattempts: The number of time the replicas have been declared suspicious
     :param vo: The VO to act on.
     """
-    replicas = replica.get_suspicious_files(rse_expression=rse_expression, younger_than=younger_than, nattempts=nattempts, filter_={'vo': vo})
+    replicas = replica.get_suspicious_files(rse_expression=rse_expression, available_elsewhere=SuspiciousAvailability["ALL"].value, younger_than=younger_than, nattempts=nattempts, filter_={'vo': vo})
     return [api_update_return_dict(r) for r in replicas]
 
 

--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -24,6 +24,7 @@
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
+# - Christoph Ames <christoph.ames@cern.ch>, 2021
 
 from collections import namedtuple
 from enum import Enum
@@ -72,8 +73,14 @@ FTS_COMPLETE_STATE = namedtuple('FTS_COMPLETE_STATE', ['OK', 'ERROR'])('Ok', 'Er
 FTS_JOB_TYPE = namedtuple('FTS_JOB_TYPE', ['MULTIPLE_REPLICA', 'MULTI_HOP', 'SESSION_REUSE', 'REGULAR'])('R', 'H', 'Y', 'N')
 
 
+class SuspiciousAvailability(Enum):
+    ALL = 0
+    EXIST_COPIES = 1
+    LAST_COPY = 2
+
+
 class ReplicaState(Enum):
-    # From rucio.db.sqla.constants, update that file at the same time than this
+    # From rucio.db.sqla.constants, update that file at the same time as this
     AVAILABLE = 'A'
     UNAVAILABLE = 'U'
     COPYING = 'C'

--- a/lib/rucio/tests/test_replica_recoverer.py
+++ b/lib/rucio/tests/test_replica_recoverer.py
@@ -33,7 +33,8 @@ from rucio.client.replicaclient import ReplicaClient
 from rucio.common.config import config_get_bool
 from rucio.common.types import InternalScope
 from rucio.core.replica import (update_replica_state, list_replicas, list_bad_replicas_status)
-from rucio.core.rse import get_rse_id
+from rucio.core.rse import get_rse_id, add_rse_attribute
+from rucio.core.did import set_metadata
 from rucio.daemons.replicarecoverer.suspicious_replica_recoverer import run, stop
 from rucio.db.sqla.constants import DIDType, BadFilesStatus, ReplicaState
 from rucio.tests.common import execute, file_generator
@@ -64,33 +65,47 @@ class TestReplicaRecoverer(unittest.TestCase):
         self.tmp_file1 = file_generator()
         self.tmp_file2 = file_generator()
         self.tmp_file3 = file_generator()
+        self.tmp_file4 = file_generator()
+        self.tmp_file5 = file_generator()
 
         self.listdids = [{'scope': self.internal_scope, 'name': path.basename(f), 'type': DIDType.FILE}
-                         for f in [self.tmp_file1, self.tmp_file2, self.tmp_file3]]
+                         for f in [self.tmp_file1, self.tmp_file2, self.tmp_file3, self.tmp_file4, self.tmp_file5]]
 
         for rse in [self.rse4suspicious, self.rse4recovery]:
-            cmd = 'rucio -v upload --rse {0} --scope {1} {2} {3} {4}'.format(rse, self.scope, self.tmp_file1, self.tmp_file2, self.tmp_file3)
+            cmd = 'rucio -v upload --rse {0} --scope {1} {2} {3} {4} {5} {6}'.format(rse, self.scope, self.tmp_file1, self.tmp_file2, self.tmp_file3, self.tmp_file4, self.tmp_file5)
             exitcode, out, err = execute(cmd)
 
             # checking if Rucio upload went OK
             assert exitcode == 0
 
+        # Set fictional datatypes
+        set_metadata(self.internal_scope, path.basename(self.tmp_file4), 'datatype', 'testtypedeclarebad')
+        set_metadata(self.internal_scope, path.basename(self.tmp_file5), 'datatype', 'testtypenopolicy')
+
+        # Allow for the RSEs to be affected by the suspicious file recovery daemon
+        add_rse_attribute(self.rse4suspicious_id, "enable_suspicious_file_recovery", True)
+        add_rse_attribute(self.rse4recovery_id, "enable_suspicious_file_recovery", True)
+
         # removing physical files from /tmp location - keeping only their DB info
         remove(self.tmp_file1)
         remove(self.tmp_file2)
         remove(self.tmp_file3)
+        remove(self.tmp_file4)
+        remove(self.tmp_file5)
 
         # Gather replica info
         replicalist = list_replicas(dids=self.listdids)
 
         # Changing the replica statuses as follows:
-        # --------------------------------------------------------------------------------------------
-        # Name         State(s) declared on MOCK_RECOVERY       State(s) declared on MOCK_SUSPICIOUS
-        # --------------------------------------------------------------------------------------------
+        # ----------------------------------------------------------------------------------------------------------------------------------
+        # Name         State(s) declared on MOCK_RECOVERY       State(s) declared on MOCK_SUSPICIOUS        Metadata "datatype"
+        # ----------------------------------------------------------------------------------------------------------------------------------
         # tmp_file1    available                                suspicious (available)
         # tmp_file2    available                                suspicious + bad (unavailable)
-        # tmp_file3    unavailable                              suspicious (available)
-        # --------------------------------------------------------------------------------------------
+        # tmp_file3    unavailable                              suspicious (available)                      RAW
+        # tmp_file4    unavailable                              suspicious (available)                      testtypedeclarebad
+        # tmp_file5    unavailable                              suspicious (available)                      testtypenopolicy
+        # ----------------------------------------------------------------------------------------------------------------------------------
 
         for replica in replicalist:
             suspicious_pfns = replica['rses'][self.rse4suspicious_id]
@@ -104,6 +119,12 @@ class TestReplicaRecoverer(unittest.TestCase):
             if replica['name'] == path.basename(self.tmp_file3):
                 print("Updating replica state as unavailable: " + replica['rses'][self.rse4recovery_id][0])
                 update_replica_state(self.rse4recovery_id, self.internal_scope, path.basename(self.tmp_file3), ReplicaState.UNAVAILABLE)
+            if replica['name'] == path.basename(self.tmp_file4):
+                print("Updating replica state as unavailable: " + replica['rses'][self.rse4recovery_id][0])
+                update_replica_state(self.rse4recovery_id, self.internal_scope, path.basename(self.tmp_file4), ReplicaState.UNAVAILABLE)
+            if replica['name'] == path.basename(self.tmp_file5):
+                print("Updating replica state as unavailable: " + replica['rses'][self.rse4recovery_id][0])
+                update_replica_state(self.rse4recovery_id, self.internal_scope, path.basename(self.tmp_file5), ReplicaState.UNAVAILABLE)
 
         # Gather replica info after setting initial replica statuses
         replicalist = list_replicas(dids=self.listdids)
@@ -119,15 +140,23 @@ class TestReplicaRecoverer(unittest.TestCase):
             if replica['name'] == path.basename(self.tmp_file3):
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
+            if replica['name'] == path.basename(self.tmp_file4):
+                assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
+                assert (self.rse4recovery_id in replica['states']) is False
+            if replica['name'] == path.basename(self.tmp_file5):
+                assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
+                assert (self.rse4recovery_id in replica['states']) is False
 
         # Checking if only self.tmp_file2 is declared as 'BAD'
         self.from_date = datetime.now() - timedelta(days=1)
         bad_replicas_list = list_bad_replicas_status(rse_id=self.rse4suspicious_id, younger_than=self.from_date, **self.vo)
         bad_checklist = [(badf['name'], badf['rse_id'], badf['state']) for badf in bad_replicas_list]
 
-        assert (path.basename(self.tmp_file2), self.rse4suspicious_id, BadFilesStatus.BAD) in bad_checklist
         assert (path.basename(self.tmp_file1), self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (path.basename(self.tmp_file2), self.rse4suspicious_id, BadFilesStatus.BAD) in bad_checklist
         assert (path.basename(self.tmp_file3), self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (path.basename(self.tmp_file4), self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (path.basename(self.tmp_file5), self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
 
         bad_replicas_list = list_bad_replicas_status(rse_id=self.rse4recovery_id, younger_than=self.from_date, **self.vo)
         bad_checklist = [(badf['name'], badf['rse_id'], badf['state']) for badf in bad_replicas_list]
@@ -135,6 +164,8 @@ class TestReplicaRecoverer(unittest.TestCase):
         assert (path.basename(self.tmp_file1), self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
         assert (path.basename(self.tmp_file2), self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
         assert (path.basename(self.tmp_file3), self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (path.basename(self.tmp_file4), self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (path.basename(self.tmp_file5), self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
 
         # On purpose not checking for status to be declared 'SUSPICIOUS' on MOCK_SUSPICIOUS.
         # The only existing function (to date) gathering info about 'SUSPICIOUS' replicas
@@ -146,16 +177,23 @@ class TestReplicaRecoverer(unittest.TestCase):
             setUp function (above) is supposed to run first
             (nose does this automatically):
 
-            - uploads 3 test files to two test RSEs ('MOCK_RECOVERY', 'MOCK_SUSPICIOUS')
+            - uploads 6 test files to two test RSEs ('MOCK_RECOVERY', 'MOCK_SUSPICIOUS')
             - prepares their statuses to be as follows:
 
-            # --------------------------------------------------------------------------------------------
-            # Name         State(s) declared on MOCK_RECOVERY       State(s) declared on MOCK_SUSPICIOUS
-            # --------------------------------------------------------------------------------------------
+            # ----------------------------------------------------------------------------------------------------------------------------------
+            # Name         State(s) declared on MOCK_RECOVERY       State(s) declared on MOCK_SUSPICIOUS        Metadata "datatype"
+            # ----------------------------------------------------------------------------------------------------------------------------------
             # tmp_file1    available                                suspicious (available)
             # tmp_file2    available                                suspicious + bad (unavailable)
-            # tmp_file3    unavailable                              suspicious (available)
-            # --------------------------------------------------------------------------------------------
+            # tmp_file3    unavailable                              suspicious (available)                      RAW
+            # tmp_file4    unavailable                              suspicious (available)                      testtypedeclare_bad
+            # tmp_file5    unavailable                              suspicious (available)                      testtypenopolicy
+            # ----------------------------------------------------------------------------------------------------------------------------------
+
+            - Explaination: Suspicious replicas that are the last remaining copy (unavailable on MOCK_RECOVERY) are handeled differently depending
+                            by their metadata "datatype". RAW files have the poilcy to be ignored. testtype_declare_bad files are of a fictional
+                            type that has the policy of being declared bad. testtype_nopolicy files are of a fictional type that doesn't have a
+                            policy specified, meaning they should be ignored by default.
 
             Runs the Test:
 
@@ -163,25 +201,27 @@ class TestReplicaRecoverer(unittest.TestCase):
 
             Concluding:
 
-            - checks that the only change made is that tmp_file1 was declared as 'BAD on 'MOCK_SUSPICIOUS'
+            - checks that tmp_file1 and tmp_file4 were declared as 'BAD' on 'MOCK_SUSPICIOUS'
 
         """
 
         # Run replica recoverer once
         try:
-            run(once=True, younger_than=1, nattempts=2, rse_expression='MOCK_SUSPICIOUS')
+            run(once=True, younger_than=1, nattempts=2, limit_suspicious_files_on_rse=5)
         except KeyboardInterrupt:
             stop()
 
         # Checking the outcome:
         # we expect to see only one change, i.e. tmp_file1 declared as bad on MOCK_SUSPICIOUS
-        # --------------------------------------------------------------------------------------------
-        # Name         State(s) declared on MOCK_RECOVERY       State(s) declared on MOCK_SUSPICIOUS
-        # --------------------------------------------------------------------------------------------
+        # ----------------------------------------------------------------------------------------------------------------------------------
+        # Name         State(s) declared on MOCK_RECOVERY       State(s) declared on MOCK_SUSPICIOUS        Metadata "datatype"
+        # ----------------------------------------------------------------------------------------------------------------------------------
         # tmp_file1    available                                suspicious + bad (unavailable)
         # tmp_file2    available                                suspicious + bad (unavailable)
-        # tmp_file3    unavailable                              suspicious (available)
-        # --------------------------------------------------------------------------------------------
+        # tmp_file3    unavailable                              suspicious (available)                      RAW
+        # tmp_file4    unavailable                              suspicious + bad (unvailable)               test_type_declare_bad
+        # tmp_file5    unavailable                              suspicious (available)                      test_type_ignore
+        # ----------------------------------------------------------------------------------------------------------------------------------
 
         # Gather replica info after replica_recoverer has run.
         replicalist = list_replicas(dids=self.listdids)
@@ -193,6 +233,12 @@ class TestReplicaRecoverer(unittest.TestCase):
             if replica['name'] == path.basename(self.tmp_file3):
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
+            if replica['name'] == path.basename(self.tmp_file4):
+                # The key 'state' only exists if the replica is available on at least one RSE. It shouldn't exist for tmp_file4.
+                assert ('states' in replica) is False
+            if replica['name'] == path.basename(self.tmp_file5):
+                assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
+                assert (self.rse4recovery_id in replica['states']) is False
 
         # Checking if replicas declared as 'BAD'
         bad_replicas_list = list_bad_replicas_status(rse_id=self.rse4suspicious_id, younger_than=self.from_date, **self.vo)
@@ -201,6 +247,8 @@ class TestReplicaRecoverer(unittest.TestCase):
         assert (path.basename(self.tmp_file1), self.rse4suspicious_id, BadFilesStatus.BAD) in bad_checklist
         assert (path.basename(self.tmp_file2), self.rse4suspicious_id, BadFilesStatus.BAD) in bad_checklist
         assert (path.basename(self.tmp_file3), self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (path.basename(self.tmp_file4), self.rse4suspicious_id, BadFilesStatus.BAD) in bad_checklist
+        assert (path.basename(self.tmp_file5), self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
 
         bad_replicas_list = list_bad_replicas_status(rse_id=self.rse4recovery_id, younger_than=self.from_date, **self.vo)
         bad_checklist = [(badf['name'], badf['rse_id'], badf['state']) for badf in bad_replicas_list]
@@ -208,3 +256,5 @@ class TestReplicaRecoverer(unittest.TestCase):
         assert (path.basename(self.tmp_file1), self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
         assert (path.basename(self.tmp_file2), self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
         assert (path.basename(self.tmp_file3), self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (path.basename(self.tmp_file4), self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (path.basename(self.tmp_file5), self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist


### PR DESCRIPTION

The idea is to expand the daemon "suspicious_replica_recoverer", so that it goes into more detail when dealing with suspicious files.

The first main change is that it can now deal with both suspicious replicas that have additional copies on other RSEs and replicas that are the last remaining copy, the latter being previously ignored. The last remaining copies are dealt with differently based on the file type / metadata of the replica:
Log files and user files are declared bad without further investigation. Replicas with the metadata " datatype='RAW' " are not declared bad, but are instead ignored (meaning that they will have to be dealt with manually).
The rest of the file types are currently being ignored, to make sure no mistakes are made. This can be easily changed by adding new entries to suspicious_replica_recoverer.json.

To be able to make these changes, the function "get_suspicious_replicas" from lib/rucio/core/replica.py had to be changed. The parameter "available_elsewhere" now has three options:
0: All suspicious replicas
1: Suspicious replicas that have at least one copy on another RSE
2: Suspicious replicas that are the last remaining copy


The second main change is that RSEs with more than a certain number of suspicious replicas (currently set to 5, but requires testing when the daemon is run in passive mode) are considered "problematic". This means that it is assumed that the high number of suspicious replicas is due to the RSE having a problem, as opposed to the replicas themselves having problems. In such a case, the suspicious replicas are declared temporarily unavailable.