### PR TITLE
Core & Internals: Enforce naming restrictions on algorithms registered from policy packages #4830

### DIFF
--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1051,7 +1051,7 @@ class InvalidAlgorithmName(RucioException):
     """
     The given algorithm name is not valid for the VO.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, algorithm, vo, *args, **kwargs):
         super(InvalidAlgorithmName, self).__init__(*args, **kwargs)
-        self.message = 'The given algorithm name is not valid for this VO'
+        self.message = 'Algorithm name %s is not valid for VO %s' % (algorithm, vo)
         self.error_code = 100

--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1045,3 +1045,13 @@ class DIDFilterSyntaxError(RucioException):
         super(DIDFilterSyntaxError, self).__init__(*args, **kwargs)
         self._message = 'Syntax error in filter expression.'
         self.error_code = 99
+
+
+class InvalidAlgorithmName(RucioException):
+    """
+    The given algorithm name is not valid for the VO.
+    """
+    def __init__(self, *args, **kwargs):
+        super(InvalidAlgorithmName, self).__init__(*args, **kwargs)
+        self.message = 'The given algorithm name is not valid for this VO'
+        self.error_code = 100

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -585,7 +585,7 @@ def _register_policy_package_surl_algorithms():
                 else:
                     # check that the names are correctly prefixed
                     for k in surl_algorithms.keys():
-                        if k.startswith(vo['vo']):
+                        if k.lower().startswith(vo['vo'].lower()):
                             _SURL_ALGORITHMS[k] = surl_algorithms[k]
                         else:
                             raise InvalidAlgorithmName('SURL algorithm name %s is not valid for VO %s' % (k, vo['vo']))

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -588,7 +588,7 @@ def _register_policy_package_surl_algorithms():
                         if k.lower().startswith(vo['vo'].lower()):
                             _SURL_ALGORITHMS[k] = surl_algorithms[k]
                         else:
-                            raise InvalidAlgorithmName('SURL algorithm name %s is not valid for VO %s' % (k, vo['vo']))
+                            raise InvalidAlgorithmName(k, vo['vo'])
         except (NoOptionError, NoSectionError, ImportError):
             pass
 

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -579,7 +579,14 @@ def _register_policy_package_surl_algorithms():
             package = config.config_get('policy', 'package' + ('' if not vo else '-' + vo['vo']))
             module = importlib.import_module(package)
             if hasattr(module, 'get_surl_algorithms'):
-                _SURL_ALGORITHMS.update(module.get_surl_algorithms())
+                surl_algorithms = module.get_surl_algorithms()
+                if not vo:
+                    _SURL_ALGORITHMS.update(surl_algorithms)
+                else:
+                    # check that the names are correctly prefixed
+                    for k in surl_algorithms.keys():
+                        if k.startswith(vo):
+                            _SURL_ALGORITHMS[k] = surl_algorithms[k]
         except (NoOptionError, NoSectionError, ImportError):
             pass
 

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -76,7 +76,7 @@ from six.moves.configparser import NoOptionError, NoSectionError
 
 from rucio.common.config import config_get, config_has_section
 from rucio.common.exception import MissingModuleException, InvalidType, InputValidationError, MetalinkJsonParsingError, RucioException, \
-    DuplicateCriteriaInDIDFilter, DIDFilterSyntaxError
+    DuplicateCriteriaInDIDFilter, DIDFilterSyntaxError, InvalidAlgorithmName
 
 from rucio.common.extra import import_extras
 from rucio.common.types import InternalAccount, InternalScope
@@ -585,8 +585,10 @@ def _register_policy_package_surl_algorithms():
                 else:
                     # check that the names are correctly prefixed
                     for k in surl_algorithms.keys():
-                        if k.startswith(vo):
+                        if k.startswith(vo['vo']):
                             _SURL_ALGORITHMS[k] = surl_algorithms[k]
+                        else:
+                            raise InvalidAlgorithmName('SURL algorithm name %s is not valid for VO %s' % (k, vo['vo']))
         except (NoOptionError, NoSectionError, ImportError):
             pass
 

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -273,7 +273,14 @@ class RSEDeterministicTranslation(object):
             package = config.config_get('policy', 'package' + ('' if not vo else '-' + vo['vo']))
             module = importlib.import_module(package)
             if hasattr(module, 'get_lfn2pfn_algorithms'):
-                RSEDeterministicTranslation._LFN2PFN_ALGORITHMS.update(module.get_lfn2pfn_algorithms())
+                lfn2pfn_algorithms = module.get_lfn2pfn_algorithms()
+                if not vo:
+                    RSEDeterministicTranslation._LFN2PFN_ALGORITHMS.update(lfn2pfn_algorithms)
+                else:
+                    # check that the names are correctly prefixed
+                    for k in lfn2pfn_algorithms.keys():
+                        if k.startswith(vo):
+                            RSEDeterministicTranslation._LFN2PFN_ALGORITHMS[k] = lfn2pfn_algorithms[k]                    
         except (NoOptionError, NoSectionError, ImportError):
             pass
 

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -279,8 +279,10 @@ class RSEDeterministicTranslation(object):
                 else:
                     # check that the names are correctly prefixed
                     for k in lfn2pfn_algorithms.keys():
-                        if k.startswith(vo):
+                        if k.startswith(vo['vo']):
                             RSEDeterministicTranslation._LFN2PFN_ALGORITHMS[k] = lfn2pfn_algorithms[k]
+                        else:
+                            raise exception.InvalidAlgorithmName('LFN2PFN algorithm name %s is not valid for VO %s' % (k, vo['vo']))
         except (NoOptionError, NoSectionError, ImportError):
             pass
 

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -280,7 +280,7 @@ class RSEDeterministicTranslation(object):
                     # check that the names are correctly prefixed
                     for k in lfn2pfn_algorithms.keys():
                         if k.startswith(vo):
-                            RSEDeterministicTranslation._LFN2PFN_ALGORITHMS[k] = lfn2pfn_algorithms[k]                    
+                            RSEDeterministicTranslation._LFN2PFN_ALGORITHMS[k] = lfn2pfn_algorithms[k]
         except (NoOptionError, NoSectionError, ImportError):
             pass
 

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -282,7 +282,7 @@ class RSEDeterministicTranslation(object):
                         if k.lower().startswith(vo['vo'].lower()):
                             RSEDeterministicTranslation._LFN2PFN_ALGORITHMS[k] = lfn2pfn_algorithms[k]
                         else:
-                            raise exception.InvalidAlgorithmName('LFN2PFN algorithm name %s is not valid for VO %s' % (k, vo['vo']))
+                            raise exception.InvalidAlgorithmName(k, vo['vo'])
         except (NoOptionError, NoSectionError, ImportError):
             pass
 

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -279,7 +279,7 @@ class RSEDeterministicTranslation(object):
                 else:
                     # check that the names are correctly prefixed
                     for k in lfn2pfn_algorithms.keys():
-                        if k.startswith(vo['vo']):
+                        if k.lower().startswith(vo['vo'].lower()):
                             RSEDeterministicTranslation._LFN2PFN_ALGORITHMS[k] = lfn2pfn_algorithms[k]
                         else:
                             raise exception.InvalidAlgorithmName('LFN2PFN algorithm name %s is not valid for VO %s' % (k, vo['vo']))


### PR DESCRIPTION
This PR ensures that algorithms registered by policy packages in multi-VO Rucio installations include the VO name at the start of the algorithm name, to avoid name clashes.