### PR TITLE
Tests: increase test_stager wait time

### DIFF
--- a/lib/rucio/tests/test_conveyor.py
+++ b/lib/rucio/tests/test_conveyor.py
@@ -477,7 +477,7 @@ def test_stager(rse_factory, did_factory, root_account, replica_client):
                                            'requested_at': datetime.now()}])
     stager(once=True, rses=[{'id': rse_id} for rse_id in all_rses])
 
-    replica = __wait_for_replica_transfer(dst_rse_id=dst_rse_id, **did)
+    replica = __wait_for_replica_transfer(dst_rse_id=dst_rse_id, max_wait_seconds=2 * MAX_POLL_WAIT_SECONDS, **did)
     assert replica['state'] == ReplicaState.AVAILABLE
 
 


### PR DESCRIPTION
Stager tests rely on the bring-online FTS daemon,
which has a resolution of 60s minimum. As a result,
it can take up to 60s to execute the request. This
may lead to failing tests due to timeout (60s).

Double the timeout to avoid this issue.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
