### PR TITLE
Tests: make abacus and undertaker test noparallel

### DIFF
--- a/lib/rucio/tests/test_abacus_collection_replica.py
+++ b/lib/rucio/tests/test_abacus_collection_replica.py
@@ -162,6 +162,7 @@ class TestAbacusCollectionReplica(unittest.TestCase):
         assert dataset_replica[0]['available_length'] == 0
 
 
+@pytest.mark.noparallel(reason='runs multiple daemons which may impact other tests run in parallel')
 @pytest.mark.parametrize("core_config_mock", [{"table_content": [
     ('reaper', 'remove_open_did', True)
 ]}], indirect=True)

--- a/lib/rucio/tests/test_undertaker.py
+++ b/lib/rucio/tests/test_undertaker.py
@@ -52,7 +52,7 @@ LOG = getLogger(__name__)
 
 
 @pytest.mark.dirty
-@pytest.mark.noparallel(reason='uses pre-defined rses, fails when run in parallel')
+@pytest.mark.noparallel(reason='uses pre-defined rses; runs undertaker, which impacts other tests')
 class TestUndertaker(unittest.TestCase):
 
     def setUp(self):
@@ -177,6 +177,7 @@ class TestUndertaker(unittest.TestCase):
             assert(len([x for x in list_rules(filters={'scope': InternalScope('archive', **self.vo), 'name': dsn['name']})]) == 1)
 
 
+@pytest.mark.noparallel(reason='runs undertaker, which impacts other tests')
 @pytest.mark.parametrize("core_config_mock", [{"table_content": [
     ('undertaker', 'purge_all_replicas', True)
 ]}], indirect=True)


### PR DESCRIPTION
They run daemons which don't support to be limited to a particular RSE.
As a result, they may impact the state of other tests which are run
in parallel and make those tests fail.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
