### PR TITLE
Transfers: mark successful transfers file by file. #4841

### DIFF
--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -49,9 +49,9 @@ SCHEME_MAP = {'srm': ['srm', 'gsiftp'],
 
 SUPPORTED_PROTOCOLS = ['gsiftp', 'srm', 'root', 'davs', 'http', 'https', 'file', 's3', 's3+rucio', 's3+https', 'storm', 'srm+https']
 
-FTS_STATE = namedtuple('FTS_STATE', ['SUBMITTED', 'READY', 'ACTIVE', 'FAILED', 'FINISHED', 'FINISHEDDIRTY',
+FTS_STATE = namedtuple('FTS_STATE', ['SUBMITTED', 'READY', 'ACTIVE', 'FAILED', 'FINISHED', 'FINISHEDDIRTY', 'NOT_USED',
                                      'CANCELED'])('SUBMITTED', 'READY', 'ACTIVE', 'FAILED', 'FINISHED', 'FINISHEDDIRTY',
-                                                  'CANCELED')
+                                                  'NOT_USED', 'CANCELED')
 
 FTS_COMPLETE_STATE = namedtuple('FTS_COMPLETE_STATE', ['OK', 'ERROR'])('Ok', 'Error')
 

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -725,16 +725,23 @@ def bulk_query_transfers(request_host, transfer_ids, transfertool='fts3', timeou
                     status_dict = fts_resps[transfer_id][request_id]
                     job_state = status_dict['job_state']
                     file_state = status_dict['file_state']
-                    if job_state in (FTS_STATE.FAILED, FTS_STATE.CANCELED):
-                        status_dict['new_state'] = RequestState.FAILED
-                    elif job_state == FTS_STATE.FINISHED:
+                    # https://fts3-docs.web.cern.ch/fts3-docs/docs/state_machine.html
+                    job_state_is_final = job_state in (FTS_STATE.FAILED, FTS_STATE.CANCELED, FTS_STATE.FINISHED, FTS_STATE.FINISHEDDIRTY)
+                    file_state_is_final = file_state in (FTS_STATE.FAILED, FTS_STATE.CANCELED, FTS_STATE.FINISHED, FTS_STATE.NOT_USED)
+                    if not file_state_is_final:
+                        continue
+
+                    if file_state == FTS_STATE.FINISHED:
                         status_dict['new_state'] = RequestState.DONE
-                    elif job_state == FTS_STATE.FINISHEDDIRTY:
-                        # Job partially completed. Verify the state of the file in the job
-                        if file_state in (FTS_STATE.FAILED, FTS_STATE.CANCELED):
-                            status_dict['new_state'] = RequestState.FAILED
-                        elif file_state == FTS_STATE.FINISHED:
+                    elif job_state_is_final and file_state in (FTS_STATE.FAILED, FTS_STATE.CANCELED):
+                        status_dict['new_state'] = RequestState.FAILED
+                    elif job_state_is_final and file_state == FTS_STATE.NOT_USED:
+                        if job_state == FTS_STATE.FINISHED:
+                            # it is a multi-source transfer. This source wasn't used, but another one was successful
                             status_dict['new_state'] = RequestState.DONE
+                        else:
+                            # failed multi-source or multi-hop (you cannot have unused sources in a successful multi-hop)
+                            status_dict['new_state'] = RequestState.FAILED
         return fts_resps
     elif transfertool == 'globus':
         try:


### PR DESCRIPTION
Only do it on success. In all other cases it's more tricky:
 - for multi-source transfers we can have failed file_state; but the
   job is not yet completed, so we must not mark the transfer as
   finished
 - both for multi-source and multi-hop transfers we can have files
   in a not_used state without it being a sign of success or failure.

This commit also fixes a race condition which I just detected:
successful intermediate hops in a multi-hop transfer were marked as
failed because the job was failed.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
