### PR TITLE
Transfers: remove retry_other_fts option from conveyor. Closes #4812

### DIFF
--- a/bin/rucio-conveyor-stager
+++ b/bin/rucio-conveyor-stager
@@ -64,8 +64,6 @@ def get_parser():
                         help='Explicit list of activities to include')
     parser.add_argument('--sleep-time', action="store", default=600, type=int,
                         help='Seconds to sleep if few requests')
-    parser.add_argument("--retry-other-fts", action="store_true", default=False,
-                        help='retry on a different FTS')
     return parser
 
 
@@ -85,7 +83,6 @@ if __name__ == "__main__":
             vos=args.vos,
             source_strategy=args.source_strategy,
             activities=args.activities,
-            sleep_time=args.sleep_time,
-            retry_other_fts=args.retry_other_fts)
+            sleep_time=args.sleep_time)
     except KeyboardInterrupt:
         stop()

--- a/bin/rucio-conveyor-submitter
+++ b/bin/rucio-conveyor-submitter
@@ -120,8 +120,6 @@ Note that attempting the use the ``--vos`` argument when in single-VO mode will 
                         help='Seconds to sleep if few requests')
     parser.add_argument('--max-sources', action="store", default=4, type=int,
                         help='Maximum source replicas per FTS job')
-    parser.add_argument("--retry-other-fts", action="store_true", default=False,
-                        help='retry on a different FTS')
     parser.add_argument('--archive-timeout-override', action="store", default=None, type=int, metavar="INTEGER_SECONDS",
                         help='Override the archive_timeout parameter for any transfers with it set (0 to unset)')
     return parser
@@ -147,7 +145,6 @@ if __name__ == "__main__":
             exclude_activities=args.exclude_activities,
             sleep_time=args.sleep_time,
             max_sources=args.max_sources,
-            retry_other_fts=args.retry_other_fts,
             archive_timeout_override=args.archive_timeout_override,
             total_threads=args.total_threads)
     except KeyboardInterrupt:

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1235,7 +1235,6 @@ def __sort_paths(candidate_paths: "Iterable[List[DirectTransferDefinition]]") ->
 def __filter_for_transfertool(
         candidate_paths: "Iterable[List[DirectTransferDefinition]]",
         transfertool: str,
-        retry_other_fts: bool,
         logger: "Callable",
 ):
     """
@@ -1274,8 +1273,6 @@ def __filter_for_transfertool(
 
             if common_fts_hosts:
                 external_host = common_fts_hosts[0]
-                if retry_other_fts:
-                    external_host = common_fts_hosts[rws.retry_count % len(common_fts_hosts)]
             else:
                 if transfertool == 'fts3':
                     logger(logging.ERROR, 'FTS attribute not defined - for at least one transfer hops {} {}'.format([str(hop) for hop in transfer_path], rws.request_id))
@@ -1288,7 +1285,7 @@ def __filter_for_transfertool(
 
 @transactional_session
 def next_transfers_to_submit(total_workers=0, worker_number=0, limit=None, activity=None, older_than=None, rses=None, schemes=None,
-                             retry_other_fts=False, failover_schemes=None, transfertool=None, request_type=RequestType.TRANSFER,
+                             failover_schemes=None, transfertool=None, request_type=RequestType.TRANSFER,
                              logger=logging.log, session=None):
     """
     Get next transfers to be submitted; grouped by the external host to which they will be submitted
@@ -1299,7 +1296,6 @@ def next_transfers_to_submit(total_workers=0, worker_number=0, limit=None, activ
     :param older_than:            Get transfers older than.
     :param rses:                  Include RSES.
     :param schemes:               Include schemes.
-    :param retry_other_fts:       Retry other fts servers.
     :param failover_schemes:      Failover schemes.
     :param transfertool:          The transfer tool as specified in rucio.cfg.
     :param request_type           The type of requests to retrieve (Transfer/Stagein)
@@ -1356,7 +1352,6 @@ def next_transfers_to_submit(total_workers=0, worker_number=0, limit=None, activ
     paths_by_external_host, reqs_no_host = __pick_and_build_path_for_transfertool(
         candidate_paths,
         transfertool=transfertool,
-        retry_other_fts=retry_other_fts,
         logger=logger
     )
 
@@ -1515,7 +1510,6 @@ def __build_transfer_paths(
 
 def __pick_and_build_path_for_transfertool(
         candidate_paths_by_request_id: "Dict[str: List[DirectTransferDefinition]]",
-        retry_other_fts: bool = False,
         transfertool: "Optional[str]" = None,
         logger: "Callable" = logging.log
 ) -> "Tuple[Dict[str, List[DirectTransferDefinition]], Set[str]]":
@@ -1532,7 +1526,7 @@ def __pick_and_build_path_for_transfertool(
         # intermediate hops (if it is a multihop) work correctly
         best_path = None
         external_host = None
-        for external_host, transfer_path in __filter_for_transfertool(candidate_paths, transfertool, retry_other_fts, logger):
+        for external_host, transfer_path in __filter_for_transfertool(candidate_paths, transfertool, logger):
             if create_missing_replicas_and_requests(transfer_path, default_tombstone_delay, logger=logger):
                 best_path = transfer_path
                 break

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -54,7 +54,7 @@ graceful_stop = threading.Event()
 
 
 def stager(once=False, rses=None, bulk=100, group_bulk=1, group_policy='rule',
-           source_strategy=None, activities=None, sleep_time=600, retry_other_fts=False):
+           source_strategy=None, activities=None, sleep_time=600):
     """
     Main loop to submit a new transfer primitive to a transfertool.
     """
@@ -137,7 +137,6 @@ def stager(once=False, rses=None, bulk=100, group_bulk=1, group_policy='rule',
                     activity=activity,
                     rses=rse_ids,
                     schemes=scheme,
-                    retry_other_fts=retry_other_fts,
                     older_than=None,
                     request_type=RequestType.STAGEIN,
                     logger=logger,
@@ -186,7 +185,7 @@ def stop(signum=None, frame=None):
 
 def run(once=False, total_threads=1, group_bulk=1, group_policy='rule',
         rses=None, include_rses=None, exclude_rses=None, vos=None, bulk=100, source_strategy=None,
-        activities=[], sleep_time=600, retry_other_fts=False):
+        activities=[], sleep_time=600):
     """
     Starts up the conveyer threads.
     """
@@ -216,8 +215,7 @@ def run(once=False, total_threads=1, group_bulk=1, group_policy='rule',
                group_bulk=group_bulk,
                group_policy=group_policy,
                source_strategy=source_strategy,
-               activities=activities,
-               retry_other_fts=retry_other_fts)
+               activities=activities)
 
     else:
         logging.info('starting stager threads')
@@ -227,8 +225,7 @@ def run(once=False, total_threads=1, group_bulk=1, group_policy='rule',
                                                            'group_policy': group_policy,
                                                            'activities': activities,
                                                            'sleep_time': sleep_time,
-                                                           'source_strategy': source_strategy,
-                                                           'retry_other_fts': retry_other_fts}) for _ in range(0, total_threads)]
+                                                           'source_strategy': source_strategy}) for _ in range(0, total_threads)]
 
         [thread.start() for thread in threads]
 

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -70,7 +70,7 @@ GET_TRANSFERS_COUNTER = Counter('rucio_daemons_conveyor_submitter_get_transfers'
 
 def submitter(once=False, rses=None, partition_wait_time=10,
               bulk=100, group_bulk=1, group_policy='rule', source_strategy=None,
-              activities=None, sleep_time=600, max_sources=4, retry_other_fts=False, archive_timeout_override=None,
+              activities=None, sleep_time=600, max_sources=4, archive_timeout_override=None,
               filter_transfertool=FILTER_TRANSFERTOOL, transfertool=TRANSFER_TOOL, transfertype=TRANSFER_TYPE):
     """
     Main loop to submit a new transfer primitive to a transfertool.
@@ -161,7 +161,6 @@ def submitter(once=False, rses=None, partition_wait_time=10,
                     activity=activity,
                     rses=rse_ids,
                     schemes=scheme,
-                    retry_other_fts=retry_other_fts,
                     transfertool=filter_transfertool,
                     older_than=None,
                     request_type=RequestType.TRANSFER,
@@ -221,7 +220,7 @@ def stop(signum=None, frame=None):
 
 def run(once=False, group_bulk=1, group_policy='rule', mock=False,
         rses=None, include_rses=None, exclude_rses=None, vos=None, bulk=100, source_strategy=None,
-        activities=None, exclude_activities=None, sleep_time=600, max_sources=4, retry_other_fts=False,
+        activities=None, exclude_activities=None, sleep_time=600, max_sources=4,
         archive_timeout_override=None, total_threads=1):
     """
     Starts up the conveyer threads.
@@ -270,7 +269,6 @@ def run(once=False, group_bulk=1, group_policy='rule', mock=False,
                                                           'sleep_time': sleep_time,
                                                           'max_sources': max_sources,
                                                           'source_strategy': source_strategy,
-                                                          'retry_other_fts': retry_other_fts,
                                                           'archive_timeout_override': archive_timeout_override}) for _ in range(0, total_threads)]
 
     [thread.start() for thread in threads]


### PR DESCRIPTION
It's a dangerous option. If the conveyor "thinks" that the submission
failed, but FTS actually accepted the transfer and executes it,
a race condition is possible because we may submit the same transfer
to another FTS instance, resulting into two parallel transfers trying
to be executed.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
