### PR TITLE
Clients: Use kebab-case for all command-line options #4865

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -48,6 +48,7 @@
 # - Christoph Ames <christoph.ames@physik.uni-muenchen.de>, 2021
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from __future__ import print_function
 

--- a/bin/rucio
+++ b/bin/rucio
@@ -79,7 +79,7 @@ from rucio.common.exception import (DataIdentifierAlreadyExists, AccessDenied, D
 from rucio.common.extra import import_extras
 from rucio.common.test_rucio_server import TestRucioServer
 from rucio.common.utils import sizefmt, Color, detect_client_location, chunks, parse_did_filter_from_string, \
-    extract_scope, setup_logger
+    extract_scope, setup_logger, StoreAndDeprecateWarningAction
 from rucio.common.constants import ReplicaState
 
 EXTRA_MODULES = import_extras(['argcomplete'])
@@ -2224,13 +2224,77 @@ You can filter by key/value, e.g.::
         selected_parser.add_argument('--transfer-timeout', dest='transfer_timeout', type=float, action='store', default=config_get('download', 'transfer_timeout', False, None), help='Transfer timeout (in seconds). Default: computed dynamically from --transfer-speed-timeout. If set to any value >= 0, --transfer-speed-timeout is ignored.')
         selected_parser.add_argument('--transfer-speed-timeout', dest='transfer_speed_timeout', type=float, action='store', default=config_get('download', 'transfer_speed_timeout', False, 500), help='Minimum allowed average transfer speed (in KBps). Default: 500. Used to dynamically compute the timeout if --transfer-timeout not set. Is not supported for --pfn.')
         selected_parser.add_argument('--aria', action='store_true', default=False, help="Use aria2c utility if possible. (EXPERIMENTAL)")
-        selected_parser.add_argument('--trace_appid', dest='trace_appid', action='store', default=os.environ.get('RUCIO_TRACE_APPID', None), help=argparse.SUPPRESS)
-        selected_parser.add_argument('--trace_dataset', dest='trace_dataset', action='store', default=os.environ.get('RUCIO_TRACE_DATASET', None), help=argparse.SUPPRESS)
-        selected_parser.add_argument('--trace_datasetscope', dest='trace_datasetscope', action='store', default=os.environ.get('RUCIO_TRACE_DATASETSCOPE', None), help=argparse.SUPPRESS)
-        selected_parser.add_argument('--trace_eventtype', dest='trace_eventtype', action='store', default=os.environ.get('RUCIO_TRACE_EVENTTYPE', None), help=argparse.SUPPRESS)
-        selected_parser.add_argument('--trace_pq', dest='trace_pq', action='store', default=os.environ.get('RUCIO_TRACE_PQ', None), help=argparse.SUPPRESS)
-        selected_parser.add_argument('--trace_taskid', dest='trace_taskid', action='store', default=os.environ.get('RUCIO_TRACE_TASKID', None), help=argparse.SUPPRESS)
-        selected_parser.add_argument('--trace_usrdn', dest='trace_usrdn', action='store', default=os.environ.get('RUCIO_TRACE_USRDN', None), help=argparse.SUPPRESS)
+
+        selected_parser.add_argument(
+            '--trace_appid',
+            '--trace-appid',
+            new_option_string='--trace-appid',
+            dest='trace_appid',
+            action=StoreAndDeprecateWarningAction,
+            default=os.environ.get('RUCIO_TRACE_APPID', None),
+            help=argparse.SUPPRESS
+        )
+
+        selected_parser.add_argument(
+            '--trace_dataset',
+            '--trace-dataset',
+            new_option_string='--trace-dataset',
+            dest='trace_dataset',
+            action=StoreAndDeprecateWarningAction,
+            default=os.environ.get('RUCIO_TRACE_DATASET', None),
+            help=argparse.SUPPRESS
+        )
+
+        selected_parser.add_argument(
+            '--trace_datasetscope',
+            '--trace-datasetscope',
+            new_option_string='--trace-datasetscope',
+            dest='trace_datasetscope',
+            action=StoreAndDeprecateWarningAction,
+            default=os.environ.get('RUCIO_TRACE_DATASETSCOPE', None),
+            help=argparse.SUPPRESS
+        )
+
+        selected_parser.add_argument(
+            '--trace_eventtype',
+            '--trace-eventtype',
+            new_option_string='--trace-eventtype',
+            dest='trace_eventtype',
+            action=StoreAndDeprecateWarningAction,
+            default=os.environ.get('RUCIO_TRACE_EVENTTYPE', None),
+            help=argparse.SUPPRESS
+        )
+
+        selected_parser.add_argument(
+            '--trace_pq',
+            '--trace-pq',
+            new_option_string='--trace-pq',
+            dest='trace_pq',
+            action=StoreAndDeprecateWarningAction,
+            default=os.environ.get('RUCIO_TRACE_PQ', None),
+            help=argparse.SUPPRESS
+        )
+
+        selected_parser.add_argument(
+            '--trace_taskid',
+            '--trace-taskid',
+            new_option_string='--trace-taskid',
+            dest='trace_taskid',
+            action=StoreAndDeprecateWarningAction,
+            default=os.environ.get('RUCIO_TRACE_TASKID', None),
+            help=argparse.SUPPRESS
+        )
+
+        selected_parser.add_argument(
+            '--trace_usrdn',
+            '--trace-usrdn',
+            new_option_string='--trace-usrdn',
+            dest='trace_usrdn',
+            action=StoreAndDeprecateWarningAction,
+            default=os.environ.get('RUCIO_TRACE_USRDN', None),
+            help=argparse.SUPPRESS
+        )
+
         selected_parser.add_argument('--filter', dest='filter', action='store', help='Filter files by key-value pairs like guid=2e2232aafac8324db452070304f8d745.')
         selected_parser.add_argument('--scope', dest='scope', action='store', help='Scope if you are using the filter option and no full DID.')
         selected_parser.add_argument('--metalink', dest='metalink_file', action='store', help='Path to a metalink file.')
@@ -2299,7 +2363,14 @@ You can filter by key/value, e.g.::
     delete_rule_parser.add_argument(dest='rule_id', action='store', help='Rule id or DID. If DID, the RSE expression is mandatory.')
     delete_rule_parser.add_argument('--purge-replicas', dest='purge_replicas', action='store_true', help='Purge rule replicas')
     delete_rule_parser.add_argument('--all', dest='delete_all', action='store_true', default=False, help='Delete all the rules, even the ones that are not owned by the account')
-    delete_rule_parser.add_argument('--rse_expression', dest='rse_expression', action='store', help='The RSE expression. Must be specified if a DID is provided.')  # TODO:remove-deprecated
+    delete_rule_parser.add_argument(
+        '--rse_expression',
+        '--rse-expression',
+        new_option_string='--rse-expression',
+        dest='rse_expression',
+        action=StoreAndDeprecateWarningAction,
+        help='The RSE expression. Must be specified if a DID is provided.'
+    )  # TODO:remove-deprecated
     delete_rule_parser.add_argument('--rses', dest='rses', action='store', help='The RSE expression. Must be specified if a DID is provided.')
     delete_rule_parser.add_argument('--account', dest='rule_account', action='store', help='The account of the rule that must be deleted')
 
@@ -2382,7 +2453,14 @@ can be found in ' + Color.BOLD + 'http://rucio.cern.ch/client_tutorial.html#addi
     list_suspicious_replicas_parser.set_defaults(function=list_suspicious_replicas)
     list_suspicious_replicas_parser.add_argument('--expression', dest='rse_expression', action='store', help='The RSE filter expression. A comprehensive help about RSE expressions \
 can be found in ' + Color.BOLD + 'http://rucio.cern.ch/client_tutorial.html#adding-rules-for-replication' + Color.END)
-    list_suspicious_replicas_parser.add_argument('--younger_than', dest='younger_than', action='store', help='List files that have been marked suspicious since the date "younger_than".')
+    list_suspicious_replicas_parser.add_argument(
+        '--younger_than',
+        '--younger-than',
+        new_option_string='--younger-than',
+        dest='younger_than',
+        action=StoreAndDeprecateWarningAction,
+        help='List files that have been marked suspicious since the date "younger_than".'
+    )
     list_suspicious_replicas_parser.add_argument('--nattempts', dest='nattempts', action='store', help='Minimum number of failed attempts to access a suspicious file.')
 
     # The list-rses-attributes command

--- a/bin/rucio-c3po
+++ b/bin/rucio-c3po
@@ -20,6 +20,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 """
 C-3PO is a dynamic data placement daemon.

--- a/bin/rucio-c3po
+++ b/bin/rucio-c3po
@@ -28,6 +28,7 @@ C-3PO is a dynamic data placement daemon.
 import argparse
 import signal
 
+from rucio.common.utils import StoreAndDeprecateWarningAction
 from rucio.daemons.c3po.c3po import run, stop
 
 
@@ -39,18 +40,89 @@ def get_parser():
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
     parser.add_argument("--threads", action="store", default=1, type=int, help='Concurrency control: number of threads')
     parser.add_argument("--only-workload", action="store_true", default=False, help='Only run the workload collector')
-    parser.add_argument("--dry_run", action="store_true", default=False, help='Do not create any rules')
+    parser.add_argument(
+        "--dry_run",
+        "--dry-run",
+        new_option_string="--dry-run",
+        action=StoreAndDeprecateWarningAction,
+        default=False,
+        help='Do not create any rules'
+    )
     parser.add_argument("--sampling", action="store_true", default=False, help='In the end flip a to decide to create a rule or not')
     parser.add_argument("--algorithms", action="store", default="t2_free_space_only_pop_with_network", type=str, help='The placement algorithm or, if in dry_run, a comma separated list of algorithms')
     parser.add_argument("--datatypes", action="store", default="NTUP,DAOD", type=str, help='Comma separated list of datatype that should trigger the placement')
-    parser.add_argument("--dest_rse_expr", action="store", default="type=DATADISK", type=str, help='RSE expression defining the allowed destination RSEs')
-    parser.add_argument("--max_bytes_hour", action="store", default=100000000000000, type=int, help='Max number of bytes that c3po is allow to replicate per hour')
-    parser.add_argument("--max_files_hour", action="store", default=100000, type=int, help='Max number of files that c3po is allow to replicate per hour')
-    parser.add_argument("--max_bytes_hour_rse", action="store", default=50000000000000, type=int, help='Max number of bytes that c3po is allow to replicate per hour per rse')
-    parser.add_argument("--max_files_hour_rse", action="store", default=10000, type=int, help='Max number of files that c3po is allow to replicate per hour prse_rse')
-    parser.add_argument("--min_popularity", action="store", default=8, type=int, help='Min number of popularity accesses for a DID in the last 7 days to trigger')
-    parser.add_argument("--min_recent_requests", action="store", default=5, type=int, help='Min number of times a DID has to be requested in the last hour to trigger')
-    parser.add_argument("--max_replicas", action="store", default=5, type=int, help='Max number of replicas above which not to trigger anymore')
+    parser.add_argument(
+        "--dest_rse_expr",
+        "--dest-rse-expr",
+        new_option_string="--dest-rse-expr",
+        action=StoreAndDeprecateWarningAction,
+        default="type=DATADISK",
+        type=str,
+        help='RSE expression defining the allowed destination RSEs'
+    )
+    parser.add_argument(
+        "--max_bytes_hour",
+        "--max-bytes-hour",
+        new_option_string="--max-bytes-hour",
+        action=StoreAndDeprecateWarningAction,
+        default=100000000000000,
+        type=int,
+        help='Max number of bytes that c3po is allow to replicate per hour'
+    )
+    parser.add_argument(
+        "--max_files_hour",
+        "--max-files-hour",
+        new_option_string="--max-files-hour",
+        action=StoreAndDeprecateWarningAction,
+        default=100000,
+        type=int,
+        help='Max number of files that c3po is allow to replicate per hour'
+    )
+    parser.add_argument(
+        "--max_bytes_hour_rse",
+        "--max-bytes-hour-rse",
+        new_option_string="--max-bytes-hour-rse",
+        action=StoreAndDeprecateWarningAction,
+        default=50000000000000,
+        type=int,
+        help='Max number of bytes that c3po is allow to replicate per hour per rse'
+    )
+    parser.add_argument(
+        "--max_files_hour_rse",
+        "--max-files-hour-rse",
+        new_option_string="--max-files-hour-rse",
+        action=StoreAndDeprecateWarningAction,
+        default=10000,
+        type=int,
+        help='Max number of files that c3po is allow to replicate per hour prse_rse'
+    )
+    parser.add_argument(
+        "--min_popularity",
+        "--min-popularity",
+        new_option_string="--min-popularity",
+        action=StoreAndDeprecateWarningAction,
+        default=8,
+        type=int,
+        help='Min number of popularity accesses for a DID in the last 7 days to trigger'
+    )
+    parser.add_argument(
+        "--min_recent_requests",
+        "--min-recent-requests",
+        new_option_string="--min-recent-requests",
+        action=StoreAndDeprecateWarningAction,
+        default=5,
+        type=int,
+        help='Min number of times a DID has to be requested in the last hour to trigger'
+    )
+    parser.add_argument(
+        "--max_replicas",
+        "--max-replicas",
+        new_option_string="--max-replicas",
+        action=StoreAndDeprecateWarningAction,
+        default=5,
+        type=int,
+        help='Max number of replicas above which not to trigger anymore'
+    )
     parser.add_argument('--waiting-time-read-free-space', action="store", default=1800, type=int, help='Waiting time for reading free space')
     parser.add_argument('--waiting-time-read-workload', action="store", default=1800, type=int, help='Waiting time for reading workload')
     parser.add_argument('--waiting-time-print-workload', action="store", default=600, type=int, help='Waiting time for printing workload')

--- a/bin/rucio-conveyor-fts-throttler
+++ b/bin/rucio-conveyor-fts-throttler
@@ -26,6 +26,7 @@ alleviated by limiting the transfer settings of FTS transfers on the particular 
 import argparse
 import signal
 
+from rucio.common.utils import StoreAndDeprecateWarningAction
 from rucio.daemons.conveyor.fts_throttler import run, stop
 
 
@@ -38,7 +39,15 @@ def get_parser():
                                      It does this by retrieving transfer failure information from elastic search, depending on their failure ratio.\
                                      it will use http requests to set the storage configurations accordingly")
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
-    parser.add_argument("--cycle_interval", action="store", default=3600, type=int, help='interval for each cycle')
+    parser.add_argument(
+        "--cycle_interval",
+        "--cycle-interval",
+        new_option_string="--cycle-interval",
+        action=StoreAndDeprecateWarningAction,
+        default=3600,
+        type=int,
+        help='interval for each cycle'
+    )
 
     return parser
 

--- a/bin/rucio-conveyor-fts-throttler
+++ b/bin/rucio-conveyor-fts-throttler
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-# Copyright 2019 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2019-2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +16,7 @@
 #
 # Authors:
 # - Dilaksun Bavarajan, <dilaksun@hotmail.com>, 2019
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 """
 Conveyor FTS Throttler is a daemon that will configure a fts storage's transfer settings

--- a/bin/rucio-reaper
+++ b/bin/rucio-reaper
@@ -17,6 +17,7 @@
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 #
 # PY3K COMPATIBLE
 

--- a/bin/rucio-reaper
+++ b/bin/rucio-reaper
@@ -26,6 +26,7 @@
 import argparse
 import signal
 
+from rucio.common.utils import StoreAndDeprecateWarningAction
 from rucio.daemons.reaper.reaper import run, stop
 
 
@@ -38,8 +39,15 @@ def get_parser():
                         help='Runs one loop iteration')
     parser.add_argument("--threads", action="store", default=1, type=int,
                         help='Concurrency control: number of threads')
-    parser.add_argument("--chunk_size", action="store", default=100, type=int,
-                        help='The size used for a bulk deletion on on RSE')
+    parser.add_argument(
+        "--chunk_size",
+        "--chunk-size",
+        new_option_string="--chunk-size",
+        action=StoreAndDeprecateWarningAction,
+        default=100,
+        type=int,
+        help='The size used for a bulk deletion on on RSE'
+    )
     parser.add_argument('--sleep-time', action="store", default=60, type=int,
                         help='Minimum time between 2 consecutive cycles')
     parser.add_argument('--greedy', action="store_true", default=False,
@@ -56,10 +64,24 @@ def get_parser():
                         help='The delay (seconds) to query replicas in BEING_DELETED state.')
     parser.add_argument('--scheme', action="store", default=None, type=str,
                         help='Force the reaper to use a particular protocol/scheme, e.g., mock')
-    parser.add_argument("--auto_exclude_threshold", action="store", default=100, type=int,
-                        help='Number of service unavailable exceptions after which the RSE gets temporarily excluded.')
-    parser.add_argument("--auto_exclude_timeout", action="store", default=600, type=int,
-                        help='Timeout for temporarily excluded RSEs.')
+    parser.add_argument(
+        "--auto_exclude_threshold",
+        "--auto-exclude-threshhold",
+        new_option_string="--auto-exclude-threshhold",
+        action=StoreAndDeprecateWarningAction,
+        default=100,
+        type=int,
+        help='Number of service unavailable exceptions after which the RSE gets temporarily excluded.'
+    )
+    parser.add_argument(
+        "--auto_exclude_timeout",
+        "--auto-exclude-timeout",
+        new_option_string="--auto-exclude-timeout",
+        action=StoreAndDeprecateWarningAction,
+        default=600,
+        type=int,
+        help='Timeout for temporarily excluded RSEs.'
+    )
 
     return parser
 

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -26,7 +26,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Tomas Javurek <tomas.javurek@cern.ch>, 2019-2020
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - James Perry <j.perry@epcc.ed.ac.uk>, 2019
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2019-2021
 # - Gabriele Fronze' <gfronze@cern.ch>, 2019
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
@@ -39,6 +39,7 @@
 # - Anil Panta <47672624+panta-123@users.noreply.github.com>, 2021
 # - Ilija Vukotic <ivukotic@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from __future__ import absolute_import, print_function
 
@@ -57,7 +58,6 @@ import socket
 import subprocess
 import tempfile
 import threading
-import typing
 import time
 import zlib
 from enum import Enum
@@ -1425,9 +1425,9 @@ class StoreAndDeprecateWarningAction(argparse.Action):
 
     def __init__(
         self,
-        option_strings: typing.List[str],
-        new_option_string: str,
-        dest: str,
+        option_strings,
+        new_option_string,
+        dest,
         **kwargs
     ):
         """
@@ -1446,6 +1446,6 @@ class StoreAndDeprecateWarningAction(argparse.Action):
         if option_string and option_string != self.new_option_string:
             # The logger gets typically initialized after the argument parser
             # to set the verbosity of the logger. Thus using simple print to console.
-            print(f"Warning: The commandline argument {option_string} is deprecated! Please use {self.new_option_string} in the future.")
+            print("Warning: The commandline argument {} is deprecated! Please use {} in the future.".format(option_string, self.new_option_string))
 
         setattr(namespace, self.dest, values)

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -42,6 +42,7 @@
 
 from __future__ import absolute_import, print_function
 
+import argparse
 import base64
 import datetime
 import errno
@@ -56,6 +57,7 @@ import socket
 import subprocess
 import tempfile
 import threading
+import typing
 import time
 import zlib
 from enum import Enum
@@ -1413,3 +1415,37 @@ class retry:
                     logger(logging.DEBUG, str(e))
                 attempt -= 1
         return self.func(*self.args, **self.kwargs)
+
+
+class StoreAndDeprecateWarningAction(argparse.Action):
+    '''
+    StoreAndDeprecateWarningAction is a descendant of :class:`argparse.Action`
+    and represents a store action with a deprecated argument name.
+    '''
+
+    def __init__(
+        self,
+        option_strings: typing.List[str],
+        new_option_string: str,
+        dest: str,
+        **kwargs
+    ):
+        """
+        :param option_strings: all possible argument name strings
+        :param new_option_string: the new option string which replaces the old
+        :param dest: name of variable to store the value in
+        :param kwargs: everything else
+        """
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            **kwargs)
+        self.new_option_string = new_option_string
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string and option_string != self.new_option_string:
+            # The logger gets typically initialized after the argument parser
+            # to set the verbosity of the logger. Thus using simple print to console.
+            print(f"Warning: The commandline argument {option_string} is deprecated! Please use {self.new_option_string} in the future.")
+
+        setattr(namespace, self.dest, values)


### PR DESCRIPTION
Kebab-case is the de facto GNU and Linux standard of naming command line
arguments. Since we are not consistent on naming our command line arguments we
adapt this style.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
