### PR TITLE
Clients: enforce rucio update-rule --cancel-requests to specify a state #3838

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -48,6 +48,7 @@
 # - Christoph Ames <christoph.ames@physik.uni-muenchen.de>, 2021
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -1348,6 +1349,9 @@ def update_rule(args):
     if args.source_replica_expression:
         options['source_replica_expression'] = None if args.source_replica_expression.lower() == 'none' else args.source_replica_expression
     if args.cancel_requests:
+        if 'state' not in options:
+            logger.error('--stuck or --suspend must be specified when running --cancel-requests')
+            return FAILURE
         options['cancel_requests'] = True
     if args.priority:
         options['priority'] = int(args.priority)

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -34,6 +34,7 @@
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -1722,3 +1723,10 @@ class TestBinRucio(unittest.TestCase):
         assert re.search("DATASET", out) is not None
         cmd = 'rm -rf %s' % folder
         execute(cmd)
+
+    def test_update_rule_cancel_requests_args(self):
+        """CLIENT(USER): update rule cancel requests must have a state defined"""
+        cmd = 'rucio update-rule --cancel-requests RULE'
+        exitcode, out, err = execute(cmd)
+        assert '--stuck or --suspend must be specified when running --cancel-requests' in err
+        assert exitcode != 0


### PR DESCRIPTION
`rucio update-rule --cancel-requests` needs a state to determine its
utilization. Right now the program exits normally without any error if no state
is given, letting the user believe everything worked out.

This commit enforces the specification of a state, with `--stuck` or
`--suspend`. If no state is given, the program exits with an error.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
