### PR TITLE
Core: Allow set_rse_usage to set number of files #4861

### DIFF
--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -29,6 +29,7 @@
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Tomas Javurek <tomas.javurek@cern.ch>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from rucio.api import permission
 from rucio.common import exception
@@ -272,7 +273,7 @@ def update_protocols(rse, scheme, data, issuer, vo='def', hostname=None, port=No
     rse_module.update_protocols(rse_id=rse_id, scheme=scheme, hostname=hostname, port=port, data=data)
 
 
-def set_rse_usage(rse, source, used, free, issuer, vo='def'):
+def set_rse_usage(rse, source, used, free, issuer, files=None, vo='def'):
     """
     Set RSE usage information.
 
@@ -281,9 +282,10 @@ def set_rse_usage(rse, source, used, free, issuer, vo='def'):
     :param used: the used space in bytes.
     :param free: the free space in bytes.
     :param issuer: The issuer account.
+    :param files: the number of files
     :param vo: The VO to act on.
 
-    :returns: List of RSE usage data.
+    :returns: True if successful, otherwise false.
     """
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
 
@@ -291,7 +293,7 @@ def set_rse_usage(rse, source, used, free, issuer, vo='def'):
     if not permission.has_permission(issuer=issuer, vo=vo, action='set_rse_usage', kwargs=kwargs):
         raise exception.AccessDenied('Account %s can not update RSE usage information for RSE %s' % (issuer, rse))
 
-    return rse_module.set_rse_usage(rse_id=rse_id, source=source, used=used, free=free)
+    return rse_module.set_rse_usage(rse_id=rse_id, source=source, used=used, free=free, files=files)
 
 
 def get_rse_usage(rse, issuer, source=None, per_account=False, vo='def'):
@@ -303,7 +305,7 @@ def get_rse_usage(rse, issuer, source=None, per_account=False, vo='def'):
     :param source: dictionary of attributes by which the results should be filtered
     :param vo: The VO to act on.
 
-    :returns: True if successful, otherwise false.
+    :returns: List of RSE usage data.
     """
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
     usages = rse_module.get_rse_usage(rse_id=rse_id, source=source, per_account=per_account)

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -29,6 +29,8 @@
 # - Tomas Javurek <tomas.javurek@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from json import dumps, loads
 
@@ -487,7 +489,7 @@ class RSEClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def set_rse_usage(self, rse, source, used, free):
+    def set_rse_usage(self, rse, source, used, free, files=None):
         """
         Set RSE usage information.
 
@@ -495,13 +497,14 @@ class RSEClient(BaseClient):
         :param source: the information source, e.g. srm.
         :param used: the used space in bytes.
         :param free: the free in bytes.
+        :param files: the number of files
 
         :returns: True if successful, otherwise false.
         """
         path = [self.RSE_BASEURL, rse, 'usage']
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        data = {'source': source, 'used': used, 'free': free}
+        data = {'source': source, 'used': used, 'free': free, 'files': files}
         r = self._send_request(url, type_='PUT', data=dumps(data))
         if r.status_code == codes.ok:
             return True

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -35,6 +35,8 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Tomas Javurek <tomas.javurek@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 import json
 from io import StringIO
@@ -659,7 +661,7 @@ def get_rse_is_checksum_supported(checksum_name, rse_id=None, session=None):
 
 
 @transactional_session
-def set_rse_usage(rse_id, source, used, free, session=None):
+def set_rse_usage(rse_id, source, used, free, files=None, session=None):
     """
     Set RSE usage information.
 
@@ -667,11 +669,12 @@ def set_rse_usage(rse_id, source, used, free, session=None):
     :param source: The information source, e.g. srm.
     :param used: the used space in bytes.
     :param free: the free in bytes.
+    :param files: the number of files
     :param session: The database session in use.
 
     :returns: True if successful, otherwise false.
     """
-    rse_usage = models.RSEUsage(rse_id=rse_id, source=source, used=used, free=free)
+    rse_usage = models.RSEUsage(rse_id=rse_id, source=source, used=used, free=free, files=files)
     # versioned_session(session)
     rse_usage = session.merge(rse_usage)
     rse_usage.save(session=session)

--- a/lib/rucio/tests/test_rse.py
+++ b/lib/rucio/tests/test_rse.py
@@ -30,6 +30,8 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -1351,10 +1353,12 @@ class TestRSEClient(unittest.TestCase):
         usages = self.client.get_rse_usage(rse='MOCK')
         for usage in usages:
             if usage['source'] == 'srm':
+                assert usage['files'] is None
                 assert usage['total'] == 1000000
-        assert self.client.set_rse_usage(rse='MOCK', source='srm', used=999920, free=80)
+        assert self.client.set_rse_usage(rse='MOCK', source='srm', used=999920, free=80, files=50)
         for usage in self.client.list_rse_usage_history(rse='MOCK'):
             assert usage['free'] == 80
+            assert usage['files'] == 50
             break
 
     @pytest.mark.noparallel(reason='uses pre-defined RSE')

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -17,6 +17,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from json import dumps
 
@@ -535,7 +536,7 @@ class Usage(ErrorHandlingMethodView):
         .. :quickref: Usage; Update RSE usage.
 
         :param rse: The RSE name.
-        :<json dict parameter: Dictionary with 'source', 'used', 'free' values to update.
+        :<json dict parameter: Dictionary with 'source', 'used', 'free', 'files' values to update.
         :status 200: OK.
         :status 400: Cannot decode json parameter dictionary.
         :status 401: Invalid Auth Token.
@@ -543,7 +544,7 @@ class Usage(ErrorHandlingMethodView):
 
         """
         parameters = json_parameters()
-        kwargs = {'source': None, 'used': None, 'free': None}
+        kwargs = {'source': None, 'used': None, 'free': None, 'files': None}
         for keyword in kwargs.keys():
             kwargs[keyword] = param_get(parameters, keyword, default=kwargs[keyword])
 


### PR DESCRIPTION
Rucio Storage Elements (RSE) have the attribute number of files (`files`). Until
now this attribute could not be set with the set functions.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
