### PR TITLE
Allow setting up default scope extraction algorithms programatically. Addresses #4886

### DIFF
--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -745,10 +745,10 @@ register_extract_scope_algorithm(extract_scope_atlas, 'atlas')
 register_extract_scope_algorithm(extract_scope_belleii, 'belleii')
 
 
-def extract_scope(did, scopes=None):
+def extract_scope(did, scopes=None, default_extract=_DEFAULT_EXTRACT):
     extract_scope_convention = config_get('common', 'extract_scope', False, None)
     if extract_scope_convention is None or extract_scope_convention not in _EXTRACT_SCOPE_ALGORITHMS:
-        extract_scope_convention = _DEFAULT_EXTRACT
+        extract_scope_convention = default_extract
     return _EXTRACT_SCOPE_ALGORITHMS[extract_scope_convention](did=did, scopes=scopes)
 
 


### PR DESCRIPTION
<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
This change addresses the issue where a config file is needed on the client side. By allowing setting a different default algorithm programmatically we eliminate the need of a config file on the client side.