### PR TITLE
Messaging: Stop SSL reconnects

### DIFF
--- a/lib/rucio/daemons/hermes/hermes.py
+++ b/lib/rucio/daemons/hermes/hermes.py
@@ -218,7 +218,7 @@ def deliver_messages(once=False, brokers_resolved=None, thread=0, bulk=1000, del
                                      ssl_cert_file=config_get('messaging-hermes', 'ssl_cert_file'),
                                      vhost=vhost,
                                      keepalive=True,
-                                     timeout=broker_timeout)
+                                     )
 
         con.set_listener('rucio-hermes',
                          HermesListener(con.transport._Transport__host_and_ports[0]))

--- a/lib/rucio/daemons/hermes/hermes2.py
+++ b/lib/rucio/daemons/hermes/hermes2.py
@@ -153,7 +153,7 @@ def setup_activemq(logger):
                                      ssl_cert_file=config_get('messaging-hermes', 'ssl_cert_file'),
                                      vhost=vhost,
                                      keepalive=True,
-                                     timeout=broker_timeout)
+                                     )
 
         con.set_listener('rucio-hermes',
                          HermesListener(con.transport._Transport__host_and_ports[0]))


### PR DESCRIPTION
This PR fixes the issue in #2606 which only affects CMS because we use SSL connections. It seems that providing the "timeout" parameter to stomp.py is actually signaling that the connection should ONLY last the length of the timeout. So no value is appropriate. 

The checks on connection status should be enough to get the connection recreated when it does drop