### PR TITLE
Client: Add activity and source-replica-expression args to move-rules Close #4855

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -48,6 +48,7 @@
 # - Christoph Ames <christoph.ames@physik.uni-muenchen.de>, 2021
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -1366,7 +1367,10 @@ def move_rule(args):
     Update a rule.
     """
     client = get_client(args)
-    print(client.move_replication_rule(rule_id=args.rule_id, rse_expression=args.rse_expression))
+    print(client.move_replication_rule(rule_id=args.rule_id,
+                                       rse_expression=args.rse_expression,
+                                       activity=args.activity,
+                                       source_replica_expression=args.source_replica_expression))
     return SUCCESS
 
 
@@ -2368,6 +2372,8 @@ You can filter by account::
     move_rule_parser.set_defaults(function=move_rule)
     move_rule_parser.add_argument(dest='rule_id', action='store', help='Rule id')
     move_rule_parser.add_argument(dest='rse_expression', action='store', help='RSE expression of new rule')
+    move_rule_parser.add_argument('--activity', dest='activity', action='store', help='Update activity for moved rule')
+    move_rule_parser.add_argument('--source-replica-expression', dest='source_replica_expression', action='store', help='Update source-replica-expression for moved rule')
 
     # The list-rses command
     list_rses_parser = subparsers.add_parser('list-rses', help='Show the list of all the registered Rucio Storage Elements (RSEs).')

--- a/lib/rucio/api/rule.py
+++ b/lib/rucio/api/rule.py
@@ -1,23 +1,32 @@
-'''
-  Copyright European Organization for Nuclear Research (CERN)
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  You may not use this file except in compliance with the License.
-  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-  Authors:
-  - Vincent Garonne, <vincent.garonne@cern.ch>, 2012
-  - Martin Barisits, <martin.barisits@cern.ch>, 2013-2018
-  - Cedric Serfon, <cedric.serfon@cern.ch>, 2014-2015
-  - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
-  - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
-  - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
-  - Ian Johnson, <ian.johnson@stfc.ac.uk>, 2021
-  - Radu Carpa <radu.carpa@cern.ch>, 2021
-  - Joel Dierkes <joel.dierkes@cern.ch>, 2021
-
-  PY3K COMPATIBLE
-'''
+# -*- coding: utf-8 -*-
+# Copyright 2012-2021 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2013
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2017
+# - Martin Barisits <martin.barisits@cern.ch>, 2013-2018
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2015
+# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2020
+# - Ian Johnson <ijjorama@gmail.com>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from rucio.api.permission import has_permission
 from rucio.common.config import config_get_bool

--- a/lib/rucio/api/rule.py
+++ b/lib/rucio/api/rule.py
@@ -14,6 +14,7 @@
   - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
   - Ian Johnson, <ian.johnson@stfc.ac.uk>, 2021
   - Radu Carpa <radu.carpa@cern.ch>, 2021
+  - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
   PY3K COMPATIBLE
 '''
@@ -283,20 +284,30 @@ def examine_replication_rule(rule_id, issuer, vo='def'):
     return result
 
 
-def move_replication_rule(rule_id, rse_expression, issuer, vo='def'):
+def move_replication_rule(rule_id, rse_expression, activity, source_replica_expression, issuer, vo='def'):
     """
     Move a replication rule to another RSE and, once done, delete the original one.
 
-    :param rule_id:             Rule to be moved.
-    :param rse_expression:      RSE expression of the new rule.
-    :param session:             The DB Session.
-    :param vo:                  The VO to act on.
-    :raises:                    RuleNotFound, RuleReplaceFailed
+    :param rule_id:                    Rule to be moved.
+    :param rse_expression:             RSE expression of the new rule.
+    :param activity:                   Activity of the new rule.
+    :param source_replica_expression:  Source-Replica-Expression of the new rule.
+    :param session:                    The DB Session.
+    :param vo:                         The VO to act on.
+    :raises:                           RuleNotFound, RuleReplaceFailed, InvalidRSEExpression, AccessDenied
     """
-    kwargs = {'rule_id': rule_id, 'rse_expression': rse_expression}
+    kwargs = {
+        'rule_id': rule_id,
+        'rse_expression': rse_expression,
+        'activity': activity,
+        'source_replica_expression': source_replica_expression
+    }
     if is_multi_vo() and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs):
         raise AccessDenied('Account %s can not access rules at other VOs.' % (issuer))
     if not has_permission(issuer=issuer, vo=vo, action='move_rule', kwargs=kwargs):
         raise AccessDenied('Account %s can not move this replication rule.' % (issuer))
 
-    return rule.move_rule(rule_id=rule_id, rse_expression=rse_expression)
+    return rule.move_rule(rule_id=rule_id,
+                          rse_expression=rse_expression,
+                          activity=activity,
+                          source_replica_expression=source_replica_expression)

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -27,6 +27,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from json import dumps, loads
 
@@ -159,18 +160,25 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def move_replication_rule(self, rule_id, rse_expression):
+    def move_replication_rule(self, rule_id, rse_expression, activity, source_replica_expression):
         """
         Move a replication rule to another RSE and, once done, delete the original one.
 
-        :param rule_id:             Rule to be moved.
-        :param rse_expression:      RSE expression of the new rule.
-        :raises:                    RuleNotFound, RuleReplaceFailed
+        :param rule_id:                    Rule to be moved.
+        :param rse_expression:             RSE expression of the new rule.
+        :param activity:                   Activity of the new rule.
+        :param source_replica_expression:  Source-Replica-Expression of the new rule.
+        :raises:                           RuleNotFound, RuleReplaceFailed
         """
 
         path = self.RULE_BASEURL + '/' + rule_id + '/move'
         url = build_url(choice(self.list_hosts), path=path)
-        data = dumps({'rule_id': rule_id, 'rse_expression': rse_expression})
+        data = dumps({
+            'rule_id': rule_id,
+            'rse_expression': rse_expression,
+            'activity': activity,
+            'source_replica_expression': source_replica_expression
+        })
         r = self._send_request(url, type_='POST', data=data)
         if r.status_code == codes.created:
             return loads(r.text)

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -35,6 +35,7 @@
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from __future__ import division
 
@@ -1484,14 +1485,16 @@ def reduce_rule(rule_id, copies, exclude_expression=None, session=None):
 
 
 @transactional_session
-def move_rule(rule_id, rse_expression, session=None):
+def move_rule(rule_id, rse_expression, activity=None, source_replica_expression=None, session=None):
     """
     Move a replication rule to another RSE and, once done, delete the original one.
 
-    :param rule_id:             Rule to be moved.
-    :param rse_expression:      RSE expression of the new rule.
-    :param session:             The DB Session.
-    :raises:                    RuleNotFound, RuleReplaceFailed
+    :param rule_id:                    Rule to be moved.
+    :param rse_expression:             RSE expression of the new rule.
+    :param activity:                   Activity of the new rule.
+    :param source_replica_expression:  Source-Replica-Expression of the new rule.
+    :param session:                    The DB Session.
+    :raises:                           RuleNotFound, RuleReplaceFailed, InvalidRSEExpression
     """
     try:
         rule = session.query(models.ReplicationRule).filter_by(id=rule_id).one()
@@ -1517,8 +1520,8 @@ def move_rule(rule_id, rse_expression, session=None):
                                lifetime=lifetime,
                                locked=rule.locked,
                                subscription_id=rule.subscription_id,
-                               source_replica_expression=rule.source_replica_expression,
-                               activity=rule.activity,
+                               source_replica_expression=source_replica_expression if source_replica_expression else rule.source_replica_expression,
+                               activity=activity if activity else rule.activity,
                                notify=notify,
                                purge_replicas=rule.purge_replicas,
                                ignore_availability=rule.ignore_availability,

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -34,6 +34,7 @@
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -1153,6 +1154,158 @@ class TestBinRucio(unittest.TestCase):
         exitcode, out, err = execute(cmd)
         print(out, err)
         assert 5 == len(out.splitlines())
+
+    def test_move_rule(self):
+        """CLIENT(USER): Rucio move rule"""
+        tmp_file1 = file_generator()
+        # add files
+        cmd = 'rucio upload --rse {0} --scope {1} {2}'.format(self.def_rse, self.user, tmp_file1)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add rse
+        tmp_rse = rse_name_generator()
+        cmd = 'rucio-admin rse add {0}'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out)
+        # add quota
+        self.account_client.set_local_account_limit('root', tmp_rse, -1)
+        # add rse atributes
+        cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add rse
+        tmp_rse = rse_name_generator()
+        cmd = 'rucio-admin rse add {0}'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add quota
+        self.account_client.set_local_account_limit('root', tmp_rse, -1)
+        # add rse atributes
+        cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add rse
+        tmp_rse = rse_name_generator()
+        cmd = 'rucio-admin rse add {0}'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add quota
+        self.account_client.set_local_account_limit('root', tmp_rse, -1)
+        # add rse atributes
+        cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add rules
+        cmd = "rucio add-rule {0}:{1} 3 'spacetoken=ATLASSCRATCHDISK'".format(self.user, tmp_file1[5:])
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out)
+        assert not err
+        rule = out[:-1]  # triming new line character
+        assert re.match(r'^\w+$', rule)
+
+        # move rule
+        new_rule_expr = "'spacetoken=ATLASSCRATCHDISK|spacetoken=ATLASSD'"
+        cmd = "rucio move-rule {} {}".format(rule, new_rule_expr)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out)
+        assert not err
+        new_rule = out[:-1]  # triming new line character
+
+        # check if rule exist for the file
+        cmd = "rucio list-rules {0}:{1}".format(self.user, tmp_file1[5:])
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        assert re.search(new_rule, out) is not None
+
+    def test_move_rule_with_arguments(self):
+        """CLIENT(USER): Rucio move rule"""
+        tmp_file1 = file_generator()
+        # add files
+        cmd = 'rucio upload --rse {0} --scope {1} {2}'.format(self.def_rse, self.user, tmp_file1)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add rse
+        tmp_rse = rse_name_generator()
+        cmd = 'rucio-admin rse add {0}'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out)
+        # add quota
+        self.account_client.set_local_account_limit('root', tmp_rse, -1)
+        # add rse atributes
+        cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add rse
+        tmp_rse = rse_name_generator()
+        cmd = 'rucio-admin rse add {0}'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add quota
+        self.account_client.set_local_account_limit('root', tmp_rse, -1)
+        # add rse atributes
+        cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add rse
+        tmp_rse = rse_name_generator()
+        cmd = 'rucio-admin rse add {0}'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add quota
+        self.account_client.set_local_account_limit('root', tmp_rse, -1)
+        # add rse atributes
+        cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        # add rules
+        cmd = "rucio add-rule {0}:{1} 3 'spacetoken=ATLASSCRATCHDISK'".format(self.user, tmp_file1[5:])
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out)
+        assert not err
+        rule = out[:-1]  # triming new line character
+        assert re.match(r'^\w+$', rule)
+        # move rule
+        new_rule_expr = "spacetoken=ATLASSCRATCHDISK|spacetoken=ATLASSD"
+        new_rule_activity = "No User Subscription"
+        new_rule_source_replica_expression = "spacetoken=ATLASSCRATCHDISK|spacetoken=ATLASSD"
+        cmd = "rucio move-rule --activity '{}' --source-replica-expression '{}' {} '{}'".format(new_rule_activity, new_rule_source_replica_expression, rule, new_rule_expr)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        assert not err
+        new_rule_id = out[:-1]  # triming new line character
+
+        # check if rule exist for the file
+        cmd = "rucio list-rules {0}:{1}".format(self.user, tmp_file1[5:])
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        assert re.search(new_rule_id, out) is not None
+        # check updated rule information
+        cmd = "rucio rule-info {0}".format(new_rule_id)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        assert new_rule_activity in out
+        assert new_rule_source_replica_expression in out
 
     def test_add_file_twice(self):
         """CLIENT(USER): Add file twice"""

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -307,9 +307,13 @@ class MoveRule(ErrorHandlingMethodView):
         parameters = json_parameters()
         rse_expression = param_get(parameters, 'rse_expression')
         rule_id = param_get(parameters, 'rule_id', default=rule_id)
+        activity = param_get(parameters, 'activity', default=None)
+        source_replica_expression = param_get(parameters, 'source_replica_expression', default=None)
         try:
             rule_ids = move_replication_rule(rule_id=rule_id,
                                              rse_expression=rse_expression,
+                                             activity=activity,
+                                             source_replica_expression=source_replica_expression,
                                              issuer=request.environ.get('issuer'),
                                              vo=request.environ.get('vo'))
         except RuleReplaceFailed as error:


### PR DESCRIPTION
`move-rules` now can specify `--activity` and `--source-replica-expression`. The
respective new 'moved' rule will have these attributes set to these values.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
