### PR TITLE
Transfers: fix LOST transfer handling. Closes #4904

### DIFF
--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -398,7 +398,7 @@ class FTS3Transfertool(Transfertool):
             record_counter('transfertool.fts3.{host}.bulk_query.failure', labels={'host': self.__extract_host(self.external_host)})
             for transfer_id in transfer_ids:
                 responses[transfer_id] = Exception('Transfer information returns None: %s' % jobs)
-        elif jobs.status_code == 200 or jobs.status_code == 207:
+        elif jobs.status_code in (200, 207, 404):
             try:
                 BULK_QUERY_COUNTER.labels(state='success', host=self.__extract_host(self.external_host)).inc()
                 jobs_response = jobs.json()


### PR DESCRIPTION
For non-existing transfers, FTS can either return a 207, or a 404,
status code. This depends on whether all queried transfers are lost,
or only some of them. Rucio incorrectly handles the 404 status code.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
