### PR TITLE
Tests: explicitly write full cache module when mocking

### DIFF
--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -292,7 +292,7 @@ def caches_mock(request):
     with ExitStack() as stack:
         for module in caches_to_mock:
             region = make_region().configure('dogpile.cache.memory', expiration_time=600)
-            stack.enter_context(mock.patch('{}.{}'.format(module, 'REGION'), new=region))
+            stack.enter_context(mock.patch(module, new=region))
 
         yield
 

--- a/lib/rucio/tests/test_abacus_collection_replica.py
+++ b/lib/rucio/tests/test_abacus_collection_replica.py
@@ -167,7 +167,7 @@ class TestAbacusCollectionReplica(unittest.TestCase):
     ('reaper', 'remove_open_did', True)
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.config', 'rucio.core.replica'
+    'rucio.core.config.REGION', 'rucio.core.replica.REGION'
 ]}], indirect=True)
 def test_abacus_collection_replica_new(vo, rse_factory, rucio_client, did_factory, core_config_mock, caches_mock):
     """ ABACUS (COLLECTION REPLICA): Test update of collection replica. """

--- a/lib/rucio/tests/test_conveyor.py
+++ b/lib/rucio/tests/test_conveyor.py
@@ -103,9 +103,9 @@ def set_query_parameters(url, params):
     ('transfers', 'multihop_tombstone_delay', -1),  # Set OBSOLETE tombstone for intermediate replicas
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by rse expression
-    'rucio.core.config',
-    'rucio.daemons.reaper.reaper',
+    'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by rse expression
+    'rucio.core.config.REGION',
+    'rucio.daemons.reaper.reaper.REGION',
 ]}], indirect=True)
 def test_multihop_intermediate_replica_lifecycle(vo, did_factory, root_account, core_config_mock, caches_mock, metrics_mock):
     """
@@ -198,8 +198,8 @@ def test_multihop_intermediate_replica_lifecycle(vo, did_factory, root_account, 
     ('transfers', 'use_multihop', True),
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by rse expression
-    'rucio.core.config',
+    'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by rse expression
+    'rucio.core.config.REGION',
 ]}], indirect=True)
 def test_fts_non_recoverable_failures_handled_on_multihop(vo, did_factory, root_account, replica_client, core_config_mock, caches_mock, metrics_mock):
     """
@@ -237,8 +237,8 @@ def test_fts_non_recoverable_failures_handled_on_multihop(vo, did_factory, root_
     ('transfers', 'use_multihop', True),
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by rse expression
-    'rucio.core.config',
+    'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by rse expression
+    'rucio.core.config.REGION',
 ]}], indirect=True)
 def test_fts_recoverable_failures_handled_on_multihop(vo, did_factory, root_account, replica_client, file_factory, core_config_mock, caches_mock, metrics_mock):
     """
@@ -289,8 +289,8 @@ def test_fts_recoverable_failures_handled_on_multihop(vo, did_factory, root_acco
     ('transfers', 'use_multihop', True),
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by rse expression
-    'rucio.core.config',
+    'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by rse expression
+    'rucio.core.config.REGION',
 ]}], indirect=True)
 def test_multisource(vo, did_factory, root_account, replica_client, core_config_mock, caches_mock, metrics_mock):
     src_rse1 = 'XRD4'
@@ -405,8 +405,8 @@ def test_multisource_receiver(vo, did_factory, replica_client, root_account, met
     ('transfers', 'use_multihop', True),
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by rse expression
-    'rucio.core.config',
+    'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by rse expression
+    'rucio.core.config.REGION',
 ]}], indirect=True)
 def test_multihop_receiver_on_failure(vo, did_factory, replica_client, root_account, core_config_mock, caches_mock, metrics_mock):
     """
@@ -455,8 +455,8 @@ def test_multihop_receiver_on_failure(vo, did_factory, replica_client, root_acco
     ('transfers', 'use_multihop', True),
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by rse expression
-    'rucio.core.config',
+    'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by rse expression
+    'rucio.core.config.REGION',
 ]}], indirect=True)
 def test_multihop_receiver_on_success(vo, did_factory, root_account, core_config_mock, caches_mock, metrics_mock):
     """
@@ -624,8 +624,8 @@ def test_stager(rse_factory, did_factory, root_account, replica_client):
     ('transfers', 'use_multihop', True)
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by an expression
-    'rucio.core.config',
+    'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by an expression
+    'rucio.core.config.REGION',
 ]}], indirect=True)
 def test_overwrite_on_tape(rse_factory, did_factory, root_account, core_config_mock, caches_mock):
     """

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -98,8 +98,8 @@ def test_request_submitted_in_order(rse_factory, did_factory, root_account):
     ('transfers', 'use_multihop', True)
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by rse expression
-    'rucio.core.config',
+    'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by rse expression
+    'rucio.core.config.REGION',
 ]}], indirect=True)
 def test_multihop_sources_created(rse_factory, did_factory, root_account, core_config_mock, caches_mock, metrics_mock):
     """

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -613,7 +613,7 @@ class TestReplicaCore:
     ('reaper', 'remove_open_did', True)
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.config', 'rucio.core.replica'
+    'rucio.core.config.REGION', 'rucio.core.replica.REGION'
 ]}], indirect=True)
 def test_delete_replicas_from_datasets_new(core_config_mock, caches_mock, rse_factory, mock_scope, root_account):
     """ REPLICA (CORE): Delete replicas from dataset """

--- a/lib/rucio/tests/test_transfer.py
+++ b/lib/rucio/tests/test_transfer.py
@@ -210,8 +210,8 @@ def test_disk_vs_tape_priority(rse_factory, root_account, mock_scope):
     ('transfers', 'use_multihop', True)
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by an expression
-    'rucio.core.config',
+    'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by an expression
+    'rucio.core.config.REGION',
 ]}], indirect=True)
 def test_multihop_requests_created(rse_factory, did_factory, root_account, core_config_mock, caches_mock):
     """
@@ -237,8 +237,8 @@ def test_multihop_requests_created(rse_factory, did_factory, root_account, core_
     ('transfers', 'use_multihop', True)
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.rse_expression_parser',  # The list of multihop RSEs is retrieved by an expression
-    'rucio.core.config',
+    'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by an expression
+    'rucio.core.config.REGION',
 ]}], indirect=True)
 def test_singlehop_vs_multihop_priority(rse_factory, root_account, mock_scope, core_config_mock, caches_mock):
     """

--- a/lib/rucio/tests/test_undertaker.py
+++ b/lib/rucio/tests/test_undertaker.py
@@ -182,7 +182,7 @@ class TestUndertaker(unittest.TestCase):
     ('undertaker', 'purge_all_replicas', True)
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
-    'rucio.core.config',
+    'rucio.core.config.REGION',
 ]}], indirect=True)
 def test_removal_all_replicas2(rse_factory, root_account, mock_scope, core_config_mock, caches_mock):
     """ UNDERTAKER (CORE): Test the undertaker is setting Epoch tombstone on all the replicas. """


### PR DESCRIPTION
Some caches have a module name != "REGION". Make it possible to also
mock those caches in tests.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
