### PR TITLE
Client: Add the option to disable FilesDownload Exceptions Fix #4924

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -52,6 +52,7 @@
 # - zoepap05 <90753392+zoepap05@users.noreply.github.com>, 2021
 # - KosKyr <90753277+KosKyr@users.noreply.github.com>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
+# - jdierkes <joel.dierkes@cern.ch>, 2021
 
 from __future__ import print_function
 
@@ -1081,6 +1082,7 @@ def download(args):
         trace_pattern['taskid'] = args.trace_taskid
     if args.trace_usrdn:
         trace_pattern['usrdn'] = args.trace_usrdn
+    deactivate_file_download_exceptions = args.deactivate_file_download_exceptions if args.deactivate_file_download_exceptions is not None else False
 
     client = get_client(args)
     from rucio.client.downloadclient import DownloadClient
@@ -1134,11 +1136,11 @@ def download(args):
             items.append(item_defaults)
 
         if args.aria:
-            result = download_client.download_aria2c(items, trace_pattern)
+            result = download_client.download_aria2c(items, trace_pattern, deactivate_file_download_exceptions=deactivate_file_download_exceptions)
         elif args.metalink_file:
-            result = download_client.download_from_metalink_file(items[0], args.metalink_file)
+            result = download_client.download_from_metalink_file(items[0], args.metalink_file, deactivate_file_download_exceptions=deactivate_file_download_exceptions)
         else:
-            result = download_client.download_dids(items, args.ndownloader, trace_pattern)
+            result = download_client.download_dids(items, args.ndownloader, trace_pattern, deactivate_file_download_exceptions=deactivate_file_download_exceptions)
     else:
         if args.aria:
             logger.warning('Ignoring --aria option because --pfn option given')
@@ -1155,7 +1157,7 @@ def download(args):
             logger.debug(args.dids)
         item_defaults['pfn'] = args.pfn
         item_defaults['did'] = did_str
-        result = download_client.download_pfns([item_defaults], 1, trace_pattern)
+        result = download_client.download_pfns([item_defaults], 1, trace_pattern, deactivate_file_download_exceptions=deactivate_file_download_exceptions)
 
     if not result:
         raise RucioException('Download API failed')
@@ -2303,6 +2305,7 @@ You can filter by key/value, e.g.::
         selected_parser.add_argument('--filter', dest='filter', action='store', help='Filter files by key-value pairs like guid=2e2232aafac8324db452070304f8d745.')
         selected_parser.add_argument('--scope', dest='scope', action='store', help='Scope if you are using the filter option and no full DID.')
         selected_parser.add_argument('--metalink', dest='metalink_file', action='store', help='Path to a metalink file.')
+        selected_parser.add_argument('--deactivate-file-download-exceptions', dest='deactivate_file_download_exceptions', action='store_true', help='Does not raise NoFilesDownloaded, NotAllFilesDownloaded or incorrect number of output queue files Exception.')  # NOQA: E501
 
     # The get-metadata subparser
     get_metadata_parser = subparsers.add_parser('get-metadata', help='Get metadata for DIDs.')

--- a/lib/rucio/tests/test_download.py
+++ b/lib/rucio/tests/test_download.py
@@ -24,6 +24,7 @@
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
 # - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 import logging
 import os
@@ -513,6 +514,14 @@ def test_trace_copy_out_and_checksum_validation(vo, rse_factory, did_factory, do
         traces = []
         download_client.download_dids([{'did': did_str, 'base_dir': tmp_dir, 'ignore_checksum': True}], traces_copy_out=traces)
         assert len(traces) == 1 and traces[0]['clientState'] == 'DONE'
+
+
+def test_disable_no_files_download_error(vo, rse_factory, did_factory, download_client):
+    rse, _ = rse_factory.make_posix_rse()
+    with TemporaryDirectory() as tmp_dir:
+        res = download_client.download_dids([{'did': 'some:randomNonExistingDid', 'base_dir': tmp_dir}], deactivate_file_download_exceptions=True)
+        print('Downloaded object', res)
+        assert res[0]['clientState'] == 'FILE_NOT_FOUND'
 
 
 def test_nrandom_respected(rse_factory, did_factory, download_client, root_account):


### PR DESCRIPTION
If no or not all files are downloaded the `DownloadClient` raises an
exception. It is not possible to see which files are not downloaded or which
are. This commit introduces the opportunity to toggle the Exception.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
