### PR TITLE
Core: `--duration` should be bounded #4956

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -69,7 +69,8 @@ from rucio.common.exception import (AccountNotFound, DataIdentifierAlreadyExists
                                     DataIdentifierNotFound, InvalidObject, ReplicaNotFound,
                                     RSENotFound, RSEOperationNotSupported, InvalidRSEExpression,
                                     DuplicateContent, RuleNotFound, CannotAuthenticate,
-                                    Duplicate, ReplicaIsLocked, ConfigNotFound, ScopeNotFound)
+                                    Duplicate, ReplicaIsLocked, ConfigNotFound, ScopeNotFound,
+                                    InputValidationError)
 from rucio.common.extra import import_extras
 from rucio.common.utils import (chunks, construct_surl, sizefmt, get_bytes_value_from_string,
                                 render_json, parse_response, extract_scope, clean_surls,
@@ -187,6 +188,10 @@ def exception_handler(function):
         except ScopeNotFound as error:
             logger.error(error)
             logger.error('This means that no scopes were found for the specified account ID.')
+            return FAILURE
+        except InputValidationError as error:
+            logger.error(error)
+            logger.error('This means that the input you provided did not meet all the requirements.')
             return FAILURE
         except Exception as error:
             if isinstance(error, IOError) and getattr(error, 'errno', None) == errno.EPIPE:

--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -21,13 +21,17 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2019-2021
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Ilija Vukotic <ivukotic@cern.ch>, 2020
+# - Ilija Vukotic <ivukotic@cern.ch>, 2020-2021
 # - Luc Goossens <luc.goossens@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eric Vaandering <ewv@fnal.gov>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
+
+import datetime
 
 from rucio.api import permission
 from rucio.db.sqla.constants import BadFilesStatus
@@ -397,6 +401,9 @@ def add_bad_pfns(pfns, issuer, state, reason=None, expires_at=None, vo='def'):
     kwargs = {'state': state}
     if not permission.has_permission(issuer=issuer, vo=vo, action='add_bad_pfns', kwargs=kwargs):
         raise exception.AccessDenied('Account %s can not declare bad PFNs' % (issuer))
+
+    if datetime.datetime.utcnow() <= expires_at and expires_at > datetime.datetime.utcnow() + datetime.timedelta(days=30):
+        raise exception.InputValidationError('The given duration of %s days exceeds the maximum duration of 30 days.' % (expires_at - datetime.datetime.utcnow()).days)
 
     issuer = InternalAccount(issuer, vo=vo)
 

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -1907,6 +1907,15 @@ class TestBinRucio(unittest.TestCase):
         assert err != 0
         assert 'the following arguments are required' in err
 
+    def test_rucio_admin_duration_out_of_bounds(self):
+        """CLIENT(USER): Warn about deprecated command line arg"""
+        cmd = 'rucio-admin replicas declare-temporary-unavailable srm://se.bfg.uni-freiburg.de/pnfs/bfg.uni-freiburg.de/data/atlasdatadisk/rucio/user/jdoe/e2/a7/jdoe.TXT.txt --duration 622080000 --reason \'test only\''
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out, err)
+        assert err != 0
+        assert re.search(r'The given duration of 7199 days exceeds the maximum duration of 30 days.', err)
+
     def test_update_rule_cancel_requests_args(self):
         """CLIENT(USER): update rule cancel requests must have a state defined"""
         cmd = 'rucio update-rule --cancel-requests RULE'

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -1036,7 +1036,7 @@ def test_client_add_temporary_unavailable_pfns(rse_factory, mock_scope, replica_
     # Submit bad PFNs
     now = datetime.utcnow()
     reason_str = generate_uuid()
-    replica_client.add_bad_pfns(pfns=list_rep, reason=str(reason_str), state='TEMPORARY_UNAVAILABLE', expires_at=now.isoformat())
+    replica_client.add_bad_pfns(pfns=list_rep, reason=str(reason_str), state='TEMPORARY_UNAVAILABLE', expires_at=(now + timedelta(seconds=10)).isoformat())
     result = get_bad_pfns(limit=10000, thread=None, total_threads=None, session=None)
     bad_pfns = {}
     for res in result:


### PR DESCRIPTION
As referenced in #4931 the CLI option `--duration` of `rucio-admin replicas
declare-temporary-unavailable` should rather have an allowed time-range than
accepting every number. This avoids the mistake of submitting time-ranges that
are too big (e.g. > 1000y).

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
