### PR TITLE
Transfers: enable usage of Request.transfertool DB attribute. #4912

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -760,19 +760,19 @@ def cancel_request_did(scope, name, dest_rse_id, request_type=RequestType.TRANSF
         archive_request(request_id=req[0], session=session)
 
 
-def cancel_request_external_id(transfer_id, transfer_host):
+def cancel_request_external_id(transfertool_obj, transfer_id):
     """
     Cancel a request based on external transfer id.
 
-    :param transfer_id:    External-ID as a 32 character hex string.
-    :param transfer_host:  Name of the external host.
+    :param transfertool_obj: Transfertool object to be used for cancellation.
+    :param transfer_id:      External-ID as a 32 character hex string.
     """
 
     record_counter('core.request.cancel_request_external_id')
     try:
-        FTS3Transfertool(external_host=transfer_host).cancel(transfer_ids=[transfer_id])
+        transfertool_obj.cancel(transfer_ids=[transfer_id])
     except Exception:
-        raise RucioException('Could not cancel FTS3 transfer %s on %s: %s' % (transfer_id, transfer_host, traceback.format_exc()))
+        raise RucioException('Could not cancel FTS3 transfer %s on %s: %s' % (transfer_id, transfertool_obj, traceback.format_exc()))
 
 
 @read_session

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -68,20 +68,19 @@ from rucio.common.utils import construct_surl
 from rucio.core import did, message as message_core, request as request_core
 from rucio.core.config import get as core_config_get
 from rucio.core.monitor import record_counter, record_timer
-from rucio.core.oidc import get_token_for_account_operation
 from rucio.core.replica import add_replicas, tombstone_from_delay, update_replica_state
 from rucio.core.request import queue_requests, set_requests_state
-from rucio.core.rse import get_rse_name, get_rse_vo, list_rses, get_rse_supported_checksums_from_attributes
+from rucio.core.rse import get_rse_name, get_rse_vo, list_rses
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla import models, filter_thread_work
 from rucio.db.sqla.constants import DIDType, RequestState, RSEType, RequestType, ReplicaState
 from rucio.db.sqla.session import read_session, transactional_session
 from rucio.rse import rsemanager as rsemgr
+from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder
 from rucio.transfertool.fts3 import FTS3Transfertool
-from rucio.transfertool.mock import MockTransfertool
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, Tuple, Union
+    from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, Tuple, Type, Union
     from sqlalchemy.orm import Session
 
 EXTRA_MODULES = import_extras(['globus_sdk'])
@@ -99,10 +98,6 @@ Requests accessed by request_id  are covered in the core request.py
 REGION_SHORT = make_region().configure('dogpile.cache.memcached',
                                        expiration_time=600,
                                        arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
-ALLOW_USER_OIDC_TOKENS = config_get('conveyor', 'allow_user_oidc_tokens', False, False)
-REQUEST_OIDC_SCOPE = config_get('conveyor', 'request_oidc_scope', False, 'fts:submit-transfer')
-REQUEST_OIDC_AUDIENCE = config_get('conveyor', 'request_oidc_audience', False, 'fts:example')
-
 WEBDAV_TRANSFER_MODE = config_get('conveyor', 'webdav_transfer_mode', False, None)
 
 DEFAULT_MULTIHOP_TOMBSTONE_DELAY = datetime.timedelta(hours=2)
@@ -183,7 +178,7 @@ class TransferDestination:
 
 class RequestWithSources:
     def __init__(self, id_, request_type, rule_id, scope, name, md5, adler32, byte_count, activity, attributes,
-                 previous_attempt_id, dest_rse_data, account, retry_count, priority):
+                 previous_attempt_id, dest_rse_data, account, retry_count, priority, transfertool):
 
         self.request_id = id_
         self.request_type = request_type
@@ -201,6 +196,7 @@ class RequestWithSources:
         self.account = account
         self.retry_count = retry_count or 0
         self.priority = priority if priority is not None else 3
+        self.transfertool = transfertool
 
         self.sources = []
 
@@ -461,122 +457,6 @@ class StageinTransferDefinition(DirectTransferDefinition):
                 self.src.source_ranking
             )]
         return self._legacy_sources
-
-
-def oidc_supported(transfer_hop: DirectTransferDefinition) -> bool:
-    """
-    checking OIDC AuthN/Z support per destination and source RSEs;
-
-    for oidc_support to be activated, all sources and the destination must explicitly support it
-    """
-    # assumes use of boolean 'oidc_support' RSE attribute
-    if not transfer_hop.dst.rse.attributes.get('oidc_support', False):
-        return False
-
-    for source in transfer_hop.sources:
-        if not source.rse.attributes.get('oidc_support', False):
-            return False
-    return True
-
-
-def checksum_validation_strategy(src_attributes, dst_attributes, logger):
-    """
-    Compute the checksum validation strategy (none, source, destination or both) and the
-    supported checksums from the attributes of the source and destination RSE.
-    """
-    source_supported_checksums = get_rse_supported_checksums_from_attributes(src_attributes)
-    dest_supported_checksums = get_rse_supported_checksums_from_attributes(dst_attributes)
-    common_checksum_names = set(source_supported_checksums).intersection(dest_supported_checksums)
-
-    verify_checksum = 'both'
-    if not dst_attributes.get('verify_checksum', True):
-        if not src_attributes.get('verify_checksum', True):
-            verify_checksum = 'none'
-        else:
-            verify_checksum = 'source'
-    else:
-        if not src_attributes.get('verify_checksum', True):
-            verify_checksum = 'destination'
-        else:
-            verify_checksum = 'both'
-
-    if len(common_checksum_names) == 0:
-        logger(logging.INFO, 'No common checksum method. Verifying destination only.')
-        verify_checksum = 'destination'
-
-    if source_supported_checksums == ['none']:
-        if dest_supported_checksums == ['none']:
-            # both endpoints support none
-            verify_checksum = 'none'
-        else:
-            # src supports none but dst does
-            verify_checksum = 'destination'
-    else:
-        if dest_supported_checksums == ['none']:
-            # source supports some but destination does not
-            verify_checksum = 'source'
-        else:
-            if len(common_checksum_names) == 0:
-                # source and dst support some bot none in common (dst priority)
-                verify_checksum = 'destination'
-            else:
-                # Don't override the value in the file_metadata
-                pass
-
-    checksums_to_use = ['none']
-    if verify_checksum == 'both':
-        checksums_to_use = common_checksum_names
-    elif verify_checksum == 'source':
-        checksums_to_use = source_supported_checksums
-    elif verify_checksum == 'destination':
-        checksums_to_use = dest_supported_checksums
-
-    return verify_checksum, checksums_to_use
-
-
-def submit_bulk_transfers(external_host, transfers, transfertool='fts3', job_params={}, timeout=None, logger=logging.log):
-    """
-    Submit transfer request to a transfertool.
-    :param external_host:  External host name as string
-    :param transfers:          List of Dictionary containing request file.
-    :param transfertool:   Transfertool as a string.
-    :param job_params:     Metadata key/value pairs for all files as a dictionary.
-    :param logger:         Optional decorated logger that can be passed from the calling daemons or servers.
-    :returns:              Transfertool external ID.
-    """
-
-    record_counter('core.request.submit_transfer')
-
-    transfer_id = None
-
-    if transfertool == 'fts3':
-        start_time = time.time()
-        # getting info about account and OIDC support of the RSEs
-        use_oidc = job_params.get('use_oidc', False)
-        transfer_token = None
-        if use_oidc:
-            logger(logging.DEBUG, 'OAuth2/OIDC available at RSEs')
-            account = job_params.get('account', None)
-            getadmintoken = False
-            if ALLOW_USER_OIDC_TOKENS is False:
-                getadmintoken = True
-            logger(logging.DEBUG, 'Attempting to get a token for account %s. Admin token option set to %s' % (account, getadmintoken))
-            # find the appropriate OIDC token and exchange it (for user accounts) if necessary
-            token_dict = get_token_for_account_operation(account, req_audience=REQUEST_OIDC_AUDIENCE, req_scope=REQUEST_OIDC_SCOPE, admin=getadmintoken)
-            if token_dict is not None:
-                logger(logging.DEBUG, 'Access token has been granted.')
-                if 'token' in token_dict:
-                    logger(logging.DEBUG, 'Access token used as transfer token.')
-                    transfer_token = token_dict['token']
-        transfer_id = FTS3Transfertool(external_host=external_host, token=transfer_token).submit(transfers=transfers, job_params=job_params, timeout=timeout)
-        record_timer('core.request.submit_transfers_fts3', (time.time() - start_time) * 1000 / len(transfers))
-    elif transfertool == 'globus':
-        logger(logging.DEBUG, '... Starting globus xfer ...')
-        logger(logging.DEBUG, 'job_files: %s' % transfers)
-        transfer_id = GlobusTransferTool(external_host=None).bulk_submit(transfers=transfers, timeout=timeout)
-    elif transfertool == 'mock':
-        transfer_id = MockTransfertool(external_host=None).submit(transfers, job_params)
-    return transfer_id
 
 
 @transactional_session
@@ -1130,6 +1010,7 @@ def __create_transfer_definitions(
                     account=rws.account,
                     retry_count=0,
                     priority=rws.priority,
+                    transfertool=rws.transfertool,
                 ),
                 protocol_factory=protocol_factory,
             )
@@ -1282,63 +1163,12 @@ def __sort_paths(candidate_paths: "Iterable[List[DirectTransferDefinition]]") ->
     yield from sorted(candidate_paths, key=__transfer_order_key)
 
 
-def __filter_for_transfertool(
-        candidate_paths: "Iterable[List[DirectTransferDefinition]]",
-        transfertool: str,
-        logger: "Callable",
-):
-    """
-    Filter out paths which cannot be handled by the given transfertool (missing globus enpoint ids; no common fts server attribute; etc)
-    Generates tuples: (<the external host which can handle the transfer>, <the associated transfer path>)
-    An empty string is a valid external host.
-    """
-    for transfer_path in candidate_paths:
-        # The last hop is the initial transfer for multihops
-        rws = transfer_path[-1].rws
-
-        external_host = ''
-        if transfertool == 'globus':
-            all_rses_have_globus_id = True
-            for hop in transfer_path:
-                source_globus_endpoint_id = hop.src.rse.attributes.get('globus_endpoint_id', None)
-                dest_globus_endpoint_id = hop.dst.rse.attributes.get('globus_endpoint_id', None)
-                if not source_globus_endpoint_id or not dest_globus_endpoint_id:
-                    all_rses_have_globus_id = False
-                    break
-
-            if not all_rses_have_globus_id:
-                logger(logging.ERROR, 'Globus endpoint attribute not defined - for at least one transfer hops {} {}'.format([str(hop) for hop in transfer_path], rws.request_id))
-                continue
-        else:
-            common_fts_hosts = []
-            for hop in transfer_path:
-                fts_hosts = hop.dst.rse.attributes.get('fts', None)
-                if hop.src.rse.attributes.get('sign_url', None) == 'gcs':
-                    fts_hosts = hop.src.rse.attributes.get('fts', None)
-                fts_hosts = fts_hosts.split(",") if fts_hosts else []
-
-                common_fts_hosts = fts_hosts if not common_fts_hosts else list(set(common_fts_hosts).intersection(fts_hosts))
-                if not common_fts_hosts:
-                    break
-
-            if common_fts_hosts:
-                external_host = common_fts_hosts[0]
-            else:
-                if transfertool == 'fts3':
-                    logger(logging.ERROR, 'FTS attribute not defined - for at least one transfer hops {} {}'.format([str(hop) for hop in transfer_path], rws.request_id))
-                    continue
-                else:
-                    external_host = ''
-
-        yield external_host, transfer_path
-
-
 @transactional_session
 def next_transfers_to_submit(total_workers=0, worker_number=0, limit=None, activity=None, older_than=None, rses=None, schemes=None,
-                             failover_schemes=None, transfertool=None, request_type=RequestType.TRANSFER,
+                             failover_schemes=None, filter_transfertool=None, transfertools_by_name=None, request_type=RequestType.TRANSFER,
                              logger=logging.log, session=None):
     """
-    Get next transfers to be submitted; grouped by the external host to which they will be submitted
+    Get next transfers to be submitted; grouped by transfertool which can submit them
     :param total_workers:         Number of total workers.
     :param worker_number:         Id of the executing worker.
     :param limit:                 Maximum number of requests to retrieve from database.
@@ -1347,17 +1177,18 @@ def next_transfers_to_submit(total_workers=0, worker_number=0, limit=None, activ
     :param rses:                  Include RSES.
     :param schemes:               Include schemes.
     :param failover_schemes:      Failover schemes.
-    :param transfertool:          The transfer tool as specified in rucio.cfg.
+    :param transfertools_by_name: Dict: {transfertool_name_str: transfertool class}
+    :param filter_transfertool:   The transfer tool to filter requests on.
     :param request_type           The type of requests to retrieve (Transfer/Stagein)
     :param logger:                Optional decorated logger that can be passed from the calling daemons or servers.
     :param session:               The database session in use.
-    :returns:                     Dict: {external_host: list of transfers (possibly multihop) to be submitted to this host}
+    :returns:                     Dict: {TransferToolBuilder: <list of transfer paths (possibly multihop) to be submitted>}
 
     Workflow:
     """
 
     include_multihop = False
-    if transfertool in ['fts3', None]:
+    if filter_transfertool in ['fts3', None]:
         include_multihop = core_config_get('transfers', 'use_multihop', default=False, expiration_time=600, session=session)
 
     multihop_rses = []
@@ -1383,7 +1214,7 @@ def next_transfers_to_submit(total_workers=0, worker_number=0, limit=None, activ
         rses=rses,
         request_type=request_type,
         request_state=RequestState.QUEUED,
-        transfertool=transfertool,
+        transfertool=filter_transfertool,
         session=session,
     )
 
@@ -1397,11 +1228,11 @@ def next_transfers_to_submit(total_workers=0, worker_number=0, limit=None, activ
         session=session,
     )
 
-    # pick the best path among the ones computed previously
+    # Assign paths to be executed by transfertools
     # if the chosen best path is a multihop, create intermediate replicas and the intermediate transfer requests
-    paths_by_external_host, reqs_no_host = __pick_and_build_path_for_transfertool(
+    paths_by_transfertool_builder, reqs_no_host = __assign_paths_to_transfertool_and_create_hops(
         candidate_paths,
-        transfertool=transfertool,
+        transfertools_by_name=transfertools_by_name,
         logger=logger
     )
 
@@ -1416,7 +1247,7 @@ def next_transfers_to_submit(total_workers=0, worker_number=0, limit=None, activ
         logger(logging.INFO, "Marking requests as scheme-mismatch: %s", reqs_scheme_mismatch)
         request_core.set_requests_state_if_possible(reqs_scheme_mismatch, RequestState.MISMATCH_SCHEME, logger=logger, session=session)
 
-    return paths_by_external_host
+    return paths_by_transfertool_builder
 
 
 def __build_transfer_paths(
@@ -1565,32 +1396,70 @@ def __build_transfer_paths(
     return candidate_paths_by_request_id, reqs_no_source, reqs_scheme_mismatch, reqs_only_tape_source
 
 
-def __pick_and_build_path_for_transfertool(
-        candidate_paths_by_request_id: "Dict[str: List[DirectTransferDefinition]]",
-        transfertool: "Optional[str]" = None,
-        logger: "Callable" = logging.log
-) -> "Tuple[Dict[str, List[DirectTransferDefinition]], Set[str]]":
+def __assign_to_transfertool(
+        candidate_paths: "Iterable[List[DirectTransferDefinition]]",
+        transfertools_by_name: "Optional[Dict[str, Type[Transfertool]]]" = None,
+        logger: "Callable" = logging.log,
+) -> "Generator[Tuple[Optional[TransferToolBuilder], List[DirectTransferDefinition]]]":
     """
-    for each request, pick the first path which can be submitted to the transfertool given in parameter.
+    Only keep candidate paths which can be submitted to a transfertool
+    """
+    if transfertools_by_name is not None:
+        for transfer_path in candidate_paths:
+            classes_to_try = set(transfertools_by_name.values())
+            # If the request has the "transfertool" attribute set in the database, ensure that we only
+            # try transfertools which both: 1) are supported by submitter; 2) are set in the request
+            request_transfertools = transfer_path[-1].rws.transfertool
+            try:
+                if request_transfertools:
+                    if isinstance(request_transfertools, str):
+                        request_transfertools = request_transfertools.split(',')
+                    classes_to_try = {tt_class for tt_name, tt_class in transfertools_by_name.items() if tt_name in request_transfertools}
+            except Exception:
+                classes_to_try = set()
+                logger(logging.WARN, "Unable to parse requested transfertools: {}".format(request_transfertools))
+
+            builder = None
+            for transfertool_class in classes_to_try:
+                builder = transfertool_class.submission_builder_for_path(transfer_path, logger=logger)
+                if builder:
+                    break
+
+            if builder:
+                yield builder, transfer_path
+    else:
+        # Keep all paths
+        yield from ((None, path) for path in candidate_paths)
+
+
+def __assign_paths_to_transfertool_and_create_hops(
+        candidate_paths_by_request_id: "Dict[str: List[DirectTransferDefinition]]",
+        transfertools_by_name: "Optional[Dict[str, Type[Transfertool]]]" = None,
+        logger: "Callable" = logging.log
+) -> "Tuple[Dict[TransferToolBuilder, List[DirectTransferDefinition]], Set[str]]":
+    """
+    for each request, pick the first path which can be submitted by one of the transfertools.
     If the chosen path is multihop, create all missing intermediate requests and replicas.
     """
     reqs_no_host = set()
-    transfers_by_host = {}
+    paths_by_transfertool_builder = {}
     default_tombstone_delay = core_config_get('transfers', 'multihop_tombstone_delay', default=DEFAULT_MULTIHOP_TOMBSTONE_DELAY, expiration_time=600)
     for request_id, candidate_paths in candidate_paths_by_request_id.items():
 
         # Selects the first path which can be submitted by the given transfertool and for which the creation of
         # intermediate hops (if it is a multihop) work correctly
         best_path = None
-        external_host = None
-        for external_host, transfer_path in __filter_for_transfertool(candidate_paths, transfertool, logger):
+        builder_to_use = None
+
+        for builder, transfer_path in __assign_to_transfertool(candidate_paths, transfertools_by_name):
             if create_missing_replicas_and_requests(transfer_path, default_tombstone_delay, logger=logger):
                 best_path = transfer_path
+                builder_to_use = builder
                 break
 
         if not best_path:
             reqs_no_host.add(request_id)
-            logger(logging.INFO, 'Cannot assign transfer host, or create intermediate requests for %s' % request_id)
+            logger(logging.INFO, 'Cannot pick transfertool, or create intermediate requests for %s' % request_id)
             continue
 
         # For multihop, the initial request is the last hop
@@ -1600,8 +1469,8 @@ def __pick_and_build_path_for_transfertool(
         else:
             logger(logging.INFO, 'Best path is direct for %s: %s' % (rws, best_path[0]))
 
-        transfers_by_host.setdefault(external_host, []).append(best_path)
-    return transfers_by_host, reqs_no_host
+        paths_by_transfertool_builder.setdefault(builder_to_use, []).append(best_path)
+    return paths_by_transfertool_builder, reqs_no_host
 
 
 @transactional_session
@@ -1724,7 +1593,8 @@ def __list_transfer_requests_and_source_replicas(
                                  models.Request.retry_count,
                                  models.Request.account,
                                  models.Request.created_at,
-                                 models.Request.priority) \
+                                 models.Request.priority,
+                                 models.Request.transfertool) \
         .with_hint(models.Request, "INDEX(REQUESTS REQUESTS_TYP_STA_UPD_IDX)", 'oracle') \
         .filter(models.Request.state == request_state) \
         .filter(models.Request.request_type == request_type) \
@@ -1767,6 +1637,7 @@ def __list_transfer_requests_and_source_replicas(
                           sub_requests.c.account,
                           sub_requests.c.retry_count,
                           sub_requests.c.priority,
+                          sub_requests.c.transfertool,
                           models.RSE.id.label("source_rse_id"),
                           models.RSE.rse,
                           models.RSEFileAssociation.path,
@@ -1798,7 +1669,7 @@ def __list_transfer_requests_and_source_replicas(
 
     requests_by_id = {}
     for (request_id, rule_id, scope, name, md5, adler32, byte_count, activity, attributes, previous_attempt_id, dest_rse_id, account, retry_count,
-         priority, source_rse_id, source_rse_name, file_path, source_ranking, source_url, distance_ranking) in query:
+         priority, transfertool, source_rse_id, source_rse_name, file_path, source_ranking, source_url, distance_ranking) in query:
 
         # rses (of unknown length) should be a temporary table to check against instead of this special case
         if rses and dest_rse_id not in rses:
@@ -1809,7 +1680,7 @@ def __list_transfer_requests_and_source_replicas(
             request = RequestWithSources(id_=request_id, request_type=request_type, rule_id=rule_id, scope=scope, name=name,
                                          md5=md5, adler32=adler32, byte_count=byte_count, activity=activity, attributes=attributes,
                                          previous_attempt_id=previous_attempt_id, dest_rse_data=RseData(id_=dest_rse_id),
-                                         account=account, retry_count=retry_count, priority=priority)
+                                         account=account, retry_count=retry_count, priority=priority, transfertool=transfertool)
             requests_by_id[request_id] = request
 
         if source_rse_id is not None:

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -41,31 +41,24 @@ Methods common to different conveyor submitter daemons.
 
 from __future__ import division
 
-from configparser import NoOptionError, NoSectionError
 import datetime
-import functools
 import logging
 import os
 import socket
 import threading
 import time
-from json import loads
 
 from rucio.common.config import config_get
 from rucio.common.exception import (InvalidRSEExpression, TransferToolTimeout, TransferToolWrongAnswer, RequestNotFound,
                                     DuplicateFileTransferSubmission, VONotFound)
 from rucio.common.logging import formatted_logger
-from rucio.common.utils import chunks
 from rucio.core import heartbeat, request, transfer as transfer_core
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core.rse import list_rses
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.vo import list_vos
-from rucio.db.sqla.session import read_session
 from rucio.db.sqla.constants import RequestState
 from rucio.rse import rsemanager as rsemgr
-
-TRANSFER_TOOL = config_get('conveyor', 'transfertool', False, None)
 
 
 class HeartbeatHandler:
@@ -112,19 +105,20 @@ class HeartbeatHandler:
         return self.last_heart_beat, self.logger
 
 
-def submit_transfer(external_host, transfers, job_params, submitter='submitter', timeout=None, logger=logging.log, transfertool=TRANSFER_TOOL):
+def submit_transfer(transfertool_obj, transfers, job_params, submitter='submitter', timeout=None, logger=logging.log):
     """
     Submit a transfer or staging request
 
-    :param external_host:         FTS server to submit to.
-    :param job:                   Job dictionary.
+    :param transfertool_obj:      The transfertool object to be used for submission
+    :param transfers:             Transfer objects to be submitted
+    :param job_params:            Parameters to be used for all transfers in the given job.
     :param submitter:             Name of the submitting entity.
     :param timeout:               Timeout
     :param logger:                Optional decorated logger that can be passed from the calling daemons or servers.
     """
 
     try:
-        transfer_core.mark_submitting_and_prepare_sources_for_transfers(transfers, external_host=external_host, logger=logger)
+        transfer_core.mark_submitting_and_prepare_sources_for_transfers(transfers, external_host=transfertool_obj.external_host, logger=logger)
     except RequestNotFound as error:
         logger(logging.ERROR, str(error))
         return
@@ -133,15 +127,15 @@ def submit_transfer(external_host, transfers, job_params, submitter='submitter',
         return
 
     try:
-        _submit_transfers(external_host, transfers, job_params, submitter, timeout, logger, transfertool)
+        _submit_transfers(transfertool_obj, transfers, job_params, submitter, timeout, logger)
     except DuplicateFileTransferSubmission as error:
         logger(logging.WARNING, 'Failed to bulk submit a job because of duplicate file : %s', str(error))
         logger(logging.INFO, 'Submitting files one by one')
         for transfer in transfers:
-            _submit_transfers(external_host, [transfer], job_params, submitter, timeout, logger, transfertool)
+            _submit_transfers(transfertool_obj, [transfer], job_params, submitter, timeout, logger)
 
 
-def _submit_transfers(external_host, transfers, job_params, submitter='submitter', timeout=None, logger=logging.log, transfertool=TRANSFER_TOOL):
+def _submit_transfers(transfertool_obj, transfers, job_params, submitter='submitter', timeout=None, logger=logging.log):
     """
     helper function for submit_transfers. Performs the actual submission of one or more transfers.
 
@@ -149,14 +143,15 @@ def _submit_transfers(external_host, transfers, job_params, submitter='submitter
     is propagated to the caller context, which is then responsible for calling this function again for each
     of the transfers separately.
     """
-    logger(logging.INFO, 'About to submit job to %s with timeout %s' % (external_host, timeout))
+    logger(logging.INFO, 'About to submit job to %s with timeout %s' % (transfertool_obj, timeout))
     # A eid is returned if the job is properly submitted otherwise an exception is raised
     is_bulk = len(transfers) > 1
     eid = None
     start_time = time.time()
     state_to_set = RequestState.SUBMISSION_FAILED
     try:
-        eid = transfer_core.submit_bulk_transfers(external_host, transfers=transfers, transfertool=transfertool, job_params=job_params, timeout=timeout)
+        record_counter('core.request.submit_transfer')
+        eid = transfertool_obj.submit(transfers, job_params, timeout)
         state_to_set = RequestState.SUBMITTED
     except DuplicateFileTransferSubmission:
         if is_bulk:
@@ -175,14 +170,14 @@ def _submit_transfers(external_host, transfers, job_params, submitter='submitter
 
     if eid is not None:
         duration = time.time() - start_time
-        logger(logging.INFO, 'Submit job %s to %s in %s seconds' % (eid, external_host, duration))
+        logger(logging.INFO, 'Submit job %s to %s in %s seconds' % (eid, transfertool_obj, duration))
         record_timer('daemons.conveyor.%s.submit_bulk_transfer.per_file' % submitter, (time.time() - start_time) * 1000 / len(transfers) or 1)
         record_counter('daemons.conveyor.{submitter}.submit_bulk_transfer', delta=len(transfers), labels={'submitter': submitter})
         record_timer('daemons.conveyor.%s.submit_bulk_transfer.files' % submitter, len(transfers))
 
     if state_to_set:
         try:
-            transfer_core.set_transfers_state(transfers, state=state_to_set, external_host=external_host,
+            transfer_core.set_transfers_state(transfers, state=state_to_set, external_host=transfertool_obj.external_host,
                                               external_id=eid, submitted_at=datetime.datetime.utcnow(), logger=logger)
         except Exception:
             logger(logging.ERROR, 'Failed to register transfer state with error', exc_info=True)
@@ -190,216 +185,10 @@ def _submit_transfers(external_host, transfers, job_params, submitter='submitter
                 # The job is still submitted in the file transfer service but the request is not updated.
                 # Possibility to have a double submission during the next cycle. Try to cancel the external request.
                 try:
-                    logger(logging.INFO, 'Cancel transfer %s on %s', eid, external_host)
-                    request.cancel_request_external_id(eid, external_host)
+                    logger(logging.INFO, 'Cancel transfer %s on %s', eid, transfertool_obj)
+                    request.cancel_request_external_id(transfertool_obj, eid)
                 except Exception:
-                    logger(logging.ERROR, 'Failed to cancel transfers %s on %s with error' % (eid, external_host), exc_info=True)
-
-
-def bulk_group_transfers_for_globus(transfer_paths, policy, group_bulk=200):
-    """
-    Group transfers in bulk based on certain criterias
-
-    :param transfer_paths:  List of transfers to group.
-    :param policy:     Policy to use to group.
-    :param group_bulk: Bulk sizes.
-    :return:           List of grouped transfers
-    """
-    if policy == 'single':
-        group_bulk = 1
-
-    grouped_jobs = []
-    for chunk in chunks(transfer_paths, group_bulk):
-        # Globus doesn't support multihop. Get the first hop only.
-        transfers = [transfer_path[0] for transfer_path in chunk]
-
-        grouped_jobs.append({
-            'transfers': transfers,
-            # Job params are not used by globus trasnfertool, but are needed for further common fts/globus code
-            'job_params': {}
-        })
-
-    return grouped_jobs
-
-
-def job_params_for_fts_transfer(transfer, bring_online, default_lifetime, archive_timeout_override, max_time_in_queue, logger):
-    """
-    Prepare the job parameters which will be passed to FTS transfertool
-    """
-
-    overwrite, bring_online_local = True, None
-    if transfer.src.rse.is_tape_or_staging_required():
-        bring_online_local = bring_online
-    if transfer.dst.rse.is_tape():
-        overwrite = False
-
-    # Get dest space token
-    dest_protocol = transfer.protocol_factory.protocol(transfer.dst.rse, transfer.dst.scheme, transfer.operation_dest)
-    dest_spacetoken = None
-    if dest_protocol.attributes and 'extended_attributes' in dest_protocol.attributes and \
-            dest_protocol.attributes['extended_attributes'] and 'space_token' in dest_protocol.attributes['extended_attributes']:
-        dest_spacetoken = dest_protocol.attributes['extended_attributes']['space_token']
-    src_spacetoken = None
-
-    strict_copy = transfer.dst.rse.attributes.get('strict_copy', False)
-    archive_timeout = transfer.dst.rse.attributes.get('archive_timeout', None)
-
-    verify_checksum, checksums_to_use = transfer_core.checksum_validation_strategy(transfer.src.rse.attributes, transfer.dst.rse.attributes, logger=logger)
-    transfer['checksums_to_use'] = checksums_to_use
-
-    job_params = {'account': transfer.rws.account,
-                  'use_oidc': transfer_core.oidc_supported(transfer),
-                  'verify_checksum': verify_checksum,
-                  'copy_pin_lifetime': transfer.rws.attributes.get('lifetime', default_lifetime),
-                  'bring_online': bring_online_local,
-                  'job_metadata': {
-                      'issuer': 'rucio',
-                      'multi_sources': True if len(transfer.legacy_sources) > 1 else False,
-                  },
-                  'overwrite': transfer.rws.attributes.get('overwrite', overwrite),
-                  'priority': transfer.rws.priority}
-
-    if transfer.get('multihop', False):
-        job_params['multihop'] = True
-    if strict_copy:
-        job_params['strict_copy'] = strict_copy
-    if dest_spacetoken:
-        job_params['spacetoken'] = dest_spacetoken
-    if src_spacetoken:
-        job_params['source_spacetoken'] = src_spacetoken
-    if transfer.use_ipv4:
-        job_params['ipv4'] = True
-        job_params['ipv6'] = False
-
-    if archive_timeout and transfer.dst.rse.is_tape():
-        try:
-            archive_timeout = int(archive_timeout)
-            if archive_timeout_override is None:
-                job_params['archive_timeout'] = archive_timeout
-            elif archive_timeout_override != 0:
-                job_params['archive_timeout'] = archive_timeout_override
-            # FTS only supports dst_file metadata if archive_timeout is set
-            job_params['dst_file_report'] = True
-            logger(logging.DEBUG, 'Added archive timeout to transfer.')
-        except ValueError:
-            logger(logging.WARNING, 'Could not set archive_timeout for %s. Must be integer.', transfer)
-            pass
-    if max_time_in_queue:
-        if transfer.rws.activity in max_time_in_queue:
-            job_params['max_time_in_queue'] = max_time_in_queue[transfer.rws.activity]
-        elif 'default' in max_time_in_queue:
-            job_params['max_time_in_queue'] = max_time_in_queue['default']
-    return job_params
-
-
-@read_session
-def bulk_group_transfers_for_fts(transfers, policy='rule', group_bulk=200, source_strategy=None, max_time_in_queue=None, session=None,
-                                 logger=logging.log, archive_timeout_override=None, bring_online=None, default_lifetime=None):
-    """
-    Group transfers in bulk based on certain criterias
-
-    :param transfers:                List of transfers to group.
-    :param plicy:                    Policy to use to group.
-    :param group_bulk:               Bulk sizes.
-    :param source_strategy:          Strategy to group sources
-    :param max_time_in_queue:        Maximum time in queue
-    :param archive_timeout_override: Override the archive_timeout parameter for any transfers with it set (0 to unset)
-    :param logger:                   Optional decorated logger that can be passed from the calling daemons or servers.
-    :return:                         List of grouped transfers.
-    """
-
-    grouped_transfers = {}
-    grouped_jobs = []
-
-    try:
-        default_source_strategy = config_get(section='conveyor', option='default-source-strategy')
-    except (NoOptionError, NoSectionError, RuntimeError):
-        default_source_strategy = 'orderly'
-
-    try:
-        activity_source_strategy = config_get(section='conveyor', option='activity-source-strategy')
-        activity_source_strategy = loads(activity_source_strategy)
-    except (NoOptionError, NoSectionError, RuntimeError):
-        activity_source_strategy = {}
-    except ValueError:
-        logger(logging.WARNING, 'activity_source_strategy not properly defined')
-        activity_source_strategy = {}
-
-    for transfer_path in transfers:
-        for i, transfer in enumerate(transfer_path):
-            if len(transfer_path) > 1:
-                transfer['multihop'] = True
-            transfer['selection_strategy'] = source_strategy if source_strategy else activity_source_strategy.get(str(transfer.rws.activity), default_source_strategy)
-
-    _build_job_params = functools.partial(job_params_for_fts_transfer,
-                                          bring_online=bring_online,
-                                          default_lifetime=default_lifetime,
-                                          archive_timeout_override=archive_timeout_override,
-                                          max_time_in_queue=max_time_in_queue,
-                                          logger=logger)
-    for transfer_path in transfers:
-        if len(transfer_path) > 1:
-            # for multihop transfers, all the path is submitted as a separate job
-            job_params = _build_job_params(transfer_path[-1])
-            for transfer in transfer_path[:-1]:
-                hop_params = _build_job_params(transfer)
-                # Only allow overwrite if all transfers in multihop allow it
-                job_params['overwrite'] = hop_params['overwrite'] and job_params['overwrite']
-                # Activate bring_online if it was requested by first hop (it is a multihop starting at a tape)
-                # We don't allow multihop via a tape, so bring_online should not be set on any other hop
-                if transfer is transfer_path[0] and hop_params['bring_online']:
-                    job_params['bring_online'] = hop_params['bring_online']
-
-            group_key = 'multihop_%s' % transfer_path[-1].rws.request_id
-            grouped_transfers[group_key] = {'transfers': transfer_path, 'job_params': job_params}
-        elif len(transfer_path[0].legacy_sources) > 1:
-            # for multi-source transfers, no bulk submission.
-            transfer = transfer_path[0]
-            grouped_jobs.append({'transfers': [transfer], 'job_params': _build_job_params(transfer)})
-        else:
-            # it's a single-hop, single-source, transfer. Hence, a candidate for bulk submission.
-            transfer = transfer_path[0]
-            job_params = _build_job_params(transfer)
-
-            # we cannot group transfers together if their job_key differ
-            job_key = '%s,%s,%s,%s,%s,%s,%s,%s' % (job_params['verify_checksum'], job_params.get('spacetoken', None),
-                                                   job_params['copy_pin_lifetime'],
-                                                   job_params['bring_online'], job_params['job_metadata'],
-                                                   job_params.get('source_spacetoken', None),
-                                                   job_params['overwrite'], job_params['priority'])
-            if 'max_time_in_queue' in job_params:
-                job_key = job_key + ',%s' % job_params['max_time_in_queue']
-
-            # Additionally, we don't want to group transfers together if their policy_key differ
-            policy_key = ''
-            if policy == 'rule':
-                policy_key = '%s' % transfer.rws.rule_id
-            if policy == 'dest':
-                policy_key = '%s' % transfer.dst.rse.name
-            if policy == 'src_dest':
-                policy_key = '%s,%s' % (transfer.src.rse.name, transfer.dst.rse.name)
-            if policy == 'rule_src_dest':
-                policy_key = '%s,%s,%s' % (transfer.rws.rule_id, transfer.src.rse.name, transfer.dst.rse.name)
-            if policy == 'activity_dest':
-                policy_key = '%s %s' % (transfer.rws.activity, transfer.dst.rse.name)
-                policy_key = "_".join(policy_key.split(' '))
-            if policy == 'activity_src_dest':
-                policy_key = '%s %s %s' % (transfer.rws.activity, transfer.src.rse.name, transfer.dst.rse.name)
-                policy_key = "_".join(policy_key.split(' '))
-                # maybe here we need to hash the key if it's too long
-
-            group_key = "%s_%s" % (job_key, policy_key)
-            if group_key not in grouped_transfers:
-                grouped_transfers[group_key] = {'transfers': [], 'job_params': job_params}
-            grouped_transfers[group_key]['transfers'].append(transfer)
-
-    # split transfer groups to have at most group_bulk elements in each one
-    for group in grouped_transfers.values():
-        job_params = group['job_params']
-        for transfers in chunks(group['transfers'], group_bulk):
-            grouped_jobs.append({'transfers': transfers, 'job_params': job_params})
-
-    return grouped_jobs
+                    logger(logging.ERROR, 'Failed to cancel transfers %s on %s with error' % (eid, transfertool_obj), exc_info=True)
 
 
 def get_conveyor_rses(rses=None, include_rses=None, exclude_rses=None, vos=None, logger=logging.log):

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -44,8 +44,9 @@ from rucio.common.config import config_get, config_get_bool
 from rucio.common.logging import setup_logging
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core import transfer as transfer_core
-from rucio.daemons.conveyor.common import submit_transfer, bulk_group_transfers_for_fts, get_conveyor_rses, HeartbeatHandler
+from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, HeartbeatHandler
 from rucio.db.sqla.constants import RequestType
+from rucio.transfertool.fts3 import FTS3Transfertool
 
 graceful_stop = threading.Event()
 
@@ -113,6 +114,16 @@ def stager(once=False, rses=None, bulk=100, group_bulk=1, group_policy='rule',
                     logger(logging.INFO, 'Starting to get stagein transfers for %s' % (activity))
                     start_time = time.time()
 
+                    transfertool_kwargs = {
+                        FTS3Transfertool: {
+                            'group_policy': group_policy,
+                            'group_bulk': group_bulk,
+                            'source_strategy': source_strategy,
+                            'max_time_in_queue': max_time_in_queue,
+                            'bring_online': bring_online,
+                            'default_lifetime': -1,
+                        }
+                    }
                     transfers = transfer_core.next_transfers_to_submit(
                         total_workers=heart_beat['nr_threads'],
                         worker_number=heart_beat['assign_thread'],
@@ -121,6 +132,7 @@ def stager(once=False, rses=None, bulk=100, group_bulk=1, group_policy='rule',
                         activity=activity,
                         rses=rse_ids,
                         schemes=scheme,
+                        transfertools_by_name={'fts3': FTS3Transfertool},
                         older_than=None,
                         request_type=RequestType.STAGEIN,
                         logger=logger,
@@ -131,16 +143,16 @@ def stager(once=False, rses=None, bulk=100, group_bulk=1, group_policy='rule',
                     record_timer('daemons.conveyor.stager.get_stagein_transfers.transfers', total_transfers)
                     logger(logging.INFO, 'Got %s stagein transfers for %s' % (total_transfers, activity))
 
-                    for external_host, transfer_paths in transfers.items():
-                        logger(logging.INFO, 'Starting to group transfers for %s (%s)' % (activity, external_host))
+                    for builder, transfer_paths in transfers.items():
+                        transfertool_obj = builder.make_transfertool(logger=logger, **transfertool_kwargs.get(builder.transfertool_class, {}))
+                        logger(logging.INFO, 'Starting to group transfers for %s (%s)' % (activity, transfertool_obj))
                         start_time = time.time()
-                        grouped_jobs = bulk_group_transfers_for_fts(transfer_paths, group_policy, group_bulk, source_strategy, max_time_in_queue,
-                                                                    bring_online=bring_online, default_lifetime=-1)
+                        grouped_jobs = transfertool_obj.group_into_submit_jobs(transfer_paths)
                         record_timer('daemons.conveyor.stager.bulk_group_transfer', (time.time() - start_time) * 1000 / (len(transfer_paths) or 1))
 
-                        logger(logging.INFO, 'Starting to submit transfers for %s (%s)' % (activity, external_host))
+                        logger(logging.INFO, 'Starting to submit transfers for %s (%s)' % (activity, transfertool_obj))
                         for job in grouped_jobs:
-                            submit_transfer(external_host=external_host, transfers=job['transfers'], job_params=job['job_params'], submitter='transfer_submitter', logger=logger)
+                            submit_transfer(transfertool_obj=transfertool_obj, transfers=job['transfers'], job_params=job['job_params'], submitter='transfer_submitter', logger=logger)
 
                     if total_transfers < group_bulk:
                         logger(logging.INFO, 'Only %s transfers for %s which is less than group bulk %s, sleep %s seconds' % (total_transfers, activity, group_bulk, sleep_time))

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -82,7 +82,7 @@ def test_request_submitted_in_order(rse_factory, did_factory, root_account):
     requests_id_in_submission_order = []
     with patch('rucio.transfertool.mock.MockTransfertool.submit') as mock_transfertool_submit:
         # Record the order of requests passed to MockTranfertool.submit()
-        mock_transfertool_submit.side_effect = lambda transfers, _: requests_id_in_submission_order.extend([t.rws.request_id for t in transfers])
+        mock_transfertool_submit.side_effect = lambda transfers, job_params, timeout: requests_id_in_submission_order.extend([t.rws.request_id for t in transfers])
 
         submitter(once=True, rses=[{'id': rse_id} for _, rse_id in dst_rses], partition_wait_time=None, transfertool='mock', transfertype='single', filter_transfertool=None)
 
@@ -170,8 +170,8 @@ def test_multihop_sources_created(rse_factory, did_factory, root_account, core_c
     replica = replica_core.get_replica(jump_rse3_id, **did)
     assert replica['tombstone'] is None
 
-    # Ensure that prometheus metrics were correctly registered. One submission for each transfer hop
-    assert metrics_mock.get_sample_value('rucio_core_request_submit_transfer_total') == 4
+    # Ensure that prometheus metrics were correctly registered. Only one submission, mock transfertool groups everything into one job.
+    assert metrics_mock.get_sample_value('rucio_core_request_submit_transfer_total') == 1
 
 
 @pytest.mark.noparallel(reason="multiple submitters cannot be run in parallel due to partial job assignment by hash")

--- a/lib/rucio/tests/test_s3.py
+++ b/lib/rucio/tests/test_s3.py
@@ -98,7 +98,7 @@ class TestS3(unittest.TestCase):
 
         rule_id = add_rule(dids=self.files3, account=self.root, copies=1, rse_expression=self.rsenons3,
                            grouping='NONE', weight=None, lifetime=None, locked=False, subscription_id=None)
-        [[_host, [transfer_path]]] = next_transfers_to_submit(rses=[self.rsenons3_id]).items()
+        [[_, [transfer_path]]] = next_transfers_to_submit(rses=[self.rsenons3_id]).items()
         assert transfer_path[0].rws.rule_id == rule_id[0]
         assert transfer_path[0].legacy_sources[0][1] == expected_src_url
         assert transfer_path[0].dest_url == expected_dst_url
@@ -112,7 +112,7 @@ class TestS3(unittest.TestCase):
         rule_id = add_rule(dids=self.filenons3, account=self.root, copies=1, rse_expression=self.rses3,
                            grouping='NONE', weight=None, lifetime=None, locked=False, subscription_id=None)
 
-        [[_host, [transfer_path]]] = next_transfers_to_submit(rses=[self.rses3_id]).items()
+        [[_, [transfer_path]]] = next_transfers_to_submit(rses=[self.rses3_id]).items()
         assert transfer_path[0].rws.rule_id == rule_id[0]
         assert transfer_path[0].legacy_sources[0][1] == expected_src_url
         assert transfer_path[0].dest_url == expected_dst_url

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -97,7 +97,7 @@ def test_tpc(containerized_rses, root_account, test_scope, did_factory, rse_clie
     assert rule['locks_ok_cnt'] == 0
     assert rule['locks_replicating_cnt'] == 1
 
-    [[_host, [transfer_path]]] = next_transfers_to_submit(rses=[rse1_id, rse2_id]).items()
+    [[_, [transfer_path]]] = next_transfers_to_submit(rses=[rse1_id, rse2_id]).items()
     assert transfer_path[0].rws.rule_id == rule_id[0]
     src_url = transfer_path[0].legacy_sources[0][1]
     dest_url = transfer_path[0].dest_url

--- a/lib/rucio/tests/test_transfer.py
+++ b/lib/rucio/tests/test_transfer.py
@@ -180,14 +180,14 @@ def test_disk_vs_tape_priority(rse_factory, root_account, mock_scope):
                 save(session=session, flush=False)
 
     # On equal priority and distance, disk should be preferred over tape. Both disk sources will be returned
-    [[_host, [transfer]]] = next_transfers_to_submit(rses=all_rses).items()
+    [[_, [transfer]]] = next_transfers_to_submit(rses=all_rses).items()
     assert len(transfer[0].legacy_sources) == 2
     assert transfer[0].legacy_sources[0][0] in (disk1_rse_name, disk2_rse_name)
 
     # Change the rating of the disk RSEs. Disk still preferred, because it must fail twice before tape is tried
     __fake_source_ranking(disk1_rse_id, -1)
     __fake_source_ranking(disk2_rse_id, -1)
-    [[_host, [transfer]]] = next_transfers_to_submit(rses=all_rses).items()
+    [[_, [transfer]]] = next_transfers_to_submit(rses=all_rses).items()
     assert len(transfer[0].legacy_sources) == 2
     assert transfer[0].legacy_sources[0][0] in (disk1_rse_name, disk2_rse_name)
 
@@ -195,20 +195,20 @@ def test_disk_vs_tape_priority(rse_factory, root_account, mock_scope):
     # Multiple tape sources are not allowed. Only one tape RSE source must be returned.
     __fake_source_ranking(disk1_rse_id, -2)
     __fake_source_ranking(disk2_rse_id, -2)
-    [[_host, transfers]] = next_transfers_to_submit(rses=all_rses).items()
+    [[_, transfers]] = next_transfers_to_submit(rses=all_rses).items()
     assert len(transfers) == 1
     transfer = transfers[0]
     assert len(transfer[0].legacy_sources) == 1
     assert transfer[0].legacy_sources[0][0] in (tape1_rse_name, tape2_rse_name)
 
     # On equal source ranking, but different distance; the smaller distance is preferred
-    [[_host, [transfer]]] = next_transfers_to_submit(rses=all_rses).items()
+    [[_, [transfer]]] = next_transfers_to_submit(rses=all_rses).items()
     assert len(transfer[0].legacy_sources) == 1
     assert transfer[0].legacy_sources[0][0] == tape2_rse_name
 
     # On different source ranking, the bigger ranking is preferred
     __fake_source_ranking(tape2_rse_id, -1)
-    [[_host, [transfer]]] = next_transfers_to_submit(rses=all_rses).items()
+    [[_, [transfer]]] = next_transfers_to_submit(rses=all_rses).items()
     assert len(transfer[0].legacy_sources) == 1
     assert transfer[0].legacy_sources[0][0] == tape1_rse_name
 
@@ -235,7 +235,7 @@ def test_multihop_requests_created(rse_factory, did_factory, root_account, core_
     did = did_factory.upload_test_file(rs0_name)
     rule_core.add_rule(dids=[did], account=root_account, copies=1, rse_expression=dst_rse_name, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
 
-    [[_host, [transfer]]] = next_transfers_to_submit(rses=rse_factory.created_rses).items()
+    [[_, [transfer]]] = next_transfers_to_submit(rses=rse_factory.created_rses).items()
     # the intermediate request was correctly created
     assert request_core.get_request_by_did(rse_id=intermediate_rse_id, **did)
 
@@ -284,7 +284,7 @@ def test_singlehop_vs_multihop_priority(rse_factory, root_account, mock_scope, c
     rule_core.add_rule(dids=[did], account=root_account, copies=1, rse_expression=rse3_name, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
 
     # The singlehop must be prioritized
-    [[_host, [transfer]]] = next_transfers_to_submit(rses=rse_factory.created_rses).items()
+    [[_, [transfer]]] = next_transfers_to_submit(rses=rse_factory.created_rses).items()
     assert len(transfer) == 1
     assert transfer[0].src.rse.id == rse2_id
     assert transfer[0].dst.rse.id == rse3_id
@@ -298,6 +298,6 @@ def test_singlehop_vs_multihop_priority(rse_factory, root_account, mock_scope, c
     rule_core.add_rule(dids=[did], account=root_account, copies=1, rse_expression=rse3_name, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
 
     # The multihop must be prioritized
-    [[_host, transfers]] = next_transfers_to_submit(rses=rse_factory.created_rses).items()
+    [[_, transfers]] = next_transfers_to_submit(rses=rse_factory.created_rses).items()
     transfer = next(iter(t for t in transfers if t[0].rws.name == file['name']))
     assert len(transfer) == 2

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -38,6 +38,7 @@ try:
     from json.decoder import JSONDecodeError
 except ImportError:
     JSONDecodeError = ValueError
+import functools
 import logging
 import time
 import traceback
@@ -48,6 +49,8 @@ except ImportError:
 import uuid
 
 import requests
+from configparser import NoOptionError, NoSectionError
+from json import loads
 from requests.adapters import ReadTimeout
 from requests.packages.urllib3 import disable_warnings  # pylint: disable=import-error
 
@@ -58,9 +61,11 @@ from prometheus_client import Summary
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.constants import FTS_STATE
 from rucio.common.exception import TransferToolTimeout, TransferToolWrongAnswer, DuplicateFileTransferSubmission
-from rucio.common.utils import APIEncoder, set_checksum_value
+from rucio.common.utils import APIEncoder, chunks, set_checksum_value
+from rucio.core.rse import get_rse_supported_checksums_from_attributes
+from rucio.core.oidc import get_token_for_account_operation
 from rucio.core.monitor import record_counter, record_timer, MultiCounter
-from rucio.transfertool.transfertool import Transfertool
+from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder
 
 logging.getLogger("requests").setLevel(logging.CRITICAL)
 disable_warnings()
@@ -87,24 +92,303 @@ QUERY_DETAILS_COUNTER = MultiCounter(prom='rucio_transfertool_fts3_query_details
 SUBMISSION_TIMER = Summary('rucio_transfertool_fts3_submit_transfer', 'Timer for transfer submission', labelnames=('host',))
 
 
+ALLOW_USER_OIDC_TOKENS = config_get('conveyor', 'allow_user_oidc_tokens', False, False)
+REQUEST_OIDC_SCOPE = config_get('conveyor', 'request_oidc_scope', False, 'fts:submit-transfer')
+REQUEST_OIDC_AUDIENCE = config_get('conveyor', 'request_oidc_audience', False, 'fts:example')
+
+
+def oidc_supported(transfer_hop) -> bool:
+    """
+    checking OIDC AuthN/Z support per destination and source RSEs;
+
+    for oidc_support to be activated, all sources and the destination must explicitly support it
+    """
+    # assumes use of boolean 'oidc_support' RSE attribute
+    if not transfer_hop.dst.rse.attributes.get('oidc_support', False):
+        return False
+
+    for source in transfer_hop.sources:
+        if not source.rse.attributes.get('oidc_support', False):
+            return False
+    return True
+
+
+def checksum_validation_strategy(src_attributes, dst_attributes, logger):
+    """
+    Compute the checksum validation strategy (none, source, destination or both) and the
+    supported checksums from the attributes of the source and destination RSE.
+    """
+    source_supported_checksums = get_rse_supported_checksums_from_attributes(src_attributes)
+    dest_supported_checksums = get_rse_supported_checksums_from_attributes(dst_attributes)
+    common_checksum_names = set(source_supported_checksums).intersection(dest_supported_checksums)
+
+    verify_checksum = 'both'
+    if not dst_attributes.get('verify_checksum', True):
+        if not src_attributes.get('verify_checksum', True):
+            verify_checksum = 'none'
+        else:
+            verify_checksum = 'source'
+    else:
+        if not src_attributes.get('verify_checksum', True):
+            verify_checksum = 'destination'
+        else:
+            verify_checksum = 'both'
+
+    if len(common_checksum_names) == 0:
+        logger(logging.INFO, 'No common checksum method. Verifying destination only.')
+        verify_checksum = 'destination'
+
+    if source_supported_checksums == ['none']:
+        if dest_supported_checksums == ['none']:
+            # both endpoints support none
+            verify_checksum = 'none'
+        else:
+            # src supports none but dst does
+            verify_checksum = 'destination'
+    else:
+        if dest_supported_checksums == ['none']:
+            # source supports some but destination does not
+            verify_checksum = 'source'
+        else:
+            if len(common_checksum_names) == 0:
+                # source and dst support some bot none in common (dst priority)
+                verify_checksum = 'destination'
+            else:
+                # Don't override the value in the file_metadata
+                pass
+
+    checksums_to_use = ['none']
+    if verify_checksum == 'both':
+        checksums_to_use = common_checksum_names
+    elif verify_checksum == 'source':
+        checksums_to_use = source_supported_checksums
+    elif verify_checksum == 'destination':
+        checksums_to_use = dest_supported_checksums
+
+    return verify_checksum, checksums_to_use
+
+
+def job_params_for_fts_transfer(transfer, bring_online, default_lifetime, archive_timeout_override, max_time_in_queue, logger):
+    """
+    Prepare the job parameters which will be passed to FTS transfertool
+    """
+
+    overwrite, bring_online_local = True, None
+    if transfer.src.rse.is_tape_or_staging_required():
+        bring_online_local = bring_online
+    if transfer.dst.rse.is_tape():
+        overwrite = False
+
+    # Get dest space token
+    dest_protocol = transfer.protocol_factory.protocol(transfer.dst.rse, transfer.dst.scheme, transfer.operation_dest)
+    dest_spacetoken = None
+    if dest_protocol.attributes and 'extended_attributes' in dest_protocol.attributes and \
+            dest_protocol.attributes['extended_attributes'] and 'space_token' in dest_protocol.attributes['extended_attributes']:
+        dest_spacetoken = dest_protocol.attributes['extended_attributes']['space_token']
+    src_spacetoken = None
+
+    strict_copy = transfer.dst.rse.attributes.get('strict_copy', False)
+    archive_timeout = transfer.dst.rse.attributes.get('archive_timeout', None)
+
+    verify_checksum, checksums_to_use = checksum_validation_strategy(transfer.src.rse.attributes, transfer.dst.rse.attributes, logger=logger)
+    transfer['checksums_to_use'] = checksums_to_use
+
+    job_params = {'account': transfer.rws.account,
+                  'verify_checksum': verify_checksum,
+                  'copy_pin_lifetime': transfer.rws.attributes.get('lifetime', default_lifetime),
+                  'bring_online': bring_online_local,
+                  'job_metadata': {
+                      'issuer': 'rucio',
+                      'multi_sources': True if len(transfer.legacy_sources) > 1 else False,
+                  },
+                  'overwrite': transfer.rws.attributes.get('overwrite', overwrite),
+                  'priority': transfer.rws.priority}
+
+    if transfer.get('multihop', False):
+        job_params['multihop'] = True
+    if strict_copy:
+        job_params['strict_copy'] = strict_copy
+    if dest_spacetoken:
+        job_params['spacetoken'] = dest_spacetoken
+    if src_spacetoken:
+        job_params['source_spacetoken'] = src_spacetoken
+    if transfer.use_ipv4:
+        job_params['ipv4'] = True
+        job_params['ipv6'] = False
+
+    if archive_timeout and transfer.dst.rse.is_tape():
+        try:
+            archive_timeout = int(archive_timeout)
+            if archive_timeout_override is None:
+                job_params['archive_timeout'] = archive_timeout
+            elif archive_timeout_override != 0:
+                job_params['archive_timeout'] = archive_timeout_override
+            # FTS only supports dst_file metadata if archive_timeout is set
+            job_params['dst_file_report'] = True
+            logger(logging.DEBUG, 'Added archive timeout to transfer.')
+        except ValueError:
+            logger(logging.WARNING, 'Could not set archive_timeout for %s. Must be integer.', transfer)
+            pass
+    if max_time_in_queue:
+        if transfer.rws.activity in max_time_in_queue:
+            job_params['max_time_in_queue'] = max_time_in_queue[transfer.rws.activity]
+        elif 'default' in max_time_in_queue:
+            job_params['max_time_in_queue'] = max_time_in_queue['default']
+    return job_params
+
+
+def bulk_group_transfers(transfer_paths, policy='rule', group_bulk=200, source_strategy=None, max_time_in_queue=None,
+                         logger=logging.log, archive_timeout_override=None, bring_online=None, default_lifetime=None):
+    """
+    Group transfers in bulk based on certain criterias
+
+    :param transfer_paths:           List of transfer paths to group. Each path is a list of single-hop transfers.
+    :param policy:                   Policy to use to group.
+    :param group_bulk:               Bulk sizes.
+    :param source_strategy:          Strategy to group sources
+    :param max_time_in_queue:        Maximum time in queue
+    :param archive_timeout_override: Override the archive_timeout parameter for any transfers with it set (0 to unset)
+    :param logger:                   Optional decorated logger that can be passed from the calling daemons or servers.
+    :return:                         List of grouped transfers.
+    """
+
+    grouped_transfers = {}
+    grouped_jobs = []
+
+    try:
+        default_source_strategy = config_get(section='conveyor', option='default-source-strategy')
+    except (NoOptionError, NoSectionError, RuntimeError):
+        default_source_strategy = 'orderly'
+
+    try:
+        activity_source_strategy = config_get(section='conveyor', option='activity-source-strategy')
+        activity_source_strategy = loads(activity_source_strategy)
+    except (NoOptionError, NoSectionError, RuntimeError):
+        activity_source_strategy = {}
+    except ValueError:
+        logger(logging.WARNING, 'activity_source_strategy not properly defined')
+        activity_source_strategy = {}
+
+    for transfer_path in transfer_paths:
+        for i, transfer in enumerate(transfer_path):
+            if len(transfer_path) > 1:
+                transfer['multihop'] = True
+            transfer['selection_strategy'] = source_strategy if source_strategy else activity_source_strategy.get(str(transfer.rws.activity), default_source_strategy)
+
+    _build_job_params = functools.partial(job_params_for_fts_transfer,
+                                          bring_online=bring_online,
+                                          default_lifetime=default_lifetime,
+                                          archive_timeout_override=archive_timeout_override,
+                                          max_time_in_queue=max_time_in_queue,
+                                          logger=logger)
+    for transfer_path in transfer_paths:
+        if len(transfer_path) > 1:
+            # for multihop transfers, all the path is submitted as a separate job
+            job_params = _build_job_params(transfer_path[-1])
+
+            for transfer in transfer_path[:-1]:
+                hop_params = _build_job_params(transfer)
+                # Only allow overwrite if all transfers in multihop allow it
+                job_params['overwrite'] = hop_params['overwrite'] and job_params['overwrite']
+                # Activate bring_online if it was requested by first hop (it is a multihop starting at a tape)
+                # We don't allow multihop via a tape, so bring_online should not be set on any other hop
+                if transfer is transfer_path[0] and hop_params['bring_online']:
+                    job_params['bring_online'] = hop_params['bring_online']
+
+            group_key = 'multihop_%s' % transfer_path[-1].rws.request_id
+            grouped_transfers[group_key] = {'transfers': transfer_path, 'job_params': job_params}
+        elif len(transfer_path[0].legacy_sources) > 1:
+            # for multi-source transfers, no bulk submission.
+            transfer = transfer_path[0]
+            grouped_jobs.append({'transfers': [transfer], 'job_params': _build_job_params(transfer)})
+        else:
+            # it's a single-hop, single-source, transfer. Hence, a candidate for bulk submission.
+            transfer = transfer_path[0]
+            job_params = _build_job_params(transfer)
+
+            # we cannot group transfers together if their job_key differ
+            job_key = '%s,%s,%s,%s,%s,%s,%s,%s' % (job_params['verify_checksum'], job_params.get('spacetoken', None),
+                                                   job_params['copy_pin_lifetime'],
+                                                   job_params['bring_online'], job_params['job_metadata'],
+                                                   job_params.get('source_spacetoken', None),
+                                                   job_params['overwrite'], job_params['priority'])
+            if 'max_time_in_queue' in job_params:
+                job_key = job_key + ',%s' % job_params['max_time_in_queue']
+
+            # Additionally, we don't want to group transfers together if their policy_key differ
+            policy_key = ''
+            if policy == 'rule':
+                policy_key = '%s' % transfer.rws.rule_id
+            if policy == 'dest':
+                policy_key = '%s' % transfer.dst.rse.name
+            if policy == 'src_dest':
+                policy_key = '%s,%s' % (transfer.src.rse.name, transfer.dst.rse.name)
+            if policy == 'rule_src_dest':
+                policy_key = '%s,%s,%s' % (transfer.rws.rule_id, transfer.src.rse.name, transfer.dst.rse.name)
+            if policy == 'activity_dest':
+                policy_key = '%s %s' % (transfer.rws.activity, transfer.dst.rse.name)
+                policy_key = "_".join(policy_key.split(' '))
+            if policy == 'activity_src_dest':
+                policy_key = '%s %s %s' % (transfer.rws.activity, transfer.src.rse.name, transfer.dst.rse.name)
+                policy_key = "_".join(policy_key.split(' '))
+                # maybe here we need to hash the key if it's too long
+
+            group_key = "%s_%s" % (job_key, policy_key)
+            if group_key not in grouped_transfers:
+                grouped_transfers[group_key] = {'transfers': [], 'job_params': job_params}
+            grouped_transfers[group_key]['transfers'].append(transfer)
+
+    # split transfer groups to have at most group_bulk elements in each one
+    for group in grouped_transfers.values():
+        job_params = group['job_params']
+        for transfer_paths in chunks(group['transfers'], group_bulk):
+            grouped_jobs.append({'transfers': transfer_paths, 'job_params': job_params})
+
+    return grouped_jobs
+
+
 class FTS3Transfertool(Transfertool):
     """
     FTS3 implementation of a Rucio transfertool
     """
 
-    def __init__(self, external_host, token=None):
+    def __init__(self, external_host, oidc_account=None, group_bulk=1, group_policy='rule', source_strategy=None,
+                 max_time_in_queue=None, bring_online=43200, default_lifetime=172800, archive_timeout_override=None,
+                 logger=logging.log):
         """
         Initializes the transfertool
 
         :param external_host:   The external host where the transfertool API is running
-        :param token: optional parameter to pass user's JWT
+        :param oidc_account:    optional oidc account to use for submission
         """
+        super().__init__(external_host, logger)
+
+        self.group_policy = group_policy
+        self.group_bulk = group_bulk
+        self.source_strategy = source_strategy
+        self.max_time_in_queue = max_time_in_queue or {}
+        self.bring_online = bring_online
+        self.default_lifetime = default_lifetime
+        self.archive_timeout_override = archive_timeout_override
+
         usercert = config_get('conveyor', 'usercert', False, None)
 
         # token for OAuth 2.0 OIDC authorization scheme (working only with dCache + davs/https protocols as of Sep 2019)
-        self.token = token
+        self.token = None
+        if oidc_account:
+            getadmintoken = False
+            if ALLOW_USER_OIDC_TOKENS is False:
+                getadmintoken = True
+            self.logger(logging.DEBUG, 'Attempting to get a token for account %s. Admin token option set to %s' % (oidc_account, getadmintoken))
+            # find the appropriate OIDC token and exchange it (for user accounts) if necessary
+            token_dict = get_token_for_account_operation(oidc_account, req_audience=REQUEST_OIDC_AUDIENCE, req_scope=REQUEST_OIDC_SCOPE, admin=getadmintoken)
+            if token_dict is not None:
+                self.logger(logging.DEBUG, 'Access token has been granted.')
+                if 'token' in token_dict:
+                    self.logger(logging.DEBUG, 'Access token used as transfer token.')
+                    self.token = token_dict['token']
+
         self.deterministic_id = config_get_bool('conveyor', 'use_deterministic_id', False, False)
-        super(FTS3Transfertool, self).__init__(external_host)
         self.headers = {'Content-Type': 'application/json'}
         if self.external_host.startswith('https://'):
             if self.token:
@@ -117,6 +401,43 @@ class FTS3Transfertool(Transfertool):
         else:
             self.cert = None
             self.verify = True  # True is the default setting of a requests.* method
+
+    @staticmethod
+    def submission_builder_for_path(transfer_path, logger=logging.log):
+        common_fts_hosts = []
+        for hop in transfer_path:
+            fts_hosts = hop.dst.rse.attributes.get('fts', None)
+            if hop.src.rse.attributes.get('sign_url', None) == 'gcs':
+                fts_hosts = hop.src.rse.attributes.get('fts', None)
+            fts_hosts = fts_hosts.split(",") if fts_hosts else []
+
+            common_fts_hosts = fts_hosts if not common_fts_hosts else list(set(common_fts_hosts).intersection(fts_hosts))
+            if not common_fts_hosts:
+                break
+
+        if not common_fts_hosts:
+            logger(logging.WARN, 'FTS3Transfertool cannot be used to submit transfer {}: no common fts host found'.format([str(hop) for hop in transfer_path]))
+            return None
+
+        oidc_account = None
+        if all(oidc_supported(t) for t in transfer_path):
+            logger(logging.DEBUG, 'OAuth2/OIDC available for transfer {}'.format([str(hop) for hop in transfer_path]))
+            oidc_account = transfer_path[-1].rws.account
+
+        return TransferToolBuilder(FTS3Transfertool, external_host=common_fts_hosts[0], oidc_account=oidc_account)
+
+    def group_into_submit_jobs(self, transfer_paths):
+        jobs = bulk_group_transfers(
+            transfer_paths,
+            policy=self.group_policy,
+            group_bulk=self.group_bulk,
+            source_strategy=self.source_strategy,
+            max_time_in_queue=self.max_time_in_queue,
+            bring_online=self.bring_online,
+            default_lifetime=self.default_lifetime,
+            archive_timeout_override=self.archive_timeout_override,
+        )
+        return jobs
 
     @classmethod
     def __file_from_transfer(cls, transfer, job_params):
@@ -160,6 +481,7 @@ class FTS3Transfertool(Transfertool):
         :param timeout:      Timeout in seconds.
         :returns:            FTS transfer identifier.
         """
+        start_time = time.time()
         files = []
         for transfer in transfers:
             if isinstance(transfer, dict):
@@ -239,6 +561,7 @@ class FTS3Transfertool(Transfertool):
 
         if not transfer_id:
             raise TransferToolWrongAnswer('No transfer id returned by %s' % self.external_host)
+        record_timer('core.request.submit_transfers_fts3', (time.time() - start_time) * 1000 / len(transfers))
         return transfer_id
 
     def cancel(self, transfer_ids, timeout=None):

--- a/lib/rucio/transfertool/mock.py
+++ b/lib/rucio/transfertool/mock.py
@@ -16,8 +16,10 @@
 # Authors:
 # - Nick Smith <nick.smith@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+import itertools
+import logging
 
-from rucio.transfertool.transfertool import Transfertool
+from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder
 import uuid
 
 
@@ -28,8 +30,15 @@ class MockTransfertool(Transfertool):
     This is not actually used anywhere at the moment
     """
 
-    def __init__(self, external_host, token=None):
-        super(MockTransfertool, self).__init__(external_host)
+    def __init__(self, external_host, logger=logging.log):
+        super(MockTransfertool, self).__init__(external_host, logger)
+
+    @staticmethod
+    def submission_builder_for_path(transfer_path, logger=logging.log):
+        return TransferToolBuilder(MockTransfertool, external_host='Mock Transfertool')
+
+    def group_into_submit_jobs(self, transfers):
+        return [{'transfers': list(itertools.chain.from_iterable(transfers)), 'job_params': {}}]
 
     def submit(self, files, job_params, timeout=None):
         return str(uuid.uuid1())


### PR DESCRIPTION
Historically, submitter has two parameters related to transfer tools:
 - transfertool: defines which Transfertool to use for submission.
 - filter_transfertool: used to filter on Requests.transfertool
   attribute when retrieving requests from the database.
As implemented until now, if "filter_transfertool" was set,
"transfertool" had to have the exact same value, otherwise it could
result in unexpected behavior. Moreover, if "filter_transfertool"
wasn't set, the conveyor completely ignored the database value and
would try to submit the transfer to whichever tool was defined by
"transfertool".

Modify this behavior, if Request.transfertool is set in the database,
it is now a hard requirement and a submitter which cannot speak this
transfertool will ignore the request. The "transfertool" submitter
parameter can be now updated to define a list of tools in order of
preference. Transfertools evaluate in order if they are able to submit
the request. The first matching is used.

The transfertool objects were updated to support this use case
and many "if transfertool == bla" code paths were substituted by
polymorphic object method calls. FTS and globus specific code was
moved to corresponding Transfertool classes.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
