### PR TITLE
Pre commit script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+- repo: https://github.com/PyCQA/flake8
+  rev: 4.0.1
+  hooks:
+  - id: flake8
+- repo: local
+  hooks:
+  - id: add-header
+    name: Run `add_header` script
+    description: Run the `add_header` script to verify the python file headers
+    entry: tools/add_header -i
+    language: system
+    types: [python]

--- a/tools/add_header
+++ b/tools/add_header
@@ -175,7 +175,7 @@ def main(arguments):
 
                 with open(MyFile, 'w') as modified:
                     modified.write(header + data)
-            else:
+            elif arguments.verbose:
                 print(header)
 
             sys.exit(0)
@@ -245,7 +245,7 @@ def main(arguments):
                         if count == 0 or not_comment_line:
                             modified.write(line)
 
-        elif not arguments.check:
+        elif not arguments.check or arguments.verbose:
             print(header)
     exit(exit_code)
 
@@ -261,6 +261,7 @@ if __name__ == '__main__':
                         help='Checks if the script would change anything (non-zero exit code equals change).')
     parser.add_argument('--disable-add-me', action='store_true',
                         help="Do not add the person who runs this command, except if there already is a contributing commit.")
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose mode')
     parser.add_argument(dest='MyFiles', action='store', nargs='+', default=None, help='The files')
 
     main(parser.parse_args())


### PR DESCRIPTION
Add a verbose cli arument to the add_header script
---
The `add_header` script prints the generated header to the console per
default. However, most of the time this is not useful, since the change itself
is not important. The fact that the header changed is.

This commit disables the output of these unnecessary informations per default
and introduces the command line argument `--verbose` to display the entire
generated header when nessecary.

Add pre-commit file
---
Before creating a commit the changed files should be checked for thier
integrity. All linter errors should be fixed and the header should be generated.

This commit introduces the `pre-commit` config for the pre-commit git hook,
which automatically runs flake8 and the add_header script before a commit. This
prevents developers from submitting non-conform code changes. The config is used
by the python `pre-commit` program.