### PR TITLE
Transfers: change db.Sources behavior. Closes #4916. Closes #4970

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -107,14 +107,15 @@ def should_retry_request(req, retry_protocol_mismatches):
 
 
 @transactional_session
-def requeue_and_archive(request, retry_protocol_mismatches=False, session=None, logger=logging.log):
+def requeue_and_archive(request, source_ranking_update=True, retry_protocol_mismatches=False, session=None, logger=logging.log):
     """
     Requeue and archive a failed request.
     TODO: Multiple requeue.
 
-    :param request:     Original request.
-    :param session:     Database session to use.
-    :param logger:      Optional decorated logger that can be passed from the calling daemons or servers.
+    :param request:               Original request.
+    :param source_ranking_update  Boolean. If True, the source ranking is decreased (making the sources less likely to be used)
+    :param session:               Database session to use.
+    :param logger:                Optional decorated logger that can be passed from the calling daemons or servers.
     """
 
     record_counter('core.request.requeue_request')
@@ -134,7 +135,7 @@ def requeue_and_archive(request, retry_protocol_mismatches=False, session=None, 
             elif new_req['state'] != RequestState.SUBMITTING:
                 new_req['retry_count'] += 1
 
-            if new_req['sources']:
+            if source_ranking_update and new_req['sources']:
                 for i in range(len(new_req['sources'])):
                     if new_req['sources'][i]['is_using']:
                         if new_req['sources'][i]['ranking'] is None:

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -617,12 +617,14 @@ def mark_submitting_and_prepare_sources_for_transfers(
                 raise RequestNotFound("Failed to prepare transfer: request %s does not exist or is not in queued state" % transfer.rws)
 
             for src_rse, src_url, src_rse_id, rank in transfer.legacy_sources:
+                # For multi-hops, sources in database are bound to the initial request
+                source_request_id = transfer.rws.attributes.get('initial_request_id', transfer.rws.request_id)
                 src_rowcount = session.query(models.Source)\
-                                      .filter_by(request_id=transfer.rws.request_id)\
+                                      .filter_by(request_id=source_request_id)\
                                       .filter(models.Source.rse_id == src_rse_id)\
                                       .update({'is_using': True}, synchronize_session=False)
                 if src_rowcount == 0:
-                    models.Source(request_id=transfer.rws.request_id,
+                    models.Source(request_id=source_request_id,
                                   scope=transfer.rws.scope,
                                   name=transfer.rws.name,
                                   rse_id=src_rse_id,

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -247,7 +247,7 @@ def __handle_requests(reqs, suspicious_patterns, retry_protocol_mismatches, logg
                 tss = time.time()
                 try:
                     if request_core.should_retry_request(req, retry_protocol_mismatches):
-                        new_req = request_core.requeue_and_archive(req, retry_protocol_mismatches, logger=logger)
+                        new_req = request_core.requeue_and_archive(req, source_ranking_update=True, retry_protocol_mismatches=retry_protocol_mismatches, logger=logger)
                         # should_retry_request and requeue_and_archive are not in one session,
                         # another process can requeue_and_archive and this one will return None.
                         record_timer('daemons.conveyor.common.update_request_state.request-requeue_and_archive', (time.time() - tss) * 1000)
@@ -274,7 +274,7 @@ def __handle_requests(reqs, suspicious_patterns, retry_protocol_mismatches, logg
                 try:
                     tss = time.time()
                     if request_core.should_retry_request(req, retry_protocol_mismatches):
-                        new_req = request_core.requeue_and_archive(req, retry_protocol_mismatches, logger=logger)
+                        new_req = request_core.requeue_and_archive(req, source_ranking_update=False, retry_protocol_mismatches=retry_protocol_mismatches, logger=logger)
                         record_timer('daemons.conveyor.common.update_request_state.request-requeue_and_archive', (time.time() - tss) * 1000)
                         logger(logging.WARNING, 'REQUEUED SUBMITTING DID %s:%s REQUEST %s AS %s TRY %s' % (req['scope'],
                                                                                                            req['name'],


### PR DESCRIPTION
- Don't update source ranking on submission failures: these sources
where not yet used by FTS, so there is no reason to decrease their
ranking.
- Bound sources in multihops to the initial request. Meaning that
intermediate hop requests will not have any sources at all. This
shouldn't be problematic, because we don't retry intermediate hops.
The sources will be attached to the last hop (initial request).
This way, if the transfer fails, all the path will be reduced in
priority. In particular, the first hop (real source) will have its
ranking decreased

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
