### PR TITLE
Monitoring & Logging: record timings and gauges to prometheus. #3416

### DIFF
--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -310,8 +310,7 @@ def get_auth_oidc(account, session=None, **kwargs):
             auth_url = build_url('https://' + auth_server.netloc,
                                  path='auth/oidc_redirect', params=access_msg)
 
-        record_counter(name='IdP_authentication.request')
-        record_timer(stat='IdP_authentication.request', time=time.time() - start)
+        record_timer(name='IdP_authentication.request', time=time.time() - start)
         return auth_url
 
     except Exception:
@@ -448,7 +447,7 @@ def get_token_oidc(auth_query_string, ip=None, session=None):
                 return {'fetchcode': fetchcode}
         else:
             return {'token': new_token}
-        record_timer(stat='IdP_authorization', time=time.time() - start)
+        record_timer(name='IdP_authorization', time=time.time() - start)
 
     except Exception:
         # TO-DO catch different exceptions - InvalidGrant etc. ...
@@ -746,7 +745,7 @@ def __exchange_token_oidc(subject_token_object, session=None, **kwargs):
         record_counter(name='IdP_authorization.access_token.saved')
         if 'refresh_token' in oidc_tokens:
             record_counter(name='IdP_authorization.refresh_token.saved')
-        record_timer(stat='IdP_authorization.token_exchange', time=time.time() - start)
+        record_timer(name='IdP_authorization.token_exchange', time=time.time() - start)
         return new_token
 
     except Exception:
@@ -957,7 +956,7 @@ def __refresh_token_oidc(token_object, session=None):
         else:
             raise CannotAuthorize("OIDC identity '%s' of the '%s' account is did not " % (token_object.identity, token_object.account)
                                   + "succeed requesting a new access and refresh tokens.")  # NOQA: W503
-        record_timer(stat='IdP_authorization.refresh_token', time=time.time() - start)
+        record_timer(name='IdP_authorization.refresh_token', time=time.time() - start)
         return new_token
 
     except Exception:

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -712,7 +712,7 @@ def archive_request(request_id, session=None):
         try:
             time_diff = req['updated_at'] - req['created_at']
             time_diff_s = time_diff.seconds + time_diff.days * 24 * 3600
-            record_timer('core.request.archive_request.%s' % req['activity'].replace(' ', '_'), time_diff_s)
+            record_timer('core.request.archive_request.{activity}', time_diff_s, labels={'activity': req['activity'].replace(' ', '_')})
             session.query(models.Source).filter_by(request_id=request_id).delete()
             session.query(models.Request).filter_by(id=request_id).delete()
         except IntegrityError as error:

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -622,7 +622,7 @@ def bulk_query_transfers(request_host, transfer_ids, transfertool='fts3', timeou
         try:
             start_time = time.time()
             fts_resps = FTS3Transfertool(external_host=request_host).bulk_query(transfer_ids=transfer_ids, timeout=timeout)
-            record_timer('core.request.bulk_query_transfers', (time.time() - start_time) * 1000 / len(transfer_ids))
+            record_timer('core.request.bulk_query_transfers_fts3', (time.time() - start_time) * 1000 / len(transfer_ids))
         except Exception:
             raise
 

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -171,9 +171,9 @@ def _submit_transfers(transfertool_obj, transfers, job_params, submitter='submit
     if eid is not None:
         duration = time.time() - start_time
         logger(logging.INFO, 'Submit job %s to %s in %s seconds' % (eid, transfertool_obj, duration))
-        record_timer('daemons.conveyor.%s.submit_bulk_transfer.per_file' % submitter, (time.time() - start_time) * 1000 / len(transfers) or 1)
+        record_timer('daemons.conveyor.{submitter}.submit_bulk_transfer.per_file', (time.time() - start_time) * 1000 / len(transfers) or 1, labels={'submitter': submitter})
         record_counter('daemons.conveyor.{submitter}.submit_bulk_transfer', delta=len(transfers), labels={'submitter': submitter})
-        record_timer('daemons.conveyor.%s.submit_bulk_transfer.files' % submitter, len(transfers))
+        record_timer('daemons.conveyor.{submitter}.submit_bulk_transfer.files', len(transfers), labels={'submitter': submitter})
 
     if state_to_set:
         try:

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -124,7 +124,7 @@ def finisher(once=False, sleep_time=60, activities=None, bulk=100, db_bulk=1000,
                                                  worker_number=heart_beat['assign_thread'],
                                                  mode_all=True,
                                                  hash_variable='rule_id')
-                    record_timer('daemons.conveyor.finisher.000-get_next', (time.time() - time1) * 1000)
+                    record_timer('daemons.conveyor.finisher.get_next', (time.time() - time1) * 1000)
                     time2 = time.time()
                     if reqs:
                         logger(logging.DEBUG, 'Updating %i requests for activity %s', len(reqs), activity)
@@ -133,7 +133,7 @@ def finisher(once=False, sleep_time=60, activities=None, bulk=100, db_bulk=1000,
                         try:
                             time3 = time.time()
                             __handle_requests(chunk, suspicious_patterns, retry_protocol_mismatches, logger=logger)
-                            record_timer('daemons.conveyor.finisher.handle_requests', (time.time() - time3) * 1000 / (len(chunk) if chunk else 1))
+                            record_timer('daemons.conveyor.finisher.handle_requests_time', (time.time() - time3) * 1000 / (len(chunk) if chunk else 1))
                             record_counter('daemons.conveyor.finisher.handle_requests', delta=len(chunk))
                         except Exception as error:
                             logger(logging.WARNING, '%s', str(error))

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -115,7 +115,7 @@ def poller(once=False, activities=None, sleep_time=60,
                                                     activity_shares=activity_shares,
                                                     transfertool=FILTER_TRANSFERTOOL)
 
-                    record_timer('daemons.conveyor.poller.000-get_next', (time.time() - start_time) * 1000)
+                    record_timer('daemons.conveyor.poller.get_next', (time.time() - start_time) * 1000)
 
                     if transfs:
                         logger(logging.DEBUG, 'Polling %i transfers for activity %s' % (len(transfs), activity))

--- a/lib/rucio/daemons/oauthmanager/oauthmanager.py
+++ b/lib/rucio/daemons/oauthmanager/oauthmanager.py
@@ -169,7 +169,7 @@ def OAuthManager(once=False, loop_rate=300, max_rows=100, sleep_time=300):
 
         tottime = time.time() - start
         logging.info('oauth_manager[%i/%i]: took %f seconds to delete %i tokens, %i session parameters and refreshed %i tokens', worker_number, total_workers, tottime, ndeleted, ndeletedreq, nrefreshed)
-        record_timer(stat='oauth_manager.duration', time=1000 * tottime)
+        record_timer(name='oauth_manager.duration', time=1000 * tottime)
 
         if once:
             break

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -190,7 +190,7 @@ def delete_from_storage(replicas, prot, rse_info, staging_areas, auto_exclude_th
                 else:
                     logger(logging.WARNING, 'Deletion UNAVAILABLE of %s:%s as %s on %s', replica['scope'], replica['name'], replica['pfn'], rse_name)
 
-                monitor.record_timer('daemons.reaper.delete.%s.%s' % (prot.attributes['scheme'], rse_name), (time.time() - start) * 1000)
+                monitor.record_timer('daemons.reaper.delete.{scheme}.{rse}', (time.time() - start) * 1000, labels={'scheme': prot.attributes['scheme'], 'rse': rse_name})
                 duration = time.time() - start
 
                 deleted_files.append({'scope': replica['scope'], 'name': replica['name']})

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -453,7 +453,7 @@ def transmogrifier(bulk=5, once=False, sleep_time=60):
             logger(logging.INFO, 'It took %f seconds to process %i DIDs' % (tottime, len(dids)))
             logger(logging.DEBUG, 'DIDs processed : %s' % (str(dids)))
             monitor.record_counter(name='transmogrifier.job.done', delta=1)
-            monitor.record_timer(stat='transmogrifier.job.duration', time=1000 * tottime)
+            monitor.record_timer(name='transmogrifier.job.duration', time=1000 * tottime)
         except Exception:
             logger(logging.ERROR, "Failed to run transmogrifier", exc_info=True)
             monitor.record_counter(name='transmogrifier.job.error', delta=1)

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -535,8 +535,8 @@ class FTS3Transfertool(Transfertool):
                                         data=params_str,
                                         headers=self.headers,
                                         timeout=timeout)
-            record_timer('transfertool.fts3.submit_transfer.%s' % self.__extract_host(self.external_host), (time.time() - start_time) * 1000 / len(files))
             labels = {'host': self.__extract_host(self.external_host)}
+            record_timer('transfertool.fts3.submit_transfer.{host}', (time.time() - start_time) * 1000 / len(files), labels=labels)
             SUBMISSION_TIMER.labels(**labels).observe((time.time() - start_time) * 1000 / len(files))
         except ReadTimeout as error:
             raise TransferToolTimeout(error)


### PR DESCRIPTION
Similarly to what was already done for counters, record gauges and
timings now. Prometheus doesn't have a notion of timing stat, so
use histograms, which are the ones most commonly used to record
execution time.

A couple of metrics had to be changed because their name was
incompatible with prometheus. Also, recording both timer and counter
with the same name is redundant (and not supported by prometheus)

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
