### PR TITLE
Transfers: fix log message

### DIFF
--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -194,7 +194,7 @@ def submitter(once=False, rses=None, partition_wait_time=10,
 
                         logger(logging.INFO, 'Starting to submit transfers for %s (%s)', activity, transfertool_obj)
                         for job in grouped_jobs:
-                            logger(logging.DEBUG, 'submitjob: %s' % job)
+                            logger(logging.DEBUG, 'submitjob: transfers=%s, job_params=%s' % ([str(t) for t in job['transfers']], job['job_params']))
                             submit_transfer(transfertool_obj=transfertool_obj, transfers=job['transfers'], job_params=job['job_params'], submitter='transfer_submitter',
                                             timeout=timeout, logger=logger)
 


### PR DESCRIPTION
otherwise it prints:
submitjob: {'transfers': [<rucio.core.transfer.DirectTransferDefinition object at 0x7f55fb224f60>], 'job_params': {...}}

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
