### PR TITLE
REST & API: decorate some APIs with session managers. Closes #5002

### DIFF
--- a/lib/rucio/api/did.py
+++ b/lib/rucio/api/did.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2020 CERN
+# Copyright 2013-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,8 +30,10 @@
 # - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-# - Gabriele Gaetano Fronze' <gabriele.fronze@to.infn.it>, 2020-2021
-# - Rob Barnsley <rob.barnsley@skao.int>, 2021
+# - James Perry <j.perry@epcc.ed.ac.uk>, 2020
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Rob Barnsley <robbarnsley@users.noreply.github.com>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 from __future__ import print_function
 
@@ -46,9 +48,11 @@ from rucio.common.utils import api_update_return_dict
 from rucio.core import did, naming_convention, meta as meta_core
 from rucio.core.rse import get_rse_id
 from rucio.db.sqla.constants import DIDType
+from rucio.db.sqla.session import read_session, stream_session, transactional_session
 
 
-def list_dids(scope, filters, did_type='collection', ignore_case=False, limit=None, offset=None, long=False, recursive=False, vo='def'):
+@stream_session
+def list_dids(scope, filters, did_type='collection', ignore_case=False, limit=None, offset=None, long=False, recursive=False, vo='def', session=None):
     """
     List dids in a scope.
 
@@ -61,6 +65,7 @@ def list_dids(scope, filters, did_type='collection', ignore_case=False, limit=No
     :param long: Long format option to display more information for each DID.
     :param recursive: Recursively list DIDs content.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     scope = InternalScope(scope, vo=vo)
 
@@ -72,13 +77,14 @@ def list_dids(scope, filters, did_type='collection', ignore_case=False, limit=No
             or_group['account'] = InternalScope(or_group['scope'], vo=vo)
 
     result = did.list_dids(scope=scope, filters=filters, did_type=did_type, ignore_case=ignore_case,
-                           limit=limit, offset=offset, long=long, recursive=recursive)
+                           limit=limit, offset=offset, long=long, recursive=recursive, session=session)
 
     for d in result:
-        yield api_update_return_dict(d)
+        yield api_update_return_dict(d, session=session)
 
 
-def list_dids_extended(scope, filters, did_type='collection', ignore_case=False, limit=None, offset=None, long=False, recursive=False, vo='def'):
+@stream_session
+def list_dids_extended(scope, filters, did_type='collection', ignore_case=False, limit=None, offset=None, long=False, recursive=False, vo='def', session=None):
     """
     List dids in a scope.
 
@@ -90,6 +96,7 @@ def list_dids_extended(scope, filters, did_type='collection', ignore_case=False,
     :param offset: Offset number.
     :param long: Long format option to display more information for each DID.
     :param recursive: Recursively list DIDs content.
+    :param session: The database session in use.
     """
     validate_schema(name='did_filters', obj=filters, vo=vo)
     scope = InternalScope(scope, vo=vo)
@@ -100,13 +107,14 @@ def list_dids_extended(scope, filters, did_type='collection', ignore_case=False,
         filters['scope'] = InternalScope(filters['scope'], vo=vo)
 
     result = did.list_dids_extended(scope=scope, filters=filters, did_type=did_type, ignore_case=ignore_case,
-                                    limit=limit, offset=offset, long=long, recursive=recursive)
+                                    limit=limit, offset=offset, long=long, recursive=recursive, session=session)
 
     for d in result:
-        yield api_update_return_dict(d)
+        yield api_update_return_dict(d, session=session)
 
 
-def add_did(scope, name, did_type, issuer, account=None, statuses={}, meta={}, rules=[], lifetime=None, dids=[], rse=None, vo='def'):
+@transactional_session
+def add_did(scope, name, did_type, issuer, account=None, statuses={}, meta={}, rules=[], lifetime=None, dids=[], rse=None, vo='def', session=None):
     """
     Add data did.
 
@@ -122,13 +130,14 @@ def add_did(scope, name, did_type, issuer, account=None, statuses={}, meta={}, r
     :param dids: The content.
     :param rse: The RSE name when registering replicas.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     v_did = {'name': name, 'type': did_type.upper(), 'scope': scope}
     validate_schema(name='did', obj=v_did, vo=vo)
     validate_schema(name='dids', obj=dids, vo=vo)
     validate_schema(name='rse', obj=rse, vo=vo)
     kwargs = {'scope': scope, 'name': name, 'type': did_type, 'issuer': issuer, 'account': account, 'statuses': statuses, 'meta': meta, 'rules': rules, 'lifetime': lifetime}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_did', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_did', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not add data identifier to scope %s' % (issuer, scope))
 
     if account is not None:
@@ -142,11 +151,11 @@ def add_did(scope, name, did_type, issuer, account=None, statuses={}, meta={}, r
 
     rse_id = None
     if rse is not None:
-        rse_id = get_rse_id(rse=rse, vo=vo)
+        rse_id = get_rse_id(rse=rse, vo=vo, session=session)
 
     if did_type == 'DATASET':
         # naming_convention validation
-        extra_meta = naming_convention.validate_name(scope=scope, name=name, did_type='D')
+        extra_meta = naming_convention.validate_name(scope=scope, name=name, did_type='D', session=session)
 
         # merge extra_meta with meta
         for k in extra_meta or {}:
@@ -157,30 +166,32 @@ def add_did(scope, name, did_type, issuer, account=None, statuses={}, meta={}, r
                 raise rucio.common.exception.InvalidObject("Provided metadata %s doesn't match the naming convention: %s != %s" % (k, meta[k], extra_meta[k]))
 
         # Validate metadata
-        meta_core.validate_meta(meta=meta, did_type=DIDType[did_type.upper()])
+        meta_core.validate_meta(meta=meta, did_type=DIDType[did_type.upper()], session=session)
 
     return did.add_did(scope=scope, name=name, did_type=DIDType[did_type.upper()], account=account or issuer,
                        statuses=statuses, meta=meta, rules=rules, lifetime=lifetime,
-                       dids=dids, rse_id=rse_id)
+                       dids=dids, rse_id=rse_id, session=session)
 
 
-def add_dids(dids, issuer, vo='def'):
+@transactional_session
+def add_dids(dids, issuer, vo='def', session=None):
     """
     Bulk Add did.
 
     :param dids: A list of dids.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     for d in dids:
         if 'rse' in d:
             rse_id = None
             if d['rse'] is not None:
-                rse_id = get_rse_id(rse=d['rse'], vo=vo)
+                rse_id = get_rse_id(rse=d['rse'], vo=vo, session=session)
             d['rse_id'] = rse_id
 
     kwargs = {'issuer': issuer, 'dids': dids}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_dids', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_dids', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not bulk add data identifier' % (issuer))
 
     issuer = InternalAccount(issuer, vo=vo)
@@ -191,27 +202,29 @@ def add_dids(dids, issuer, vo='def'):
         if 'dids' in d.keys():
             for child in d['dids']:
                 child['scope'] = InternalScope(child['scope'], vo=vo)
-    return did.add_dids(dids, account=issuer)
+    return did.add_dids(dids, account=issuer, session=session)
 
 
-def attach_dids(scope, name, attachment, issuer, vo='def'):
+@transactional_session
+def attach_dids(scope, name, attachment, issuer, vo='def', session=None):
     """
     Append content to data did.
 
     :param attachment: The attachment.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     validate_schema(name='attachment', obj=attachment, vo=vo)
 
     rse_id = None
     if 'rse' in attachment:
         if attachment['rse'] is not None:
-            rse_id = get_rse_id(rse=attachment['rse'], vo=vo)
+            rse_id = get_rse_id(rse=attachment['rse'], vo=vo, session=session)
         attachment['rse_id'] = rse_id
 
     kwargs = {'scope': scope, 'name': name, 'attachment': attachment}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='attach_dids', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='attach_dids', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not add data identifiers to %s:%s' % (issuer, scope, name))
 
     scope = InternalScope(scope, vo=vo)
@@ -225,15 +238,16 @@ def attach_dids(scope, name, attachment, issuer, vo='def'):
 
     if rse_id is not None:
         dids = did.attach_dids(scope=scope, name=name, dids=attachment['dids'],
-                               account=attachment.get('account', issuer), rse_id=rse_id)
+                               account=attachment.get('account', issuer), rse_id=rse_id, session=session)
     else:
         dids = did.attach_dids(scope=scope, name=name, dids=attachment['dids'],
-                               account=attachment.get('account', issuer))
+                               account=attachment.get('account', issuer), session=session)
 
     return dids
 
 
-def attach_dids_to_dids(attachments, issuer, ignore_duplicate=False, vo='def'):
+@transactional_session
+def attach_dids_to_dids(attachments, issuer, ignore_duplicate=False, vo='def', session=None):
     """
     Append content to dids.
 
@@ -241,6 +255,7 @@ def attach_dids_to_dids(attachments, issuer, ignore_duplicate=False, vo='def'):
     :param issuer: The issuer account.
     :param ignore_duplicate: If True, ignore duplicate entries.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     validate_schema(name='attachments', obj=attachments, vo=vo)
 
@@ -248,10 +263,10 @@ def attach_dids_to_dids(attachments, issuer, ignore_duplicate=False, vo='def'):
         if 'rse' in a:
             rse_id = None
             if a['rse'] is not None:
-                rse_id = get_rse_id(rse=a['rse'], vo=vo)
+                rse_id = get_rse_id(rse=a['rse'], vo=vo, session=session)
             a['rse_id'] = rse_id
 
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='attach_dids_to_dids', kwargs={'attachments': attachments}):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='attach_dids_to_dids', kwargs={'attachments': attachments}, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not add data identifiers' % (issuer))
 
     issuer = InternalAccount(issuer, vo=vo)
@@ -263,10 +278,11 @@ def attach_dids_to_dids(attachments, issuer, ignore_duplicate=False, vo='def'):
                 d['account'] = InternalAccount(d['account'], vo=vo)
 
     return did.attach_dids_to_dids(attachments=attachments, account=issuer,
-                                   ignore_duplicate=ignore_duplicate)
+                                   ignore_duplicate=ignore_duplicate, session=session)
 
 
-def detach_dids(scope, name, dids, issuer, vo='def'):
+@transactional_session
+def detach_dids(scope, name, dids, issuer, vo='def', session=None):
     """
     Detach data identifier
 
@@ -275,19 +291,21 @@ def detach_dids(scope, name, dids, issuer, vo='def'):
     :param dids: The content.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     kwargs = {'scope': scope, 'name': name, 'dids': dids, 'issuer': issuer}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='detach_dids', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='detach_dids', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not detach data identifiers from %s:%s' % (issuer, scope, name))
 
     scope = InternalScope(scope, vo=vo)
     for d in dids:
         d['scope'] = InternalScope(d['scope'], vo=vo)
 
-    return did.detach_dids(scope=scope, name=name, dids=dids)
+    return did.detach_dids(scope=scope, name=name, dids=dids, session=session)
 
 
-def list_new_dids(did_type=None, thread=None, total_threads=None, chunk_size=1000, vo='def'):
+@stream_session
+def list_new_dids(did_type=None, thread=None, total_threads=None, chunk_size=1000, vo='def', session=None):
     """
     List recent identifiers.
 
@@ -296,14 +314,16 @@ def list_new_dids(did_type=None, thread=None, total_threads=None, chunk_size=100
     :param total_threads: The total number of threads of all necromancers.
     :param chunk_size: Number of requests to return per yield.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
-    dids = did.list_new_dids(did_type=did_type and DIDType[did_type.upper()], thread=thread, total_threads=total_threads, chunk_size=chunk_size)
+    dids = did.list_new_dids(did_type=did_type and DIDType[did_type.upper()], thread=thread, total_threads=total_threads, chunk_size=chunk_size, session=session)
     for d in dids:
         if d['scope'].vo == vo:
-            yield api_update_return_dict(d)
+            yield api_update_return_dict(d, session=session)
 
 
-def set_new_dids(dids, new_flag=True, vo='def'):
+@transactional_session
+def set_new_dids(dids, new_flag=True, vo='def', session=None):
     """
     Set/reset the flag new
 
@@ -311,47 +331,53 @@ def set_new_dids(dids, new_flag=True, vo='def'):
     :param name: The data identifier name.
     :param new_flag: A boolean to flag new DIDs.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     for d in dids:
         d['scope'] = InternalScope(d['scope'], vo=vo)
 
-    return did.set_new_dids(dids, new_flag)
+    return did.set_new_dids(dids, new_flag, session=session)
 
 
-def list_content(scope, name, vo='def'):
+@stream_session
+def list_content(scope, name, vo='def', session=None):
     """
     List data identifier contents.
 
     :param scope: The scope name.
     :param name: The data identifier name.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
     scope = InternalScope(scope, vo=vo)
 
-    dids = did.list_content(scope=scope, name=name)
+    dids = did.list_content(scope=scope, name=name, session=session)
     for d in dids:
-        yield api_update_return_dict(d)
+        yield api_update_return_dict(d, session=session)
 
 
-def list_content_history(scope, name, vo='def'):
+@stream_session
+def list_content_history(scope, name, vo='def', session=None):
     """
     List data identifier contents history.
 
     :param scope: The scope name.
     :param name: The data identifier name.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
     scope = InternalScope(scope, vo=vo)
 
-    dids = did.list_content_history(scope=scope, name=name)
+    dids = did.list_content_history(scope=scope, name=name, session=session)
 
     for d in dids:
-        yield api_update_return_dict(d)
+        yield api_update_return_dict(d, session=session)
 
 
-def list_files(scope, name, long, vo='def'):
+@stream_session
+def list_files(scope, name, long, vo='def', session=None):
     """
     List data identifier file contents.
 
@@ -359,17 +385,19 @@ def list_files(scope, name, long, vo='def'):
     :param name: The data identifier name.
     :param long:       A boolean to choose if GUID is returned or not.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
     scope = InternalScope(scope, vo=vo)
 
-    dids = did.list_files(scope=scope, name=name, long=long)
+    dids = did.list_files(scope=scope, name=name, long=long, session=session)
 
     for d in dids:
-        yield api_update_return_dict(d)
+        yield api_update_return_dict(d, session=session)
 
 
-def scope_list(scope, name=None, recursive=False, vo='def'):
+@stream_session
+def scope_list(scope, name=None, recursive=False, vo='def', session=None):
     """
     List data identifiers in a scope.
 
@@ -377,11 +405,12 @@ def scope_list(scope, name=None, recursive=False, vo='def'):
     :param name: The data identifier name.
     :param recursive: boolean, True or False.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
     scope = InternalScope(scope, vo=vo)
 
-    dids = did.scope_list(scope, name=name, recursive=recursive)
+    dids = did.scope_list(scope, name=name, recursive=recursive, session=session)
 
     for d in dids:
         ret_did = deepcopy(d)
@@ -391,7 +420,8 @@ def scope_list(scope, name=None, recursive=False, vo='def'):
         yield ret_did
 
 
-def get_did(scope, name, dynamic=False, vo='def'):
+@read_session
+def get_did(scope, name, dynamic=False, vo='def', session=None):
     """
     Retrieve a single data did.
 
@@ -400,15 +430,17 @@ def get_did(scope, name, dynamic=False, vo='def'):
     :param dynamic:  Dynamically resolve the bytes and length of the did
     :param vo: The VO to act on.
     :return did: Dictionary containing {'name', 'scope', 'type'}, Exception otherwise
+    :param session: The database session in use.
     """
 
     scope = InternalScope(scope, vo=vo)
 
-    d = did.get_did(scope=scope, name=name, dynamic=dynamic)
-    return api_update_return_dict(d)
+    d = did.get_did(scope=scope, name=name, dynamic=dynamic, session=session)
+    return api_update_return_dict(d, session=session)
 
 
-def set_metadata(scope, name, key, value, issuer, recursive=False, vo='def'):
+@transactional_session
+def set_metadata(scope, name, key, value, issuer, recursive=False, vo='def', session=None):
     """
     Add metadata to data did.
 
@@ -419,20 +451,22 @@ def set_metadata(scope, name, key, value, issuer, recursive=False, vo='def'):
     :param issuer: The issuer account.
     :param recursive: Option to propagate the metadata update to content.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     kwargs = {'scope': scope, 'name': name, 'key': key, 'value': value, 'issuer': issuer}
 
     if key in RESERVED_KEYS:
         raise rucio.common.exception.AccessDenied('Account %s can not change this metadata value to data identifier %s:%s' % (issuer, scope, name))
 
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not add metadata to data identifier %s:%s' % (issuer, scope, name))
 
     scope = InternalScope(scope, vo=vo)
-    return did.set_metadata(scope=scope, name=name, key=key, value=value, recursive=recursive)
+    return did.set_metadata(scope=scope, name=name, key=key, value=value, recursive=recursive, session=session)
 
 
-def set_metadata_bulk(scope, name, meta, issuer, recursive=False, vo='def'):
+@transactional_session
+def set_metadata_bulk(scope, name, meta, issuer, recursive=False, vo='def', session=None):
     """
     Add metadata to data did.
 
@@ -442,6 +476,7 @@ def set_metadata_bulk(scope, name, meta, issuer, recursive=False, vo='def'):
     :param issuer: The issuer account.
     :param recursive: Option to propagate the metadata update to content.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     kwargs = {'scope': scope, 'name': name, 'meta': meta, 'issuer': issuer}
 
@@ -449,14 +484,15 @@ def set_metadata_bulk(scope, name, meta, issuer, recursive=False, vo='def'):
         if key in RESERVED_KEYS:
             raise rucio.common.exception.AccessDenied('Account %s can not change the value of the metadata key %s to data identifier %s:%s' % (issuer, key, scope, name))
 
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata_bulk', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata_bulk', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not add metadata to data identifier %s:%s' % (issuer, scope, name))
 
     scope = InternalScope(scope, vo=vo)
-    return did.set_metadata_bulk(scope=scope, name=name, meta=meta, recursive=recursive)
+    return did.set_metadata_bulk(scope=scope, name=name, meta=meta, recursive=recursive, session=session)
 
 
-def set_dids_metadata_bulk(dids, issuer, recursive=False, vo='def'):
+@transactional_session
+def set_dids_metadata_bulk(dids, issuer, recursive=False, vo='def', session=None):
     """
     Add metadata to a list of data identifiers.
 
@@ -464,11 +500,12 @@ def set_dids_metadata_bulk(dids, issuer, recursive=False, vo='def'):
     :param dids: A list of dids including metadata.
     :param recursive: Option to propagate the metadata update to content.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
     for entry in dids:
         kwargs = {'scope': entry['scope'], 'name': entry['name'], 'meta': entry['meta'], 'issuer': issuer}
-        if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata_bulk', kwargs=kwargs):
+        if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata_bulk', kwargs=kwargs, session=session):
             raise rucio.common.exception.AccessDenied('Account %s can not add metadata to data identifier %s:%s' % (issuer, entry['scope'], entry['name']))
         entry['scope'] = InternalScope(entry['scope'], vo=vo)
         meta = entry['meta']
@@ -476,41 +513,46 @@ def set_dids_metadata_bulk(dids, issuer, recursive=False, vo='def'):
             if key in RESERVED_KEYS:
                 raise rucio.common.exception.AccessDenied('Account %s can not change the value of the metadata key %s to data identifier %s:%s' % (issuer, key, entry['scope'], entry['name']))
 
-    return did.set_dids_metadata_bulk(dids=dids, recursive=recursive)
+    return did.set_dids_metadata_bulk(dids=dids, recursive=recursive, session=session)
 
 
-def get_metadata(scope, name, plugin='DID_COLUMN', vo='def'):
+@read_session
+def get_metadata(scope, name, plugin='DID_COLUMN', vo='def', session=None):
     """
     Get data identifier metadata
 
     :param scope: The scope name.
     :param name: The data identifier name.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
     scope = InternalScope(scope, vo=vo)
 
-    d = did.get_metadata(scope=scope, name=name, plugin=plugin)
-    return api_update_return_dict(d)
+    d = did.get_metadata(scope=scope, name=name, plugin=plugin, session=session)
+    return api_update_return_dict(d, session=session)
 
 
-def get_metadata_bulk(dids, inherit=False, vo='def'):
+@stream_session
+def get_metadata_bulk(dids, inherit=False, vo='def', session=None):
     """
     Get metadata for a list of dids
     :param dids:               A list of dids.
     :param inherit:            A boolean. If set to true, the metadata of the parent are concatenated.
     :param vo:                 The VO to act on.
+    :param session: The database session in use.
     """
 
     validate_schema(name='dids', obj=dids, vo=vo)
     for entry in dids:
         entry['scope'] = InternalScope(entry['scope'], vo=vo)
-    meta = did.get_metadata_bulk(dids, inherit=inherit)
+    meta = did.get_metadata_bulk(dids, inherit=inherit, session=session)
     for met in meta:
-        yield api_update_return_dict(met)
+        yield api_update_return_dict(met, session=session)
 
 
-def delete_metadata(scope, name, key, vo='def'):
+@transactional_session
+def delete_metadata(scope, name, key, vo='def', session=None):
     """
     Delete a key from the metadata column
 
@@ -518,13 +560,15 @@ def delete_metadata(scope, name, key, vo='def'):
     :param name: the name of the did
     :param key: the key to be deleted
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
     scope = InternalScope(scope, vo=vo)
-    return did.delete_metadata(scope=scope, name=name, key=key)
+    return did.delete_metadata(scope=scope, name=name, key=key, session=session)
 
 
-def set_status(scope, name, issuer, vo='def', **kwargs):
+@transactional_session
+def set_status(scope, name, issuer, vo='def', session=None, **kwargs):
     """
     Set data identifier status
 
@@ -533,50 +577,56 @@ def set_status(scope, name, issuer, vo='def', **kwargs):
     :param issuer: The issuer account.
     :param kwargs:  Keyword arguments of the form status_name=value.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='set_status', kwargs={'scope': scope, 'name': name, 'issuer': issuer}):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='set_status', kwargs={'scope': scope, 'name': name, 'issuer': issuer}, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not set status on data identifier %s:%s' % (issuer, scope, name))
 
     scope = InternalScope(scope, vo=vo)
 
-    return did.set_status(scope=scope, name=name, **kwargs)
+    return did.set_status(scope=scope, name=name, session=session, **kwargs)
 
 
-def get_dataset_by_guid(guid, vo='def'):
+@stream_session
+def get_dataset_by_guid(guid, vo='def', session=None):
     """
     Get the parent datasets for a given GUID.
     :param guid: The GUID.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: A did
     """
-    dids = did.get_dataset_by_guid(guid=guid)
+    dids = did.get_dataset_by_guid(guid=guid, session=session)
 
     for d in dids:
         if d['scope'].vo != vo:
             raise RucioException('GUID unavailable on VO {}'.format(vo))
-        yield api_update_return_dict(d)
+        yield api_update_return_dict(d, session=session)
 
 
-def list_parent_dids(scope, name, vo='def'):
+@stream_session
+def list_parent_dids(scope, name, vo='def', session=None):
     """
     List parent datasets and containers of a did.
 
     :param scope:   The scope.
     :param name:    The name.
     :param vo:      The VO to act on.
+    :param session: The database session in use.
     """
 
     scope = InternalScope(scope, vo=vo)
 
-    dids = did.list_parent_dids(scope=scope, name=name)
+    dids = did.list_parent_dids(scope=scope, name=name, session=session)
 
     for d in dids:
-        yield api_update_return_dict(d)
+        yield api_update_return_dict(d, session=session)
 
 
-def create_did_sample(input_scope, input_name, output_scope, output_name, issuer, nbfiles, vo='def'):
+@transactional_session
+def create_did_sample(input_scope, input_name, output_scope, output_name, issuer, nbfiles, vo='def', session=None):
     """
     Create a sample from an input collection.
 
@@ -588,9 +638,10 @@ def create_did_sample(input_scope, input_name, output_scope, output_name, issuer
     :param nbfiles: The number of files to register in the output dataset.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     kwargs = {'issuer': issuer, 'scope': output_scope}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='create_did_sample', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='create_did_sample', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not bulk add data identifier' % (issuer))
 
     input_scope = InternalScope(input_scope, vo=vo)
@@ -598,44 +649,50 @@ def create_did_sample(input_scope, input_name, output_scope, output_name, issuer
 
     issuer = InternalAccount(issuer, vo=vo)
 
-    return did.create_did_sample(input_scope=input_scope, input_name=input_name, output_scope=output_scope, output_name=output_name, account=issuer, nbfiles=nbfiles)
+    return did.create_did_sample(input_scope=input_scope, input_name=input_name, output_scope=output_scope, output_name=output_name,
+                                 account=issuer, nbfiles=nbfiles, session=session)
 
 
-def resurrect(dids, issuer, vo='def'):
+@transactional_session
+def resurrect(dids, issuer, vo='def', session=None):
     """
     Resurrect DIDs.
 
     :param dids: A list of dids.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     kwargs = {'issuer': issuer}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='resurrect', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='resurrect', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not resurrect data identifiers' % (issuer))
     validate_schema(name='dids', obj=dids, vo=vo)
 
     for d in dids:
         d['scope'] = InternalScope(d['scope'], vo=vo)
 
-    return did.resurrect(dids=dids)
+    return did.resurrect(dids=dids, session=session)
 
 
-def list_archive_content(scope, name, vo='def'):
+@stream_session
+def list_archive_content(scope, name, vo='def', session=None):
     """
     List archive contents.
 
     :param scope: The archive scope name.
     :param name: The archive data identifier name.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
     scope = InternalScope(scope, vo=vo)
 
-    dids = did.list_archive_content(scope=scope, name=name)
+    dids = did.list_archive_content(scope=scope, name=name, session=session)
     for d in dids:
-        yield api_update_return_dict(d)
+        yield api_update_return_dict(d, session=session)
 
 
+@transactional_session
 def add_did_to_followed(scope, name, account, session=None, vo='def'):
     """
     Mark a did as followed by the given account
@@ -650,6 +707,7 @@ def add_did_to_followed(scope, name, account, session=None, vo='def'):
     return did.add_did_to_followed(scope=scope, name=name, account=account, session=session)
 
 
+@transactional_session
 def add_dids_to_followed(dids, account, session=None, vo='def'):
     """
     Bulk mark datasets as followed
@@ -662,6 +720,7 @@ def add_dids_to_followed(dids, account, session=None, vo='def'):
     return did.add_dids_to_followed(dids=dids, account=account, session=session)
 
 
+@stream_session
 def get_users_following_did(name, scope, session=None, vo='def'):
     """
     Return list of users following a did
@@ -677,6 +736,7 @@ def get_users_following_did(name, scope, session=None, vo='def'):
         yield user
 
 
+@transactional_session
 def remove_did_from_followed(scope, name, account, issuer, session=None, vo='def'):
     """
     Mark a did as not followed
@@ -688,7 +748,7 @@ def remove_did_from_followed(scope, name, account, issuer, session=None, vo='def
     :param issuer: The issuer account
     """
     kwargs = {'scope': scope, 'issuer': issuer}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='remove_did_from_followed', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='remove_did_from_followed', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not remove data identifiers from followed table' % (issuer))
 
     scope = InternalScope(scope, vo=vo)
@@ -696,6 +756,7 @@ def remove_did_from_followed(scope, name, account, issuer, session=None, vo='def
     return did.remove_did_from_followed(scope=scope, name=name, account=account, session=session)
 
 
+@transactional_session
 def remove_dids_from_followed(dids, account, issuer, session=None, vo='def'):
     """
     Bulk mark datasets as not followed
@@ -705,7 +766,7 @@ def remove_dids_from_followed(dids, account, issuer, session=None, vo='def'):
     :param session: The database session in use.
     """
     kwargs = {'dids': dids, 'issuer': issuer}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='remove_dids_from_followed', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='remove_dids_from_followed', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not bulk remove data identifiers from followed table' % (issuer))
 
     account = InternalAccount(account, vo=vo)

--- a/lib/rucio/api/permission.py
+++ b/lib/rucio/api/permission.py
@@ -1,19 +1,24 @@
-'''
-  Copyright European Organization for Nuclear Research (CERN)
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  You may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-               http://www.apache.org/licenses/LICENSE-2.0
-
-  Authors:
-  - Angelos Molfetas, <angelos.molfetas@cern.ch>, 2012
-  - Vincent Garonne, <vincent.garonne@cern.ch>, 2012-2017
-  - Mario Lassnig, <mario.lassnig@cern.ch>, 2012
-  - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
-
-  PY3K COMPATIBLE
-'''
+# -*- coding: utf-8 -*-
+# Copyright 2012-2022 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2013
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2017
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 from copy import deepcopy
 from rucio.common.types import InternalAccount, InternalScope
@@ -22,22 +27,23 @@ from rucio.core.rse import get_rse_id
 from rucio.common.exception import RSENotFound
 
 
-def has_permission(issuer, action, kwargs, vo='def'):
+def has_permission(issuer, action, kwargs, vo='def', session=None):
     """
     Checks if an account has the specified permission to
     execute an action with parameters.
 
-    :param issuer: The Account issuer.
-    :param vo:     The VO to check against.
-    :param action: The action (API call) called by the account.
-    :param kwargs: List of arguments for the action.
+    :param issuer:  The Account issuer.
+    :param vo:      The VO to check against.
+    :param action:  The action (API call) called by the account.
+    :param session: The db session to use
+    :param kwargs:  List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
 
     kwargs = deepcopy(kwargs)
     if 'rse' in kwargs and 'rse_id' not in kwargs:
         try:
-            rse_id = get_rse_id(rse=kwargs.get('rse'), vo=vo)
+            rse_id = get_rse_id(rse=kwargs.get('rse'), vo=vo, session=session)
         except RSENotFound:
             rse_id = None
         kwargs.update({'rse_id': rse_id})
@@ -63,4 +69,4 @@ def has_permission(issuer, action, kwargs, vo='def'):
 
     issuer = InternalAccount(issuer, vo=vo)
 
-    return permission.has_permission(issuer=issuer, action=action, kwargs=kwargs)
+    return permission.has_permission(issuer=issuer, action=action, kwargs=kwargs, session=session)

--- a/lib/rucio/api/rule.py
+++ b/lib/rucio/api/rule.py
@@ -25,7 +25,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Ian Johnson <ijjorama@gmail.com>, 2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021-2022
 
 from rucio.api.permission import has_permission
@@ -35,19 +35,22 @@ from rucio.common.schema import validate_schema
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import api_update_return_dict
 from rucio.core import rule
+from rucio.db.sqla.session import read_session, stream_session, transactional_session
 
 
-def is_multi_vo():
+@read_session
+def is_multi_vo(session=None):
     """
     Check whether this instance is configured for multi-VO
     returns: Boolean True if running in multi-VO
     """
-    return config_get_bool('common', 'multi_vo', raise_exception=False, default=False)
+    return config_get_bool('common', 'multi_vo', raise_exception=False, default=False, session=session)
 
 
+@transactional_session
 def add_replication_rule(dids, copies, rse_expression, weight, lifetime, grouping, account, locked, subscription_id, source_replica_expression,
                          activity, notify, purge_replicas, ignore_availability, comment, ask_approval, asynchronous, delay_injection, priority,
-                         split_container, meta, issuer, vo='def'):
+                         split_container, meta, issuer, vo='def', session=None):
     """
     Adds a replication rule.
 
@@ -75,6 +78,7 @@ def add_replication_rule(dids, copies, rse_expression, weight, lifetime, groupin
     :param meta:                       WFMS metadata as a dictionary.
     :param issuer:                     The issuing account of this operation.
     :param vo:                         The VO to act on.
+    :param session:                    The database session in use.
     :returns:                          List of created replication rules.
     """
     if account is None:
@@ -92,7 +96,7 @@ def add_replication_rule(dids, copies, rse_expression, weight, lifetime, groupin
 
     validate_schema(name='rule', obj=kwargs, vo=vo)
 
-    if not has_permission(issuer=issuer, vo=vo, action='add_rule', kwargs=kwargs):
+    if not has_permission(issuer=issuer, vo=vo, action='add_rule', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not add replication rule' % (issuer))
 
     account = InternalAccount(account, vo=vo)
@@ -119,30 +123,35 @@ def add_replication_rule(dids, copies, rse_expression, weight, lifetime, groupin
                          delay_injection=delay_injection,
                          priority=priority,
                          split_container=split_container,
-                         meta=meta)
+                         meta=meta,
+                         session=session)
 
 
-def get_replication_rule(rule_id, issuer, vo='def'):
+@read_session
+def get_replication_rule(rule_id, issuer, vo='def', session=None):
     """
     Get replication rule by it's id.
 
     :param rule_id: The rule_id to get.
     :param issuer: The issuing account of this operation.
     :param vo: The VO of the issuer.
+    :param session: The database session in use.
     """
     kwargs = {'rule_id': rule_id}
-    if is_multi_vo() and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs):
+    if is_multi_vo(session=session) and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not access rules at other VOs.' % (issuer))
-    result = rule.get_rule(rule_id)
-    return api_update_return_dict(result)
+    result = rule.get_rule(rule_id, session=session)
+    return api_update_return_dict(result, session=session)
 
 
-def list_replication_rules(filters={}, vo='def'):
+@stream_session
+def list_replication_rules(filters={}, vo='def', session=None):
     """
     Lists replication rules based on a filter.
 
     :param filters: dictionary of attributes by which the results should be filtered.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     # If filters is empty, create a new dict to avoid overwriting the function's default
     if not filters:
@@ -160,54 +169,61 @@ def list_replication_rules(filters={}, vo='def'):
         account = '*'
     filters['account'] = InternalAccount(account=account, vo=vo)
 
-    rules = rule.list_rules(filters)
+    rules = rule.list_rules(filters, session=session)
     for r in rules:
-        yield api_update_return_dict(r)
+        yield api_update_return_dict(r, session=session)
 
 
-def list_replication_rule_history(rule_id, issuer, vo='def'):
+@read_session
+def list_replication_rule_history(rule_id, issuer, vo='def', session=None):
     """
     Lists replication rule history..
 
     :param rule_id: The rule_id to list.
     :param issuer: The issuing account of this operation.
     :param vo: The VO of the issuer.
+    :param session: The database session in use.
     """
     kwargs = {'rule_id': rule_id}
-    if is_multi_vo() and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs):
+    if is_multi_vo(session=session) and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not access rules at other VOs.' % (issuer))
-    return rule.list_rule_history(rule_id)
+    return rule.list_rule_history(rule_id, session=session)
 
 
-def list_replication_rule_full_history(scope, name, vo='def'):
+@stream_session
+def list_replication_rule_full_history(scope, name, vo='def', session=None):
     """
     List the rule history of a DID.
 
     :param scope: The scope of the DID.
     :param name: The name of the DID.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     scope = InternalScope(scope, vo=vo)
-    rules = rule.list_rule_full_history(scope, name)
+    rules = rule.list_rule_full_history(scope, name, session=session)
     for r in rules:
-        yield api_update_return_dict(r)
+        yield api_update_return_dict(r, session=session)
 
 
-def list_associated_replication_rules_for_file(scope, name, vo='def'):
+@stream_session
+def list_associated_replication_rules_for_file(scope, name, vo='def', session=None):
     """
     Lists associated replication rules by file.
 
     :param scope: Scope of the file..
     :param name:  Name of the file.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     scope = InternalScope(scope, vo=vo)
-    rules = rule.list_associated_rules_for_file(scope=scope, name=name)
+    rules = rule.list_associated_rules_for_file(scope=scope, name=name, session=session)
     for r in rules:
-        yield api_update_return_dict(r)
+        yield api_update_return_dict(r, session=session)
 
 
-def delete_replication_rule(rule_id, purge_replicas, issuer, vo='def'):
+@transactional_session
+def delete_replication_rule(rule_id, purge_replicas, issuer, vo='def', session=None):
     """
     Deletes a replication rule and all associated locks.
 
@@ -215,17 +231,19 @@ def delete_replication_rule(rule_id, purge_replicas, issuer, vo='def'):
     :param purge_replicas: Purge the replicas immediately
     :param issuer:         The issuing account of this operation
     :param vo:             The VO to act on.
+    :param session:        The database session in use.
     :raises:               RuleNotFound, AccessDenied
     """
     kwargs = {'rule_id': rule_id, 'purge_replicas': purge_replicas}
-    if is_multi_vo() and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs):
+    if is_multi_vo(session=session) and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not access rules at other VOs.' % (issuer))
     if not has_permission(issuer=issuer, vo=vo, action='del_rule', kwargs=kwargs):
         raise AccessDenied('Account %s can not remove this replication rule.' % (issuer))
-    rule.delete_rule(rule_id=rule_id, purge_replicas=purge_replicas, soft=True)
+    rule.delete_rule(rule_id=rule_id, purge_replicas=purge_replicas, soft=True, session=session)
 
 
-def update_replication_rule(rule_id, options, issuer, vo='def'):
+@transactional_session
+def update_replication_rule(rule_id, options, issuer, vo='def', session=None):
     """
     Update lock state of a replication rule.
 
@@ -233,29 +251,31 @@ def update_replication_rule(rule_id, options, issuer, vo='def'):
     :param options:     Options dictionary.
     :param issuer:      The issuing account of this operation
     :param vo:          The VO to act on.
+    :param session:     The database session in use.
     :raises:            RuleNotFound if no Rule can be found.
     """
     kwargs = {'rule_id': rule_id, 'options': options}
-    if is_multi_vo() and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs):
+    if is_multi_vo(session=session) and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not access rules at other VOs.' % (issuer))
     if 'approve' in options:
-        if not has_permission(issuer=issuer, vo=vo, action='approve_rule', kwargs=kwargs):
+        if not has_permission(issuer=issuer, vo=vo, action='approve_rule', kwargs=kwargs, session=session):
             raise AccessDenied('Account %s can not approve/deny this replication rule.' % (issuer))
 
         issuer = InternalAccount(issuer, vo=vo)
         if options['approve']:
-            rule.approve_rule(rule_id=rule_id, approver=issuer)
+            rule.approve_rule(rule_id=rule_id, approver=issuer, session=session)
         else:
-            rule.deny_rule(rule_id=rule_id, approver=issuer, reason=options.get('comment', None))
+            rule.deny_rule(rule_id=rule_id, approver=issuer, reason=options.get('comment', None), session=session)
     else:
-        if not has_permission(issuer=issuer, vo=vo, action='update_rule', kwargs=kwargs):
+        if not has_permission(issuer=issuer, vo=vo, action='update_rule', kwargs=kwargs, session=session):
             raise AccessDenied('Account %s can not update this replication rule.' % (issuer))
         if 'account' in options:
             options['account'] = InternalAccount(options['account'], vo=vo)
-        rule.update_rule(rule_id=rule_id, options=options)
+        rule.update_rule(rule_id=rule_id, options=options, session=session)
 
 
-def reduce_replication_rule(rule_id, copies, exclude_expression, issuer, vo='def'):
+@transactional_session
+def reduce_replication_rule(rule_id, copies, exclude_expression, issuer, vo='def', session=None):
     """
     Reduce the number of copies for a rule by atomically replacing the rule.
 
@@ -264,36 +284,40 @@ def reduce_replication_rule(rule_id, copies, exclude_expression, issuer, vo='def
     :param exclude_expression:  RSE Expression of RSEs to exclude.
     :param issuer:              The issuing account of this operation
     :param vo:                  The VO to act on.
+    :param session:             The database session in use.
     :raises:                    RuleReplaceFailed, RuleNotFound
     """
     kwargs = {'rule_id': rule_id, 'copies': copies, 'exclude_expression': exclude_expression}
-    if is_multi_vo() and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs):
+    if is_multi_vo(session=session) and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not access rules at other VOs.' % (issuer))
-    if not has_permission(issuer=issuer, vo=vo, action='reduce_rule', kwargs=kwargs):
+    if not has_permission(issuer=issuer, vo=vo, action='reduce_rule', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not reduce this replication rule.' % (issuer))
 
-    return rule.reduce_rule(rule_id=rule_id, copies=copies, exclude_expression=exclude_expression)
+    return rule.reduce_rule(rule_id=rule_id, copies=copies, exclude_expression=exclude_expression, session=session)
 
 
-def examine_replication_rule(rule_id, issuer, vo='def'):
+@read_session
+def examine_replication_rule(rule_id, issuer, vo='def', session=None):
     """
     Examine a replication rule.
 
     :param rule_id: The rule_id to get.
     :param issuer: The issuing account of this operation.
     :param vo: The VO of the issuer.
+    :param session: The database session in use.
     """
     kwargs = {'rule_id': rule_id}
-    if is_multi_vo() and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs):
+    if is_multi_vo(session=session) and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not access rules at other VOs.' % (issuer))
-    result = rule.examine_rule(rule_id)
-    result = api_update_return_dict(result)
+    result = rule.examine_rule(rule_id, session=session)
+    result = api_update_return_dict(result, session=session)
     if 'transfers' in result:
-        result['transfers'] = [api_update_return_dict(t) for t in result['transfers']]
+        result['transfers'] = [api_update_return_dict(t, session=session) for t in result['transfers']]
     return result
 
 
-def move_replication_rule(rule_id, rse_expression, activity, source_replica_expression, issuer, vo='def'):
+@transactional_session
+def move_replication_rule(rule_id, rse_expression, activity, source_replica_expression, issuer, vo='def', session=None):
     """
     Move a replication rule to another RSE and, once done, delete the original one.
 
@@ -311,12 +335,13 @@ def move_replication_rule(rule_id, rse_expression, activity, source_replica_expr
         'activity': activity,
         'source_replica_expression': source_replica_expression
     }
-    if is_multi_vo() and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs):
+    if is_multi_vo(session=session) and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not access rules at other VOs.' % (issuer))
-    if not has_permission(issuer=issuer, vo=vo, action='move_rule', kwargs=kwargs):
+    if not has_permission(issuer=issuer, vo=vo, action='move_rule', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not move this replication rule.' % (issuer))
 
     return rule.move_rule(rule_id=rule_id,
                           rse_expression=rse_expression,
                           activity=activity,
-                          source_replica_expression=source_replica_expression)
+                          source_replica_expression=source_replica_expression,
+                          session=session)

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1451,11 +1451,12 @@ def run_cmd_process(cmd, timeout=3600):
     return returncode, stdout
 
 
-def api_update_return_dict(dictionary):
+def api_update_return_dict(dictionary, session=None):
     """
     Ensure that rse is in a dictionary returned from core
 
     :param dictionary: The dictionary to edit
+    :param session: The DB session to use
     :returns dictionary: The edited dictionary
     """
     if not isinstance(dictionary, dict):
@@ -1471,7 +1472,7 @@ def api_update_return_dict(dictionary):
                     dictionary = dictionary.copy()
                     copied = True
                 import rucio.core.rse
-                dictionary[rse_str] = rucio.core.rse.get_rse_name(rse_id=dictionary[rse_id_str])
+                dictionary[rse_str] = rucio.core.rse.get_rse_name(rse_id=dictionary[rse_id_str], session=session)
 
     if 'account' in dictionary.keys() and dictionary['account'] is not None:
         if not copied:

--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -1,4 +1,5 @@
-# Copyright 2016-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2016-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,8 +20,9 @@
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2019-2020
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Thysk <timx2tt@hotmail.co.uk>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 try:
     from ConfigParser import NoOptionError, NoSectionError
@@ -95,7 +97,7 @@ def load_permission_for_vo(vo):
     permission_modules[vo] = module
 
 
-def has_permission(issuer, action, kwargs):
+def has_permission(issuer, action, kwargs, session=None):
     if issuer.vo not in permission_modules:
         load_permission_for_vo(issuer.vo)
-    return permission_modules[issuer.vo].has_permission(issuer, action, kwargs)
+    return permission_modules[issuer.vo].has_permission(issuer, action, kwargs, session=session)

--- a/lib/rucio/core/permission/atlas.py
+++ b/lib/rucio/core/permission/atlas.py
@@ -46,14 +46,15 @@ if TYPE_CHECKING:
     from typing import Dict
 
 
-def has_permission(issuer, action, kwargs):
+def has_permission(issuer, action, kwargs, session=None):
     """
     Checks if an account has the specified permission to
     execute an action with parameters.
 
-    :param issuer: Account identifier which issues the command..
+    :param issuer:  Account identifier which issues the command..
     :param action:  The action(API call) called by the account.
-    :param kwargs: List of arguments for the action.
+    :param kwargs:  List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     perm = {'add_account': perm_add_account,
@@ -139,354 +140,379 @@ def has_permission(issuer, action, kwargs):
             'access_rule_vo': perm_access_rule_vo,
             'export': perm_export}
 
-    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs)
+    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs, session=session)
 
 
 def _is_root(issuer):
     return issuer.external == 'root' or issuer.external == 'ddmadmin'
 
 
-def perm_default(issuer, kwargs):
+def perm_default(issuer, kwargs, session=None):
     """
     Default permission.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_add_rse(issuer, kwargs):
+def perm_add_rse(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_rse(issuer, kwargs):
+def perm_update_rse(issuer, kwargs, session=None):
     """
     Checks if an account can update a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_rule(issuer, kwargs):
+def perm_add_rule(issuer, kwargs, session=None):
     """
     Checks if an account can add a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs['account'] == issuer and not kwargs['locked']:
         return True
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     return False
 
 
-def perm_add_subscription(issuer, kwargs):
+def perm_add_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can add a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     return False
 
 
-def perm_add_rse_attribute(issuer, kwargs):
+def perm_add_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     if kwargs['key'] in ['rule_deleters', 'auto_approve_bytes', 'auto_approve_files', 'rule_approvers', 'default_account_limit_bytes', 'default_limit_files', 'block_manual_approve']:
         # Check if user is a country admin
         admin_in_country = []
-        for kv in list_account_attributes(account=issuer):
+        for kv in list_account_attributes(account=issuer, session=session):
             if kv['key'].startswith('country-') and kv['value'] == 'admin':
                 admin_in_country.append(kv['key'].partition('-')[2])
         if admin_in_country:
-            if list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+            if list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
                 return True
     return False
 
 
-def perm_del_rse_attribute(issuer, kwargs):
+def perm_del_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     if kwargs['key'] in ['rule_deleters', 'auto_approve_bytes', 'auto_approve_files', 'rule_approvers', 'default_account_limit_bytes', 'default_limit_files', 'block_manual_approve']:
         # Check if user is a country admin
         admin_in_country = []
-        for kv in list_account_attributes(account=issuer):
+        for kv in list_account_attributes(account=issuer, session=session):
             if kv['key'].startswith('country-') and kv['value'] == 'admin':
                 admin_in_country.append(kv['key'].partition('-')[2])
         if admin_in_country:
-            if list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+            if list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
                 return True
     return False
 
 
-def perm_del_rse(issuer, kwargs):
+def perm_del_rse(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_account(issuer, kwargs):
+def perm_add_account(issuer, kwargs, session=None):
     """
     Checks if an account can add an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_del_account(issuer, kwargs):
+def perm_del_account(issuer, kwargs, session=None):
     """
     Checks if an account can del an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_update_account(issuer, kwargs):
+def perm_update_account(issuer, kwargs, session=None):
     """
     Checks if an account can update an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_scope(issuer, kwargs):
+def perm_add_scope(issuer, kwargs, session=None):
     """
     Checks if an account can add a scop to a account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_get_auth_token_user_pass(issuer, kwargs):
+def perm_get_auth_token_user_pass(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_gss(issuer, kwargs):
+def perm_get_auth_token_gss(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_x509(issuer, kwargs):
+def perm_get_auth_token_x509(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_saml(issuer, kwargs):
+def perm_get_auth_token_saml(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with saml_nameid for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_add_account_identity(issuer, kwargs):
+def perm_add_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can add an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_del_account_identity(issuer, kwargs):
+def perm_del_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_del_identity(issuer, kwargs):
+def perm_del_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer.external in kwargs.get('accounts')
 
 
-def perm_add_did(issuer, kwargs):
+def perm_add_did(issuer, kwargs, session=None):
     """
     Checks if an account can add an data identifier to a scope.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
         for rule in kwargs.get('rules', []):
             if rule['account'] != issuer:
                 return False
 
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == u'mock'
 
 
-def perm_add_dids(issuer, kwargs):
+def perm_add_dids(issuer, kwargs, session=None):
     """
     Checks if an account can bulk add data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
         for did in kwargs['dids']:
             for rule in did.get('rules', []):
                 if rule['account'] != issuer:
                     return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_attach_dids(issuer, kwargs):
+def perm_attach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_attach_dids_to_dids(issuer, kwargs):
+def perm_attach_dids_to_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     attachments = kwargs['attachments']
     scopes = [did['scope'] for did in attachments]
     scopes = list(set(scopes))
     for scope in scopes:
-        if not rucio.core.scope.is_scope_owner(scope, issuer):
+        if not rucio.core.scope.is_scope_owner(scope, issuer, session=session):
             return False
     return True
 
 
-def perm_create_did_sample(issuer, kwargs):
+def perm_create_did_sample(issuer, kwargs, session=None):
     """
     Checks if an account can create a sample of a data identifier collection.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_del_rule(issuer, kwargs):
+def perm_del_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can delete a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     if _is_root(issuer):
@@ -496,20 +522,20 @@ def perm_del_rule(issuer, kwargs):
 
     # Check if user is a country admin
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
 
     rule = get_rule(rule_id=kwargs['rule_id'])
-    rses = parse_expression(rule['rse_expression'], filter_={'vo': issuer.vo})
+    rses = parse_expression(rule['rse_expression'], filter_={'vo': issuer.vo}, session=session)
     if admin_in_country:
         for rse in rses:
-            if list_rse_attributes(rse_id=rse['id']).get('country') in admin_in_country:
+            if list_rse_attributes(rse_id=rse['id'], session=session).get('country') in admin_in_country:
                 return True
 
     # DELETERS can approve the rule
     for rse in rses:
-        rse_attr = list_rse_attributes(rse_id=rse['id'])
+        rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
         if rse_attr.get('rule_deleters'):
             if issuer.external in rse_attr.get('rule_deleters').split(','):
                 return True
@@ -517,16 +543,17 @@ def perm_del_rule(issuer, kwargs):
     return False
 
 
-def perm_update_rule(issuer, kwargs):
+def perm_update_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can update a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     # Admin accounts can do everything
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     admin_reserved = {'account', 'state', 'priority', 'child_rule_id', 'meta', 'boost_rule'}
@@ -535,15 +562,15 @@ def perm_update_rule(issuer, kwargs):
 
     # Country admins are allowed to change the rest.
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
 
     rule = get_rule(rule_id=kwargs['rule_id'])
-    rses = parse_expression(rule['rse_expression'], filter_={'vo': issuer.vo})
+    rses = parse_expression(rule['rse_expression'], filter_={'vo': issuer.vo}, session=session)
     if admin_in_country:
         for rse in rses:
-            if list_rse_attributes(rse_id=rse['id']).get('country') in admin_in_country:
+            if list_rse_attributes(rse_id=rse['id'], session=session).get('country') in admin_in_country:
                 return True
 
     # Only admin and country-admin are allowed to change locked state of rule
@@ -557,21 +584,22 @@ def perm_update_rule(issuer, kwargs):
     return False
 
 
-def perm_move_rule(issuer, kwargs):
+def perm_move_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can move a replication rule.
 
     :param issuer:   Account identifier which issues the command.
     :param kwargs:   List of arguments for the action.
+    :param session: The DB session to use
     :returns:        True if account is allowed to call the API call, otherwise False
     """
     # Admin accounts can do everything
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     # Country admins are allowed to change the but need to be admin for the original, as well as future rule
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
 
@@ -580,15 +608,15 @@ def perm_move_rule(issuer, kwargs):
 
     if admin_in_country:
         rule = get_rule(rule_id=kwargs['rule_id'])
-        rses = parse_expression(rule['rse_expression'], filter_={'vo': issuer.vo})
+        rses = parse_expression(rule['rse_expression'], filter_={'vo': issuer.vo}, session=session)
         for rse in rses:
-            if list_rse_attributes(rse_id=rse['id']).get('country') in admin_in_country:
+            if list_rse_attributes(rse_id=rse['id'], session=session).get('country') in admin_in_country:
                 admin_source = True
                 break
 
-        rses = parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})
+        rses = parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)
         for rse in rses:
-            if list_rse_attributes(rse_id=rse['id']).get('country') in admin_in_country:
+            if list_rse_attributes(rse_id=rse['id'], session=session).get('country') in admin_in_country:
                 admin_destination = True
                 break
 
@@ -598,48 +626,49 @@ def perm_move_rule(issuer, kwargs):
     return False
 
 
-def perm_approve_rule(issuer, kwargs):
+def perm_approve_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can approve a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     # Admin accounts can do everything
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     rule = get_rule(rule_id=kwargs['rule_id'])
-    rses = parse_expression(rule['rse_expression'], filter_={'vo': issuer.vo})
+    rses = parse_expression(rule['rse_expression'], filter_={'vo': issuer.vo}, session=session)
 
     # APPROVERS can approve the rule
     for rse in rses:
-        rse_attr = list_rse_attributes(rse_id=rse['id'])
+        rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
         if rse_attr.get('rule_approvers'):
             if issuer.external in rse_attr.get('rule_approvers').split(','):
                 return True
 
     # LOCALGROUPDISK/LOCALGROUPTAPE admins can approve the rule
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
     if admin_in_country:
         for rse in rses:
-            rse_attr = list_rse_attributes(rse_id=rse['id'])
+            rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
             if rse_attr.get('type', '') in ('LOCALGROUPDISK', 'LOCALGROUPTAPE'):
                 if rse_attr.get('country', '') in admin_in_country:
                     return True
 
     # GROUPDISK admins can approve the rule
     admin_for_phys_group = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('group-') and kv['value'] == 'admin':
             admin_for_phys_group.append(kv['key'].partition('-')[2])
     if admin_for_phys_group:
         for rse in rses:
-            rse_attr = list_rse_attributes(rse_id=rse['id'])
+            rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
             if rse_attr.get('type', '') == 'GROUPDISK':
                 if rse_attr.get('physgroup', '') in admin_for_phys_group:
                     return True
@@ -647,170 +676,183 @@ def perm_approve_rule(issuer, kwargs):
     return False
 
 
-def perm_reduce_rule(issuer, kwargs):
+def perm_reduce_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can reduce a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_update_subscription(issuer, kwargs):
+def perm_update_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can update a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     return False
 
 
-def perm_detach_dids(issuer, kwargs):
+def perm_detach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can detach an data identifier from the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return perm_attach_dids(issuer, kwargs)
+    return perm_attach_dids(issuer, kwargs, session=session)
 
 
-def perm_set_metadata(issuer, kwargs):
+def perm_set_metadata(issuer, kwargs, session=None):
     """
     Checks if an account can set a metadata on a data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    cond = _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    cond = _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
     if kwargs['scope'].external != 'archive':
-        return cond or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
-    meta = rucio.core.did.get_metadata(scope=kwargs['scope'], name=kwargs['name'])
+        return cond or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
+    meta = rucio.core.did.get_metadata(scope=kwargs['scope'], name=kwargs['name'], session=session)
     return cond or meta.get('account', False) == issuer
 
 
-def perm_set_status(issuer, kwargs):
+def perm_set_status(issuer, kwargs, session=None):
     """
     Checks if an account can set status on an data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs.get('open', False):
-        if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+        if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
             return False
-    cond = (_is_root(issuer) or has_account_attribute(account=issuer, key='admin'))
+    cond = (_is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session))
     if kwargs['scope'].external != 'archive':
-        return cond or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
-    meta = rucio.core.did.get_metadata(scope=kwargs['scope'], name=kwargs['name'])
+        return cond or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
+    meta = rucio.core.did.get_metadata(scope=kwargs['scope'], name=kwargs['name'], session=session)
     return cond or meta.get('account', False) == issuer
 
 
-def perm_add_protocol(issuer, kwargs):
+def perm_add_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can add a protocol to an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_protocol(issuer, kwargs):
+def perm_del_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can delete protocols from an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_protocol(issuer, kwargs):
+def perm_update_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can update protocols of an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_qos_policy(issuer, kwargs):
+def perm_add_qos_policy(issuer, kwargs, session=None):
     """
     Checks if an account can add QoS policies to an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_delete_qos_policy(issuer, kwargs):
+def perm_delete_qos_policy(issuer, kwargs, session=None):
     """
     Checks if an account can delete QoS policies from an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_declare_bad_file_replicas(issuer, kwargs):
+def perm_declare_bad_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    is_cloud_admin = bool([acc_attr for acc_attr in list_account_attributes(account=issuer) if (acc_attr['key'].startswith('cloud-')) and (acc_attr['value'] == 'admin')])
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or is_cloud_admin
+    is_cloud_admin = bool([acc_attr for acc_attr in list_account_attributes(account=issuer, session=session) if (acc_attr['key'].startswith('cloud-')) and (acc_attr['value'] == 'admin')])
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or is_cloud_admin
 
 
-def perm_declare_suspicious_file_replicas(issuer, kwargs):
+def perm_declare_suspicious_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare suspicious file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_add_replicas(issuer, kwargs):
+def perm_add_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can add replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     rse_id = str(kwargs.get('rse_id', ''))
     group = []
 
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if (kv['key'].startswith('group-') or kv['key'].startswith('country-')) and kv['value'] in ['admin', 'user']:
             group.append(kv['key'].partition('-')[2])
-    rse_attr = list_rse_attributes(rse_id=rse_id)
+    rse_attr = list_rse_attributes(rse_id=rse_id, session=session)
     if group:
         if rse_attr.get('type', '') == 'GROUPDISK':
             if rse_attr.get('physgroup', '') in group:
@@ -821,46 +863,49 @@ def perm_add_replicas(issuer, kwargs):
 
     return rse_attr.get('type', '') in ['SCRATCHDISK', 'MOCK', 'TEST']\
         or _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')
+        or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_skip_availability_check(issuer, kwargs):
+def perm_skip_availability_check(issuer, kwargs, session=None):
     """
     Checks if an account can skip the availabity check to add/delete file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_delete_replicas(issuer, kwargs):
+def perm_delete_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return False
 
 
-def perm_update_replicas_states(issuer, kwargs):
+def perm_update_replicas_states(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     rse_id = str(kwargs.get('rse_id', ''))
     group = []
 
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if (kv['key'].startswith('group-') or kv['key'].startswith('country-')) and kv['value'] in ['admin', 'user']:
             group.append(kv['key'].partition('-')[2])
-    rse_attr = list_rse_attributes(rse_id=rse_id)
+    rse_attr = list_rse_attributes(rse_id=rse_id, session=session)
     if group:
         if rse_attr.get('type', '') == 'GROUPDISK':
             if rse_attr.get('physgroup', '') in group:
@@ -871,91 +916,98 @@ def perm_update_replicas_states(issuer, kwargs):
 
     return rse_attr.get('type', '') in ['SCRATCHDISK', 'MOCK', 'TEST']\
         or _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')
+        or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_queue_requests(issuer, kwargs):
+def perm_queue_requests(issuer, kwargs, session=None):
     """
     Checks if an account can submit transfer or deletion requests on destination RSEs for data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_get_request_by_did(issuer, kwargs):
+def perm_get_request_by_did(issuer, kwargs, session=None):
     """
     Checks if an account can get a request by DID.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_cancel_request(issuer, kwargs):
+def perm_cancel_request(issuer, kwargs, session=None):
     """
     Checks if an account can cancel a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_get_next(issuer, kwargs):
+def perm_get_next(issuer, kwargs, session=None):
     """
     Checks if an account can retrieve the next request matching the request type and state.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_set_rse_usage(issuer, kwargs):
+def perm_set_rse_usage(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE usage information.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_set_rse_limits(issuer, kwargs):
+def perm_set_rse_limits(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE limits.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_set_local_account_limit(issuer, kwargs):
+def perm_set_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set an account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    rse_attr = list_rse_attributes(rse_id=kwargs['rse_id'])
+    rse_attr = list_rse_attributes(rse_id=kwargs['rse_id'], session=session)
     if admin_in_country and rse_attr.get('country') in admin_in_country:
         return True
     quota_approvers = rse_attr.get('quota_approvers', None)
@@ -964,64 +1016,69 @@ def perm_set_local_account_limit(issuer, kwargs):
     return False
 
 
-def perm_set_global_account_limit(issuer, kwargs):
+def perm_set_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set a global account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country') for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})}
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                              for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
     if resolved_rse_countries.issubset(admin_in_country):
         return True
     return False
 
 
-def perm_delete_global_account_limit(issuer, kwargs):
+def perm_delete_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete a global account limit.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country') for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})}
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                              for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
     if resolved_rse_countries.issubset(admin_in_country):
         return True
     return False
 
 
-def perm_delete_local_account_limit(issuer, kwargs):
+def perm_delete_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete an account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    rse_attr = list_rse_attributes(rse_id=kwargs['rse_id'])
+    rse_attr = list_rse_attributes(rse_id=kwargs['rse_id'], session=session)
     if admin_in_country and rse_attr.get('country') in admin_in_country:
         return True
     quota_approvers = rse_attr.get('quota_approvers', None)
@@ -1030,73 +1087,79 @@ def perm_delete_local_account_limit(issuer, kwargs):
     return False
 
 
-def perm_config(issuer, kwargs):
+def perm_config(issuer, kwargs, session=None):
     """
     Checks if an account can read/write the configuration.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_local_account_usage(issuer, kwargs):
+def perm_get_local_account_usage(issuer, kwargs, session=None):
     """
     Checks if an account can get the account usage of an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_get_global_account_usage(issuer: str, kwargs: 'Dict[str, str]') -> bool:
+def perm_get_global_account_usage(issuer: str, kwargs: 'Dict[str, str]', session=None) -> bool:
     """
     Checks if an account can get the account usage of an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_add_account_attribute(issuer, kwargs):
+def perm_add_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_account_attribute(issuer, kwargs):
+def perm_del_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return perm_add_account_attribute(issuer, kwargs)
+    return perm_add_account_attribute(issuer, kwargs, session=session)
 
 
-def perm_list_heartbeats(issuer, kwargs):
+def perm_list_heartbeats(issuer, kwargs, session=None):
     """
     Checks if an account can list heartbeats.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_send_heartbeats(issuer, kwargs):
+def perm_send_heartbeats(issuer, kwargs, session=None):
     """
     Checks if an account can send heartbeats.
 
@@ -1104,157 +1167,170 @@ def perm_send_heartbeats(issuer, kwargs):
     :param kwargs: List of arguments for the action.
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_resurrect(issuer, kwargs):
+def perm_resurrect(issuer, kwargs, session=None):
     """
     Checks if an account can resurrect DIDS.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_lifetime_exceptions(issuer, kwargs):
+def perm_update_lifetime_exceptions(issuer, kwargs, session=None):
     """
     Checks if an account can approve/reject Lifetime Model exceptions.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_ssh_challenge_token(issuer, kwargs):
+def perm_get_ssh_challenge_token(issuer, kwargs, session=None):
     """
     Checks if an account can request a challenge token.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return True
 
 
-def perm_get_signed_url(issuer, kwargs):
+def perm_get_signed_url(issuer, kwargs, session=None):
     """
     Checks if an account can request a signed URL.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='sign-gcs')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='sign-gcs', session=session)
 
 
-def perm_add_bad_pfns(issuer, kwargs):
+def perm_add_bad_pfns(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad PFNs.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs['state'] in [BadPFNStatus.BAD.name, BadPFNStatus.TEMPORARY_UNAVAILABLE.name]:
-        is_cloud_admin = bool([acc_attr for acc_attr in list_account_attributes(account=issuer) if (acc_attr['key'].startswith('cloud-')) and (acc_attr['value'] == 'admin')])
-        return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or is_cloud_admin
+        is_cloud_admin = bool([acc_attr for acc_attr in list_account_attributes(account=issuer, session=session) if (acc_attr['key'].startswith('cloud-')) and (acc_attr['value'] == 'admin')])
+        return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or is_cloud_admin
     elif kwargs['state'] == BadPFNStatus.SUSPICIOUS.name:
         return True
     return _is_root(issuer)
 
 
-def perm_remove_did_from_followed(issuer, kwargs):
+def perm_remove_did_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can remove did from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
         or kwargs['account'] == issuer\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_remove_dids_from_followed(issuer, kwargs):
+def perm_remove_dids_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can bulk remove dids from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     if not kwargs['account'] == issuer:
         return False
     return True
 
 
-def perm_add_vo(issuer, kwargs):
+def perm_add_vo(issuer, kwargs, session=None):
     """
     Checks if an account can add a VO.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_list_vos(issuer, kwargs):
+def perm_list_vos(issuer, kwargs, session=None):
     """
     Checks if an account can list a VO.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_recover_vo_root_identity(issuer, kwargs):
+def perm_recover_vo_root_identity(issuer, kwargs, session=None):
     """
     Checks if an account can recover identities for VOs.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_update_vo(issuer, kwargs):
+def perm_update_vo(issuer, kwargs, session=None):
     """
     Checks if an account can update a VO.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_access_rule_vo(issuer, kwargs):
+def perm_access_rule_vo(issuer, kwargs, session=None):
     """
     Checks if we're at the same VO as the rule_id's
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return get_rule(kwargs['rule_id'])['scope'].vo == issuer.vo
 
 
-def perm_export(issuer, kwargs):
+def perm_export(issuer, kwargs, session=None):
     """
     Checks if an account can export the RSE info.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    is_cloud_admin = bool([acc_attr for acc_attr in list_account_attributes(account=issuer) if (acc_attr['key'].startswith('cloud-')) and (acc_attr['value'] == 'admin')])
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or is_cloud_admin
+    is_cloud_admin = bool([acc_attr for acc_attr in list_account_attributes(account=issuer, session=session) if (acc_attr['key'].startswith('cloud-')) and (acc_attr['value'] == 'admin')])
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or is_cloud_admin

--- a/lib/rucio/core/permission/belleii.py
+++ b/lib/rucio/core/permission/belleii.py
@@ -30,7 +30,7 @@ from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla.constants import IdentityType
 
 
-def has_permission(issuer, action, kwargs):
+def has_permission(issuer, action, kwargs, session=None):
     """
     Checks if an account has the specified permission to
     execute an action with parameters.
@@ -38,6 +38,7 @@ def has_permission(issuer, action, kwargs):
     :param issuer: Account identifier which issues the command..
     :param action:  The action(API call) called by the account.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     perm = {'add_account': perm_add_account,
@@ -114,866 +115,934 @@ def has_permission(issuer, action, kwargs):
             'remove_did_from_followed': perm_remove_did_from_followed,
             'remove_dids_from_followed': perm_remove_dids_from_followed}
 
-    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs)
+    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs, session=session)
 
 
 def _is_root(issuer):
     return issuer.external == 'root'
 
 
-def perm_default(issuer, kwargs):
+def perm_default(issuer, kwargs, session=None):
     """
     Default permission.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_rse(issuer, kwargs):
+def perm_add_rse(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_rse(issuer, kwargs):
+def perm_update_rse(issuer, kwargs, session=None):
     """
     Checks if an account can update a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_rule(issuer, kwargs):
+def perm_add_rule(issuer, kwargs, session=None):
     """
     Checks if an account can add a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs['account'] == issuer and not kwargs['locked']:
         return True
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_add_subscription(issuer, kwargs):
+def perm_add_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can add a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_add_rse_attribute(issuer, kwargs):
+def perm_add_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_del_rse_attribute(issuer, kwargs):
+def perm_del_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_del_rse(issuer, kwargs):
+def perm_del_rse(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_account(issuer, kwargs):
+def perm_add_account(issuer, kwargs, session=None):
     """
     Checks if an account can add an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_account(issuer, kwargs):
+def perm_del_account(issuer, kwargs, session=None):
     """
     Checks if an account can del an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_account(issuer, kwargs):
+def perm_update_account(issuer, kwargs, session=None):
     """
     Checks if an account can update an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_scope(issuer, kwargs):
+def perm_add_scope(issuer, kwargs, session=None):
     """
     Checks if an account can add a scope to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_auth_token_user_pass(issuer, kwargs):
+def perm_get_auth_token_user_pass(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_gss(issuer, kwargs):
+def perm_get_auth_token_gss(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_x509(issuer, kwargs):
+def perm_get_auth_token_x509(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_saml(issuer, kwargs):
+def perm_get_auth_token_saml(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_add_account_identity(issuer, kwargs):
+def perm_add_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can add an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_account_identity(issuer, kwargs):
+def perm_del_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_identity(issuer, kwargs):
+def perm_del_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_did(issuer, kwargs):
+def perm_add_did(issuer, kwargs, session=None):
     """
     Checks if an account can add an data identifier to a scope.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if issuer != 'root' and not has_account_attribute(account=issuer, key='admin'):
+    if issuer != 'root' and not has_account_attribute(account=issuer, key='admin', session=session):
         for rule in kwargs.get('rules', []):
             if rule['account'] != issuer:
                 return False
 
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
-def perm_add_dids(issuer, kwargs):
+def perm_add_dids(issuer, kwargs, session=None):
     """
     Checks if an account can bulk add data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if issuer != 'root' and not has_account_attribute(account=issuer, key='admin'):
+    if issuer != 'root' and not has_account_attribute(account=issuer, key='admin', session=session):
         for did in kwargs['dids']:
-            if not rucio.core.scope.is_scope_owner(scope=InternalScope(did['scope']), account=issuer):
+            if not rucio.core.scope.is_scope_owner(scope=InternalScope(did['scope']), account=issuer, session=session):
                 return False
             for rule in did.get('rules', []):
                 if rule['account'] != issuer:
                     return False
         return True
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_attach_dids(issuer, kwargs):
+def perm_attach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
-def perm_attach_dids_to_dids(issuer, kwargs):
+def perm_attach_dids_to_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     else:
         attachments = kwargs['attachments']
         scopes = [did['scope'] for did in attachments]
         scopes = list(set(scopes))
         for scope in scopes:
-            if not rucio.core.scope.is_scope_owner(scope, issuer):
+            if not rucio.core.scope.is_scope_owner(scope, issuer, session=session):
                 return False
         return True
 
 
-def perm_create_did_sample(issuer, kwargs):
+def perm_create_did_sample(issuer, kwargs, session=None):
     """
     Checks if an account can create a sample of a data identifier collection.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
-def perm_del_rule(issuer, kwargs):
+def perm_del_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can delete a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_update_rule(issuer, kwargs):
+def perm_update_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can update a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_approve_rule(issuer, kwargs):
+def perm_approve_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can approve a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_reduce_rule(issuer, kwargs):
+def perm_reduce_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can reduce a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_move_rule(issuer, kwargs):
+def perm_move_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can move a replication rule.
 
     :param issuer:   Account identifier which issues the command.
     :param kwargs:   List of arguments for the action.
+    :param session: The DB session to use
     :returns:        True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_update_subscription(issuer, kwargs):
+def perm_update_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can update a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     return False
 
 
-def perm_detach_dids(issuer, kwargs):
+def perm_detach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can detach an data identifier from the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return perm_attach_dids(issuer, kwargs)
+    return perm_attach_dids(issuer, kwargs, session=session)
 
 
-def perm_set_metadata(issuer, kwargs):
+def perm_set_metadata(issuer, kwargs, session=None):
     """
     Checks if an account can set a metadata on a data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
-def perm_set_status(issuer, kwargs):
+def perm_set_status(issuer, kwargs, session=None):
     """
     Checks if an account can set status on an data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs.get('open', False):
-        if issuer != 'root' and not has_account_attribute(account=issuer, key='admin'):
+        if issuer != 'root' and not has_account_attribute(account=issuer, key='admin', session=session):
             return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
-def perm_add_protocol(issuer, kwargs):
+def perm_add_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can add a protocol to an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_protocol(issuer, kwargs):
+def perm_del_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can delete protocols from an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_protocol(issuer, kwargs):
+def perm_update_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can update protocols of an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_declare_bad_file_replicas(issuer, kwargs):
+def perm_declare_bad_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_declare_suspicious_file_replicas(issuer, kwargs):
+def perm_declare_suspicious_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare suspicious file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_add_replicas(issuer, kwargs):
+def perm_add_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can add replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return str(kwargs.get('rse', '')).endswith('TMP-SE')\
         or _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')
+        or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_skip_availability_check(issuer, kwargs):
+def perm_skip_availability_check(issuer, kwargs, session=None):
     """
     Checks if an account can skip the availabity check to add/delete file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_delete_replicas(issuer, kwargs):
+def perm_delete_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return False
 
 
-def perm_update_replicas_states(issuer, kwargs):
+def perm_update_replicas_states(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_queue_requests(issuer, kwargs):
+def perm_queue_requests(issuer, kwargs, session=None):
     """
     Checks if an account can submit transfer or deletion requests on destination RSEs for data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_query_request(issuer, kwargs):
+def perm_query_request(issuer, kwargs, session=None):
     """
     Checks if an account can query a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_get_request_by_did(issuer, kwargs):
+def perm_get_request_by_did(issuer, kwargs, session=None):
     """
     Checks if an account can get a request by DID.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_cancel_request(issuer, kwargs):
+def perm_cancel_request(issuer, kwargs, session=None):
     """
     Checks if an account can cancel a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_get_next(issuer, kwargs):
+def perm_get_next(issuer, kwargs, session=None):
     """
     Checks if an account can retrieve the next request matching the request type and state.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_set_rse_usage(issuer, kwargs):
+def perm_set_rse_usage(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE usage information.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_set_rse_limits(issuer, kwargs):
+def perm_set_rse_limits(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE limits.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_set_local_account_limit(issuer, kwargs):
+def perm_set_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set an account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
         return True
     return False
 
 
-def perm_set_global_account_limit(issuer, kwargs):
+def perm_set_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set a global account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country') for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})}
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                              for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
     if resolved_rse_countries.issubset(admin_in_country):
         return True
     return False
 
 
-def perm_delete_local_account_limit(issuer, kwargs):
+def perm_delete_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete an account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
         return True
     return False
 
 
-def perm_delete_global_account_limit(issuer, kwargs):
+def perm_delete_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete a global account limit.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
     if admin_in_country:
-        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country') for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})}
+        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                                  for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
         if resolved_rse_countries.issubset(admin_in_country):
             return True
     return False
 
 
-def perm_config(issuer, kwargs):
+def perm_config(issuer, kwargs, session=None):
     """
     Checks if an account can read/write the configuration.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_local_account_usage(issuer, kwargs):
+def perm_get_local_account_usage(issuer, kwargs, session=None):
     """
     Checks if an account can get the account usage of an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or kwargs.get('account') == issuer:
         return True
     # Check if user is a country admin
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             return True
     return False
 
 
-def perm_get_global_account_usage(issuer, kwargs):
+def perm_get_global_account_usage(issuer, kwargs, session=None):
     """
     Checks if an account can get the account usage of an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or kwargs.get('account') == issuer:
         return True
 
     # Check if user is a country admin for all involved countries
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country')
-                              for rse in parse_expression(kwargs['rse_exp'], filter_={'vo': issuer.vo})}
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                              for rse in parse_expression(kwargs['rse_exp'], filter_={'vo': issuer.vo}, session=session)}
 
     if resolved_rse_countries.issubset(admin_in_country):
         return True
     return False
 
 
-def perm_add_account_attribute(issuer, kwargs):
+def perm_add_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_account_attribute(issuer, kwargs):
+def perm_del_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return perm_add_account_attribute(issuer, kwargs)
+    return perm_add_account_attribute(issuer, kwargs, session=session)
 
 
-def perm_list_heartbeats(issuer, kwargs):
+def perm_list_heartbeats(issuer, kwargs, session=None):
     """
     Checks if an account can list heartbeats.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_resurrect(issuer, kwargs):
+def perm_resurrect(issuer, kwargs, session=None):
     """
     Checks if an account can resurrect DIDS.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_lifetime_exceptions(issuer, kwargs):
+def perm_update_lifetime_exceptions(issuer, kwargs, session=None):
     """
     Checks if an account can approve/reject Lifetime Model exceptions.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     if kwargs['vo'] is not None:
-        exceptions = next(list_exceptions(exception_id=kwargs['exception_id'], states=False))
+        exceptions = next(list_exceptions(exception_id=kwargs['exception_id'], states=False, session=session))
         if exceptions['scope'].vo != kwargs['vo']:
             return False
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_ssh_challenge_token(issuer, kwargs):
+def perm_get_ssh_challenge_token(issuer, kwargs, session=None):
     """
     Checks if an account can request a challenge token.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return True
 
 
-def perm_get_signed_url(issuer, kwargs):
+def perm_get_signed_url(issuer, kwargs, session=None):
     """
     Checks if an account can request a signed URL.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_add_bad_pfns(issuer, kwargs):
+def perm_add_bad_pfns(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad PFNs.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_remove_did_from_followed(issuer, kwargs):
+def perm_remove_did_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can remove did from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
         or kwargs['account'] == issuer
 
 
-def perm_remove_dids_from_followed(issuer, kwargs):
+def perm_remove_dids_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can bulk remove dids from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     if not kwargs['account'] == issuer:
         return False

--- a/lib/rucio/core/permission/cms.py
+++ b/lib/rucio/core/permission/cms.py
@@ -45,7 +45,7 @@ except NameError:
     basestring = str
 
 
-def has_permission(issuer, action, kwargs):
+def has_permission(issuer, action, kwargs, session=None):
     """
     Checks if an account has the specified permission to
     execute an action with parameters.
@@ -53,6 +53,7 @@ def has_permission(issuer, action, kwargs):
     :param issuer: Account identifier which issues the command..
     :param action:  The action(API call) called by the account.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     perm = {'add_account': perm_add_account,
@@ -136,56 +137,60 @@ def has_permission(issuer, action, kwargs):
             'update_vo': perm_update_vo,
             'access_rule_vo': perm_access_rule_vo}
 
-    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs)
+    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs, session=session)
 
 
 def _is_root(issuer):
     return issuer.external == 'root'
 
 
-def perm_default(issuer, kwargs):
+def perm_default(issuer, kwargs, session=None):
     """
     Default permission.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_rse(issuer, kwargs):
+def perm_add_rse(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_rse(issuer, kwargs):
+def perm_update_rse(issuer, kwargs, session=None):
     """
     Checks if an account can update a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_rule(issuer, kwargs):
+def perm_add_rule(issuer, kwargs, session=None):
     """
     Checks if an account can add a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
-    rses = parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})
+    rses = parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)
 
     # Keep while sync is running so it can make rules on all RSEs
     if _is_root(issuer) and repr(kwargs['account']).startswith('sync_'):
@@ -197,7 +202,7 @@ def perm_add_rule(issuer, kwargs):
     # Anyone can use _Temp RSEs if a lifetime is set and under a month
     all_temp = True
     for rse in rses:
-        rse_attr = list_rse_attributes(rse_id=rse['id'])
+        rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
         rse_type = rse_attr.get('cms_type', None)
         if rse_type not in ['temp']:
             all_temp = False
@@ -207,203 +212,219 @@ def perm_add_rule(issuer, kwargs):
 
     if kwargs['account'] == issuer and not kwargs['locked']:
         return True
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_add_subscription(issuer, kwargs):
+def perm_add_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can add a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_add_rse_attribute(issuer, kwargs):
+def perm_add_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_del_rse_attribute(issuer, kwargs):
+def perm_del_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_del_rse(issuer, kwargs):
+def perm_del_rse(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_account(issuer, kwargs):
+def perm_add_account(issuer, kwargs, session=None):
     """
     Checks if an account can add an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_del_account(issuer, kwargs):
+def perm_del_account(issuer, kwargs, session=None):
     """
     Checks if an account can del an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_update_account(issuer, kwargs):
+def perm_update_account(issuer, kwargs, session=None):
     """
     Checks if an account can update an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_scope(issuer, kwargs):
+def perm_add_scope(issuer, kwargs, session=None):
     """
     Checks if an account can add a scop to a account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_get_auth_token_user_pass(issuer, kwargs):
+def perm_get_auth_token_user_pass(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_gss(issuer, kwargs):
+def perm_get_auth_token_gss(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_x509(issuer, kwargs):
+def perm_get_auth_token_x509(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_saml(issuer, kwargs):
+def perm_get_auth_token_saml(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_add_account_identity(issuer, kwargs):
+def perm_add_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can add an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_del_account_identity(issuer, kwargs):
+def perm_del_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_del_identity(issuer, kwargs):
+def perm_del_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer.external in kwargs.get('accounts')
 
 
-def perm_add_did(issuer, kwargs):
+def perm_add_did(issuer, kwargs, session=None):
     """
     Checks if an account can add an data identifier to a scope.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
         for rule in kwargs.get('rules', []):
             if rule['account'] != issuer:
                 return False
@@ -417,86 +438,91 @@ def perm_add_did(issuer, kwargs):
                 return False
 
     return (_is_root(issuer)
-            or has_account_attribute(account=issuer, key='admin')  # NOQA: W503
-            or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)  # NOQA: W503
+            or has_account_attribute(account=issuer, key='admin', session=session)  # NOQA: W503
+            or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)  # NOQA: W503
             or kwargs['scope'].external == u'mock')  # NOQA: W503
 
 
-def perm_add_dids(issuer, kwargs):
+def perm_add_dids(issuer, kwargs, session=None):
     """
     Checks if an account can bulk add data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
         for did in kwargs['dids']:
             for rule in did.get('rules', []):
                 if rule['account'] != issuer:
                     return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_attach_dids(issuer, kwargs):
+def perm_attach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (_is_root(issuer)
-            or has_account_attribute(account=issuer, key='admin')  # NOQA: W503
-            or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)  # NOQA: W503
+            or has_account_attribute(account=issuer, key='admin', session=session)  # NOQA: W503
+            or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)  # NOQA: W503
             or kwargs['scope'].external == 'mock')  # NOQA: W503
 
 
-def perm_attach_dids_to_dids(issuer, kwargs):
+def perm_attach_dids_to_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     else:
         attachments = kwargs['attachments']
         scopes = [did['scope'] for did in attachments]
         scopes = list(set(scopes))
         for scope in scopes:
-            if not rucio.core.scope.is_scope_owner(scope, issuer):
+            if not rucio.core.scope.is_scope_owner(scope, issuer, session=session):
                 return False
         return True
 
 
-def perm_create_did_sample(issuer, kwargs):
+def perm_create_did_sample(issuer, kwargs, session=None):
     """
     Checks if an account can create a sample of a data identifier collection.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return issuer == ('root'
-                      or has_account_attribute(account=issuer, key='admin')  # NOQA: W503
-                      or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)  # NOQA: W503
+                      or has_account_attribute(account=issuer, key='admin', session=session)  # NOQA: W503
+                      or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)  # NOQA: W503
                       or kwargs['scope'].external == 'mock')  # NOQA: W503
 
 
-def perm_del_rule(issuer, kwargs):
+def perm_del_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can delete a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     if get_rule(kwargs['rule_id'])['account'] == issuer:
         return True
@@ -504,36 +530,38 @@ def perm_del_rule(issuer, kwargs):
     return False
 
 
-def perm_update_rule(issuer, kwargs):
+def perm_update_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can update a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_approve_rule(issuer, kwargs):
+def perm_approve_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can approve a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     rule = get_rule(rule_id=kwargs['rule_id'])
-    rses = parse_expression(rule['rse_expression'], filter_={'vo': issuer.vo})
+    rses = parse_expression(rule['rse_expression'], filter_={'vo': issuer.vo}, session=session)
 
     # Those in rule_approvers can approve the rule
     for rse in rses:
-        rse_attr = list_rse_attributes(rse_id=rse['id'])
+        rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
         rule_approvers = rse_attr.get('rule_approvers', None)
         if rule_approvers and issuer.external in rule_approvers.split(','):
             return True
@@ -541,301 +569,325 @@ def perm_approve_rule(issuer, kwargs):
     return False
 
 
-def perm_reduce_rule(issuer, kwargs):
+def perm_reduce_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can reduce a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_move_rule(issuer, kwargs):
+def perm_move_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can move a replication rule.
 
     :param issuer:   Account identifier which issues the command.
     :param kwargs:   List of arguments for the action.
+    :param session: The DB session to use
     :returns:        True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_update_subscription(issuer, kwargs):
+def perm_update_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can update a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     return False
 
 
-def perm_detach_dids(issuer, kwargs):
+def perm_detach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can detach an data identifier from the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return perm_attach_dids(issuer, kwargs)
+    return perm_attach_dids(issuer, kwargs, session=session)
 
 
-def perm_set_metadata(issuer, kwargs):
+def perm_set_metadata(issuer, kwargs, session=None):
     """
     Checks if an account can set a metadata on a data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return (_is_root(issuer) or has_account_attribute(account=issuer, key='admin')
-            or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer))  # NOQA: W503
+    return (_is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+            or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session))  # NOQA: W503
 
 
-def perm_set_status(issuer, kwargs):
+def perm_set_status(issuer, kwargs, session=None):
     """
     Checks if an account can set status on an data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs.get('open', False):
-        if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+        if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
             return False
 
-    return (_is_root(issuer) or has_account_attribute(account=issuer, key='admin')
-            or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer))  # NOQA: W503
+    return (_is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+            or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session))  # NOQA: W503
 
 
-def perm_add_protocol(issuer, kwargs):
+def perm_add_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can add a protocol to an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_protocol(issuer, kwargs):
+def perm_del_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can delete protocols from an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_protocol(issuer, kwargs):
+def perm_update_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can update protocols of an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_qos_policy(issuer, kwargs):
+def perm_add_qos_policy(issuer, kwargs, session=None):
     """
     Checks if an account can add QoS policies to an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_delete_qos_policy(issuer, kwargs):
+def perm_delete_qos_policy(issuer, kwargs, session=None):
     """
     Checks if an account can delete QoS policies from an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_declare_bad_file_replicas(issuer, kwargs):
+def perm_declare_bad_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_declare_suspicious_file_replicas(issuer, kwargs):
+def perm_declare_suspicious_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare suspicious file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_add_replicas(issuer, kwargs):
+def perm_add_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can add replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     is_root = _is_root(issuer)
     is_temp = str(kwargs.get('rse', '')).endswith('_Temp')
-    is_admin = has_account_attribute(account=issuer, key='admin')
+    is_admin = has_account_attribute(account=issuer, key='admin', session=session)
 
     return is_root or is_temp or is_admin
 
 
-def perm_skip_availability_check(issuer, kwargs):
+def perm_skip_availability_check(issuer, kwargs, session=None):
     """
     Checks if an account can skip the availabity check to add/delete file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_delete_replicas(issuer, kwargs):
+def perm_delete_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     # FIXME: Remove after the transition is over?
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_replicas_states(issuer, kwargs):
+def perm_update_replicas_states(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_queue_requests(issuer, kwargs):
+def perm_queue_requests(issuer, kwargs, session=None):
     """
     Checks if an account can submit transfer or deletion requests on destination RSEs for data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_get_request_by_did(issuer, kwargs):
+def perm_get_request_by_did(issuer, kwargs, session=None):
     """
     Checks if an account can get a request by DID.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_cancel_request(issuer, kwargs):
+def perm_cancel_request(issuer, kwargs, session=None):
     """
     Checks if an account can cancel a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_get_next(issuer, kwargs):
+def perm_get_next(issuer, kwargs, session=None):
     """
     Checks if an account can retrieve the next request matching the request type and state.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_set_rse_usage(issuer, kwargs):
+def perm_set_rse_usage(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE usage information.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_set_rse_limits(issuer, kwargs):
+def perm_set_rse_limits(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE limits.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_set_local_account_limit(issuer, kwargs):
+def perm_set_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set an account limit.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # # Check if user is a country admin
     # admin_in_country = []
     # from rucio.core.account import has_account_attribute, list_account_attributes
-    # for kv in list_account_attributes(account=issuer):
+    # for kv in list_account_attributes(account=issuer, session=session):
     #     if kv['key'].startswith('country-') and kv['value'] == 'admin':
     #         admin_in_country.append(kv['key'].partition('-')[2])
-    # if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+    # if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
     #     return True
 
     # Those listed as quota approvers can add to quotas
-    rse_attr = list_rse_attributes(rse_id=kwargs['rse_id'])
+    rse_attr = list_rse_attributes(rse_id=kwargs['rse_id'], session=session)
     quota_approvers = rse_attr.get('quota_approvers', None)
     if quota_approvers and issuer.external in quota_approvers.split(','):
         return True
@@ -843,70 +895,73 @@ def perm_set_local_account_limit(issuer, kwargs):
     return False
 
 
-def perm_set_global_account_limit(issuer, kwargs):
+def perm_set_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set a global account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # # Check if user is a country admin
     # admin_in_country = set()
-    # for kv in list_account_attributes(account=issuer):
+    # for kv in list_account_attributes(account=issuer, session=session):
     #     if kv['key'].startswith('country-') and kv['value'] == 'admin':
     #         admin_in_country.add(kv['key'].partition('-')[2])
-    # resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country')
-    #                           for rse in parse_expression(kwargs['rse_expression'], filter={'vo': issuer.vo})}
+    # resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+    #                           for rse in parse_expression(kwargs['rse_expression'], filter={'vo': issuer.vo}, session=session)}
     # if resolved_rse_countries.issubset(admin_in_country):
     #     return True
     return False
 
 
-def perm_delete_global_account_limit(issuer, kwargs):
+def perm_delete_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete a global account limit.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # # Check if user is a country admin
     # admin_in_country = set()
-    # for kv in list_account_attributes(account=issuer):
+    # for kv in list_account_attributes(account=issuer, session=session):
     #     if kv['key'].startswith('country-') and kv['value'] == 'admin':
     #         admin_in_country.add(kv['key'].partition('-')[2])
     # if admin_in_country:
-    #     resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country')
-    #                               for rse in parse_expression(kwargs['rse_expression'], filter={'vo': issuer.vo})}
+    #     resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+    #                               for rse in parse_expression(kwargs['rse_expression'], filter={'vo': issuer.vo}, session=session)}
     #     if resolved_rse_countries.issubset(admin_in_country):
     #         return True
     return False
 
 
-def perm_delete_local_account_limit(issuer, kwargs):
+def perm_delete_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete an account limit.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # # Check if user is a country admin
     # admin_in_country = []
-    # for kv in list_account_attributes(account=issuer):
+    # for kv in list_account_attributes(account=issuer, session=session):
     #     if kv['key'].startswith('country-') and kv['value'] == 'admin':
     #         admin_in_country.append(kv['key'].partition('-')[2])
-    # if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+    # if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
     #     return True
 
-    rse_attr = list_rse_attributes(rse_id=kwargs['rse_id'])
+    rse_attr = list_rse_attributes(rse_id=kwargs['rse_id'], session=session)
     quota_approvers = rse_attr.get('quota_approvers', None)
     if quota_approvers and issuer.external in quota_approvers.split(','):
         return True
@@ -914,195 +969,213 @@ def perm_delete_local_account_limit(issuer, kwargs):
     return False
 
 
-def perm_config(issuer, kwargs):
+def perm_config(issuer, kwargs, session=None):
     """
     Checks if an account can read/write the configuration.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_local_account_usage(issuer, kwargs):
+def perm_get_local_account_usage(issuer, kwargs, session=None):
     """
     Checks if an account can get the account usage of an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or kwargs.get('account') == issuer:
         return True
     # # Check if user is a country admin
-    # for kv in list_account_attributes(account=issuer):
+    # for kv in list_account_attributes(account=issuer, session=session):
     #     if kv['key'].startswith('country-') and kv['value'] == 'admin':
     #         return True
     return False
 
 
-def perm_add_account_attribute(issuer, kwargs):
+def perm_add_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_account_attribute(issuer, kwargs):
+def perm_del_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return perm_add_account_attribute(issuer, kwargs)
+    return perm_add_account_attribute(issuer, kwargs, session=session)
 
 
-def perm_list_heartbeats(issuer, kwargs):
+def perm_list_heartbeats(issuer, kwargs, session=None):
     """
     Checks if an account can list heartbeats.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_resurrect(issuer, kwargs):
+def perm_resurrect(issuer, kwargs, session=None):
     """
     Checks if an account can resurrect DIDS.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_lifetime_exceptions(issuer, kwargs):
+def perm_update_lifetime_exceptions(issuer, kwargs, session=None):
     """
     Checks if an account can approve/reject Lifetime Model exceptions.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_ssh_challenge_token(issuer, kwargs):
+def perm_get_ssh_challenge_token(issuer, kwargs, session=None):
     """
     Checks if an account can request a challenge token.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return True
 
 
-def perm_get_signed_url(issuer, kwargs):
+def perm_get_signed_url(issuer, kwargs, session=None):
     """
     Checks if an account can request a signed URL.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_add_bad_pfns(issuer, kwargs):
+def perm_add_bad_pfns(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad PFNs.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_remove_did_from_followed(issuer, kwargs):
+def perm_remove_did_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can remove did from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (_is_root(issuer)
-            or has_account_attribute(account=issuer, key='admin')  # NOQA: W503
+            or has_account_attribute(account=issuer, key='admin', session=session)  # NOQA: W503
             or kwargs['account'] == issuer  # NOQA: W503
             or kwargs['scope'].external == 'mock')  # NOQA: W503
 
 
-def perm_remove_dids_from_followed(issuer, kwargs):
+def perm_remove_dids_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can bulk remove dids from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     if not kwargs['account'] == issuer:
         return False
     return True
 
 
-def perm_add_vo(issuer, kwargs):
+def perm_add_vo(issuer, kwargs, session=None):
     """
     Checks if an account can add a VO.
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_list_vos(issuer, kwargs):
+def perm_list_vos(issuer, kwargs, session=None):
     """
     Checks if an account can list a VO.
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_recover_vo_root_identity(issuer, kwargs):
+def perm_recover_vo_root_identity(issuer, kwargs, session=None):
     """
     Checks if an account can recover identities for VOs.
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_update_vo(issuer, kwargs):
+def perm_update_vo(issuer, kwargs, session=None):
     """
     Checks if an account can update a VO.
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_access_rule_vo(issuer, kwargs):
+def perm_access_rule_vo(issuer, kwargs, session=None):
     """
     Checks if we're at the same VO as the rule_id's
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return get_rule(kwargs['rule_id'])['scope'].vo == issuer.vo

--- a/lib/rucio/core/permission/escape.py
+++ b/lib/rucio/core/permission/escape.py
@@ -26,7 +26,7 @@ from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla.constants import IdentityType
 
 
-def has_permission(issuer, action, kwargs):
+def has_permission(issuer, action, kwargs, session=None):
     """
     Checks if an account has the specified permission to
     execute an action with parameters.
@@ -34,6 +34,7 @@ def has_permission(issuer, action, kwargs):
     :param issuer: Account identifier which issues the command..
     :param action:  The action(API call) called by the account.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     perm = {'add_account': perm_add_account,
@@ -113,528 +114,569 @@ def has_permission(issuer, action, kwargs):
             'remove_dids_from_followed': perm_remove_dids_from_followed,
             'export': perm_export}
 
-    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs)
+    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs, session=session)
 
 
 def _is_root(issuer):
     return issuer.external == 'root'
 
 
-def perm_default(issuer, kwargs):
+def perm_default(issuer, kwargs, session=None):
     """
     Default permission.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_rse(issuer, kwargs):
+def perm_add_rse(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_rse(issuer, kwargs):
+def perm_update_rse(issuer, kwargs, session=None):
     """
     Checks if an account can update a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_rule(issuer, kwargs):
+def perm_add_rule(issuer, kwargs, session=None):
     """
     Checks if an account can add a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs['account'] == issuer and not kwargs['locked']:
         return True
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_add_subscription(issuer, kwargs):
+def perm_add_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can add a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_add_rse_attribute(issuer, kwargs):
+def perm_add_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_del_rse_attribute(issuer, kwargs):
+def perm_del_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_del_rse(issuer, kwargs):
+def perm_del_rse(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_account(issuer, kwargs):
+def perm_add_account(issuer, kwargs, session=None):
     """
     Checks if an account can add an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_del_account(issuer, kwargs):
+def perm_del_account(issuer, kwargs, session=None):
     """
     Checks if an account can del an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_update_account(issuer, kwargs):
+def perm_update_account(issuer, kwargs, session=None):
     """
     Checks if an account can update an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_scope(issuer, kwargs):
+def perm_add_scope(issuer, kwargs, session=None):
     """
     Checks if an account can add a scop to a account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_get_auth_token_user_pass(issuer, kwargs):
+def perm_get_auth_token_user_pass(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_gss(issuer, kwargs):
+def perm_get_auth_token_gss(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_x509(issuer, kwargs):
+def perm_get_auth_token_x509(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_saml(issuer, kwargs):
+def perm_get_auth_token_saml(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_add_account_identity(issuer, kwargs):
+def perm_add_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can add an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_del_account_identity(issuer, kwargs):
+def perm_del_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_del_identity(issuer, kwargs):
+def perm_del_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer.external in kwargs.get('accounts')
 
 
-def perm_add_did(issuer, kwargs):
+def perm_add_did(issuer, kwargs, session=None):
     """
     Checks if an account can add an data identifier to a scope.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
         for rule in kwargs.get('rules', []):
             if rule['account'] != issuer:
                 return False
 
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == u'mock'
 
 
-def perm_add_dids(issuer, kwargs):
+def perm_add_dids(issuer, kwargs, session=None):
     """
     Checks if an account can bulk add data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
         for did in kwargs['dids']:
             for rule in did.get('rules', []):
                 if rule['account'] != issuer:
                     return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_attach_dids(issuer, kwargs):
+def perm_attach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_attach_dids_to_dids(issuer, kwargs):
+def perm_attach_dids_to_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     else:
         attachments = kwargs['attachments']
         scopes = [did['scope'] for did in attachments]
         scopes = list(set(scopes))
         for scope in scopes:
-            if not rucio.core.scope.is_scope_owner(scope, issuer):
+            if not rucio.core.scope.is_scope_owner(scope, issuer, session=session):
                 return False
         return True
 
 
-def perm_create_did_sample(issuer, kwargs):
+def perm_create_did_sample(issuer, kwargs, session=None):
     """
     Checks if an account can create a sample of a data identifier collection.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_del_rule(issuer, kwargs):
+def perm_del_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can delete a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_update_rule(issuer, kwargs):
+def perm_update_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can update a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_approve_rule(issuer, kwargs):
+def perm_approve_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can approve a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_reduce_rule(issuer, kwargs):
+def perm_reduce_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can reduce a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_move_rule(issuer, kwargs):
+def perm_move_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can move a replication rule.
 
     :param issuer:   Account identifier which issues the command.
     :param kwargs:   List of arguments for the action.
+    :param session: The DB session to use
     :returns:        True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_update_subscription(issuer, kwargs):
+def perm_update_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can update a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     return False
 
 
-def perm_detach_dids(issuer, kwargs):
+def perm_detach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can detach an data identifier from the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return perm_attach_dids(issuer, kwargs)
+    return perm_attach_dids(issuer, kwargs, session=session)
 
 
-def perm_set_metadata(issuer, kwargs):
+def perm_set_metadata(issuer, kwargs, session=None):
     """
     Checks if an account can set a metadata on a data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
-def perm_set_status(issuer, kwargs):
+def perm_set_status(issuer, kwargs, session=None):
     """
     Checks if an account can set status on an data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs.get('open', False):
-        if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+        if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
             return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
-def perm_add_protocol(issuer, kwargs):
+def perm_add_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can add a protocol to an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_protocol(issuer, kwargs):
+def perm_del_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can delete protocols from an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_protocol(issuer, kwargs):
+def perm_update_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can update protocols of an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_qos_policy(issuer, kwargs):
+def perm_add_qos_policy(issuer, kwargs, session=None):
     """
     Checks if an account can add QoS policies to an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_delete_qos_policy(issuer, kwargs):
+def perm_delete_qos_policy(issuer, kwargs, session=None):
     """
     Checks if an account can delete QoS policies from an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_declare_bad_file_replicas(issuer, kwargs):
+def perm_declare_bad_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_declare_suspicious_file_replicas(issuer, kwargs):
+def perm_declare_suspicious_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare suspicious file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_add_replicas(issuer, kwargs):
+def perm_add_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can add replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return str(kwargs.get('rse', '')).endswith('SCRATCHDISK')\
@@ -642,361 +684,390 @@ def perm_add_replicas(issuer, kwargs):
         or str(kwargs.get('rse', '')).endswith('MOCK')\
         or str(kwargs.get('rse', '')).endswith('LOCALGROUPDISK')\
         or _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')
+        or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_skip_availability_check(issuer, kwargs):
+def perm_skip_availability_check(issuer, kwargs, session=None):
     """
     Checks if an account can skip the availabity check to add/delete file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_delete_replicas(issuer, kwargs):
+def perm_delete_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return False
 
 
-def perm_update_replicas_states(issuer, kwargs):
+def perm_update_replicas_states(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_queue_requests(issuer, kwargs):
+def perm_queue_requests(issuer, kwargs, session=None):
     """
     Checks if an account can submit transfer or deletion requests on destination RSEs for data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_get_request_by_did(issuer, kwargs):
+def perm_get_request_by_did(issuer, kwargs, session=None):
     """
     Checks if an account can get a request by DID.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_cancel_request(issuer, kwargs):
+def perm_cancel_request(issuer, kwargs, session=None):
     """
     Checks if an account can cancel a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_get_next(issuer, kwargs):
+def perm_get_next(issuer, kwargs, session=None):
     """
     Checks if an account can retrieve the next request matching the request type and state.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_set_rse_usage(issuer, kwargs):
+def perm_set_rse_usage(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE usage information.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_set_rse_limits(issuer, kwargs):
+def perm_set_rse_limits(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE limits.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_set_local_account_limit(issuer, kwargs):
+def perm_set_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set an account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
         return True
     return False
 
 
-def perm_set_global_account_limit(issuer, kwargs):
+def perm_set_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set a global account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country') for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})}
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                              for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
     if resolved_rse_countries.issubset(admin_in_country):
         return True
     return False
 
 
-def perm_delete_local_account_limit(issuer, kwargs):
+def perm_delete_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete an account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
         return True
     return False
 
 
-def perm_delete_global_account_limit(issuer, kwargs):
+def perm_delete_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete a global account limit.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
     if admin_in_country:
-        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country') for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})}
+        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                                  for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
         if resolved_rse_countries.issubset(admin_in_country):
             return True
     return False
 
 
-def perm_config(issuer, kwargs):
+def perm_config(issuer, kwargs, session=None):
     """
     Checks if an account can read/write the configuration.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_local_account_usage(issuer, kwargs):
+def perm_get_local_account_usage(issuer, kwargs, session=None):
     """
     Checks if an account can get the account usage of an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or kwargs.get('account') == issuer:
         return True
     # Check if user is a country admin
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             return True
     return False
 
 
-def perm_get_global_account_usage(issuer, kwargs):
+def perm_get_global_account_usage(issuer, kwargs, session=None):
     """
     Checks if an account can get the account usage of an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or kwargs.get('account') == issuer:
         return True
 
     # Check if user is a country admin for all involved countries
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             return True
     return False
 
 
-def perm_add_account_attribute(issuer, kwargs):
+def perm_add_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_account_attribute(issuer, kwargs):
+def perm_del_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return perm_add_account_attribute(issuer, kwargs)
+    return perm_add_account_attribute(issuer, kwargs, session=session)
 
 
-def perm_list_heartbeats(issuer, kwargs):
+def perm_list_heartbeats(issuer, kwargs, session=None):
     """
     Checks if an account can list heartbeats.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_resurrect(issuer, kwargs):
+def perm_resurrect(issuer, kwargs, session=None):
     """
     Checks if an account can resurrect DIDS.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_lifetime_exceptions(issuer, kwargs):
+def perm_update_lifetime_exceptions(issuer, kwargs, session=None):
     """
     Checks if an account can approve/reject Lifetime Model exceptions.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     if kwargs['vo'] is not None:
-        exceptions = next(list_exceptions(exception_id=kwargs['exception_id'], states=False))
+        exceptions = next(list_exceptions(exception_id=kwargs['exception_id'], states=False, session=session))
         if exceptions['scope'].vo != kwargs['vo']:
             return False
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_ssh_challenge_token(issuer, kwargs):
+def perm_get_ssh_challenge_token(issuer, kwargs, session=None):
     """
     Checks if an account can request a challenge token.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return True
 
 
-def perm_get_signed_url(issuer, kwargs):
+def perm_get_signed_url(issuer, kwargs, session=None):
     """
     Checks if an account can request a signed URL.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_bad_pfns(issuer, kwargs):
+def perm_add_bad_pfns(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad PFNs.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_remove_did_from_followed(issuer, kwargs):
+def perm_remove_did_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can remove did from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
         or kwargs['account'] == issuer\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_remove_dids_from_followed(issuer, kwargs):
+def perm_remove_dids_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can bulk remove dids from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     if not kwargs['account'] == issuer:
         return False
     return True
 
 
-def perm_export(issuer, kwargs):
+def perm_export(issuer, kwargs, session=None):
     """
     Checks if an account can export the RSE info.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -39,7 +39,7 @@ from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla.constants import IdentityType
 
 
-def has_permission(issuer, action, kwargs):
+def has_permission(issuer, action, kwargs, session=None):
     """
     Checks if an account has the specified permission to
     execute an action with parameters.
@@ -47,6 +47,7 @@ def has_permission(issuer, action, kwargs):
     :param issuer: Account identifier which issues the command..
     :param action:  The action(API call) called by the account.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     perm = {'add_account': perm_add_account,
@@ -129,528 +130,569 @@ def has_permission(issuer, action, kwargs):
             'remove_dids_from_followed': perm_remove_dids_from_followed,
             'export': perm_export}
 
-    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs)
+    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs, session=session)
 
 
 def _is_root(issuer):
     return issuer.external == 'root'
 
 
-def perm_default(issuer, kwargs):
+def perm_default(issuer, kwargs, session=None):
     """
     Default permission.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_rse(issuer, kwargs):
+def perm_add_rse(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_rse(issuer, kwargs):
+def perm_update_rse(issuer, kwargs, session=None):
     """
     Checks if an account can update a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_rule(issuer, kwargs):
+def perm_add_rule(issuer, kwargs, session=None):
     """
     Checks if an account can add a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs['account'] == issuer and not kwargs['locked']:
         return True
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_add_subscription(issuer, kwargs):
+def perm_add_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can add a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_add_rse_attribute(issuer, kwargs):
+def perm_add_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_del_rse_attribute(issuer, kwargs):
+def perm_del_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_del_rse(issuer, kwargs):
+def perm_del_rse(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_account(issuer, kwargs):
+def perm_add_account(issuer, kwargs, session=None):
     """
     Checks if an account can add an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_del_account(issuer, kwargs):
+def perm_del_account(issuer, kwargs, session=None):
     """
     Checks if an account can del an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_update_account(issuer, kwargs):
+def perm_update_account(issuer, kwargs, session=None):
     """
     Checks if an account can update an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_scope(issuer, kwargs):
+def perm_add_scope(issuer, kwargs, session=None):
     """
     Checks if an account can add a scop to a account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_get_auth_token_user_pass(issuer, kwargs):
+def perm_get_auth_token_user_pass(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_gss(issuer, kwargs):
+def perm_get_auth_token_gss(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_x509(issuer, kwargs):
+def perm_get_auth_token_x509(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_saml(issuer, kwargs):
+def perm_get_auth_token_saml(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_add_account_identity(issuer, kwargs):
+def perm_add_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can add an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_del_account_identity(issuer, kwargs):
+def perm_del_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_del_identity(issuer, kwargs):
+def perm_del_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer.external in kwargs.get('accounts')
 
 
-def perm_add_did(issuer, kwargs):
+def perm_add_did(issuer, kwargs, session=None):
     """
     Checks if an account can add an data identifier to a scope.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
         for rule in kwargs.get('rules', []):
             if rule['account'] != issuer:
                 return False
 
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == u'mock'
 
 
-def perm_add_dids(issuer, kwargs):
+def perm_add_dids(issuer, kwargs, session=None):
     """
     Checks if an account can bulk add data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
         for did in kwargs['dids']:
             for rule in did.get('rules', []):
                 if rule['account'] != issuer:
                     return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_attach_dids(issuer, kwargs):
+def perm_attach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_attach_dids_to_dids(issuer, kwargs):
+def perm_attach_dids_to_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     else:
         attachments = kwargs['attachments']
         scopes = [did['scope'] for did in attachments]
         scopes = list(set(scopes))
         for scope in scopes:
-            if not rucio.core.scope.is_scope_owner(scope, issuer):
+            if not rucio.core.scope.is_scope_owner(scope, issuer, session=session):
                 return False
         return True
 
 
-def perm_create_did_sample(issuer, kwargs):
+def perm_create_did_sample(issuer, kwargs, session=None):
     """
     Checks if an account can create a sample of a data identifier collection.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_del_rule(issuer, kwargs):
+def perm_del_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can delete a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_update_rule(issuer, kwargs):
+def perm_update_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can update a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_approve_rule(issuer, kwargs):
+def perm_approve_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can approve a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_reduce_rule(issuer, kwargs):
+def perm_reduce_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can reduce a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_move_rule(issuer, kwargs):
+def perm_move_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can move a replication rule.
 
     :param issuer:   Account identifier which issues the command.
     :param kwargs:   List of arguments for the action.
+    :param session: The DB session to use
     :returns:        True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_update_subscription(issuer, kwargs):
+def perm_update_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can update a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     return False
 
 
-def perm_detach_dids(issuer, kwargs):
+def perm_detach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can detach an data identifier from the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return perm_attach_dids(issuer, kwargs)
+    return perm_attach_dids(issuer, kwargs, session=session)
 
 
-def perm_set_metadata(issuer, kwargs):
+def perm_set_metadata(issuer, kwargs, session=None):
     """
     Checks if an account can set a metadata on a data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
-def perm_set_status(issuer, kwargs):
+def perm_set_status(issuer, kwargs, session=None):
     """
     Checks if an account can set status on an data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs.get('open', False):
-        if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+        if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
             return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
-def perm_add_protocol(issuer, kwargs):
+def perm_add_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can add a protocol to an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_protocol(issuer, kwargs):
+def perm_del_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can delete protocols from an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_protocol(issuer, kwargs):
+def perm_update_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can update protocols of an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_qos_policy(issuer, kwargs):
+def perm_add_qos_policy(issuer, kwargs, session=None):
     """
     Checks if an account can add QoS policies to an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_delete_qos_policy(issuer, kwargs):
+def perm_delete_qos_policy(issuer, kwargs, session=None):
     """
     Checks if an account can delete QoS policies from an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_declare_bad_file_replicas(issuer, kwargs):
+def perm_declare_bad_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_declare_suspicious_file_replicas(issuer, kwargs):
+def perm_declare_suspicious_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare suspicious file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_add_replicas(issuer, kwargs):
+def perm_add_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can add replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return str(kwargs.get('rse', '')).endswith('SCRATCHDISK')\
@@ -658,394 +700,426 @@ def perm_add_replicas(issuer, kwargs):
         or str(kwargs.get('rse', '')).endswith('MOCK')\
         or str(kwargs.get('rse', '')).endswith('LOCALGROUPDISK')\
         or _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')
+        or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_skip_availability_check(issuer, kwargs):
+def perm_skip_availability_check(issuer, kwargs, session=None):
     """
     Checks if an account can skip the availabity check to add/delete file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_delete_replicas(issuer, kwargs):
+def perm_delete_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return False
 
 
-def perm_update_replicas_states(issuer, kwargs):
+def perm_update_replicas_states(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_queue_requests(issuer, kwargs):
+def perm_queue_requests(issuer, kwargs, session=None):
     """
     Checks if an account can submit transfer or deletion requests on destination RSEs for data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_list_requests(issuer, kwargs):
+def perm_list_requests(issuer, kwargs, session=None):
     """
     Checks if an account can list requests.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_list_requests_history(issuer, kwargs):
+def perm_list_requests_history(issuer, kwargs, session=None):
     """
     Checks if an account can list historical requests.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_request_by_did(issuer, kwargs):
+def perm_get_request_by_did(issuer, kwargs, session=None):
     """
     Checks if an account can get a request by DID.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_get_request_history_by_did(issuer, kwargs):
+def perm_get_request_history_by_did(issuer, kwargs, session=None):
     """
     Checks if an account can get a historical request by DID.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_cancel_request(issuer, kwargs):
+def perm_cancel_request(issuer, kwargs, session=None):
     """
     Checks if an account can cancel a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_get_next(issuer, kwargs):
+def perm_get_next(issuer, kwargs, session=None):
     """
     Checks if an account can retrieve the next request matching the request type and state.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_set_rse_usage(issuer, kwargs):
+def perm_set_rse_usage(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE usage information.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_set_rse_limits(issuer, kwargs):
+def perm_set_rse_limits(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE limits.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_set_local_account_limit(issuer, kwargs):
+def perm_set_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set an account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
         return True
     return False
 
 
-def perm_set_global_account_limit(issuer, kwargs):
+def perm_set_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set a global account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country') for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})}
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                              for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
     if resolved_rse_countries.issubset(admin_in_country):
         return True
     return False
 
 
-def perm_delete_local_account_limit(issuer, kwargs):
+def perm_delete_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete an account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
         return True
     return False
 
 
-def perm_delete_global_account_limit(issuer, kwargs):
+def perm_delete_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete a global account limit.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
     if admin_in_country:
-        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country') for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})}
+        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                                  for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
         if resolved_rse_countries.issubset(admin_in_country):
             return True
     return False
 
 
-def perm_config(issuer, kwargs):
+def perm_config(issuer, kwargs, session=None):
     """
     Checks if an account can read/write the configuration.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_local_account_usage(issuer, kwargs):
+def perm_get_local_account_usage(issuer, kwargs, session=None):
     """
     Checks if an account can get the account usage of an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or kwargs.get('account') == issuer:
         return True
     # Check if user is a country admin
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             return True
     return False
 
 
-def perm_get_global_account_usage(issuer, kwargs):
+def perm_get_global_account_usage(issuer, kwargs, session=None):
     """
     Checks if an account can get the account usage of an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or kwargs.get('account') == issuer:
         return True
 
     # Check if user is a country admin for all involved countries
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             return True
     return False
 
 
-def perm_add_account_attribute(issuer, kwargs):
+def perm_add_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_account_attribute(issuer, kwargs):
+def perm_del_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return perm_add_account_attribute(issuer, kwargs)
+    return perm_add_account_attribute(issuer, kwargs, session=session)
 
 
-def perm_list_heartbeats(issuer, kwargs):
+def perm_list_heartbeats(issuer, kwargs, session=None):
     """
     Checks if an account can list heartbeats.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_resurrect(issuer, kwargs):
+def perm_resurrect(issuer, kwargs, session=None):
     """
     Checks if an account can resurrect DIDS.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_lifetime_exceptions(issuer, kwargs):
+def perm_update_lifetime_exceptions(issuer, kwargs, session=None):
     """
     Checks if an account can approve/reject Lifetime Model exceptions.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     if kwargs['vo'] is not None:
-        exceptions = next(list_exceptions(exception_id=kwargs['exception_id'], states=False))
+        exceptions = next(list_exceptions(exception_id=kwargs['exception_id'], states=False, session=session))
         if exceptions['scope'].vo != kwargs['vo']:
             return False
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_ssh_challenge_token(issuer, kwargs):
+def perm_get_ssh_challenge_token(issuer, kwargs, session=None):
     """
     Checks if an account can request a challenge token.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return True
 
 
-def perm_get_signed_url(issuer, kwargs):
+def perm_get_signed_url(issuer, kwargs, session=None):
     """
     Checks if an account can request a signed URL.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_add_bad_pfns(issuer, kwargs):
+def perm_add_bad_pfns(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad PFNs.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_remove_did_from_followed(issuer, kwargs):
+def perm_remove_did_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can remove did from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
         or kwargs['account'] == issuer\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_remove_dids_from_followed(issuer, kwargs):
+def perm_remove_dids_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can bulk remove dids from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     if not kwargs['account'] == issuer:
         return False
     return True
 
 
-def perm_export(issuer, kwargs):
+def perm_export(issuer, kwargs, session=None):
     """
     Checks if an account can export the RSE info.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)

--- a/lib/rucio/core/permission/generic_multi_vo.py
+++ b/lib/rucio/core/permission/generic_multi_vo.py
@@ -29,7 +29,7 @@ from rucio.core.rule import get_rule
 from rucio.db.sqla.constants import IdentityType
 
 
-def has_permission(issuer, action, kwargs):
+def has_permission(issuer, action, kwargs, session=None):
     """
     Checks if an account has the specified permission to
     execute an action with parameters.
@@ -37,6 +37,7 @@ def has_permission(issuer, action, kwargs):
     :param issuer: Account identifier which issues the command..
     :param action:  The action(API call) called by the account.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     perm = {'add_account': perm_add_account,
@@ -121,506 +122,545 @@ def has_permission(issuer, action, kwargs):
             'update_vo': perm_update_vo,
             'access_rule_vo': perm_access_rule_vo}
 
-    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs)
+    return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs, session=session)
 
 
 def _is_root(issuer):
     return issuer.external == 'root'
 
 
-def perm_default(issuer, kwargs):
+def perm_default(issuer, kwargs, session=None):
     """
     Default permission.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_rse(issuer, kwargs):
+def perm_add_rse(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_rse(issuer, kwargs):
+def perm_update_rse(issuer, kwargs, session=None):
     """
     Checks if an account can update a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_rule(issuer, kwargs):
+def perm_add_rule(issuer, kwargs, session=None):
     """
     Checks if an account can add a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs['account'] == issuer and not kwargs['locked']:
         return True
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_add_subscription(issuer, kwargs):
+def perm_add_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can add a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_add_rse_attribute(issuer, kwargs):
+def perm_add_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_del_rse_attribute(issuer, kwargs):
+def perm_del_rse_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE attribute.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_del_rse(issuer, kwargs):
+def perm_del_rse(issuer, kwargs, session=None):
     """
     Checks if an account can delete a RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_account(issuer, kwargs):
+def perm_add_account(issuer, kwargs, session=None):
     """
     Checks if an account can add an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_del_account(issuer, kwargs):
+def perm_del_account(issuer, kwargs, session=None):
     """
     Checks if an account can del an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_update_account(issuer, kwargs):
+def perm_update_account(issuer, kwargs, session=None):
     """
     Checks if an account can update an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_add_scope(issuer, kwargs):
+def perm_add_scope(issuer, kwargs, session=None):
     """
     Checks if an account can add a scop to a account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_get_auth_token_user_pass(issuer, kwargs):
+def perm_get_auth_token_user_pass(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['username'], type_=IdentityType.USERPASS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_gss(issuer, kwargs):
+def perm_get_auth_token_gss(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['gsscred'], type_=IdentityType.GSS, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_x509(issuer, kwargs):
+def perm_get_auth_token_x509(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['dn'], type_=IdentityType.X509, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_get_auth_token_saml(issuer, kwargs):
+def perm_get_auth_token_saml(issuer, kwargs, session=None):
     """
     Checks if a user can request a token with user_pass for an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account']):
+    if exist_identity_account(identity=kwargs['saml_nameid'], type_=IdentityType.SAML, account=kwargs['account'], session=session):
         return True
     return False
 
 
-def perm_add_account_identity(issuer, kwargs):
+def perm_add_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can add an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_del_account_identity(issuer, kwargs):
+def perm_del_account_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity to an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer == kwargs.get('account')
 
 
-def perm_del_identity(issuer, kwargs):
+def perm_del_identity(issuer, kwargs, session=None):
     """
     Checks if an account can delete an identity.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
 
     return _is_root(issuer) or issuer.external in kwargs.get('accounts')
 
 
-def perm_add_did(issuer, kwargs):
+def perm_add_did(issuer, kwargs, session=None):
     """
     Checks if an account can add an data identifier to a scope.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
         for rule in kwargs.get('rules', []):
             if rule['account'] != issuer:
                 return False
 
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == u'mock'
 
 
-def perm_add_dids(issuer, kwargs):
+def perm_add_dids(issuer, kwargs, session=None):
     """
     Checks if an account can bulk add data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     # Check the accounts of the issued rules
-    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+    if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
         for did in kwargs['dids']:
             for rule in did.get('rules', []):
                 if rule['account'] != issuer:
                     return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_attach_dids(issuer, kwargs):
+def perm_attach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_attach_dids_to_dids(issuer, kwargs):
+def perm_attach_dids_to_dids(issuer, kwargs, session=None):
     """
     Checks if an account can append an data identifier to the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     else:
         attachments = kwargs['attachments']
         scopes = [did['scope'] for did in attachments]
         scopes = list(set(scopes))
         for scope in scopes:
-            if not rucio.core.scope.is_scope_owner(scope, issuer):
+            if not rucio.core.scope.is_scope_owner(scope, issuer, session=session):
                 return False
         return True
 
 
-def perm_create_did_sample(issuer, kwargs):
+def perm_create_did_sample(issuer, kwargs, session=None):
     """
     Checks if an account can create a sample of a data identifier collection.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_del_rule(issuer, kwargs):
+def perm_del_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can delete a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_update_rule(issuer, kwargs):
+def perm_update_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can update a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_approve_rule(issuer, kwargs):
+def perm_approve_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can approve a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_reduce_rule(issuer, kwargs):
+def perm_reduce_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can reduce a replication rule.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_move_rule(issuer, kwargs):
+def perm_move_rule(issuer, kwargs, session=None):
     """
     Checks if an issuer can move a replication rule.
 
     :param issuer:   Account identifier which issues the command.
     :param kwargs:   List of arguments for the action.
+    :param session: The DB session to use
     :returns:        True if account is allowed to call the API call, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     return False
 
 
-def perm_update_subscription(issuer, kwargs):
+def perm_update_subscription(issuer, kwargs, session=None):
     """
     Checks if an account can update a subscription.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
 
     return False
 
 
-def perm_detach_dids(issuer, kwargs):
+def perm_detach_dids(issuer, kwargs, session=None):
     """
     Checks if an account can detach an data identifier from the other data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return perm_attach_dids(issuer, kwargs)
+    return perm_attach_dids(issuer, kwargs, session=session)
 
 
-def perm_set_metadata(issuer, kwargs):
+def perm_set_metadata(issuer, kwargs, session=None):
     """
     Checks if an account can set a metadata on a data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
-def perm_set_status(issuer, kwargs):
+def perm_set_status(issuer, kwargs, session=None):
     """
     Checks if an account can set status on an data identifier.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     if kwargs.get('open', False):
-        if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin'):
+        if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
             return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
-def perm_add_protocol(issuer, kwargs):
+def perm_add_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can add a protocol to an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_protocol(issuer, kwargs):
+def perm_del_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can delete protocols from an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_protocol(issuer, kwargs):
+def perm_update_protocol(issuer, kwargs, session=None):
     """
     Checks if an account can update protocols of an RSE.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_declare_bad_file_replicas(issuer, kwargs):
+def perm_declare_bad_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_declare_suspicious_file_replicas(issuer, kwargs):
+def perm_declare_suspicious_file_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can declare suspicious file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_add_replicas(issuer, kwargs):
+def perm_add_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can add replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return str(kwargs.get('rse', '')).endswith('SCRATCHDISK')\
@@ -628,444 +668,480 @@ def perm_add_replicas(issuer, kwargs):
         or str(kwargs.get('rse', '')).endswith('MOCK')\
         or str(kwargs.get('rse', '')).endswith('LOCALGROUPDISK')\
         or _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')
+        or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_skip_availability_check(issuer, kwargs):
+def perm_skip_availability_check(issuer, kwargs, session=None):
     """
     Checks if an account can skip the availabity check to add/delete file replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_delete_replicas(issuer, kwargs):
+def perm_delete_replicas(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return False
 
 
-def perm_update_replicas_states(issuer, kwargs):
+def perm_update_replicas_states(issuer, kwargs, session=None):
     """
     Checks if an account can delete replicas.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_queue_requests(issuer, kwargs):
+def perm_queue_requests(issuer, kwargs, session=None):
     """
     Checks if an account can submit transfer or deletion requests on destination RSEs for data identifiers.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_list_requests(issuer, kwargs):
+def perm_list_requests(issuer, kwargs, session=None):
     """
     Checks if an account can list requests.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_list_requests_history(issuer, kwargs):
+def perm_list_requests_history(issuer, kwargs, session=None):
     """
     Checks if an account can list historical requests.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_request_by_did(issuer, kwargs):
+def perm_get_request_by_did(issuer, kwargs, session=None):
     """
     Checks if an account can get a request by DID.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return True
 
 
-def perm_get_request_history_by_did(issuer, kwargs):
+def perm_get_request_history_by_did(issuer, kwargs, session=None):
     """
     Checks if an account can get a historical request by DID.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_cancel_request(issuer, kwargs):
+def perm_cancel_request(issuer, kwargs, session=None):
     """
     Checks if an account can cancel a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_get_next(issuer, kwargs):
+def perm_get_next(issuer, kwargs, session=None):
     """
     Checks if an account can retrieve the next request matching the request type and state.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_set_rse_usage(issuer, kwargs):
+def perm_set_rse_usage(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE usage information.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_set_rse_limits(issuer, kwargs):
+def perm_set_rse_limits(issuer, kwargs, session=None):
     """
     Checks if an account can set RSE limits.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_set_local_account_limit(issuer, kwargs):
+def perm_set_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set an account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
         return True
     return False
 
 
-def perm_set_global_account_limit(issuer, kwargs):
+def perm_set_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can set a global account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country') for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})}
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                              for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
     if resolved_rse_countries.issubset(admin_in_country):
         return True
     return False
 
 
-def perm_delete_local_account_limit(issuer, kwargs):
+def perm_delete_local_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete an account limit.
 
     :param account: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = []
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id']).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
         return True
     return False
 
 
-def perm_delete_global_account_limit(issuer, kwargs):
+def perm_delete_global_account_limit(issuer, kwargs, session=None):
     """
     Checks if an account can delete a global account limit.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     # Check if user is a country admin
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
     if admin_in_country:
-        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country') for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo})}
+        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                                  for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
         if resolved_rse_countries.issubset(admin_in_country):
             return True
     return False
 
 
-def perm_config(issuer, kwargs):
+def perm_config(issuer, kwargs, session=None):
     """
     Checks if an account can read/write the configuration.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_local_account_usage(issuer, kwargs):
+def perm_get_local_account_usage(issuer, kwargs, session=None):
     """
     Checks if an account can get the account usage of an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or kwargs.get('account') == issuer:
         return True
     # Check if user is a country admin
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             return True
     return False
 
 
-def perm_get_global_account_usage(issuer, kwargs):
+def perm_get_global_account_usage(issuer, kwargs, session=None):
     """
     Checks if an account can get the account usage of an account.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin') or kwargs.get('account') == issuer:
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or kwargs.get('account') == issuer:
         return True
 
     # Check if user is a country admin for all involved countries
     admin_in_country = set()
-    for kv in list_account_attributes(account=issuer):
+    for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id']).get('country')
-                              for rse in parse_expression(kwargs['rse_exp'], filter_={'vo': issuer.vo})}
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+                              for rse in parse_expression(kwargs['rse_exp'], filter_={'vo': issuer.vo}, session=session)}
 
     if resolved_rse_countries.issubset(admin_in_country):
         return True
     return False
 
 
-def perm_add_account_attribute(issuer, kwargs):
+def perm_add_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_del_account_attribute(issuer, kwargs):
+def perm_del_account_attribute(issuer, kwargs, session=None):
     """
     Checks if an account can add attributes to accounts.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return perm_add_account_attribute(issuer, kwargs)
+    return perm_add_account_attribute(issuer, kwargs, session=session)
 
 
-def perm_list_heartbeats(issuer, kwargs):
+def perm_list_heartbeats(issuer, kwargs, session=None):
     """
     Checks if an account can list heartbeats.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_resurrect(issuer, kwargs):
+def perm_resurrect(issuer, kwargs, session=None):
     """
     Checks if an account can resurrect DIDS.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_update_lifetime_exceptions(issuer, kwargs):
+def perm_update_lifetime_exceptions(issuer, kwargs, session=None):
     """
     Checks if an account can approve/reject Lifetime Model exceptions.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     if kwargs['vo'] is not None:
-        exceptions = next(list_exceptions(exception_id=kwargs['exception_id'], states=False))
+        exceptions = next(list_exceptions(exception_id=kwargs['exception_id'], states=False, session=session))
         if exceptions['scope'].vo != kwargs['vo']:
             return False
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
-def perm_get_ssh_challenge_token(issuer, kwargs):
+def perm_get_ssh_challenge_token(issuer, kwargs, session=None):
     """
     Checks if an account can request a challenge token.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return True
 
 
-def perm_get_signed_url(issuer, kwargs):
+def perm_get_signed_url(issuer, kwargs, session=None):
     """
     Checks if an account can request a signed URL.
 
     :param issuer: Account identifier which issues the command.
+    :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_add_bad_pfns(issuer, kwargs):
+def perm_add_bad_pfns(issuer, kwargs, session=None):
     """
     Checks if an account can declare bad PFNs.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
 
 
-def perm_remove_did_from_followed(issuer, kwargs):
+def perm_remove_did_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can remove did from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin')\
+        or has_account_attribute(account=issuer, key='admin', session=session)\
         or kwargs['account'] == issuer\
         or kwargs['scope'].external == 'mock'
 
 
-def perm_remove_dids_from_followed(issuer, kwargs):
+def perm_remove_dids_from_followed(issuer, kwargs, session=None):
     """
     Checks if an account can bulk remove dids from followed table.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin'):
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
         return True
     if not kwargs['account'] == issuer:
         return False
     return True
 
 
-def perm_add_vo(issuer, kwargs):
+def perm_add_vo(issuer, kwargs, session=None):
     """
     Checks if an account can add a VO.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_list_vos(issuer, kwargs):
+def perm_list_vos(issuer, kwargs, session=None):
     """
     Checks if an account can list a VO.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_recover_vo_root_identity(issuer, kwargs):
+def perm_recover_vo_root_identity(issuer, kwargs, session=None):
     """
     Checks if an account can recover identities for VOs.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_update_vo(issuer, kwargs):
+def perm_update_vo(issuer, kwargs, session=None):
     """
     Checks if an account can update a VO.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return (issuer.internal == 'super_root')
 
 
-def perm_access_rule_vo(issuer, kwargs):
+def perm_access_rule_vo(issuer, kwargs, session=None):
     """
     Checks if we're at the same VO as the rule_id's
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
     return get_rule(kwargs['rule_id'])['scope'].vo == issuer.vo


### PR DESCRIPTION
Only create the session object once per api call to rules enpoint
and pass it through. The goal is to test if the number of un-needed
rollbacks on the database side is decreased thanks to avoiding
sessionmaker.remove() calls.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
