### PR TITLE
Transfers: enable per-vo certs for interacting with fts. Closes #4731 

### DIFF
--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -608,7 +608,7 @@ def is_recoverable_fts_overwrite_error(fts_status_dict):
     return False
 
 
-def bulk_query_transfers(request_host, transfers_by_eid, transfertool='fts3', timeout=None, logger=logging.log):
+def bulk_query_transfers(request_host, transfers_by_eid, transfertool='fts3', vo=None, timeout=None, logger=logging.log):
     """
     Query the status of a transfer.
     :param request_host:     Name of the external host.
@@ -623,7 +623,7 @@ def bulk_query_transfers(request_host, transfers_by_eid, transfertool='fts3', ti
 
     if transfertool == 'fts3':
         start_time = time.time()
-        fts_resps = FTS3Transfertool(external_host=request_host).bulk_query(transfer_ids=list(transfers_by_eid), timeout=timeout)
+        fts_resps = FTS3Transfertool(external_host=request_host, vo=vo).bulk_query(transfer_ids=list(transfers_by_eid), timeout=timeout)
         record_timer('core.request.bulk_query_transfers_fts3', (time.time() - start_time) * 1000 / len(transfers_by_eid))
 
         for external_id, transfers in transfers_by_eid.items():

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -121,7 +121,10 @@ class TemporaryRSEFactory:
 
     def _make_rse(self, scheme, protocol_impl, parameters=None, add_rse_kwargs=None):
         rse_name = rse_name_generator()
-        rse_id = rse_core.add_rse(rse_name, vo=self.vo, **(add_rse_kwargs or {}))
+        if add_rse_kwargs and 'vo' in add_rse_kwargs:
+            rse_id = rse_core.add_rse(rse_name, **add_rse_kwargs)
+        else:
+            rse_id = rse_core.add_rse(rse_name, vo=self.vo, **(add_rse_kwargs or {}))
         if scheme and protocol_impl:
             protocol_parameters = {
                 'scheme': scheme,

--- a/lib/rucio/transfertool/globus.py
+++ b/lib/rucio/transfertool/globus.py
@@ -67,8 +67,8 @@ class GlobusTransferTool(Transfertool):
         self.group_policy = group_policy
         # TODO: initialize vars from config file here
 
-    @staticmethod
-    def submission_builder_for_path(transfer_path, logger=logging.log):
+    @classmethod
+    def submission_builder_for_path(cls, transfer_path, logger=logging.log):
         if len(transfer_path) != 1:
             # Only accept single hop
             logger(logging.WARNING, "Globus cannot submit multi-hop transfers. Skipping {}".format([str(hop) for hop in transfer_path]))
@@ -81,7 +81,7 @@ class GlobusTransferTool(Transfertool):
             logger(logging.WARNING, "Source or destination globus_endpoint_id not set. Skipping {}".format(hop))
             return None
 
-        return TransferToolBuilder(GlobusTransferTool, external_host='Globus Online Transfertool')
+        return TransferToolBuilder(cls, external_host='Globus Online Transfertool')
 
     def group_into_submit_jobs(self, transfer_paths):
         jobs = bulk_group_transfers(transfer_paths, policy=self.group_policy, group_bulk=self.group_bulk)

--- a/lib/rucio/transfertool/mock.py
+++ b/lib/rucio/transfertool/mock.py
@@ -33,9 +33,9 @@ class MockTransfertool(Transfertool):
     def __init__(self, external_host, logger=logging.log):
         super(MockTransfertool, self).__init__(external_host, logger)
 
-    @staticmethod
-    def submission_builder_for_path(transfer_path, logger=logging.log):
-        return TransferToolBuilder(MockTransfertool, external_host='Mock Transfertool')
+    @classmethod
+    def submission_builder_for_path(cls, transfer_path, logger=logging.log):
+        return TransferToolBuilder(cls, external_host='Mock Transfertool')
 
     def group_into_submit_jobs(self, transfers):
         return [{'transfers': list(itertools.chain.from_iterable(transfers)), 'job_params': {}}]

--- a/lib/rucio/transfertool/transfertool.py
+++ b/lib/rucio/transfertool/transfertool.py
@@ -68,8 +68,8 @@ class Transfertool(object):
         return self.external_host
 
     @staticmethod
-    @abstractmethod
-    def submission_builder_for_path(transfer_path, logger=logging.log):
+    @classmethod
+    def submission_builder_for_path(cls, transfer_path, logger=logging.log):
         """
         Analyze the transfer path. If this transfertool class can submit the given transfers, return
         a TransferToolBuilder instance capable to build transfertool objects configured for this


### PR DESCRIPTION
To be able to add the test, I had to perform a couple of minor changes
in the functional code:
- support passing an empty "older_than" in poller. Otherwise,
utcnow() - timedelta(seconds=0) was filtering out the test request which
was just added to the database (only on oracle).
- make submission_builder_for_path a classmethod: to be able to subclass
from FTS3Transfertool while building correct object in child class.