### PR TITLE
Transfers: populate reason in cancelled hops. #3902

### DIFF
--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -66,6 +66,9 @@ FTS_STATE = namedtuple('FTS_STATE', ['SUBMITTED', 'READY', 'ACTIVE', 'FAILED', '
 
 FTS_COMPLETE_STATE = namedtuple('FTS_COMPLETE_STATE', ['OK', 'ERROR'])('Ok', 'Error')
 
+# https://gitlab.cern.ch/fts/fts3/-/blob/master/src/db/generic/Job.h#L41
+FTS_JOB_TYPE = namedtuple('FTS_JOB_TYPE', ['MULTIPLE_REPLICA', 'MULTI_HOP', 'SESSION_REUSE', 'REGULAR'])('R', 'H', 'Y', 'N')
+
 
 class ReplicaState(Enum):
     # From rucio.db.sqla.constants, update that file at the same time than this

--- a/lib/rucio/tests/test_conveyor.py
+++ b/lib/rucio/tests/test_conveyor.py
@@ -251,6 +251,7 @@ def test_fts_non_recoverable_failures_handled_on_multihop(vo, did_factory, root_
     submitter(once=True, rses=[{'id': rse_id} for rse_id in all_rses], group_bulk=2, partition_wait_time=None, transfertype='single', filter_transfertool=None)
 
     request = __wait_for_request_state(dst_rse_id=dst_rse_id, state=RequestState.FAILED, **did)
+    assert 'Cancelled hop in multi-hop' in request['err_msg']
     assert request['state'] == RequestState.FAILED
     request = request_core.get_request_by_did(rse_id=jump_rse_id, **did)
     assert request['state'] == RequestState.FAILED
@@ -478,6 +479,7 @@ def test_multihop_receiver_on_failure(vo, did_factory, replica_client, root_acco
         # TODO: set the run_poller argument to False if we ever manage to make the receiver correctly handle multi-hop failures.
         request = __wait_for_request_state(dst_rse_id=dst_rse_id, state=RequestState.FAILED, run_poller=True, **did)
         assert request['state'] == RequestState.FAILED
+        assert 'Cancelled hop in multi-hop' in request['err_msg']
 
         # First hop will be handled by receiver; second hop by poller
         assert metrics_mock.get_sample_value('rucio_daemons_conveyor_receiver_update_request_state_total', labels={'updated': 'True'}) >= 1

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -59,7 +59,7 @@ from dogpile.cache.api import NoValue
 from prometheus_client import Summary
 
 from rucio.common.config import config_get, config_get_bool
-from rucio.common.constants import FTS_STATE
+from rucio.common.constants import FTS_JOB_TYPE, FTS_STATE
 from rucio.common.exception import TransferToolTimeout, TransferToolWrongAnswer, DuplicateFileTransferSubmission
 from rucio.common.utils import APIEncoder, chunks, set_checksum_value
 from rucio.core.rse import get_rse_supported_checksums_from_attributes
@@ -965,10 +965,12 @@ class FTS3Transfertool(Transfertool):
 
         resps = {}
         multi_sources = fts_job_response['job_metadata'].get('multi_sources', False)
+        multi_hop = fts_job_response.get('job_type') == FTS_JOB_TYPE.MULTI_HOP
         for file_resp in fts_files_response:
+            file_state = file_resp['file_state']
             # for multiple source replicas jobs, the file_metadata(request_id) will be the same.
             # The next used file will overwrite the current used one. Only the last used file will return.
-            if multi_sources and file_resp['file_state'] == 'NOT_USED':
+            if multi_sources and file_state == FTS_STATE.NOT_USED:
                 continue
 
             if file_resp['start_time'] is None or file_resp['finish_time'] is None:
@@ -978,11 +980,14 @@ class FTS3Transfertool(Transfertool):
                             - datetime.datetime.strptime(file_resp['start_time'], '%Y-%m-%dT%H:%M:%S')).seconds  # NOQA: W503
 
             request_id = file_resp['file_metadata']['request_id']
+            reason = file_resp.get('reason', None)
+            if not reason and file_state == FTS_STATE.NOT_USED and multi_hop:
+                reason = 'Cancelled hop in multi-hop'
             resps[request_id] = {'new_state': None,
                                  'transfer_id': fts_job_response.get('job_id'),
                                  'job_state': fts_job_response.get('job_state', None),
                                  'priority': fts_job_response.get('priority', None),
-                                 'file_state': file_resp.get('file_state', None),
+                                 'file_state': file_state,
                                  'src_url': file_resp.get('source_surl', None),
                                  'dst_url': file_resp.get('dest_surl', None),
                                  'started_at': datetime.datetime.strptime(file_resp['start_time'], '%Y-%m-%dT%H:%M:%S') if file_resp['start_time'] else None,
@@ -990,7 +995,7 @@ class FTS3Transfertool(Transfertool):
                                  'staging_finished': datetime.datetime.strptime(file_resp['staging_finished'], '%Y-%m-%dT%H:%M:%S') if file_resp['staging_finished'] else None,
                                  'transferred_at': datetime.datetime.strptime(file_resp['finish_time'], '%Y-%m-%dT%H:%M:%S') if file_resp['finish_time'] else None,
                                  'duration': duration,
-                                 'reason': file_resp.get('reason', None),
+                                 'reason': reason,
                                  'scope': file_resp['file_metadata'].get('scope', None),
                                  'name': file_resp['file_metadata'].get('name', None),
                                  'src_type': file_resp['file_metadata'].get('src_type', None),
@@ -1011,7 +1016,7 @@ class FTS3Transfertool(Transfertool):
                                  'details': {'files': file_resp['file_metadata']}}
 
             # multiple source replicas jobs and we found the successful one, it's the final state.
-            if multi_sources and file_resp['file_state'] in [FTS_STATE.FINISHED]:
+            if multi_sources and file_state in [FTS_STATE.FINISHED]:
                 break
         return resps
 


### PR DESCRIPTION
For multi-hop transfers, populate the reason field in all cancelled
hops. This will make things more explicit in the monitoring dashboards,
but is only a quick compromise solution which doesn't solve the
whole underlying problem of multihop monitoring.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
