### PR TITLE
Core: allow `move_rule` to override all options Fix #4995

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -1443,10 +1443,16 @@ def move_rule(args):
     Update a rule.
     """
     client = get_client(args)
+
+    override = {}
+    if args.activity:
+        override['activity'] = args.activity
+    if args.source_replica_expression:
+        override['source_replica_expression'] = None if args.source_replica_expression.lower() == "none" else args.source_replica_expression
+
     print(client.move_replication_rule(rule_id=args.rule_id,
                                        rse_expression=args.rse_expression,
-                                       activity=args.activity,
-                                       source_replica_expression=args.source_replica_expression))
+                                       override=override))
     return SUCCESS
 
 
@@ -2524,8 +2530,8 @@ You can filter by account::
     move_rule_parser.set_defaults(function=move_rule)
     move_rule_parser.add_argument(dest='rule_id', action='store', help='Rule id')
     move_rule_parser.add_argument(dest='rse_expression', action='store', help='RSE expression of new rule')
-    move_rule_parser.add_argument('--activity', dest='activity', action='store', help='Update activity for moved rule')
-    move_rule_parser.add_argument('--source-replica-expression', dest='source_replica_expression', action='store', help='Update source-replica-expression for moved rule')
+    move_rule_parser.add_argument('--activity', dest='activity', action='store', help='Update activity for moved rule.')
+    move_rule_parser.add_argument('--source-replica-expression', dest='source_replica_expression', action='store', help='Update source-replica-expression for moved rule. Use "None" to remove the old value.')
 
     # The list-rses command
     list_rses_parser = subparsers.add_parser('list-rses', help='Show the list of all the registered Rucio Storage Elements (RSEs).')

--- a/lib/rucio/api/rule.py
+++ b/lib/rucio/api/rule.py
@@ -317,14 +317,13 @@ def examine_replication_rule(rule_id, issuer, vo='def', session=None):
 
 
 @transactional_session
-def move_replication_rule(rule_id, rse_expression, activity, source_replica_expression, issuer, vo='def', session=None):
+def move_replication_rule(rule_id, rse_expression, override, issuer, vo='def', session=None):
     """
     Move a replication rule to another RSE and, once done, delete the original one.
 
     :param rule_id:                    Rule to be moved.
     :param rse_expression:             RSE expression of the new rule.
-    :param activity:                   Activity of the new rule.
-    :param source_replica_expression:  Source-Replica-Expression of the new rule.
+    :param override:                   Configurations to update for the new rule.
     :param session:                    The DB Session.
     :param vo:                         The VO to act on.
     :raises:                           RuleNotFound, RuleReplaceFailed, InvalidRSEExpression, AccessDenied
@@ -332,16 +331,12 @@ def move_replication_rule(rule_id, rse_expression, activity, source_replica_expr
     kwargs = {
         'rule_id': rule_id,
         'rse_expression': rse_expression,
-        'activity': activity,
-        'source_replica_expression': source_replica_expression
+        'override': override,
     }
+
     if is_multi_vo(session=session) and not has_permission(issuer=issuer, vo=vo, action='access_rule_vo', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not access rules at other VOs.' % (issuer))
     if not has_permission(issuer=issuer, vo=vo, action='move_rule', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not move this replication rule.' % (issuer))
 
-    return rule.move_rule(rule_id=rule_id,
-                          rse_expression=rse_expression,
-                          activity=activity,
-                          source_replica_expression=source_replica_expression,
-                          session=session)
+    return rule.move_rule(**kwargs, session=session)

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -157,14 +157,13 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def move_replication_rule(self, rule_id, rse_expression, activity, source_replica_expression):
+    def move_replication_rule(self, rule_id, rse_expression, override):
         """
         Move a replication rule to another RSE and, once done, delete the original one.
 
         :param rule_id:                    Rule to be moved.
         :param rse_expression:             RSE expression of the new rule.
-        :param activity:                   Activity of the new rule.
-        :param source_replica_expression:  Source-Replica-Expression of the new rule.
+        :param override:                   Configurations to update for the new rule.
         :raises:                           RuleNotFound, RuleReplaceFailed
         """
 
@@ -173,8 +172,7 @@ class RuleClient(BaseClient):
         data = dumps({
             'rule_id': rule_id,
             'rse_expression': rse_expression,
-            'activity': activity,
-            'source_replica_expression': source_replica_expression
+            'override': override,
         })
         r = self._send_request(url, type_='POST', data=data)
         if r.status_code == codes.created:

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -18,6 +18,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021-2022
+# - Martin Barisits <martin.barisits@cern.ch>, 2022
 
 from json import dumps
 
@@ -571,13 +572,20 @@ class MoveRule(ErrorHandlingMethodView):
         parameters = json_parameters()
         rse_expression = param_get(parameters, 'rse_expression')
         rule_id = param_get(parameters, 'rule_id', default=rule_id)
+        override = param_get(parameters, 'override', default={})
+
+        # For backwards-compatibility, deprecate in the future.
         activity = param_get(parameters, 'activity', default=None)
+        if activity and 'activity' not in override:
+            override['activity'] = activity
         source_replica_expression = param_get(parameters, 'source_replica_expression', default=None)
+        if source_replica_expression and 'source_replica_expression' not in override:
+            override['source_replica_expression'] = source_replica_expression
+
         try:
             rule_ids = move_replication_rule(rule_id=rule_id,
                                              rse_expression=rse_expression,
-                                             activity=activity,
-                                             source_replica_expression=source_replica_expression,
+                                             override=override,
                                              issuer=request.environ.get('issuer'),
                                              vo=request.environ.get('vo'))
         except RuleReplaceFailed as error:


### PR DESCRIPTION
Before the commit `move_rule` could only override two attributes of the new
rule. After the commit `move_rule` can override every field of the new rule with
the argument `override`.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
