### PR TITLE
adding permissions and endpoint

### DIFF
--- a/lib/rucio/api/heartbeat.py
+++ b/lib/rucio/api/heartbeat.py
@@ -42,7 +42,6 @@ def create_heartbeat(executable, hostname, pid, thread, older_than, payload, iss
     :param pid: UNIX Process ID as a number, e.g., 1234.
     :param thread: Python Thread Object.
     :param older_than: Ignore specified heartbeats older than specified nr of seconds.
-    :param hash_executable: Hash of the executable.
     :param payload: Payload identifier which can be further used to identify the work a certain thread is executing.
 
     """

--- a/lib/rucio/api/heartbeat.py
+++ b/lib/rucio/api/heartbeat.py
@@ -8,6 +8,7 @@
 # Authors:
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2015
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Ilija Vukotic <ivukotic@uchicago.edu>, 2021
 #
 # PY3K COMPATIBLE
 
@@ -29,3 +30,23 @@ def list_heartbeats(issuer=None, vo='def'):
     if not permission.has_permission(issuer=issuer, vo=vo, action='list_heartbeats', kwargs=kwargs):
         raise exception.AccessDenied('%s cannot list heartbeats' % issuer)
     return heartbeat.list_heartbeats()
+
+
+def create_heartbeat(executable, hostname, pid, thread, older_than, payload, issuer=None, vo='def'):
+    """
+    Creates a heartbeat.
+    :param issuer: The issuer account.
+    :param vo: the VO for the issuer.
+    :param executable: Executable name as a string, e.g., conveyor-submitter.
+    :param hostname: Hostname as a string, e.g., rucio-daemon-prod-01.cern.ch.
+    :param pid: UNIX Process ID as a number, e.g., 1234.
+    :param thread: Python Thread Object.
+    :param older_than: Ignore specified heartbeats older than specified nr of seconds.
+    :param hash_executable: Hash of the executable.
+    :param payload: Payload identifier which can be further used to identify the work a certain thread is executing.
+
+    """
+    kwargs = {'issuer': issuer}
+    if not permission.has_permission(issuer=issuer, vo=vo, action='send_heartbeats', kwargs=kwargs):
+        raise exception.AccessDenied('%s cannot send heartbeats' % issuer)
+    heartbeat.live(executable=executable, hostname=hostname, pid=pid, thread=thread, older_than=older_than, payload=payload)

--- a/lib/rucio/core/permission/atlas.py
+++ b/lib/rucio/core/permission/atlas.py
@@ -28,6 +28,7 @@
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
+# - Ilija Vukotic <ivukotic@uchicago.edu>, 2021
 
 from typing import TYPE_CHECKING
 
@@ -121,6 +122,7 @@ def has_permission(issuer, action, kwargs):
             'add_attribute': perm_add_account_attribute,
             'del_attribute': perm_del_account_attribute,
             'list_heartbeats': perm_list_heartbeats,
+            'send_heartbeats': perm_send_heartbeats,
             'resurrect': perm_resurrect,
             'update_lifetime_exceptions': perm_update_lifetime_exceptions,
             'get_ssh_challenge_token': perm_get_ssh_challenge_token,
@@ -1103,6 +1105,17 @@ def perm_list_heartbeats(issuer, kwargs):
     :returns: True if account is allowed to call the API call, otherwise False
     """
     return _is_root(issuer)
+
+
+def perm_send_heartbeats(issuer, kwargs):
+    """
+    Checks if an account can send heartbeats.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :returns: True if account is allowed to call the API call, otherwise False
+    """
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin')
 
 
 def perm_resurrect(issuer, kwargs):

--- a/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
+++ b/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
@@ -20,15 +20,17 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Ilija Vukotic <ivukotic@uchicago.edu>, 2021
 
 import json
 
 from flask import Flask, Blueprint, Response, request
 
-from rucio.api.heartbeat import list_heartbeats
+from rucio.api.heartbeat import list_heartbeats, create_heartbeat
 from rucio.common.utils import APIEncoder
+from rucio.common.exception import UnsupportedValueType, UnsupportedKeyType, KeyNotFound
 from rucio.web.rest.flaskapi.v1.common import request_auth_env, response_headers, check_accept_header_wrapper_flask, \
-    ErrorHandlingMethodView
+    ErrorHandlingMethodView, json_parameters, param_get, generate_http_error_flask
 
 
 class Heartbeat(ErrorHandlingMethodView):
@@ -49,12 +51,41 @@ class Heartbeat(ErrorHandlingMethodView):
         """
         return Response(json.dumps(list_heartbeats(issuer=request.environ.get('issuer'), vo=request.environ.get('vo')), cls=APIEncoder), content_type='application/json')
 
+    def post(self):
+        """
+        Accepts a heartbeat.
+
+        .. :quickref: Heartbeat; Accepts a heartbeat.
+
+
+        :<json dict parameter: Dictionary with 'executable', 'hostname', 'pid', 'thread', 'older_than', 'payload'
+        :status 201: Created.
+        :status 400: Cannot decode json parameter list.
+        :status 401: Invalid Auth Token.
+        """
+        parameters = json_parameters()
+        try:
+            create_heartbeat(
+                executable=param_get(parameters, 'executable'),
+                hostname=param_get(parameters, 'hostname'),
+                pid=param_get(parameters, 'pid'),
+                thread=param_get(parameters, 'thread'),
+                older_than=param_get(parameters, 'older_than', default=None),
+                payload=param_get(parameters, 'payload', default=None),
+                issuer=request.environ.get('issuer'),
+                vo=request.environ.get('vo'),
+            )
+        except (UnsupportedValueType, UnsupportedKeyType) as error:
+            return generate_http_error_flask(400, error)
+        except KeyNotFound as error:
+            return generate_http_error_flask(404, error)
+
 
 def blueprint():
     bp = Blueprint('heartbeats', __name__, url_prefix='/heartbeats')
 
     heartbeat_view = Heartbeat.as_view('heartbeat')
-    bp.add_url_rule('', view_func=heartbeat_view, methods=['get', ])
+    bp.add_url_rule('', view_func=heartbeat_view, methods=['get', 'post'])
 
     bp.before_request(request_auth_env)
     bp.after_request(response_headers)

--- a/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
+++ b/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
@@ -28,7 +28,7 @@ from flask import Flask, Blueprint, Response, request
 
 from rucio.api.heartbeat import list_heartbeats, create_heartbeat
 from rucio.common.utils import APIEncoder
-from rucio.common.exception import UnsupportedValueType, UnsupportedKeyType, KeyNotFound
+from rucio.common.exception import UnsupportedValueType, UnsupportedKeyType, KeyNotFound, AccessDenied
 from rucio.web.rest.flaskapi.v1.common import request_auth_env, response_headers, check_accept_header_wrapper_flask, \
     ErrorHandlingMethodView, json_parameters, param_get, generate_http_error_flask
 
@@ -59,9 +59,10 @@ class Heartbeat(ErrorHandlingMethodView):
 
 
         :<json dict parameter: Dictionary with 'executable', 'hostname', 'pid', 'thread', 'older_than', 'payload'
-        :status 201: Created.
+        :status 200: OK.
         :status 400: Cannot decode json parameter list.
         :status 401: Invalid Auth Token.
+        :status 404: Key not Found.
         """
         parameters = json_parameters()
         try:
@@ -77,6 +78,8 @@ class Heartbeat(ErrorHandlingMethodView):
             )
         except (UnsupportedValueType, UnsupportedKeyType) as error:
             return generate_http_error_flask(400, error)
+        except AccessDenied as error:
+            return generate_http_error_flask(401, error)
         except KeyNotFound as error:
             return generate_http_error_flask(404, error)
 


### PR DESCRIPTION
adding an endpoint to send heartbeats to. This is  one of several PRs that will integrate Virtual Placement in Rucio. For the Rucio to know what XCache instances are running, it has to have an endpoint to which XCaches will send heartbeats. Heartbeats will contain small json documents with XCache name, address, size, etc.