### PR TITLE
Common: Fix did construction error Fix #5037

### DIFF
--- a/lib/rucio/common/test_rucio_server.py
+++ b/lib/rucio/common/test_rucio_server.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2021 CERN
+# Copyright 2021 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,16 +14,16 @@
 # limitations under the License.
 #
 # Authors:
-# - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2014-2018
-# - Cedric Serfon <cedric.serfon@cern.ch>, 2015
-# - Martin Barisits <martin.barisits@cern.ch>, 2019
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
-# - Mayank Sharma <mayank.sharma@cern.ch>, 2021
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
+# - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from __future__ import print_function
 
 import unittest
 from os import remove
+from os.path import basename
+
 
 from rucio.common.utils import generate_uuid as uuid, execute
 
@@ -56,7 +56,7 @@ def get_scope_and_rses():
 def delete_rules(did):
     # get the rules for the file
     print('Deleting rules')
-    cmd = "rucio list-rules --did {0} | grep {0} | cut -f1 -d\\ ".format(did)
+    cmd = "rucio list-rules {0} | grep {0} | cut -f1 -d\\ ".format(did)
     print(cmd)
     exitcode, out, err = execute(cmd)
     print(out, err)
@@ -79,7 +79,7 @@ class TestRucioServer(unittest.TestCase):
     def tearDown(self):
         for did in self.generated_dids:
             delete_rules(did)
-            self.generated_dids.remove(did)
+        self.generated_dids = []
 
     def test_ping(self):
         """CLIENT (USER): rucio ping"""
@@ -145,8 +145,8 @@ class TestRucioServer(unittest.TestCase):
         self.assertEqual(exitcode, 0)
 
         # cleaning
-        remove('/tmp/{0}/'.format(tmp_dsn) + tmp_file1[5:])
-        remove('/tmp/{0}/'.format(tmp_dsn) + tmp_file2[5:])
-        remove('/tmp/{0}/'.format(tmp_dsn) + tmp_file3[5:])
-        added_dids = ['{0}:{1}'.format(self.scope, did) for did in (tmp_file1, tmp_file2, tmp_file3, tmp_dsn)]
+        remove('/tmp/{0}/'.format(tmp_dsn) + basename(tmp_file1))
+        remove('/tmp/{0}/'.format(tmp_dsn) + basename(tmp_file2))
+        remove('/tmp/{0}/'.format(tmp_dsn) + basename(tmp_file3))
+        added_dids = ['{0}:{1}'.format(self.scope, did) for did in (basename(tmp_file1), basename(tmp_file2), basename(tmp_file3), tmp_dsn)]
         self.generated_dids += added_dids


### PR DESCRIPTION
The construction of the dids to delete used the filepath of the file on the
client. This should be just the filename, since the did is only constructed with
the filename.

Plus some small refactors.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
