### PR TITLE
PolicyPackageNotFound: Module rucio.common.permission.generic_multi_v…

### DIFF
--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -85,7 +85,7 @@ def load_permission_for_vo(vo):
                 POLICY = GENERIC_FALLBACK
             POLICY = 'rucio.core.permission.' + POLICY.lower()
     else:
-        POLICY = 'rucio.common.permission.' + GENERIC_FALLBACK.lower()
+        POLICY = 'rucio.core.permission.' + GENERIC_FALLBACK.lower()
 
     try:
         module = importlib.import_module(POLICY)


### PR DESCRIPTION
Fixes #4579
Fix from rucio.common to actual rucio.core to ensure generic_fallback is available when needed


