### PR TITLE
Common: `is_client` should return `True` if no configuration file is found Fix #5041

### DIFF
--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1564,12 +1564,16 @@ def is_client():
     :returns client_mode: True if is called from a client, False if it is called from a server/daemon
     """
     if 'RUCIO_CLIENT_MODE' not in os.environ:
-        if config_has_section('database'):
-            client_mode = False
-        elif config_has_section('client'):
+        try:
+            if config_has_section('database'):
+                client_mode = False
+            elif config_has_section('client'):
+                client_mode = True
+            else:
+                client_mode = False
+        except RuntimeError:
+            # If no configuration file is found the default value should be True
             client_mode = True
-        else:
-            client_mode = False
     else:
         if os.environ['RUCIO_CLIENT_MODE']:
             client_mode = True


### PR DESCRIPTION
`config_has_section` raises an exception if no configuration file is
found. `is_client` just forwards this exception, which breaks some runs on
DIRACs site.

The default behavior in this case should be that `is_client` returns `True` if
no configuration file is found.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
