### PR TITLE
Transfers: more compact logging in submitter. Closes #5053

### DIFF
--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1272,6 +1272,8 @@ def __build_transfer_paths(
         logger(logging.INFO, 'Found following sources for %s: %s', rws, [str(src.rse) for src in rws.sources])
         # Assume request doesn't have any sources. Will be removed later if sources are found.
         reqs_no_source.add(rws.request_id)
+        if not rws.sources:
+            continue
 
         # Check if destination is blocked
         if not ignore_availability and rws.dest_rse.id in unavailable_write_rse_ids:


### PR DESCRIPTION
Transfers: more compact logging in submitter. Closes #5053

Emphasis on only logging exceptional events: skipping request,
skipping sources, etc. Ensure that the request_id is always
logged in these messages, to make it appear in search.

Also, make more compact messages and remove rse.id from logs
(only print name).

Only print request_id in most messages. Print scope:name once at the
beginning to be able to find request_id by scope:name in kibana.