### PR TITLE
Replicas: Fix `expires_at` is None error Fix #5066

### DIFF
--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -402,7 +402,7 @@ def add_bad_pfns(pfns, issuer, state, reason=None, expires_at=None, vo='def'):
     if not permission.has_permission(issuer=issuer, vo=vo, action='add_bad_pfns', kwargs=kwargs):
         raise exception.AccessDenied('Account %s can not declare bad PFNs' % (issuer))
 
-    if datetime.datetime.utcnow() <= expires_at and expires_at > datetime.datetime.utcnow() + datetime.timedelta(days=30):
+    if expires_at and datetime.datetime.utcnow() <= expires_at and expires_at > datetime.datetime.utcnow() + datetime.timedelta(days=30):
         raise exception.InputValidationError('The given duration of %s days exceeds the maximum duration of 30 days.' % (expires_at - datetime.datetime.utcnow()).days)
 
     issuer = InternalAccount(issuer, vo=vo)


### PR DESCRIPTION
The duration bound introduced in #4962 checks if the value of `expires_at` is in
a specific timerange. While `expires_at` is always set for calls from
`declare_temporary_unavailable_replicas`, calls from `declare_bad_file_replicas`
don't set this value. This is the desired behaivior, since they should be set
`BAD` indefinitely. However not setting `expires_at` throws an error.

This commit only checks the duration bound on `expires_at` if the argument is
set. If it is not set, the program executes as desired without throwing any
errors.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
