### PR TITLE
Replicas: Verify the value of `expires_at` Fix #5071

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -3116,6 +3116,11 @@ def add_bad_pfns(pfns, account, state, reason=None, expires_at=None, session=Non
     else:
         rep_state = state
 
+    if rep_state == BadPFNStatus.TEMPORARY_UNAVAILABLE and expires_at is None:
+        raise exception.InputValidationError("When adding a TEMPORARY UNAVAILABLE pfn the expires_at value should be set.")
+    elif rep_state == BadPFNStatus.BAD and expires_at is not None:
+        raise exception.InputValidationError("When adding a BAD pfn the expires_at value shouldn't be set.")
+
     pfns = clean_surls(pfns)
     for pfn in pfns:
         new_pfn = models.BadPFNs(path=str(pfn), account=account, state=rep_state, reason=reason, expires_at=expires_at)


### PR DESCRIPTION
When a replica is declared as `TEMPORARY UNAVAILABLE`, a value should be
provided in `expires_at`. When it is declared as `BAD`, the argument should not
be populated (`None`). While the CLI complies to these constraints, the user
could provide wrong arguments in the API/Python client.

This commit throws an exception if these constraints are not met.

Needs to be applied after #5070 since the `expires_at` error needs to be resolved.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
