### PR TITLE
Transfers: set reason for canceled hops in multi-hop. Closes #5086

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -510,26 +510,6 @@ def set_request_state(request_id, new_state, transfer_id=None, transferred_at=No
 
 
 @transactional_session
-def set_requests_state(request_ids, new_state, session=None, logger=logging.log):
-    """
-    Bulk update the state of requests.
-
-    :param request_ids:  List of (Request-ID as a 32 character hex string).
-    :param new_state:    New state as string.
-    :param session:      Database session to use.
-    :param logger:       Optional decorated logger that can be passed from the calling daemons or servers.
-    """
-
-    record_counter('core.request.set_requests_state')
-
-    try:
-        for request_id in request_ids:
-            set_request_state(request_id, new_state, session=session, logger=logger)
-    except IntegrityError as error:
-        raise RucioException(error.args)
-
-
-@transactional_session
 def set_requests_state_if_possible(request_ids, new_state, session=None, logger=logging.log):
     """
     Bulk update the state of requests. Skips silently if the request_id does not exist.

--- a/lib/rucio/tests/test_conveyor.py
+++ b/lib/rucio/tests/test_conveyor.py
@@ -253,7 +253,7 @@ def test_fts_non_recoverable_failures_handled_on_multihop(vo, did_factory, root_
     submitter(once=True, rses=[{'id': rse_id} for rse_id in all_rses], group_bulk=2, partition_wait_time=None, transfertype='single', filter_transfertool=None)
 
     request = __wait_for_request_state(dst_rse_id=dst_rse_id, state=RequestState.FAILED, **did)
-    assert 'Cancelled hop in multi-hop' in request['err_msg']
+    assert 'Unused hop in multi-hop' in request['err_msg']
     assert request['state'] == RequestState.FAILED
     request = request_core.get_request_by_did(rse_id=jump_rse_id, **did)
     assert request['state'] == RequestState.FAILED
@@ -481,7 +481,7 @@ def test_multihop_receiver_on_failure(vo, did_factory, replica_client, root_acco
         # TODO: set the run_poller argument to False if we ever manage to make the receiver correctly handle multi-hop failures.
         request = __wait_for_request_state(dst_rse_id=dst_rse_id, state=RequestState.FAILED, run_poller=True, **did)
         assert request['state'] == RequestState.FAILED
-        assert 'Cancelled hop in multi-hop' in request['err_msg']
+        assert 'Unused hop in multi-hop' in request['err_msg']
 
         # First hop will be handled by receiver; second hop by poller
         assert metrics_mock.get_sample_value('rucio_daemons_conveyor_receiver_update_request_state_total', labels={'updated': 'True'}) >= 1

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -989,7 +989,7 @@ class FTS3Transfertool(Transfertool):
             request_id = file_resp['file_metadata']['request_id']
             reason = file_resp.get('reason', None)
             if not reason and file_state == FTS_STATE.NOT_USED and multi_hop:
-                reason = 'Cancelled hop in multi-hop'
+                reason = 'Unused hop in multi-hop'
             resps[request_id] = {'new_state': None,
                                  'transfer_id': fts_job_response.get('job_id'),
                                  'job_state': fts_job_response.get('job_state', None),


### PR DESCRIPTION
Change the reason for unused hops.
Also remove the set_requests_state (plural) function. It is not used
anymore.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
