### PR TITLE
Clients: Add `expiration-date` for upload Fix #5069

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -53,6 +53,7 @@
 # - KosKyr <90753277+KosKyr@users.noreply.github.com>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 # - jdierkes <joel.dierkes@cern.ch>, 2021
+# - Igor Mandrichenko <ivm@fnal.gov>, 2021
 # - Rob Barnsley <robbarnsley@users.noreply.github.com>, 2021
 
 from __future__ import print_function
@@ -71,6 +72,7 @@ import time
 import traceback
 import unittest
 import uuid
+from datetime import datetime
 from functools import wraps
 
 from six.moves.configparser import NoOptionError, NoSectionError
@@ -1004,6 +1006,15 @@ def upload(args):
 
     Upload files into Rucio
     """
+    if args.lifetime and args.expiration_date:
+        logger.error("--lifetime and --expiration-date cannot be specified at the same time.")
+        return FAILURE
+    elif args.expiration_date:
+        expiration_date = datetime.strptime(args.expiration_date, "%Y-%m-%d-%H:%M:%S")
+        if expiration_date < datetime.utcnow():
+            logger.error("The specified expiration date should be in the future!")
+            return FAILURE
+        args.lifetime = (expiration_date - datetime.utcnow()).total_seconds()
 
     dsscope = None
     dsname = None
@@ -2284,6 +2295,7 @@ You can filter by key/value, e.g.::
     upload_parser.set_defaults(function=upload)
     upload_parser.add_argument('--rse', dest='rse', action='store', help='Rucio Storage Element (RSE) name.', required=True).completer = rse_completer
     upload_parser.add_argument('--lifetime', type=int, action='store', help='Lifetime of the rule in seconds.')
+    upload_parser.add_argument('--expiration-date', action='store', help='The date when the rule expires in UTC, format: <year>-<month>-<day>-<hour>:<minute>:<second>. E.g. 2022-10-20-20:00:00')
     upload_parser.add_argument('--scope', dest='scope', action='store', help='Scope name.')
     upload_parser.add_argument('--impl', dest='impl', action='store', help='Transfer protocol implementation to use (e.g: xrootd, gfal.NoRename, webdav, ssh.Rsync, rclone).')
     # The --no-register option is hidden. This is pilot ONLY. Users should not use this. Will lead to unregistered data on storage!

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -569,6 +569,43 @@ class TestBinRucio(unittest.TestCase):
         assert meta['md5'] == file_md5
         remove(filename)
 
+    def test_upload_expiration_date(self):
+        """CLIENT(USER): Rucio upload files"""
+        tmp_file = file_generator()
+        cmd = 'rucio -v upload --rse {0} --scope {1} --expiration-date 2021-10-10-20:00:00 --lifetime 20000  {2}'.format(self.def_rse, self.user, tmp_file)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out)
+        print(err)
+        assert exitcode != 0
+        assert "--lifetime and --expiration-date cannot be specified at the same time." in err
+
+        cmd = 'rucio -v upload --rse {0} --scope {1} --expiration-date 2021----10-10-20:00:00 {2}'.format(self.def_rse, self.user, tmp_file)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out)
+        print(err)
+        assert exitcode != 0
+        assert "does not match format '%Y-%m-%d-%H:%M:%S'" in err
+
+        cmd = 'rucio -v upload --rse {0} --scope {1} --expiration-date 2021-10-10-20:00:00 {2}'.format(self.def_rse, self.user, tmp_file)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out)
+        print(err)
+        assert exitcode != 0
+        assert "The specified expiration date should be in the future!" in err
+
+        cmd = 'rucio -v upload --rse {0} --scope {1} --expiration-date 2030-10-10-20:00:00 {2}'.format(self.def_rse, self.user, tmp_file)
+        print(self.marker + cmd)
+        exitcode, out, err = execute(cmd)
+        print(out)
+        print(err)
+        assert exitcode == 0
+        remove(tmp_file)
+        upload_string = (self.upload_success_str % path.basename(tmp_file))
+        assert upload_string in out or upload_string in err
+
     def test_create_dataset(self):
         """CLIENT(USER): Rucio add dataset"""
         tmp_name = self.user + ':DSet' + rse_name_generator()  # something like mock:DSetMOCK_S0M37HING


### PR DESCRIPTION
The upload command takes the `--lifetime` argument, which specifies the lifetime
of the created rule in seconds. This commit also adds the `--expiraion-date`,
which specifies the timestamp on which the rule will be obsolet. They both can't
be used the same time and `--expiration-date` has to have a fixed format to
avoid ambiguousity.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
