### PR TITLE
Tools: Add `--disable-add-me` argument to `add_header` script

### DIFF
--- a/tools/add_header
+++ b/tools/add_header
@@ -136,7 +136,7 @@ def main(arguments):
             if authors[author]['name'] == username:
                 authors[author]['max'] = now.year
 
-        if username not in authors:
+        if not arguments.disable_add_me and username not in authors:
             authors[username] = {'name': username,
                                  'mail': email,
                                  'max': max_,
@@ -258,6 +258,8 @@ if __name__ == '__main__':
     parser.add_argument('--dry-run', '-d', action='store_true', help='Dry run mode')
     parser.add_argument('--check', '-c', action='store_true',
                         help='Checks if the script would change anything (non-zero exit code equals change).')
+    parser.add_argument('--disable-add-me', action='store_true',
+                        help="Do not add the person who runs this command, except if there already is a contributing commit.")
     parser.add_argument(dest='MyFiles', action='store', nargs='+', default=None, help='The files')
 
     main(parser.parse_args())


### PR DESCRIPTION
The `add_header` script automatically adds the author who runns the script to
the list of authors. While this is the desired behaviour for the developer, we
don't want this to happen if we check the integrity of a header in a file.

The `--disable-add-me` argument does not add the author who runns the script to
the list of authors, except if the author has already committed changes to the
file in the history.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
