### PR TITLE
common.utils: modularise hash algorithms #5079

### DIFF
--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -59,7 +59,7 @@ from rucio.common.didtype import DIDType
 from rucio.common.pcache import Pcache
 from rucio.common.utils import adler32, detect_client_location, generate_uuid, parse_replicas_from_string, \
     send_trace, sizefmt, execute, parse_replicas_from_file, extract_scope
-from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS, CHECKSUM_ALGO_DICT, PREFERRED_CHECKSUM
+from rucio.common.hash_algorithms import CHECKSUM_ALGO_DICT, GLOBALLY_SUPPORTED_CHECKSUMS, PREFERRED_CHECKSUM
 from rucio.rse import rsemanager as rsemgr
 from rucio import version
 

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -59,8 +59,9 @@ from rucio.common.exception import (RucioException, RSEWriteBlocked, DataIdentif
                                     DataIdentifierNotFound, NoFilesUploaded, NotAllFilesUploaded, FileReplicaAlreadyExists,
                                     ResourceTemporaryUnavailable, ServiceUnavailable, InputValidationError, RSEChecksumUnavailable,
                                     ScopeNotFound)
+from rucio.common.hash_algorithms import GLOBALLY_SUPPORTED_CHECKSUMS
 from rucio.common.utils import (adler32, detect_client_location, execute, generate_uuid, make_valid_did, md5, send_trace,
-                                retry, GLOBALLY_SUPPORTED_CHECKSUMS)
+                                retry)
 from rucio.rse import rsemanager as rsemgr
 from rucio import version
 

--- a/lib/rucio/common/hash_algorithms/__init__.py
+++ b/lib/rucio/common/hash_algorithms/__init__.py
@@ -1,0 +1,27 @@
+from abc import ABC, abstractmethod
+from importlib import import_module
+from pathlib import Path
+from pkgutil import iter_modules
+
+
+class RucioHashAlgorithm(ABC):
+    @staticmethod
+    @abstractmethod
+    def compute_on_file(file):
+        raise NotImplementedError("Abstract method called")
+
+
+package_dir = Path(__file__).resolve().parent
+for (_, module_name, _) in iter_modules([package_dir]):
+    module = import_module("%s.%s" % (__name__, module_name))
+    for attribute_name in dir(module):
+        attribute = getattr(module, attribute_name)
+
+        try:
+            if issubclass(attribute, RucioHashAlgorithm):
+                algorithm_name = attribute_name.lower()
+                # TODO: check uniqueness of algorithm names
+                globals()[algorithm_name] = attribute
+        except TypeError:
+            # We are only interested in classes here
+            pass

--- a/lib/rucio/common/hash_algorithms/__init__.py
+++ b/lib/rucio/common/hash_algorithms/__init__.py
@@ -11,6 +11,35 @@ class RucioHashAlgorithm(ABC):
         raise NotImplementedError("Abstract method called")
 
 
+GLOBALLY_SUPPORTED_CHECKSUMS = ["adler32", "md5"]
+PREFERRED_CHECKSUM = GLOBALLY_SUPPORTED_CHECKSUMS[0]
+CHECKSUM_ALGO_DICT = {}
+
+
+def is_checksum_valid(checksum_name):
+    """
+    A simple function to check wether a checksum algorithm is supported.
+    Relies on GLOBALLY_SUPPORTED_CHECKSUMS to allow for expandability.
+
+    :param checksum_name: The name of the checksum to be verified.
+    :returns: True if checksum_name is in GLOBALLY_SUPPORTED_CHECKSUMS list, False otherwise.
+    """
+
+    return checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS
+
+
+def set_preferred_checksum(checksum_name):
+    """
+    A simple function to set the preferred checksum algorithm.
+    Unsupported algorithms are quietly ignored.
+
+    :param checksum_name: The name of the checksum algorithm to be made preferred.
+    """
+    if is_checksum_valid(checksum_name):
+        global PREFERRED_CHECKSUM
+        PREFERRED_CHECKSUM = checksum_name
+
+
 package_dir = Path(__file__).resolve().parent
 for (_, module_name, _) in iter_modules([package_dir]):
     module = import_module("%s.%s" % (__name__, module_name))
@@ -20,8 +49,10 @@ for (_, module_name, _) in iter_modules([package_dir]):
         try:
             if issubclass(attribute, RucioHashAlgorithm):
                 algorithm_name = attribute_name.lower()
+
                 # TODO: check uniqueness of algorithm names
                 globals()[algorithm_name] = attribute
+                CHECKSUM_ALGO_DICT[algorithm_name] = attribute.compute_on_file
         except TypeError:
             # We are only interested in classes here
             pass

--- a/lib/rucio/common/hash_algorithms/default.py
+++ b/lib/rucio/common/hash_algorithms/default.py
@@ -1,0 +1,112 @@
+import hashlib
+import io
+import mmap
+import zlib
+
+from functools import partial
+
+from . import RucioHashAlgorithm
+
+
+class Adler32(RucioHashAlgorithm):
+    @staticmethod
+    def compute_on_file(file):
+        """
+        An Adler-32 checksum is obtained by calculating two 16-bit checksums A and B
+        and concatenating their bits into a 32-bit integer. A is the sum of all bytes in the
+        stream plus one, and B is the sum of the individual values of A from each step.
+
+        :param file: file name
+        :returns: Hexified string, padded to 8 values.
+        :raises: Exception: if checksum calculation failed
+        """
+
+        # adler starting value is _not_ 0
+        adler = 1
+
+        can_mmap = False
+        try:
+            with open(file, "r+b") as f:
+                can_mmap = True
+        except:
+            pass
+
+        try:
+            # use mmap if possible
+            if can_mmap:
+                with open(file, "r+b") as f:
+                    m = mmap.mmap(f.fileno(), 0)
+                    # partial block reads at slightly increased buffer sizes
+                    for block in iter(partial(m.read, io.DEFAULT_BUFFER_SIZE * 8), b""):
+                        adler = zlib.adler32(block, adler)
+            else:
+                with open(file, "rb") as f:
+                    # partial block reads at slightly increased buffer sizes
+                    for block in iter(partial(f.read, io.DEFAULT_BUFFER_SIZE * 8), b""):
+                        adler = zlib.adler32(block, adler)
+
+        except Exception as e:
+            raise Exception(
+                "FATAL - could not get Adler-32 checksum of file %s: %s" % (file, e)
+            )
+
+        # backflip on 32bit -- can be removed once everything is fully migrated to 64bit
+        if adler < 0:
+            adler = adler + 2 ** 32
+
+        return str("%08x" % adler)
+
+
+class CRC32(RucioHashAlgorithm):
+    @staticmethod
+    def compute_on_file(file):
+        """
+        Runs the CRC32 algorithm on the binary content of the file named file
+        and returns the hexadecimal digest
+
+        :param file: file name
+        :returns: string of 32 hexadecimal digits
+        """
+        prev = 0
+        for eachLine in open(file, "rb"):
+            prev = zlib.crc32(eachLine, prev)
+        return "%x" % (prev & 0xFFFFFFFF)
+
+
+class MD5(RucioHashAlgorithm):
+    @staticmethod
+    def compute_on_file(file):
+        """
+        Runs the MD5 algorithm (RFC-1321) on the binary content of the file named file
+        and returns the hexadecimal digest
+
+        :param file: file name
+        :returns: string of 32 hexadecimal digits
+        :raises: Exception: if checksum calculation failed
+        """
+        hash_md5 = hashlib.md5()
+        try:
+            with open(file, "rb") as f:
+                list(map(hash_md5.update, iter(lambda: f.read(4096), b"")))
+        except Exception as e:
+            raise Exception(
+                "FATAL - could not get MD5 checksum of file %s - %s" % (file, e)
+            )
+
+        return hash_md5.hexdigest()
+
+
+class SHA256(RucioHashAlgorithm):
+    @staticmethod
+    def compute_on_file(file):
+        """
+        Runs the SHA256 algorithm on the binary content of the file named file
+        and returns the hexadecimal digest
+
+        :param file: file name
+        :returns: string of 32 hexadecimal digits
+        """
+        with open(file, "rb") as f:
+            bytes_ = f.read()  # read entire file as bytes
+            readable_hash = hashlib.sha256(bytes_).hexdigest()
+            return readable_hash

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -53,12 +53,9 @@ import base64
 import datetime
 import errno
 import getpass
-import hashlib
-import io
 import itertools
 import json
 import logging
-import mmap
 import os
 import os.path
 import re
@@ -67,10 +64,8 @@ import subprocess
 import tempfile
 import threading
 import time
-import zlib
 from collections import OrderedDict
 from enum import Enum
-from functools import partial
 from uuid import uuid4 as uuid
 from xml.etree import ElementTree
 
@@ -79,6 +74,8 @@ from six import string_types, text_type, binary_type, ensure_text, PY3
 from six.moves import StringIO, zip_longest as izip_longest
 from six.moves.urllib.parse import urlparse, urlencode, quote, parse_qsl, urlunparse
 from six.moves.configparser import NoOptionError, NoSectionError
+
+import rucio.common.hash_algorithms
 
 from rucio.common.config import config_get, config_has_section
 from rucio.common.exception import MissingModuleException, InvalidType, InputValidationError, MetalinkJsonParsingError, RucioException, \
@@ -272,100 +269,32 @@ def set_checksum_value(file, checksum_names_list):
 
 
 def adler32(file):
-    """
-    An Adler-32 checksum is obtained by calculating two 16-bit checksums A and B
-    and concatenating their bits into a 32-bit integer. A is the sum of all bytes in the
-    stream plus one, and B is the sum of the individual values of A from each step.
-
-    :param file: file name
-    :returns: Hexified string, padded to 8 values.
-    """
-
-    # adler starting value is _not_ 0
-    adler = 1
-
-    can_mmap = False
-    try:
-        with open(file, 'r+b') as f:
-            can_mmap = True
-    except:
-        pass
-
-    try:
-        # use mmap if possible
-        if can_mmap:
-            with open(file, 'r+b') as f:
-                m = mmap.mmap(f.fileno(), 0)
-                # partial block reads at slightly increased buffer sizes
-                for block in iter(partial(m.read, io.DEFAULT_BUFFER_SIZE * 8), b''):
-                    adler = zlib.adler32(block, adler)
-        else:
-            with open(file, 'rb') as f:
-                # partial block reads at slightly increased buffer sizes
-                for block in iter(partial(f.read, io.DEFAULT_BUFFER_SIZE * 8), b''):
-                    adler = zlib.adler32(block, adler)
-
-    except Exception as e:
-        raise Exception('FATAL - could not get Adler-32 checksum of file %s: %s' % (file, e))
-
-    # backflip on 32bit -- can be removed once everything is fully migrated to 64bit
-    if adler < 0:
-        adler = adler + 2 ** 32
-
-    return str('%08x' % adler)
+    """For backward compatibility"""
+    return rucio.common.hash_algorithms.adler32.compute_on_file(file)
 
 
 CHECKSUM_ALGO_DICT['adler32'] = adler32
 
 
 def md5(file):
-    """
-    Runs the MD5 algorithm (RFC-1321) on the binary content of the file named file and returns the hexadecimal digest
-
-    :param file: file name
-    :returns: string of 32 hexadecimal digits
-    """
-    hash_md5 = hashlib.md5()
-    try:
-        with open(file, "rb") as f:
-            list(map(hash_md5.update, iter(lambda: f.read(4096), b"")))
-    except Exception as e:
-        raise Exception('FATAL - could not get MD5 checksum of file %s - %s' % (file, e))
-
-    return hash_md5.hexdigest()
+    """For backward compatibility"""
+    return rucio.common.hash_algorithms.md5.compute_on_file(file)
 
 
 CHECKSUM_ALGO_DICT['md5'] = md5
 
 
 def sha256(file):
-    """
-    Runs the SHA256 algorithm on the binary content of the file named file and returns the hexadecimal digest
-
-    :param file: file name
-    :returns: string of 32 hexadecimal digits
-    """
-    with open(file, "rb") as f:
-        bytes_ = f.read()  # read entire file as bytes
-        readable_hash = hashlib.sha256(bytes_).hexdigest()
-        print(readable_hash)
-        return readable_hash
+    """For backward compatibility"""
+    return rucio.common.hash_algorithms.sha256.compute_on_file(file)
 
 
 CHECKSUM_ALGO_DICT['sha256'] = sha256
 
 
 def crc32(file):
-    """
-    Runs the CRC32 algorithm on the binary content of the file named file and returns the hexadecimal digest
-
-    :param file: file name
-    :returns: string of 32 hexadecimal digits
-    """
-    prev = 0
-    for eachLine in open(file, "rb"):
-        prev = zlib.crc32(eachLine, prev)
-    return "%X" % (prev & 0xFFFFFFFF)
+    """For backward compatibility"""
+    return rucio.common.hash_algorithms.crc32.compute_on_file(file)
 
 
 CHECKSUM_ALGO_DICT['crc32'] = crc32

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -228,43 +228,11 @@ def generate_uuid_bytes():
     return uuid().bytes
 
 
-# GLOBALLY_SUPPORTED_CHECKSUMS = ['adler32', 'md5', 'sha256', 'crc32']
-GLOBALLY_SUPPORTED_CHECKSUMS = ['adler32', 'md5']
-CHECKSUM_ALGO_DICT = {}
-PREFERRED_CHECKSUM = GLOBALLY_SUPPORTED_CHECKSUMS[0]
-CHECKSUM_KEY = 'supported_checksums'
-
-
-def is_checksum_valid(checksum_name):
-    """
-    A simple function to check wether a checksum algorithm is supported.
-    Relies on GLOBALLY_SUPPORTED_CHECKSUMS to allow for expandability.
-
-    :param checksum_name: The name of the checksum to be verified.
-    :returns: True if checksum_name is in GLOBALLY_SUPPORTED_CHECKSUMS list, False otherwise.
-    """
-
-    return checksum_name in GLOBALLY_SUPPORTED_CHECKSUMS
-
-
-def set_preferred_checksum(checksum_name):
-    """
-    A simple function to check wether a checksum algorithm is supported.
-    Relies on GLOBALLY_SUPPORTED_CHECKSUMS to allow for expandability.
-
-    :param checksum_name: The name of the checksum to be verified.
-    :returns: True if checksum_name is in GLOBALLY_SUPPORTED_CHECKSUMS list, False otherwise.
-    """
-    if is_checksum_valid(checksum_name):
-        global PREFERRED_CHECKSUM
-        PREFERRED_CHECKSUM = checksum_name
-
-
 def set_checksum_value(file, checksum_names_list):
     for checksum_name in checksum_names_list:
         if checksum_name in file['metadata'].keys() and file['metadata'][checksum_name]:
             file['checksum'] = '%s:%s' % (checksum_name.upper(), str(file['metadata'][checksum_name]))
-            if checksum_name == PREFERRED_CHECKSUM:
+            if checksum_name == rucio.common.hash_algorithms.PREFERRED_CHECKSUM:
                 break
 
 
@@ -273,15 +241,9 @@ def adler32(file):
     return rucio.common.hash_algorithms.adler32.compute_on_file(file)
 
 
-CHECKSUM_ALGO_DICT['adler32'] = adler32
-
-
 def md5(file):
     """For backward compatibility"""
     return rucio.common.hash_algorithms.md5.compute_on_file(file)
-
-
-CHECKSUM_ALGO_DICT['md5'] = md5
 
 
 def sha256(file):
@@ -289,15 +251,9 @@ def sha256(file):
     return rucio.common.hash_algorithms.sha256.compute_on_file(file)
 
 
-CHECKSUM_ALGO_DICT['sha256'] = sha256
-
-
 def crc32(file):
     """For backward compatibility"""
     return rucio.common.hash_algorithms.crc32.compute_on_file(file)
-
-
-CHECKSUM_ALGO_DICT['crc32'] = crc32
 
 
 def str_to_date(string):

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -58,7 +58,7 @@ import rucio.core.account_counter
 from rucio.common import exception, utils
 from rucio.common.cache import make_region_memcached
 from rucio.common.config import get_lfn2pfn_algorithm_default
-from rucio.common.utils import CHECKSUM_KEY, is_checksum_valid, GLOBALLY_SUPPORTED_CHECKSUMS
+from rucio.common.hash_algorithms import is_checksum_valid, GLOBALLY_SUPPORTED_CHECKSUMS
 from rucio.core.rse_counter import add_counter, get_counter
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import (RSEType, ReplicaState)
@@ -67,6 +67,8 @@ from rucio.db.sqla.session import read_session, transactional_session, stream_se
 if TYPE_CHECKING:
     from typing import Dict, Optional
     from sqlalchemy.orm import Session
+
+CHECKSUM_KEY = 'supported_checksums'
 
 REGION = make_region_memcached(expiration_time=900)
 

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -50,7 +50,7 @@ from threading import Timer
 
 from rucio.common import exception, config
 from rucio.common.constraints import STRING_TYPES
-from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS, PREFERRED_CHECKSUM
+from rucio.common.hash_algorithms import GLOBALLY_SUPPORTED_CHECKSUMS, PREFERRED_CHECKSUM
 from rucio.rse.protocols import protocol
 
 try:

--- a/lib/rucio/rse/protocols/rclone.py
+++ b/lib/rucio/rse/protocols/rclone.py
@@ -22,7 +22,8 @@ import logging
 
 from rucio.common import exception
 from rucio.common.config import get_config_dirs, get_rse_credentials
-from rucio.common.utils import execute, PREFERRED_CHECKSUM
+from rucio.common.hash_algorithms import PREFERRED_CHECKSUM
+from rucio.common.utils import execute
 from rucio.rse.protocols import protocol
 
 

--- a/lib/rucio/rse/protocols/ssh.py
+++ b/lib/rucio/rse/protocols/ssh.py
@@ -21,7 +21,8 @@ import os
 import re
 
 from rucio.common import exception
-from rucio.common.utils import execute, PREFERRED_CHECKSUM
+from rucio.common.hash_algorithms import PREFERRED_CHECKSUM
+from rucio.common.utils import execute
 from rucio.rse.protocols import protocol
 
 

--- a/lib/rucio/rse/protocols/xrootd.py
+++ b/lib/rucio/rse/protocols/xrootd.py
@@ -30,8 +30,9 @@ import os
 import logging
 
 from rucio.common import exception
+from rucio.common.hash_algorithms import PREFERRED_CHECKSUM
+from rucio.common.utils import execute
 from rucio.rse.protocols import protocol
-from rucio.common.utils import execute, PREFERRED_CHECKSUM
 
 
 class Default(protocol.RSEProtocol):

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -56,8 +56,9 @@ except ImportError:
 from rucio.common import exception, utils, constants
 from rucio.common.config import config_get_int
 from rucio.common.constraints import STRING_TYPES
+from rucio.common.hash_algorithms import GLOBALLY_SUPPORTED_CHECKSUMS
 from rucio.common.logging import formatted_logger
-from rucio.common.utils import make_valid_did, GLOBALLY_SUPPORTED_CHECKSUMS
+from rucio.common.utils import make_valid_did
 
 
 def get_rse_info(rse=None, vo='def', rse_id=None, session=None):

--- a/lib/rucio/tests/test_rse_protocol_rclone.py
+++ b/lib/rucio/tests/test_rse_protocol_rclone.py
@@ -28,7 +28,8 @@ from uuid import uuid4 as uuid
 import pytest
 
 from rucio.common import exception
-from rucio.common.utils import execute, PREFERRED_CHECKSUM, set_preferred_checksum
+from rucio.common.hash_algorithms import PREFERRED_CHECKSUM, set_preferred_checksum
+from rucio.common.utils import execute
 from rucio.rse import rsemanager
 from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 from rucio.tests.rsemgr_api_test import MgrTestCases

--- a/lib/rucio/tests/test_rse_protocol_rsync.py
+++ b/lib/rucio/tests/test_rse_protocol_rsync.py
@@ -28,7 +28,8 @@ from uuid import uuid4 as uuid
 import pytest
 
 from rucio.common import exception
-from rucio.common.utils import execute, PREFERRED_CHECKSUM, set_preferred_checksum
+from rucio.common.hash_algorithms import PREFERRED_CHECKSUM, set_preferred_checksum
+from rucio.common.utils import execute
 from rucio.rse import rsemanager
 from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 from rucio.tests.rsemgr_api_test import MgrTestCases

--- a/lib/rucio/tests/test_rse_protocol_ssh.py
+++ b/lib/rucio/tests/test_rse_protocol_ssh.py
@@ -28,7 +28,8 @@ from uuid import uuid4 as uuid
 import pytest
 
 from rucio.common import exception
-from rucio.common.utils import execute, PREFERRED_CHECKSUM, set_preferred_checksum
+from rucio.common.hash_algorithms import PREFERRED_CHECKSUM, set_preferred_checksum
+from rucio.common.utils import execute
 from rucio.rse import rsemanager
 from rucio.tests.common import skip_rse_tests_with_accounts, load_test_conf_file
 from rucio.tests.rsemgr_api_test import MgrTestCases

--- a/pylintrc
+++ b/pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=
+extension-pkg-whitelist=rucio.common.hash_algorithms
 
 # Add files or directories to the blocklist. They should be base names, not
 # paths.

--- a/setup_rucio_client.py
+++ b/setup_rucio_client.py
@@ -43,7 +43,7 @@ install_requires, extras_require = match_define_requirements(clients_requirement
 # Arguments to the setup script to build Basic/Lite distributions
 name = 'rucio-clients'
 packages = ['rucio', 'rucio.client', 'rucio.common', 'rucio.common.schema',
-            'rucio.rse.protocols', 'rucio.rse']
+            'rucio.common.hash_algorithms', 'rucio.rse.protocols', 'rucio.rse']
 description = "Rucio Client Lite Package"
 data_files = [
     ('', ['requirements.txt']),


### PR DESCRIPTION
The first, and likely the easiest, part of implementing support for generic checksum/hash algorithms - implement a common package for the algorithms, complete with the ability to add new algorithms by dropping more files into the right directory. All four originally implemented algorithms have been put in the same file but I also created a proof-of-concept BLAKE2b implementation (using hashlib) in a separate file, which worked fine.