### PR TITLE
Add header workflow integration 2

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -5,6 +5,25 @@ on:
   - push
 
 jobs:
+  header-lint:
+    if: 'github.event_name == ''pull_request'''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check headers
+        shell: bash
+        run: |
+          git pull origin master
+          echo "Current git rev $(git rev-parse HEAD)"
+          echo "Common ancestor git rev $(git merge-base HEAD remotes/origin/master)"
+          echo "If a file header needs to be changed run 'tools/add_header -i FILE' from the rucio project directory."
+          FILES=$(git diff --name-status HEAD $(git merge-base HEAD remotes/origin/master) | grep -v '^A' | cut -f 2 | grep -E '\.py$|^bin/') || echo "No Files found"
+          if [[ -n $FILES ]]; then
+            echo "Files to check: $FILES"
+            tools/add_header --disable-add-me -cd $FILES
+          fi
   setup:
     runs-on: ubuntu-latest
     steps:

--- a/tools/add_header
+++ b/tools/add_header
@@ -95,6 +95,7 @@ def main(arguments):
     email = '<%s>' % email
     exit_code = 0
 
+    print("Checking %i files" % (len(arguments.MyFiles)))
     for MyFile in arguments.MyFiles:
         # Query log history
         cmd = '''git log --reverse --date=short --format='%s'  %s ''' % ('%aN,<%aE>,%ad', MyFile)
@@ -244,7 +245,7 @@ def main(arguments):
                         if count == 0 or not_comment_line:
                             modified.write(line)
 
-        else:
+        elif not arguments.check:
             print(header)
     exit(exit_code)
 


### PR DESCRIPTION
This commit adds a header check to the github actions.

As of right now, the headers get checked on every push. We could change that to every pull-request if required.

See individual commits for more information.
<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
