### PR TITLE
Clients: allow policy packages on client #4918

### DIFF
--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -242,7 +242,7 @@ class DownloadClient:
             item['name'] = did_name
             item['sources'] = [{'pfn': pfn, 'rse': rse}]
             did_path_name = did_name
-            if self.extract_scope_convention and self.extract_scope_convention == 'belleii' and did_name.startswith('/'):
+            if did_name.startswith('/'):
                 did_path_name = did_name[1:]
             dest_file_path = os.path.join(dest_dir_path, did_path_name)
             item['dest_file_paths'] = [dest_file_path]
@@ -1318,7 +1318,7 @@ class DownloadClient:
                         path = os.path.join(self._prepare_dest_dir(base_dir, input_did.name, no_subdir), file_did_path)
                     else:
                         # if no datasets were given only prepare the given destination paths
-                        if self.extract_scope_convention == 'belleii' and file_did_path.startswith('/'):
+                        if file_did_path.startswith('/'):
                             file_did_path = file_did_path[1:]
                         path = os.path.join(self._prepare_dest_dir(base_dir, file_did.scope, no_subdir), file_did_path)
 
@@ -1538,7 +1538,7 @@ class DownloadClient:
         :returns: the absolut path of the destination directory
         """
         # append dest_dir_name, if subdir should be used
-        if self.extract_scope_convention == 'belleii' and dest_dir_name.startswith('/'):
+        if dest_dir_name.startswith('/'):
             dest_dir_name = dest_dir_name[1:]
         dest_dir_path = os.path.join(os.path.abspath(base_dir), '' if no_subdir else dest_dir_name)
 

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -20,6 +20,8 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 
+from os import environ
+
 try:
     from ConfigParser import NoOptionError, NoSectionError
 except ImportError:
@@ -48,7 +50,10 @@ if not multivo:
 
     if config.config_has_section('policy'):
         try:
-            POLICY = config.config_get('policy', 'package', check_config_table=False) + ".schema"
+            if 'RUCIO_POLICY_PACKAGE' in environ:
+                POLICY = environ['RUCIO_POLICY_PACKAGE'] + ".schema"
+            else:
+                POLICY = config.config_get('policy', 'package', check_config_table=False) + ".schema"
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             try:
@@ -72,7 +77,11 @@ def load_schema_for_vo(vo):
     GENERIC_FALLBACK = 'generic_multi_vo'
     if config.config_has_section('policy'):
         try:
-            POLICY = config.config_get('policy', 'package-' + vo, check_config_table=False) + ".schema"
+            env_name = 'RUCIO_POLICY_PACKAGE_' + vo.upper()
+            if env_name in environ:
+                POLICY = environ[env_name] + ".schema"
+            else:
+                POLICY = config.config_get('policy', 'package-' + vo, check_config_table=False) + ".schema"
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             try:

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -618,47 +618,11 @@ register_surl_algorithm(construct_surl_DQ2, 'DQ2')
 register_surl_algorithm(construct_surl_BelleII, 'BelleII')
 
 
-def _register_policy_package_surl_algorithms():
-    def try_importing_policy(vo=None):
-        import importlib
-        try:
-            package = config.config_get('policy', 'package' + ('' if not vo else '-' + vo['vo']))
-            module = importlib.import_module(package)
-            if hasattr(module, 'get_surl_algorithms'):
-                surl_algorithms = module.get_surl_algorithms()
-                if not vo:
-                    _SURL_ALGORITHMS.update(surl_algorithms)
-                else:
-                    # check that the names are correctly prefixed
-                    for k in surl_algorithms.keys():
-                        if k.lower().startswith(vo['vo'].lower()):
-                            _SURL_ALGORITHMS[k] = surl_algorithms[k]
-                        else:
-                            raise InvalidAlgorithmName(k, vo['vo'])
-        except (NoOptionError, NoSectionError, ImportError):
-            pass
-
-    from rucio.common import config
-    from rucio.core.vo import list_vos
-    try:
-        multivo = config.config_get_bool('common', 'multi_vo')
-    except (NoOptionError, NoSectionError):
-        multivo = False
-    if not multivo:
-        # single policy package
-        try_importing_policy()
-    else:
-        # policy package per VO
-        vos = list_vos()
-        for vo in vos:
-            try_importing_policy(vo)
-
-
 def construct_surl(dsn, filename, naming_convention=None):
     global _loaded_policy_modules
     if not _loaded_policy_modules:
         # on first call, register any SURL functions from the policy packages
-        _register_policy_package_surl_algorithms()
+        register_policy_package_algorithms('surl', _SURL_ALGORITHMS)
         _loaded_policy_modules = True
 
     if naming_convention is None or naming_convention not in _SURL_ALGORITHMS:
@@ -721,6 +685,7 @@ def clean_surls(surls):
 
 _EXTRACT_SCOPE_ALGORITHMS = {}
 _DEFAULT_EXTRACT = 'atlas'
+_loaded_policy_package_scope_algorithms = False
 
 
 def extract_scope_atlas(did, scopes):
@@ -825,6 +790,10 @@ register_extract_scope_algorithm(extract_scope_belleii, 'belleii')
 
 
 def extract_scope(did, scopes=None, default_extract=_DEFAULT_EXTRACT):
+    global _loaded_policy_package_scope_algorithms
+    if not _loaded_policy_package_scope_algorithms:
+        register_policy_package_algorithms('scope', _EXTRACT_SCOPE_ALGORITHMS)
+        _loaded_policy_package_scope_algorithms = True
     extract_scope_convention = config_get('common', 'extract_scope', False, None)
     if extract_scope_convention is None or extract_scope_convention not in _EXTRACT_SCOPE_ALGORITHMS:
         extract_scope_convention = default_extract
@@ -1801,3 +1770,72 @@ class PriorityQueue:
 
         self.container[self.heap[pos]].pos = pos
         return heap_changed
+
+
+def register_policy_package_algorithms(algorithm_type, dictionary):
+    '''
+    Loads all the algorithms of a given type from the policy package(s) and registers them
+    :param algorithm_type: the type of algorithm to register (e.g. 'surl', 'lfn2pfn')
+    :param dictionary: the dictionary to register them in
+    :param vo: the name of the relevant VO (None for single VO)
+    '''
+    def try_importing_policy(algorithm_type, dictionary, vo=None):
+        import importlib
+        try:
+            env_name = 'RUCIO_POLICY_PACKAGE' + ('' if not vo else '_' + vo.upper())
+            if env_name in os.environ:
+                package = os.environ[env_name]
+            else:
+                package = config.config_get('policy', 'package' + ('' if not vo else '-' + vo))
+            module = importlib.import_module(package)
+            if hasattr(module, 'get_algorithms'):
+                all_algorithms = module.get_algorithms()
+                if algorithm_type in all_algorithms:
+                    algorithms = all_algorithms[algorithm_type]
+                    if not vo:
+                        dictionary.update(algorithms)
+                    else:
+                        # check that the names are correctly prefixed
+                        for k in algorithms.keys():
+                            if k.lower().startswith(vo.lower()):
+                                dictionary[k] = algorithms[k]
+                            else:
+                                raise InvalidAlgorithmName(k, vo)
+        except (NoOptionError, NoSectionError, ImportError):
+            pass
+
+    from rucio.common import config
+    try:
+        multivo = config.config_get_bool('common', 'multi_vo')
+    except (NoOptionError, NoSectionError):
+        multivo = False
+    if not multivo:
+        # single policy package
+        try_importing_policy(algorithm_type, dictionary)
+    else:
+        # determine whether on client or server
+        client = False
+        if 'RUCIO_CLIENT_MODE' not in os.environ:
+            if not config.config_has_section('database') and config.config_has_section('client'):
+                client = True
+        else:
+            if os.environ['RUCIO_CLIENT_MODE']:
+                client = True
+
+        # on client, only register algorithms for selected VO
+        if client:
+            if 'RUCIO_VO' in os.environ:
+                vo = os.environ['RUCIO_VO']
+            else:
+                try:
+                    vo = config.config_get('client', 'vo')
+                except (NoOptionError, NoSectionError):
+                    vo = 'def'
+            try_importing_policy(algorithm_type, dictionary, vo)
+        # on server, list all VOs and register their algorithms
+        else:
+            from rucio.core.vo import list_vos
+            # policy package per VO
+            vos = list_vos()
+            for vo in vos:
+                try_importing_policy(algorithm_type, dictionary, vo['vo'])

--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -22,6 +22,8 @@
 #
 # PY3K COMPATIBLE
 
+from os import environ
+
 try:
     from ConfigParser import NoOptionError, NoSectionError
 except ImportError:
@@ -57,7 +59,10 @@ if not multivo:
 
     if config.config_has_section('policy'):
         try:
-            POLICY = config.config_get('policy', 'package', check_config_table=False) + ".permission"
+            if 'RUCIO_POLICY_PACKAGE' in environ:
+                POLICY = environ['RUCIO_POLICY_PACKAGE'] + ".permission"
+            else:
+                POLICY = config.config_get('policy', 'package', check_config_table=False) + ".permission"
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             POLICY = 'rucio.core.permission.' + FALLBACK_POLICY.lower()
@@ -76,7 +81,11 @@ def load_permission_for_vo(vo):
     GENERIC_FALLBACK = 'generic_multi_vo'
     if config.config_has_section('policy'):
         try:
-            POLICY = config.config_get('policy', 'package-' + vo) + ".permission"
+            env_name = 'RUCIO_POLICY_PACKAGE_' + vo.upper()
+            if env_name in environ:
+                POLICY = environ[env_name] + ".permission"
+            else:
+                POLICY = config.config_get('policy', 'package-' + vo) + ".permission"
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             try:


### PR DESCRIPTION
This PR improves policy package support to allow policy packages to load on the client. It also makes algorithm registration in policy packages more generic and allows scope extraction algorithms to be registered from policy packages. To avoid the need for a config file, the policy package can be specified via an environment variable.

One of the reasons for this was to get rid of the Belle II specific code in `downloadclient.py`. I have made the removal of the trailing slash generic, since this is something that could potentially affect any experiment. However, I have left the Belle II specific scope extraction code for the moment, since removing it could break things for Belle II. Once Belle II have their scope extraction algorithm available in a policy package, it should be possible to remove this.
