### PR TITLE
Make Dirac server plugin Multi-VO capable

### DIFF
--- a/lib/rucio/api/dirac.py
+++ b/lib/rucio/api/dirac.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 CERN
+# Copyright 2020-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Martin Barisits <martin.barisits@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - martynia <janusz.martyniak@googlemail.com>, 2021
+# - Janusz Martyniak <janusz.martyniak@googlemail.com>, 2022
 
 from __future__ import print_function
 
@@ -30,7 +32,7 @@ from rucio.common.exception import AccessDenied
 from rucio.common.utils import extract_scope
 
 
-def add_files(lfns, issuer, ignore_availability):
+def add_files(lfns, issuer, ignore_availability, vo='def'):
     """
     Bulk add files :
     - Create the file and replica.
@@ -40,8 +42,10 @@ def add_files(lfns, issuer, ignore_availability):
     :param lfns: List of lfn (dictionary {'lfn': <lfn>, 'rse': <rse>, 'bytes': <bytes>, 'adler32': <adler32>, 'guid': <guid>, 'pfn': <pfn>}
     :param issuer: The issuer account.
     :param ignore_availability: A boolean to ignore blocked sites.
+    :param vo: The VO to act on.
+
     """
-    scopes = list_scopes()
+    scopes = list_scopes(vo=vo)
     dids = []
     rses = {}
     for lfn in lfns:
@@ -49,7 +53,7 @@ def add_files(lfns, issuer, ignore_availability):
         dids.append({'scope': scope, 'name': name})
         rse = lfn['rse']
         if rse not in rses:
-            rse_id = get_rse_id(rse=rse)
+            rse_id = get_rse_id(rse=rse, vo=vo)
             rses[rse] = rse_id
         lfn['rse_id'] = rses[rse]
 
@@ -57,14 +61,14 @@ def add_files(lfns, issuer, ignore_availability):
     for rse in rses:
         rse_id = rses[rse]
         kwargs = {'rse': rse, 'rse_id': rse_id}
-        if not has_permission(issuer=issuer, action='add_replicas', kwargs=kwargs):
-            raise AccessDenied('Account %s can not add file replicas on %s' % (issuer, rse))
-        if not has_permission(issuer=issuer, action='skip_availability_check', kwargs=kwargs):
+        if not has_permission(issuer=issuer, action='add_replicas', kwargs=kwargs, vo=vo):
+            raise AccessDenied('Account %s can not add file replicas on %s for VO %s' % (issuer, rse, vo))
+        if not has_permission(issuer=issuer, action='skip_availability_check', kwargs=kwargs, vo=vo):
             ignore_availability = False
 
     # Check if the issuer can add the files
     kwargs = {'issuer': issuer, 'dids': dids}
-    if not has_permission(issuer=issuer, action='add_dids', kwargs=kwargs):
-        raise AccessDenied('Account %s can not bulk add data identifier' % (issuer))
+    if not has_permission(issuer=issuer, action='add_dids', kwargs=kwargs, vo=vo):
+        raise AccessDenied('Account %s can not bulk add data identifier for VO %s' % (issuer, vo))
 
-    dirac.add_files(lfns=lfns, account=issuer, ignore_availability=ignore_availability, session=None)
+    dirac.add_files(lfns=lfns, account=issuer, ignore_availability=ignore_availability, session=None, vo=vo)

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2021 CERN
+# Copyright 2012-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,13 @@
 # - Anil Panta <47672624+panta-123@users.noreply.github.com>, 2021
 # - Ilija Vukotic <ivukotic@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - martynia <janusz.martyniak@googlemail.com>, 2021-2022
+# - jdierkes <joel.dierkes@cern.ch>, 2021
+# - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
+# - Rob Barnsley <robbarnsley@users.noreply.github.com>, 2021
+# - Igor Mandrichenko <ivm@fnal.gov>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
+# - Janusz Martyniak <janusz.martyniak@googlemail.com>, 2022
 
 from __future__ import absolute_import, print_function
 
@@ -741,6 +747,17 @@ def extract_scope_atlas(did, scopes):
         return scope, did
 
 
+def extract_scope_dirac(did, scopes):
+    # Default dirac scope extract algorithm. Scope is the second element in the LFN or the first one (VO name)
+    # if only one element is the result of a split.
+    elem = did.rstrip('/').split('/')
+    if len(elem) > 2:
+        scope = elem[2]
+    else:
+        scope = elem[1]
+    return scope, did
+
+
 def extract_scope_belleii(did, scopes):
     split_did = did.split('/')
     if did.startswith('/belle/MC/'):
@@ -822,6 +839,7 @@ def register_extract_scope_algorithm(extract_callable, name=[]):
 
 register_extract_scope_algorithm(extract_scope_atlas, 'atlas')
 register_extract_scope_algorithm(extract_scope_belleii, 'belleii')
+register_extract_scope_algorithm(extract_scope_dirac, 'dirac')
 
 
 def extract_scope(did, scopes=None, default_extract=_DEFAULT_EXTRACT):

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -39,7 +39,7 @@
 # - Anil Panta <47672624+panta-123@users.noreply.github.com>, 2021
 # - Ilija Vukotic <ivukotic@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
-# - martynia <janusz.martyniak@googlemail.com>, 2021-2022
+# - martynia <janusz.martyniak@googlemail.com>, 2021
 # - jdierkes <joel.dierkes@cern.ch>, 2021
 # - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
 # - Rob Barnsley <robbarnsley@users.noreply.github.com>, 2021

--- a/lib/rucio/core/dirac.py
+++ b/lib/rucio/core/dirac.py
@@ -19,7 +19,7 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
-# - martynia <janusz.martyniak@googlemail.com>, 2021-2022
+# - martynia <janusz.martyniak@googlemail.com>, 2021
 # - Janusz Martyniak <janusz.martyniak@googlemail.com>, 2022
 
 from __future__ import print_function

--- a/lib/rucio/core/dirac.py
+++ b/lib/rucio/core/dirac.py
@@ -54,7 +54,7 @@ def _exists(scope, name, session=None):
 
 
 @transactional_session
-def add_files(lfns, account, ignore_availability, session=None, vo='def'):
+def add_files(lfns, account, ignore_availability, vo='def', session=None):
     """
     Bulk add files :
     - Create the file and replica.
@@ -64,13 +64,13 @@ def add_files(lfns, account, ignore_availability, session=None, vo='def'):
     :param lfns: List of lfn (dictionary {'lfn': <lfn>, 'rse': <rse>, 'bytes': <bytes>, 'adler32': <adler32>, 'guid': <guid>, 'pfn': <pfn>}
     :param issuer: The issuer account.
     :param ignore_availability: A boolean to ignore blocklisted sites.
-    :param session: The session used
     :param vo: The VO to act on
+    :param session: The session used
     """
     attachments = []
     # The list of scopes is necessary for the extract_scope
     filter_ = {'scope': InternalScope(scope='*', vo=vo)}
-    scopes = list_scopes(session=session, filter_=filter_)
+    scopes = list_scopes(filter_=filter_, session=session)
     scopes = [scope.external for scope in scopes]
     exist_lfn = []
     for lfn in lfns:

--- a/lib/rucio/web/rest/flaskapi/v1/dirac.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dirac.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 CERN
+# Copyright 2020-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,10 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
+# - martynia <janusz.martyniak@googlemail.com>, 2021
+# - Janusz Martyniak <janusz.martyniak@googlemail.com>, 2022
 
+import logging
 from flask import Flask, Blueprint, request
 
 from rucio.api.dirac import add_files
@@ -55,8 +58,11 @@ class AddFiles(ErrorHandlingMethodView):
         lfns = param_get(parameters, 'lfns')
         ignore_availability = param_get(parameters, 'ignore_availability', default=False)
 
+        LOGGER = logging.getLogger('Dirac.addFiles')
+        LOGGER.setLevel(logging.INFO)
         try:
-            add_files(lfns=lfns, issuer=request.environ.get('issuer'), ignore_availability=ignore_availability)
+            add_files(lfns=lfns, issuer=request.environ.get('issuer'), ignore_availability=ignore_availability,
+                      vo=request.environ.get('vo'))
         except InvalidPath as error:
             return generate_http_error_flask(400, error)
         except AccessDenied as error:

--- a/lib/rucio/web/rest/flaskapi/v1/dirac.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dirac.py
@@ -20,7 +20,6 @@
 # - martynia <janusz.martyniak@googlemail.com>, 2021
 # - Janusz Martyniak <janusz.martyniak@googlemail.com>, 2022
 
-import logging
 from flask import Flask, Blueprint, request
 
 from rucio.api.dirac import add_files
@@ -58,8 +57,6 @@ class AddFiles(ErrorHandlingMethodView):
         lfns = param_get(parameters, 'lfns')
         ignore_availability = param_get(parameters, 'ignore_availability', default=False)
 
-        LOGGER = logging.getLogger('Dirac.addFiles')
-        LOGGER.setLevel(logging.INFO)
         try:
             add_files(lfns=lfns, issuer=request.environ.get('issuer'), ignore_availability=ignore_availability,
                       vo=request.environ.get('vo'))


### PR DESCRIPTION
The changes in 3 dirac.py files  (core, api,  flaskapi/v1) make Dirac-Rucio multi-VO capable.
Adresses #4961

To have a scope properly extracted by the server the value of  `SCOPE_NAME_REGEXP` has to be set: 
```
SCOPE_NAME_REGEXP = '/([^/]*)(/.*)' 
```

In addition the server has to be configured to select a Dirac scope algorithm (as defined in `rucio/common/utils.py` in this PR).
The client will work without a config file.



<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
