### PR TITLE
Transfers: don't allow timedelta obj in tombstone_from_delay. Fix #5110

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1421,11 +1421,7 @@ def tombstone_from_delay(tombstone_delay):
     if not tombstone_delay:
         return None
 
-    if not isinstance(tombstone_delay, timedelta):
-        try:
-            tombstone_delay = timedelta(seconds=int(tombstone_delay))
-        except ValueError:
-            return None
+    tombstone_delay = timedelta(seconds=int(tombstone_delay))
 
     if not tombstone_delay:
         return None


### PR DESCRIPTION
It is an additional case to handle, which already had a nasty bug.
Rather than trying to handle the special case, simplify the code.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
