### PR TITLE
Core & API: switch to memcached for most caches. Closes #5152 

### DIFF
--- a/lib/rucio/common/cache.py
+++ b/lib/rucio/common/cache.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
+
+from dogpile.cache import make_region
+
+from rucio.common.config import config_get
+
+def make_region_memcached(expiration_time, function_key_generator=None):
+    """
+    Make and configure a dogpile.cache.memcached region
+    """
+    if function_key_generator:
+        region = make_region(function_key_generator=function_key_generator)
+    else:
+        region = make_region()
+
+    region.configure(
+        'dogpile.cache.memcached',
+        expiration_time=3600,
+        arguments={
+            'url': config_get('cache', 'url', False, '127.0.0.1:11211', check_config_table=False),
+            'distributed_lock': True,
+            'memcached_expire_time': expiration_time + 60,  # must be bigger than expiration_time
+        }
+    )
+
+    return region

--- a/lib/rucio/common/rse_attributes.py
+++ b/lib/rucio/common/rse_attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2020 CERN
+# Copyright 2015-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +20,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2020
-#
-# PY3K COMPATIBLE
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 """
 methods to get closeness between sites
@@ -30,16 +29,12 @@ methods to get closeness between sites
 import logging
 import traceback
 
-from dogpile.cache import make_region
 from dogpile.cache.api import NoValue
 
 from rucio.core import rse as rse_core
-from rucio.common.config import config_get
+from rucio.common.cache import make_region_memcached
 
-REGION = make_region().configure('dogpile.cache.memcached',
-                                 expiration_time=3600,
-                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
-
+REGION = make_region_memcached(expiration_time=3600)
 
 def get_rse_attributes(rse_id, session=None):
     """

--- a/lib/rucio/core/authentication.py
+++ b/lib/rucio/core/authentication.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2021 CERN
+# Copyright 2012-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import datetime
 import hashlib
@@ -37,10 +38,10 @@ import traceback
 from base64 import b64decode
 
 import paramiko
-from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 from sqlalchemy import and_, or_, select, delete
 
+from rucio.common.cache import make_region_memcached
 from rucio.common.exception import CannotAuthenticate, RucioException
 from rucio.common.utils import chunks, generate_uuid
 from rucio.core.account import account_exists
@@ -59,12 +60,7 @@ def token_key_generator(namespace, fni, **kwargs):
     return generate_key
 
 
-TOKENREGION = make_region(
-    function_key_generator=token_key_generator
-).configure(
-    'dogpile.cache.memory',
-    expiration_time=3600
-)
+TOKENREGION = make_region_memcached(expiration_time=3600, function_key_generator=token_key_generator)
 
 
 @transactional_session

--- a/lib/rucio/core/config.py
+++ b/lib/rucio/core/config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2021 CERN
+# Copyright 2014-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,22 +20,19 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Martin Barisits <martin.barisits@cern.ch>, 2019-2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 
-from dogpile.cache import make_region
 from dogpile.cache.api import NoValue
 from sqlalchemy import func
 
-from rucio.common.config import config_get
+from rucio.common.cache import make_region_memcached
 from rucio.common.exception import ConfigNotFound
 from rucio.db.sqla import models
 from rucio.db.sqla.session import read_session, transactional_session
 
 
-REGION = make_region().configure('dogpile.cache.memcached',
-                                 expiration_time=3600,
-                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211',
-                                                              check_config_table=False), 'distributed_lock': True})
+REGION = make_region_memcached(expiration_time=3600)
+
 SECTIONS_CACHE_KEY = 'sections'
 
 

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 CERN
+# Copyright 2018-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import base64
 import datetime
@@ -27,20 +28,19 @@ from hashlib import sha1
 
 import boto3
 from botocore.client import Config
-from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 from oauth2client.service_account import ServiceAccountCredentials
 from six import integer_types
 from six.moves.urllib.parse import urlparse, urlencode
 
+from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get, get_rse_credentials
 from rucio.common.exception import UnsupportedOperation
 from rucio.core.monitor import record_timer_block
 
 CREDS_GCS = None
 
-REGION = make_region().configure('dogpile.cache.memory',
-                                 expiration_time=3600)
+REGION = make_region_memcached(expiration_time=3600)
 
 
 def get_signed_url(rse_id, service, operation, url, lifetime=600):

--- a/lib/rucio/core/message.py
+++ b/lib/rucio/core/message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2021 CERN
+# Copyright 2014-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import json
 from configparser import NoOptionError, NoSectionError
@@ -30,9 +31,9 @@ from configparser import NoOptionError, NoSectionError
 from sqlalchemy import or_, delete, update
 from sqlalchemy.exc import IntegrityError
 
-from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 
+from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get
 from rucio.common.exception import InvalidObject, RucioException
 from rucio.common.utils import APIEncoder
@@ -40,11 +41,7 @@ from rucio.db.sqla import filter_thread_work
 from rucio.db.sqla.models import Message, MessageHistory
 from rucio.db.sqla.session import transactional_session
 
-
-REGION = make_region().configure('dogpile.cache.memcached',
-                                 expiration_time=3600,
-                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'),
-                                            'distributed_lock': True})
+REGION = make_region_memcached(expiration_time=3600)
 
 
 @transactional_session

--- a/lib/rucio/core/naming_convention.py
+++ b/lib/rucio/core/naming_convention.py
@@ -1,4 +1,5 @@
-# Copyright 2013-2019 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2015-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +18,7 @@
 # - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018
 # - Brandon White, <bjwhite@fnal.gov>, 2019
 # - Martin Barisits, <martin.barisits@cern.ch>, 2019
-#
-# PY3K COMPATIBLE
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 from __future__ import print_function
 
@@ -26,20 +26,15 @@ from re import match, compile, error
 from sqlalchemy.exc import IntegrityError
 from traceback import format_exc
 
-from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 
 from rucio.common.exception import Duplicate, RucioException, InvalidObject
-from rucio.common.config import config_get
+from rucio.common.cache import make_region_memcached
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import KeyType
 from rucio.db.sqla.session import read_session, transactional_session
 
-
-REGION = make_region().configure('dogpile.cache.memcached',
-                                 expiration_time=3600,
-                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'),
-                                            'distributed_lock': True})
+REGION = make_region_memcached(expiration_time=3600)
 
 
 @transactional_session

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2021 CERN
+# Copyright 2013-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Eric Vaandering <ewv@fnal.gov>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - Gabriele Fronzé <sucre.91@hotmail.it>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
@@ -58,7 +58,6 @@ from struct import unpack
 from traceback import format_exc
 
 import requests
-from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 from six import string_types
 from sqlalchemy import func, and_, or_, exists, not_, update, delete
@@ -71,6 +70,7 @@ from sqlalchemy.sql.expression import case, select, text, false, true
 import rucio.core.did
 import rucio.core.lock
 from rucio.common import exception
+from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get
 from rucio.common.types import InternalScope
 from rucio.common.utils import chunks, clean_surls, str_to_date, add_url_query
@@ -87,7 +87,7 @@ from rucio.db.sqla.session import (read_session, stream_session, transactional_s
                                    DEFAULT_SCHEMA_NAME, BASE)
 from rucio.rse import rsemanager as rsemgr
 
-REGION = make_region().configure('dogpile.cache.memory', expiration_time=60)
+REGION = make_region_memcached(expiration_time=60)
 
 
 @read_session

--- a/lib/rucio/core/replica_sorter.py
+++ b/lib/rucio/core/replica_sorter.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 REGION = make_region(function_key_generator=utils.my_key_generator).configure(
     'dogpile.cache.memory',
-    expiration_time=30 * 86400,
+    expiration_time=1800,
 )
 
 

--- a/lib/rucio/core/replica_sorter.py
+++ b/lib/rucio/core/replica_sorter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 CERN
+# Copyright 2020-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 # - Ilija Vukotic <ivukotic@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 
 # This product includes GeoLite data created by MaxMind,
 # available from <a href="http://www.maxmind.com">http://www.maxmind.com</a>
@@ -36,10 +37,10 @@ from urllib.parse import urlparse
 
 import geoip2.database
 import requests
-from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 
 from rucio.common import utils
+from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import InvalidRSEExpression
 from rucio.core.rse_expression_parser import parse_expression
@@ -47,10 +48,7 @@ from rucio.core.rse_expression_parser import parse_expression
 if TYPE_CHECKING:
     from typing import Dict, List, Optional
 
-REGION = make_region(function_key_generator=utils.my_key_generator).configure(
-    'dogpile.cache.memory',
-    expiration_time=1800,
-)
+REGION = make_region_memcached(expiration_time=1800, function_key_generator=utils.my_key_generator)
 
 
 def __download_geoip_db(directory, filename):

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2021 CERN
+# Copyright 2012-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Tomas Javurek <tomas.javurek@cern.ch>, 2020
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 import json
@@ -45,7 +45,6 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy
 import sqlalchemy.orm
-from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 from six import string_types
 from sqlalchemy.exc import DatabaseError, IntegrityError, OperationalError
@@ -55,7 +54,8 @@ from sqlalchemy.sql.expression import or_, false
 
 import rucio.core.account_counter
 from rucio.common import exception, utils
-from rucio.common.config import get_lfn2pfn_algorithm_default, config_get
+from rucio.common.cache import make_region_memcached
+from rucio.common.config import get_lfn2pfn_algorithm_default
 from rucio.common.utils import CHECKSUM_KEY, is_checksum_valid, GLOBALLY_SUPPORTED_CHECKSUMS
 from rucio.core.rse_counter import add_counter, get_counter
 from rucio.db.sqla import models
@@ -66,11 +66,7 @@ if TYPE_CHECKING:
     from typing import Dict, Optional
     from sqlalchemy.orm import Session
 
-REGION = make_region().configure('dogpile.cache.memcached',
-                                 expiration_time=3600,
-                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211',
-                                                              check_config_table=False),
-                                            'distributed_lock': True})
+REGION = make_region_memcached(expiration_time=3600)
 
 
 @transactional_session

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2021 CERN
+# Copyright 2013-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,16 +24,16 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Eric Vaandering <ewv@fnal.gov>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import abc
 import re
 
-from dogpile.cache import make_region
 from dogpile.cache.api import NoValue
 from hashlib import sha256
 from six import add_metaclass
 
-from rucio.common.config import config_get
+from rucio.common.cache import make_region_memcached
 from rucio.common.exception import InvalidRSEExpression, RSEWriteBlocked
 from rucio.core.rse import list_rses, get_rses_with_attribute, get_rse_attribute
 from rucio.db.sqla.session import transactional_session
@@ -48,10 +48,7 @@ COMPLEMENT = r'(\\%s)' % (PRIMITIVE)
 
 PATTERN = r'^%s(%s|%s|%s)*' % (PRIMITIVE, UNION, INTERSECTION, COMPLEMENT)
 
-
-REGION = make_region().configure('dogpile.cache.memcached',
-                                 expiration_time=600,
-                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
+REGION = make_region_memcached(expiration_time=600)
 
 
 @transactional_session

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2021 CERN
+# Copyright 2012-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Eric Vaandering <ewv@fnal.gov>, 2020-2021
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2020
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
@@ -68,6 +68,7 @@ import rucio.core.lock  # import get_replica_locks, get_files_and_replica_locks_
 import rucio.core.replica  # import get_and_lock_file_replicas, get_and_lock_file_replicas_for_dataset
 from rucio.common.policy import policy_filter, get_scratchdisk_lifetime
 
+from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get
 from rucio.common.exception import (InvalidRSEExpression, InvalidReplicationRule, InsufficientAccountLimit,
                                     DataIdentifierNotFound, RuleNotFound, InputValidationError, RSEOverQuota,
@@ -95,10 +96,7 @@ from rucio.db.sqla.session import read_session, transactional_session, stream_se
 from rucio.extensions.forecast import T3CModel
 
 
-REGION = make_region().configure('dogpile.cache.memcached',
-                                 expiration_time=3600,
-                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'),
-                                            'distributed_lock': True})
+REGION = make_region_memcached(expiration_time=3600)
 
 
 @transactional_session

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2021 CERN
+# Copyright 2013-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - Sahan Dilshan <32576163+sahandilshan@users.noreply.github.com>, 2021
 # - Petr Vokac <petr.vokac@fjfi.cvut.cz>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
@@ -50,13 +50,13 @@ import time
 from heapq import heappop, heappush
 from typing import TYPE_CHECKING
 
-from dogpile.cache import make_region
 from dogpile.cache.api import NoValue
 from sqlalchemy import and_, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import false
 
 from rucio.common import constants
+from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.constants import SUPPORTED_PROTOCOLS, FTS_STATE
 from rucio.common.exception import (InvalidRSEExpression, NoDistance,
@@ -96,9 +96,8 @@ where the external_id is already known.
 Requests accessed by request_id  are covered in the core request.py
 """
 
-REGION_SHORT = make_region().configure('dogpile.cache.memcached',
-                                       expiration_time=600,
-                                       arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
+REGION_SHORT = make_region_memcached(expiration_time=600)
+
 WEBDAV_TRANSFER_MODE = config_get('conveyor', 'webdav_transfer_mode', False, None)
 
 DEFAULT_MULTIHOP_TOMBSTONE_DELAY = int(datetime.timedelta(hours=2).total_seconds())

--- a/lib/rucio/core/transfer_limits.py
+++ b/lib/rucio/core/transfer_limits.py
@@ -1,25 +1,32 @@
-# Copyright European Organization for Nuclear Research (CERN)
+# -*- coding: utf-8 -*-
+# Copyright 2017-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
 # - Martin Barisits, <martin.barisits@cern.ch>, 2017
 # - Vincent Garonne, <vgaronne@gmail.com>, 2018
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
-#
-# PY3K COMPATIBLE
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import logging
 import traceback
 
-from dogpile.cache import make_region
 from dogpile.cache.api import NoValue
 
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.cache import make_region_memcached
+from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.core import config as config_core
 from rucio.core.rse import get_rse_id, get_rse_transfer_limits
 
@@ -33,10 +40,7 @@ if config_memcache.upper() == 'TRUE':
 else:
     using_memcache = False
 
-cache_time = int(config_get('conveyor', 'cache_time', False, 600))
-
-REGION_SHORT = make_region().configure('dogpile.cache.memory',
-                                       expiration_time=cache_time)
+REGION = make_region_memcached(expiration_time=config_get_int('conveyor', 'cache_time', False, 600))
 
 
 def get_transfer_limits(activity, rse_id, logger=logging.log):

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2021 CERN
+# Copyright 2015-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Matt Snyder <msnyder@bnl.gov>, 2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 """
@@ -48,6 +48,7 @@ from dogpile.cache.api import NoValue
 from sqlalchemy.exc import DatabaseError
 
 import rucio.db.sqla.util
+from rucio.common.cache import make_region_memcached
 from rucio.common.exception import DatabaseException, ConfigNotFound, UnsupportedOperation, ReplicaNotFound, RequestNotFound
 from rucio.common.logging import setup_logging
 from rucio.common.types import InternalAccount
@@ -68,7 +69,7 @@ except ImportError:
 
 graceful_stop = threading.Event()
 
-region = make_region().configure('dogpile.cache.memory', expiration_time=3600)
+REGION_SHORT = make_region_memcached(expiration_time=3600)
 
 
 def finisher(once=False, sleep_time=60, activities=None, bulk=100, db_bulk=1000, partition_wait_time=10):

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2021 CERN
+# Copyright 2016-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Matt Snyder <msnyder@bnl.gov>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 
 '''
 Reaper is a daemon to manage file deletion.
@@ -48,13 +48,13 @@ from datetime import datetime, timedelta
 from math import ceil
 from typing import TYPE_CHECKING
 
-from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
 from prometheus_client import Gauge
 from sqlalchemy.exc import DatabaseError, IntegrityError
 
 import rucio.db.sqla.util
 from rucio.common.config import config_get, config_get_bool
+from rucio.common.cache import make_region_memcached
 from rucio.common.exception import (DatabaseException, RSENotFound,
                                     ReplicaUnAvailable, ReplicaNotFound, ServiceUnavailable,
                                     RSEAccessDenied, ResourceTemporaryUnavailable, SourceNotFound,
@@ -77,10 +77,7 @@ if TYPE_CHECKING:
 
 GRACEFUL_STOP = threading.Event()
 
-REGION = make_region().configure('dogpile.cache.memcached',
-                                 expiration_time=600,
-                                 arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'),
-                                            'distributed_lock': True})
+REGION = make_region_memcached(expiration_time=600)
 
 DELETION_COUNTER = monitor.MultiCounter(prom='rucio_daemons_reaper_deletion_done', statsd='reaper.deletion.done',
                                         documentation='Number of deleted replicas')

--- a/lib/rucio/rse/__init__.py
+++ b/lib/rucio/rse/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2021 CERN
+# Copyright 2012-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,9 +25,11 @@
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 # - Gabriele Fronzé <sucre.91@hotmail.it>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 from dogpile.cache import make_region
 
+from rucio.common.cache import make_region_memcached
 from rucio.common.utils import is_client
 from rucio.rse import rsemanager
 from rucio.common import config
@@ -106,8 +108,5 @@ if rsemanager.SERVER_MODE:   # pylint:disable=no-member
 
     setattr(rsemanager, '__request_rse_info', tmp_rse_info)
     setattr(rsemanager, '__get_signed_url', get_signed_url_server)
-    RSE_REGION = make_region(function_key_generator=rse_key_generator).configure(
-        'dogpile.cache.memcached',
-        expiration_time=3600,
-        arguments={'url': config.config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True})
+    RSE_REGION = make_region_memcached(expiration_time=3600)
     setattr(rsemanager, 'RSE_REGION', RSE_REGION)

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2021 CERN
+# Copyright 2013-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Sahan Dilshan <32576163+sahandilshan@users.noreply.github.com>, 2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
 
 from __future__ import absolute_import, division
@@ -56,9 +56,9 @@ from json import loads
 from requests.adapters import ReadTimeout
 from requests.packages.urllib3 import disable_warnings  # pylint: disable=import-error
 
-from dogpile.cache import make_region
 from dogpile.cache.api import NoValue
 
+from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.constants import FTS_JOB_TYPE, FTS_STATE
 from rucio.common.exception import TransferToolTimeout, TransferToolWrongAnswer, DuplicateFileTransferSubmission
@@ -71,8 +71,7 @@ from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder
 logging.getLogger("requests").setLevel(logging.CRITICAL)
 disable_warnings()
 
-REGION_SHORT = make_region().configure('dogpile.cache.memory',
-                                       expiration_time=1800)
+REGION_SHORT = make_region_memcached(expiration_time=1800)
 
 SUBMISSION_COUNTER = MultiCounter(prom='rucio_transfertool_fts3_submission', statsd='transfertool.fts3.{host}.submission.{state}',
                                   documentation='Number of transfers submitted', labelnames=('state', 'host'))


### PR DESCRIPTION
Only keep the memory backend in clients and for policies.

Also, configure automatic purge of entries from memcached by setting
the memcached_expire_time argument.