### PR TITLE
Monitoring & Logging: prometheus metrics for servers. Closes #3416

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/metrics.py
+++ b/lib/rucio/web/rest/flaskapi/v1/metrics.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021-2022 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
+
+from flask import Flask, Blueprint
+from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView
+from rucio.core.monitor import generate_prometheus_metrics
+
+
+class Metrics(ErrorHandlingMethodView):
+    def get(self):
+        return generate_prometheus_metrics()
+
+
+def blueprint(standalone=False):
+    bp = Blueprint('metrics', __name__, url_prefix='/' if standalone else '/metrics')
+    metrics_view = Metrics.as_view('metrics')
+    bp.add_url_rule('/', view_func=metrics_view, methods=['get', ])
+    return bp
+
+
+def make_doc():
+    doc_app = Flask(__name__)
+    doc_app.register_blueprint(blueprint())
+    return doc_app

--- a/lib/rucio/web/rest/metrics.py
+++ b/lib/rucio/web/rest/metrics.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021-2022 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
+
+from rucio.common.logging import setup_logging
+from flask import Flask
+from rucio.web.rest.flaskapi.v1.metrics import blueprint as metrics_blueprint
+
+# Allow to run the /metrics endpoint as a separate application on a separate PORT
+
+setup_logging()
+application = Flask(__name__)
+application.register_blueprint(metrics_blueprint(standalone=True))
+
+if __name__ == '__main__':
+    application.run()


### PR DESCRIPTION
Mostly rely on prometheus_client library's functions for the job,
but had to do some small tweaks:
- The library has two type of supported value classes: MutexValue,
which is intended to be used in single-process (possible multi-threaded)
env; and MultiProcessValue, which is not thread-safe, but is backed by
a mmap-ed file, so can be shared between processes. As we use the apache
MPM module, which is both multi-processes and multi-threaded, had to
implement an additional value type and use it in servers.
- It can happen that mmap-ed *.db files are not correctly cleaned
up if an apache subprocess ends unexpectedly. Try to cleanup old files
when the endpoint is queried.

The prometheus_client library uses 'prometheus_multiproc_dir' env
variable to decide if it must switch to multiprocess mode. This is
backed soo deep into all the corners of the library, that it's not
reasonable to try to configure the behavior via a rucio config value.
As a result, to activate prometheus metrics in rucio servers, some
would have to set this counter-intuitive env variable.
Thankfully, if the env var is not set, the message output by
'generate_latest()' is quite clear about what has to be done.

Add a new /metrics endpoint, which can either be used as any other
route on the same port, or on a completely separate port via a
separate WSGI application.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
