### PR TITLE
Testing: Do not pull master in add_header script #5188

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Check headers
         shell: bash
         run: |
-          git pull origin master
           echo "Current git rev $(git rev-parse HEAD)"
           echo "Common ancestor git rev $(git merge-base HEAD remotes/origin/master)"
           echo "If a file header needs to be changed run 'tools/add_header -i FILE' from the rucio project directory."


### PR DESCRIPTION
The `git pull origin master` in the `add_header` script pulls the master branch
and merges it with the current one. This is not desired, since we only want to
pull the newest chages in the master branch.

We do not have to pull the master in the add_header script. The `fetch-depth: 0`
will automatically pull the master into the newest version.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
