### PR TITLE
Rules: Fix syntax errors

### DIFF
--- a/lib/rucio/core/rse_selector.py
+++ b/lib/rucio/core/rse_selector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2021 CERN
+# Copyright 2013-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 # - Robert Illingworth <illingwo@fnal.gov>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - Yutaro Iiyama <yutaro.iiyama@cern.ch>, 2022
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2022
 
 from random import uniform, shuffle
 
@@ -249,34 +251,34 @@ class RSESelector():
             if pick <= weight:
                 return (rse['rse_id'], rse['staging_area'], rse['availability_write'])
 
-    
+
 @read_session
 def resolve_rse_expression(rse_expression, account, weight=None, copies=1, ignore_account_limit=False, size=0, preferred_rses=[], blocklist=[], prioritize_order_over_weight=False, existing_rse_size=None, session=None):
     """
     Resolve a potentially complex RSE expression into `copies` single-RSE expressions. Uses `parse_expression()`
     to decompose the expression, then `RSESelector.select_rse()` to pick the target RSEs.
     """
-    
+
     rses = parse_expression(rse_expression, filter_={'vo': account.vo}, session=session)
 
     rse_to_id = dict((rse_dict['rse'], rse_dict['id']) for rse_dict in rses)
     id_to_rse = dict((rse_dict['id'], rse_dict['rse']) for rse_dict in rses)
-    
+
     selector = RSESelector(account=account,
                            rses=rses,
                            weight=weight,
                            copies=copies,
                            ignore_account_limit=ignore_account_limit,
                            session=session)
-    
+
     preferred_rse_ids = [rse_to_id[rse] for rse in preferred_rses if rse in rse_to_id]
 
     preferred_unmatched = list(set(preferred_rses) - set(rse_dict['rse'] for rse_dict in rses))
-    
+
     selection_result = selector.select_rse(size=size,
                                            preferred_rse_ids=preferred_rse_ids,
                                            blocklist=blocklist,
                                            prioritize_order_over_weight=prioritize_order_over_weight,
                                            existing_rse_size=existing_rse_size)
-   
+
     return [id_to_rse[rse_id] for rse_id, _, _ in selection_result], preferred_unmatched

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 CERN
+# Copyright 2018-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Yutaro Iiyama <yutaro.iiyama@cern.ch>, 2022
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2022
 
 import logging
 import os
@@ -341,7 +343,7 @@ def transmogrifier(bulk=5, once=False, sleep_time=60):
                                                 for rse_dict in parse_expression(rule['rse_expression'], filter_={'vo': account.vo}):
                                                     preferred_rses.add(rse_dict['rse'])
                                             preferred_rses = list(preferred_rses)
-                                               
+
                                             try:
                                                 selected_rses, preferred_unmatched = resolve_rse_expression(rse_expression,
                                                                                                             account,
@@ -374,7 +376,7 @@ def transmogrifier(bulk=5, once=False, sleep_time=60):
                                                     # The DID won't be reevaluated at the next cycle
                                                     did_success = did_success and True
                                                     continue
-                                                    
+
                                             if len(preferred_rses) - len(preferred_unmatched) >= copies:
                                                 skip_rule_creation = True
 


### PR DESCRIPTION
flake8 throws some syntax errors:
```
===============================
Running flake8
===============================
lib/rucio/core/rse_selector.py:252:1: W293 blank line contains whitespace
lib/rucio/core/rse_selector.py:259:1: W293 blank line contains whitespace
lib/rucio/core/rse_selector.py:264:1: W293 blank line contains whitespace
lib/rucio/core/rse_selector.py:271:1: W293 blank line contains whitespace
lib/rucio/core/rse_selector.py:275:1: W293 blank line contains whitespace
lib/rucio/core/rse_selector.py:281:1: W293 blank line contains whitespace
lib/rucio/daemons/transmogrifier/transmogrifier.py:344:1: W293 blank line contains whitespace
lib/rucio/daemons/transmogrifier/transmogrifier.py:377:1: W293 blank line contains whitespace
```

They were introduced in 7c71fedff8a36d652a08e4e427662141630c5e87

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
