### PR TITLE
Testing: Fix add_header job bug #5197

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -12,6 +12,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          # Check out pull request's HEAD commit instead of the merge commit to
+          # work-around an issue where wrong a commit is being checked out.
+          # For more details, see:
+          # https://github.com/actions/checkout/issues/299.
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check headers
         shell: bash
         run: |


### PR DESCRIPTION
The GitHub Checkout Actions checks out the wrong commit when the commit is
force-pushed. This error is known and reported
already. (https://github.com/actions/checkout/issues/299)

To fix this error, we use the sha provided by the pull request.

<!-- Please read https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst before submitting a pull request -->
