### PR TITLE
Transfers: homogenize daemon infinite loop handling. Closes #5231

### DIFF
--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2021 CERN
+# Copyright 2014-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@
 # - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019-2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - Nick Smith <nick.smith@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
@@ -52,6 +52,7 @@ from rucio.common.config import config_get
 from rucio.common.exception import (InvalidRSEExpression, TransferToolTimeout, TransferToolWrongAnswer, RequestNotFound,
                                     DuplicateFileTransferSubmission, VONotFound)
 from rucio.common.logging import formatted_logger
+from rucio.common.utils import PriorityQueue
 from rucio.core import heartbeat, request, transfer as transfer_core
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core.request import set_request_state
@@ -104,6 +105,56 @@ class HeartbeatHandler:
             self.logger(logging.DEBUG, 'Heartbeat renewed')
 
         return self.last_heart_beat, self.logger
+
+
+def run_conveyor_daemon(once, graceful_stop, executable, logger_prefix, partition_wait_time, sleep_time, run_once_fnc, activities=None, heart_beat_older_than=None):
+
+    with HeartbeatHandler(executable=executable, logger_prefix=logger_prefix) as heartbeat_handler:
+        logger = heartbeat_handler.logger
+        logger(logging.INFO, 'started')
+
+        if partition_wait_time:
+            graceful_stop.wait(partition_wait_time)
+
+        activity_next_exe_time = PriorityQueue()
+        for activity in activities or [None]:
+            activity_next_exe_time[activity] = time.time()
+
+        while not graceful_stop.is_set() and activity_next_exe_time:
+            if once:
+                activity = activity_next_exe_time.pop()
+                time_to_sleep = 0
+            else:
+                activity = activity_next_exe_time.top()
+                time_to_sleep = activity_next_exe_time[activity] - time.time()
+
+            if time_to_sleep > 0:
+                if activity:
+                    logger(logging.DEBUG, 'Switching to activity %s and sleeping %s seconds', activity, time_to_sleep)
+                else:
+                    logger(logging.DEBUG, 'Sleeping %s seconds', time_to_sleep)
+                graceful_stop.wait(time_to_sleep)
+            else:
+                if activity:
+                    logger(logging.DEBUG, 'Switching to activity %s', activity)
+                else:
+                    logger(logging.DEBUG, 'Starting next iteration')
+
+            heart_beat, logger = heartbeat_handler.live(older_than=heart_beat_older_than)
+
+            must_sleep = True
+            try:
+                must_sleep = run_once_fnc(activity=activity, total_workers=heart_beat['nr_threads'], worker_number=heart_beat['assign_thread'], logger=logger)
+            except Exception:
+                logger(logging.CRITICAL, "Exception", exc_info=True)
+                if once:
+                    raise
+
+            if not once:
+                if must_sleep:
+                    activity_next_exe_time[activity] = time.time() + sleep_time
+                else:
+                    activity_next_exe_time[activity] = time.time() + 1
 
 
 def submit_transfer(transfertool_obj, transfers, job_params, submitter='submitter', timeout=None, logger=logging.log):

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -17,7 +17,7 @@
 # - Wen Guan <wen.guan@cern.ch>, 2015-2016
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2015-2020
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2015-2018
-# - Martin Barisits <martin.barisits@cern.ch>, 2015-2021
+# - Martin Barisits <martin.barisits@cern.ch>, 2015-2022
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2017-2020
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Robert Illingworth <illingwo@fnal.gov>, 2019
@@ -37,6 +37,7 @@ Conveyor finisher is a daemon to update replicas and rules based on requests.
 from __future__ import division
 
 import datetime
+import functools
 import logging
 import os
 import re
@@ -51,12 +52,12 @@ from rucio.common.cache import make_region_memcached
 from rucio.common.exception import DatabaseException, ConfigNotFound, UnsupportedOperation, ReplicaNotFound, RequestNotFound
 from rucio.common.logging import setup_logging
 from rucio.common.types import InternalAccount
-from rucio.common.utils import chunks, daemon_sleep
+from rucio.common.utils import chunks
 from rucio.core import request as request_core, replica as replica_core
 from rucio.core.config import items
 from rucio.core.monitor import record_timer, record_counter
 from rucio.core.rse import list_rses
-from rucio.daemons.conveyor.common import HeartbeatHandler
+from rucio.daemons.conveyor.common import run_conveyor_daemon
 from rucio.db.sqla.constants import RequestState, RequestType, ReplicaState, BadFilesStatus
 from rucio.db.sqla.session import transactional_session
 from rucio.rse import rsemanager
@@ -69,6 +70,45 @@ except ImportError:
 graceful_stop = threading.Event()
 
 region = make_region_memcached(expiration_time=3600)
+
+
+def run_once(bulk, db_bulk, suspicious_patterns, retry_protocol_mismatches, total_workers, worker_number, logger, activity):
+    try:
+        logger(logging.DEBUG, 'Working on activity %s', activity)
+        time1 = time.time()
+        reqs = request_core.get_next(request_type=[RequestType.TRANSFER, RequestType.STAGEIN, RequestType.STAGEOUT],
+                                     state=[RequestState.DONE, RequestState.FAILED,
+                                            RequestState.LOST, RequestState.SUBMITTING,
+                                            RequestState.SUBMISSION_FAILED, RequestState.NO_SOURCES,
+                                            RequestState.ONLY_TAPE_SOURCES, RequestState.MISMATCH_SCHEME],
+                                     limit=db_bulk,
+                                     older_than=datetime.datetime.utcnow(),
+                                     total_workers=total_workers,
+                                     worker_number=worker_number,
+                                     mode_all=True,
+                                     hash_variable='rule_id')
+        record_timer('daemons.conveyor.finisher.get_next', (time.time() - time1) * 1000)
+        time2 = time.time()
+        if reqs:
+            logger(logging.DEBUG, 'Updating %i requests for activity %s', len(reqs), activity)
+
+        for chunk in chunks(reqs, bulk):
+            try:
+                time3 = time.time()
+                __handle_requests(chunk, suspicious_patterns, retry_protocol_mismatches, logger=logger)
+                record_timer('daemons.conveyor.finisher.handle_requests_time', (time.time() - time3) * 1000 / (len(chunk) if chunk else 1))
+                record_counter('daemons.conveyor.finisher.handle_requests', delta=len(chunk))
+            except Exception as error:
+                logger(logging.WARNING, '%s', str(error))
+        if reqs:
+            logger(logging.DEBUG, 'Finish to update %s finished requests for activity %s in %s seconds', len(reqs), activity, time.time() - time2)
+
+    except (DatabaseException, DatabaseError) as error:
+        if re.match('.*ORA-00054.*', error.args[0]) or re.match('.*ORA-00060.*', error.args[0]) or 'ERROR 1205 (HY000)' in error.args[0]:
+            logger(logging.WARNING, 'Lock detected when handling request - skipping: %s', str(error))
+        else:
+            raise
+    return True
 
 
 def finisher(once=False, sleep_time=60, activities=None, bulk=100, db_bulk=1000, partition_wait_time=10):
@@ -96,64 +136,23 @@ def finisher(once=False, sleep_time=60, activities=None, bulk=100, db_bulk=1000,
         activities.sort()
         executable += '--activities ' + str(activities)
 
-    with HeartbeatHandler(executable=executable, logger_prefix=logger_prefix) as heartbeat_handler:
-        logger = heartbeat_handler.logger
-        logger(logging.INFO, 'Finisher starting - db_bulk(%i) bulk (%i)', db_bulk, bulk)
-
-        if partition_wait_time:
-            graceful_stop.wait(partition_wait_time)
-        while not graceful_stop.is_set():
-
-            start_time = time.time()
-            try:
-                heart_beat, logger = heartbeat_handler.live(older_than=3600)
-                if activities is None:
-                    activities = [None]
-
-                for activity in activities:
-                    logger(logging.DEBUG, 'Working on activity %s', activity)
-                    time1 = time.time()
-                    reqs = request_core.get_next(request_type=[RequestType.TRANSFER, RequestType.STAGEIN, RequestType.STAGEOUT],
-                                                 state=[RequestState.DONE, RequestState.FAILED,
-                                                        RequestState.LOST, RequestState.SUBMITTING,
-                                                        RequestState.SUBMISSION_FAILED, RequestState.NO_SOURCES,
-                                                        RequestState.ONLY_TAPE_SOURCES, RequestState.MISMATCH_SCHEME],
-                                                 limit=db_bulk,
-                                                 older_than=datetime.datetime.utcnow(),
-                                                 total_workers=heart_beat['nr_threads'],
-                                                 worker_number=heart_beat['assign_thread'],
-                                                 mode_all=True,
-                                                 hash_variable='rule_id')
-                    record_timer('daemons.conveyor.finisher.get_next', (time.time() - time1) * 1000)
-                    time2 = time.time()
-                    if reqs:
-                        logger(logging.DEBUG, 'Updating %i requests for activity %s', len(reqs), activity)
-
-                    for chunk in chunks(reqs, bulk):
-                        try:
-                            time3 = time.time()
-                            __handle_requests(chunk, suspicious_patterns, retry_protocol_mismatches, logger=logger)
-                            record_timer('daemons.conveyor.finisher.handle_requests_time', (time.time() - time3) * 1000 / (len(chunk) if chunk else 1))
-                            record_counter('daemons.conveyor.finisher.handle_requests', delta=len(chunk))
-                        except Exception as error:
-                            logger(logging.WARNING, '%s', str(error))
-                    if reqs:
-                        logger(logging.DEBUG, 'Finish to update %s finished requests for activity %s in %s seconds', len(reqs), activity, time.time() - time2)
-
-            except (DatabaseException, DatabaseError) as error:
-                if re.match('.*ORA-00054.*', error.args[0]) or re.match('.*ORA-00060.*', error.args[0]) or 'ERROR 1205 (HY000)' in error.args[0]:
-                    logger(logging.WARNING, 'Lock detected when handling request - skipping: %s', str(error))
-                else:
-                    logger(logging.ERROR, 'Exception', exc_info=True)
-            except Exception:
-                logger(logging.CRITICAL, 'Exception', exc_info=True)
-                if once:
-                    raise
-
-            if once:
-                break
-
-            daemon_sleep(start_time=start_time, sleep_time=sleep_time, graceful_stop=graceful_stop, logger=logger)
+    run_conveyor_daemon(
+        once=once,
+        graceful_stop=graceful_stop,
+        executable=executable,
+        logger_prefix=logger_prefix,
+        partition_wait_time=partition_wait_time,
+        sleep_time=sleep_time,
+        run_once_fnc=functools.partial(
+            run_once,
+            bulk=bulk,
+            db_bulk=db_bulk,
+            suspicious_patterns=suspicious_patterns,
+            retry_protocol_mismatches=retry_protocol_mismatches,
+        ),
+        activities=activities,
+        heart_beat_older_than=3600,
+    )
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2021 CERN
+# Copyright 2015-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 
 """
 Conveyor stager is a daemon to manage stagein file transfers.
@@ -31,10 +31,10 @@ Conveyor stager is a daemon to manage stagein file transfers.
 
 from __future__ import division
 
+import functools
 import logging
 import threading
 import time
-from collections import defaultdict
 
 from six.moves.configparser import NoOptionError
 
@@ -44,11 +44,50 @@ from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.logging import setup_logging
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core import transfer as transfer_core
-from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, HeartbeatHandler
+from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, run_conveyor_daemon
 from rucio.db.sqla.constants import RequestType
 from rucio.transfertool.fts3 import FTS3Transfertool
 
 graceful_stop = threading.Event()
+
+
+def run_once(bulk, group_bulk, rse_ids, scheme, failover_scheme, transfertool_kwargs, total_workers, worker_number, logger, activity):
+    start_time = time.time()
+    transfers = transfer_core.next_transfers_to_submit(
+        total_workers=total_workers,
+        worker_number=worker_number,
+        failover_schemes=failover_scheme,
+        limit=bulk,
+        activity=activity,
+        rses=rse_ids,
+        schemes=scheme,
+        transfertools_by_name={'fts3': FTS3Transfertool},
+        older_than=None,
+        request_type=RequestType.STAGEIN,
+        logger=logger,
+    )
+    total_transfers = len(list(hop for paths in transfers.values() for path in paths for hop in path))
+    record_timer('daemons.conveyor.stager.get_stagein_transfers.per_transfer', (time.time() - start_time) * 1000 / (total_transfers if transfers else 1))
+    record_counter('daemons.conveyor.stager.get_stagein_transfers', total_transfers)
+    record_timer('daemons.conveyor.stager.get_stagein_transfers.transfers', total_transfers)
+    logger(logging.INFO, 'Got %s stagein transfers for %s' % (total_transfers, activity))
+
+    for builder, transfer_paths in transfers.items():
+        transfertool_obj = builder.make_transfertool(logger=logger, **transfertool_kwargs.get(builder.transfertool_class, {}))
+        logger(logging.INFO, 'Starting to group transfers for %s (%s)' % (activity, transfertool_obj))
+        start_time = time.time()
+        grouped_jobs = transfertool_obj.group_into_submit_jobs(transfer_paths)
+        record_timer('daemons.conveyor.stager.bulk_group_transfer', (time.time() - start_time) * 1000 / (len(transfer_paths) or 1))
+
+        logger(logging.INFO, 'Starting to submit transfers for %s (%s)' % (activity, transfertool_obj))
+        for job in grouped_jobs:
+            submit_transfer(transfertool_obj=transfertool_obj, transfers=job['transfers'], job_params=job['job_params'], submitter='transfer_submitter', logger=logger)
+
+    queue_empty = False
+    if total_transfers < group_bulk:
+        queue_empty = True
+        logger(logging.INFO, 'Only %s transfers for %s which is less than group bulk %s' % (total_transfers, activity, group_bulk))
+    return queue_empty
 
 
 def stager(once=False, rses=None, bulk=100, group_bulk=1, group_policy='rule',
@@ -85,84 +124,46 @@ def stager(once=False, rses=None, bulk=100, group_bulk=1, group_policy='rule',
         max_time_in_queue['default'] = 168
     logging.debug("Maximum time in queue for different activities: %s" % max_time_in_queue)
 
-    activity_next_exe_time = defaultdict(time.time)
     logger_prefix = executable = 'conveyor-stager'
     if activities:
         activities.sort()
         executable += '--activities ' + str(activities)
-    with HeartbeatHandler(executable=executable, logger_prefix=logger_prefix) as heartbeat_handler:
-        logger = heartbeat_handler.logger
-        logger(logging.INFO, 'Stager starting with bring_online %s seconds' % (bring_online))
 
-        while not graceful_stop.is_set():
+    if rses:
+        rse_ids = [rse['id'] for rse in rses]
+    else:
+        rse_ids = None
 
-            try:
-                heart_beat, logger = heartbeat_handler.live()
+    transfertool_kwargs = {
+        FTS3Transfertool: {
+            'group_policy': group_policy,
+            'group_bulk': group_bulk,
+            'source_strategy': source_strategy,
+            'max_time_in_queue': max_time_in_queue,
+            'bring_online': bring_online,
+            'default_lifetime': -1,
+        }
+    }
 
-                if activities is None:
-                    activities = [None]
-                if rses:
-                    rse_ids = [rse['id'] for rse in rses]
-                else:
-                    rse_ids = None
-
-                for activity in activities:
-                    if activity_next_exe_time[activity] > time.time():
-                        graceful_stop.wait(1)
-                        continue
-
-                    logger(logging.INFO, 'Starting to get stagein transfers for %s' % (activity))
-                    start_time = time.time()
-
-                    transfertool_kwargs = {
-                        FTS3Transfertool: {
-                            'group_policy': group_policy,
-                            'group_bulk': group_bulk,
-                            'source_strategy': source_strategy,
-                            'max_time_in_queue': max_time_in_queue,
-                            'bring_online': bring_online,
-                            'default_lifetime': -1,
-                        }
-                    }
-                    transfers = transfer_core.next_transfers_to_submit(
-                        total_workers=heart_beat['nr_threads'],
-                        worker_number=heart_beat['assign_thread'],
-                        failover_schemes=failover_scheme,
-                        limit=bulk,
-                        activity=activity,
-                        rses=rse_ids,
-                        schemes=scheme,
-                        transfertools_by_name={'fts3': FTS3Transfertool},
-                        older_than=None,
-                        request_type=RequestType.STAGEIN,
-                        logger=logger,
-                    )
-                    total_transfers = len(list(hop for paths in transfers.values() for path in paths for hop in path))
-                    record_timer('daemons.conveyor.stager.get_stagein_transfers.per_transfer', (time.time() - start_time) * 1000 / (total_transfers if transfers else 1))
-                    record_counter('daemons.conveyor.stager.get_stagein_transfers', total_transfers)
-                    record_timer('daemons.conveyor.stager.get_stagein_transfers.transfers', total_transfers)
-                    logger(logging.INFO, 'Got %s stagein transfers for %s' % (total_transfers, activity))
-
-                    for builder, transfer_paths in transfers.items():
-                        transfertool_obj = builder.make_transfertool(logger=logger, **transfertool_kwargs.get(builder.transfertool_class, {}))
-                        logger(logging.INFO, 'Starting to group transfers for %s (%s)' % (activity, transfertool_obj))
-                        start_time = time.time()
-                        grouped_jobs = transfertool_obj.group_into_submit_jobs(transfer_paths)
-                        record_timer('daemons.conveyor.stager.bulk_group_transfer', (time.time() - start_time) * 1000 / (len(transfer_paths) or 1))
-
-                        logger(logging.INFO, 'Starting to submit transfers for %s (%s)' % (activity, transfertool_obj))
-                        for job in grouped_jobs:
-                            submit_transfer(transfertool_obj=transfertool_obj, transfers=job['transfers'], job_params=job['job_params'], submitter='transfer_submitter', logger=logger)
-
-                    if total_transfers < group_bulk:
-                        logger(logging.INFO, 'Only %s transfers for %s which is less than group bulk %s, sleep %s seconds' % (total_transfers, activity, group_bulk, sleep_time))
-                        if activity_next_exe_time[activity] < time.time():
-                            activity_next_exe_time[activity] = time.time() + sleep_time
-            except Exception:
-                raise
-
-            if once:
-                break
+    run_conveyor_daemon(
+        once=once,
+        graceful_stop=graceful_stop,
+        executable=executable,
+        logger_prefix=logger_prefix,
+        partition_wait_time=None,
+        sleep_time=sleep_time,
+        run_once_fnc=functools.partial(
+            run_once,
+            bulk=bulk,
+            group_bulk=group_bulk,
+            scheme=scheme,
+            failover_scheme=failover_scheme,
+            rse_ids=rse_ids,
+            transfertool_kwargs=transfertool_kwargs,
+        ),
+        activities=activities,
+        heart_beat_older_than=None,
+    )
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2021 CERN
+# Copyright 2013-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2020
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 
 """
 Conveyor transfer submitter is a daemon to manage non-tape file transfers.
@@ -39,10 +39,10 @@ Conveyor transfer submitter is a daemon to manage non-tape file transfers.
 
 from __future__ import division
 
+import functools
 import logging
 import threading
 import time
-from collections import defaultdict
 
 from six.moves.configparser import NoOptionError
 
@@ -51,10 +51,9 @@ from rucio.common import exception
 from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.logging import setup_logging
 from rucio.common.schema import get_schema_value
-from rucio.common.utils import PriorityQueue
 from rucio.core import transfer as transfer_core
 from rucio.core.monitor import MultiCounter, record_timer
-from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, HeartbeatHandler
+from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, run_conveyor_daemon
 from rucio.db.sqla.constants import RequestType
 from rucio.transfertool.fts3 import FTS3Transfertool
 from rucio.transfertool.globus import GlobusTransferTool
@@ -74,6 +73,54 @@ TRANSFERTOOL_CLASSES_BY_NAME = {
     'globus': GlobusTransferTool,
     'mock': MockTransfertool,
 }
+
+
+def run_once(bulk, group_bulk, filter_transfertool, transfertool, ignore_availability, rse_ids,
+             scheme, failover_scheme, partition_hash_var, timeout, transfertool_kwargs,
+             total_workers, worker_number, logger, activity):
+
+    start_time = time.time()
+    transfers = transfer_core.next_transfers_to_submit(
+        total_workers=total_workers,
+        worker_number=worker_number,
+        partition_hash_var=partition_hash_var,
+        failover_schemes=failover_scheme,
+        limit=bulk,
+        activity=activity,
+        rses=rse_ids,
+        schemes=scheme,
+        filter_transfertool=filter_transfertool,
+        transfertools_by_name={transfertool: TRANSFERTOOL_CLASSES_BY_NAME[transfertool]},
+        older_than=None,
+        request_type=RequestType.TRANSFER,
+        ignore_availability=ignore_availability,
+        logger=logger,
+    )
+    total_transfers = len(list(hop for paths in transfers.values() for path in paths for hop in path))
+
+    record_timer('daemons.conveyor.transfer_submitter.get_transfers.per_transfer', (time.time() - start_time) * 1000 / (total_transfers or 1))
+    GET_TRANSFERS_COUNTER.inc(total_transfers)
+    record_timer('daemons.conveyor.transfer_submitter.get_transfers.transfers', total_transfers)
+    logger(logging.INFO, 'Got %s transfers for %s in %s seconds', total_transfers, activity, time.time() - start_time)
+
+    for builder, transfer_paths in transfers.items():
+        transfertool_obj = builder.make_transfertool(logger=logger, **transfertool_kwargs.get(builder.transfertool_class, {}))
+        start_time = time.time()
+        logger(logging.DEBUG, 'Starting to group transfers for %s (%s)', activity, transfertool_obj)
+        grouped_jobs = transfertool_obj.group_into_submit_jobs(transfer_paths)
+        record_timer('daemons.conveyor.transfer_submitter.bulk_group_transfer', (time.time() - start_time) * 1000 / (len(transfer_paths) or 1))
+
+        logger(logging.DEBUG, 'Starting to submit transfers for %s (%s)', activity, transfertool_obj)
+        for job in grouped_jobs:
+            logger(logging.DEBUG, 'submitjob: transfers=%s, job_params=%s' % ([str(t) for t in job['transfers']], job['job_params']))
+            submit_transfer(transfertool_obj=transfertool_obj, transfers=job['transfers'], job_params=job['job_params'], submitter='transfer_submitter',
+                            timeout=timeout, logger=logger)
+
+    queue_empty = False
+    if total_transfers < group_bulk:
+        queue_empty = True
+        logger(logging.DEBUG, 'Only %s transfers for %s which is less than group bulk %s', total_transfers, activity, group_bulk)
+    return queue_empty
 
 
 def submitter(once=False, rses=None, partition_wait_time=10,
@@ -122,112 +169,57 @@ def submitter(once=False, rses=None, partition_wait_time=10,
         max_time_in_queue['default'] = 168
     logging.debug("Maximum time in queue for different activities: %s", max_time_in_queue)
 
-    activity_next_exe_time = defaultdict(time.time)
     logger_prefix = executable = "conveyor-submitter"
     if activities:
         activities.sort()
         executable += '--activities ' + str(activities)
     if filter_transfertool:
         executable += ' --filter-transfertool ' + filter_transfertool
-
-    if activities is None:
-        activities = [None]
     if rses:
         rse_ids = [rse['id'] for rse in rses]
     else:
         rse_ids = None
 
-    with HeartbeatHandler(executable=executable, logger_prefix=logger_prefix) as heartbeat_handler:
-        logger = heartbeat_handler.logger
-        logger(logging.INFO, 'Submitter starting with timeout %s', timeout)
+    transfertool_kwargs = {
+        FTS3Transfertool: {
+            'group_policy': group_policy,
+            'group_bulk': group_bulk,
+            'source_strategy': source_strategy,
+            'max_time_in_queue': max_time_in_queue,
+            'bring_online': bring_online,
+            'default_lifetime': 172800,
+            'archive_timeout_override': archive_timeout_override,
+        },
+        GlobusTransferTool: {
+            'group_policy': transfertype,
+            'group_bulk': group_bulk,
+        },
+    }
 
-        if partition_wait_time:
-            graceful_stop.wait(partition_wait_time)
-
-        activity_next_exe_time = PriorityQueue()
-        for activity in activities:
-            activity_next_exe_time[activity] = time.time()
-
-        while not graceful_stop.is_set() and activity_next_exe_time:
-            try:
-                time_to_sleep = 0
-                if once:
-                    activity = activity_next_exe_time.pop()
-                else:
-                    activity = activity_next_exe_time.top()
-                    time_to_sleep = activity_next_exe_time[activity] - time.time()
-                    activity_next_exe_time[activity] = time.time() + 1
-                if time_to_sleep > 0:
-                    logger(logging.DEBUG, 'Switching to activity %s and sleeping %s seconds', activity, time_to_sleep)
-                    graceful_stop.wait(time_to_sleep)
-                else:
-                    logger(logging.DEBUG, 'Switching to activity %s', activity)
-
-                heart_beat, logger = heartbeat_handler.live(older_than=3600)
-
-                start_time = time.time()
-
-                transfertool_kwargs = {
-                    FTS3Transfertool: {
-                        'group_policy': group_policy,
-                        'group_bulk': group_bulk,
-                        'source_strategy': source_strategy,
-                        'max_time_in_queue': max_time_in_queue,
-                        'bring_online': bring_online,
-                        'default_lifetime': 172800,
-                        'archive_timeout_override': archive_timeout_override,
-                    },
-                    GlobusTransferTool: {
-                        'group_policy': transfertype,
-                        'group_bulk': group_bulk,
-                    },
-                }
-                transfers = transfer_core.next_transfers_to_submit(
-                    total_workers=heart_beat['nr_threads'],
-                    worker_number=heart_beat['assign_thread'],
-                    partition_hash_var=partition_hash_var,
-                    failover_schemes=failover_scheme,
-                    limit=bulk,
-                    activity=activity,
-                    rses=rse_ids,
-                    schemes=scheme,
-                    filter_transfertool=filter_transfertool,
-                    transfertools_by_name={transfertool: TRANSFERTOOL_CLASSES_BY_NAME[transfertool]},
-                    older_than=None,
-                    request_type=RequestType.TRANSFER,
-                    ignore_availability=ignore_availability,
-                    logger=logger,
-                )
-                total_transfers = len(list(hop for paths in transfers.values() for path in paths for hop in path))
-
-                record_timer('daemons.conveyor.transfer_submitter.get_transfers.per_transfer', (time.time() - start_time) * 1000 / (total_transfers or 1))
-                GET_TRANSFERS_COUNTER.inc(total_transfers)
-                record_timer('daemons.conveyor.transfer_submitter.get_transfers.transfers', total_transfers)
-                logger(logging.INFO, '%sGot %s transfers for %s in %s seconds',
-                       'Slept %s seconds, then ' % time_to_sleep if time_to_sleep > 0 else '',
-                       total_transfers, activity, time.time() - start_time)
-
-                for builder, transfer_paths in transfers.items():
-                    transfertool_obj = builder.make_transfertool(logger=logger, **transfertool_kwargs.get(builder.transfertool_class, {}))
-                    start_time = time.time()
-                    logger(logging.DEBUG, 'Starting to group transfers for %s (%s)', activity, transfertool_obj)
-                    grouped_jobs = transfertool_obj.group_into_submit_jobs(transfer_paths)
-                    record_timer('daemons.conveyor.transfer_submitter.bulk_group_transfer', (time.time() - start_time) * 1000 / (len(transfer_paths) or 1))
-
-                    logger(logging.DEBUG, 'Starting to submit transfers for %s (%s)', activity, transfertool_obj)
-                    for job in grouped_jobs:
-                        logger(logging.DEBUG, 'submitjob: transfers=%s, job_params=%s' % ([str(t) for t in job['transfers']], job['job_params']))
-                        submit_transfer(transfertool_obj=transfertool_obj, transfers=job['transfers'], job_params=job['job_params'], submitter='transfer_submitter',
-                                        timeout=timeout, logger=logger)
-
-                if not once and total_transfers < group_bulk:
-                    logger(logging.DEBUG, 'Only %s transfers for %s which is less than group bulk %s, sleep %s seconds', total_transfers, activity, group_bulk, sleep_time)
-                    activity_next_exe_time[activity] = time.time() + sleep_time
-
-            except Exception:
-                logger(logging.CRITICAL, 'Exception', exc_info=True)
-                if once:
-                    raise
+    run_conveyor_daemon(
+        once=once,
+        graceful_stop=graceful_stop,
+        executable=executable,
+        logger_prefix=logger_prefix,
+        partition_wait_time=partition_wait_time,
+        sleep_time=sleep_time,
+        run_once_fnc=functools.partial(
+            run_once,
+            bulk=bulk,
+            group_bulk=group_bulk,
+            filter_transfertool=filter_transfertool,
+            transfertool=transfertool,
+            ignore_availability=ignore_availability,
+            scheme=scheme,
+            failover_scheme=failover_scheme,
+            partition_hash_var=partition_hash_var,
+            rse_ids=rse_ids,
+            timeout=timeout,
+            transfertool_kwargs=transfertool_kwargs,
+        ),
+        activities=activities,
+        heart_beat_older_than=3600,
+    )
 
 
 def stop(signum=None, frame=None):

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2021 CERN
+# Copyright 2016-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 # - Brandon White <bjwhite@fnal.gov>, 2019
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2020-2021
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 
 """
 Conveyor throttler is a daemon to manage rucio internal queue.
@@ -34,7 +34,6 @@ from __future__ import division
 import logging
 import math
 import threading
-import time
 import traceback
 
 import rucio.db.sqla.util
@@ -45,7 +44,7 @@ from rucio.core import config as config_core
 from rucio.core.monitor import record_counter, record_gauge
 from rucio.core.request import get_stats_by_activity_direction_state, release_all_waiting_requests, release_waiting_requests_fifo, release_waiting_requests_grouped_fifo
 from rucio.core.rse import get_rse, set_rse_transfer_limits, delete_rse_transfer_limits, get_rse_transfer_limits
-from rucio.daemons.conveyor.common import HeartbeatHandler
+from rucio.daemons.conveyor.common import run_conveyor_daemon
 from rucio.db.sqla.constants import RequestState
 
 graceful_stop = threading.Event()
@@ -60,42 +59,17 @@ def throttler(once=False, sleep_time=600, partition_wait_time=10):
 
     logger_prefix = executable = 'conveyor-throttler'
 
-    with HeartbeatHandler(executable=executable, logger_prefix=logger_prefix) as heartbeat_handler:
-        logger = heartbeat_handler.logger
-        logger(logging.INFO, 'Throttler started - timeout (%s)' % sleep_time)
-
-        current_time = time.time()
-
-        if partition_wait_time:
-            graceful_stop.wait(partition_wait_time)
-        while not graceful_stop.is_set():
-
-            try:
-                heart_beat, logger = heartbeat_handler.live(older_than=3600)
-                if heart_beat['assign_thread'] != 0:
-                    logger(logging.INFO, 'Throttler thread id is not 0, will sleep. Only thread 0 will work')
-                    if once:
-                        break
-                    if time.time() < current_time + sleep_time:
-                        graceful_stop.wait(int((current_time + sleep_time) - time.time()))
-                    current_time = time.time()
-                    continue
-
-                logger(logging.INFO, "Throttler - schedule requests")
-                run_once(logger=logger)
-
-                if once:
-                    break
-                if time.time() < current_time + sleep_time:
-                    graceful_stop.wait(int((current_time + sleep_time) - time.time()))
-                current_time = time.time()
-            except Exception:
-                logger(logging.CRITICAL, 'Throtter crashed %s' % (traceback.format_exc()))
-                if once:
-                    raise
-
-            if once:
-                break
+    run_conveyor_daemon(
+        once=once,
+        graceful_stop=graceful_stop,
+        executable=executable,
+        logger_prefix=logger_prefix,
+        partition_wait_time=partition_wait_time,
+        sleep_time=sleep_time,
+        run_once_fnc=run_once,
+        activities=None,
+        heart_beat_older_than=3600,
+    )
 
 
 def stop(signum=None, frame=None):
@@ -200,10 +174,14 @@ def __get_request_stats(all_activities=False, direction='destination'):
     return result_dict
 
 
-def run_once(logger=logging.log, session=None):
+def run_once(worker_number=0, logger=logging.log, session=None, **kwargs):
     """
     Schedule requests
     """
+    if worker_number != 0:
+        logger(logging.INFO, 'Throttler thread id is not 0, will sleep. Only thread 0 will work')
+        return True
+    logger(logging.INFO, "Throttler - schedule requests")
     try:
         throttler_mode = config_core.get('throttler', 'mode', default='DEST_PER_ACT', use_cache=False)
         direction, all_activities = get_parsed_throttler_mode(throttler_mode)
@@ -220,6 +198,7 @@ def run_once(logger=logging.log, session=None):
                         __release_per_activity(result_dict[rse_id], direction, rse_name, rse_id, logger=logger, session=session)
     except Exception:
         logger(logging.CRITICAL, "Failed to schedule requests, error: %s" % (traceback.format_exc()))
+    return True
 
 
 def __release_all_activities(stats, direction, rse_name, rse_id, logger, session):


### PR DESCRIPTION
Each conveyor daemon had its own copy-pasted version of the same
loop: with minor adjustements which were at different level of quality
depending on when (and from which other daemon) the loop was copied.

Create a run_conveyor_daemon function which is used now by all daemons.
The common loop is based on the one previously used in submitter:
using a priority queue to avoid busy looping and for prioritizing the
activities which actually have work to do.

Rework all daemons to have a run_once function which is transmitted
as a callback. Some daemons already had such function, so it was
slightly adapted to do the work. For other daemons it's just code move.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
