### PR TITLE
 Set the itsdangerous module version prior to 2.1.0 #5258

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ geoip2==4.1.0                                               # GeoIP2 API (for IP
 oauth2client==4.1.3                                         # OAuth 2.0 client library
 retrying==1.3.3                                             # general-purpose retrying library to simplify the task of adding retry behavior to just about anything
 redis==3.5.3                                                # Python client for Redis key-value store
+itsdangerous<2.1.0                                          # Flask dependency, broken support since 2.1.0 https://github.com/pallets/flask/issues/4455
 Flask==1.1.2                                                # Python web framework
 oic==1.2.1                                                  # for authentication via OpenID Connect protocol
 prometheus_client==0.9.0                                    # Python client for the Prometheus monitoring system

--- a/setuputil.py
+++ b/setuputil.py
@@ -96,6 +96,7 @@ server_requirements_table = {
         'oauth2client',
         'retrying',
         'redis',
+        'itsdangerous',
         'flask',
         'oic',
         'prometheus_client',


### PR DESCRIPTION
The new `itsdangerous` package version 2.1.0 is incompatible with the Flask
version 1.1.2.