### PR TITLE
Set the itsdangerous module version prior to 2.1.0 #5258

### DIFF
--- a/etc/pip-requires
+++ b/etc/pip-requires
@@ -18,6 +18,7 @@ redis==3.4.1                                      # Python client for Redis key-
 numpy==1.14.2; python_version <= '3.5'            # Numpy for forecasting T3C (1.17.0 is Py3 only)
 numpy==1.19.0; python_version >= '3.6'            # Numpy for forecasting T3C
 paramiko==2.7.1                                   # SSH2 protocol library
+itsdangerous<2.1.0                                # Flask dependency, broken support since 2.1.0 https://github.com/pallets/flask/issues/4455
 Flask==1.1.1                                      # Python web framework
 M2Crypto<=0.35.2                                  # Dependency of FTS rest API; Temporary fix since 0.33 does not install on CC7
 oic==0.15.1; python_version <= '3.5'              # for authentication via OpenID Connect protocol

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -17,6 +17,7 @@ redis==3.4.1                                      # Python client for Redis key-
 numpy==1.14.2; python_version <= '3.5'            # Numpy for forecasting T3C (1.17.0 is Py3 only)
 numpy==1.19.0; python_version >= '3.6'            # Numpy for forecasting T3C
 paramiko==2.7.1                                   # SSH2 protocol library
+itsdangerous<2.1.0                                # Flask dependency, broken support since 2.1.0 https://github.com/pallets/flask/issues/4455
 Flask==1.1.1                                      # Python web framework
 M2Crypto<=0.35.2                                  # Dependency of FTS rest API; Temporary fix since 0.33 does not install on CC7
 oic==0.15.1                                       # for authentication via OpenID Connect protocol


### PR DESCRIPTION
The new `itsdangerous` package version 2.1.0 is incompatible with the Flask
version 1.1.1.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
