### PR TITLE
Transfers: disentangle fts3 code from poller/receiver. Closes #4873. Closes #4576

### DIFF
--- a/lib/rucio/api/request.py
+++ b/lib/rucio/api/request.py
@@ -20,6 +20,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - Rob Barnsley <rob.barnsley@skao.int>, 2021-2022
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 """
 Interface for the requests abstraction layer
@@ -54,24 +55,6 @@ def queue_requests(requests, issuer, vo='def'):
 
     new_requests = request.queue_requests(requests)
     return [api_update_return_dict(r) for r in new_requests]
-
-
-def query_request(request_id, issuer, account, vo='def'):
-    """
-    Query the status of a request.
-
-    :param request_id: Request-ID as a 32 character hex string.
-    :param issuer: Issuing account as a string.
-    :param account: Account identifier as a string.
-    :param vo: The VO to act on.
-    :returns: Request status information as a dictionary.
-    """
-
-    kwargs = {'account': account, 'issuer': issuer, 'request_id': request_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='query_request', kwargs=kwargs):
-        raise exception.AccessDenied('%s cannot query request %s' % (account, request_id))
-
-    return request.query_request(request_id)
 
 
 def cancel_request(request_id, issuer, account, vo='def'):

--- a/lib/rucio/common/rse_attributes.py
+++ b/lib/rucio/common/rse_attributes.py
@@ -33,8 +33,62 @@ from dogpile.cache.api import NoValue
 
 from rucio.core import rse as rse_core
 from rucio.common.cache import make_region_memcached
+from rucio.db.sqla.constants import RSEType
+from rucio.db.sqla.session import read_session
+from rucio.rse import rsemanager as rsemgr
 
 REGION = make_region_memcached(expiration_time=3600)
+
+
+class RseData:
+    """
+    Helper data class storing rse data grouped in one place.
+    """
+    def __init__(self, id_, name=None, attributes=None, info=None):
+        self.id = id_
+        self.name = name
+        self.attributes = attributes
+        self.info = info
+
+    def __str__(self):
+        if self.name is not None:
+            return self.name
+        return self.id
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+        return self.id == other.id
+
+    def is_tape(self):
+        if self.info['rse_type'] == RSEType.TAPE or self.info['rse_type'] == 'TAPE':
+            return True
+        return False
+
+    def is_tape_or_staging_required(self):
+        if self.is_tape() or self.attributes.get('staging_required', False):
+            return True
+        return False
+
+    @read_session
+    def load_name(self, session=None):
+        if self.name is None:
+            self.name = rse_core.get_rse_name(rse_id=self.id, session=session)
+        return self.name
+
+    @read_session
+    def load_attributes(self, session=None):
+        if self.attributes is None:
+            self.attributes = get_rse_attributes(self.id, session=session)
+        return self.attributes
+
+    @read_session
+    def load_info(self, session=None):
+        if self.info is None:
+            self.info = rsemgr.get_rse_info(rse=self.load_name(session=session),
+                                            vo=rse_core.get_rse_vo(rse_id=self.id, session=session),
+                                            session=session)
+        return self.info
 
 
 def get_rse_attributes(rse_id, session=None):

--- a/lib/rucio/core/permission/atlas.py
+++ b/lib/rucio/core/permission/atlas.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2021 CERN
+# Copyright 2016-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
-# - Ilija Vukotic <ivukotic@uchicago.edu>, 2021
+# - Ilija Vukotic <ivukotic@uchicago.edu>, 2022
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 from typing import TYPE_CHECKING
 
@@ -99,7 +100,6 @@ def has_permission(issuer, action, kwargs):
             'queue_requests': perm_queue_requests,
             'set_rse_usage': perm_set_rse_usage,
             'set_rse_limits': perm_set_rse_limits,
-            'query_request': perm_query_request,
             'get_request_by_did': perm_get_request_by_did,
             'cancel_request': perm_cancel_request,
             'get_next': perm_get_next,
@@ -877,17 +877,6 @@ def perm_update_replicas_states(issuer, kwargs):
 def perm_queue_requests(issuer, kwargs):
     """
     Checks if an account can submit transfer or deletion requests on destination RSEs for data identifiers.
-
-    :param issuer: Account identifier which issues the command.
-    :param kwargs: List of arguments for the action.
-    :returns: True if account is allowed, otherwise False
-    """
-    return _is_root(issuer)
-
-
-def perm_query_request(issuer, kwargs):
-    """
-    Checks if an account can query a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/core/permission/belleii.py
+++ b/lib/rucio/core/permission/belleii.py
@@ -1,4 +1,5 @@
-# Copyright 2016-2020 CERN
+# -*- coding: utf-8 -*-
+# Copyright 2020-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +14,11 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne <vgaronne@gmail.com>, 2016
-# - Cedric Serfon <cedric.serfon@cern.ch>, 2016-2020
-# - Martin Barisits <martin.barisits@cern.ch>, 2017-2020
-# - Mario Lassnig <mario.lassnig@cern.ch>, 2018
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
-# - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
-# - Eric Vaandering, <ewv@fnal.gov>, 2020
-#
-# PY3K COMPATIBLE
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2020
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 from rucio.common.types import InternalScope
 from rucio.core.lifetime_exception import list_exceptions
@@ -86,7 +82,6 @@ def has_permission(issuer, action, kwargs):
             'queue_requests': perm_queue_requests,
             'set_rse_usage': perm_set_rse_usage,
             'set_rse_limits': perm_set_rse_limits,
-            'query_request': perm_query_request,
             'get_request_by_did': perm_get_request_by_did,
             'cancel_request': perm_cancel_request,
             'get_next': perm_get_next,

--- a/lib/rucio/core/permission/cms.py
+++ b/lib/rucio/core/permission/cms.py
@@ -1,23 +1,32 @@
-# Copyright European Organization for Nuclear Research (CERN)
+# -*- coding: utf-8 -*-
+# Copyright 2017-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2016
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2016-2018
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2017-2020
-# - Martin Barisits, <martin.barisits@cern.ch>, 2017-2020
-# - Eric Vaandering, <ewv@fnal.gov>, 2018-2020
-# - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Ruturaj Gujar, <ruturaj.gujar23@gmail.com>, 2019
-# - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
-# - Eli Chadwick, <eli.chadwick@stfc.ac.uk>, 2020
-# - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
-#
-# PY3K COMPATIBLE
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2017
+# - Eric Vaandering <ewv@fnal.gov>, 2018-2021
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2018-2020
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2018
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2019-2020
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019
+# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import rucio.core.scope
 from rucio.core.account import has_account_attribute
@@ -90,7 +99,6 @@ def has_permission(issuer, action, kwargs):
             'queue_requests': perm_queue_requests,
             'set_rse_usage': perm_set_rse_usage,
             'set_rse_limits': perm_set_rse_limits,
-            'query_request': perm_query_request,
             'get_request_by_did': perm_get_request_by_did,
             'cancel_request': perm_cancel_request,
             'get_next': perm_get_next,
@@ -744,17 +752,6 @@ def perm_update_replicas_states(issuer, kwargs):
 def perm_queue_requests(issuer, kwargs):
     """
     Checks if an account can submit transfer or deletion requests on destination RSEs for data identifiers.
-
-    :param issuer: Account identifier which issues the command.
-    :param kwargs: List of arguments for the action.
-    :returns: True if account is allowed, otherwise False
-    """
-    return _is_root(issuer)
-
-
-def perm_query_request(issuer, kwargs):
-    """
-    Checks if an account can query a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/core/permission/escape.py
+++ b/lib/rucio/core/permission/escape.py
@@ -1,4 +1,5 @@
-# Copyright 2016-2020 CERN for the benefit of the ATLAS collaboration.
+# -*- coding: utf-8 -*-
+# Copyright 2021-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +14,8 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne <vgaronne@gmail.com>, 2016
-# - Cedric Serfon <cedric.serfon@cern.ch>, 2016-2021
-# - Martin Barisits <martin.barisits@cern.ch>, 2017-2020
-# - Mario Lassnig <mario.lassnig@cern.ch>, 2018-2020
-# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
-# - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
-# - Eric Vaandering, <ewv@fnal.gov>, 2020
-# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-# - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
-# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
-# - Rizart Dona <rizart.dona@cern.ch>, 2021
-#
-# PY3K COMPATIBLE
+# - Rizart Dona <rizart.dona@gmail.com>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import rucio.core.scope
 from rucio.core.account import list_account_attributes, has_account_attribute
@@ -91,7 +80,6 @@ def has_permission(issuer, action, kwargs):
             'queue_requests': perm_queue_requests,
             'set_rse_usage': perm_set_rse_usage,
             'set_rse_limits': perm_set_rse_limits,
-            'query_request': perm_query_request,
             'get_request_by_did': perm_get_request_by_did,
             'cancel_request': perm_cancel_request,
             'get_next': perm_get_next,
@@ -693,17 +681,6 @@ def perm_update_replicas_states(issuer, kwargs):
 def perm_queue_requests(issuer, kwargs):
     """
     Checks if an account can submit transfer or deletion requests on destination RSEs for data identifiers.
-
-    :param issuer: Account identifier which issues the command.
-    :param kwargs: List of arguments for the action.
-    :returns: True if account is allowed, otherwise False
-    """
-    return _is_root(issuer)
-
-
-def perm_query_request(issuer, kwargs):
-    """
-    Checks if an account can query a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -28,6 +28,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 # - Rob Barnsley <rob.barnsley@skao.int>, 2021-2022
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import rucio.core.scope
 from rucio.core.account import list_account_attributes, has_account_attribute
@@ -92,7 +93,6 @@ def has_permission(issuer, action, kwargs):
             'queue_requests': perm_queue_requests,
             'set_rse_usage': perm_set_rse_usage,
             'set_rse_limits': perm_set_rse_limits,
-            'query_request': perm_query_request,
             'list_requests': perm_list_requests,
             'list_requests_history': perm_list_requests_history,
             'get_request_by_did': perm_get_request_by_did,
@@ -697,17 +697,6 @@ def perm_update_replicas_states(issuer, kwargs):
 def perm_queue_requests(issuer, kwargs):
     """
     Checks if an account can submit transfer or deletion requests on destination RSEs for data identifiers.
-
-    :param issuer: Account identifier which issues the command.
-    :param kwargs: List of arguments for the action.
-    :returns: True if account is allowed, otherwise False
-    """
-    return _is_root(issuer)
-
-
-def perm_query_request(issuer, kwargs):
-    """
-    Checks if an account can query a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/core/permission/generic_multi_vo.py
+++ b/lib/rucio/core/permission/generic_multi_vo.py
@@ -17,6 +17,7 @@
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 # - Rob Barnsley <rob.barnsley@skao.int>, 2021-2022
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import rucio.core.scope
 from rucio.core.account import list_account_attributes, has_account_attribute
@@ -80,7 +81,6 @@ def has_permission(issuer, action, kwargs):
             'queue_requests': perm_queue_requests,
             'set_rse_usage': perm_set_rse_usage,
             'set_rse_limits': perm_set_rse_limits,
-            'query_request': perm_query_request,
             'list_requests': perm_list_requests,
             'list_requests_history': perm_list_requests_history,
             'get_request_by_did': perm_get_request_by_did,
@@ -667,17 +667,6 @@ def perm_update_replicas_states(issuer, kwargs):
 def perm_queue_requests(issuer, kwargs):
     """
     Checks if an account can submit transfer or deletion requests on destination RSEs for data identifiers.
-
-    :param issuer: Account identifier which issues the command.
-    :param kwargs: List of arguments for the action.
-    :returns: True if account is allowed, otherwise False
-    """
-    return _is_root(issuer)
-
-
-def perm_query_request(issuer, kwargs):
-    """
-    Checks if an account can query a request.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -407,7 +407,7 @@ def __create_missing_replicas_and_requests(
                initial_request_id, transfer_path[0].src, transfer_path[-1].dst)
         try:
             for request_id in created_requests:
-                set_request_state(request_id=request_id, new_state=RequestState.FAILED,
+                set_request_state(request_id=request_id, state=RequestState.FAILED,
                                   err_msg="Cancelled hop in multi-hop", session=session)
         except UnsupportedOperation:
             logger(logging.ERROR, '%s: Multihop : Cannot cancel all the parent requests : %s', initial_request_id, str(created_requests))
@@ -435,7 +435,7 @@ def submit_transfer(transfertool_obj, transfers, job_params, submitter='submitte
             return
         except Exception:
             logger(logging.ERROR, 'Failed to prepare requests %s state to SUBMITTING. Mark it SUBMISSION_FAILED and abort submission.' % [str(t.rws) for t in transfers], exc_info=True)
-            set_request_state(request_id=transfer.rws.request_id, new_state=RequestState.SUBMISSION_FAILED)
+            set_request_state(request_id=transfer.rws.request_id, state=RequestState.SUBMISSION_FAILED)
             return
 
     try:

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -47,21 +47,29 @@ import os
 import socket
 import threading
 import time
+from typing import TYPE_CHECKING
 
-from rucio.common.config import config_get
+from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import (InvalidRSEExpression, TransferToolTimeout, TransferToolWrongAnswer, RequestNotFound,
-                                    DuplicateFileTransferSubmission, VONotFound)
+                                    DuplicateFileTransferSubmission, VONotFound, UnsupportedOperation)
 from rucio.common.logging import formatted_logger
 from rucio.common.utils import PriorityQueue
-from rucio.core import heartbeat, request, transfer as transfer_core
+from rucio.core import heartbeat, request as request_core, transfer as transfer_core
 from rucio.core.monitor import record_counter, record_timer
-from rucio.core.request import set_request_state
+from rucio.core.replica import add_replicas, tombstone_from_delay, update_replica_state
+from rucio.core.request import set_request_state, queue_requests
 from rucio.core.rse import list_rses
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.vo import list_vos
-from rucio.db.sqla.constants import RequestState
+from rucio.db.sqla.constants import RequestState, RequestType, ReplicaState
+from rucio.db.sqla.session import transactional_session
 from rucio.rse import rsemanager as rsemgr
 
+if TYPE_CHECKING:
+    from typing import Callable, Dict, List, Optional, Set, Tuple, Type
+    from rucio.core.request import RequestWithSources
+    from rucio.core.transfer import DirectTransferDefinition
+    from sqlalchemy.orm import Session
 
 class HeartbeatHandler:
     """
@@ -155,6 +163,254 @@ def run_conveyor_daemon(once, graceful_stop, executable, logger_prefix, partitio
                     activity_next_exe_time[activity] = time.time() + sleep_time
                 else:
                     activity_next_exe_time[activity] = time.time() + 1
+
+
+@transactional_session
+def next_transfers_to_submit(total_workers=0, worker_number=0, partition_hash_var=None, limit=None, activity=None, older_than=None, rses=None, schemes=None,
+                             failover_schemes=None, filter_transfertool=None, transfertools_by_name=None, request_type=RequestType.TRANSFER,
+                             ignore_availability=False, logger=logging.log, session=None):
+    """
+    Get next transfers to be submitted; grouped by transfertool which can submit them
+    :param total_workers:         Number of total workers.
+    :param worker_number:         Id of the executing worker.
+    :param partition_hash_var     The hash variable used for partitioning thread work
+    :param limit:                 Maximum number of requests to retrieve from database.
+    :param activity:              Activity.
+    :param older_than:            Get transfers older than.
+    :param rses:                  Include RSES.
+    :param schemes:               Include schemes.
+    :param failover_schemes:      Failover schemes.
+    :param transfertools_by_name: Dict: {transfertool_name_str: transfertool class}
+    :param filter_transfertool:   The transfer tool to filter requests on.
+    :param request_type           The type of requests to retrieve (Transfer/Stagein)
+    :param ignore_availability:   Ignore blocklisted RSEs
+    :param logger:                Optional decorated logger that can be passed from the calling daemons or servers.
+    :param session:               The database session in use.
+    :returns:                     Dict: {TransferToolBuilder: <list of transfer paths (possibly multihop) to be submitted>}
+    """
+    candidate_paths, reqs_no_source, reqs_scheme_mismatch, reqs_only_tape_source = transfer_core.get_transfer_paths(
+        total_workers=total_workers,
+        worker_number=worker_number,
+        partition_hash_var=partition_hash_var,
+        limit=limit,
+        activity=activity,
+        older_than=older_than,
+        rses=rses,
+        schemes=schemes,
+        failover_schemes=failover_schemes,
+        filter_transfertool=filter_transfertool,
+        ignore_availability=ignore_availability,
+        request_type=request_type,
+        logger=logger,
+        session=session,
+    )
+
+    # Assign paths to be executed by transfertools
+    # if the chosen best path is a multihop, create intermediate replicas and the intermediate transfer requests
+    paths_by_transfertool_builder, reqs_no_host, reqs_unsupported_transfertool = __assign_paths_to_transfertool_and_create_hops(
+        candidate_paths,
+        transfertools_by_name=transfertools_by_name,
+        logger=logger,
+        session=session,
+    )
+
+    if reqs_unsupported_transfertool:
+        logger(logging.INFO, "Ignoring request because of unsupported transfertool: %s", reqs_unsupported_transfertool)
+    reqs_no_source.update(reqs_no_host)
+    if reqs_no_source:
+        logger(logging.INFO, "Marking requests as no-sources: %s", reqs_no_source)
+        request_core.set_requests_state_if_possible(reqs_no_source, RequestState.NO_SOURCES, logger=logger, session=session)
+    if reqs_only_tape_source:
+        logger(logging.INFO, "Marking requests as only-tape-sources: %s", reqs_only_tape_source)
+        request_core.set_requests_state_if_possible(reqs_only_tape_source, RequestState.ONLY_TAPE_SOURCES, logger=logger, session=session)
+    if reqs_scheme_mismatch:
+        logger(logging.INFO, "Marking requests as scheme-mismatch: %s", reqs_scheme_mismatch)
+        request_core.set_requests_state_if_possible(reqs_scheme_mismatch, RequestState.MISMATCH_SCHEME, logger=logger, session=session)
+
+    return paths_by_transfertool_builder
+
+
+def __parse_request_transfertools(
+        rws: "RequestWithSources",
+        logger: "Callable" = logging.log,
+):
+    """
+    Parse a set of desired transfertool names from the database field request.transfertool
+    """
+    request_transfertools = set()
+    try:
+        if rws.transfertool:
+            request_transfertools = {tt.strip() for tt in rws.transfertool.split(',')}
+    except Exception:
+        logger(logging.WARN, "Unable to parse requested transfertools: {}".format(request_transfertools))
+        request_transfertools = None
+    return request_transfertools
+
+
+def __assign_paths_to_transfertool_and_create_hops(
+        candidate_paths_by_request_id: "Dict[str: List[DirectTransferDefinition]]",
+        transfertools_by_name: "Optional[Dict[str, Type[Transfertool]]]" = None,
+        logger: "Callable" = logging.log,
+        session: "Optional[Session]" = None,
+) -> "Tuple[Dict[TransferToolBuilder, List[DirectTransferDefinition]], Set[str], Set[str]]":
+    """
+    for each request, pick the first path which can be submitted by one of the transfertools.
+    If the chosen path is multihop, create all missing intermediate requests and replicas.
+    """
+    reqs_no_host = set()
+    reqs_unsupported_transfertool = set()
+    paths_by_transfertool_builder = {}
+    default_tombstone_delay = config_get_bool('transfers', 'multihop_tombstone_delay', default=transfer_core.DEFAULT_MULTIHOP_TOMBSTONE_DELAY, expiration_time=600)
+    for request_id, candidate_paths in candidate_paths_by_request_id.items():
+        # Get the rws object from any candidate path. It is the same for all candidate paths. For multihop, the initial request is the last hop
+        rws = candidate_paths[0][-1].rws
+
+        request_transfertools = __parse_request_transfertools(rws, logger)
+        if request_transfertools is None:
+            # Parsing failed
+            reqs_no_host.add(request_id)
+            continue
+        if request_transfertools and transfertools_by_name and not request_transfertools.intersection(transfertools_by_name):
+            # The request explicitly asks for a transfertool which this submitter doesn't support
+            reqs_unsupported_transfertool.add(request_id)
+            continue
+
+        # Selects the first path which can be submitted by a supported transfertool and for which the creation of
+        # intermediate hops (if it is a multihop) work correctly
+        best_path = None
+        builder_to_use = None
+        concurrent_submission_detected = False
+        for transfer_path in candidate_paths:
+            builder = None
+            if transfertools_by_name:
+                transfertools_to_try = set(transfertools_by_name)
+                if request_transfertools:
+                    transfertools_to_try = transfertools_to_try.intersection(request_transfertools)
+                for transfertool in transfertools_to_try:
+                    builder = transfertools_by_name[transfertool].submission_builder_for_path(transfer_path, logger=logger)
+                    if builder:
+                        break
+            if builder or not transfertools_by_name:
+                created, concurrent_submission_detected = __create_missing_replicas_and_requests(
+                    transfer_path, default_tombstone_delay, logger=logger, session=session
+                )
+                if created:
+                    best_path = transfer_path
+                    builder_to_use = builder
+                if created or concurrent_submission_detected:
+                    break
+
+        if concurrent_submission_detected:
+            logger(logging.INFO, '%s: Request is being handled by another submitter. Skipping for now.' % request_id)
+            continue
+
+        if not best_path:
+            reqs_no_host.add(request_id)
+            logger(logging.INFO, '%s: Cannot pick transfertool, or create intermediate requests' % request_id)
+            continue
+
+        if len(best_path) > 1:
+            logger(logging.INFO, '%s: Best path is multihop: %s' % (rws.request_id, transfer_core.transfer_path_str(best_path)))
+        elif best_path is not candidate_paths[0] or len(best_path[0].sources) > 1:
+            # Only print singlehop if it brings additional information:
+            # - either it's not the first candidate path
+            # - or it's a multi-source
+            # in other cases, it doesn't bring any additional information to what is known from previous logs
+            logger(logging.INFO, '%s: Best path is direct: %s' % (rws.request_id, transfer_core.transfer_path_str(best_path)))
+
+        paths_by_transfertool_builder.setdefault(builder_to_use, []).append(best_path)
+    return paths_by_transfertool_builder, reqs_no_host, reqs_unsupported_transfertool
+
+
+@transactional_session
+def __create_missing_replicas_and_requests(
+        transfer_path: "List[DirectTransferDefinition]",
+        default_tombstone_delay: int,
+        logger: "Callable",
+        session: "Optional[Session]" = None
+) -> "Tuple[bool, bool]":
+    """
+    Create replicas and requests in the database for the intermediate hops
+    """
+    initial_request_id = transfer_path[-1].rws.request_id
+    creation_successful = True
+    concurrent_submission_detected = False
+    created_requests = []
+    # Iterate the path in reverse order. The last hop is the initial request, so
+    # next_hop.rws.request_id will always be initialized when handling the current hop.
+    for i in reversed(range(len(transfer_path))):
+        hop = transfer_path[i]
+        rws = hop.rws
+        if rws.request_id:
+            continue
+
+        tombstone_delay = rws.dest_rse.attributes.get('multihop_tombstone_delay', default_tombstone_delay)
+        try:
+            tombstone = tombstone_from_delay(tombstone_delay)
+        except ValueError:
+            logger(logging.ERROR, "%s: Cannot parse multihop tombstone delay %s", initial_request_id, tombstone_delay)
+            creation_successful = False
+            break
+
+        files = [{'scope': rws.scope,
+                  'name': rws.name,
+                  'bytes': rws.byte_count,
+                  'adler32': rws.adler32,
+                  'md5': rws.md5,
+                  'tombstone': tombstone,
+                  'state': 'C'}]
+        try:
+            add_replicas(rse_id=rws.dest_rse.id,
+                         files=files,
+                         account=rws.account,
+                         ignore_availability=False,
+                         dataset_meta=None,
+                         session=session)
+            # Set replica state to Copying in case replica already existed in another state.
+            # Can happen when a multihop transfer failed previously, and we are re-scheduling it now.
+            update_replica_state(rse_id=rws.dest_rse.id, scope=rws.scope, name=rws.name, state=ReplicaState.COPYING, session=session)
+        except Exception as error:
+            logger(logging.ERROR, '%s: Problem adding replicas on %s : %s', initial_request_id, rws.dest_rse, str(error))
+
+        rws.attributes['next_hop_request_id'] = transfer_path[i + 1].rws.request_id
+        rws.attributes['initial_request_id'] = initial_request_id
+        rws.attributes['source_replica_expression'] = hop.src.rse.name
+        new_req = queue_requests(requests=[{'dest_rse_id': rws.dest_rse.id,
+                                            'scope': rws.scope,
+                                            'name': rws.name,
+                                            'rule_id': '00000000000000000000000000000000',  # Dummy Rule ID used for multihop. TODO: Replace with actual rule_id once we can flag intermediate requests
+                                            'attributes': rws.attributes,
+                                            'request_type': rws.request_type,
+                                            'retry_count': rws.retry_count,
+                                            'account': rws.account,
+                                            'requested_at': datetime.datetime.now()}], session=session)
+        # If a request already exists, new_req will be an empty list.
+        if not new_req:
+            creation_successful = False
+
+            existing_request = request_core.get_request_by_did(rws.scope, rws.name, rws.dest_rse.id, session=session)
+            if existing_request['requested_at'] and \
+                    datetime.datetime.utcnow() - transfer_core.CONCURRENT_SUBMISSION_TOLERATION_DELAY < existing_request['requested_at']:
+                concurrent_submission_detected = True
+
+            break
+        rws.request_id = new_req[0]['id']
+        logger(logging.DEBUG, '%s: New request created for the transfer between %s and %s : %s', initial_request_id, transfer_path[0].src, transfer_path[-1].dst, rws.request_id)
+        set_request_state(rws.request_id, RequestState.QUEUED, session=session, logger=logger)
+        created_requests.append(rws.request_id)
+
+    if not concurrent_submission_detected and not creation_successful:
+        # Need to fail all the intermediate requests
+        logger(logging.WARNING, '%s: Multihop : A request already exists for the transfer between %s and %s. Will cancel all the parent requests',
+               initial_request_id, transfer_path[0].src, transfer_path[-1].dst)
+        try:
+            for request_id in created_requests:
+                set_request_state(request_id=request_id, new_state=RequestState.FAILED,
+                                  err_msg="Cancelled hop in multi-hop", session=session)
+        except UnsupportedOperation:
+            logger(logging.ERROR, '%s: Multihop : Cannot cancel all the parent requests : %s', initial_request_id, str(created_requests))
+
+    return creation_successful, concurrent_submission_detected
 
 
 def submit_transfer(transfertool_obj, transfers, job_params, submitter='submitter', timeout=None, logger=logging.log):

--- a/lib/rucio/daemons/conveyor/preparer.py
+++ b/lib/rucio/daemons/conveyor/preparer.py
@@ -30,8 +30,7 @@ from rucio.common import exception
 from rucio.common.exception import RucioException
 from rucio.common.logging import setup_logging
 from rucio.core.request import preparer_update_requests, reduce_requests, sort_requests_minimum_distance, \
-    get_transfertool_filter, get_supported_transfertools, rse_lookup_filter
-from rucio.core.transfer import __list_transfer_requests_and_source_replicas
+    get_transfertool_filter, get_supported_transfertools, rse_lookup_filter, list_transfer_requests_and_source_replicas
 from rucio.daemons.conveyor.common import run_conveyor_daemon
 from rucio.db.sqla.constants import RequestState
 
@@ -110,7 +109,7 @@ def preparer(once, sleep_time, bulk, partition_wait_time=10):
 def run_once(bulk: int = 100, total_workers: int = 0, worker_number: int = 0, limit: "Optional[int]" = None, logger=logging.log, session: "Optional[Session]" = None, **kwargs) -> bool:
     start_time = time()
     try:
-        req_sources = __list_transfer_requests_and_source_replicas(
+        req_sources = list_transfer_requests_and_source_replicas(
             total_workers=total_workers,
             worker_number=worker_number,
             limit=limit,

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -43,8 +43,7 @@ from rucio.common import exception
 from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.logging import setup_logging
 from rucio.core.monitor import record_counter, record_timer
-from rucio.core import transfer as transfer_core
-from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, run_conveyor_daemon
+from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, run_conveyor_daemon, next_transfers_to_submit
 from rucio.db.sqla.constants import RequestType
 from rucio.transfertool.fts3 import FTS3Transfertool
 
@@ -53,7 +52,7 @@ graceful_stop = threading.Event()
 
 def run_once(bulk, group_bulk, rse_ids, scheme, failover_scheme, transfertool_kwargs, total_workers, worker_number, logger, activity):
     start_time = time.time()
-    transfers = transfer_core.next_transfers_to_submit(
+    transfers = next_transfers_to_submit(
         total_workers=total_workers,
         worker_number=worker_number,
         failover_schemes=failover_scheme,

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -51,9 +51,8 @@ from rucio.common import exception
 from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.logging import setup_logging
 from rucio.common.schema import get_schema_value
-from rucio.core import transfer as transfer_core
 from rucio.core.monitor import MultiCounter, record_timer
-from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, run_conveyor_daemon
+from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, run_conveyor_daemon, next_transfers_to_submit
 from rucio.db.sqla.constants import RequestType
 from rucio.transfertool.fts3 import FTS3Transfertool
 from rucio.transfertool.globus import GlobusTransferTool
@@ -80,7 +79,7 @@ def run_once(bulk, group_bulk, filter_transfertool, transfertool, ignore_availab
              total_workers, worker_number, logger, activity):
 
     start_time = time.time()
-    transfers = transfer_core.next_transfers_to_submit(
+    transfers = next_transfers_to_submit(
         total_workers=total_workers,
         worker_number=worker_number,
         partition_hash_var=partition_hash_var,

--- a/lib/rucio/tests/test_judge_repairer.py
+++ b/lib/rucio/tests/test_judge_repairer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2021 CERN
+# Copyright 2014-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 # - Nick Smith <nick.smith@cern.ch>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 
 import itertools
 import unittest
@@ -41,6 +43,7 @@ from rucio.core.did import add_did, attach_dids
 from rucio.core.lock import successful_transfer, failed_transfer, get_replica_locks
 from rucio.core.replica import get_replica
 from rucio.core.request import cancel_request_did
+from rucio.core.transfer import cancel_transfers
 from rucio.core.rse import add_rse_attribute, add_rse, update_rse, get_rse_id
 from rucio.core.rule import get_rule, add_rule
 from rucio.daemons.judge.evaluator import re_evaluator
@@ -264,8 +267,10 @@ class TestJudgeRepairer(unittest.TestCase):
         successful_transfer(scope=scope, name=files[1]['name'], rse_id=get_replica_locks(scope=files[1]['scope'], name=files[2]['name'])[0].rse_id, nowait=False)
         failed_transfer(scope=scope, name=files[2]['name'], rse_id=get_replica_locks(scope=files[2]['scope'], name=files[2]['name'])[0].rse_id)
         failed_transfer(scope=scope, name=files[3]['name'], rse_id=get_replica_locks(scope=files[3]['scope'], name=files[3]['name'])[0].rse_id)
-        cancel_request_did(scope=scope, name=files[2]['name'], dest_rse_id=get_replica_locks(scope=files[2]['scope'], name=files[2]['name'])[0].rse_id)
-        cancel_request_did(scope=scope, name=files[3]['name'], dest_rse_id=get_replica_locks(scope=files[3]['scope'], name=files[2]['name'])[0].rse_id)
+        transfs = cancel_request_did(scope=scope, name=files[2]['name'], dest_rse_id=get_replica_locks(scope=files[2]['scope'], name=files[2]['name'])[0].rse_id)
+        cancel_transfers(transfs)
+        transfs = cancel_request_did(scope=scope, name=files[3]['name'], dest_rse_id=get_replica_locks(scope=files[3]['scope'], name=files[2]['name'])[0].rse_id)
+        cancel_transfers(transfs)
 
         assert(rule_id == get_rule(rule_id)['id'].replace('-', '').lower())
         assert(RuleState.STUCK == get_rule(rule_id)['state'])

--- a/lib/rucio/tests/test_preparer.py
+++ b/lib/rucio/tests/test_preparer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 CERN
+# Copyright 2020-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 #
 # Authors:
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from typing import TYPE_CHECKING
 
@@ -26,9 +28,8 @@ from rucio.core import config as rucio_config
 from rucio.core.did import add_did, delete_dids
 from rucio.core.distance import get_distances, add_distance
 from rucio.core.replica import add_replicas, delete_replicas
-from rucio.core.request import sort_requests_minimum_distance, get_transfertool_filter, get_supported_transfertools
+from rucio.core.request import sort_requests_minimum_distance, get_transfertool_filter, get_supported_transfertools, list_transfer_requests_and_source_replicas
 from rucio.core.rse import set_rse_transfer_limits, add_rse, del_rse, add_rse_attribute
-from rucio.core.transfer import __list_transfer_requests_and_source_replicas
 from rucio.daemons.conveyor import preparer
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import RequestState, DIDType
@@ -203,7 +204,7 @@ def dest_throttler(db_session, mock_request):
 
 
 def test_listing_preparing_transfers(db_session, mock_request):
-    req_sources = __list_transfer_requests_and_source_replicas(request_state=RequestState.PREPARING, session=db_session)
+    req_sources = list_transfer_requests_and_source_replicas(request_state=RequestState.PREPARING, session=db_session)
 
     assert len(req_sources) != 0
     found_requests = list(filter(lambda rws: rws.request_id == mock_request.id, req_sources))

--- a/lib/rucio/tests/test_s3.py
+++ b/lib/rucio/tests/test_s3.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 CERN
+# Copyright 2020-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 
 import unittest
 
@@ -30,7 +30,7 @@ from rucio.core.distance import add_distance
 from rucio.core.replica import add_replicas, delete_replicas
 from rucio.core.rse import add_rse, del_rse, add_protocol, add_rse_attribute
 from rucio.core.rule import add_rule
-from rucio.core.transfer import next_transfers_to_submit
+from rucio.daemons.conveyor.common import next_transfers_to_submit
 from rucio.tests.common import rse_name_generator
 from rucio.tests.common_server import get_vo
 

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2021 CERN
+# Copyright 2021-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 # Authors:
 # - Mayank Sharma <imptodefeat@gmail.com>, 2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 
 import time
 import datetime
@@ -25,10 +25,10 @@ import re
 
 from rucio.core.request import get_request_by_did
 from rucio.core.rule import add_rule
-from rucio.core.transfer import next_transfers_to_submit
 from rucio.common.utils import generate_uuid
 from rucio.daemons.judge.evaluator import re_evaluator
 from rucio.daemons.conveyor import submitter, poller, finisher
+from rucio.daemons.conveyor.common import next_transfers_to_submit
 from rucio.client.rseclient import RSEClient
 from rucio.client.ruleclient import RuleClient
 from rucio.common.utils import run_cmd_process

--- a/lib/rucio/tests/test_transfer.py
+++ b/lib/rucio/tests/test_transfer.py
@@ -23,7 +23,7 @@ from concurrent.futures import ThreadPoolExecutor
 from rucio.common.exception import NoDistance
 from rucio.core.distance import add_distance
 from rucio.core.replica import add_replicas
-from rucio.core.transfer import get_hops, next_transfers_to_submit
+from rucio.core.transfer import get_hops
 from rucio.core import rule as rule_core
 from rucio.core import request as request_core
 from rucio.core import rse as rse_core
@@ -31,6 +31,7 @@ from rucio.db.sqla import models
 from rucio.db.sqla.constants import RSEType, RequestState
 from rucio.db.sqla.session import transactional_session
 from rucio.common.utils import generate_uuid
+from rucio.daemons.conveyor.common import next_transfers_to_submit
 
 
 def test_get_hops(rse_factory):

--- a/tools/submit_fts3_transfer.py
+++ b/tools/submit_fts3_transfer.py
@@ -1,14 +1,23 @@
-# Copyright European Organization for Nuclear Research (CERN)
+# -*- coding: utf-8 -*-
+# Copyright 2013-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2013
-# - Jaroslav Guenther, <jaroslav.guenther@cern.ch>, 2019
-# - Gabriele Gaetano Fronze' <gabriele.fronze@to.infn.it>, 2020
+# - Mario Lassnig <mario.lassnig@cern.ch>, 2013
+# - Jaroslav Guenther <jaroslav.guenther@cern.ch>, 2019
+# - Gabriele Fronze' <gfronze@cern.ch>, 2020
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 """
 This submits a transfer to FTS3 via the transfertool.
@@ -40,5 +49,5 @@ if __name__ == "__main__":
     transfer_id = FTS3_TransferTool.submit(files, job_params, timeout=300)
     print("transfer_id = ", transfer_id)
     time.sleep(10)
-    status = FTS3_TransferTool.bulk_query(transfer_id)
+    status = FTS3_TransferTool.query([transfer_id])
     pprint(status)


### PR DESCRIPTION
Refactor poller and receiver with the goal to get rid of fts-specifics in code paths which should be transfertool-agnostic.

Refer to individual commits for more details.