### PR TITLE
Select containers based on release brach for Integration Tests (1.26) Close #5256

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -35,10 +35,45 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: rucio/containers
+          fetch-depth: 0
       - uses: actions/checkout@v2
         name: Checkout rucio source
         with:
           path: dev/rucio
+          fetch-depth: 0
+      - name: Select tag for rucio containers
+        shell: bash
+        run: | 
+          # Change to cloned rucio/rucio repo
+          cd $GITHUB_WORKSPACE/dev/rucio
+          
+          # Get current branch and corresponding latest tag in rucio/rucio repo
+          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          OWNER="${{ github.repository_owner }}"
+          
+          if [ $OWNER != 'rucio' ]; then
+            echo "The workflow is running in user ${OWNER}'s fork. Fetching branches and tags from rucio/rucio instead."
+            git remote add rucio https://github.com/rucio/rucio
+            git fetch rucio --tags
+          fi
+
+          echo "On branch ${BRANCH}"
+          if [ $BRANCH == 'master' ]; then
+              GIT_REF="master"
+          else
+              GIT_REF=$(git describe --tags --abbrev=0)
+              echo "Latest tagged release on branch $BRANCH is $GIT_REF"
+          fi
+
+          cd $GITHUB_WORKSPACE
+
+          # Check if rucio/containers has a corresponding $GIT_REF 
+          if [ $(git tag -l "$GIT_REF") ]; then
+              git checkout tags/$GIT_REF
+          else
+              echo "Tag $GIT_REF not found in rucio/containers. Integration test containers will be built against the master branch instead."
+              git checkout master
+          fi
       - name: Use rucio/containers Dockerfile for integration tests
         shell: bash
         run: |


### PR DESCRIPTION
Added a `Select tag for rucio containers` step. It basically finds the latest tag for the current branch based on the commit history and then does a git checkout to that tag in the containers repo.