### PR TITLE
Transfers: store transfer paths in a new database table. Closes #5177

### DIFF
--- a/etc/sql/oracle/schema.sql
+++ b/etc/sql/oracle/schema.sql
@@ -1904,3 +1904,20 @@ CREATE TABLE VIRTUAL_PLACEMENTS (
 	CONSTRAINT VP_PK PRIMARY KEY (scope, name),
 	CONSTRAINT VP_FK FOREIGN KEY (scope, name) REFERENCES dids (scope, name) 
 );
+
+-- 69 ) ================ TRANSFER HOPS table  ================
+
+CREATE TABLE TRANSFER_HOPS (
+    request_id RAW(16),
+    next_hop_request_id RAW(16),
+    initial_request_id RAW(16),
+    created_at DATE,
+    updated_at DATE,
+    CONSTRAINT TRANSFER_HOPS_CREATED_NN CHECK (created_at IS NOT NULL),
+    CONSTRAINT TRANSFER_HOPS_UPDATED_NN CHECK (updated_at IS NOT NULL),
+    CONSTRAINT TRANSFER_HOPS_PK PRIMARY KEY (request_id, next_hop_request_id, initial_request_id),
+    CONSTRAINT TRANSFER_HOPS_INIT_REQ_ID_FK FOREIGN KEY (initial_request_id) REFERENCES REQUESTS(id),
+    CONSTRAINT TRANSFER_HOPS_NH_REQ_ID_FK FOREIGN KEY (next_hop_request_id) REFERENCES REQUESTS(id),
+);
+
+CREATE INDEX TRANSFER_HOPS_INITIAL_REQ ON TRANSFER_HOPS (initial_request_id);

--- a/lib/rucio/alembicrevision.py
+++ b/lib/rucio/alembicrevision.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 CERN
+# Copyright 2020-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,11 @@
 #
 # Authors:
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
-# - Martin Barisits <martin.barisits@cern.ch>, 2020
+# - Martin Barisits <martin.barisits@cern.ch>, 2020-2021
 # - Matt Snyder <msnyder@bnl.gov>, 2021
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2021
-# - Joaquin Bogado <joaquinbogado@gmail.com>, 2021
+# - joaquinbogado <joaquinbogado@gmail.com>, 2021
 # - Ilija Vukotic <ivukotic@uchicago.edu>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
-ALEMBIC_REVISION = '9a45bc4ea66d'  # the current alembic head revision
+ALEMBIC_REVISION = '0f1adb7a599a'  # the current alembic head revision

--- a/lib/rucio/db/sqla/migrate_repo/versions/0f1adb7a599a_create_transfer_hops_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/0f1adb7a599a_create_transfer_hops_table.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
+
+''' create transfer hops table '''
+
+import datetime
+
+import sqlalchemy as sa
+
+from alembic import context
+from alembic.op import (create_table, create_primary_key, create_foreign_key,
+                        create_check_constraint, create_index, drop_table)
+
+from rucio.db.sqla.types import GUID
+
+
+# Alembic revision identifiers
+revision = '0f1adb7a599a'
+down_revision = '9a45bc4ea66d'
+
+
+def upgrade():
+    '''
+    Upgrade the database to this revision
+    '''
+
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        create_table('transfer_hops',
+                     sa.Column('request_id', GUID()),
+                     sa.Column('next_hop_request_id', GUID()),
+                     sa.Column('initial_request_id', GUID()),
+                     sa.Column('created_at', sa.DateTime, default=datetime.datetime.utcnow),
+                     sa.Column('updated_at', sa.DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow))
+
+        create_primary_key('TRANSFER_HOPS_PK', 'transfer_hops', ['request_id', 'next_hop_request_id', 'initial_request_id'])
+        create_foreign_key('TRANSFER_HOPS_INIT_REQ_ID_FK', 'transfer_hops', 'requests', ['initial_request_id'], ['id'])
+        create_foreign_key('TRANSFER_HOPS_REQ_ID_FK', 'transfer_hops', 'requests', ['request_id'], ['id'])
+        create_foreign_key('TRANSFER_HOPS_NH_REQ_ID_FK', 'transfer_hops', 'requests', ['next_hop_request_id'], ['id'])
+        create_check_constraint('TRANSFER_HOPS_CREATED_NN', 'transfer_hops', 'created_at is not null')
+        create_check_constraint('TRANSFER_HOPS_UPDATED_NN', 'transfer_hops', 'updated_at is not null')
+        create_index('TRANSFER_HOPS_INITIAL_REQ', 'transfer_hops', ['initial_request_id'])
+
+
+def downgrade():
+    '''
+    Downgrade the database to the previous revision
+    '''
+
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        drop_table('transfer_hops')

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2021 CERN
+# Copyright 2015-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 # - Matt Snyder <msnyder@bnl.gov>, 2021
 # - joaquinbogado <joaquinbogado@gmail.com>, 2021
 # - Ilija Vukotic <ivukotic@uchicago.edu>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import datetime
 import sys
@@ -1310,6 +1311,19 @@ class Request(BASE, ModelBase):
                    Index('REQUESTS_TYP_STA_TRA_ACT_IDX', 'request_type', 'state', 'transfertool', 'activity'))
 
 
+class TransferHop(BASE, ModelBase):
+    """Represents source files for transfers"""
+    __tablename__ = 'transfer_hops'
+    request_id = Column(GUID())
+    next_hop_request_id = Column(GUID())
+    initial_request_id = Column(GUID())
+    _table_args = (PrimaryKeyConstraint('request_id', 'next_hop_request_id', 'initial_request_id', name='TRANSFER_HOPS_PK'),
+                   ForeignKeyConstraint(['initial_request_id'], ['requests.id'], name='TRANSFER_HOPS_INIT_REQ_ID_FK'),
+                   ForeignKeyConstraint(['request_id'], ['requests.id'], name='TRANSFER_HOPS_REQ_ID_FK'),
+                   ForeignKeyConstraint(['next_hop_request_id'], ['requests.id'], name='TRANSFER_HOPS_NH_REQ_ID_FK'),
+                   Index('TRANSFER_HOPS_INITIAL_REQ', 'initial_request_id'))
+
+
 class RequestHistory(BASE, ModelBase):
     """Represents request history"""
     __tablename__ = 'requests_history'
@@ -1743,6 +1757,7 @@ def register_models(engine):
               ReplicationRuleHistoryRecent,
               Request,
               RequestHistory,
+              TransferHop,
               Scope,
               Source,
               SourceHistory,
@@ -1812,6 +1827,7 @@ def unregister_models(engine):
               ReplicationRuleHistoryRecent,
               Request,
               RequestHistory,
+              TransferHop,
               Scope,
               Source,
               SourceHistory,

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2021 CERN
+# Copyright 2015-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 # - Eric Vaandering <ewv@fnal.gov>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 from __future__ import print_function
 
@@ -306,7 +308,7 @@ def read_session(function):
                 session.remove()
         try:
             return function(*args, **kwargs)
-        except:
+        except Exception:
             raise
     new_funct.__doc__ = function.__doc__
     return new_funct

--- a/lib/rucio/tests/test_conveyor.py
+++ b/lib/rucio/tests/test_conveyor.py
@@ -73,7 +73,7 @@ def __wait_for_replica_transfer(dst_rse_id, scope, name, state=ReplicaState.AVAI
     return replica
 
 
-def __wait_for_request_state(dst_rse_id, scope, name, state, max_wait_seconds=MAX_POLL_WAIT_SECONDS, run_poller=True, run_finisher=False):
+def __wait_for_request_state(dst_rse_id, scope, name, state, max_wait_seconds=MAX_POLL_WAIT_SECONDS, run_poller=True):
     """
     Wait for the request state to be updated to the given expected state as a result of a pending transfer
     """
@@ -81,8 +81,6 @@ def __wait_for_request_state(dst_rse_id, scope, name, state, max_wait_seconds=MA
     for _ in range(max_wait_seconds):
         if run_poller:
             poller(once=True, older_than=0, partition_wait_time=None)
-        if run_finisher:
-            finisher(once=True, partition_wait_time=None)
         request = request_core.get_request_by_did(rse_id=dst_rse_id, scope=scope, name=name)
         if request['state'] == state:
             break
@@ -124,7 +122,6 @@ def __get_source(request_id, src_rse_id, scope, name, session=None):
         .first()
 
 
-@pytest.mark.skip(reason="Needs to be improved as discussed in #5190")
 @skip_rse_tests_with_accounts
 @pytest.mark.dirty(reason="leaves files in XRD containers")
 @pytest.mark.noparallel(reason="uses predefined RSEs; runs submitter, poller and finisher; changes XRD3 usage and limits")
@@ -189,6 +186,25 @@ def test_multihop_intermediate_replica_lifecycle(vo, did_factory, root_account, 
         assert replica['tombstone'] == datetime(year=1970, month=1, day=1)
         assert replica['state'] == ReplicaState.COPYING
 
+        request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
+        # Fake an existing unused source with raking of 0 for the second source.
+        # The ranking of this source should remain at 0 till the end.
+
+        @transactional_session
+        def __fake_source_ranking(session=None):
+            models.Source(request_id=request['id'],
+                          scope=request['scope'],
+                          name=request['name'],
+                          rse_id=src_rse2_id,
+                          dest_rse_id=request['dest_rse_id'],
+                          ranking=0,
+                          bytes=request['bytes'],
+                          url=None,
+                          is_using=False). \
+                save(session=session, flush=False)
+
+        __fake_source_ranking()
+
         # The intermediate replica is protected by its state (Copying)
         rucio.daemons.reaper.reaper.REGION.invalidate()
         reaper(once=True, rses=[], include_rses=jump_rse_name, exclude_rses=None)
@@ -199,12 +215,16 @@ def test_multihop_intermediate_replica_lifecycle(vo, did_factory, root_account, 
         replica = __wait_for_replica_transfer(dst_rse_id=jump_rse_id, **did)
         assert replica['state'] == ReplicaState.AVAILABLE
 
-        # FTS can fail the second transfer
+        # ensure tha the ranking was correct for all sources and intermediate rses
+        assert __get_source(request_id=request['id'], src_rse_id=src_rse1_id, **did).ranking == 0
+        assert __get_source(request_id=request['id'], src_rse_id=jump_rse_id, **did).ranking == 0
+        assert __get_source(request_id=request['id'], src_rse_id=src_rse2_id, **did).ranking == 0
+        # Only group_bulk=1 part of the path was submitted.
         # run submitter again to copy from jump rse to destination rse
         submitter(once=True, rses=[{'id': rse_id} for rse_id in all_rses], partition_wait_time=None, transfertype='single', filter_transfertool=None)
 
         # Wait for the destination replica to become ready
-        replica = __wait_for_replica_transfer(dst_rse_id=dst_rse_id, **did, max_wait_seconds=120)
+        replica = __wait_for_replica_transfer(dst_rse_id=dst_rse_id, **did)
         assert replica['state'] == ReplicaState.AVAILABLE
 
         rucio.daemons.reaper.reaper.REGION.invalidate()
@@ -213,10 +233,10 @@ def test_multihop_intermediate_replica_lifecycle(vo, did_factory, root_account, 
         with pytest.raises(ReplicaNotFound):
             replica_core.get_replica(rse_id=jump_rse_id, **did)
 
-        # 4 request: copy to second source + 1 multihop with two hops (but second hop fails) + re-scheduled second hop
+        # 3 request: copy to second source + 2 hops (each separately)
         # Use inequalities, because there can be left-overs from other tests
-        assert metrics_mock.get_sample_value('rucio_daemons_conveyor_poller_update_request_state_total', labels={'updated': 'True'}) >= 4
-        assert metrics_mock.get_sample_value('rucio_core_request_submit_transfer_total') >= 4
+        assert metrics_mock.get_sample_value('rucio_daemons_conveyor_poller_update_request_state_total', labels={'updated': 'True'}) >= 3
+        assert metrics_mock.get_sample_value('rucio_core_request_submit_transfer_total') >= 3
         # at least the failed hop
         assert metrics_mock.get_sample_value('rucio_daemons_conveyor_finisher_handle_requests_total') > 0
     finally:
@@ -489,16 +509,11 @@ def test_multihop_receiver_on_failure(vo, did_factory, replica_client, root_acco
 
         request = __wait_for_request_state(dst_rse_id=jump_rse_id, state=RequestState.FAILED, run_poller=False, **did)
         assert request['state'] == RequestState.FAILED
-        # We use FTS "Completion" messages in receiver. In case of multi-hops transfer failures, FTS doesn't start
-        # next transfers; so it never sends a "completion" message for some hops. Rely on poller in such cases.
-        # TODO: set the run_poller argument to False if we ever manage to make the receiver correctly handle multi-hop failures.
-        request = __wait_for_request_state(dst_rse_id=dst_rse_id, state=RequestState.FAILED, run_poller=True, **did)
+        request = __wait_for_request_state(dst_rse_id=dst_rse_id, state=RequestState.FAILED, run_poller=False, **did)
         assert request['state'] == RequestState.FAILED
         assert 'Unused hop in multi-hop' in request['err_msg']
 
-        # First hop will be handled by receiver; second hop by poller
         assert metrics_mock.get_sample_value('rucio_daemons_conveyor_receiver_update_request_state_total', labels={'updated': 'True'}) >= 1
-        assert metrics_mock.get_sample_value('rucio_daemons_conveyor_poller_update_request_state_total', labels={'updated': 'True'}) >= 1
 
         finisher(once=True, partition_wait_time=None)
         # The intermediate request must not be re-scheduled by finisher
@@ -1096,3 +1111,118 @@ def test_multi_vo_certificates(file_config_mock, rse_factory, did_factory, scope
     with patch('rucio.daemons.conveyor.poller.FTS3Transfertool', _FTSWrapper):
         poller(once=True, older_than=0, partition_wait_time=None)
         assert sorted(certs_used_by_poller) == ['DEFAULT_DUMMY_CERT', 'NEW_VO_DUMMY_CERT']
+
+
+@skip_rse_tests_with_accounts
+@pytest.mark.noparallel(reason="runs submitter; poller and finisher")
+@pytest.mark.parametrize("core_config_mock", [
+    {"table_content": [
+        ('transfers', 'use_multihop', True),
+        ('transfers', 'multihop_tombstone_delay', -1),  # Set OBSOLETE tombstone for intermediate replicas
+    ]},
+], indirect=True)
+@pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
+    'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by rse expression
+    'rucio.core.config.REGION',
+    'rucio.daemons.reaper.reaper.REGION',
+]}], indirect=True)
+def test_two_multihops_same_intermediate_rse(rse_factory, did_factory, root_account, core_config_mock, caches_mock):
+    """
+    Handle correctly two multihop transfers having to both jump via the same intermediate hops
+    """
+    # +------+    +------+    +------+    +------+    +------+
+    # |      |    |      |    |      |    |      |    |      |
+    # | RSE1 +--->| RSE2 +--->| RSE3 +--->| RSE4 +--->| RSE5 |
+    # |      |    |      |    |      |    |      |    |      |
+    # +------+    +------+    +---+--+    +------+    +------+
+    #                             |
+    #                             |       +------+    +------+
+    #                             |       |      |    |      |
+    #                             +------>| RSE6 +--->| RSE7 |
+    #                                     |      |    |      |
+    #                                     +------+    +------+
+    _, _, reaper_cache_region = caches_mock
+    rse1, rse1_id = rse_factory.make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.posix.Default')
+    rse2, rse2_id = rse_factory.make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.posix.Default')
+    rse3, rse3_id = rse_factory.make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.posix.Default')
+    rse4, rse4_id = rse_factory.make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.posix.Default')
+    rse5, rse5_id = rse_factory.make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.posix.Default')
+    rse6, rse6_id = rse_factory.make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.posix.Default')
+    rse7, rse7_id = rse_factory.make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.posix.Default')
+    all_rses = [rse1_id, rse2_id, rse3_id, rse4_id, rse5_id, rse6_id, rse7_id]
+    for rse_id in all_rses:
+        rse_core.add_rse_attribute(rse_id, 'fts', TEST_FTS_HOST)
+        rse_core.add_rse_attribute(rse_id, 'available_for_multihop', True)
+        rse_core.set_rse_limits(rse_id=rse_id, name='MinFreeSpace', value=1)
+        rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=1, free=0)
+    distance_core.add_distance(rse1_id, rse2_id, ranking=10)
+    distance_core.add_distance(rse2_id, rse3_id, ranking=10)
+    distance_core.add_distance(rse3_id, rse4_id, ranking=10)
+    distance_core.add_distance(rse4_id, rse5_id, ranking=10)
+    distance_core.add_distance(rse3_id, rse6_id, ranking=10)
+    distance_core.add_distance(rse6_id, rse7_id, ranking=10)
+
+    did = did_factory.upload_test_file(rse1)
+    rule_core.add_rule(dids=[did], account=root_account, copies=2, rse_expression=f'{rse5}|{rse7}', grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
+
+    class _FTSWrapper(FTSWrapper):
+        @staticmethod
+        def on_submit(file):
+            # Simulate using the mock gfal plugin a transfer failure
+            file['sources'] = [set_query_parameters(s_url, {'errno': 2}) for s_url in file['sources']]
+
+    # Submit the first time, but force a failure to verify that retries are correctly handled
+    with patch('rucio.daemons.conveyor.submitter.TRANSFERTOOL_CLASSES_BY_NAME') as tt_mock:
+        tt_mock.__getitem__.return_value = _FTSWrapper
+        submitter(once=True, rses=[{'id': rse_id} for rse_id in all_rses], group_bulk=10, partition_wait_time=None, transfertype='single', filter_transfertool=None)
+
+    request = __wait_for_request_state(dst_rse_id=rse2_id, state=RequestState.FAILED, **did)
+    assert request['state'] == RequestState.FAILED
+
+    # Re-submit the transfer without simulating a failure. Everything should go as normal starting now.
+    finisher(once=True, partition_wait_time=None)
+    submitter(once=True, rses=[{'id': rse_id} for rse_id in all_rses], group_bulk=10, partition_wait_time=None, transfertype='single', filter_transfertool=None)
+    # one request must be submitted, but the second will only be queued
+    if request_core.get_request_by_did(rse_id=rse5_id, **did)['state'] == RequestState.QUEUED:
+        rse_id_second_to_last_queued, rse_id_queued = rse4_id, rse5_id
+        rse_id_second_to_last_submit, rse_id_submitted = rse6_id, rse7_id
+    else:
+        rse_id_second_to_last_queued, rse_id_queued = rse6_id, rse7_id
+        rse_id_second_to_last_submit, rse_id_submitted = rse4_id, rse5_id
+    request = request_core.get_request_by_did(rse_id=rse_id_queued, **did)
+    assert request['state'] == RequestState.QUEUED
+    request = request_core.get_request_by_did(rse_id=rse_id_submitted, **did)
+    assert request['state'] == RequestState.SUBMITTED
+
+    # Calling submitter again will not unblock the queued requests
+    submitter(once=True, rses=[{'id': rse_id} for rse_id in all_rses], group_bulk=10, partition_wait_time=None, transfertype='single', filter_transfertool=None)
+    replica = __wait_for_replica_transfer(dst_rse_id=rse_id_submitted, **did)
+    assert replica['state'] == ReplicaState.AVAILABLE
+    request = request_core.get_request_by_did(rse_id=rse_id_queued, **did)
+    assert request['state'] == RequestState.QUEUED
+
+    # Once the submitted transfer is done, the submission will continue for second request (one hop at a time)
+    # First of the remaining two hops submitted
+    submitter(once=True, rses=[{'id': rse_id} for rse_id in all_rses], group_bulk=10, partition_wait_time=None, transfertype='single', filter_transfertool=None)
+    replica = __wait_for_replica_transfer(dst_rse_id=rse_id_second_to_last_queued, **did)
+    assert replica['state'] == ReplicaState.AVAILABLE
+
+    # One of the intermediate replicas is eligible for deletion. Others are blocked by entries in source table
+    reaper_cache_region.invalidate()
+    reaper(once=True, rses=[], include_rses='|'.join([rse2, rse3, rse4, rse6]), exclude_rses=None)
+    with pytest.raises(ReplicaNotFound):
+        replica_core.get_replica(rse_id=rse_id_second_to_last_submit, **did)
+    for rse_id in [rse2_id, rse3_id, rse_id_second_to_last_queued]:
+        replica_core.get_replica(rse_id=rse_id, **did)
+
+    # Final hop
+    submitter(once=True, rses=[{'id': rse_id} for rse_id in all_rses], group_bulk=10, partition_wait_time=None, transfertype='single', filter_transfertool=None)
+    replica = __wait_for_replica_transfer(dst_rse_id=rse_id_queued, **did)
+    assert replica['state'] == ReplicaState.AVAILABLE
+
+    # All intermediate replicas can be deleted
+    reaper_cache_region.invalidate()
+    reaper(once=True, rses=[], include_rses='|'.join([rse2, rse3, rse4, rse6]), exclude_rses=None)
+    for rse_id in [rse2_id, rse3_id, rse4_id, rse6_id]:
+        with pytest.raises(ReplicaNotFound):
+            replica_core.get_replica(rse_id=rse_id, **did)

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -174,16 +174,17 @@ def test_multihop_sources_created(rse_factory, did_factory, root_account, core_c
         assert request_core.get_request_by_did(rse_id=rse_id, **did)
 
     @read_session
-    def __ensure_source_exists(rse_id, scope, name, session=None):
+    def __number_sources(rse_id, scope, name, session=None):
         return session.query(Source). \
             filter(Source.rse_id == rse_id). \
             filter(Source.scope == scope). \
             filter(Source.name == name). \
-            one()
+            count()
 
     # Ensure that sources where created for transfers
-    for rse_id in jump_rses + [src_rse_id]:
-        __ensure_source_exists(rse_id, **did)
+    for rse_id in [src_rse_id, jump_rse1_id, jump_rse2_id]:
+        assert __number_sources(rse_id, **did) == 2
+    assert __number_sources(jump_rse3_id, **did) == 1
 
     # Ensure the tombstone is correctly set on intermediate replicas
     expected_tombstone = datetime.utcnow() + timedelta(seconds=rse_multihop_tombstone_delay)

--- a/lib/rucio/tests/test_transfer.py
+++ b/lib/rucio/tests/test_transfer.py
@@ -279,8 +279,7 @@ def test_multihop_concurrent_submitters(rse_factory, did_factory, root_account, 
     dst_request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
     assert jmp_request['state'] == dst_request['state'] == RequestState.QUEUED
     assert jmp_request['attributes']['source_replica_expression'] == src_rse
-    assert jmp_request['attributes']['initial_request_id'] == dst_request['id']
-    assert jmp_request['attributes']['next_hop_request_id'] == dst_request['id']
+    assert jmp_request['attributes']['is_intermediate_hop']
 
 
 @pytest.mark.parametrize("core_config_mock", [{"table_content": [

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -301,7 +301,7 @@ def bulk_group_transfers(transfer_paths, policy='rule', group_bulk=200, source_s
                     job_params['bring_online'] = hop_params['bring_online']
 
             group_key = 'multihop_%s' % transfer_path[-1].rws.request_id
-            grouped_transfers[group_key] = {'transfers': transfer_path, 'job_params': job_params}
+            grouped_transfers[group_key] = {'transfers': transfer_path[0:group_bulk], 'job_params': job_params}
         elif len(transfer_path[0].legacy_sources) > 1:
             # for multi-source transfers, no bulk submission.
             transfer = transfer_path[0]

--- a/tools/docker_activate_rses.sh
+++ b/tools/docker_activate_rses.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2019-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,11 @@
 #
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2019
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Mayank Sharma <mayank.sharma@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
+
+echo "Creating RSEs"
 
 # Create the following topology:
 # +------+   1   +------+
@@ -76,11 +79,11 @@ rucio-admin rse set-attribute --rse XRD3 --key available_for_multihop --value Tr
 rucio-admin rse add-distance --distance 1 --ranking 1 XRD1 XRD2
 rucio-admin rse add-distance --distance 1 --ranking 1 XRD1 XRD3
 rucio-admin rse add-distance --distance 1 --ranking 1 XRD2 XRD1
-rucio-admin rse add-distance --distance 1 --ranking 1 XRD2 XRD3
+rucio-admin rse add-distance --distance 2 --ranking 2 XRD2 XRD3
 rucio-admin rse add-distance --distance 1 --ranking 1 XRD3 XRD1
-rucio-admin rse add-distance --distance 1 --ranking 1 XRD3 XRD2
-rucio-admin rse add-distance --distance 2 --ranking 2 XRD3 XRD4
-rucio-admin rse add-distance --distance 2 --ranking 2 XRD4 XRD3
+rucio-admin rse add-distance --distance 2 --ranking 2 XRD3 XRD2
+rucio-admin rse add-distance --distance 3 --ranking 3 XRD3 XRD4
+rucio-admin rse add-distance --distance 3 --ranking 3 XRD4 XRD3
 
 # Indefinite limits for root
 rucio-admin account set-limits root XRD1 -1


### PR DESCRIPTION
Until now, a multihop transfer didn't have a real database state.
Each hop of the multihop was a separate transfer request with almost
no relationship between individual requests (only a loosely coupled
json attribute). This behavior is source of multiple issues:
 - we have recurrent problems with intermediate hops living their
own life (their lifetime should be linked to the initial request
and they shouldn't be retried on their own).
 - multiple multi-hops sharing a common sub-path are not possible
and result in permanent failures of one of the transfers until the
second finishes.
 - it doesn't allow implementation of cross-tranfertool multihops

For these particular reasons, we introduce a table storing the
relationship between independent requests of a path. I change the
workflows to rely on joins with this table:
- (1) submitter only retrieves from database requests which don't have
any pending previous hops.
- (2) submitter is capable to detect that a sub-path of the current
multi-hop transfer already exists in the database. It only creates
the link with the existing sub-path and aborts submission. Submission
automatically resumes once the common sub-path is transferred thanks to
behavior mentioned in (1)
- (3) when an intermediate hop fails, the poller/receiver will also
fail the next requests in all affected paths.