### PR TITLE
Fix the rest api doc generation

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/credentials.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credentials.py
@@ -70,31 +70,31 @@ class SignURL(ErrorHandlingMethodView):
         tags:
           - Credentials
         parameters:
-        - rse:
+        - name: rse
           in: query
           description: The RSE to authenticate against.
           schema:
             type: string
           required: true
-        - lifetime:
+        - name: lifetime
           in: query
           description: The lifetime, default 600s.
           schema:
             type: string
           required: false
-        - svc:
+        - name: svc
           in: query
           description: The service, default gcs.
           schema:
             type: string
           required: false
-        - op:
+        - name: op
           in: query
           description: The operation.
           schema:
             type: string
           required: false
-        - url:
+        - name: url
           in: query
           description: The Url of the authentification.
           schema:

--- a/lib/rucio/web/rest/flaskapi/v1/export.py
+++ b/lib/rucio/web/rest/flaskapi/v1/export.py
@@ -33,12 +33,12 @@ class Export(ErrorHandlingMethodView):
     def get(self):
         """
         ---
-        SUMMARY: Export data
+        summary: Export data
         description: Export data from rucio.
         tags:
           - Export
         parameters:
-        - distance:
+        - name: distance
           in: query
           description: Should the distance be enabled?
           schema:


### PR DESCRIPTION
The rest api docs use the OpenApi specification. It is strict in it's input and
requests an array with objects with the field `name` as input for parameters.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
