### PR TITLE
 Temp tables to delete replicas. #4793. Closes #5166

### DIFF
--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -35,7 +35,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Vivek Nigam <viveknigam.nigam3@gmail.com>, 2020
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 # - Rob Barnsley <robbarnsley@users.noreply.github.com>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2022
@@ -650,8 +650,8 @@ def delete_dids(dids, account, expire_rules=False, session=None, logger=logging.
             # Archive content
         archive_content = config_core.get('deletion', 'archive_content', default=False, session=session)
         if archive_content:
-            insert_content_history(content_clause=[and_(models.DataIdentifierAssociation.scope == did['scope'],
-                                                        models.DataIdentifierAssociation.name == did['name'])],
+            insert_content_history(filter_=[and_(models.DataIdentifierAssociation.scope == did['scope'],
+                                                 models.DataIdentifierAssociation.name == did['name'])],
                                    did_created_at=did.get('created_at'),
                                    session=session)
 
@@ -1993,11 +1993,11 @@ def create_reports(total_workers, worker_number, session=None):
 
 
 @transactional_session
-def insert_content_history(content_clause, did_created_at, session=None):
+def insert_content_history(filter_, did_created_at, session=None):
     """
     Insert into content history a list of did
 
-    :param content_clause: Content clause of the files to archive
+    :param filter_: Content clause of the files to archive
     :param did_created_at: Creation date of the did
     :param session: The database session in use.
     """
@@ -2016,7 +2016,7 @@ def insert_content_history(content_clause, did_created_at, session=None):
                           models.DataIdentifierAssociation.rule_evaluation,
                           models.DataIdentifierAssociation.created_at,
                           models.DataIdentifierAssociation.updated_at).\
-        filter(or_(*content_clause))
+        filter(filter_)
 
     for cont in query.all():
         if not did_created_at:

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -70,7 +70,7 @@ import rucio.core.did
 import rucio.core.lock
 from rucio.common import exception
 from rucio.common.cache import make_region_memcached
-from rucio.common.config import config_get
+from rucio.common.config import config_get, config_get_bool
 from rucio.common.schema import get_schema_value
 from rucio.common.types import InternalScope
 from rucio.common.utils import chunks, clean_surls, str_to_date, add_url_query
@@ -1641,6 +1641,14 @@ def delete_replicas(rse_id, files, ignore_availability=True, session=None):
     :param ignore_availability: Ignore the RSE blocklisting.
     :param session: The database session in use.
     """
+    use_temp_tables = config_get_bool('core', 'use_temp_tables', default=False)
+    if use_temp_tables:
+        __delete_replicas(rse_id, files, ignore_availability=ignore_availability, session=session)
+    else:
+        __delete_replicas_without_temp_tables(rse_id, files, ignore_availability=ignore_availability, session=session)
+
+
+def __delete_replicas(rse_id, files, ignore_availability=True, session=None):
     replica_rse = get_rse(rse_id=rse_id, session=session)
 
     if not (replica_rse.availability & 1) and not ignore_availability:
@@ -1692,6 +1700,404 @@ def delete_replicas(rse_id, files, ignore_availability=True, session=None):
 
 @transactional_session
 def __cleanup_after_replica_deletion(rse_id, files, session=None):
+    """
+    Perform update of collections/archive associations/dids after the removal of their replicas
+    :param rse_id: the rse id
+    :param files: list of files whose replica got deleted
+    :param session: The database session in use.
+    """
+    parent_condition, did_condition = [], []
+    clt_replica_condition, dst_replica_condition = [], []
+    incomplete_condition, messages, clt_is_not_archive_condition, archive_contents_condition = [], [], [], []
+    for file in files:
+
+        # Schedule update of all collections containing this file and having a collection replica in the RSE
+        dst_replica_condition.append(
+            and_(models.DataIdentifierAssociation.child_scope == file['scope'],
+                 models.DataIdentifierAssociation.child_name == file['name'],
+                 exists(select([1]).prefix_with("/*+ INDEX(COLLECTION_REPLICAS COLLECTION_REPLICAS_PK) */", dialect='oracle')).where(
+                     and_(models.CollectionReplica.scope == models.DataIdentifierAssociation.scope,
+                          models.CollectionReplica.name == models.DataIdentifierAssociation.name,
+                          models.CollectionReplica.rse_id == rse_id))))
+
+        # If the file doesn't have any replicas anymore, we should perform cleanups of objects
+        # related to this file. However, if the file is "lost", it's removal wasn't intentional,
+        # so we want to skip deleting the metadata here. Perform cleanups:
+
+        # 1) schedule removal of this file from all parent datasets
+        parent_condition.append(
+            and_(models.DataIdentifierAssociation.child_scope == file['scope'],
+                 models.DataIdentifierAssociation.child_name == file['name'],
+                 ~exists(select([1]).prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle')).where(
+                     and_(models.DataIdentifier.scope == file['scope'],
+                          models.DataIdentifier.name == file['name'],
+                          models.DataIdentifier.availability == DIDAvailability.LOST)),
+                 ~exists(select([1]).prefix_with("/*+ INDEX(REPLICAS REPLICAS_PK) */", dialect='oracle')).where(
+                     and_(models.RSEFileAssociation.scope == file['scope'],
+                          models.RSEFileAssociation.name == file['name'])),
+                 ~exists(select([1]).prefix_with("/*+ INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_PK) */", dialect='oracle')).where(
+                     and_(models.ConstituentAssociation.child_scope == file['scope'],
+                          models.ConstituentAssociation.child_name == file['name']))))
+
+        # 2) schedule removal of this file from the DID table
+        did_condition.append(
+            and_(models.DataIdentifier.scope == file['scope'],
+                 models.DataIdentifier.name == file['name'],
+                 models.DataIdentifier.availability != DIDAvailability.LOST,
+                 ~exists(select([1]).prefix_with("/*+ INDEX(REPLICAS REPLICAS_PK) */", dialect='oracle')).where(
+                     and_(models.RSEFileAssociation.scope == file['scope'],
+                          models.RSEFileAssociation.name == file['name'])),
+                 ~exists(select([1]).prefix_with("/*+ INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_PK) */", dialect='oracle')).where(
+                     and_(models.ConstituentAssociation.child_scope == file['scope'],
+                          models.ConstituentAssociation.child_name == file['name']))))
+
+        # 3) if the file is an archive, schedule cleanup on the files from inside the archive
+        archive_contents_condition.append(
+            and_(models.ConstituentAssociation.scope == file['scope'],
+                 models.ConstituentAssociation.name == file['name'],
+                 ~exists(select([1]).prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle')).where(
+                     and_(models.DataIdentifier.scope == file['scope'],
+                          models.DataIdentifier.name == file['name'],
+                          models.DataIdentifier.availability == DIDAvailability.LOST)),
+                 ~exists(select([1]).prefix_with("/*+ INDEX(REPLICAS REPLICAS_PK) */", dialect='oracle')).where(
+                     and_(models.RSEFileAssociation.scope == file['scope'],
+                          models.RSEFileAssociation.name == file['name']))))
+
+    # Get all collection_replicas at RSE, insert them into UpdatedCollectionReplica
+    if dst_replica_condition:
+        for chunk in chunks(dst_replica_condition, 10):
+            query = session.query(models.DataIdentifierAssociation.scope, models.DataIdentifierAssociation.name). \
+                filter(or_(*chunk)). \
+                distinct()
+
+            for parent_scope, parent_name in query:
+                models.UpdatedCollectionReplica(scope=parent_scope,
+                                                name=parent_name,
+                                                did_type=DIDType.DATASET,
+                                                rse_id=rse_id). \
+                    save(session=session, flush=False)
+
+    # Delete did from the content for the last did
+    while parent_condition:
+        child_did_condition, tmp_parent_condition = [], []
+        for chunk in chunks(parent_condition, 10):
+
+            stmt = select(
+                models.DataIdentifierAssociation.scope,
+                models.DataIdentifierAssociation.name,
+                models.DataIdentifierAssociation.did_type,
+                models.DataIdentifierAssociation.child_scope,
+                models.DataIdentifierAssociation.child_name,
+            ).prefix_with(
+                "/*+ USE_CONCAT NO_INDEX_FFS(CONTENTS CONTENTS_PK) */",
+                dialect='oracle',
+            ).where(
+                or_(*chunk)
+            )
+            for parent_scope, parent_name, did_type, child_scope, child_name in session.execute(stmt):
+
+                # Schedule removal of child file/dataset/container from the parent dataset/container
+                child_did_condition.append(
+                    and_(models.DataIdentifierAssociation.scope == parent_scope,
+                         models.DataIdentifierAssociation.name == parent_name,
+                         models.DataIdentifierAssociation.child_scope == child_scope,
+                         models.DataIdentifierAssociation.child_name == child_name))
+
+                # Schedule setting is_archive = False on parents which don't have any children with is_archive == True anymore
+                clt_is_not_archive_condition.append(
+                    and_(models.DataIdentifierAssociation.scope == parent_scope,
+                         models.DataIdentifierAssociation.name == parent_name,
+                         exists(select([1]).prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle')).where(
+                             and_(models.DataIdentifier.scope == models.DataIdentifierAssociation.scope,
+                                  models.DataIdentifier.name == models.DataIdentifierAssociation.name,
+                                  models.DataIdentifier.is_archive == true())),
+                         ~exists(select([1]).prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle')).where(
+                             and_(models.DataIdentifier.scope == models.DataIdentifierAssociation.child_scope,
+                                  models.DataIdentifier.name == models.DataIdentifierAssociation.child_name,
+                                  models.DataIdentifier.is_archive == true()))))
+
+                # If the parent dataset/container becomes empty as a result of the child removal
+                # (it was the last children), metadata cleanup has to be done:
+                #
+                # 1) Schedule to remove the replicas of this empty collection
+                clt_replica_condition.append(
+                    and_(models.CollectionReplica.scope == parent_scope,
+                         models.CollectionReplica.name == parent_name,
+                         exists(select([1]).prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle')).where(
+                             and_(models.DataIdentifier.scope == parent_scope,
+                                  models.DataIdentifier.name == parent_name)),
+                         ~exists(select([1]).prefix_with("/*+ INDEX(CONTENTS CONTENTS_PK) */", dialect='oracle')).where(
+                             and_(models.DataIdentifierAssociation.scope == parent_scope,
+                                  models.DataIdentifierAssociation.name == parent_name))))
+
+                # 2) Schedule removal of this empty collection from its own parent collections
+                tmp_parent_condition.append(
+                    and_(models.DataIdentifierAssociation.child_scope == parent_scope,
+                         models.DataIdentifierAssociation.child_name == parent_name,
+                         ~exists(select([1]).prefix_with("/*+ INDEX(CONTENTS CONTENTS_PK) */", dialect='oracle')).where(
+                             and_(models.DataIdentifierAssociation.scope == parent_scope,
+                                  models.DataIdentifierAssociation.name == parent_name))))
+
+                # 3) Schedule removal of the entry from the DIDs table
+                remove_open_did = config_get('reaper', 'remove_open_did', default=False, session=session)
+                if remove_open_did:
+                    did_condition.append(
+                        and_(models.DataIdentifier.scope == parent_scope,
+                             models.DataIdentifier.name == parent_name,
+                             ~exists([1]).where(
+                                 and_(models.DataIdentifierAssociation.child_scope == parent_scope,
+                                      models.DataIdentifierAssociation.child_name == parent_name)),
+                             ~exists([1]).where(
+                                 and_(models.DataIdentifierAssociation.scope == parent_scope,
+                                      models.DataIdentifierAssociation.name == parent_name))))
+                else:
+                    did_condition.append(
+                        and_(models.DataIdentifier.scope == parent_scope,
+                             models.DataIdentifier.name == parent_name,
+                             models.DataIdentifier.is_open == False,  # NOQA
+                             ~exists([1]).where(
+                                 and_(models.DataIdentifierAssociation.child_scope == parent_scope,
+                                      models.DataIdentifierAssociation.child_name == parent_name)),
+                             ~exists([1]).where(
+                                 and_(models.DataIdentifierAssociation.scope == parent_scope,
+                                      models.DataIdentifierAssociation.name == parent_name))))
+
+        if child_did_condition:
+
+            # get the list of modified parent scope, name
+            for chunk in chunks(child_did_condition, 10):
+                modifieds = session.query(models.DataIdentifierAssociation.scope,
+                                          models.DataIdentifierAssociation.name,
+                                          models.DataIdentifierAssociation.did_type). \
+                    distinct(). \
+                    with_hint(models.DataIdentifierAssociation, "INDEX(CONTENTS CONTENTS_PK)", 'oracle'). \
+                    filter(or_(*chunk)). \
+                    filter(exists(select([1]).
+                                  prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle')).
+                           where(and_(models.DataIdentifierAssociation.scope == models.DataIdentifier.scope,
+                                      models.DataIdentifierAssociation.name == models.DataIdentifier.name,
+                                      or_(models.DataIdentifier.complete == true(),
+                                          models.DataIdentifier.complete is None))))
+                for parent_scope, parent_name, parent_did_type in modifieds:
+                    message = {'scope': parent_scope,
+                               'name': parent_name,
+                               'did_type': parent_did_type,
+                               'event_type': 'INCOMPLETE'}
+                    if message not in messages:
+                        messages.append(message)
+                        incomplete_condition.append(
+                            and_(models.DataIdentifier.scope == parent_scope,
+                                 models.DataIdentifier.name == parent_name,
+                                 models.DataIdentifier.did_type == parent_did_type))
+
+            for chunk in chunks(child_did_condition, 10):
+                rucio.core.did.insert_content_history(content_clause=chunk, did_created_at=None, session=session)
+                session.query(models.DataIdentifierAssociation). \
+                    filter(or_(*chunk)). \
+                    delete(synchronize_session=False)
+
+        parent_condition = tmp_parent_condition
+
+    for chunk in chunks(clt_replica_condition, 10):
+        session.query(models.CollectionReplica). \
+            filter(or_(*chunk)). \
+            delete(synchronize_session=False)
+
+    # Update incomplete state
+    for chunk in chunks(incomplete_condition, 10):
+        stmt = update(models.DataIdentifier). \
+            prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle'). \
+            where(or_(*chunk)). \
+            where(models.DataIdentifier.complete != false()). \
+            execution_options(synchronize_session=False). \
+            values(complete=False)
+        session.execute(stmt)
+
+    # delete empty dids
+    messages, deleted_dids, deleted_rules, deleted_did_meta = [], [], [], []
+    for chunk in chunks(did_condition, 10):
+        query = session.query(models.DataIdentifier.scope,
+                              models.DataIdentifier.name,
+                              models.DataIdentifier.did_type). \
+            with_hint(models.DataIdentifier, "INDEX(DIDS DIDS_PK)", 'oracle'). \
+            filter(or_(*chunk))
+        for scope, name, did_type in query:
+            if did_type == DIDType.DATASET:
+                messages.append({'event_type': 'ERASE',
+                                 'payload': dumps({'scope': scope.external,
+                                                   'name': name,
+                                                   'account': 'root'})})
+            deleted_rules.append(and_(models.ReplicationRule.scope == scope,
+                                      models.ReplicationRule.name == name))
+            deleted_dids.append(and_(models.DataIdentifier.scope == scope,
+                                     models.DataIdentifier.name == name))
+            if session.bind.dialect.name == 'oracle':
+                oracle_version = int(session.connection().connection.version.split('.')[0])
+                if oracle_version >= 12:
+                    deleted_did_meta.append(and_(models.DidMeta.scope == scope,
+                                                 models.DidMeta.name == name))
+            else:
+                deleted_did_meta.append(and_(models.DidMeta.scope == scope,
+                                             models.DidMeta.name == name))
+
+    # Remove Archive Constituents
+    removed_constituents = []
+    constituents_to_delete_condition = []
+    for chunk in chunks(archive_contents_condition, 30):
+        query = session.query(models.ConstituentAssociation). \
+            with_hint(models.ConstituentAssociation, "INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_CHILD_IDX)", 'oracle'). \
+            filter(or_(*chunk))
+        for constituent in query:
+            removed_constituents.append({'scope': constituent.child_scope, 'name': constituent.child_name})
+            constituents_to_delete_condition.append(
+                and_(models.ConstituentAssociation.scope == constituent.scope,
+                     models.ConstituentAssociation.name == constituent.name,
+                     models.ConstituentAssociation.child_scope == constituent.child_scope,
+                     models.ConstituentAssociation.child_name == constituent.child_name))
+
+            models.ConstituentAssociationHistory(
+                child_scope=constituent.child_scope,
+                child_name=constituent.child_name,
+                scope=constituent.scope,
+                name=constituent.name,
+                bytes=constituent.bytes,
+                adler32=constituent.adler32,
+                md5=constituent.md5,
+                guid=constituent.guid,
+                length=constituent.length,
+                updated_at=constituent.updated_at,
+                created_at=constituent.created_at,
+            ).save(session=session, flush=False)
+
+            if len(constituents_to_delete_condition) > 200:
+                stmt = delete(models.ConstituentAssociation). \
+                    prefix_with("/*+ INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_PK) */", dialect='oracle'). \
+                    where(or_(*constituents_to_delete_condition)). \
+                    execution_options(synchronize_session=False)
+                session.execute(stmt)
+                constituents_to_delete_condition.clear()
+
+                __cleanup_after_replica_deletion(rse_id=rse_id, files=removed_constituents, session=session)
+                removed_constituents.clear()
+    if constituents_to_delete_condition:
+        stmt = delete(models.ConstituentAssociation). \
+            prefix_with("/*+ INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_PK) */", dialect='oracle'). \
+            where(or_(*constituents_to_delete_condition)). \
+            execution_options(synchronize_session=False)
+        session.execute(stmt)
+        __cleanup_after_replica_deletion(rse_id=rse_id, files=removed_constituents, session=session)
+
+    # Remove rules in Waiting for approval or Suspended
+    for chunk in chunks(deleted_rules, 100):
+        stmt = delete(models.ReplicationRule). \
+            prefix_with("/*+ INDEX(RULES RULES_SCOPE_NAME_IDX) */", dialect='oracle'). \
+            where(or_(*chunk)). \
+            where(models.ReplicationRule.state.in_((RuleState.SUSPENDED,
+                                                    RuleState.WAITING_APPROVAL))). \
+            execution_options(synchronize_session=False)
+        session.execute(stmt)
+
+    # Remove DID Metadata
+    for chunk in chunks(deleted_did_meta, 100):
+        session.query(models.DidMeta). \
+            filter(or_(*chunk)). \
+            delete(synchronize_session=False)
+
+    for chunk in chunks(messages, 100):
+        session.bulk_insert_mappings(models.Message, chunk)
+
+    for chunk in chunks(deleted_dids, 100):
+        stmt = delete(models.DataIdentifier). \
+            prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle'). \
+            where(or_(*chunk)). \
+            execution_options(synchronize_session=False)
+        archive_dids = config_core.get('deletion', 'archive_dids', default=False, session=session)
+        if archive_dids:
+            rucio.core.did.insert_deleted_dids(chunk, session=session)
+        session.execute(stmt)
+
+    # Set is_archive = false on collections which don't have archive children anymore
+    for chunk in chunks(clt_is_not_archive_condition, 100):
+        clt_to_update = list(session
+                             .query(models.DataIdentifierAssociation.scope,
+                                    models.DataIdentifierAssociation.name)
+                             .distinct(models.DataIdentifierAssociation.scope,
+                                       models.DataIdentifierAssociation.name)
+                             .with_hint(models.DataIdentifierAssociation, "INDEX(CONTENTS CONTENTS_PK)", 'oracle')
+                             .filter(or_(*chunk)))
+        if clt_to_update:
+            stmt = update(models.DataIdentifier). \
+                prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle'). \
+                where(or_(and_(models.DataIdentifier.scope == scope,
+                               models.DataIdentifier.name == name,
+                               models.DataIdentifier.is_archive == true())
+                          for scope, name in clt_to_update)). \
+                execution_options(synchronize_session=False). \
+                values(is_archive=False)
+            session.execute(stmt)
+
+
+@transactional_session
+def __delete_replicas_without_temp_tables(rse_id, files, ignore_availability=True, session=None):
+    """
+    Delete file replicas.
+
+    :param rse_id: the rse id.
+    :param files: the list of files to delete.
+    :param ignore_availability: Ignore the RSE blocklisting.
+    :param session: The database session in use.
+    """
+    replica_rse = get_rse(rse_id=rse_id, session=session)
+
+    if not (replica_rse.availability & 1) and not ignore_availability:
+        raise exception.ResourceTemporaryUnavailable('%s is temporary unavailable'
+                                                     'for deleting' % replica_rse.rse)
+
+    replica_condition, src_condition = [], []
+    for file in files:
+        replica_condition.append(
+            and_(models.RSEFileAssociation.scope == file['scope'],
+                 models.RSEFileAssociation.name == file['name']))
+
+        src_condition.append(
+            and_(models.Source.scope == file['scope'],
+                 models.Source.name == file['name'],
+                 models.Source.rse_id == rse_id))
+
+    delta, bytes_, rowcount = 0, 0, 0
+
+    # WARNING : This should not be necessary since that would mean the replica is used as a source.
+    for chunk in chunks(src_condition, 10):
+        rowcount = session.query(models.Source). \
+            filter(or_(*chunk)). \
+            delete(synchronize_session=False)
+
+    rowcount = 0
+    for chunk in chunks(replica_condition, 10):
+        for (scope, name, rid, replica_bytes) in session.query(models.RSEFileAssociation.scope, models.RSEFileAssociation.name, models.RSEFileAssociation.rse_id, models.RSEFileAssociation.bytes). \
+                with_hint(models.RSEFileAssociation, "INDEX(REPLICAS REPLICAS_PK)", 'oracle').filter(models.RSEFileAssociation.rse_id == rse_id).filter(or_(*chunk)):
+            bytes_ += replica_bytes
+            delta += 1
+
+        stmt = delete(models.RSEFileAssociation). \
+            prefix_with("/*+ INDEX(REPLICAS REPLICAS_PK) */", dialect='oracle'). \
+            where(models.RSEFileAssociation.rse_id == rse_id). \
+            where(or_(*chunk)). \
+            execution_options(synchronize_session=False)
+        result = session.execute(stmt)
+        rowcount += result.rowcount
+
+    if rowcount != len(files):
+        raise exception.ReplicaNotFound("One or several replicas don't exist.")
+
+    __cleanup_after_replica_deletion_without_temp_table(rse_id=rse_id, files=files, session=session)
+
+    # Decrease RSE counter
+    decrease(rse_id=rse_id, files=delta, bytes_=bytes_, session=session)
+
+
+@transactional_session
+def __cleanup_after_replica_deletion_without_temp_table(rse_id, files, session=None):
     """
     Perform update of collections/archive associations/dids after the removal of their replicas
     :param rse_id: the rse id
@@ -1969,7 +2375,7 @@ def __cleanup_after_replica_deletion(rse_id, files, session=None):
                 session.execute(stmt)
                 constituents_to_delete_condition.clear()
 
-                __cleanup_after_replica_deletion(rse_id=rse_id, files=removed_constituents, session=session)
+                __cleanup_after_replica_deletion_without_temp_table(rse_id=rse_id, files=removed_constituents, session=session)
                 removed_constituents.clear()
     if constituents_to_delete_condition:
         stmt = delete(models.ConstituentAssociation). \
@@ -1977,7 +2383,7 @@ def __cleanup_after_replica_deletion(rse_id, files, session=None):
             where(or_(*constituents_to_delete_condition)). \
             execution_options(synchronize_session=False)
         session.execute(stmt)
-        __cleanup_after_replica_deletion(rse_id=rse_id, files=removed_constituents, session=session)
+        __cleanup_after_replica_deletion_without_temp_table(rse_id=rse_id, files=removed_constituents, session=session)
 
     # Remove rules in Waiting for approval or Suspended
     for chunk in chunks(deleted_rules, 100):

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1723,7 +1723,7 @@ def __cleanup_after_replica_deletion(scope_name_temp_table, rse_id, files, sessi
     parents_to_analyze = set()
     did_condition = []
     clt_replica_condition, dst_replica_condition = [], []
-    incomplete_condition, messages, clt_is_not_archive_condition, archive_contents_condition = [], [], [], []
+    incomplete_condition, messages, clt_to_set_not_archive, archive_contents_condition = [], [], [], []
     for file in files:
 
         # Schedule update of all collections containing this file and having a collection replica in the RSE
@@ -1829,6 +1829,7 @@ def __cleanup_after_replica_deletion(scope_name_temp_table, rse_id, files, sessi
             models.ConstituentAssociation.child_scope == null()
         )
 
+        clt_to_set_not_archive.append(set())
         if True:  # Todo: de-indent the code in a separate commit
             for parent_scope, parent_name, did_type, child_scope, child_name in session.execute(stmt):
 
@@ -1840,17 +1841,7 @@ def __cleanup_after_replica_deletion(scope_name_temp_table, rse_id, files, sessi
                          models.DataIdentifierAssociation.child_name == child_name))
 
                 # Schedule setting is_archive = False on parents which don't have any children with is_archive == True anymore
-                clt_is_not_archive_condition.append(
-                    and_(models.DataIdentifierAssociation.scope == parent_scope,
-                         models.DataIdentifierAssociation.name == parent_name,
-                         exists(select([1]).prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle')).where(
-                             and_(models.DataIdentifier.scope == models.DataIdentifierAssociation.scope,
-                                  models.DataIdentifier.name == models.DataIdentifierAssociation.name,
-                                  models.DataIdentifier.is_archive == true())),
-                         ~exists(select([1]).prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle')).where(
-                             and_(models.DataIdentifier.scope == models.DataIdentifierAssociation.child_scope,
-                                  models.DataIdentifier.name == models.DataIdentifierAssociation.child_name,
-                                  models.DataIdentifier.is_archive == true()))))
+                clt_to_set_not_archive[-1].add(ScopeName(scope=parent_scope, name=parent_name))
 
                 # If the parent dataset/container becomes empty as a result of the child removal
                 # (it was the last children), metadata cleanup has to be done:
@@ -2046,24 +2037,53 @@ def __cleanup_after_replica_deletion(scope_name_temp_table, rse_id, files, sessi
         session.execute(stmt)
 
     # Set is_archive = false on collections which don't have archive children anymore
-    for chunk in chunks(clt_is_not_archive_condition, 100):
-        clt_to_update = list(session
-                             .query(models.DataIdentifierAssociation.scope,
-                                    models.DataIdentifierAssociation.name)
-                             .distinct(models.DataIdentifierAssociation.scope,
-                                       models.DataIdentifierAssociation.name)
-                             .with_hint(models.DataIdentifierAssociation, "INDEX(CONTENTS CONTENTS_PK)", 'oracle')
-                             .filter(or_(*chunk)))
-        if clt_to_update:
-            stmt = update(models.DataIdentifier). \
-                prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle'). \
-                where(or_(and_(models.DataIdentifier.scope == scope,
-                               models.DataIdentifier.name == name,
-                               models.DataIdentifier.is_archive == true())
-                          for scope, name in clt_to_update)). \
-                execution_options(synchronize_session=False). \
-                values(is_archive=False)
-            session.execute(stmt)
+    while clt_to_set_not_archive:
+        session.query(scope_name_temp_table).delete()
+        session.bulk_insert_mappings(scope_name_temp_table, [sn._asdict() for sn in clt_to_set_not_archive[0]])
+
+        data_identifier_alias = aliased(models.DataIdentifier, name='did_alias')
+
+        stmt = select(
+            models.DataIdentifier.scope,
+            models.DataIdentifier.name,
+        ).distinct(
+        ).where(
+            models.DataIdentifier.is_archive == true()
+        ).join(
+            scope_name_temp_table,
+            and_(scope_name_temp_table.scope == models.DataIdentifier.scope,
+                 scope_name_temp_table.name == models.DataIdentifier.name)
+        ).join(
+            models.DataIdentifierAssociation,
+            and_(models.DataIdentifier.scope == models.DataIdentifierAssociation.scope,
+                 models.DataIdentifier.name == models.DataIdentifierAssociation.name)
+        ).outerjoin(
+            data_identifier_alias,
+            and_(data_identifier_alias.scope == models.DataIdentifierAssociation.child_scope,
+                 data_identifier_alias.name == models.DataIdentifierAssociation.child_name,
+                 data_identifier_alias.is_archive == true())
+        ).where(
+            data_identifier_alias.scope == null()
+        )
+
+        clt_to_update = list(session.execute(stmt))
+
+        session.query(scope_name_temp_table).delete()
+        session.bulk_insert_mappings(scope_name_temp_table, [{'scope': scope, 'name': name} for scope, name in clt_to_update])
+        stmt = update(
+            models.DataIdentifier,
+        ).where(
+            exists(select([1]).prefix_with("/*+ INDEX(DIDS DIDS_PK) */", dialect='oracle')
+                   .where(and_(models.DataIdentifier.scope == scope_name_temp_table.scope,
+                               models.DataIdentifier.name == scope_name_temp_table.name)))
+        ).execution_options(
+            synchronize_session=False
+        ).values(
+            is_archive=False,
+        )
+        session.execute(stmt)
+
+        clt_to_set_not_archive.pop(0)
 
 
 @transactional_session

--- a/lib/rucio/tests/test_dataset_replicas.py
+++ b/lib/rucio/tests/test_dataset_replicas.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2021 CERN
+# Copyright 2015-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import unittest
 
@@ -256,6 +258,7 @@ class TestDatasetReplicaUpdate(unittest.TestCase):
 
         # Delete one file replica -> dataset replica should be unavailable
         delete_replicas(rse_id=self.rse_id, files=[files[0]], session=self.db_session)
+        self.db_session.commit()
         update_request = self.db_session.query(models.UpdatedCollectionReplica).filter_by(rse_id=self.rse_id, scope=self.scope, name=dataset_name).one()  # pylint: disable=no-member
         update_collection_replica(update_request=update_request.to_dict(), session=self.db_session)
         dataset_replica = self.db_session.query(models.CollectionReplica).filter_by(scope=self.scope, name=dataset_name).one()  # pylint: disable=no-member
@@ -281,6 +284,7 @@ class TestDatasetReplicaUpdate(unittest.TestCase):
         # Old behaviour, open empty datasets are not deleted
         # Delete all file replicas -> dataset replica should be deleted
         delete_replicas(rse_id=self.rse_id, files=files, session=self.db_session)
+        self.db_session.commit()
         with pytest.raises(NoResultFound):
             update_collection_replica(update_request=update_request.to_dict(), session=self.db_session)
 
@@ -306,6 +310,7 @@ class TestDatasetReplicaUpdate(unittest.TestCase):
 
         # Delete first replica on first RSE -> replica on first RSE should be unavailable, replica on second RSE should be still available
         delete_replicas(rse_id=self.rse_id, files=[files[0]], session=self.db_session)
+        self.db_session.commit()
         models.UpdatedCollectionReplica(scope=self.scope, name=dataset_name, did_type=constants.DIDType.DATASET).save(session=self.db_session)
         # delete_replica creates also update object but with rse_id -> extra filter for rse_id is NULL
         update_request = self.db_session.query(models.UpdatedCollectionReplica).filter(models.UpdatedCollectionReplica.scope == self.scope, models.UpdatedCollectionReplica.name == dataset_name,  # pylint: disable=no-member
@@ -346,6 +351,7 @@ class TestDatasetReplicaUpdate(unittest.TestCase):
 
         # Delete first replica on second RSE -> file is not longer part of dataset -> both replicas should be available
         delete_replicas(rse_id=self.rse2_id, files=[files[0]], session=self.db_session)
+        self.db_session.commit()
         models.UpdatedCollectionReplica(scope=self.scope, name=dataset_name, did_type=constants.DIDType.DATASET).save(session=self.db_session)
         update_request = self.db_session.query(models.UpdatedCollectionReplica).filter(models.UpdatedCollectionReplica.scope == self.scope, models.UpdatedCollectionReplica.name == dataset_name,  # pylint: disable=no-member
                                                                                        models.UpdatedCollectionReplica.rse_id.is_(None)).one()  # pylint: disable=no-member


### PR DESCRIPTION
Use temporary tables to implement delete_replicas. 

I start by simply copying the existing delete_replicas code 
and using a configuration switch to activate the new behavior.

This PR is split into multiple commits for easier review. Each
commit migrates a small subset of existing queries to using
temp tables. One of the commits also fixes an existing bug.
