### PR TITLE
Transfers: rework heartbeat handling. Closes #5252

### DIFF
--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -67,7 +67,9 @@ TRANSFER_TOOL = config_get('conveyor', 'transfertool', False, None)  # NOTE: Thi
 FILTER_TRANSFERTOOL = config_get('conveyor', 'filter_transfertool', False, None)  # NOTE: TRANSFERTOOL to filter requests on
 
 
-def run_once(fts_bulk, db_bulk, older_than, activity_shares, multi_vo, timeout, activity, total_workers, worker_number, logger):
+def run_once(fts_bulk, db_bulk, older_than, activity_shares, multi_vo, timeout, activity, heartbeat_handler):
+    worker_number, total_workers, logger = heartbeat_handler.live()
+
     start_time = time.time()
     logger(logging.DEBUG, 'Start to poll transfers older than %i seconds for activity %s using transfer tool: %s' % (older_than, activity, FILTER_TRANSFERTOOL))
     transfs = request_core.get_next(request_type=[RequestType.TRANSFER, RequestType.STAGEIN, RequestType.STAGEOUT],
@@ -110,6 +112,7 @@ def run_once(fts_bulk, db_bulk, older_than, activity_shares, multi_vo, timeout, 
                     transfertool_obj = GlobusTransferTool(external_host=None)
                 else:
                     transfertool_obj = FTS3Transfertool(external_host=external_host, vo=vo)
+                worker_number, total_workers, logger = heartbeat_handler.live()
                 poll_transfers(transfertool_obj=transfertool_obj, transfers_by_eid=chunk, timeout=timeout, logger=logger)
             except Exception:
                 logger(logging.ERROR, 'Exception', exc_info=True)
@@ -162,7 +165,6 @@ def poller(once=False, activities=None, sleep_time=60,
             timeout=timeout,
         ),
         activities=activities,
-        heart_beat_older_than=3600,
     )
 
 

--- a/lib/rucio/daemons/conveyor/preparer.py
+++ b/lib/rucio/daemons/conveyor/preparer.py
@@ -37,6 +37,7 @@ from rucio.db.sqla.constants import RequestState
 if TYPE_CHECKING:
     from typing import Optional
     from sqlalchemy.orm import Session
+    from rucio.daemons.conveyor.common import HeartbeatHandler
 
 graceful_stop = threading.Event()
 
@@ -102,11 +103,16 @@ def preparer(once, sleep_time, bulk, partition_wait_time=10):
             bulk=bulk
         ),
         activities=None,
-        heart_beat_older_than=None,
     )
 
 
-def run_once(bulk: int = 100, total_workers: int = 0, worker_number: int = 0, limit: "Optional[int]" = None, logger=logging.log, session: "Optional[Session]" = None, **kwargs) -> bool:
+def run_once(bulk: int = 100, heartbeat_handler: "Optional[HeartbeatHandler]" = None, limit: "Optional[int]" = None, session: "Optional[Session]" = None, **kwargs) -> bool:
+    if heartbeat_handler:
+        worker_number, total_workers, logger = heartbeat_handler.live()
+    else:
+        # This is used in tests
+        worker_number, total_workers, logger = 0, 0, logging.log
+
     start_time = time()
     try:
         req_sources = list_transfer_requests_and_source_replicas(

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -177,11 +177,11 @@ def receiver(id_, total_threads=1, full_mode=False, all_vos=False):
 
     logging.info('receiver started')
 
-    with HeartbeatHandler(executable=executable, logger_prefix=logger_prefix) as heartbeat_handler:
+    with HeartbeatHandler(executable=executable, renewal_interval=30, logger_prefix=logger_prefix) as heartbeat_handler:
 
         while not graceful_stop.is_set():
 
-            _, logger = heartbeat_handler.live()
+            _, _, logger = heartbeat_handler.live()
 
             for conn in conns:
 

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -50,7 +50,9 @@ from rucio.transfertool.fts3 import FTS3Transfertool
 graceful_stop = threading.Event()
 
 
-def run_once(bulk, group_bulk, rse_ids, scheme, failover_scheme, transfertool_kwargs, total_workers, worker_number, logger, activity):
+def run_once(bulk, group_bulk, rse_ids, scheme, failover_scheme, transfertool_kwargs, heartbeat_handler, activity):
+    worker_number, total_workers, logger = heartbeat_handler.live()
+
     start_time = time.time()
     transfers = next_transfers_to_submit(
         total_workers=total_workers,
@@ -80,6 +82,7 @@ def run_once(bulk, group_bulk, rse_ids, scheme, failover_scheme, transfertool_kw
 
         logger(logging.INFO, 'Starting to submit transfers for %s (%s)' % (activity, transfertool_obj))
         for job in grouped_jobs:
+            worker_number, total_workers, logger = heartbeat_handler.live()
             submit_transfer(transfertool_obj=transfertool_obj, transfers=job['transfers'], job_params=job['job_params'], submitter='transfer_submitter', logger=logger)
 
     queue_empty = False
@@ -161,7 +164,6 @@ def stager(once=False, rses=None, bulk=100, group_bulk=1, group_policy='rule',
             transfertool_kwargs=transfertool_kwargs,
         ),
         activities=activities,
-        heart_beat_older_than=None,
     )
 
 

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -76,7 +76,8 @@ TRANSFERTOOL_CLASSES_BY_NAME = {
 
 def run_once(bulk, group_bulk, filter_transfertool, transfertool, ignore_availability, rse_ids,
              scheme, failover_scheme, partition_hash_var, timeout, transfertool_kwargs,
-             total_workers, worker_number, logger, activity):
+             heartbeat_handler, activity):
+    worker_number, total_workers, logger = heartbeat_handler.live()
 
     start_time = time.time()
     transfers = next_transfers_to_submit(
@@ -111,6 +112,7 @@ def run_once(bulk, group_bulk, filter_transfertool, transfertool, ignore_availab
 
         logger(logging.DEBUG, 'Starting to submit transfers for %s (%s)', activity, transfertool_obj)
         for job in grouped_jobs:
+            worker_number, total_workers, logger = heartbeat_handler.live()
             logger(logging.DEBUG, 'submitjob: transfers=%s, job_params=%s' % ([str(t) for t in job['transfers']], job['job_params']))
             submit_transfer(transfertool_obj=transfertool_obj, transfers=job['transfers'], job_params=job['job_params'], submitter='transfer_submitter',
                             timeout=timeout, logger=logger)
@@ -217,7 +219,6 @@ def submitter(once=False, rses=None, partition_wait_time=10,
             transfertool_kwargs=transfertool_kwargs,
         ),
         activities=activities,
-        heart_beat_older_than=3600,
     )
 
 

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -68,7 +68,6 @@ def throttler(once=False, sleep_time=600, partition_wait_time=10):
         sleep_time=sleep_time,
         run_once_fnc=run_once,
         activities=None,
-        heart_beat_older_than=3600,
     )
 
 


### PR DESCRIPTION
Right now heartbeats are updated in the database at each iteration
(each activity for multi-activity daemons). This forces us to use
a big "older_than" value to avoid the race condition when a big bulk
size and slow access to transfertool makes hearbeats expire.
At the same time, this puts strain on database with un-needed heartbeat
updates when the daemons are lightly loaded.

Rework this behavior to perform hearbeat_handler.live() more frequently
(each submission, for example), but modify live() to only perform a
database update if enough time has passed from last update.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
