### PR TITLE
WebUI: add link to survey

### DIFF
--- a/lib/rucio/web/ui/flask/templates/base.html
+++ b/lib/rucio/web/ui/flask/templates/base.html
@@ -168,6 +168,10 @@
         <div class="right" id="div-subtitle" style="padding-right: 1em;">
           Rucio Version ( WebUI / Server ): <span id="rucio_webui_version"></span> / <span id="rucio_server_version">[loading]</span>
         </div>
+        <br>
+        <div class="left" id="div-subtitle" style="padding-left: 1em;">
+          Hello there! Would you like to help improve Rucio UI. Fill this quick <span id="subbar-details"><a href="https://forms.gle/QQdhuWPLrFhgcWaNA">survey</a> to let us know how.</span>
+        </div>
       </div>
 
       <div id="content" style="margin: 1em;">


### PR DESCRIPTION
Close #5305 

![](https://snipboard.io/z7bIuX.jpg)

[The survey is here](https://docs.google.com/forms/d/e/1FAIpQLSdpD81jcjC4CScK8O_gJdfSw3ze4uvuKuEROrOaN_V74LmXCg/viewform) 

If we wish to enable or disable this via `rucio.cfg`, I could make that happen. 