### PR TITLE
Core & Internals: allow external cache for auth tokens. Closes #5297

### DIFF
--- a/lib/rucio/core/authentication.py
+++ b/lib/rucio/core/authentication.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2021 CERN
+# Copyright 2012-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Rahul Chauhan <omrahulchauhan@gmail.com>, 2021
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
-# - Joel Dierkes <joel.dierkes@cern.ch>, 2021
+# - jdierkes <joel.dierkes@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import datetime
 import hashlib
@@ -37,10 +38,12 @@ import traceback
 from base64 import b64decode
 
 import paramiko
-from dogpile.cache import make_region
 from dogpile.cache.api import NO_VALUE
+from dogpile.cache import make_region
 from sqlalchemy import and_, or_, select, delete
 
+from rucio.common.cache import make_region_memcached
+from rucio.common.config import config_get_bool
 from rucio.common.exception import CannotAuthenticate, RucioException
 from rucio.common.utils import chunks, generate_uuid
 from rucio.core.account import account_exists
@@ -59,12 +62,10 @@ def token_key_generator(namespace, fni, **kwargs):
     return generate_key
 
 
-TOKENREGION = make_region(
-    function_key_generator=token_key_generator
-).configure(
-    'dogpile.cache.memory',
-    expiration_time=3600
-)
+if config_get_bool('cache', 'use_external_cache_for_auth_tokens', default=False):
+    TOKENREGION = make_region_memcached(expiration_time=900, function_key_generator=token_key_generator)
+else:
+    TOKENREGION = make_region(function_key_generator=token_key_generator).configure('dogpile.cache.memory', expiration_time=900)
 
 
 @transactional_session


### PR DESCRIPTION
Allow setting auth tokens in memcached, but make it configurable and
default this behavior to disabled.

Also reduce the duration of token, for https://github.com/rucio/rucio/issues/5303
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
