### PR TITLE
Core & Internals: reduce default cache expiration lifetime. Closes #5303

### DIFF
--- a/lib/rucio/common/cache.py
+++ b/lib/rucio/common/cache.py
@@ -32,7 +32,7 @@ def make_region_memcached(expiration_time, function_key_generator=None):
 
     region.configure(
         'dogpile.cache.memcached',
-        expiration_time=3600,
+        expiration_time=expiration_time,
         arguments={
             'url': config_get('cache', 'url', False, '127.0.0.1:11211', check_config_table=False),
             'distributed_lock': True,

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2021 CERN
+# Copyright 2012-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,8 +24,9 @@
 # - Tobias Wegner <twegner@cern.ch>, 2019
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Tomas Javurek <tomas.javurek@cern.ch>, 2020
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - martynia <martynia@users.noreply.github.com>, 2021
 
 """Provides functions to access the local configuration. The configuration locations are provided by get_config_dirs."""
 
@@ -44,7 +45,7 @@ from rucio.common import exception
 
 
 def config_get(section, option, raise_exception=True, default=None, clean_cached=False, check_config_table=True,
-               session=None, use_cache=True, expiration_time=3600):
+               session=None, use_cache=True, expiration_time=900):
     """
     Return the string value for a given option in a section
 
@@ -111,7 +112,7 @@ def config_add_section(section):
 
 
 def config_get_int(section, option, raise_exception=True, default=None, check_config_table=True, session=None,
-                   use_cache=True, expiration_time=3600):
+                   use_cache=True, expiration_time=900):
     """
     Return the integer value for a given option in a section
 
@@ -158,7 +159,7 @@ def config_get_int(section, option, raise_exception=True, default=None, check_co
 
 
 def config_get_float(section, option, raise_exception=True, default=None, check_config_table=True, session=None,
-                     use_cache=True, expiration_time=3600):
+                     use_cache=True, expiration_time=900):
     """
     Return the floating point value for a given option in a section
 
@@ -205,7 +206,7 @@ def config_get_float(section, option, raise_exception=True, default=None, check_
 
 
 def config_get_bool(section, option, raise_exception=True, default=None, check_config_table=True, session=None,
-                    use_cache=True, expiration_time=3600):
+                    use_cache=True, expiration_time=900):
     """
     Return the boolean value for a given option in a section
 
@@ -252,7 +253,7 @@ def config_get_bool(section, option, raise_exception=True, default=None, check_c
 
 
 def __config_get_table(section, option, raise_exception=True, default=None, clean_cached=False, session=None,
-                       use_cache=True, expiration_time=3600):
+                       use_cache=True, expiration_time=900):
     """
     Search for a section-option configuration parameter in the configuration table
 

--- a/lib/rucio/common/policy.py
+++ b/lib/rucio/common/policy.py
@@ -1,21 +1,26 @@
-"""
- Copyright European Organization for Nuclear Research (CERN)
-
- Licensed under the Apache License, Version 2.0 (the "License");
- You may not use this file except in compliance with the License.
- You may obtain a copy of the License at
- http://www.apache.org/licenses/LICENSE-2.0
-
- Authors:
- - Cedric Serfon <cedric.serfon@cern.ch>, 2016-2018
- - Martin Barisits <martin.barisits@cern.ch>, 2017-2018
- - Vincent Garonne <vgaronne@gmail.com>, 2017-2018
- - Brian Bockelman <bbockelm@cse.unl.edu>, 2017
- - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
- - Thomas Beermann <thomas.beermann@cern.ch>, 2021
-
- PY3K COMPATIBLE
-"""
+# -*- coding: utf-8 -*-
+# Copyright 2016-2022 CERN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors:
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2016-2021
+# - Martin Barisits <martin.barisits@cern.ch>, 2017-2018
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2017-2018
+# - Brian Bockelman <bbockelm@cse.unl.edu>, 2017
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
+# - Thomas Beermann <thomas.beermann@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import json
 import os
@@ -35,7 +40,7 @@ from rucio.common.config import config_get
 from rucio.common.exception import UndefinedPolicy
 
 REGION = make_region().configure('dogpile.cache.memory',
-                                 expiration_time=1800)
+                                 expiration_time=900)
 
 
 def get_policy():

--- a/lib/rucio/common/rse_attributes.py
+++ b/lib/rucio/common/rse_attributes.py
@@ -34,7 +34,7 @@ from dogpile.cache.api import NoValue
 from rucio.core import rse as rse_core
 from rucio.common.cache import make_region_memcached
 
-REGION = make_region_memcached(expiration_time=3600)
+REGION = make_region_memcached(expiration_time=900)
 
 
 def get_rse_attributes(rse_id, session=None):

--- a/lib/rucio/core/config.py
+++ b/lib/rucio/core/config.py
@@ -19,8 +19,9 @@
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2017
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
-# - Martin Barisits <martin.barisits@cern.ch>, 2019-2021
+# - Martin Barisits <martin.barisits@cern.ch>, 2019
 # - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 from dogpile.cache.api import NoValue
 from sqlalchemy import func
@@ -31,7 +32,7 @@ from rucio.db.sqla import models
 from rucio.db.sqla.session import read_session, transactional_session
 
 
-REGION = make_region_memcached(expiration_time=3600)
+REGION = make_region_memcached(expiration_time=900)
 
 SECTIONS_CACHE_KEY = 'sections'
 
@@ -57,7 +58,7 @@ def _value_cache_key(section, option):
 
 
 @read_session
-def sections(use_cache=True, expiration_time=3600, session=None):
+def sections(use_cache=True, expiration_time=900, session=None):
     """
     Return a list of the sections available.
 
@@ -90,7 +91,7 @@ def add_section(section, session=None):
 
 
 @read_session
-def has_section(section, use_cache=True, expiration_time=3600, session=None):
+def has_section(section, use_cache=True, expiration_time=900, session=None):
     """
     Indicates whether the named section is present in the configuration.
 
@@ -112,7 +113,7 @@ def has_section(section, use_cache=True, expiration_time=3600, session=None):
 
 
 @read_session
-def options(section, use_cache=True, expiration_time=3600, session=None):
+def options(section, use_cache=True, expiration_time=900, session=None):
     """
     Returns a list of options available in the specified section.
 
@@ -134,7 +135,7 @@ def options(section, use_cache=True, expiration_time=3600, session=None):
 
 
 @read_session
-def has_option(section, option, use_cache=True, expiration_time=3600, session=None):
+def has_option(section, option, use_cache=True, expiration_time=900, session=None):
     """
     Check if the given section exists and contains the given option.
 
@@ -157,7 +158,7 @@ def has_option(section, option, use_cache=True, expiration_time=3600, session=No
 
 
 @read_session
-def get(section, option, default=None, use_cache=True, expiration_time=3600, session=None):
+def get(section, option, default=None, use_cache=True, expiration_time=900, session=None):
     """
     Get an option value for the named section. Value can be auto-coerced to string, int, float, bool, None.
 
@@ -192,7 +193,7 @@ def get(section, option, default=None, use_cache=True, expiration_time=3600, ses
 
 
 @read_session
-def items(section, use_cache=True, expiration_time=3600, session=None):
+def items(section, use_cache=True, expiration_time=900, session=None):
     """
     Return a list of (option, value) pairs for each option in the given section. Values are auto-coerced as in get().
 
@@ -324,7 +325,7 @@ def __convert_type(value):
     return value
 
 
-def read_from_cache(key, expiration_time=3600):
+def read_from_cache(key, expiration_time=900):
     """
     Try to read a value from a cache.
 

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -41,7 +41,7 @@ from rucio.core.monitor import record_timer_block
 
 CREDS_GCS = None
 
-REGION = make_region_memcached(expiration_time=3600)
+REGION = make_region_memcached(expiration_time=900)
 
 
 def get_signed_url(rse_id, service, operation, url, lifetime=600):

--- a/lib/rucio/core/message.py
+++ b/lib/rucio/core/message.py
@@ -41,7 +41,7 @@ from rucio.db.sqla import filter_thread_work
 from rucio.db.sqla.models import Message, MessageHistory
 from rucio.db.sqla.session import transactional_session
 
-REGION = make_region_memcached(expiration_time=3600)
+REGION = make_region_memcached(expiration_time=900)
 
 
 @transactional_session

--- a/lib/rucio/core/naming_convention.py
+++ b/lib/rucio/core/naming_convention.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 #
 # Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2015
-# - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018
-# - Brandon White, <bjwhite@fnal.gov>, 2019
-# - Martin Barisits, <martin.barisits@cern.ch>, 2019
+# - Vincent Garonne <vincent.garonne@cern.ch>, 2015
+# - Cedric Serfon <cedric.serfon@cern.ch>, 2018
+# - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
+# - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Brandon White <bjwhite@fnal.gov>, 2019
+# - Martin Barisits <martin.barisits@cern.ch>, 2019
+# - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 from __future__ import print_function
@@ -34,7 +37,7 @@ from rucio.db.sqla import models
 from rucio.db.sqla.constants import KeyType
 from rucio.db.sqla.session import read_session, transactional_session
 
-REGION = make_region_memcached(expiration_time=3600)
+REGION = make_region_memcached(expiration_time=900)
 
 
 @transactional_session

--- a/lib/rucio/core/replica_sorter.py
+++ b/lib/rucio/core/replica_sorter.py
@@ -47,7 +47,7 @@ from rucio.core.rse_expression_parser import parse_expression
 if TYPE_CHECKING:
     from typing import Dict, List, Optional
 
-REGION = make_region_memcached(expiration_time=1800, function_key_generator=utils.my_key_generator)
+REGION = make_region_memcached(expiration_time=900, function_key_generator=utils.my_key_generator)
 
 # This product uses GeoLite data created by MaxMind,
 # available from <a href="http://www.maxmind.com">http://www.maxmind.com</a>

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -17,7 +17,7 @@
 # - Vincent Garonne <vincent.garonne@cern.ch>, 2012-2018
 # - Ralph Vigne <ralph.vigne@cern.ch>, 2012-2015
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2012-2021
-# - Martin Barisits <martin.barisits@cern.ch>, 2013-2021
+# - Martin Barisits <martin.barisits@cern.ch>, 2013-2020
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2013-2021
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2014-2017
 # - Wen Guan <wen.guan@cern.ch>, 2015-2016
@@ -25,7 +25,7 @@
 # - Frank Berghaus <frank.berghaus@cern.ch>, 2018
 # - Joaquín Bogado <jbogado@linti.unlp.edu.ar>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
-# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018-2020
+# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2018-2021
 # - James Perry <j.perry@epcc.ed.ac.uk>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Brandon White <bjwhite@fnal.gov>, 2019
@@ -37,6 +37,7 @@
 # - Tomas Javurek <tomas.javurek@cern.ch>, 2020
 # - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
 
 import json
 from io import StringIO
@@ -66,7 +67,7 @@ if TYPE_CHECKING:
     from typing import Dict, Optional
     from sqlalchemy.orm import Session
 
-REGION = make_region_memcached(expiration_time=3600)
+REGION = make_region_memcached(expiration_time=900)
 
 
 @transactional_session

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -94,7 +94,7 @@ from rucio.db.sqla.constants import (LockState, ReplicaState, RuleState, RuleGro
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
 
 
-REGION = make_region_memcached(expiration_time=3600)
+REGION = make_region_memcached(expiration_time=900)
 
 
 @transactional_session

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -69,7 +69,7 @@ except ImportError:
 
 graceful_stop = threading.Event()
 
-region = make_region_memcached(expiration_time=3600)
+region = make_region_memcached(expiration_time=900)
 
 
 def run_once(bulk, db_bulk, suspicious_patterns, retry_protocol_mismatches, total_workers, worker_number, logger, activity):

--- a/lib/rucio/rse/__init__.py
+++ b/lib/rucio/rse/__init__.py
@@ -88,7 +88,7 @@ if rsemanager.CLIENT_MODE:   # pylint:disable=no-member
     # Preparing region for dogpile.cache
     RSE_REGION = make_region(function_key_generator=rse_key_generator).configure(
         'dogpile.cache.memory',
-        expiration_time=3600)
+        expiration_time=900)
     setattr(rsemanager, 'RSE_REGION', RSE_REGION)
 
 
@@ -107,5 +107,5 @@ if rsemanager.SERVER_MODE:   # pylint:disable=no-member
 
     setattr(rsemanager, '__request_rse_info', tmp_rse_info)
     setattr(rsemanager, '__get_signed_url', get_signed_url_server)
-    RSE_REGION = make_region_memcached(expiration_time=3600)
+    RSE_REGION = make_region_memcached(expiration_time=900)
     setattr(rsemanager, 'RSE_REGION', RSE_REGION)

--- a/lib/rucio/tests/test_judge_repairer.py
+++ b/lib/rucio/tests/test_judge_repairer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2021 CERN
+# Copyright 2014-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 # - Nick Smith <nick.smith@cern.ch>, 2021
+# - David Población Criado <david.poblacion.criado@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 
 import itertools
 import unittest
@@ -312,7 +314,7 @@ class TestJudgeRepairer(unittest.TestCase):
 
         region = make_region().configure(
             'dogpile.cache.memcached',
-            expiration_time=3600,
+            expiration_time=900,
             arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True}
         )
 

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -72,7 +72,7 @@ from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder
 logging.getLogger("requests").setLevel(logging.CRITICAL)
 disable_warnings()
 
-REGION_SHORT = make_region_memcached(expiration_time=1800)
+REGION_SHORT = make_region_memcached(expiration_time=900)
 
 SUBMISSION_COUNTER = MultiCounter(prom='rucio_transfertool_fts3_submission', statsd='transfertool.fts3.{host}.submission.{state}',
                                   documentation='Number of transfers submitted', labelnames=('state', 'host'))


### PR DESCRIPTION
Reduce to 15m where it was >15m.

Also fix a bug where it wasn't correctly passed through and a default
value of 3600 was used for creating memcached region.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
