### PR TITLE
Testing: add py3 fts rest client + integration test improvements

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -54,7 +54,7 @@ jobs:
           if [ $OWNER != 'rucio' ]; then
             echo "The workflow is running in user ${OWNER}'s fork. Fetching branches and tags from rucio/rucio instead."
             git remote add rucio https://github.com/rucio/rucio
-            git fetch rucio --tags
+            git fetch rucio --tags -f
           fi
 
           echo "On branch ${BRANCH}"
@@ -62,7 +62,22 @@ jobs:
               GIT_REF="master"
           else
               GIT_REF=$(git describe --tags --abbrev=0)
-              echo "Latest tagged release on branch $BRANCH is $GIT_REF"
+              IFS=. read major minor micro build <<<"${GIT_REF}"
+
+              RELEASE_FAMILY=$major.$minor
+              LATEST_RELEASE_IN_RELEASE_FAMILY=$(git for-each-ref --format '%(refname)' refs/tags/$RELEASE_FAMILY.* | sort -k 1.11V | tail -1 | awk -F'/' '{print $3}')
+              LATEST_RUCIO_RELEASE_FAMILY=$(git for-each-ref --format '%(refname)' refs/tags | sort -k 1.11V | tail -1 | awk -F'/' '{print $3}' | awk -F'.' '{print $1 "." $2}')
+              
+              echo "Release line for ${BRANCH} is ${RELEASE_FAMILY}" 
+              echo "The latest release line for rucio is ${LATEST_RUCIO_RELEASE_FAMILY}"
+              echo "The latest release in ${RELEASE_FAMILY} is ${LATEST_RELEASE_IN_RELEASE_FAMILY}"
+              
+              if [ $LATEST_RUCIO_RELEASE_FAMILY = $RELEASE_FAMILY ]; then
+                  GIT_REF='master' # always use containers/master when working on latest rucio/rucio release line
+              else
+                  GIT_REF=$LATEST_RELEASE_IN_RELEASE_FAMILY # for non-master release line, use the latest rucio/containers tag for the given release family
+              fi
+
           fi
 
           cd $GITHUB_WORKSPACE

--- a/lib/rucio/tests/test_tpc.py
+++ b/lib/rucio/tests/test_tpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2021 CERN
+# Copyright 2021-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # Authors:
-# - Mayank Sharma <imptodefeat@gmail.com>, 2021
+# - Mayank Sharma <imptodefeat@gmail.com>, 2021-2022
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 
 import time
@@ -60,7 +60,7 @@ def check_url(pfn, hostname, path):
 
 
 def poll_fts_transfer_status(request_id, timeout=30):
-    rcode, out = run_cmd_process(f"/usr/bin/python2 /usr/bin/fts-rest-transfer-status -v -s https://fts:8446 {request_id}", timeout=timeout)
+    rcode, out = run_cmd_process(f"fts-rest-transfer-status -v -s https://fts:8446 {request_id}", timeout=timeout)
     transfer_status = None
     if rcode == 0:
         transfer_status = re.search("Status: (.*)", out).group(1)

--- a/tools/docker_activate_rses.sh
+++ b/tools/docker_activate_rses.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019 CERN for the benefit of the ATLAS collaboration.
+# Copyright 2019-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,23 +15,11 @@
 #
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2019
+# - Mayank Sharma <mayank.sharma@cern.ch>, 2021-2022
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
 
-# Create the following topology:
-# +------+   1   +------+
-# |      |<----->|      |
-# | XRD1 |       | XRD2 |
-# |      |   +-->|      |
-# +------+   |   +------+
-#    ^       |
-#    | 1     | 1
-#    v       |
-# +------+   |   +------+
-# |      |<--+   |      |
-# | XRD3 |       | XRD4 |
-# |      |<----->|      |
-# +------+   2   +------+
+xrdgsiproxy init -bits 2048 -valid 9999:00 -cert /opt/rucio/etc/usercert.pem  -key /opt/rucio/etc/userkey.pem
 
 # First, create the RSEs
 rucio-admin rse add XRD1
@@ -92,9 +80,6 @@ rucio-admin account set-limits root SSH1 -1
 # Create a default scope for testing
 rucio-admin scope add --account root --scope test
 
-# Delegate credentials to FTS
-/usr/bin/python2.7 /usr/bin/fts-rest-delegate -vf -s https://fts:8446 -H 9999
-
 # Create initial transfer testing data
 dd if=/dev/urandom of=file1 bs=10M count=1
 dd if=/dev/urandom of=file2 bs=10M count=1
@@ -120,3 +105,9 @@ rucio add-rule test:container 1 XRD3
 # Create complication
 rucio add-dataset test:dataset3
 rucio attach test:dataset3 test:file4
+
+# FTS Check
+fts-rest-whoami -v -s https://fts:8446
+
+# Delegate credentials to FTS
+fts-rest-delegate -vf -s https://fts:8446 -H 9999

--- a/tools/docker_activate_rses.sh
+++ b/tools/docker_activate_rses.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2022 CERN
+# Copyright 2019 CERN for the benefit of the ATLAS collaboration.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,25 @@
 #
 # Authors:
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2019
-# - Mayank Sharma <mayank.sharma@cern.ch>, 2021-2022
 # - Radu Carpa <radu.carpa@cern.ch>, 2021
 # - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
 
+# Create the following topology:
+# +------+   1   +------+
+# |      |<----->|      |
+# | XRD1 |       | XRD2 |
+# |      |   +-->|      |
+# +------+   |   +------+
+#    ^       |
+#    | 1     | 1
+#    v       |
+# +------+   |   +------+
+# |      |<--+   |      |
+# | XRD3 |       | XRD4 |
+# |      |<----->|      |
+# +------+   2   +------+
+
+# Step zero, get a compliant proxy
 xrdgsiproxy init -bits 2048 -valid 9999:00 -cert /opt/rucio/etc/usercert.pem  -key /opt/rucio/etc/userkey.pem
 
 # First, create the RSEs


### PR DESCRIPTION
Fixes `docker_activate_rses.sh` and `test_tpc.py` to support the py3 `fts-rest-client` as originally done by @mlassnig  in #5324. This should fix the integration tests.

Also, improves the selection of `rucio/containers` for integration tests by picking `rucio/containers#master` if the current branch in the owner's fork is based on `rucio/rucio#master`. Otherwise, for older release lines, the latest release in the old release line is used to provide the containers for integration tests.

Also, force fetches the tags in case the owner's tag and corresponding `rucio/rucio` tag exist at different commits despite the same name. This causes errors like

```
! [rejected]            1.3.0.post1      -> 1.3.0.post1  (would clobber existing tag)
 ! [rejected]            1.3.0.post2      -> 1.3.0.post2  (would clobber existing tag)
```
which should now be fixed.