### PR TITLE
Always print the integration test logs #5253

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -145,6 +145,7 @@ jobs:
             exit 1
           fi
       - name: Print server error logs
+        if: ${{ success() || failure() }}
         shell: bash
         run: |
           docker exec -t dev_rucio_1 cat /var/log/rucio/httpd_error_log


### PR DESCRIPTION
If any job before the `Print server error logs` fails, the job itself will not
run. Since these are the cases in which the logs can provide additional
information, they should be printed.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
