### PR TITLE
Client: Option to change replica sort algorithm in download client Closes #5355

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -61,6 +61,7 @@ Individual contributors to the source code
 - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
 - Fabio Luchetti <fabio.luchetti@cern.ch>, 2021
 - Stefan Piperov <stefan.piperov@cern.ch>, 2021
+- Jensen Zhang <hack@jensen-zhang.site>, 2022
 
 Organisations employing contributors
 ------------------------------------

--- a/bin/rucio
+++ b/bin/rucio
@@ -1121,11 +1121,13 @@ def download(args):
             items.append(item_defaults)
 
         if args.aria:
-            result = download_client.download_aria2c(items, trace_pattern, deactivate_file_download_exceptions=deactivate_file_download_exceptions)
+            result = download_client.download_aria2c(items, trace_pattern, deactivate_file_download_exceptions=deactivate_file_download_exceptions, sort=args.sort)
         elif args.metalink_file:
             result = download_client.download_from_metalink_file(items[0], args.metalink_file, deactivate_file_download_exceptions=deactivate_file_download_exceptions)
+            if args.sort:
+                logger.warning('Ignoring --replica-selection option because --metalink option given')
         else:
-            result = download_client.download_dids(items, args.ndownloader, trace_pattern, deactivate_file_download_exceptions=deactivate_file_download_exceptions, sort=args.replica_sort)
+            result = download_client.download_dids(items, args.ndownloader, trace_pattern, deactivate_file_download_exceptions=deactivate_file_download_exceptions, sort=args.sort)
     else:
         if args.aria:
             logger.warning('Ignoring --aria option because --pfn option given')
@@ -2365,7 +2367,7 @@ You can filter by key/value, e.g.::
         selected_parser.add_argument('--scope', dest='scope', action='store', help='Scope if you are using the filter option and no full DID.')
         selected_parser.add_argument('--metalink', dest='metalink_file', action='store', help='Path to a metalink file.')
         selected_parser.add_argument('--deactivate-file-download-exceptions', dest='deactivate_file_download_exceptions', action='store_true', help='Does not raise NoFilesDownloaded, NotAllFilesDownloaded or incorrect number of output queue files Exception.')  # NOQA: E501
-        selected_parser.add_argument('--replica-sort', action='store', help='Select best replica by replica sorting algorithm.')
+        selected_parser.add_argument('--replica-selection', dest='sort', action='store', help='Select the best replica using a replica sorting algorithm provided by replica sorter (e.g., random, geoip).')
 
     # The get-metadata subparser
     get_metadata_parser = subparsers.add_parser('get-metadata', help='Get metadata for DIDs.')

--- a/bin/rucio
+++ b/bin/rucio
@@ -1125,7 +1125,7 @@ def download(args):
         elif args.metalink_file:
             result = download_client.download_from_metalink_file(items[0], args.metalink_file, deactivate_file_download_exceptions=deactivate_file_download_exceptions)
         else:
-            result = download_client.download_dids(items, args.ndownloader, trace_pattern, deactivate_file_download_exceptions=deactivate_file_download_exceptions)
+            result = download_client.download_dids(items, args.ndownloader, trace_pattern, deactivate_file_download_exceptions=deactivate_file_download_exceptions, sort=args.replica_sort)
     else:
         if args.aria:
             logger.warning('Ignoring --aria option because --pfn option given')
@@ -2365,6 +2365,7 @@ You can filter by key/value, e.g.::
         selected_parser.add_argument('--scope', dest='scope', action='store', help='Scope if you are using the filter option and no full DID.')
         selected_parser.add_argument('--metalink', dest='metalink_file', action='store', help='Path to a metalink file.')
         selected_parser.add_argument('--deactivate-file-download-exceptions', dest='deactivate_file_download_exceptions', action='store_true', help='Does not raise NoFilesDownloaded, NotAllFilesDownloaded or incorrect number of output queue files Exception.')  # NOQA: E501
+        selected_parser.add_argument('--replica-sort', action='store', help='Select best replica by replica sorting algorithm.')
 
     # The get-metadata subparser
     get_metadata_parser = subparsers.add_parser('get-metadata', help='Get metadata for DIDs.')


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Allow the rucio download client to specify the replica sorting algorithm using CLI as follows:

```
rucio download --replica-selection random test:file1
```

or using the client API as follows:

```
download_client.download_dids(items, sort="random")
```