### PR TITLE
Authentication & Authorisation:: Replace deprecated oauth2client dependency Closes #5343

### DIFF
--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -30,7 +30,7 @@ from hashlib import sha1
 import boto3
 from botocore.client import Config
 from dogpile.cache.api import NO_VALUE
-from oauth2client.service_account import ServiceAccountCredentials
+from google.oauth2.service_account import Credentials
 from six import integer_types
 from six.moves.urllib.parse import urlparse, urlencode
 
@@ -79,9 +79,9 @@ def get_signed_url(rse_id, service, operation, url, lifetime=600):
     signed_url = None
     if service == 'gcs':
         if not CREDS_GCS:
-            CREDS_GCS = ServiceAccountCredentials.from_json_keyfile_name(config_get('credentials', 'gcs',
-                                                                                    raise_exception=False,
-                                                                                    default='/opt/rucio/etc/google-cloud-storage-test.json'))
+            CREDS_GCS = Credentials.from_service_account_file(config_get('credentials', 'gcs',
+                                                                         raise_exception=False,
+                                                                         default='/opt/rucio/etc/google-cloud-storage-test.json'))
         components = urlparse(url)
         host = components.netloc
 
@@ -106,7 +106,7 @@ def get_signed_url(rse_id, service, operation, url, lifetime=600):
 
         # create URL-capable signature
         # first character is always a '=', remove it
-        signature = urlencode({'': base64.b64encode(CREDS_GCS.sign_blob(to_sign)[1])})[1:]
+        signature = urlencode({'': base64.b64encode(CREDS_GCS.sign_bytes(to_sign))})[1:]
 
         # assemble final signed URL
         signed_url = 'https://%s%s?GoogleAccessId=%s&Expires=%s&Signature=%s' % (host,

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -20,6 +20,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 # - Radu Carpa <radu.carpa@cern.ch>, 2022
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2022
+# - Rizart Dona <rizart.dona@cern.ch>, 2022
 
 import base64
 import datetime

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ python-dateutil==2.8.2                                      # Extensions to the 
 stomp.py==6.1.1                                             # ActiveMQ Messaging Protocol
 statsd==3.3.0                                               # Needed to log into graphite with more than 1 Hz
 geoip2==4.5.0                                               # GeoIP2 API (for IPv6 support)
-oauth2client==4.1.3                                         # OAuth 2.0 client library
+google-auth==2.6.0                                          # Google authentication library for Python
 retrying==1.3.3                                             # general-purpose retrying library to simplify the task of adding retry behavior to just about anything
 redis==4.1.4                                                # Python client for Redis key-value store
 Flask==2.0.3                                                # Python web framework

--- a/setuputil.py
+++ b/setuputil.py
@@ -93,7 +93,7 @@ server_requirements_table = {
         'stomp.py',
         'statsd',
         'geoip2',
-        'oauth2client',
+        'google-auth',
         'retrying',
         'redis',
         'flask',


### PR DESCRIPTION
Replaced the oauth2client deprecated library and made the relevant changes in the GCS URL signing logic.