### PR TITLE
Core & Internals: forward compatibility with the 1.28 release. Closes #5372

### DIFF
--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -925,6 +925,11 @@ def add_protocol(rse_id, parameter, session=None):
                 parameter[op_name] = parameter['domains'][s][op]
         del parameter['domains']
 
+    # This is needed for forward-compatibility with the 1.28 version, which relies on _read/_write columns
+    if parameter.get('third_party_copy') is not None and parameter.get('third_party_copy_read') is None and parameter.get('third_party_copy_write') is None:
+        parameter['third_party_copy_read'] = parameter['third_party_copy']
+        parameter['third_party_copy_write'] = parameter['third_party_copy']
+
     if ('extended_attributes' in parameter) and parameter['extended_attributes']:
         try:
             parameter['extended_attributes'] = json.dumps(parameter['extended_attributes'], separators=(',', ':'))

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -408,7 +408,7 @@ def __update_bulk_replicas(replicas, session=None, logger=logging.log):
 
     for replica in replicas:
         if not replica['archived']:
-            request_core.archive_request(replica['request_id'], session=session)
+            request_core.archive_request(replica['request_id'], session=session, logger=logger)
         logger(logging.INFO, "HANDLED REQUEST %s DID %s:%s AT RSE %s STATE %s", replica['request_id'], replica['scope'], replica['name'], replica['rse_id'], str(replica['state']))
     return True
 
@@ -427,7 +427,7 @@ def __update_replica(replica, session=None, logger=logging.log):
     try:
         replica_core.update_replicas_states([replica], nowait=True, session=session)
         if not replica['archived']:
-            request_core.archive_request(replica['request_id'], session=session)
+            request_core.archive_request(replica['request_id'], session=session, logger=logger)
         logger(logging.INFO, "HANDLED REQUEST %s DID %s:%s AT RSE %s STATE %s", replica['request_id'], replica['scope'], replica['name'], replica['rse_id'], str(replica['state']))
     except (UnsupportedOperation, ReplicaNotFound) as error:
         logger(logging.WARNING, "ERROR WHEN HANDLING REQUEST %s DID %s:%s AT RSE %s STATE %s: %s", replica['request_id'], replica['scope'], replica['name'], replica['rse_id'], str(replica['state']), str(error))
@@ -445,7 +445,7 @@ def __update_replica(replica, session=None, logger=logging.log):
                                          tombstone=datetime.datetime.utcnow(),
                                          session=session)
             if not replica['archived']:
-                request_core.archive_request(replica['request_id'], session=session)
+                request_core.archive_request(replica['request_id'], session=session, logger=logger)
             logger(logging.INFO, "HANDLED REQUEST %s DID %s:%s AT RSE %s STATE %s", replica['request_id'], replica['scope'], replica['name'], replica['rse_id'], str(replica['state']))
         except Exception as error:
             logger(logging.ERROR, 'Cannot register replica for DID %s:%s at RSE %s - potential dark data - %s', replica['scope'], replica['name'], replica['rse_id'], str(error))


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
