### PR TITLE
Transfers: ignore transfers finisher/submitter if they are next_hops. Closes #5381

### DIFF
--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -88,6 +88,7 @@ def run_once(bulk, db_bulk, suspicious_patterns, retry_protocol_mismatches, hear
                                      total_workers=total_workers,
                                      worker_number=worker_number,
                                      mode_all=True,
+                                     include_dependent=False,
                                      hash_variable='rule_id')
         record_timer('daemons.conveyor.finisher.get_next', (time.time() - time1) * 1000)
         time2 = time.time()


### PR DESCRIPTION
The leftmost transfer in a path a->b->c (here: 'a') should never be
a next_hop. So things should converge correctly eventually.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
