### PR TITLE
Set the `Jinja2` module version prior to 3.1.0 1.26 lts #5398

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ retrying==1.3.3                                             # general-purpose re
 redis==3.5.3                                                # Python client for Redis key-value store
 numpy==1.19.4                                               # Numpy for forecasting T3C
 itsdangerous<2.1.0                                          # Flask dependency, broken support since 2.1.0 https://github.com/pallets/flask/issues/4455
+Jinja2<3.1.0                                                # Flask dependency, broken support since jinja2 3.1.0 https://github.com/pallets/jinja/issues/1626
 Flask==1.1.2                                                # Python web framework
 oic==1.2.1                                                  # for authentication via OpenID Connect protocol
 prometheus_client==0.9.0                                    # Python client for the Prometheus monitoring system

--- a/setuputil.py
+++ b/setuputil.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2021 CERN
+# Copyright 2021-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 # Authors:
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 # - Martin Barisits <martin.barisits@cern.ch>, 2021
+# - Joel Dierkes <joel.dierkes@cern.ch>, 2022
 
 from __future__ import print_function
 
@@ -96,6 +97,7 @@ server_requirements_table = {
         'redis',
         'numpy',
         'itsdangerous',
+        'jinja2',
         'flask',
         'oic',
         'prometheus_client',


### PR DESCRIPTION
The new `Jinja2` package version 3.1.0 is incompatible with the Flask
version 1.1.2.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
