### PR TITLE
Tests: fix metrics_mock fixture

### DIFF
--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -15,14 +15,12 @@
 #
 # Authors:
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020-2021
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
 # - Mayank Sharma <imptodefeat@gmail.com>, 2021-2022
 # - Simon Fayer <simon.fayer05@imperial.ac.uk>, 2021
 # - Rakshita Varadarajan <rakshitajps@gmail.com>, 2021
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2021
 # - Cedric Serfon <cedric.serfon@cern.ch>, 2021
-# - Cedric Serfon <cedric.serfon@cern.ch>, 2021-2022
-
 
 from __future__ import print_function
 
@@ -371,7 +369,11 @@ def metrics_mock():
     """
 
     from unittest import mock
-    from prometheus_client import CollectorRegistry
+    from prometheus_client import CollectorRegistry, values
 
-    with mock.patch('rucio.core.monitor.REGISTRY', new=CollectorRegistry()) as registry, mock.patch('rucio.core.monitor.COUNTERS', new={}):
+    with mock.patch('rucio.core.monitor.REGISTRY', new=CollectorRegistry()) as registry, \
+            mock.patch('rucio.core.monitor.COUNTERS', new={}), \
+            mock.patch('rucio.core.monitor.GAUGES', new={}), \
+            mock.patch('rucio.core.monitor.TIMINGS', new={}), \
+            mock.patch('prometheus_client.values.ValueClass', new=values.MutexValue):
         yield registry


### PR DESCRIPTION
We recently set the prometheus_multiproc_dir env variable by default
in the dev container. As a result, the values written by the mock
are now persisted to disk and hence between test runs when we run
tests in the dev container.
As the pipeline doesn't use this dev container, tests pass without
issues, but the same tests will fail when run locally by a developer.

Fix the fixture by substituting the valueClass with a mutexValue,
ensuring that values aren't persisted between tests.

Also, add the GAUGE and TIMING mock, even if they aren't yet used.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
