### PR TITLE
Transfers: native multi-hop between transfertools. Closes #5403

### DIFF
--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -351,12 +351,21 @@ def transfer_path_str(transfer_path: "List[DirectTransferDefinition]") -> str:
     if not transfer_path:
         return 'empty transfer path'
 
+    multi_tt = False
+    if len({hop.rws.transfertool for hop in transfer_path if hop.rws.transfertool}) > 1:
+        # The path relies on more than one transfertool
+        multi_tt = True
+
     if len(transfer_path) == 1:
         return str(transfer_path[0])
 
     path_str = str(transfer_path[0].src.rse)
     for hop in transfer_path:
-        path_str += '--{request_id}->{destination}'.format(request_id=hop.rws.request_id or '', destination=hop.dst.rse)
+        path_str += '--{request_id}{transfertool}->{destination}'.format(
+            request_id=hop.rws.request_id or '',
+            transfertool=':{}'.format(hop.rws.transfertool) if multi_tt else '',
+            destination=hop.dst.rse,
+        )
     return path_str
 
 
@@ -942,9 +951,7 @@ def get_transfer_paths(total_workers=0, worker_number=0, partition_hash_var=None
     Workflow:
     """
 
-    include_multihop = False
-    if filter_transfertool in ['fts3', None]:
-        include_multihop = core_config_get('transfers', 'use_multihop', default=False, expiration_time=600, session=session)
+    include_multihop = core_config_get('transfers', 'use_multihop', default=False, expiration_time=600, session=session)
 
     multihop_rses = []
     if include_multihop:
@@ -982,6 +989,7 @@ def get_transfer_paths(total_workers=0, worker_number=0, partition_hash_var=None
         activity=activity,
         older_than=older_than,
         rses=rses,
+        multihop_rses=multihop_rses,
         request_type=request_type,
         request_state=RequestState.QUEUED,
         ignore_availability=ignore_availability,

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -928,7 +928,7 @@ def __sort_paths(candidate_paths: "Iterable[List[DirectTransferDefinition]]") ->
 
 @transactional_session
 def get_transfer_paths(total_workers=0, worker_number=0, partition_hash_var=None, limit=None, activity=None, older_than=None, rses=None, schemes=None,
-                       failover_schemes=None, filter_transfertool=None, request_type=RequestType.TRANSFER,
+                       failover_schemes=None, active_transfertools=None, filter_transfertool=None, request_type=RequestType.TRANSFER,
                        ignore_availability=False, logger=logging.log, session=None):
     """
     Get next transfers to be submitted; grouped by transfertool which can submit them
@@ -942,6 +942,7 @@ def get_transfer_paths(total_workers=0, worker_number=0, partition_hash_var=None
     :param schemes:               Include schemes.
     :param failover_schemes:      Failover schemes.
     :param filter_transfertool:   The transfer tool to filter requests on.
+    :param active_transfertools:  The transfer tool names which are supported by the calling context.
     :param request_type           The type of requests to retrieve (Transfer/Stagein)
     :param ignore_availability:   Ignore blocklisted RSEs
     :param logger:                Optional decorated logger that can be passed from the calling daemons or servers.
@@ -1007,9 +1008,27 @@ def get_transfer_paths(total_workers=0, worker_number=0, partition_hash_var=None
         failover_schemes=failover_schemes,
         admin_accounts=admin_accounts,
         ignore_availability=ignore_availability,
+        active_transfertools=active_transfertools,
         logger=logger,
         session=session,
     )
+
+
+def __parse_request_transfertools(
+        rws: "RequestWithSources",
+        logger: "Callable" = logging.log,
+):
+    """
+    Parse a set of desired transfertool names from the database field request.transfertool
+    """
+    request_transfertools = set()
+    try:
+        if rws.transfertool:
+            request_transfertools = {tt.strip() for tt in rws.transfertool.split(',')}
+    except Exception:
+        logger(logging.WARN, "Unable to parse requested transfertools: {}".format(request_transfertools))
+        request_transfertools = None
+    return request_transfertools
 
 
 def __build_transfer_paths(
@@ -1020,6 +1039,7 @@ def __build_transfer_paths(
         schemes: "List[str]",
         failover_schemes: "List[str]",
         admin_accounts: "Set[InternalAccount]",
+        active_transfertools: "Set[str]" = None,
         ignore_availability: bool = False,
         logger: "Callable" = logging.log,
         session: "Optional[Session]" = None,
@@ -1049,6 +1069,7 @@ def __build_transfer_paths(
         multihop_rses = list(set(multihop_rses).difference(unavailable_write_rse_ids).difference(unavailable_read_rse_ids))
 
     candidate_paths_by_request_id, reqs_no_source, reqs_only_tape_source, reqs_scheme_mismatch = {}, set(), set(), set()
+    reqs_unsupported_transfertool = set()
     for rws in requests_with_sources:
 
         ctx.ensure_fully_loaded(rws.dest_rse)
@@ -1072,6 +1093,17 @@ def __build_transfer_paths(
             continue
         if rws.account not in admin_accounts and rws.dest_rse.id in restricted_write_rses:
             logger(logging.WARNING, '%s: dst RSE is restricted for write. Will skip the submission', rws.request_id)
+            continue
+
+        request_transfertool = __parse_request_transfertools(rws, logger)
+        if request_transfertool is None:
+            logger(logging.WARNING, '%s: failed to parse transfertool from request', rws.request_id)
+            continue
+        if request_transfertool and active_transfertools and not request_transfertool.intersection(active_transfertools):
+            # The request explicitly asks for a transfertool which this submitter doesn't support
+            logger(logging.INFO, '%s: unsupported transfertool. Skipping.', rws.request_id)
+            reqs_unsupported_transfertool.add(rws.request_id)
+            reqs_no_source.remove(rws.request_id)
             continue
 
         # parse source expression
@@ -1181,7 +1213,7 @@ def __build_transfer_paths(
         candidate_paths_by_request_id[rws.request_id] = candidate_paths
         reqs_no_source.remove(rws.request_id)
 
-    return candidate_paths_by_request_id, reqs_no_source, reqs_scheme_mismatch, reqs_only_tape_source
+    return candidate_paths_by_request_id, reqs_no_source, reqs_scheme_mismatch, reqs_only_tape_source, reqs_unsupported_transfertool
 
 
 @read_session

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -184,7 +184,7 @@ def run_conveyor_daemon(once, graceful_stop, executable, logger_prefix, partitio
 
 @transactional_session
 def next_transfers_to_submit(total_workers=0, worker_number=0, partition_hash_var=None, limit=None, activity=None, older_than=None, rses=None, schemes=None,
-                             failover_schemes=None, filter_transfertool=None, transfertools_by_name=None, request_type=RequestType.TRANSFER,
+                             failover_schemes=None, filter_transfertool=None, transfertool_classes=None, request_type=RequestType.TRANSFER,
                              ignore_availability=False, logger=logging.log, session=None):
     """
     Get next transfers to be submitted; grouped by transfertool which can submit them
@@ -197,7 +197,7 @@ def next_transfers_to_submit(total_workers=0, worker_number=0, partition_hash_va
     :param rses:                  Include RSES.
     :param schemes:               Include schemes.
     :param failover_schemes:      Failover schemes.
-    :param transfertools_by_name: Dict: {transfertool_name_str: transfertool class}
+    :param transfertool_classes:  List of transfertool classes which can be used by this submitter
     :param filter_transfertool:   The transfer tool to filter requests on.
     :param request_type           The type of requests to retrieve (Transfer/Stagein)
     :param ignore_availability:   Ignore blocklisted RSEs
@@ -226,7 +226,7 @@ def next_transfers_to_submit(total_workers=0, worker_number=0, partition_hash_va
     # if the chosen best path is a multihop, create intermediate replicas and the intermediate transfer requests
     paths_by_transfertool_builder, reqs_no_host, reqs_unsupported_transfertool = __assign_paths_to_transfertool_and_create_hops(
         candidate_paths,
-        transfertools_by_name=transfertools_by_name,
+        transfertool_classes=transfertool_classes,
         logger=logger,
         session=session,
     )
@@ -264,9 +264,49 @@ def __parse_request_transfertools(
     return request_transfertools
 
 
+def __assign_to_transfertool(
+        transfer_path: "List[DirectTransferDefinition]",
+        transfertool_classes: "List[Type[Transfertool]]",
+        logger: "Callable",
+) -> "List[Tuple[List[DirectTransferDefinition], Optional[TransferToolBuilder]]]":
+    """
+    Iterate over a multihop path and assign sub-paths to transfertools in chucks from left to right.
+
+    Assignment is done in a greedy way. At each step, the first transfertool which can submit any non-empty prefix
+    is selected. No backtracking is done to find better alternatives.
+
+    For example, for a path A->B->C->D->E, A->B->C may be assigned to transfertool1; while C->D->E to transfertool2.
+    This even if transfertool2 could submit the full path in one step without splitting it.
+    """
+    if transfertool_classes is None:
+        return [(transfer_path, None)]
+
+    remaining_hops = transfer_path
+    tt_builder_for_hops = []
+    while remaining_hops:
+        tt_builder = None
+        assigned_hops = []
+        for transfertool_cls in transfertool_classes:
+            assigned_hops, tt_builder = transfertool_cls.submission_builder_for_path(remaining_hops, logger=logger)
+            if assigned_hops:
+                break
+
+        if not assigned_hops:
+            break
+
+        remaining_hops = remaining_hops[len(assigned_hops):]
+        tt_builder_for_hops.append((assigned_hops, tt_builder))
+
+    if remaining_hops:
+        # We cannot submit the whole path
+        return []
+
+    return tt_builder_for_hops
+
+
 def __assign_paths_to_transfertool_and_create_hops(
         candidate_paths_by_request_id: "Dict[str: List[DirectTransferDefinition]]",
-        transfertools_by_name: "Optional[Dict[str, Type[Transfertool]]]" = None,
+        transfertool_classes: "Optional[List[Type[Transfertool]]]" = None,
         logger: "Callable" = logging.log,
         session: "Optional[Session]" = None,
 ) -> "Tuple[Dict[TransferToolBuilder, List[DirectTransferDefinition]], Set[str], Set[str]]":
@@ -282,40 +322,45 @@ def __assign_paths_to_transfertool_and_create_hops(
         # Get the rws object from any candidate path. It is the same for all candidate paths. For multihop, the initial request is the last hop
         rws = candidate_paths[0][-1].rws
 
-        request_transfertools = __parse_request_transfertools(rws, logger)
-        if request_transfertools is None:
+        initial_request_transfertool = __parse_request_transfertools(rws, logger)
+        if initial_request_transfertool is None:
             # Parsing failed
             reqs_no_host.add(request_id)
             continue
-        if request_transfertools and transfertools_by_name and not request_transfertools.intersection(transfertools_by_name):
+        if initial_request_transfertool and transfertool_classes and \
+                not initial_request_transfertool.intersection(t.external_name for t in transfertool_classes):
             # The request explicitly asks for a transfertool which this submitter doesn't support
             reqs_unsupported_transfertool.add(request_id)
             continue
 
-        # Selects the first path which can be submitted by a supported transfertool and for which the creation of
-        # intermediate hops (if it is a multihop) work correctly
+        # Selects the first path which can be submitted using a chain of supported transfertools
+        # and for which the creation of intermediate hops (if it is a multihop) works correctly
         best_path = None
         builder_to_use = None
+        hops_to_submit = []
         must_skip_submission = False
-        for transfer_path in candidate_paths:
-            builder = None
-            if transfertools_by_name:
-                transfertools_to_try = set(transfertools_by_name)
-                if request_transfertools:
-                    transfertools_to_try = transfertools_to_try.intersection(request_transfertools)
-                for transfertool in transfertools_to_try:
-                    builder = transfertools_by_name[transfertool].submission_builder_for_path(transfer_path, logger=logger)
-                    if builder:
-                        break
-            if builder or not transfertools_by_name:
-                created, must_skip_submission = __create_missing_replicas_and_requests(
-                    transfer_path, default_tombstone_delay, logger=logger, session=session
-                )
-                if created:
-                    best_path = transfer_path
-                    builder_to_use = builder
-                if created or must_skip_submission:
-                    break
+
+        tt_assignments = [(transfer_path, __assign_to_transfertool(transfer_path, transfertool_classes, logger=logger))
+                          for transfer_path in candidate_paths]
+        # Prioritize the paths which need less transfertool transitions.
+        # Ideally, the entire path should be submitted to a single transfertool
+        for transfer_path, tt_assignment in sorted(tt_assignments, key=lambda t: len(t[1])):
+            # Set the 'transfertool' field on the intermediate hops which should be created in the database
+            for sub_path, tt_builder in tt_assignment:
+                if tt_builder:
+                    for hop in sub_path:
+                        if hop is not transfer_path[-1]:
+                            hop.rws.transfertool = tt_builder.transfertool_class.external_name
+            created, must_skip_submission = __create_missing_replicas_and_requests(
+                transfer_path, default_tombstone_delay, logger=logger, session=session
+            )
+            if created:
+                best_path = transfer_path
+                # Only the first sub-path will be submitted to the corresponding transfertool,
+                # the rest of the hops will wait for first hops to be transferred
+                hops_to_submit, builder_to_use = tt_assignment[0]
+            if created or must_skip_submission:
+                break
 
         if not best_path:
             reqs_no_host.add(request_id)
@@ -337,7 +382,10 @@ def __assign_paths_to_transfertool_and_create_hops(
             logger(logging.INFO, '%s: Part of the transfer is already being handled. Skip for now.' % request_id)
             continue
 
-        paths_by_transfertool_builder.setdefault(builder_to_use, []).append(best_path)
+        if len(hops_to_submit) < len(best_path):
+            logger(logging.INFO, '%s: Only first %d hops will be submitted by %s', request_id, len(hops_to_submit), builder_to_use)
+
+        paths_by_transfertool_builder.setdefault(builder_to_use, []).append(hops_to_submit)
     return paths_by_transfertool_builder, reqs_no_host, reqs_unsupported_transfertool
 
 
@@ -397,21 +445,22 @@ def __create_missing_replicas_and_requests(
         rws.attributes['next_hop_request_id'] = transfer_path[i + 1].rws.request_id
         rws.attributes['initial_request_id'] = initial_request_id
         rws.attributes['source_replica_expression'] = hop.src.rse.name
-        new_req = queue_requests(requests=[{'dest_rse_id': rws.dest_rse.id,
-                                            'scope': rws.scope,
-                                            'name': rws.name,
-                                            'rule_id': '00000000000000000000000000000000',  # Dummy Rule ID used for multihop. TODO: Replace with actual rule_id once we can flag intermediate requests
-                                            'attributes': rws.attributes,
-                                            'request_type': rws.request_type,
-                                            'retry_count': rws.retry_count,
-                                            'account': rws.account,
-                                            'requested_at': datetime.datetime.now()}], session=session)
+        req_to_queue = {'dest_rse_id': rws.dest_rse.id,
+                        'state': RequestState.QUEUED,
+                        'scope': rws.scope,
+                        'name': rws.name,
+                        'rule_id': '00000000000000000000000000000000',  # Dummy Rule ID used for multihop. TODO: Replace with actual rule_id once we can flag intermediate requests
+                        'attributes': rws.attributes,
+                        'request_type': rws.request_type,
+                        'retry_count': rws.retry_count,
+                        'account': rws.account,
+                        'requested_at': datetime.datetime.now()}
+        if rws.transfertool:
+            req_to_queue['transfertool'] = rws.transfertool
+        new_req = queue_requests(requests=[req_to_queue], session=session)
         # If a request already exists, new_req will be an empty list.
         if new_req:
             db_req = new_req[0]
-            # queue_request may put it in PREPARING state; we don't want that.
-            # TODO: maybe better to not relly on queue_request here?
-            set_request_state(db_req['id'], RequestState.QUEUED, session=session, logger=logger)
             logger(logging.DEBUG, '%s: New request created for the transfer between %s and %s : %s', initial_request_id, transfer_path[0].src, transfer_path[-1].dst, db_req['id'])
         else:
             db_req = request_core.get_request_by_did(rws.scope, rws.name, rws.dest_rse.id, session=session)

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -62,7 +62,7 @@ def run_once(bulk, group_bulk, rse_ids, scheme, failover_scheme, transfertool_kw
         activity=activity,
         rses=rse_ids,
         schemes=scheme,
-        transfertools_by_name={'fts3': FTS3Transfertool},
+        transfertool_classes=[FTS3Transfertool],
         older_than=None,
         request_type=RequestType.STAGEIN,
         logger=logger,

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -641,6 +641,8 @@ class FTS3Transfertool(Transfertool):
     FTS3 implementation of a Rucio transfertool
     """
 
+    external_name = 'fts3'
+
     def __init__(self, external_host, oidc_account=None, vo=None, group_bulk=1, group_policy='rule', source_strategy=None,
                  max_time_in_queue=None, bring_online=43200, default_lifetime=172800, archive_timeout_override=None,
                  logger=logging.log):
@@ -699,28 +701,32 @@ class FTS3Transfertool(Transfertool):
         if config_get_bool('common', 'multi_vo', False, None):
             vo = transfer_path[-1].rws.scope.vo
 
-        all_hops_have_an_fts_attr = True
+        sub_path = []
         fts_hosts = []
         for hop in transfer_path:
-            fts_hosts = hop.dst.rse.attributes.get('fts', None)
+            src_and_dst_have_fts_attribute = hop.src.rse.attributes.get('fts', None) is not None and hop.dst.rse.attributes.get('fts', None) is not None
+            hosts = hop.dst.rse.attributes.get('fts', None)
             if hop.src.rse.attributes.get('sign_url', None) == 'gcs':
-                fts_hosts = hop.src.rse.attributes.get('fts', None)
-            fts_hosts = fts_hosts.split(",") if fts_hosts else []
+                hosts = hop.src.rse.attributes.get('fts', None)
+            hosts = hosts.split(",") if hosts else []
 
-            if not fts_hosts:
-                all_hops_have_an_fts_attr = False
+            if src_and_dst_have_fts_attribute and hosts:
+                fts_hosts = hosts
+                sub_path.append(hop)
+            else:
                 break
 
-        if not fts_hosts or not all_hops_have_an_fts_attr:
-            logger(logging.WARN, 'FTS3Transfertool cannot be used to submit transfer {}: some hops do not have an fts attribute'.format([str(hop) for hop in transfer_path]))
-            return None
+        if len(sub_path) < len(transfer_path):
+            logger(logging.INFO, 'FTS3Transfertool can only submit {} hops from {}'.format(len(sub_path), [str(hop) for hop in transfer_path]))
 
-        oidc_account = None
-        if all(oidc_supported(t) for t in transfer_path):
-            logger(logging.DEBUG, 'OAuth2/OIDC available for transfer {}'.format([str(hop) for hop in transfer_path]))
-            oidc_account = transfer_path[-1].rws.account
-
-        return TransferToolBuilder(cls, external_host=fts_hosts[0], oidc_account=oidc_account, vo=vo)
+        if sub_path:
+            oidc_account = None
+            if all(oidc_supported(t) for t in sub_path):
+                logger(logging.DEBUG, 'OAuth2/OIDC available for transfer {}'.format([str(hop) for hop in sub_path]))
+                oidc_account = transfer_path[-1].rws.account
+            return sub_path, TransferToolBuilder(cls, external_host=fts_hosts[0], oidc_account=oidc_account, vo=vo)
+        else:
+            return [], None
 
     def group_into_submit_jobs(self, transfer_paths):
         jobs = bulk_group_transfers(

--- a/lib/rucio/transfertool/globus.py
+++ b/lib/rucio/transfertool/globus.py
@@ -87,6 +87,9 @@ class GlobusTransferTool(Transfertool):
     """
     Globus implementation of Transfertool abstract base class
     """
+
+    external_name = 'globus'
+
     def __init__(self, external_host, logger=logging.log, group_bulk=200, group_policy='single'):
         """
         Initializes the transfertool
@@ -102,19 +105,14 @@ class GlobusTransferTool(Transfertool):
 
     @classmethod
     def submission_builder_for_path(cls, transfer_path, logger=logging.log):
-        if len(transfer_path) != 1:
-            # Only accept single hop
-            logger(logging.WARNING, "Globus cannot submit multi-hop transfers. Skipping {}".format([str(hop) for hop in transfer_path]))
-            return None
-
-        [hop] = transfer_path
+        hop = transfer_path[0]
         source_globus_endpoint_id = hop.src.rse.attributes.get('globus_endpoint_id', None)
         dest_globus_endpoint_id = hop.dst.rse.attributes.get('globus_endpoint_id', None)
         if not source_globus_endpoint_id or not dest_globus_endpoint_id:
             logger(logging.WARNING, "Source or destination globus_endpoint_id not set. Skipping {}".format(hop))
-            return None
+            return [], None
 
-        return TransferToolBuilder(cls, external_host='Globus Online Transfertool')
+        return [hop], TransferToolBuilder(cls, external_host='Globus Online Transfertool')
 
     def group_into_submit_jobs(self, transfer_paths):
         jobs = bulk_group_transfers(transfer_paths, policy=self.group_policy, group_bulk=self.group_bulk)

--- a/lib/rucio/transfertool/globus_library.py
+++ b/lib/rucio/transfertool/globus_library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2021 CERN
+# Copyright 2021-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 # Authors:
 # - Matt Snyder <msnyder@bnl.gov>, 2021
 # - Joel Dierkes <joel.dierkes@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2022
 
 import datetime
 import logging
@@ -83,7 +84,8 @@ def submit_xfer(source_endpoint_id, destination_endpoint_id, source_path, dest_p
     # a file is transferred, Globus will compute checksums on the source and destination files to verify that the file was transferred
     # correctly.  If the checksums do not match, it will redo the transfer of that file.
     # tdata = TransferData(tc, source_endpoint_id, destination_endpoint_id, label=job_label, sync_level="checksum", verify_checksum=True)
-    tdata = TransferData(tc, source_endpoint_id, destination_endpoint_id, label=job_label, sync_level="checksum")
+    tdata = TransferData(tc, source_endpoint_id, destination_endpoint_id, label=job_label,
+                         sync_level="checksum", notify_on_succeeded=False, notify_on_failed=False)
     tdata.add_item(source_path, dest_path, recursive=recursive)
 
     # logging.info('submitting transfer...')

--- a/lib/rucio/transfertool/mock.py
+++ b/lib/rucio/transfertool/mock.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 CERN
+# Copyright 2020-2022 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
 #
 # Authors:
 # - Nick Smith <nick.smith@cern.ch>, 2020
-# - Radu Carpa <radu.carpa@cern.ch>, 2021
+# - Radu Carpa <radu.carpa@cern.ch>, 2021-2022
+
 import itertools
 import logging
 
@@ -30,12 +31,14 @@ class MockTransfertool(Transfertool):
     This is not actually used anywhere at the moment
     """
 
+    external_name = 'mock'
+
     def __init__(self, external_host, logger=logging.log):
         super(MockTransfertool, self).__init__(external_host, logger)
 
     @classmethod
     def submission_builder_for_path(cls, transfer_path, logger=logging.log):
-        return TransferToolBuilder(cls, external_host='Mock Transfertool')
+        return transfer_path, TransferToolBuilder(cls, external_host='Mock Transfertool')
 
     def group_into_submit_jobs(self, transfers):
         return [{'transfers': list(itertools.chain.from_iterable(transfers)), 'job_params': {}}]

--- a/lib/rucio/transfertool/transfertool.py
+++ b/lib/rucio/transfertool/transfertool.py
@@ -38,6 +38,9 @@ class TransferToolBuilder(object):
         self.transfertool_class = transfertool_class
         self.fixed_kwargs = frozenset(kwargs.items())
 
+    def __str__(self):
+        return self.transfertool_class.__name__
+
     def __hash__(self):
         return hash(frozenset(self.__dict__.items()))
 
@@ -139,7 +142,8 @@ class Transfertool(object):
         particular submission.
         :param transfer_path:  List of DirectTransferDefinitions
         :param logger: logger instance
-        :return: a TransfertoolBuilder instance or None
+        :return: a tuple: a sub-path starting at the first node from transfer_path, and a TransfertoolBuilder instance
+        capable to submit this sub-path. Returns ([], None) if submission is impossible.
         """
         pass
 


### PR DESCRIPTION
Adapt the transfertool argument of the submitter to also accept
a comma-separated list of transfertool names. Most of the needed
functionality to accept such a list was already implemented.
I perform a small refactoring to put the "external_name" of each
transfertool class as a class attribute. This allows for a more
generic code in some parts.

Also adapt the logic which prepares the path submission to a
transfertool. Until now, the submitter was forced to submit the
full path to a single transfertool. This commit changes the
behavior. Now a full path can be splitted into sub-paths, each
of them handled by a different transfertool. In one submitter
iteration, only the first sub-path will be submitted, the rest
will be left in a "queued" state, but protected from being
picked by another submitter thanks to the new "transfer_hops"
table. When the first sub-path will be completed, submission
will resume naturally.

To ensure intermediate hops left in the queued state are picked
by the correct submitter, we now set the "transfertool" field
on intermediate requests. Obviously, the value of this field
can be different from that of the initial request.

Because of the experimental nature of the globus transfertool,
I add a hard-coded protection which ensures that submission is
only done to globus if it's the first element in the submitters
"transfertool" argument.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
