### PR TITLE
Set the `paramiko` package version to 2.10.3 #5412

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ typing; python_version < '3.5'                              # typing package sup
 enum34<=1.1.10; python_version < '3.5'                      # Enum package backport for python 2.7
 
 # All dependencies needed in extras for rucio client (and server/daemons) should be defined here
-paramiko~=2.9.2                                             # ssh_extras; SSH2 protocol library (also needed in the server)
+paramiko~=2.10.3                                            # ssh_extras; SSH2 protocol library (also needed in the server) Race condition before 2.10.1 (https://github.com/advisories/GHSA-f8q4-jwww-x3wv)
 kerberos~=1.3.1                                             # kerberos_extras for client and server
 pykerberos~=1.2.1                                           # kerberos_extras for client and server
 requests-kerberos>=0.12.0                                   # kerberos_extras for client and server


### PR DESCRIPTION
`paramiko` package version prior to 2.10.1 has a race condition which could be a
potential security issue.

https://github.com/advisories/GHSA-f8q4-jwww-x3wv

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
