### PR TITLE
Set the `paramiko`, `werkzeug` and `Jinja2` package version1.23 lts #5412

### DIFF
--- a/etc/pip-requires
+++ b/etc/pip-requires
@@ -17,6 +17,7 @@ functools32==3.2.3.post2; python_version == '2.7' # explicitly needed on CC7
 redis==3.4.1                                      # Python client for Redis key-value store
 numpy==1.14.2; python_version <= '3.5'            # Numpy for forecasting T3C (1.17.0 is Py3 only)
 numpy==1.19.0; python_version >= '3.6'            # Numpy for forecasting T3C
+Jinja2<3.1.0                                      # Flask dependency, broken support since jinja2 3.1.0 https://github.com/pallets/jinja/issues/1626
 paramiko~=2.10.3                                  # SSH2 protocol library
 itsdangerous<2.1.0                                # Flask dependency, broken support since 2.1.0 https://github.com/pallets/flask/issues/4455
 werkzeug<2.1.0                                    # Flask dependency, broker support since 2.1.0 https://github.com/pallets/flask/issues/4494#issuecomment-1082701754

--- a/etc/pip-requires
+++ b/etc/pip-requires
@@ -17,7 +17,7 @@ functools32==3.2.3.post2; python_version == '2.7' # explicitly needed on CC7
 redis==3.4.1                                      # Python client for Redis key-value store
 numpy==1.14.2; python_version <= '3.5'            # Numpy for forecasting T3C (1.17.0 is Py3 only)
 numpy==1.19.0; python_version >= '3.6'            # Numpy for forecasting T3C
-paramiko==2.7.1                                   # SSH2 protocol library
+paramiko~=2.10.3                                  # SSH2 protocol library
 itsdangerous<2.1.0                                # Flask dependency, broken support since 2.1.0 https://github.com/pallets/flask/issues/4455
 werkzeug<2.1.0                                    # Flask dependency, broker support since 2.1.0 https://github.com/pallets/flask/issues/4494#issuecomment-1082701754
 Flask==1.1.1                                      # Python web framework

--- a/etc/pip-requires
+++ b/etc/pip-requires
@@ -19,6 +19,7 @@ numpy==1.14.2; python_version <= '3.5'            # Numpy for forecasting T3C (1
 numpy==1.19.0; python_version >= '3.6'            # Numpy for forecasting T3C
 paramiko==2.7.1                                   # SSH2 protocol library
 itsdangerous<2.1.0                                # Flask dependency, broken support since 2.1.0 https://github.com/pallets/flask/issues/4455
+werkzeug<2.1.0                                    # Flask dependency, broker support since 2.1.0 https://github.com/pallets/flask/issues/4494#issuecomment-1082701754
 Flask==1.1.1                                      # Python web framework
 M2Crypto<=0.35.2                                  # Dependency of FTS rest API; Temporary fix since 0.33 does not install on CC7
 oic==0.15.1; python_version <= '3.5'              # for authentication via OpenID Connect protocol

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -16,7 +16,7 @@ functools32==3.2.3.post2; python_version == '2.7' # explicitly needed on CC7
 redis==3.4.1                                      # Python client for Redis key-value store
 numpy==1.14.2; python_version <= '3.5'            # Numpy for forecasting T3C (1.17.0 is Py3 only)
 numpy==1.19.0; python_version >= '3.6'            # Numpy for forecasting T3C
-paramiko==2.7.1                                   # SSH2 protocol library
+paramiko~=2.10.3                                  # SSH2 protocol library
 itsdangerous<2.1.0                                # Flask dependency, broken support since 2.1.0 https://github.com/pallets/flask/issues/4455
 werkzeug<2.1.0                                    # Flask dependency, broker support since 2.1.0 https://github.com/pallets/flask/issues/4494#issuecomment-1082701754
 Flask==1.1.1                                      # Python web framework

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -18,6 +18,7 @@ numpy==1.14.2; python_version <= '3.5'            # Numpy for forecasting T3C (1
 numpy==1.19.0; python_version >= '3.6'            # Numpy for forecasting T3C
 paramiko~=2.10.3                                  # SSH2 protocol library
 itsdangerous<2.1.0                                # Flask dependency, broken support since 2.1.0 https://github.com/pallets/flask/issues/4455
+Jinja2<3.1.0                                      # Flask dependency, broken support since jinja2 3.1.0 https://github.com/pallets/jinja/issues/1626
 werkzeug<2.1.0                                    # Flask dependency, broker support since 2.1.0 https://github.com/pallets/flask/issues/4494#issuecomment-1082701754
 Flask==1.1.1                                      # Python web framework
 M2Crypto<=0.35.2                                  # Dependency of FTS rest API; Temporary fix since 0.33 does not install on CC7

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -18,6 +18,7 @@ numpy==1.14.2; python_version <= '3.5'            # Numpy for forecasting T3C (1
 numpy==1.19.0; python_version >= '3.6'            # Numpy for forecasting T3C
 paramiko==2.7.1                                   # SSH2 protocol library
 itsdangerous<2.1.0                                # Flask dependency, broken support since 2.1.0 https://github.com/pallets/flask/issues/4455
+werkzeug<2.1.0                                    # Flask dependency, broker support since 2.1.0 https://github.com/pallets/flask/issues/4494#issuecomment-1082701754
 Flask==1.1.1                                      # Python web framework
 M2Crypto<=0.35.2                                  # Dependency of FTS rest API; Temporary fix since 0.33 does not install on CC7
 oic==0.15.1                                       # for authentication via OpenID Connect protocol

--- a/setup_rucio_client.py
+++ b/setup_rucio_client.py
@@ -56,7 +56,7 @@ if os.path.exists('lib/rucio_clients.egg-info/'):
 if os.path.exists('lib/rucio.egg-info/'):
     shutil.rmtree('lib/rucio.egg-info/')
 
-SSH_EXTRAS = ['paramiko==1.18.4']
+SSH_EXTRAS = ['paramiko~=2.10.3']
 KERBEROS_EXTRAS = ['kerberos>=1.2.5', 'pykerberos>=1.1.14', 'requests-kerberos>=0.11.0']
 SWIFT_EXTRAS = ['python-swiftclient>=3.5.0', ]
 EXTRAS_REQUIRES = dict(ssh=SSH_EXTRAS,

--- a/tools/test/run_tests.py
+++ b/tools/test/run_tests.py
@@ -208,8 +208,11 @@ def run_case(caseenv, image, use_podman, use_namespace, copy_rucio_logs, logs_di
             run('docker', *namespace_args, 'exec', cid, 'cat', '/var/log/httpd/error_log', check=False)
             raise
 
-        # Running test.sh
-        run('docker', *namespace_args, 'exec', cid, './tools/test/test.sh')
+        try:
+            run('docker', *namespace_args, 'exec', cid, './tools/test/test.sh')
+        except Exception as e:
+            run('docker', *namespace_args, 'exec', cid, 'cat', '/var/log/httpd/error_log', check=False)
+            raise e
 
         # if everything went through without an exception, mark this case as a success
         success = True


### PR DESCRIPTION
## Set the `Jinja2` module version prior to 3.1.0 #5398

The new `Jinja2` package version 3.1.0 is incompatible with the Flask
version 1.1.1.

## Set the `paramiko` package version to 2.10.3 #5412
    
`paramiko` package version prior to 2.10.1 has a race condition which could be a
potential security issue.
    
https://github.com/advisories/GHSA-f8q4-jwww-x3wv

## Set the `werkzeug` module version prior to 2.1.0 #5419
    
The new `werkzeug` package version 2.1.0 is incompatible with the Flask
version 1.1.2.
    
```python
from werkzeug.wrappers import BaseResponse ImportError: cannot import
name 'BaseResponse' from 'werkzeug.wrappers'
```
    
Due to commit pallets/werkzeug#7b52ecd8f the BaseResponse class is not imported
in the `werkzeug.wrappers`.

## Add aditional log information to the CI tests
    
The CI tests do not print the server logs in case of an exception. The server
logs can provide us with additional information, like the origin of the
exception. They are crucial and should be printed.