### PR TITLE
Set the `paramiko` and `werkzeug` package version 1.26 lts #5412

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ retrying==1.3.3                                             # general-purpose re
 redis==3.5.3                                                # Python client for Redis key-value store
 numpy==1.19.4                                               # Numpy for forecasting T3C
 itsdangerous<2.1.0                                          # Flask dependency, broken support since 2.1.0 https://github.com/pallets/flask/issues/4455
+werkzeug<2.1.0                                              # Flask dependency. broker support since 2.1.0 https://github.com/pallets/flask/issues/4494#issuecomment-1082701754
 Jinja2<3.1.0                                                # Flask dependency, broken support since jinja2 3.1.0 https://github.com/pallets/jinja/issues/1626
 Flask==1.1.2                                                # Python web framework
 oic==1.2.1                                                  # for authentication via OpenID Connect protocol

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ jsonschema>=3.2.0                                           # For JSON schema va
 enum34<=1.1.10; python_version < '3.5'                      # Enum package backport for python 2.7
 
 # All dependencies needed in extras for rucio client (and server/daemons) should be defined here
-paramiko==2.7.2                                             # ssh_extras; SSH2 protocol library (also needed in the server)
+paramiko~=2.10.3                                            # ssh_extras; SSH2 protocol library (also needed in the server), Race condition before 2.10.1 (https://github.com/advisories/GHSA-f8q4-jwww-x3wv)
 kerberos>=1.3.0                                             # kerberos_extras for client and server
 pykerberos>=1.2.1                                           # kerberos_extras for client and server
 requests-kerberos>=0.12.0                                   # kerberos_extras for client and server

--- a/setuputil.py
+++ b/setuputil.py
@@ -97,6 +97,7 @@ server_requirements_table = {
         'redis',
         'numpy',
         'itsdangerous',
+        'werkzeug'
         'jinja2',
         'flask',
         'oic',


### PR DESCRIPTION
## Set the `paramiko` package version prior to 2.10.3 lts #5412
`paramiko` package version prior to 2.10.1 has a race condition which could be a
potential security issue.

https://github.com/advisories/GHSA-f8q4-jwww-x3wv

## Set the `werkzeug` module version prior to 2.1.0 https://github.com/rucio/rucio/issues/5419

The new `werkzeug` package version 2.1.0 is incompatible with the Flask
version 1.1.2.

```python
from werkzeug.wrappers import BaseResponse ImportError: cannot import
name 'BaseResponse' from 'werkzeug.wrappers'
```

Due to commit pallets/werkzeug#7b52ecd8f the BaseResponse class is not imported
in the `werkzeug.wrappers`.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
