### PR TITLE
Docker & Kubernetes: Deprecate the `py3` dev docker conainter tag #4198

### DIFF
--- a/etc/docker/dev/docker-compose-storage-externalmetadata.yml
+++ b/etc/docker/dev/docker-compose-storage-externalmetadata.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   rucio:
-    image: docker.io/rucio/rucio-dev:py3
+    image: docker.io/rucio/rucio-dev
     extra_hosts:
       - "ruciodb:127.0.0.1"
       - "graphite:127.0.0.1"


### PR DESCRIPTION
The `py3` dev docker container tag got deprecated in #5324 due to the
deprecation of Python2 (#5435). A merge of an older PR re-introduced the `py3`
tag.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
