### PR TITLE
Feature 4455 mypy static code analysis

### DIFF
--- a/.github/actions/checkout_ancestor_commit/action.yaml
+++ b/.github/actions/checkout_ancestor_commit/action.yaml
@@ -1,0 +1,63 @@
+name: "Checkout Ancestor Commit"
+description: >-
+  Checks out the most recent common ancestor of two commits.
+
+  This action clones all necessary repositories, no prior clone required.
+
+inputs:
+  ref:
+    description: >-
+      The reference for which the ancestor commit, with the current checked out
+      commit, should be found.
+    required: false
+    default: master
+  repository:
+    description: >-
+      `repository_owner/repository_name` of the repository containing the
+      reference commit. For example, rucio/rucio.
+    default: rucio/rucio
+  files_to_copy:
+    description: >-
+      Necessary files to copy (e.g. scripts, configurations, ...) to run code in
+      the older version of the project. This is for the case an ancestor commit
+      gets checked out wich does not contain the required files.
+
+      New line character as delimiter of items.
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Checkout Ancestor Commit
+      shell: bash
+      env:
+        COMMON_ANCESTOR_REPO: upstream
+      run: |
+        echo "Fetch the repository of the common ancestor branch."
+        git remote add $COMMON_ANCESTOR_REPO https://github.com/${{ inputs.repository }}.git
+
+        echo "Fetch the branch of the common ancestor."
+        git fetch $COMMON_ANCESTOR_REPO ${{ inputs.ref }}
+
+        FORK_POINT=$(git merge-base $COMMON_ANCESTOR_REPO/${{ inputs.ref }} HEAD)
+        echo "The fork point of the current branch with the master is $FORK_POINT"
+
+        echo "Backup all specified files since they could be changed."
+        IFS=$'\n'
+        FILES_TO_COPY=$'.github/actions/checkout_ancestor_commit/action.yaml\n${{ inputs.files_to_copy }}'
+        for f in $FILES_TO_COPY; do
+          mkdir -p ../tmp/$(dirname $f)
+          cp $f ../tmp/$f
+        done
+
+        echo "Checking out the fork point"
+        git checkout $FORK_POINT
+
+        echo "Restore backed up files."
+        for f in $FILES_TO_COPY; do
+          mkdir -p $(dirname $f)
+          cp ../tmp/$f $f
+        done

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -19,6 +19,52 @@ jobs:
         shell: bash
         run: |
           python3 tools/add_header --dry-run --disable-progress-bar
+  python_annotations:
+    name: Check Python Type Annotations
+    runs-on: ubuntu-latest
+    env:
+      UPDATED_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE: ../updated_type_annotation_report.txt
+      INITIAL_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE: ../initial_type_annotation_report.txt
+    steps:
+      - uses: actions/checkout@v3
+      - name: Count current number of missing type annotations
+        id: count_updated
+        shell: bash
+        run: |
+          pip install flake8 flake8-annotations
+          source tools/count_missing_type_annotations_utils.sh
+          create_missing_python_type_annotations_report ${{ env.UPDATED_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE }}
+          echo "The current number of missing python type annotations: $(wc -l < ${{ env.UPDATED_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE }})"
+      - name: Checkout ancestor commit with rucio/master
+        uses: ./.github/actions/checkout_ancestor_commit
+        with:
+          files_to_copy: |
+            tools/count_missing_type_annotations.sh
+            tools/count_missing_type_annotations_utils.sh
+      - name: Count initial number of missing type annotations
+        id: count_initial
+        shell: bash
+        run: |
+          source tools/count_missing_type_annotations_utils.sh
+          create_missing_python_type_annotations_report ${{ env.INITIAL_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE }}
+          echo "The initial number of missing python type annotations: $(wc -l < ${{ env.INITIAL_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE }})"
+      - name: Diff of missing annotations
+        shell: bash
+        run: |
+          diff ${{ env.INITIAL_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE }} ${{ env.UPDATED_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE }} || true
+      - name: Compare numbers of missing type annotations
+        shell: bash
+        run: |
+          INITIAL_NUMBER_OF_MISSING_TYPE_ANNOTATIONS=$(wc -l < ${{ env.INITIAL_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE }})
+          UPDATED_NUMBER_OF_MISSING_TYPE_ANNOTATIONS=$(wc -l < ${{ env.UPDATED_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE }})
+
+          echo "The initial number of missing type annotations is: $INITIAL_NUMBER_OF_MISSING_TYPE_ANNOTATIONS"
+          echo "The updated number of missing type annotations is: $UPDATED_NUMBER_OF_MISSING_TYPE_ANNOTATIONS"
+          if [ $UPDATED_NUMBER_OF_MISSING_TYPE_ANNOTATIONS -gt $INITIAL_NUMBER_OF_MISSING_TYPE_ANNOTATIONS ]; then
+            echo "The number of missing python type annotations should never increase! This way we ensure that new functions are type annotated."
+            echo "Look into 'Diff of missing type annotations' to see what changed."
+            exit 1
+          fi
   setup:
     runs-on: ubuntu-latest
     steps:

--- a/tools/count_missing_type_annotations.sh
+++ b/tools/count_missing_type_annotations.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Copyright CERN since 2022
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to count the number of missing python type annotations in the project.
+
+set -e
+
+
+source $(dirname "$0")/count_missing_type_annotations_utils.sh
+
+
+TMP_FILE_NAME=python_type_annotations_report.txt
+create_missing_python_type_annotations_report $TMP_FILE_NAME
+NUMBER_MISSING_TYPE_ANNOTATIONS=$(wc -l < $TMP_FILE_NAME)
+
+echo "Number of missing annotations: $NUMBER_MISSING_TYPE_ANNOTATIONS"
+
+rm $TMP_FILE_NAME

--- a/tools/count_missing_type_annotations_utils.sh
+++ b/tools/count_missing_type_annotations_utils.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Copyright CERN since 2022
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script with all tools to count the missing python type annotations in the
+# project. Installes all necessary python packages temporarly if needed. To use
+# it run: `scource count_missing_annotations_utils.sh`.
+
+set -e
+
+
+ensure_install() {
+    # Checks if a python package is installed via pip. It installes the package,
+    # and removes it after the script run automatically.
+    #
+    # All debug output is redirected to the stderr stream, to not interfear with
+    # other output.
+    #
+    # :param $1: The name of the pip package.
+    if [[ ! $(pip list) =~ $1 ]]
+    then
+        >&2 echo "Pip package $1 not installed! Installing it now..."
+        >&2 pip install --user $1
+
+        >&2 echo "The package will automatically be uninstalled."
+        trap ">&2 pip uninstall --yes $1" EXIT
+    fi
+}
+
+
+create_missing_python_type_annotations_report() {
+    # Created a report of the missing python annotations.
+    #
+    # This does not include tests, tools, database and bin files.
+    # :param $1: The name of the output file.
+
+    flake8 lib/rucio --exclude tools,lib/rucio/tests,lib/rucio/db --output-file $1 --select ANN || true
+}
+
+
+ensure_install "flake8"
+ensure_install "flake8-annotations"


### PR DESCRIPTION
## Check the python type annotation count in the CI #4455

Since we want to introduce python annotations in our repository, we need a way
to check if new PRs include type annotations.

Since the repository contains a lot of code, we can not add type annotations in
a big PR. We should rather ensure that PRs annotate their new code and gradually
annotate old code.

This commit compared the number of missing type annotations before the PR,
i.e. on the most recent common ancestor commit with the rucio master, and after
the PR. The CI job fails if the number of missing type annotations increases,
since this means that new unannotated code was introduced. The re-viewers are
responsible for checking the integrity of the type-annotations for now.

## Add the `Checkout ancestor commit` action #4455

Getting the commit from which a branch is branched off of is helpful. The
progress of an implementation in a branch can be measured by comparing some
generated numbers before the feature branch and after. This enables us to do CI
tests based on differences in the committed code to the initial one.

This commit introduces the `Checkout common ancestor` action, which checks out
the most recent ancestor of the current working HEAD and a specified reference.

This implementation can copy files from the edited branch to the most recent
ancestor. This is necessary in case the file got modified and the modified one
is needed in the ancestor commit.

## Add the `count_missing_python_annotations` script #4455

With rucio 1.29 python2 got deprecated. This deprecation enables us to introduce
new features used by python3. One of these features is type annotations on the
code itself.

Type hints allow us to run a static type checker like `mypy` and analyze the
code for inconsistencies. Having a strongly typed codebase enables us to avoid
type inconsistency bugs, and it makes the code more readable, thus potentially
shorten the time to add new features.

The plan is to integrate a job in the CI/CD, which reports an error if the
number of missing type annotations is increased by a PR. This is the result of
newly written code, which is not annotated. This forces the user to annotate
their (or potentially some other) code.

This commit introduces the `count_missing_python_annotations_rucio` functions,
which uses `flake8` and the flake8 plugin `flake8-annotations` to count the
number of missing type annotations.

`mypy` enables us to check the type annotations for inconsistencies. However, we
can not use `mypy` to count the number of missing type annotations, since it
caps the number of reported errors to 200. We can use `mypy` in a later step to
 check the annotations for consistency.

Certain directories are excluded from the type checking:
 
- The test directory: Type checking the tests is not our goal right now. It
  decreases the time to write test code while providing very little additive.

- The db migration directory: The db migration should focus on the database, not
  the implementation. We could enable this in the future, but it has no priority
  right now.

- The tools directory: Scripts should be written quickly and should not
  necessarily require typed annotations. This can also be changed in the future,
  to enable type-save scripts.

- The bin directory: A strategy is required here on how to handle type
  annotations properly.