### PR TITLE
Clients: Return information on download exception #5250

### DIFF
--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -424,6 +424,8 @@ class DownloadClient:
             except Exception as error:
                 logger(logging.ERROR, '%sFailed to download item' % log_prefix)
                 logger(logging.DEBUG, error)
+                item["clientState"] = "FAILED"
+                output_queue.put(item)
 
     @staticmethod
     def _compute_actual_transfer_timeout(item):

--- a/lib/rucio/tests/test_download.py
+++ b/lib/rucio/tests/test_download.py
@@ -86,6 +86,18 @@ def test_download_without_base_dir(rse_factory, did_factory, download_client):
         shutil.rmtree(scope)
 
 
+def test_download_exception_return_information(did_factory, rse_factory, download_client):
+    rse, _ = rse_factory.make_posix_rse()
+    did = did_factory.upload_test_file(rse)
+    did_str = '%s:%s' % (did['scope'], did['name'])
+
+    with patch('rucio.client.downloadclient.DownloadClient._download_item', side_effect=Exception()):
+        res = download_client.download_dids([{"did": did_str}], deactivate_file_download_exceptions=True)
+
+    assert len(res) == 1
+    assert res[0]["clientState"] == "FAILED"
+
+
 @pytest.mark.dirty(reason='creates a new scope which is not cleaned up')
 def test_overlapping_did_names(rse_factory, did_factory, download_client, root_account, mock_scope, vo):
     """


### PR DESCRIPTION
The different download functions in the `DownloadClient` return lists containing
the files and the states of the corresponding downloads. These states also
include failed states.

If an unknown exception is thrown in the `_download_item` method, the
corresponding file, which should be downloaded, is not present in the output
list. This leads to two problems; both can be solved by adding the file with the
download status `FAILED` to the output list:

- The number of files in the input queue and output queue is different, which
  throws an error. This is easily resolved by setting the file download status
  to `FAILED`. An error is later thrown.

- The client does not print the summary in case there is no items in the output
  queue. By adding the file to the output queue this problem is resolved.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
