### PR TITLE
Set the `cryptography` module version prior to 37.0.0 #5500

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ typing; python_version < '3.5'                              # typing package sup
 enum34<=1.1.10; python_version < '3.5'                      # Enum package backport for python 2.7
 
 # All dependencies needed in extras for rucio client (and server/daemons) should be defined here
+cryptography<37.0.0                                         # Broken paramiko dependency due to deprecation message
 paramiko~=2.10.3                                            # ssh_extras; SSH2 protocol library (also needed in the server) Race condition before 2.10.1 (https://github.com/advisories/GHSA-f8q4-jwww-x3wv)
 kerberos~=1.3.1                                             # kerberos_extras for client and server
 pykerberos~=1.2.1                                           # kerberos_extras for client and server
@@ -68,4 +69,3 @@ pydoc-markdown~=3.13.0; python_version >= '3.5'             # Used for generatin
 sh~=1.14.2                                                  # Convenience library for running subprocesses in Python
 apispec==5.1.1                                              # Generate OpenApi definition out of pydoc comments
 apispec-webframeworks==0.5.2                                # Integration of apispec in Flask
-

--- a/setuputil.py
+++ b/setuputil.py
@@ -34,7 +34,7 @@ clients_requirements_table = {
         'typing',
         'enum34',
     ],
-    'ssh': ['paramiko'],
+    'ssh': ['cryptography', 'paramiko'],
     'kerberos': [
         'kerberos',
         'pykerberos',
@@ -76,6 +76,7 @@ server_requirements_table = {
         'argcomplete',
         'boto',
         'python-magic',
+        'cryptography',
         'paramiko',
         'boto3',
         'pysftp',


### PR DESCRIPTION
The new `cryptography` package version 37.0.0 throws some deprecation message
due to it's usage in `paramiko`.  https://github.com/paramiko/paramiko/pull/2039

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
