### PR TITLE
Core & Internals: ignore cryptography deprecation warnings. Closes #5500

### DIFF
--- a/lib/rucio/common/extra.py
+++ b/lib/rucio/common/extra.py
@@ -17,6 +17,7 @@
 # - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2021
 
 import importlib
+import warnings
 
 
 def import_extras(module_list):
@@ -24,7 +25,12 @@ def import_extras(module_list):
     for mod in module_list:
         out[mod] = None
         try:
-            out[mod] = importlib.import_module(mod)
+            with warnings.catch_warnings():
+                # TODO: remove when https://github.com/paramiko/paramiko/issues/2038 is fixed
+                warnings.filterwarnings('ignore', 'Blowfish has been deprecated', module='paramiko')
+                # TODO: deprecated python 2 and 3.6 too ...
+                warnings.filterwarnings('ignore', 'Python .* is no longer supported', module='paramiko')
+                out[mod] = importlib.import_module(mod)
         except ImportError:
             pass
     return out


### PR DESCRIPTION
Paramiko.transport imports cryptography.Blowfish, which is deprecated.
Also, python 2 and 3.6 are deprecated in cryptography.
This makes our tests fail due to a warning.
Catch that warning and ignore it with the filter.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
