### PR TITLE
Add Belle II tests : Closes #4864

### DIFF
--- a/etc/docker/test/extra/rucio_multi_vo_ts2_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_ts2_postgres14.cfg
@@ -179,4 +179,4 @@ idpsecrets = /opt/rucio/etc/idpsecrets.json
 admin_issuer = wlcg
 
 [api]
-endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos
+endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, dirac, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos

--- a/etc/docker/test/extra/rucio_multi_vo_tst_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_tst_postgres14.cfg
@@ -179,4 +179,4 @@ idpsecrets = /opt/rucio/etc/idpsecrets.json
 admin_issuer = wlcg
 
 [api]
-endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos
+endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, dirac, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos

--- a/etc/docker/test/extra/rucio_mysql8.cfg
+++ b/etc/docker/test/extra/rucio_mysql8.cfg
@@ -176,4 +176,4 @@ idpsecrets = /opt/rucio/etc/idpsecrets.json
 admin_issuer = wlcg
 
 [api]
-endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos
+endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, dirac, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos

--- a/etc/docker/test/extra/rucio_oracle.cfg
+++ b/etc/docker/test/extra/rucio_oracle.cfg
@@ -176,4 +176,4 @@ idpsecrets = /opt/rucio/etc/idpsecrets.json
 admin_issuer = wlcg
 
 [api]
-endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos
+endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, dirac, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos

--- a/etc/docker/test/extra/rucio_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_postgres14.cfg
@@ -176,4 +176,4 @@ idpsecrets = /opt/rucio/etc/idpsecrets.json
 admin_issuer = wlcg
 
 [api]
-endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos
+endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, dirac, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos

--- a/etc/docker/test/extra/rucio_postgres9.cfg
+++ b/etc/docker/test/extra/rucio_postgres9.cfg
@@ -176,4 +176,4 @@ idpsecrets = /opt/rucio/etc/idpsecrets.json
 admin_issuer = wlcg
 
 [api]
-endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos
+endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, dirac, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos

--- a/etc/docker/test/extra/rucio_sqlite.cfg
+++ b/etc/docker/test/extra/rucio_sqlite.cfg
@@ -173,4 +173,4 @@ idpsecrets = /opt/rucio/etc/idpsecrets.json
 admin_issuer = wlcg
 
 [api]
-endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos
+endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, dirac, export, heartbeats, identities, import, lifetime_exceptions, locks, meta, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, tmp_dids, traces, vos

--- a/etc/docker/test/matrix_policy_package_tests.yml
+++ b/etc/docker/test/matrix_policy_package_tests.yml
@@ -1,6 +1,97 @@
+atlas:
+  installation_cmd: ""
+  config_overrides:
+    permission: atlas
+    extract_scope:  atlas
+    schema: atlas
+    lfn2pfn_algorithm_default: "hash"
+  tests:
+    allow:
+      - rucio_tests
+    deny:
+      - rucio_tests/test_bad_replica.py
+      - rucio_tests/test_rule.py
+      - rucio_tests/test_replica.py
+      - rucio_tests/test_account.py
+      - rucio_tests/test_rse_selector.py
+      - rucio_tests/test_s3.py
+      - rucio_tests/test_judge_injector.py
+      - rucio_tests/test_qos.py
+      - rucio_tests/test_did_meta_plugins.py
+      - rucio_tests/test_throttler.py
+      - rucio_tests/test_abacus_account.py
+      - rucio_tests/test_api_external_representation.py
+      - rucio_tests/test_authentication.py
+      - rucio_tests/test_bb8.py
+      - rucio_tests/test_rse_protocol_s3.py
+      - rucio_tests/test_oauthmanager.py
+      - rucio_tests/test_rse_lfn2path.py
+      - rucio_tests/test_oidc.py
+      - rucio_tests/test_pfns.py
+      - rucio_tests/test_curl.py
+      - rucio_tests/test_abacus_rse.py
+      - rucio_tests/test_boolean.py
+      - rucio_tests/test_meta.py
+      - rucio_tests/test_dumper_data_model.py
+      - rucio_tests/test_clients.py
+      - rucio_tests/test_did.py
+      - rucio_tests/test_dirac.py
+      - rucio_tests/test_permission.py
+      - rucio_tests/test_judge_evaluator.py
+      - rucio_tests/test_dataset_replicas.py
+      - rucio_tests/test_rse_protocol_gfal2.py
+      - rucio_tests/test_bin_rucio.py
+      - rucio_tests/test_rse_protocol_s3boto.py
+      - rucio_tests/test_rse_protocol_sftp.py
+      - rucio_tests/test_auditor.py
+      - rucio_tests/test_identity.py
+      - rucio_tests/test_import_export.py
+      - rucio_tests/test_judge_cleaner.py
+      - rucio_tests/rucioxdist.py
+      - rucio_tests/test_scope.py
+      - rucio_tests/test_rse_protocol_mock.py
+      - rucio_tests/test_judge_repairer.py
+      - rucio_tests/test_heartbeat.py
+      - rucio_tests/test_rse_expression_parser.py
+      - rucio_tests/test_config.py
+      - rucio_tests/test_utils.py
+      - rucio_tests/test_meta_did.py
+      - rucio_tests/test_naming_convention.py
+      - rucio_tests/test_rse_protocol_srm.py
+      - rucio_tests/test_rse_protocol_posix.py
+      - rucio_tests/test_rse_protocol_webdav.py
+      - rucio_tests/test_dumper_consistency.py
+      - rucio_tests/test_replica_recoverer.py
+      - rucio_tests/test_request.py
+      - rucio_tests/test_common_types.py
+      - rucio_tests/test_undertaker.py
+      - rucio_tests/test_auditor_hdfs.py
+      - rucio_tests/test_rse.py
+      - rucio_tests/test_credential.py
+      - rucio_tests/test_counter.py
+      - rucio_tests/test_redirect.py
+      - rucio_tests/test_rse_protocol_xrootd.py
+      - rucio_tests/test_account_limits.py
+      - rucio_tests/test_abacus_collection_replica.py
+      - rucio_tests/test_multi_vo.py
+      - rucio_tests/test_subscription.py
+      - rucio_tests/test_filter_engine.py
+      - rucio_tests/test_impl_upload_download.py
+      - rucio_tests/test_rse_protocol_rclone.py
+      - rucio_tests/test_rse_protocol_rsync.py
+      - rucio_tests/test_rse_protocol_ssh.py
+  rdbms:
+    - postgres14
+  python:
+    - "3.6"
+  dists:
+    - centos7
+  image_identifier:
+    - atlas
+
 belleii:
   installation_cmd: ""
-  config_overrides: 
+  config_overrides:
     permission: belleii
     extract_scope: belleii
     schema: belleii
@@ -80,13 +171,11 @@ belleii:
       - rucio_tests/test_curl.py
       - rucio_tests/test_auditor_hdfs.py
       - rucio_tests/test_abacus_account.py
-
-      
-  rdbms: 
+  rdbms:
     - postgres14
   python:
     - "3.6"
   dists:
     - centos7
-  image_identifier: 
+  image_identifier:
     - belleii

--- a/etc/docker/test/matrix_policy_package_tests.yml
+++ b/etc/docker/test/matrix_policy_package_tests.yml
@@ -12,7 +12,6 @@ belleii:
       - rucio_tests/test_judge_injector.py
       - rucio_tests/test_qos.py
       - rucio_tests/test_throttler.py
-      - rucio_tests/test_abacus_account.py
       - rucio_tests/test_api_external_representation.py
       - rucio_tests/test_authentication.py
       - rucio_tests/test_rse_protocol_s3.py
@@ -80,6 +79,7 @@ belleii:
       - rucio_tests/test_permission.py
       - rucio_tests/test_curl.py
       - rucio_tests/test_auditor_hdfs.py
+      - rucio_tests/test_abacus_account.py
 
       
   rdbms: 

--- a/etc/docker/test/matrix_policy_package_tests.yml
+++ b/etc/docker/test/matrix_policy_package_tests.yml
@@ -1,46 +1,29 @@
-atlas:
+belleii:
   installation_cmd: ""
   config_overrides: 
-    permission: atlas
-    extract_scope:  atlas
-    schema: atlas
-    lfn2pfn_algorithm_default: "hash"
+    permission: belleii
+    extract_scope: belleii
+    schema: belleii
+    lfn2pfn_algorithm_default: "belleii"
   tests:
     allow:
-      - rucio_tests
-    deny:
-      - rucio_tests/test_bad_replica.py
-      - rucio_tests/test_rule.py
-      - rucio_tests/test_replica.py
-      - rucio_tests/test_account.py
+      - rucio_tests/test_belleii.py
       - rucio_tests/test_rse_selector.py
-      - rucio_tests/test_s3.py
       - rucio_tests/test_judge_injector.py
       - rucio_tests/test_qos.py
-      - rucio_tests/test_did_meta_plugins.py
       - rucio_tests/test_throttler.py
       - rucio_tests/test_abacus_account.py
       - rucio_tests/test_api_external_representation.py
       - rucio_tests/test_authentication.py
-      - rucio_tests/test_bb8.py
       - rucio_tests/test_rse_protocol_s3.py
       - rucio_tests/test_oauthmanager.py
-      - rucio_tests/test_rse_lfn2path.py
       - rucio_tests/test_oidc.py
       - rucio_tests/test_pfns.py
-      - rucio_tests/test_curl.py
-      - rucio_tests/test_abacus_rse.py
-      - rucio_tests/test_boolean.py
       - rucio_tests/test_meta.py
       - rucio_tests/test_dumper_data_model.py
       - rucio_tests/test_clients.py
-      - rucio_tests/test_did.py
-      - rucio_tests/test_dirac.py
-      - rucio_tests/test_permission.py
       - rucio_tests/test_judge_evaluator.py
-      - rucio_tests/test_dataset_replicas.py
       - rucio_tests/test_rse_protocol_gfal2.py
-      - rucio_tests/test_bin_rucio.py
       - rucio_tests/test_rse_protocol_s3boto.py
       - rucio_tests/test_rse_protocol_sftp.py
       - rucio_tests/test_auditor.py
@@ -56,30 +39,47 @@ atlas:
       - rucio_tests/test_config.py
       - rucio_tests/test_utils.py
       - rucio_tests/test_meta_did.py
-      - rucio_tests/test_naming_convention.py
       - rucio_tests/test_rse_protocol_srm.py
       - rucio_tests/test_rse_protocol_posix.py
       - rucio_tests/test_rse_protocol_webdav.py
       - rucio_tests/test_dumper_consistency.py
-      - rucio_tests/test_replica_recoverer.py
       - rucio_tests/test_request.py
       - rucio_tests/test_common_types.py
       - rucio_tests/test_undertaker.py
-      - rucio_tests/test_auditor_hdfs.py
-      - rucio_tests/test_rse.py
-      - rucio_tests/test_credential.py
       - rucio_tests/test_counter.py
-      - rucio_tests/test_redirect.py
       - rucio_tests/test_rse_protocol_xrootd.py
       - rucio_tests/test_account_limits.py
-      - rucio_tests/test_abacus_collection_replica.py
-      - rucio_tests/test_multi_vo.py
-      - rucio_tests/test_subscription.py
       - rucio_tests/test_filter_engine.py
       - rucio_tests/test_impl_upload_download.py
       - rucio_tests/test_rse_protocol_rclone.py
       - rucio_tests/test_rse_protocol_rsync.py
+    deny:
       - rucio_tests/test_rse_protocol_ssh.py
+      - rucio_tests/test_redirect.py
+      - rucio_tests/test_credential.py
+      - rucio_tests/test_bad_replica.py
+      - rucio_tests/test_replica_recoverer.py
+      - rucio_tests/test_bb8.py
+      - rucio_tests/test_rse_lfn2path.py
+      - rucio_tests/test_s3.py
+      - rucio_tests/test_abacus_collection_replica.py
+      - rucio_tests/test_rule.py
+      - rucio_tests/test_subscription.py
+      - rucio_tests/test_multi_vo.py
+      - rucio_tests/test_rse.py
+      - rucio_tests/test_naming_convention.py
+      - rucio_tests/test_abacus_rse.py
+      - rucio_tests/test_dataset_replicas.py
+      - rucio_tests/test_did_meta_plugins.py
+      - rucio_tests/test_did.py
+      - rucio_tests/test_replica.py
+      - rucio_tests/test_bin_rucio.py
+      - rucio_tests/test_dirac.py
+      - rucio_tests/test_boolean.py
+      - rucio_tests/test_account.py
+      - rucio_tests/test_permission.py
+      - rucio_tests/test_curl.py
+      - rucio_tests/test_auditor_hdfs.py
 
       
   rdbms: 
@@ -89,5 +89,4 @@ atlas:
   dists:
     - centos7
   image_identifier: 
-    - atlas
-  
+    - belleii

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -783,7 +783,7 @@ def extract_scope(did, scopes=None, default_extract=_DEFAULT_EXTRACT):
     if not _loaded_policy_package_scope_algorithms:
         register_policy_package_algorithms('scope', _EXTRACT_SCOPE_ALGORITHMS)
         _loaded_policy_package_scope_algorithms = True
-    extract_scope_convention = config_get('common', 'extract_scope', False, None)
+    extract_scope_convention = config_get('common', 'extract_scope', False, None) or config_get('policy', 'extract_scope', False, None)
     if extract_scope_convention is None or extract_scope_convention not in _EXTRACT_SCOPE_ALGORITHMS:
         extract_scope_convention = default_extract
     return _EXTRACT_SCOPE_ALGORITHMS[extract_scope_convention](did=did, scopes=scopes)

--- a/lib/rucio/core/dirac.py
+++ b/lib/rucio/core/dirac.py
@@ -124,7 +124,7 @@ def add_files(lfns, account, ignore_availability, vo='def', session=None):
                     account=InternalAccount(account, vo=vo),
                     statuses=None,
                     meta=None,
-                    rules=[{'copies': 1, 'rse_expression': 'ANY=true', 'weight': None, 'account': InternalAccount(account, vo=vo), 'lifetime': None, 'grouping': 'NONE'}],
+                    rules=[{'copies': 1, 'rse_expression': 'ANY=true', 'weight': None, 'account': InternalAccount(account, vo=vo), 'lifetime': lifetime, 'grouping': 'NONE'}],
                     lifetime=None,
                     dids=None,
                     rse_id=None,

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -69,7 +69,7 @@ def rse_name_generator(size=10):
 
     :returns: A random RSE name
     """
-    return 'MOCK_' + ''.join(choice(ascii_uppercase) for x in range(size))
+    return 'MOCK-' + ''.join(choice(ascii_uppercase) for x in range(size))
 
 
 def file_generator(size=2, namelen=10):

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -64,6 +64,26 @@ def scope_name_generator():
     return 'mock_' + str(uuid()).lower()[:16]
 
 
+def did_name_generator(did_type='file'):
+    """ Generate random did name.
+
+    :returns: A random did name
+    """
+    if os.getenv('POLICY') == 'belleii':
+        path = '/belle'
+        path += '/cont_%s' % str(uuid())
+        if did_type == 'container':
+            return path
+        path += '/dataset_%s' % str(uuid())
+        if did_type == 'dataset':
+            return path
+        path += '/file_%s' % str(uuid())
+        return path
+    if did_type in ['file', 'dataset', 'container']:
+        return '%s_%s' % (did_type, str(uuid()))
+    return 'mock_' + str(uuid())
+
+
 def rse_name_generator(size=10):
     """ Generate random RSE name.
 

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -35,6 +35,8 @@ skiplimitedsql = pytest.mark.skipif('RDBMS' in os.environ and os.environ['RDBMS'
                                     reason="does not work in SQLite because of missing features")
 skip_multivo = pytest.mark.skipif('SUITE' in os.environ and os.environ['SUITE'] == 'multi_vo',
                                   reason="does not work for multiVO")
+skip_non_belleii = pytest.mark.skipif(not ('POLICY' in os.environ and os.environ['POLICY'] == 'belleii'),
+                                      reason="specific belleii tests")
 
 
 def get_long_vo():

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -83,6 +83,7 @@ def scope_client():
     return ScopeClient()
 
 
+@pytest.fixture(scope='module')
 def dirac_client():
     from rucio.client.diracclient import DiracClient
 

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -83,6 +83,12 @@ def scope_client():
     return ScopeClient()
 
 
+def dirac_client():
+    from rucio.client.diracclient import DiracClient
+
+    return DiracClient()
+
+
 @pytest.fixture
 def rest_client():
     from rucio.tests.common import print_response

--- a/lib/rucio/tests/test_belleii.py
+++ b/lib/rucio/tests/test_belleii.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright CERN since 2021
+# Copyright CERN since 2022
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,9 +20,10 @@ import pytest
 from rucio.common.exception import InvalidObject
 from rucio.common.schema.belleii import validate_schema
 from rucio.common.utils import generate_uuid, extract_scope
-from rucio.tests.common import did_name_generator
+from rucio.tests.common import did_name_generator, skip_non_belleii
 
 
+@skip_non_belleii
 def test_dirac_addfile(rse_factory, did_factory, root_account, did_client, dirac_client, rse_client, replica_client):
     """ DIRAC (CLIENT): Test the functionality of the addfile method """
     nbfiles = 5
@@ -67,6 +68,7 @@ def test_dirac_addfile(rse_factory, did_factory, root_account, did_client, dirac
         assert datetime.now() - rules[0]['expires_at'] < timedelta(hours=24)
 
 
+@skip_non_belleii
 def test_belle2_schema(rse_factory, did_factory, root_account, did_client):
     """ BELLE2 SCHEMA (COMMON): Basic tests on Belle II schema """
     bad_paths = ['invalid_name', '/belle/invalid@/did']

--- a/lib/rucio/tests/test_belleii.py
+++ b/lib/rucio/tests/test_belleii.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright CERN since 2021
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from rucio.common.utils import generate_uuid, extract_scope
+from rucio.core import distance as distance_core
+from rucio.core import rse as rse_core
+
+
+def test_dirac_addfile(rse_factory, did_factory, root_account, did_client, dirac_client, rse_client, replica_client, vo):
+
+    src_rses = [rse_factory.make_posix_rse() for _ in range(2)]
+    dst_rses = [rse_factory.make_posix_rse() for _ in range(3)]
+    for _, src_rse_id in src_rses:
+        for _, dst_rse_id in dst_rses:
+            distance_core.add_distance(src_rse_id=src_rse_id, dest_rse_id=dst_rse_id, ranking=10)
+            distance_core.add_distance(src_rse_id=dst_rse_id, dest_rse_id=src_rse_id, ranking=10)
+    print([rse for rse in rse_core.list_rses()])
+    print([did for did in did_client.list_content('other', '/belle')])
+    nbfiles = 5
+    # Adding replicas to deterministic RSE
+    rse1, rse1_id = rse_factory.make_srm_rse(deterministic=True)
+    rse_client.add_rse_attribute(rse=rse1, key='ANY', value='True')
+
+    # Create replicas on rse1
+    lfns = [{'lfn': '/belle/MC/test_dir/file_%s' % generate_uuid(), 'rse': rse1, 'bytes': 1, 'adler32': '0cc737eb', 'guid': generate_uuid()} for _ in range(nbfiles)]
+    files = [{'scope': extract_scope(lfn['lfn'], [])[0], 'name': lfn['lfn']} for lfn in lfns]
+    reps = [{'scope': extract_scope(lfn['lfn'], [])[0], 'name': lfn['lfn'], 'rse': rse1} for lfn in lfns]
+    dirac_client.add_files(lfns=lfns, ignore_availability=False)
+    replicas = [rep for rep in replica_client.list_replicas(dids=files)]
+    for replica in replicas:
+        assert {'scope': replica['scope'], 'name': replica['name'], 'rse': list(replica['rses'].keys())[0]} in reps

--- a/lib/rucio/tests/test_belleii.py
+++ b/lib/rucio/tests/test_belleii.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright CERN since 2022
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/rucio/web/rest/flaskapi/v1/main.py
+++ b/lib/rucio/web/rest/flaskapi/v1/main.py
@@ -28,6 +28,7 @@ DEFAULT_ENDPOINTS = [
     'config',
     'credentials',
     'dids',
+    'dirac',
     'export',
     'heartbeats',
     'identities',

--- a/tools/bootstrap_tests.py
+++ b/tools/bootstrap_tests.py
@@ -27,11 +27,11 @@ from rucio.api.vo import add_vo  # noqa: E402
 from rucio.client import Client  # noqa: E402
 from rucio.common.config import config_get, config_get_bool  # noqa: E402
 from rucio.common.exception import Duplicate, RucioException, DuplicateContent  # noqa: E402
+from rucio.common.utils import extract_scope  # noqa: E402
 from rucio.core.account import add_account_attribute  # noqa: E402
 from rucio.core.vo import map_vo  # noqa: E402
 from rucio.common.types import InternalAccount  # noqa: E402
 from rucio.tests.common_server import reset_config_table  # noqa: E402
-from rucio.common.utils import extract_scope
 
 
 def belleii_bootstrap(client):

--- a/tools/sync_rses.py
+++ b/tools/sync_rses.py
@@ -25,7 +25,7 @@ import sys  # noqa: E402
 import traceback  # noqa: E402
 
 from rucio.client import Client  # noqa: E402
-from rucio.common.exception import Duplicate  # noqa: E402
+from rucio.common.exception import Duplicate, InvalidObject  # noqa: E402
 
 UNKNOWN = 3
 CRITICAL = 2
@@ -60,6 +60,9 @@ def main(argv):
                       continent=continent, time_zone=time_zone, ISP=ISP)
         except Duplicate:
             print('%(rse)s already added' % locals())
+        except InvalidObject as err:
+            print(err)
+            continue
         except:
             errno, errstr = sys.exc_info()[:2]
             trcbck = traceback.format_exc()


### PR DESCRIPTION
Add Belle II tests : Closes #4864

- Basic tests on B2 schema and add_file method in dirac
- Introduce new `did_name_generator` to generate DIDs valid for multiple VOs
- Fix r`se_name_generator` to match B2 schema