### PR TITLE
REST & API: Fix the rses api docs #4992

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -400,7 +400,7 @@ class RSE(ErrorHandlingMethodView):
                       type: string
                     time_zone:
                       description: The time zone of the RSE.
-                    type: string
+                      type: string
                     ISP:
                       description: The internet service provider of the RSE.
                       type: string


### PR DESCRIPTION
There was a mistake in the indentation of the documentation, which lead to an
error in the generation of the REST API documentation.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
