### PR TITLE
Feature 5491 rucio admin rse update shows no error for unsupported options

### DIFF
--- a/lib/rucio/core/importer.py
+++ b/lib/rucio/core/importer.py
@@ -34,14 +34,16 @@ def import_rses(rses, rse_sync_method='edit', attr_sync_method='edit', protocol_
         if rse_module.rse_exists(rse_name, vo=vo, include_deleted=False, session=session):
             # RSE exists and is active
             rse_id = rse_module.get_rse_id(rse=rse_name, vo=vo, session=session)
-            rse_module.update_rse(rse_id=rse_id, parameters=rse, session=session)
+            selected_rse_properties = {key: rse[key] for key in rse if key in rse_module.MUTABLE_RSE_PROPERTIES}
+            rse_module.update_rse(rse_id=rse_id, parameters=selected_rse_properties, session=session)
         elif rse_module.rse_exists(rse_name, vo=vo, include_deleted=True, session=session):
             # RSE exists but in deleted state
             # Should only modify the RSE if importer is configured for edit or hard sync
             if rse_sync_method in ['edit', 'hard']:
                 rse_id = rse_module.get_rse_id(rse=rse_name, vo=vo, include_deleted=True, session=session)
                 rse_module.restore_rse(rse_id, session=session)
-                rse_module.update_rse(rse_id=rse_id, parameters=rse, session=session)
+                selected_rse_properties = {key: rse[key] for key in rse if key in rse_module.MUTABLE_RSE_PROPERTIES}
+                rse_module.update_rse(rse_id=rse_id, parameters=selected_rse_properties, session=session)
             else:
                 # Config is in RSE append only mode, should not modify the disabled RSE
                 continue

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -41,7 +41,7 @@ from rucio.db.sqla.constants import (RSEType, ReplicaState)
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
 
 if TYPE_CHECKING:
-    from typing import Dict, Optional, Sequence
+    from typing import Any, Dict, Optional, Sequence
     from sqlalchemy.orm import Session
 
 REGION = make_region_memcached(expiration_time=900)
@@ -1395,7 +1395,7 @@ MUTABLE_RSE_PROPERTIES = {
 
 
 @transactional_session
-def update_rse(rse_id, parameters, session=None):
+def update_rse(rse_id: str, parameters: 'Dict[str, Any]', session=None):
     """
     Update RSE properties like availability or name.
 

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -1374,6 +1374,26 @@ def del_protocols(rse_id, scheme, hostname=None, port=None, session=None):
                     i += 1
 
 
+MUTABLE_RSE_PROPERTIES = {
+    'name',
+    'availability_read',
+    'availability_write',
+    'availability_delete',
+    'latitude',
+    'longitude',
+    'time_zone',
+    'rse_type',
+    'volatile',
+    'deterministic',
+    'region_code',
+    'country_name',
+    'city',
+    'staging_area',
+    'qos_class',
+    'availability'
+}
+
+
 @transactional_session
 def update_rse(rse_id, parameters, session=None):
     """
@@ -1384,7 +1404,12 @@ def update_rse(rse_id, parameters, session=None):
     :param session: The database session in use.
 
     :raises RSENotFound: If RSE is not found.
+    :raises InputValidationError: If a parameter does not exist. Nothing will be added then.
     """
+    for key in parameters.keys():
+        if key not in MUTABLE_RSE_PROPERTIES:
+            raise exception.InputValidationError(f"The key '{key}' does not exist for RSE properties.")
+
     try:
         query = session.query(models.RSE).filter_by(id=rse_id).one()
     except sqlalchemy.orm.exc.NoResultFound:
@@ -1406,9 +1431,9 @@ def update_rse(rse_id, parameters, session=None):
                 availability = availability | availability_mapping[key]
             else:
                 availability = availability & ~availability_mapping[key]
-        elif key in ['latitude', 'longitude', 'time_zone', 'rse_type', 'volatile', 'deterministic', 'region_code', 'country_name', 'city', 'staging_area', 'qos_class']:
+        elif key in MUTABLE_RSE_PROPERTIES - {'name', 'availability_read', 'availability_write', 'availability_delete'}:
             param[key] = parameters[key]
-    param['availability'] = availability
+    param['availability'] = availability or param['availability']
 
     # handle null-able keys
     for key in parameters:

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -2201,3 +2201,15 @@ class TestBinRucio(unittest.TestCase):
         except OSError as err:
             if err.args[0] != 2:
                 raise err
+
+    def test_admin_rse_update_unsupported_option(self):
+        """ ADMIN CLIENT: Rse update should throw an unsupported option exception on an unsupported exception."""
+        exitcode, out, err = execute("rucio-admin rse update --setting test_with_non_existing_option --value 3 --rse {}".format(self.def_rse))
+        print(out, err)
+        assert exitcode != 0
+        assert "There is an error with one of the input parameters.\nDetails: The key 'test_with_non_existing_option' does not exist for RSE properties.\nThis means that the input you provided did not meet all the requirements." in err
+
+        exitcode, out, err = execute("rucio-admin rse update --setting country_name --value France --rse {}".format(self.def_rse))
+        print(out, err)
+        assert exitcode == 0
+        assert not err

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -24,7 +24,7 @@ from rucio.api.rse import add_rse, update_rse, list_rses, del_rse, add_rse_attri
     add_distance, get_distance, update_distance, delete_distance, list_qos_policies, add_qos_policy, delete_qos_policy
 from rucio.common.exception import Duplicate, AccessDenied, RSENotFound, RSEOperationNotSupported, \
     RSEProtocolNotSupported, InvalidObject, RSEProtocolDomainNotSupported, RSEProtocolPriorityError, \
-    InvalidRSEExpression, RSEAttributeNotFound, CounterNotFound, InvalidPath, ReplicaNotFound
+    InvalidRSEExpression, RSEAttributeNotFound, CounterNotFound, InvalidPath, ReplicaNotFound, InputValidationError
 from rucio.common.utils import render_json, APIEncoder
 from rucio.rse import rsemanager
 from rucio.web.rest.flaskapi.v1.common import request_auth_env, response_headers, check_accept_header_wrapper_flask, \
@@ -329,7 +329,7 @@ class RSE(ErrorHandlingMethodView):
                   type: string
                   enum: ["Created"]
           400:
-            description: Cannot decode json parameter dictionary
+            description: Cannot decode json parameter dictionary or invalid option provided
           401:
             description: Invalid Auth Token
           404:
@@ -342,7 +342,7 @@ class RSE(ErrorHandlingMethodView):
         }
         try:
             update_rse(rse, **kwargs)
-        except InvalidObject as error:
+        except (InvalidObject, InputValidationError) as error:
             return generate_http_error_flask(400, error)
         except AccessDenied as error:
             return generate_http_error_flask(401, error)


### PR DESCRIPTION
Core & Internals: Throw an exception on wrong RSE update option #5491

The user can only change specific values of an RSE. If they tried changing an
option which does not exist, the server and therefore the client simply did not
change anything and continued as normal. We want to throw an exception in this
case, to notify the user that there was an invalid input.

This commit changes the RSE update function to throw an exception if the caller
tries to change a non-existing property.
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
