### PR TITLE
Core & API: add session to the API level. Closes #5439. Closes #4945.

### DIFF
--- a/lib/rucio/api/account.py
+++ b/lib/rucio/api/account.py
@@ -23,9 +23,11 @@ from rucio.common.schema import validate_schema
 from rucio.common.utils import api_update_return_dict
 from rucio.common.types import InternalAccount
 from rucio.db.sqla.constants import AccountType
+from rucio.db.sqla.session import read_session, stream_session, transactional_session
 
 
-def add_account(account, type_, email, issuer, vo='def'):
+@transactional_session
+def add_account(account, type_, email, issuer, vo='def', session=None):
     """
     Creates an account with the provided account name, contact information, etc.
 
@@ -35,55 +37,61 @@ def add_account(account, type_, email, issuer, vo='def'):
 
     :param issuer: The issuer account_core.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     """
 
     validate_schema(name='account', obj=account, vo=vo)
 
     kwargs = {'account': account, 'type': type_}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_account', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_account', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not add account' % (issuer))
 
     account = InternalAccount(account, vo=vo)
 
-    account_core.add_account(account, AccountType[type_.upper()], email)
+    account_core.add_account(account, AccountType[type_.upper()], email, session=session)
 
 
-def del_account(account, issuer, vo='def'):
+@transactional_session
+def del_account(account, issuer, vo='def', session=None):
     """
     Disables an account with the provided account name.
 
     :param account: The account name.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     """
     kwargs = {'account': account}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='del_account', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='del_account', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not delete account' % (issuer))
 
     account = InternalAccount(account, vo=vo)
 
-    account_core.del_account(account)
+    account_core.del_account(account, session=session)
 
 
-def get_account_info(account, vo='def'):
+@read_session
+def get_account_info(account, vo='def', session=None):
     """
     Returns the info like the statistics information associated to an account_core.
 
     :param account: The account name.
     :returns: A list with all account information.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
     account = InternalAccount(account, vo=vo)
 
-    acc = account_core.get_account(account)
+    acc = account_core.get_account(account, session=session)
     acc.account = acc.account.external
     return acc
 
 
-def update_account(account, key, value, issuer='root', vo='def'):
+@transactional_session
+def update_account(account, key, value, issuer='root', vo='def', session=None):
     """ Update a property of an account_core.
 
     :param account: Name of the account_core.
@@ -91,18 +99,20 @@ def update_account(account, key, value, issuer='root', vo='def'):
     :param value: Property value.
     :param issuer: The issuer account
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     validate_schema(name='account', obj=account, vo=vo)
     kwargs = {}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='update_account', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='update_account', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not change %s  of the account' % (issuer, key))
 
     account = InternalAccount(account, vo=vo)
 
-    return account_core.update_account(account, key, value)
+    return account_core.update_account(account, key, value, session=session)
 
 
-def list_accounts(filter_={}, vo='def'):
+@stream_session
+def list_accounts(filter_={}, vo='def', session=None):
     """
     Lists all the Rucio account names.
 
@@ -110,6 +120,7 @@ def list_accounts(filter_={}, vo='def'):
 
     :param filter_: Dictionary of attributes by which the input data should be filtered
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: List of all accounts.
     """
@@ -121,51 +132,58 @@ def list_accounts(filter_={}, vo='def'):
         filter_['account'] = InternalAccount(filter_['account'], vo=vo)
     else:
         filter_['account'] = InternalAccount(account='*', vo=vo)
-    for result in account_core.list_accounts(filter_=filter_):
-        yield api_update_return_dict(result)
+    for result in account_core.list_accounts(filter_=filter_, session=session):
+        yield api_update_return_dict(result, session=session)
 
 
-def account_exists(account, vo='def'):
+@read_session
+def account_exists(account, vo='def', session=None):
     """
     Checks to see if account exists. This procedure does not check it's status.
 
     :param account: Name of the account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     :returns: True if found, otherwise false.
     """
 
     account = InternalAccount(account, vo=vo)
 
-    return account_core.account_exists(account)
+    return account_core.account_exists(account, session=session)
 
 
-def list_identities(account, vo='def'):
+@read_session
+def list_identities(account, vo='def', session=None):
     """
     List all identities on an account_core.
 
     :param account: The account name.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
     account = InternalAccount(account, vo=vo)
 
-    return account_core.list_identities(account)
+    return account_core.list_identities(account, session=session)
 
 
-def list_account_attributes(account, vo='def'):
+@read_session
+def list_account_attributes(account, vo='def', session=None):
     """
     Returns all the attributes for the given account.
 
     :param account: The account name.
     :param vo: The VO to act on
+    :param session: The database session in use.
     """
 
     account = InternalAccount(account, vo=vo)
 
-    return account_core.list_account_attributes(account)
+    return account_core.list_account_attributes(account, session=session)
 
 
-def add_account_attribute(key, value, account, issuer, vo='def'):
+@transactional_session
+def add_account_attribute(key, value, account, issuer, vo='def', session=None):
     """
     Add an attribute to an account.
 
@@ -174,20 +192,22 @@ def add_account_attribute(key, value, account, issuer, vo='def'):
     :param account: The account name.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     validate_schema(name='account_attribute', obj=key, vo=vo)
     validate_schema(name='account_attribute', obj=value, vo=vo)
 
     kwargs = {'account': account, 'key': key, 'value': value}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_attribute', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='add_attribute', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not add attributes' % (issuer))
 
     account = InternalAccount(account, vo=vo)
 
-    account_core.add_account_attribute(account, key, value)
+    account_core.add_account_attribute(account, key, value, session=session)
 
 
-def del_account_attribute(key, account, issuer, vo='def'):
+@transactional_session
+def del_account_attribute(key, account, issuer, vo='def', session=None):
     """
     Delete an attribute to an account.
 
@@ -195,17 +215,19 @@ def del_account_attribute(key, account, issuer, vo='def'):
     :param account: The account name.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     kwargs = {'account': account, 'key': key}
-    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='del_attribute', kwargs=kwargs):
+    if not rucio.api.permission.has_permission(issuer=issuer, vo=vo, action='del_attribute', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not delete attribute' % (issuer))
 
     account = InternalAccount(account, vo=vo)
 
-    account_core.del_account_attribute(account, key)
+    account_core.del_account_attribute(account, key, session=session)
 
 
-def get_usage(rse, account, issuer, vo='def'):
+@read_session
+def get_usage(rse, account, issuer, vo='def', session=None):
     """
     Returns current values of the specified counter, or raises CounterNotFound if the counter does not exist.
 
@@ -213,15 +235,17 @@ def get_usage(rse, account, issuer, vo='def'):
     :param account:          The account name.
     :param issuer:           The issuer account.
     :param vo:               The VO to act on.
+    :param session:          The database session in use.
     :returns:                A dictionary with total and bytes.
     """
-    rse_id = get_rse_id(rse=rse, vo=vo)
+    rse_id = get_rse_id(rse=rse, vo=vo, session=session)
     account = InternalAccount(account, vo=vo)
 
-    return account_core.get_usage(rse_id, account)
+    return account_core.get_usage(rse_id, account, session=session)
 
 
-def get_usage_history(rse, account, issuer, vo='def'):
+@read_session
+def get_usage_history(rse, account, issuer, vo='def', session=None):
     """
     Returns historical values of the specified counter, or raises CounterNotFound if the counter does not exist.
 
@@ -229,9 +253,10 @@ def get_usage_history(rse, account, issuer, vo='def'):
     :param account:          The account name.
     :param issuer:           The issuer account.
     :param vo:               The VO to act on.
+    :param session:          The database session in use.
     :returns:                A dictionary with total and bytes.
     """
-    rse_id = get_rse_id(rse=rse, vo=vo)
+    rse_id = get_rse_id(rse=rse, vo=vo, session=session)
     account = InternalAccount(account, vo=vo)
 
-    return account_core.get_usage_history(rse_id, account)
+    return account_core.get_usage_history(rse_id, account, session=session)

--- a/lib/rucio/api/authentication.py
+++ b/lib/rucio/api/authentication.py
@@ -19,23 +19,27 @@ from rucio.common.types import InternalAccount
 from rucio.common.utils import api_update_return_dict
 from rucio.core import authentication, identity, oidc
 from rucio.db.sqla.constants import IdentityType
+from rucio.db.sqla.session import transactional_session
 
 
-def refresh_cli_auth_token(token_string, account, vo='def'):
+@transactional_session
+def refresh_cli_auth_token(token_string, account, vo='def', session=None):
     """
     Checks if there is active refresh token and if so returns
     either active token with expiration timestamp or requests a new
     refresh and returns new access token.
     :param token_string: token string
     :param account: Rucio account for which token refresh should be considered
+    :param session: The database session in use.
 
     :return: tuple of (access token, expiration epoch), None otherswise
     """
     account = InternalAccount(account, vo=vo)
-    return oidc.refresh_cli_auth_token(token_string, account)
+    return oidc.refresh_cli_auth_token(token_string, account, session=session)
 
 
-def redirect_auth_oidc(authn_code, fetchtoken=False):
+@transactional_session
+def redirect_auth_oidc(authn_code, fetchtoken=False, session=None):
     """
     Finds the Authentication URL in the Rucio DB oauth_requests table
     and redirects user's browser to this URL.
@@ -50,10 +54,11 @@ def redirect_auth_oidc(authn_code, fetchtoken=False):
               token if a user asks with the correct code) or None.
               Exception thrown in case of an unexpected crash.
     """
-    return authentication.redirect_auth_oidc(authn_code, fetchtoken)
+    return authentication.redirect_auth_oidc(authn_code, fetchtoken, session=session)
 
 
-def get_auth_oidc(account, vo='def', **kwargs):
+@transactional_session
+def get_auth_oidc(account, vo='def', session=None, **kwargs):
     """
     Assembles the authorization request of the Rucio Client tailored to the Rucio user
     & Identity Provider. Saves authentication session parameters in the oauth_requests
@@ -89,10 +94,11 @@ def get_auth_oidc(account, vo='def', **kwargs):
     # no permission layer for the moment !
 
     account = InternalAccount(account, vo=vo)
-    return oidc.get_auth_oidc(account, **kwargs)
+    return oidc.get_auth_oidc(account, session=session, **kwargs)
 
 
-def get_token_oidc(auth_query_string, ip=None):
+@transactional_session
+def get_token_oidc(auth_query_string, ip=None, session=None):
     """
     After Rucio User got redirected to Rucio /auth/oidc_token (or /auth/oidc_code)
     REST endpoints with authz code and session state encoded within the URL.
@@ -107,10 +113,11 @@ def get_token_oidc(auth_query_string, ip=None):
               (no auto, auto, polling).
     """
     # no permission layer for the moment !
-    return oidc.get_token_oidc(auth_query_string, ip)
+    return oidc.get_token_oidc(auth_query_string, ip, session=session)
 
 
-def get_auth_token_user_pass(account, username, password, appid, ip=None, vo='def'):
+@transactional_session
+def get_auth_token_user_pass(account, username, password, appid, ip=None, vo='def', session=None):
     """
     Authenticate a Rucio account temporarily via username and password.
 
@@ -122,20 +129,22 @@ def get_auth_token_user_pass(account, username, password, appid, ip=None, vo='de
     :param appid: The application identifier as a string.
     :param ip: IP address of the client as a string.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: A dict with token and expires_at entries.
     """
 
     kwargs = {'account': account, 'username': username, 'password': password}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_user_pass', kwargs=kwargs):
+    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_user_pass', kwargs=kwargs, session=session):
         raise exception.AccessDenied('User with identity %s can not log to account %s' % (username, account))
 
     account = InternalAccount(account, vo=vo)
 
-    return authentication.get_auth_token_user_pass(account, username, password, appid, ip)
+    return authentication.get_auth_token_user_pass(account, username, password, appid, ip, session=session)
 
 
-def get_auth_token_gss(account, gsscred, appid, ip=None, vo='def'):
+@transactional_session
+def get_auth_token_gss(account, gsscred, appid, ip=None, vo='def', session=None):
     """
     Authenticate a Rucio account temporarily via a GSS token.
 
@@ -146,20 +155,22 @@ def get_auth_token_gss(account, gsscred, appid, ip=None, vo='def'):
     :param appid: The application identifier as a string.
     :param ip: IP address of the client as a string.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: A dict with token and expires_at entries.
     """
 
     kwargs = {'account': account, 'gsscred': gsscred}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_gss', kwargs=kwargs):
+    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_gss', kwargs=kwargs, session=session):
         raise exception.AccessDenied('User with identity %s can not log to account %s' % (gsscred, account))
 
     account = InternalAccount(account, vo=vo)
 
-    return authentication.get_auth_token_gss(account, gsscred, appid, ip)
+    return authentication.get_auth_token_gss(account, gsscred, appid, ip, session=session)
 
 
-def get_auth_token_x509(account, dn, appid, ip=None, vo='def'):
+@transactional_session
+def get_auth_token_x509(account, dn, appid, ip=None, vo='def', session=None):
     """
     Authenticate a Rucio account temporarily via an x509 certificate.
 
@@ -170,6 +181,7 @@ def get_auth_token_x509(account, dn, appid, ip=None, vo='def'):
     :param appid: The application identifier as a string.
     :param ip: IP address of the client as a string.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: A dict with token and expires_at entries.
     """
@@ -178,15 +190,16 @@ def get_auth_token_x509(account, dn, appid, ip=None, vo='def'):
         account = identity.get_default_account(dn, IdentityType.X509).external
 
     kwargs = {'account': account, 'dn': dn}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_x509', kwargs=kwargs):
+    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_x509', kwargs=kwargs, session=session):
         raise exception.AccessDenied('User with identity %s can not log to account %s' % (dn, account))
 
     account = InternalAccount(account, vo=vo)
 
-    return authentication.get_auth_token_x509(account, dn, appid, ip)
+    return authentication.get_auth_token_x509(account, dn, appid, ip, session=session)
 
 
-def get_auth_token_ssh(account, signature, appid, ip=None, vo='def'):
+@transactional_session
+def get_auth_token_ssh(account, signature, appid, ip=None, vo='def', session=None):
     """
     Authenticate a Rucio account temporarily via SSH key exchange.
 
@@ -197,20 +210,22 @@ def get_auth_token_ssh(account, signature, appid, ip=None, vo='def'):
     :param appid: The application identifier as a string.
     :param ip: IP address of the client as a string.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: A dict with token and expires_at entries.
     """
 
     kwargs = {'account': account, 'signature': signature}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_ssh', kwargs=kwargs):
+    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_ssh', kwargs=kwargs, session=session):
         raise exception.AccessDenied('User with provided signature can not log to account %s' % account)
 
     account = InternalAccount(account, vo=vo)
 
-    return authentication.get_auth_token_ssh(account, signature, appid, ip)
+    return authentication.get_auth_token_ssh(account, signature, appid, ip, session=session)
 
 
-def get_ssh_challenge_token(account, appid, ip=None, vo='def'):
+@transactional_session
+def get_ssh_challenge_token(account, appid, ip=None, vo='def', session=None):
     """
     Get a challenge token for subsequent SSH public key authentication.
 
@@ -220,20 +235,22 @@ def get_ssh_challenge_token(account, appid, ip=None, vo='def'):
     :param appid: The application identifier as a string.
     :param ip: IP address of the client as a string.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: A dict with token and expires_at entries.
     """
 
     kwargs = {'account': account}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_ssh_challenge_token', kwargs=kwargs):
+    if not permission.has_permission(issuer=account, vo=vo, action='get_ssh_challenge_token', kwargs=kwargs, session=session):
         raise exception.AccessDenied('User can not get challenge token for account %s' % account)
 
     account = InternalAccount(account, vo=vo)
 
-    return authentication.get_ssh_challenge_token(account, appid, ip)
+    return authentication.get_ssh_challenge_token(account, appid, ip, session=session)
 
 
-def get_auth_token_saml(account, saml_nameid, appid, ip=None, vo='def'):
+@transactional_session
+def get_auth_token_saml(account, saml_nameid, appid, ip=None, vo='def', session=None):
     """
     Authenticate a Rucio account temporarily via SSO.
 
@@ -243,24 +260,27 @@ def get_auth_token_saml(account, saml_nameid, appid, ip=None, vo='def'):
     :param saml_nameid: NameId returned in SAML response as a string.
     :param appid: The application identifier as a string.
     :param ip: IP address of the client as a string.
+    :param session: The database session in use.
 
     :returns: A dict with token and expires_at entries.
     """
 
     kwargs = {'account': account, 'saml_nameid': saml_nameid}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_saml', kwargs=kwargs):
+    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_saml', kwargs=kwargs, session=session):
         raise exception.AccessDenied('User with identity %s can not log to account %s' % (saml_nameid, account))
 
     account = InternalAccount(account, vo=vo)
 
-    return authentication.get_auth_token_saml(account, saml_nameid, appid, ip)
+    return authentication.get_auth_token_saml(account, saml_nameid, appid, ip, session=session)
 
 
-def validate_auth_token(token):
+@transactional_session
+def validate_auth_token(token, session=None):
     """
     Validate an authentication token.
 
     :param token: Authentication token as a variable-length string.
+    :param session: The database session in use.
 
     :returns: dictionary { account: <account name>,
                            identity: <identity>,
@@ -271,9 +291,9 @@ def validate_auth_token(token):
               if successful, None otherwise.
     """
 
-    auth = authentication.validate_auth_token(token)
+    auth = authentication.validate_auth_token(token, session=session)
     if auth is not None:
         vo = auth['account'].vo
-        auth = api_update_return_dict(auth)
+        auth = api_update_return_dict(auth, session=session)
         auth['vo'] = vo
     return auth

--- a/lib/rucio/api/config.py
+++ b/lib/rucio/api/config.py
@@ -16,6 +16,7 @@
 from rucio.api import permission
 from rucio.common import exception
 from rucio.core import config
+from rucio.db.sqla.session import read_session, transactional_session
 
 """
 ConfigParser compatible interface.
@@ -25,69 +26,78 @@ ConfigParser compatible interface.
 """
 
 
-def sections(issuer=None, vo='def'):
+@read_session
+def sections(issuer=None, vo='def', session=None):
     """
     Return a list of the sections available.
 
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     :returns: ['section_name', ...]
     """
 
     kwargs = {'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_sections', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='config_sections', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot retrieve sections' % issuer)
-    return config.sections()
+    return config.sections(session=session)
 
 
-def add_section(section, issuer=None, vo='def'):
+@transactional_session
+def add_section(section, issuer=None, vo='def', session=None):
     """
     Add a section to the configuration.
 
     :param section: The name of the section.
     :param issuer: The issuer account.
+    :param session: The database session in use.
     :param vo: The VO to act on.
     """
 
     kwargs = {'issuer': issuer, 'section': section}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_add_section', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='config_add_section', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot add section %s' % (issuer, section))
-    return config.add_section(section)
+    return config.add_section(section, session=session)
 
 
-def has_section(section, issuer=None, vo='def'):
+@read_session
+def has_section(section, issuer=None, vo='def', session=None):
     """
     Indicates whether the named section is present in the configuration.
 
     :param section: The name of the section.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     :returns: True/False
     """
 
     kwargs = {'issuer': issuer, 'section': section}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_has_section', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='config_has_section', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot check existence of section %s' % (issuer, section))
-    return config.has_section(section)
+    return config.has_section(section, session=session)
 
 
-def options(section, issuer=None, vo='def'):
+@read_session
+def options(section, issuer=None, vo='def', session=None):
     """
     Returns a list of options available in the specified section.
 
     :param section: The name of the section.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     :returns: ['option', ...]
     """
 
     kwargs = {'issuer': issuer, 'section': section}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_options', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='config_options', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot retrieve options from section %s' % (issuer, section))
-    return config.options(section)
+    return config.options(section, session=session)
 
 
-def has_option(section, option, issuer=None, vo='def'):
+@read_session
+def has_option(section, option, issuer=None, vo='def', session=None):
     """
     Check if the given section exists and contains the given option.
 
@@ -95,16 +105,18 @@ def has_option(section, option, issuer=None, vo='def'):
     :param option: The name of the option.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     :returns: True/False
     """
 
     kwargs = {'issuer': issuer, 'section': section, 'option': option}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_has_option', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='config_has_option', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot check existence of option %s from section %s' % (issuer, option, section))
-    return config.has_option(section, option)
+    return config.has_option(section, option, session=session)
 
 
-def get(section, option, issuer=None, vo='def'):
+@read_session
+def get(section, option, issuer=None, vo='def', session=None):
     """
     Get an option value for the named section. Value can be auto-coerced to int, float, and bool; string otherwise.
 
@@ -115,16 +127,18 @@ def get(section, option, issuer=None, vo='def'):
     :param option: The name of the option.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     :returns: The auto-coerced value.
     """
 
     kwargs = {'issuer': issuer, 'section': section, 'option': option}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_get', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='config_get', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot retrieve option %s from section %s' % (issuer, option, section))
-    return config.get(section, option)
+    return config.get(section, option, session=session)
 
 
-def items(section, issuer=None, vo='def'):
+@read_session
+def items(section, issuer=None, vo='def', session=None):
     """
     Return a list of (option, value) pairs for each option in the given section. Values are auto-coerced as in get().
 
@@ -132,16 +146,18 @@ def items(section, issuer=None, vo='def'):
     :param value: The content of the value.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     :returns: [('option', auto-coerced value), ...]
     """
 
     kwargs = {'issuer': issuer, 'section': section}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_items', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='config_items', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot retrieve options and values from section %s' % (issuer, section))
-    return config.items(section)
+    return config.items(section, session=session)
 
 
-def set(section, option, value, issuer=None, vo='def'):
+@transactional_session
+def set(section, option, value, issuer=None, vo='def', session=None):
     """
     Set the given option to the specified value.
 
@@ -150,31 +166,35 @@ def set(section, option, value, issuer=None, vo='def'):
     :param value: The content of the value.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
 
     kwargs = {'issuer': issuer, 'section': section, 'option': option, 'value': value}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_set', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='config_set', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot set option %s to %s in section %s' % (issuer, option, value, section))
-    return config.set(section, option, value)
+    return config.set(section, option, value, session=session)
 
 
-def remove_section(section, issuer=None, vo='def'):
+@transactional_session
+def remove_section(section, issuer=None, vo='def', session=None):
     """
     Remove the specified option from the specified section.
 
     :param section: The name of the section.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     :returns: True/False.
     """
 
     kwargs = {'issuer': issuer, 'section': section}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_remove_section', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='config_remove_section', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot remove section %s' % (issuer, section))
-    return config.remove_section(section)
+    return config.remove_section(section, session=session)
 
 
-def remove_option(section, option, issuer=None, vo='def'):
+@transactional_session
+def remove_option(section, option, issuer=None, vo='def', session=None):
     """
     Remove the specified section from the configuration.
 
@@ -182,10 +202,11 @@ def remove_option(section, option, issuer=None, vo='def'):
     :param option: The name of the option.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     :returns: True/False
     """
 
     kwargs = {'issuer': issuer, 'section': section, 'option': option}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_remove_option', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='config_remove_option', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot remove option %s from section %s' % (issuer, option, section))
-    return config.remove_option(section, option)
+    return config.remove_option(section, option, session=session)

--- a/lib/rucio/api/credential.py
+++ b/lib/rucio/api/credential.py
@@ -17,9 +17,11 @@ from rucio.api import permission
 from rucio.common import exception
 from rucio.core import credential
 from rucio.core.rse import get_rse_id
+from rucio.db.sqla.session import read_session
 
 
-def get_signed_url(account, appid, ip, rse, service, operation, url, lifetime, vo='def'):
+@read_session
+def get_signed_url(account, appid, ip, rse, service, operation, url, lifetime, vo='def', session=None):
     """
     Get a signed URL for a particular service and operation.
 
@@ -34,11 +36,12 @@ def get_signed_url(account, appid, ip, rse, service, operation, url, lifetime, v
     :param url: The URL to sign.
     :param lifetime: Lifetime in seconds.
     :param vo: The vo to act on.
+    :param session: The database session in use.
     :returns: Signed URL as a variable-length string.
     """
 
     kwargs = {'account': account}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_signed_url', kwargs=kwargs):
+    if not permission.has_permission(issuer=account, vo=vo, action='get_signed_url', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not get signed URL for rse=%s, service=%s, operation=%s, url=%s, lifetime=%s' % (account,
                                                                                                                                       rse,
                                                                                                                                       service,
@@ -47,6 +50,6 @@ def get_signed_url(account, appid, ip, rse, service, operation, url, lifetime, v
                                                                                                                                       lifetime))
 
     # look up RSE ID for name
-    rse_id = get_rse_id(rse, vo=vo)
+    rse_id = get_rse_id(rse, vo=vo, session=session)
 
     return credential.get_signed_url(rse_id, service, operation, url, lifetime)

--- a/lib/rucio/api/dirac.py
+++ b/lib/rucio/api/dirac.py
@@ -22,9 +22,11 @@ from rucio.core.rse import get_rse_id
 from rucio.core import dirac
 from rucio.common.exception import AccessDenied
 from rucio.common.utils import extract_scope
+from rucio.db.sqla.session import transactional_session
 
 
-def add_files(lfns, issuer, ignore_availability, vo='def'):
+@transactional_session
+def add_files(lfns, issuer, ignore_availability, vo='def', session=None):
     """
     Bulk add files :
     - Create the file and replica.
@@ -35,9 +37,10 @@ def add_files(lfns, issuer, ignore_availability, vo='def'):
     :param issuer: The issuer account.
     :param ignore_availability: A boolean to ignore blocked sites.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     """
-    scopes = list_scopes(vo=vo)
+    scopes = list_scopes(vo=vo, session=session)
     dids = []
     rses = {}
     for lfn in lfns:
@@ -45,7 +48,7 @@ def add_files(lfns, issuer, ignore_availability, vo='def'):
         dids.append({'scope': scope, 'name': name})
         rse = lfn['rse']
         if rse not in rses:
-            rse_id = get_rse_id(rse=rse, vo=vo)
+            rse_id = get_rse_id(rse=rse, vo=vo, session=session)
             rses[rse] = rse_id
         lfn['rse_id'] = rses[rse]
 
@@ -53,14 +56,14 @@ def add_files(lfns, issuer, ignore_availability, vo='def'):
     for rse in rses:
         rse_id = rses[rse]
         kwargs = {'rse': rse, 'rse_id': rse_id}
-        if not has_permission(issuer=issuer, action='add_replicas', kwargs=kwargs, vo=vo):
+        if not has_permission(issuer=issuer, action='add_replicas', kwargs=kwargs, vo=vo, session=session):
             raise AccessDenied('Account %s can not add file replicas on %s for VO %s' % (issuer, rse, vo))
-        if not has_permission(issuer=issuer, action='skip_availability_check', kwargs=kwargs, vo=vo):
+        if not has_permission(issuer=issuer, action='skip_availability_check', kwargs=kwargs, vo=vo, session=session):
             ignore_availability = False
 
     # Check if the issuer can add the files
     kwargs = {'issuer': issuer, 'dids': dids}
-    if not has_permission(issuer=issuer, action='add_dids', kwargs=kwargs, vo=vo):
+    if not has_permission(issuer=issuer, action='add_dids', kwargs=kwargs, vo=vo, session=session):
         raise AccessDenied('Account %s can not bulk add data identifier for VO %s' % (issuer, vo))
 
-    dirac.add_files(lfns=lfns, account=issuer, ignore_availability=ignore_availability, session=None, vo=vo)
+    dirac.add_files(lfns=lfns, account=issuer, ignore_availability=ignore_availability, vo=vo, session=session)

--- a/lib/rucio/api/heartbeat.py
+++ b/lib/rucio/api/heartbeat.py
@@ -16,24 +16,28 @@
 from rucio.api import permission
 from rucio.common import exception
 from rucio.core import heartbeat
+from rucio.db.sqla.session import read_session, transactional_session
 
 
-def list_heartbeats(issuer=None, vo='def'):
+@read_session
+def list_heartbeats(issuer=None, vo='def', session=None):
     """
     Return a list of tuples of all heartbeats.
 
     :param issuer: The issuer account.
     :param vo: the VO for the issuer.
+    :param session: The database session in use.
     :returns: List of tuples [('Executable', 'Hostname', ...), ...]
     """
 
     kwargs = {'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='list_heartbeats', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='list_heartbeats', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot list heartbeats' % issuer)
-    return heartbeat.list_heartbeats()
+    return heartbeat.list_heartbeats(session=session)
 
 
-def create_heartbeat(executable, hostname, pid, thread, older_than, payload, issuer=None, vo='def'):
+@transactional_session
+def create_heartbeat(executable, hostname, pid, thread, older_than, payload, issuer=None, vo='def', session=None):
     """
     Creates a heartbeat.
     :param issuer: The issuer account.
@@ -44,9 +48,10 @@ def create_heartbeat(executable, hostname, pid, thread, older_than, payload, iss
     :param thread: Python Thread Object.
     :param older_than: Ignore specified heartbeats older than specified nr of seconds.
     :param payload: Payload identifier which can be further used to identify the work a certain thread is executing.
+    :param session: The database session in use.
 
     """
     kwargs = {'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='send_heartbeats', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='send_heartbeats', kwargs=kwargs, session=session):
         raise exception.AccessDenied('%s cannot send heartbeats' % issuer)
-    heartbeat.live(executable=executable, hostname=hostname, pid=pid, thread=thread, older_than=older_than, payload=payload)
+    heartbeat.live(executable=executable, hostname=hostname, pid=pid, thread=thread, older_than=older_than, payload=payload, session=session)

--- a/lib/rucio/api/identity.py
+++ b/lib/rucio/api/identity.py
@@ -22,9 +22,11 @@ from rucio.common import exception
 from rucio.common.types import InternalAccount
 from rucio.core import identity
 from rucio.db.sqla.constants import IdentityType
+from rucio.db.sqla.session import read_session, transactional_session
 
 
-def add_identity(identity_key, id_type, email, password=None):
+@transactional_session
+def add_identity(identity_key, id_type, email, password=None, session=None):
     """
     Creates a user identity.
 
@@ -32,27 +34,31 @@ def add_identity(identity_key, id_type, email, password=None):
     :param id_type: The type of the authentication (x509, gss, userpass, ssh, saml)
     :param email: The Email address associated with the identity.
     :param password: If type==userpass, this sets the password.
+    :param session: The database session in use.
     """
-    return identity.add_identity(identity_key, IdentityType[id_type.upper()], email, password=password)
+    return identity.add_identity(identity_key, IdentityType[id_type.upper()], email, password=password, session=session)
 
 
-def del_identity(identity_key, id_type, issuer, vo='def'):
+@transactional_session
+def del_identity(identity_key, id_type, issuer, vo='def', session=None):
     """
     Deletes a user identity.
     :param identity_key: The identity key name. For example x509 DN, or a username.
     :param id_type: The type of the authentication (x509, gss, userpass, ssh, saml).
     :param issuer: The issuer account.
     :param vo: the VO of the issuer.
+    :param session: The database session in use.
     """
     id_type = IdentityType[id_type.upper()]
-    kwargs = {'accounts': identity.list_accounts_for_identity(identity_key, id_type)}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='del_identity', kwargs=kwargs):
+    kwargs = {'accounts': identity.list_accounts_for_identity(identity_key, id_type, session=session)}
+    if not permission.has_permission(issuer=issuer, vo=vo, action='del_identity', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not delete identity' % (issuer))
 
-    return identity.del_identity(identity_key, id_type)
+    return identity.del_identity(identity_key, id_type, session=session)
 
 
-def add_account_identity(identity_key, id_type, account, email, issuer, default=False, password=None, vo='def'):
+@transactional_session
+def add_account_identity(identity_key, id_type, account, email, issuer, default=False, password=None, vo='def', session=None):
     """
     Adds a membership association between identity and account.
 
@@ -64,17 +70,20 @@ def add_account_identity(identity_key, id_type, account, email, issuer, default=
     :param default: If True, the account should be used by default with the provided identity.
     :param password: Password if id_type is userpass.
     :param vo: the VO to act on.
+    :param session: The database session in use.
     """
     kwargs = {'identity': identity_key, 'type': id_type, 'account': account}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_account_identity', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='add_account_identity', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not add account identity' % (issuer))
 
     account = InternalAccount(account, vo=vo)
 
-    return identity.add_account_identity(identity=identity_key, type_=IdentityType[id_type.upper()], default=default, email=email, account=account, password=password)
+    return identity.add_account_identity(identity=identity_key, type_=IdentityType[id_type.upper()], default=default,
+                                         email=email, account=account, password=password, session=session)
 
 
-def del_account_identity(identity_key, id_type, account, issuer, vo='def'):
+@transactional_session
+def del_account_identity(identity_key, id_type, account, issuer, vo='def', session=None):
     """
     Removes a membership association between identity and account.
 
@@ -83,44 +92,51 @@ def del_account_identity(identity_key, id_type, account, issuer, vo='def'):
     :param account: The account name.
     :param issuer: The issuer account.
     :param vo: the VO to act on.
+    :param session: The database session in use.
     """
     kwargs = {'account': account}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='del_account_identity', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='del_account_identity', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not delete account identity' % (issuer))
 
     account = InternalAccount(account, vo=vo)
 
-    return identity.del_account_identity(identity_key, IdentityType[id_type.upper()], account)
+    return identity.del_account_identity(identity_key, IdentityType[id_type.upper()], account, session=session)
 
 
-def list_identities(**kwargs):
+@read_session
+def list_identities(session=None, **kwargs):
     """
     Returns a list of all enabled identities.
 
+    :param session: The database session in use.
     returns: A list of all enabled identities.
     """
-    return identity.list_identities(**kwargs)
+    return identity.list_identities(session=session, **kwargs)
 
 
-def get_default_account(identity_key, id_type):
+@read_session
+def get_default_account(identity_key, id_type, session=None):
     """
     Returns the default account for this identity.
 
     :param identity_key: The identity key name. For example x509 DN, or a username.
     :param id_type: The type of the authentication (x509, gss, userpass, ssh, saml).
+    :param session: The database session in use.
     """
-    account = identity.get_default_account(identity_key, IdentityType[id_type.upper()])
+    account = identity.get_default_account(identity_key, IdentityType[id_type.upper()], session=session)
     return account.external
 
 
-def list_accounts_for_identity(identity_key, id_type):
+@read_session
+def list_accounts_for_identity(identity_key, id_type, session=None):
     """
     Returns a list of all accounts for an identity.
 
     :param identity: The identity key name. For example x509 DN, or a username.
     :param id_type: The type of the authentication (x509, gss, userpass, ssh, saml).
+    :param session: The database session in use.
 
     returns: A list of all accounts for the identity.
     """
-    accounts = identity.list_accounts_for_identity(identity_key, IdentityType[id_type.upper()])
+    accounts = identity.list_accounts_for_identity(identity_key, IdentityType[id_type.upper()], session=session)
     return [account.external for account in accounts]

--- a/lib/rucio/api/importer.py
+++ b/lib/rucio/api/importer.py
@@ -18,21 +18,24 @@ from rucio.common import exception
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalAccount
 from rucio.core import importer
+from rucio.db.sqla.session import transactional_session
 
 
-def import_data(data, issuer, vo='def'):
+@transactional_session
+def import_data(data, issuer, vo='def', session=None):
     """
     Import data to add/update/delete records in Rucio.
 
     :param data: data to be imported.
     :param issuer: the issuer.
     :param vo: the VO of the issuer.
+    :param session: The database session in use.
     """
     kwargs = {'issuer': issuer}
     validate_schema(name='import', obj=data, vo=vo)
-    if not permission.has_permission(issuer=issuer, vo=vo, action='import', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='import', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not import data' % issuer)
 
     for account in data.get('accounts', []):
         account['account'] = InternalAccount(account['account'], vo=vo)
-    return importer.import_data(data, vo=vo)
+    return importer.import_data(data, vo=vo, session=session)

--- a/lib/rucio/api/meta.py
+++ b/lib/rucio/api/meta.py
@@ -16,30 +16,37 @@
 from rucio.api.permission import has_permission
 from rucio.common.exception import AccessDenied
 from rucio.core import meta
+from rucio.db.sqla.session import read_session, transactional_session
 
 
-def list_keys():
+@read_session
+def list_keys(session=None):
     """
     Lists all keys.
 
+    :param session: The database session in use.
+
     :returns: A list containing all keys.
     """
-    return meta.list_keys()
+    return meta.list_keys(session=session)
 
 
-def list_values(key):
+@read_session
+def list_values(key, session=None):
     """
     Lists all values for a key.
 
     :param key: the name for the key.
+    :param session: The database session in use.
 
 
     :returns: A list containing all values.
     """
-    return meta.list_values(key=key)
+    return meta.list_values(key=key, session=session)
 
 
-def add_key(key, key_type, issuer, value_type=None, value_regexp=None, vo='def'):
+@transactional_session
+def add_key(key, key_type, issuer, value_type=None, value_regexp=None, vo='def', session=None):
     """
     Add a new allowed key.
 
@@ -49,22 +56,25 @@ def add_key(key, key_type, issuer, value_type=None, value_regexp=None, vo='def')
     :param value_type: the type of the value, if defined.
     :param value_regexp: the regular expression that values should match, if defined.
     :param vo: The vo to act on
+    :param session: The database session in use.
     """
     kwargs = {'key': key, 'key_type': key_type, 'value_type': value_type, 'value_regexp': value_regexp}
-    if not has_permission(issuer=issuer, vo=vo, action='add_key', kwargs=kwargs):
+    if not has_permission(issuer=issuer, vo=vo, action='add_key', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not add key' % (issuer))
-    return meta.add_key(key=key, key_type=key_type, value_type=value_type, value_regexp=value_regexp)
+    return meta.add_key(key=key, key_type=key_type, value_type=value_type, value_regexp=value_regexp, session=session)
 
 
-def add_value(key, value, issuer, vo='def'):
+@transactional_session
+def add_value(key, value, issuer, vo='def', session=None):
     """
     Add a new value to a key.
 
     :param key: the name for the key.
     :param value: the value.
     :param vo: the vo to act on.
+    :param session: The database session in use.
     """
     kwargs = {'key': key, 'value': value}
-    if not has_permission(issuer=issuer, vo=vo, action='add_value', kwargs=kwargs):
+    if not has_permission(issuer=issuer, vo=vo, action='add_value', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not add value %s to key %s' % (issuer, value, key))
-    return meta.add_value(key=key, value=value)
+    return meta.add_value(key=key, value=value, session=session)

--- a/lib/rucio/api/permission.py
+++ b/lib/rucio/api/permission.py
@@ -18,8 +18,10 @@ from rucio.common.types import InternalAccount, InternalScope
 from rucio.core import permission
 from rucio.core.rse import get_rse_id
 from rucio.common.exception import RSENotFound
+from rucio.db.sqla.session import read_session
 
 
+@read_session
 def has_permission(issuer, action, kwargs, vo='def', session=None):
     """
     Checks if an account has the specified permission to

--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -39,7 +39,7 @@ def get_bad_replicas_summary(rse_expression=None, from_date=None, to_date=None, 
     :param session: The database session in use.
     """
     replicas = replica.get_bad_replicas_summary(rse_expression=rse_expression, from_date=from_date, to_date=to_date, filter_={'vo': vo}, session=session)
-    return [api_update_return_dict(r) for r in replicas]
+    return [api_update_return_dict(r, session=session) for r in replicas]
 
 
 @read_session
@@ -60,7 +60,7 @@ def list_bad_replicas_status(state=BadFilesStatus.BAD, rse=None, younger_than=No
 
     replicas = replica.list_bad_replicas_status(state=state, rse_id=rse_id, younger_than=younger_than,
                                                 older_than=older_than, limit=limit, list_pfns=list_pfns, vo=vo, session=session)
-    return [api_update_return_dict(r) for r in replicas]
+    return [api_update_return_dict(r, session=session) for r in replicas]
 
 
 @transactional_session
@@ -386,7 +386,7 @@ def list_dataset_replicas_vp(scope, name, deep=False, vo='def', session=None):
 
     scope = InternalScope(scope, vo=vo)
     for r in replica.list_dataset_replicas_vp(scope=scope, name=name, deep=deep, session=session):
-        yield api_update_return_dict(r)
+        yield api_update_return_dict(r, session=session)
 
 
 @stream_session

--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -20,12 +20,14 @@ from rucio.common.utils import api_update_return_dict
 from rucio.core import distance as distance_module
 from rucio.core import rse as rse_module
 from rucio.core.rse_expression_parser import parse_expression
+from rucio.db.sqla.session import read_session, stream_session, transactional_session
 
 
+@transactional_session
 def add_rse(rse, issuer, vo='def', deterministic=True, volatile=False, city=None, region_code=None,
             country_name=None, continent=None, time_zone=None, ISP=None,
             staging_area=False, rse_type=None, latitude=None, longitude=None, ASN=None,
-            availability=None):
+            availability=None, session=None):
     """
     Creates a new Rucio Storage Element(RSE).
 
@@ -46,57 +48,64 @@ def add_rse(rse, issuer, vo='def', deterministic=True, volatile=False, city=None
     :param longitude: Longitude coordinate of RSE.
     :param ASN: Access service network.
     :param availability: Availability.
+    :param session: The database session in use.
     """
     validate_schema(name='rse', obj=rse, vo=vo)
     kwargs = {'rse': rse}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_rse', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='add_rse', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not add RSE' % (issuer))
 
     return rse_module.add_rse(rse, vo=vo, deterministic=deterministic, volatile=volatile, city=city,
                               region_code=region_code, country_name=country_name, staging_area=staging_area,
                               continent=continent, time_zone=time_zone, ISP=ISP, rse_type=rse_type, latitude=latitude,
-                              longitude=longitude, ASN=ASN, availability=availability)
+                              longitude=longitude, ASN=ASN, availability=availability, session=session)
 
 
-def get_rse(rse, vo='def'):
+@read_session
+def get_rse(rse, vo='def', session=None):
     """
     Provides details about the specified RSE.
 
     :param rse: The RSE name.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: a dict with details about the RSE
 
     :raises RSENotFound: if the referred RSE was not found in the database
     """
 
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
-    return rse_module.get_rse_protocols(rse_id=rse_id)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
+    return rse_module.get_rse_protocols(rse_id=rse_id, session=session)
 
 
-def del_rse(rse, issuer, vo='def'):
+@transactional_session
+def del_rse(rse, issuer, vo='def', session=None):
     """
     Disables an RSE with the provided RSE name.
 
     :param rse: The RSE name.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='del_rse', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='del_rse', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not delete RSE' % (issuer))
 
-    return rse_module.del_rse(rse_id)
+    return rse_module.del_rse(rse_id, session=session)
 
 
-def list_rses(filters={}, vo='def'):
+@read_session
+def list_rses(filters={}, vo='def', session=None):
     """
     Lists all RSEs.
 
     :param filters: dictionary of attributes by which the results should be filtered.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: List of all RSEs.
     """
@@ -105,30 +114,33 @@ def list_rses(filters={}, vo='def'):
 
     filters['vo'] = vo
 
-    return rse_module.list_rses(filters=filters)
+    return rse_module.list_rses(filters=filters, session=session)
 
 
-def del_rse_attribute(rse, key, issuer, vo='def'):
+@transactional_session
+def del_rse_attribute(rse, key, issuer, vo='def', session=None):
     """
     Delete a RSE attribute.
 
     :param rse: the name of the rse_module.
     :param key: the attribute key.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :return: True if RSE attribute was deleted successfully, False otherwise.
     """
 
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id, 'key': key}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='del_rse_attribute', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='del_rse_attribute', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not delete RSE attributes' % (issuer))
 
-    return rse_module.del_rse_attribute(rse_id=rse_id, key=key)
+    return rse_module.del_rse_attribute(rse_id=rse_id, key=key, session=session)
 
 
-def add_rse_attribute(rse, key, value, issuer, vo='def'):
+@transactional_session
+def add_rse_attribute(rse, key, value, issuer, vo='def', session=None):
     """ Adds a RSE attribute.
 
     :param rse: the rse name.
@@ -136,56 +148,64 @@ def add_rse_attribute(rse, key, value, issuer, vo='def'):
     :param value: the value name.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     returns: True if successful, False otherwise.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id, 'key': key, 'value': value}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_rse_attribute', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='add_rse_attribute', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not add RSE attributes' % (issuer))
 
-    return rse_module.add_rse_attribute(rse_id=rse_id, key=key, value=value)
+    return rse_module.add_rse_attribute(rse_id=rse_id, key=key, value=value, session=session)
 
 
-def list_rse_attributes(rse, vo='def'):
+@read_session
+def list_rse_attributes(rse, vo='def', session=None):
     """
     List RSE attributes for a RSE_MODULE.
 
     :param rse: The RSE name.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: List of all RSE attributes for a RSE_MODULE.
     """
 
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
-    return rse_module.list_rse_attributes(rse_id=rse_id)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
+    return rse_module.list_rse_attributes(rse_id=rse_id, session=session)
 
 
-def has_rse_attribute(rse_id, key):
+@read_session
+def has_rse_attribute(rse_id, key, session=None):
     """
     Indicates whether the named key is present for the RSE.
 
     :param rse_id: The RSE id.
     :param key: The key for the attribute.
+    :param session: The database session in use.
 
     :returns: True or False
     """
-    return rse_module.has_rse_attribute(rse_id=rse_id, key=key)
+    return rse_module.has_rse_attribute(rse_id=rse_id, key=key, session=session)
 
 
-def get_rses_with_attribute(key):
+@read_session
+def get_rses_with_attribute(key, session=None):
     """
     Return all RSEs with a certain attribute.
 
     :param key: The key for the attribute.
+    :param session: The database session in use.
 
     :returns: List of rse dictionaries
     """
-    return rse_module.get_rses_with_attribute(key=key)
+    return rse_module.get_rses_with_attribute(key=key, session=session)
 
 
-def add_protocol(rse, issuer, vo='def', **data):
+@transactional_session
+def add_protocol(rse, issuer, vo='def', session=None, **data):
     """
     Creates a new protocol entry for an existing RSE.
 
@@ -193,30 +213,34 @@ def add_protocol(rse, issuer, vo='def', **data):
     :param issuer: The issuer account.
     :param vo: The VO to act on.
     :param data: Parameters (protocol identifier, port, hostname, ...) provided by the request.
+    :param session: The database session in use.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_protocol', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='add_protocol', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not add protocols to RSE %s' % (issuer, rse))
-    rse_module.add_protocol(rse_id, data['data'])
+    rse_module.add_protocol(rse_id, data['data'], session=session)
 
 
-def get_rse_protocols(rse, issuer, vo='def'):
+@read_session
+def get_rse_protocols(rse, issuer, vo='def', session=None):
     """
     Returns all matching protocols (including detailed information) for the given RSE.
 
     :param rse: The RSE name.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: A dict with all supported protocols and their attibutes.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
-    return rse_module.get_rse_protocols(rse_id)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
+    return rse_module.get_rse_protocols(rse_id, session=session)
 
 
-def del_protocols(rse, scheme, issuer, vo='def', hostname=None, port=None):
+@transactional_session
+def del_protocols(rse, scheme, issuer, vo='def', hostname=None, port=None, session=None):
     """
     Deletes all matching protocol entries for the given RSE..
 
@@ -228,15 +252,17 @@ def del_protocols(rse, scheme, issuer, vo='def', hostname=None, port=None):
                      same identifier are present)
     :param port: The port (to be used if more than one protocol using the same
                  identifier and hostname are present)
+    :param session: The database session in use.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='del_protocol', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='del_protocol', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not delete protocols from RSE %s' % (issuer, rse))
-    rse_module.del_protocols(rse_id=rse_id, scheme=scheme, hostname=hostname, port=port)
+    rse_module.del_protocols(rse_id=rse_id, scheme=scheme, hostname=hostname, port=port, session=session)
 
 
-def update_protocols(rse, scheme, data, issuer, vo='def', hostname=None, port=None):
+@transactional_session
+def update_protocols(rse, scheme, data, issuer, vo='def', hostname=None, port=None, session=None):
     """
     Updates all provided attributes for all matching protocol entries of the given RSE..
 
@@ -247,15 +273,17 @@ def update_protocols(rse, scheme, data, issuer, vo='def', hostname=None, port=No
     :param data: A dict including the attributes of the protocol to be updated. Keys must match the column names in the database.
     :param hostname: The hostname (to be used if more then one protocol using the same identifier are present)
     :param port: The port (to be used if more than one protocol using the same identifier and hostname are present)
+    :param session: The database session in use.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='update_protocol', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='update_protocol', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not update protocols from RSE %s' % (issuer, rse))
-    rse_module.update_protocols(rse_id=rse_id, scheme=scheme, hostname=hostname, port=port, data=data)
+    rse_module.update_protocols(rse_id=rse_id, scheme=scheme, hostname=hostname, port=port, data=data, session=session)
 
 
-def set_rse_usage(rse, source, used, free, issuer, files=None, vo='def'):
+@transactional_session
+def set_rse_usage(rse, source, used, free, issuer, files=None, vo='def', session=None):
     """
     Set RSE usage information.
 
@@ -266,19 +294,21 @@ def set_rse_usage(rse, source, used, free, issuer, files=None, vo='def'):
     :param issuer: The issuer account.
     :param files: the number of files
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: True if successful, otherwise false.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='set_rse_usage', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='set_rse_usage', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not update RSE usage information for RSE %s' % (issuer, rse))
 
-    return rse_module.set_rse_usage(rse_id=rse_id, source=source, used=used, free=free, files=files)
+    return rse_module.set_rse_usage(rse_id=rse_id, source=source, used=used, free=free, files=files, session=session)
 
 
-def get_rse_usage(rse, issuer, source=None, per_account=False, vo='def'):
+@read_session
+def get_rse_usage(rse, issuer, source=None, per_account=False, vo='def', session=None):
     """
     get RSE usage information.
 
@@ -286,20 +316,22 @@ def get_rse_usage(rse, issuer, source=None, per_account=False, vo='def'):
     :param issuer: The issuer account.
     :param source: dictionary of attributes by which the results should be filtered
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: List of RSE usage data.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
-    usages = rse_module.get_rse_usage(rse_id=rse_id, source=source, per_account=per_account)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
+    usages = rse_module.get_rse_usage(rse_id=rse_id, source=source, per_account=per_account, session=session)
 
     for u in usages:
         if 'account_usages' in u:
             for account_usage in u['account_usages']:
                 account_usage['account'] = account_usage['account'].external
-    return [api_update_return_dict(u) for u in usages]
+    return [api_update_return_dict(u, session=session) for u in usages]
 
 
-def list_rse_usage_history(rse, issuer, source=None, vo='def'):
+@stream_session
+def list_rse_usage_history(rse, issuer, source=None, vo='def', session=None):
     """
     List RSE usage history information.
 
@@ -307,15 +339,17 @@ def list_rse_usage_history(rse, issuer, source=None, vo='def'):
     :param issuer: The issuer account.
     :param source: The source of the usage information (srm, rucio).
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: A list of historic RSE usage.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
-    for u in rse_module.list_rse_usage_history(rse_id=rse_id, source=source):
-        yield api_update_return_dict(u)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
+    for u in rse_module.list_rse_usage_history(rse_id=rse_id, source=source, session=session):
+        yield api_update_return_dict(u, session=session)
 
 
-def set_rse_limits(rse, name, value, issuer, vo='def'):
+@transactional_session
+def set_rse_limits(rse, name, value, issuer, vo='def', session=None):
     """
     Set RSE limits.
 
@@ -324,18 +358,20 @@ def set_rse_limits(rse, name, value, issuer, vo='def'):
     :param value: The feature value.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: True if successful, otherwise false.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='set_rse_limits', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='set_rse_limits', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not update RSE limits for RSE %s' % (issuer, rse))
 
-    return rse_module.set_rse_limits(rse_id=rse_id, name=name, value=value)
+    return rse_module.set_rse_limits(rse_id=rse_id, name=name, value=value, session=session)
 
 
-def delete_rse_limits(rse, name, issuer, vo='def'):
+@transactional_session
+def delete_rse_limits(rse, name, issuer, vo='def', session=None):
     """
     Set RSE limits.
 
@@ -343,46 +379,52 @@ def delete_rse_limits(rse, name, issuer, vo='def'):
     :param name: The name of the limit.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: True if successful, otherwise false.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='delete_rse_limits', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='delete_rse_limits', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not update RSE limits for RSE %s' % (issuer, rse))
 
-    return rse_module.delete_rse_limits(rse_id=rse_id, name=name)
+    return rse_module.delete_rse_limits(rse_id=rse_id, name=name, session=session)
 
 
-def get_rse_limits(rse, issuer, vo='def'):
+@read_session
+def get_rse_limits(rse, issuer, vo='def', session=None):
     """
     Get RSE limits.
 
     :param rse: The RSE name.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: True if successful, otherwise false.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
-    return rse_module.get_rse_limits(rse_id=rse_id)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
+    return rse_module.get_rse_limits(rse_id=rse_id, session=session)
 
 
-def parse_rse_expression(rse_expression, vo='def'):
+@transactional_session
+def parse_rse_expression(rse_expression, vo='def', session=None):
     """
     Parse an RSE expression and return the list of RSEs.
 
     :param rse_expression:  The RSE expression.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns:  List of RSEs
     :raises:   InvalidRSEExpression
     """
-    rses = parse_expression(rse_expression, filter_={'vo': vo})
+    rses = parse_expression(rse_expression, filter_={'vo': vo}, session=session)
     return [rse['rse'] for rse in rses]
 
 
-def update_rse(rse, parameters, issuer, vo='def'):
+@transactional_session
+def update_rse(rse, parameters, issuer, vo='def', session=None):
     """
     Update RSE properties like availability or name.
 
@@ -390,19 +432,21 @@ def update_rse(rse, parameters, issuer, vo='def'):
     :param parameters: A dictionnary with property (name, read, write, delete as keys).
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :raises RSENotFound: If RSE is not found.
     """
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='update_rse', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='update_rse', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not update RSE' % (issuer))
-    return rse_module.update_rse(rse_id=rse_id, parameters=parameters)
+    return rse_module.update_rse(rse_id=rse_id, parameters=parameters, session=session)
 
 
+@transactional_session
 def add_distance(source, destination, issuer, vo='def', ranking=None, distance=None,
                  geoip_distance=None, active=None, submitted=None, finished=None,
-                 failed=None, transfer_speed=None):
+                 failed=None, transfer_speed=None, session=None):
     """
     Add a src-dest distance.
 
@@ -418,23 +462,25 @@ def add_distance(source, destination, issuer, vo='def', ranking=None, distance=N
     :param finished: Finished FTS transfers as an integer.
     :param failed: Failed FTS transfers as an integer.
     :param transfer_speed: FTS transfer speed as an integer.
+    :param session: The database session in use.
     """
     kwargs = {'source': source, 'destination': destination}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_distance', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='add_distance', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not add RSE distances' % (issuer))
     try:
-        return distance_module.add_distance(src_rse_id=rse_module.get_rse_id(source, vo=vo),
-                                            dest_rse_id=rse_module.get_rse_id(destination, vo=vo),
+        return distance_module.add_distance(src_rse_id=rse_module.get_rse_id(source, vo=vo, session=session),
+                                            dest_rse_id=rse_module.get_rse_id(destination, vo=vo, session=session),
                                             ranking=ranking, agis_distance=distance,
                                             geoip_distance=geoip_distance, active=active,
                                             submitted=submitted, finished=finished,
-                                            failed=failed, transfer_speed=transfer_speed)
+                                            failed=failed, transfer_speed=transfer_speed, session=session)
     except exception.Duplicate:
         # use source and destination RSE names
         raise exception.Duplicate('Distance from %s to %s already exists!' % (source, destination))
 
 
-def update_distance(source, destination, parameters, issuer, vo='def'):
+@transactional_session
+def update_distance(source, destination, parameters, issuer, vo='def', session=None):
     """
     Update distances with the given RSE ids.
 
@@ -444,20 +490,22 @@ def update_distance(source, destination, parameters, issuer, vo='def'):
     :param session: The database session to use.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     kwargs = {'source': source, 'destination': destination}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='update_distance', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='update_distance', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not update RSE distances' % (issuer))
     if 'distance' in parameters:
         parameters['agis_distance'] = parameters['distance']
         parameters.pop('distance', None)
 
-    return distance_module.update_distances(src_rse_id=rse_module.get_rse_id(source, vo=vo),
-                                            dest_rse_id=rse_module.get_rse_id(destination, vo=vo),
-                                            parameters=parameters)
+    return distance_module.update_distances(src_rse_id=rse_module.get_rse_id(source, vo=vo, session=session),
+                                            dest_rse_id=rse_module.get_rse_id(destination, vo=vo, session=session),
+                                            parameters=parameters, session=session)
 
 
-def get_distance(source, destination, issuer, vo='def'):
+@read_session
+def get_distance(source, destination, issuer, vo='def', session=None):
     """
     Get distances between rses.
 
@@ -465,16 +513,19 @@ def get_distance(source, destination, issuer, vo='def'):
     :param destination: The destination RSE.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns distance: List of dictionaries.
     """
-    distances = distance_module.get_distances(src_rse_id=rse_module.get_rse_id(source, vo=vo),
-                                              dest_rse_id=rse_module.get_rse_id(destination, vo=vo))
+    distances = distance_module.get_distances(src_rse_id=rse_module.get_rse_id(source, vo=vo, session=session),
+                                              dest_rse_id=rse_module.get_rse_id(destination, vo=vo, session=session),
+                                              session=session)
 
-    return [api_update_return_dict(d) for d in distances]
+    return [api_update_return_dict(d, session=session) for d in distances]
 
 
-def delete_distance(source, destination, issuer, vo='def'):
+@transactional_session
+def delete_distance(source, destination, issuer, vo='def', session=None):
     """
     Delete distances with the given RSE ids.
 
@@ -482,16 +533,19 @@ def delete_distance(source, destination, issuer, vo='def'):
     :param destination: The destination RSE.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     kwargs = {'source': source, 'destination': destination}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='delete_distance', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, vo=vo, action='delete_distance', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not update RSE distances' % issuer)
 
-    return distance_module.delete_distances(src_rse_id=rse_module.get_rse_id(source, vo=vo),
-                                            dest_rse_id=rse_module.get_rse_id(destination, vo=vo))
+    return distance_module.delete_distances(src_rse_id=rse_module.get_rse_id(source, vo=vo, session=session),
+                                            dest_rse_id=rse_module.get_rse_id(destination, vo=vo, session=session),
+                                            session=session)
 
 
-def add_qos_policy(rse, qos_policy, issuer, vo='def'):
+@transactional_session
+def add_qos_policy(rse, qos_policy, issuer, vo='def', session=None):
     """
     Add a QoS policy from an RSE.
 
@@ -499,20 +553,22 @@ def add_qos_policy(rse, qos_policy, issuer, vo='def'):
     :param qos_policy: The QoS policy to add.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :raises Duplicate: If the QoS policy already exists.
     :returns: True if successful, except otherwise.
     """
 
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, action='add_qos_policy', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, action='add_qos_policy', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s cannot add QoS policies to RSE %s' % (issuer, rse))
 
-    return rse_module.add_qos_policy(rse_id, qos_policy)
+    return rse_module.add_qos_policy(rse_id, qos_policy, session=session)
 
 
-def delete_qos_policy(rse, qos_policy, issuer, vo='def'):
+@transactional_session
+def delete_qos_policy(rse, qos_policy, issuer, vo='def', session=None):
     """
     Delete a QoS policy from an RSE.
 
@@ -520,28 +576,31 @@ def delete_qos_policy(rse, qos_policy, issuer, vo='def'):
     :param qos_policy: The QoS policy to delete.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: True if successful, silent failure if QoS policy does not exist.
     """
 
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse_id': rse}
-    if not permission.has_permission(issuer=issuer, action='delete_qos_policy', kwargs=kwargs):
+    if not permission.has_permission(issuer=issuer, action='delete_qos_policy', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s cannot delete QoS policies from RSE %s' % (issuer, rse))
 
-    return rse_module.delete_qos_policy(rse_id, qos_policy)
+    return rse_module.delete_qos_policy(rse_id, qos_policy, session=session)
 
 
-def list_qos_policies(rse, issuer, vo='def'):
+@read_session
+def list_qos_policies(rse, issuer, vo='def', session=None):
     """
     List all QoS policies of an RSE.
 
     :param rse: The id of the RSE.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
 
     :returns: List containing all QoS policies.
     """
 
-    rse_id = rse_module.get_rse_id(rse=rse, vo=vo)
-    return rse_module.list_qos_policies(rse_id)
+    rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
+    return rse_module.list_qos_policies(rse_id, session=session)

--- a/lib/rucio/api/subscription.py
+++ b/lib/rucio/api/subscription.py
@@ -21,12 +21,14 @@ from rucio.common.exception import InvalidObject, AccessDenied
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core import subscription
+from rucio.db.sqla.session import read_session, stream_session, transactional_session
 
 
 SubscriptionRuleState = namedtuple('SubscriptionRuleState', ['account', 'name', 'state', 'count'])
 
 
-def add_subscription(name, account, filter_, replication_rules, comments, lifetime, retroactive, dry_run, priority=None, issuer=None, vo='def'):
+@transactional_session
+def add_subscription(name, account, filter_, replication_rules, comments, lifetime, retroactive, dry_run, priority=None, issuer=None, vo='def', session=None):
     """
     Adds a new subscription which will be verified against every new added file and dataset
 
@@ -53,10 +55,11 @@ def add_subscription(name, account, filter_, replication_rules, comments, lifeti
     :type issuer:  String
     :param vo: The VO to act on.
     :type vo: String
+    :param session: The database session in use.
     :returns: subscription_id
     :rtype:   String
     """
-    if not has_permission(issuer=issuer, vo=vo, action='add_subscription', kwargs={'account': account}):
+    if not has_permission(issuer=issuer, vo=vo, action='add_subscription', kwargs={'account': account}, session=session):
         raise AccessDenied('Account %s can not add subscription' % (issuer))
     try:
         if filter_:
@@ -85,10 +88,13 @@ def add_subscription(name, account, filter_, replication_rules, comments, lifeti
             else:
                 filter_[_key] = _type(filter_[_key], vo=vo).internal
 
-    return subscription.add_subscription(name=name, account=account, filter_=dumps(filter_), replication_rules=dumps(replication_rules), comments=comments, lifetime=lifetime, retroactive=retroactive, dry_run=dry_run, priority=priority)
+    return subscription.add_subscription(name=name, account=account, filter_=dumps(filter_), replication_rules=dumps(replication_rules),
+                                         comments=comments, lifetime=lifetime, retroactive=retroactive, dry_run=dry_run, priority=priority,
+                                         session=session)
 
 
-def update_subscription(name, account, metadata=None, issuer=None, vo='def'):
+@transactional_session
+def update_subscription(name, account, metadata=None, issuer=None, vo='def', session=None):
     """
     Updates a subscription
 
@@ -102,9 +108,10 @@ def update_subscription(name, account, metadata=None, issuer=None, vo='def'):
     :type issuer: String
     :param vo: The VO to act on.
     :type vo: String
+    :param session: The database session in use.
     :raises: SubscriptionNotFound if subscription is not found
     """
-    if not has_permission(issuer=issuer, vo=vo, action='update_subscription', kwargs={'account': account}):
+    if not has_permission(issuer=issuer, vo=vo, action='update_subscription', kwargs={'account': account}, session=session):
         raise AccessDenied('Account %s can not update subscription' % (issuer))
     try:
         if not isinstance(metadata, dict):
@@ -136,10 +143,11 @@ def update_subscription(name, account, metadata=None, issuer=None, vo='def'):
                 else:
                     filter_[_key] = _type(filter_[_key], vo=vo).internal
 
-    return subscription.update_subscription(name=name, account=account, metadata=metadata)
+    return subscription.update_subscription(name=name, account=account, metadata=metadata, session=session)
 
 
-def list_subscriptions(name=None, account=None, state=None, vo='def'):
+@stream_session
+def list_subscriptions(name=None, account=None, state=None, vo='def', session=None):
     """
     Returns a dictionary with the subscription information :
     Examples: ``{'status': 'INACTIVE/ACTIVE/BROKEN', 'last_modified_date': ...}``
@@ -152,6 +160,7 @@ def list_subscriptions(name=None, account=None, state=None, vo='def'):
     :type state: String
     :param vo: The VO to act on.
     :type vo: String
+    :param session: The database session in use.
     :returns: Dictionary containing subscription parameter
     :rtype:   Dict
     :raises: exception.NotFound if subscription is not found
@@ -162,7 +171,7 @@ def list_subscriptions(name=None, account=None, state=None, vo='def'):
     else:
         account = InternalAccount('*', vo=vo)
 
-    subs = subscription.list_subscriptions(name, account, state)
+    subs = subscription.list_subscriptions(name, account, state, session=session)
 
     for sub in subs:
         sub['account'] = sub['account'].external
@@ -178,19 +187,21 @@ def list_subscriptions(name=None, account=None, state=None, vo='def'):
         yield sub
 
 
-def list_subscription_rule_states(name=None, account=None, vo='def'):
+@stream_session
+def list_subscription_rule_states(name=None, account=None, vo='def', session=None):
     """Returns a list of with the number of rules per state for a subscription.
 
     :param name: Name of the subscription
     :param account: Account identifier
     :param vo: The VO to act on.
+    :param session: The database session in use.
     :returns: Sequence with SubscriptionRuleState named tuples (account, name, state, count)
     """
     if account is not None:
         account = InternalAccount(account, vo=vo)
     else:
         account = InternalAccount('*', vo=vo)
-    subs = subscription.list_subscription_rule_states(name, account)
+    subs = subscription.list_subscription_rule_states(name, account, session=session)
     for sub in subs:
         # sub is an immutable Row so return new named tuple with edited entries
         d = sub._asdict()
@@ -198,28 +209,32 @@ def list_subscription_rule_states(name=None, account=None, vo='def'):
         yield SubscriptionRuleState(**d)
 
 
-def delete_subscription(subscription_id, vo='def'):
+@transactional_session
+def delete_subscription(subscription_id, vo='def', session=None):
     """
     Deletes a subscription
 
     :param subscription_id: Subscription identifier
     :param vo: The VO of the user issuing command
+    :param session: The database session in use.
     :type subscription_id:  String
     """
 
     raise NotImplementedError
 
 
-def get_subscription_by_id(subscription_id, vo='def'):
+@read_session
+def get_subscription_by_id(subscription_id, vo='def', session=None):
     """
     Get a specific subscription by id.
 
     :param subscription_id: The subscription_id to select.
     :param vo: The VO of the user issuing command.
+    :param session: The database session in use.
 
     :raises: SubscriptionNotFound if no Subscription can be found.
     """
-    sub = subscription.get_subscription_by_id(subscription_id)
+    sub = subscription.get_subscription_by_id(subscription_id, session=session)
     if sub['account'].vo != vo:
         raise AccessDenied('Unable to get subscription')
 

--- a/lib/rucio/api/temporary_did.py
+++ b/lib/rucio/api/temporary_did.py
@@ -16,21 +16,24 @@
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core import temporary_did
 from rucio.core.rse import get_rse_id
+from rucio.db.sqla.session import transactional_session
 
 
-def add_temporary_dids(dids, issuer, vo='def'):
+@transactional_session
+def add_temporary_dids(dids, issuer, vo='def', session=None):
     """
     Bulk add temporary data identifiers.
 
     :param dids: A list of dids.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
+    :param session: The database session in use.
     """
     for did in dids:
         if 'rse' in did and 'rse_id' not in did:
             rse_id = None
             if did['rse'] is not None:
-                rse_id = get_rse_id(rse=did['rse'], vo=vo)
+                rse_id = get_rse_id(rse=did['rse'], vo=vo, session=session)
             did['rse_id'] = rse_id
         if 'scope' in did:
             did['scope'] = InternalScope(did['scope'], vo=vo)
@@ -38,4 +41,4 @@ def add_temporary_dids(dids, issuer, vo='def'):
             did['parent_scope'] = InternalScope(did['parent_scope'], vo=vo)
 
     issuer = InternalAccount(issuer, vo=vo)
-    return temporary_did.add_temporary_dids(dids=dids, account=issuer)
+    return temporary_did.add_temporary_dids(dids=dids, account=issuer, session=session)

--- a/lib/rucio/api/vo.py
+++ b/lib/rucio/api/vo.py
@@ -20,9 +20,11 @@ from rucio.common.types import InternalAccount
 from rucio.core import identity
 from rucio.core import vo as vo_core
 from rucio.db.sqla.constants import IdentityType
+from rucio.db.sqla.session import read_session, transactional_session
 
 
-def add_vo(new_vo, issuer, description=None, email=None, vo='def'):
+@transactional_session
+def add_vo(new_vo, issuer, description=None, email=None, vo='def', session=None):
     '''
     Add a new VO.
 
@@ -31,33 +33,37 @@ def add_vo(new_vo, issuer, description=None, email=None, vo='def'):
     :param email: A contact for the VO.
     :param issuer: The user issuing the command.
     :param vo: The vo of the user issuing the command.
+    :param session: The database session in use.
     '''
 
     new_vo = vo_core.map_vo(new_vo)
     validate_schema('vo', new_vo, vo=vo)
 
     kwargs = {}
-    if not has_permission(issuer=issuer, action='add_vo', kwargs=kwargs, vo=vo):
+    if not has_permission(issuer=issuer, action='add_vo', kwargs=kwargs, vo=vo, session=session):
         raise exception.AccessDenied('Account {} cannot add a VO'.format(issuer))
 
-    vo_core.add_vo(vo=new_vo, description=description, email=email)
+    vo_core.add_vo(vo=new_vo, description=description, email=email, session=session)
 
 
-def list_vos(issuer, vo='def'):
+@read_session
+def list_vos(issuer, vo='def', session=None):
     '''
     List the VOs.
 
     :param issuer: The user issuing the command.
     :param vo: The vo of the user issuing the command.
+    :param session: The database session in use.
     '''
     kwargs = {}
-    if not has_permission(issuer=issuer, action='list_vos', kwargs=kwargs, vo=vo):
+    if not has_permission(issuer=issuer, action='list_vos', kwargs=kwargs, vo=vo, session=session):
         raise exception.AccessDenied('Account {} cannot list VOs'.format(issuer))
 
-    return vo_core.list_vos()
+    return vo_core.list_vos(session=session)
 
 
-def recover_vo_root_identity(root_vo, identity_key, id_type, email, issuer, default=False, password=None, vo='def'):
+@transactional_session
+def recover_vo_root_identity(root_vo, identity_key, id_type, email, issuer, default=False, password=None, vo='def', session=None):
     """
     Adds a membership association between identity and the root account for given VO.
 
@@ -69,18 +75,21 @@ def recover_vo_root_identity(root_vo, identity_key, id_type, email, issuer, defa
     :param default: If True, the account should be used by default with the provided identity.
     :param password: Password if id_type is userpass.
     :param vo: the VO to act on.
+    :param session: The database session in use.
     """
     kwargs = {}
     root_vo = vo_core.map_vo(root_vo)
-    if not has_permission(issuer=issuer, vo=vo, action='recover_vo_root_identity', kwargs=kwargs):
+    if not has_permission(issuer=issuer, vo=vo, action='recover_vo_root_identity', kwargs=kwargs, session=session):
         raise exception.AccessDenied('Account %s can not recover root identity' % (issuer))
 
     account = InternalAccount('root', vo=root_vo)
 
-    return identity.add_account_identity(identity=identity_key, type_=IdentityType[id_type.upper()], default=default, email=email, account=account, password=password)
+    return identity.add_account_identity(identity=identity_key, type_=IdentityType[id_type.upper()], default=default,
+                                         email=email, account=account, password=password, session=session)
 
 
-def update_vo(updated_vo, parameters, issuer, vo='def'):
+@transactional_session
+def update_vo(updated_vo, parameters, issuer, vo='def', session=None):
     """
     Update VO properties (email, description).
 
@@ -88,10 +97,11 @@ def update_vo(updated_vo, parameters, issuer, vo='def'):
     :param parameters: A dictionary with the new properties.
     :param issuer: The user issuing the command.
     :param vo: The VO of the user issusing the command.
+    :param session: The database session in use.
     """
     kwargs = {}
     updated_vo = vo_core.map_vo(updated_vo)
-    if not has_permission(issuer=issuer, action='update_vo', kwargs=kwargs, vo=vo):
+    if not has_permission(issuer=issuer, action='update_vo', kwargs=kwargs, vo=vo, session=session):
         raise exception.AccessDenied('Account {} cannot update VO'.format(issuer))
 
-    return vo_core.update_vo(vo=updated_vo, parameters=parameters)
+    return vo_core.update_vo(vo=updated_vo, parameters=parameters, session=session)


### PR DESCRIPTION
Ensure that all API endpoints only initialize/destroy
the session object once. Some API endpoints (did/rules/...)
were already updated in the past. This proved to heavily
reduce the number of spurious rollbacks on the database
side.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
