### PR TITLE
Clean-up unneeded RSEs + Start introducing rse_factory in tests : Closes #5499

### DIFF
--- a/etc/rse_repository.json
+++ b/etc/rse_repository.json
@@ -302,60 +302,6 @@
     },
     "storage_usage_tool": "rucio.rse.protocols.posix.Default.getSpace"
   },
-  "MOCK_SUSPICIOUS":{
-    "backend_type": "POSIX",
-    "deterministic": true,
-    "protocols": {
-      "default": "file",
-      "supported": {
-        "file": {
-          "prefix": "/tmp/rucio_rse1/",
-          "impl": "rucio.rse.protocols.posix.Default",
-          "extended_attributes": {"web_service_path": "/srm/managerv2?SFN=", "space_token": "ATLASDATADISK1"},
-          "domains": {
-            "lan": {
-              "read": 1,
-              "write": 1,
-              "delete": 1
-            },
-            "wan": {
-              "read": 1,
-              "write": 1,
-              "delete": 1
-            }
-          }
-        }
-      }
-    },
-    "storage_usage_tool": "rucio.rse.protocols.posix.Default.getSpace"
-  },
-  "MOCK_RECOVERY":{
-    "backend_type": "POSIX",
-    "deterministic": true,
-    "protocols": {
-      "default": "file",
-      "supported": {
-        "file": {
-          "prefix": "/tmp/rucio_rse2/",
-          "impl": "rucio.rse.protocols.posix.Default",
-          "extended_attributes": {"web_service_path": "/srm/managerv2?SFN=", "space_token": "ATLASDATADISK2"},
-          "domains": {
-            "lan": {
-              "read": 1,
-              "write": 1,
-              "delete": 1
-            },
-            "wan": {
-              "read": 1,
-              "write": 1,
-              "delete": 1
-            }
-          }
-        }
-      }
-    },
-    "storage_usage_tool": "rucio.rse.protocols.posix.Default.getSpace"
-  },
   "FZK-LCG2_SCRATCHDISK":{
     "backend_type": "dCache",
     "protocols": {
@@ -402,35 +348,6 @@
     },
     "storage_usage_tool": "rucio.rse.protocols.webdav.Default.getSpace"
   },
-  "CERN-PROD_TZERO":{
-    "backend_type": "Castor",
-    "deterministic": false,
-    "protocols": {
-      "default": "castor",
-      "supported": {
-        "rfio": {
-          "impl": "rucio.rse.protocols.rfio.Default",
-          "hostname": "castoratlas.cern.ch.mock",
-          "port": 9002,
-          "prefix": "/castor/cern.ch/grid/atlas/tzero/",
-          "domains": {
-            "lan": {
-              "read": 1,
-              "write": 1,
-              "delete": 1
-            },
-            "wan": {
-              "read": 1,
-              "write": 1,
-              "delete": 1
-            }
-          },
-          "extended_attributes": "{'The One After the Port': '/srm/managerv2'}"
-        }
-      }
-    },
-    "storage_usage_tool": "rucio.rse.protocols.webdav.Default.getSpace"
-  },
   "WJ-XROOTD":{
     "backend_type": "XROOTD",
     "deterministic": true,
@@ -459,7 +376,7 @@
     },
     "storage_usage_tool": "rucio.rse.protocols.xrootd.Default.getSpace"
   },
-  "SSH_DISK":{
+  "SSH-DISK":{
     "backend_type": "SSH",
     "deterministic": true,
     "protocols": {

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -132,7 +132,7 @@ class TemporaryRSEFactory:
                 'scheme': scheme,
                 'hostname': '%s.cern.ch' % rse_id,
                 'port': 0,
-                'prefix': '/test/',
+                'prefix': '/test_%s/' % rse_id,
                 'impl': protocol_impl,
                 'domains': {
                     'wan': {
@@ -141,6 +141,11 @@ class TemporaryRSEFactory:
                         'delete': 1,
                         'third_party_copy_read': 1,
                         'third_party_copy_write': 1,
+                    },
+                    'lan': {
+                        'read': 1,
+                        'write': 1,
+                        'delete': 1,
                     }
                 }
             }
@@ -156,7 +161,7 @@ class TemporaryRSEFactory:
         return self._make_rse(scheme='file', protocol_impl='rucio.rse.protocols.posix.Default', add_rse_kwargs=kwargs)
 
     def make_mock_rse(self, **kwargs):
-        return self._make_rse(scheme='MOCK', protocol_impl='rucio.rse.protocols.mock.Default', add_rse_kwargs=kwargs)
+        return self._make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.mock.Default', add_rse_kwargs=kwargs)
 
     def make_xroot_rse(self, **kwargs):
         return self._make_rse(scheme='root', protocol_impl='rucio.rse.protocols.xrootd.Default', add_rse_kwargs=kwargs)

--- a/lib/rucio/tests/test_bad_replica.py
+++ b/lib/rucio/tests/test_bad_replica.py
@@ -70,7 +70,7 @@ def test_add_list_bad_replicas(rse_factory, mock_scope, root_account):
     # Adding replicas to non-deterministic RSE
     _, rse2_id = rse_factory.make_srm_rse(deterministic=False)
     files = [{'scope': mock_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb',
-              'pfn': 'srm://%s.cern.ch/srm/managerv2?SFN=/test/%s/%s' % (rse2_id, mock_scope, generate_uuid()), 'meta': {'events': 10}} for _ in range(nbfiles)]
+              'pfn': 'srm://%s.cern.ch/srm/managerv2?SFN=/test_%s/%s/%s' % (rse2_id, rse2_id, mock_scope, generate_uuid()), 'meta': {'events': 10}} for _ in range(nbfiles)]
     add_replicas(rse_id=rse2_id, files=files, account=root_account, ignore_availability=True)
 
     # Listing replicas on non-deterministic RSE
@@ -101,7 +101,7 @@ def test_add_list_bad_replicas(rse_factory, mock_scope, root_account):
     assert list1 == list2
 
     # Now adding non-existing bad replicas
-    files = ['srm://%s.cern.ch/test/%s/%s' % (rse2_id, mock_scope, generate_uuid()), ]
+    files = ['srm://%s.cern.ch/test_%s/%s/%s' % (rse2_id, rse2_id, mock_scope, generate_uuid()), ]
     r = declare_bad_file_replicas(files, 'This is a good reason', root_account)
     output = ['%s Unknown replica' % rep for rep in files]
     assert r == {rse2_id: output}
@@ -204,7 +204,7 @@ def test_client_add_list_bad_replicas(rse_factory, replica_client, did_client):
     # Adding replicas to non-deterministic RSE
     rse2, rse2_id = rse_factory.make_srm_rse(deterministic=False)
     files = [{'scope': tmp_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb',
-              'pfn': 'srm://%s.cern.ch/srm/managerv2?SFN=/test/%s/%s' % (rse2_id, tmp_scope, generate_uuid()), 'meta': {'events': 10}} for _ in range(nbfiles)]
+              'pfn': 'srm://%s.cern.ch/srm/managerv2?SFN=/test_%s/%s/%s' % (rse2_id, rse2_id, tmp_scope, generate_uuid()), 'meta': {'events': 10}} for _ in range(nbfiles)]
     replica_client.add_replicas(rse=rse2, files=files)
 
     # Listing replicas on non-deterministic RSE
@@ -224,7 +224,7 @@ def test_client_add_list_bad_replicas(rse_factory, replica_client, did_client):
     assert len(replicas) == nbbadrep
 
     # Now adding non-existing bad replicas
-    files = ['srm://%s.cern.ch/test/%s/%s' % (rse2_id, tmp_scope, generate_uuid()), ]
+    files = ['srm://%s.cern.ch/test_%s/%s/%s' % (rse2_id, rse2_id, tmp_scope, generate_uuid()), ]
     r = replica_client.declare_bad_file_replicas(files, 'This is a good reason')
     output = ['%s Unknown replica' % rep for rep in files]
     assert r == {rse2: output}
@@ -252,7 +252,7 @@ def test_client_add_list_bad_replicas(rse_factory, replica_client, did_client):
     assert len(replicas) == nbbadrep
 
     # InvalidType is raised if list_rep contains a mixture of replicas and PFNs
-    list_rep.extend(['srm://%s.cern.ch/test/%s/%s' % (rse2_id, tmp_scope, generate_uuid()), ])
+    list_rep.extend(['srm://%s.cern.ch/test_%s/%s/%s' % (rse2_id, rse2_id, tmp_scope, generate_uuid()), ])
     with pytest.raises(InvalidType):
         r = replica_client.declare_bad_file_replicas(list_rep, 'This is a good reason')
 
@@ -278,7 +278,7 @@ def test_client_add_suspicious_replicas(rse_factory, replica_client):
     # Adding replicas to non-deterministic RSE
     rse2, rse2_id = rse_factory.make_srm_rse(deterministic=False)
     files = [{'scope': tmp_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb',
-              'pfn': 'srm://%s.cern.ch/srm/managerv2?SFN=/test/%s/%s' % (rse2_id, tmp_scope, generate_uuid()), 'meta': {'events': 10}} for _ in range(nbfiles)]
+              'pfn': 'srm://%s.cern.ch/srm/managerv2?SFN=/test_%s/%s/%s' % (rse2_id, rse2_id, tmp_scope, generate_uuid()), 'meta': {'events': 10}} for _ in range(nbfiles)]
     replica_client.add_replicas(rse=rse2, files=files)
 
     # Listing replicas on non-deterministic RSE
@@ -290,7 +290,7 @@ def test_client_add_suspicious_replicas(rse_factory, replica_client):
     r = replica_client.declare_suspicious_file_replicas(replicas, 'This is a good reason')
     assert r == {}
     # Now adding non-existing bad replicas
-    files = ['srm://%s.cern.ch/test/%s/%s' % (rse2_id, tmp_scope, generate_uuid()), ]
+    files = ['srm://%s.cern.ch/test_%s/%s/%s' % (rse2_id, rse2_id, tmp_scope, generate_uuid()), ]
     r = replica_client.declare_suspicious_file_replicas(files, 'This is a good reason')
     output = ['%s Unknown replica' % rep for rep in files]
     assert r == {rse2: output}

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -953,7 +953,7 @@ class TestReplicaMetalink:
         rse_info = rsemgr.get_rse_info(rse=rse, vo=vo)
         assert rse_info['deterministic'] is False
         files = [{'scope': mock_scope, 'name': 'file_%s' % generate_uuid(), 'bytes': 1, 'adler32': '0cc737eb',
-                  'pfn': 'srm://%s.cern.ch/srm/managerv2?SFN=/test/%s/%s' % (rse_id, mock_scope, generate_uuid()), 'meta': {'events': 10}} for _ in range(nbfiles)]
+                  'pfn': 'srm://%s.cern.ch/srm/managerv2?SFN=/test_%s/%s/%s' % (rse_id, rse_id, mock_scope, generate_uuid()), 'meta': {'events': 10}} for _ in range(nbfiles)]
         for f in files:
             input_[f['pfn']] = {'scope': f['scope'].external, 'name': f['name']}
         add_replicas(rse_id=rse_id, files=files, account=root_account, ignore_availability=True)

--- a/lib/rucio/tests/test_rse_protocol_rclone.py
+++ b/lib/rucio/tests/test_rse_protocol_rclone.py
@@ -40,7 +40,7 @@ def load_rse_info(request, containerized_rses):
     rses = [rse for rse in containerized_rses if rse[0] == 'SSH1']
 
     data = load_test_conf_file('rse_repository.json')
-    request.cls.prefix = data['SSH_DISK']['protocols']['supported']['rclone']['prefix']
+    request.cls.prefix = data['SSH-DISK']['protocols']['supported']['rclone']['prefix']
 
     if len(rses) == 0:
         request.cls.rse_id = 'SSH-RSE'

--- a/lib/rucio/tests/test_rse_protocol_rsync.py
+++ b/lib/rucio/tests/test_rse_protocol_rsync.py
@@ -40,9 +40,9 @@ def load_rse_info(request, containerized_rses):
     rses = [rse for rse in containerized_rses if rse[0] == 'SSH1']
 
     data = load_test_conf_file('rse_repository.json')
-    request.cls.prefix = data['SSH_DISK']['protocols']['supported']['rsync']['prefix']
-    request.cls.port = data['SSH_DISK']['protocols']['supported']['rsync']['port']
-    request.cls.sshuser = data['SSH_DISK']['protocols']['supported']['rsync']['extended_attributes']['user']
+    request.cls.prefix = data['SSH-DISK']['protocols']['supported']['rsync']['prefix']
+    request.cls.port = data['SSH-DISK']['protocols']['supported']['rsync']['port']
+    request.cls.sshuser = data['SSH-DISK']['protocols']['supported']['rsync']['extended_attributes']['user']
 
     if len(rses) == 0:
         request.cls.rse_id = 'SSH-RSE'

--- a/lib/rucio/tests/test_rse_protocol_ssh.py
+++ b/lib/rucio/tests/test_rse_protocol_ssh.py
@@ -40,9 +40,9 @@ def load_rse_info(request, containerized_rses):
     rses = [rse for rse in containerized_rses if rse[0] == 'SSH1']
 
     data = load_test_conf_file('rse_repository.json')
-    request.cls.prefix = data['SSH_DISK']['protocols']['supported']['ssh']['prefix']
-    request.cls.port = data['SSH_DISK']['protocols']['supported']['ssh']['port']
-    request.cls.sshuser = data['SSH_DISK']['protocols']['supported']['ssh']['extended_attributes']['user']
+    request.cls.prefix = data['SSH-DISK']['protocols']['supported']['ssh']['prefix']
+    request.cls.port = data['SSH-DISK']['protocols']['supported']['ssh']['port']
+    request.cls.sshuser = data['SSH-DISK']['protocols']['supported']['ssh']['extended_attributes']['user']
 
     if len(rses) == 0:
         request.cls.rse_id = 'SSH-RSE'


### PR DESCRIPTION
 Tests : Cleanup unneeded RSEs in sync_rses.py #5499 

- Remove unneeded RSEs
- Start moving to `rse_factory` in a few tests `test_dids`, `test_subscriptions`, etc.