### PR TITLE
Rules: only re-evaluate dataset size, but on all databases.  Closes #5531 

### DIFF
--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -1484,7 +1484,7 @@ def re_evaluate_did(scope, name, rule_evaluation_action, session=None):
         __evaluate_did_detach(did, session=session)
 
     # Update size and length of did
-    if session.bind.dialect.name == 'oracle':
+    if did.did_type == DIDType.DATASET:
         stmt = select(
             func.count(),
             func.sum(models.DataIdentifierAssociation.bytes),


### PR DESCRIPTION
The evaluation of the container size gives completely wrong results,
because DataIdentifierAssociation bytes is not updated for collections.
Moreover, for containers, it will always compute the number of
children in the container, not the number of files, which is probably
not what we want.

So make it explicit that we don't re-evaluate containers.

Also, remove the constraint of doing this evaluation only on oracle,
which makes no sense.