### PR TITLE
Clients: Change the download client state to an enum #5250

### DIFF
--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -16,6 +16,7 @@
 from __future__ import division
 
 import copy
+import enum
 import itertools
 import logging
 import os
@@ -40,6 +41,21 @@ from rucio.common.utils import adler32, detect_client_location, generate_uuid, p
 from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS, CHECKSUM_ALGO_DICT, PREFERRED_CHECKSUM
 from rucio.rse import rsemanager as rsemgr
 from rucio import version
+
+
+@enum.unique
+class FileDownloadState(str, enum.Enum):
+    """
+    The state a file can be in before/while/after downloading.
+    """
+    PROCESSING = "PROCESSING"
+    DOWNLOAD_ATTEMPT = "DOWNLOAD_ATTEMPT"
+    DONE = "DONE"
+    ALREADY_DONE = "ALREADY_DONE"
+    FOUND_IN_PCACHE = "FOUND_IN_PCACHE"
+    FILE_NOT_FOUND = "FILE_NOT_FOUND"
+    FAIL_VALIDATE = "FAIL_VALIDATE"
+    FAILED = "FAILED"
 
 
 class BaseExtractionTool:
@@ -479,7 +495,7 @@ class DownloadClient:
         trace.setdefault('datasetScope', item.get('dataset_scope', ''))
         trace.setdefault('dataset', item.get('dataset_name', ''))
         trace.setdefault('filesize', item.get('bytes'))
-        trace.setdefault('clientState', 'PROCESSING')
+        trace.setdefault('clientState', FileDownloadState.PROCESSING)
         trace.setdefault('stateReason', 'UNKNOWN')
 
         dest_file_paths = item['dest_file_paths']
@@ -508,10 +524,10 @@ class DownloadClient:
                     if not os.path.isfile(missing_file_path):
                         logger(logging.DEBUG, "copying '%s' to '%s'" % (dest_file_path, missing_file_path))
                         shutil.copy2(dest_file_path, missing_file_path)
-                item['clientState'] = 'ALREADY_DONE'
+                item['clientState'] = FileDownloadState.ALREADY_DONE
                 trace['transferStart'] = time.time()
                 trace['transferEnd'] = time.time()
-                trace['clientState'] = 'ALREADY_DONE'
+                trace['clientState'] = FileDownloadState.ALREADY_DONE
                 send_trace(trace, self.client.host, self.client.user_agent)
                 return item
 
@@ -519,8 +535,8 @@ class DownloadClient:
         sources = item.get('sources')
         if not sources or not len(sources):
             logger(logging.WARNING, '%sNo available source found for file: %s' % (log_prefix, did_str))
-            item['clientState'] = 'FILE_NOT_FOUND'
-            trace['clientState'] = 'FILE_NOT_FOUND'
+            item['clientState'] = FileDownloadState.FILE_NOT_FOUND
+            trace['clientState'] = FileDownloadState.FILE_NOT_FOUND
             trace['stateReason'] = 'No available sources'
             self._send_trace(trace)
             return item
@@ -553,10 +569,10 @@ class DownloadClient:
             # if file found in pcache, send trace and return
             if pcache_state == 0 and hardlink_state == 1:
                 logger(logging.INFO, 'File found in pcache.')
-                item['clientState'] = 'FOUND_IN_PCACHE'
+                item['clientState'] = FileDownloadState.FOUND_IN_PCACHE
                 trace['transferStart'] = time.time()
                 trace['transferEnd'] = time.time()
-                trace['clientState'] = 'FOUND_IN_PCACHE'
+                trace['clientState'] = FileDownloadState.FOUND_IN_PCACHE
                 self._send_trace(trace)
                 return item
             else:
@@ -581,7 +597,7 @@ class DownloadClient:
                 continue
 
             trace['remoteSite'] = rse_name
-            trace['clientState'] = 'DOWNLOAD_ATTEMPT'
+            trace['clientState'] = FileDownloadState.DOWNLOAD_ATTEMPT
             trace['protocol'] = scheme
 
             transfer_timeout = self._compute_actual_transfer_timeout(item)
@@ -623,7 +639,7 @@ class DownloadClient:
                     success = True
                 except Exception as error:
                     logger(logging.DEBUG, error)
-                    trace['clientState'] = str(type(error).__name__)
+                    trace['clientState'] = FileDownloadState.FAILED
                     trace['stateReason'] = str(error)
 
                 end_time = time.time()
@@ -635,7 +651,7 @@ class DownloadClient:
                         os.unlink(temp_file_path)
                         logger(logging.WARNING, '%sChecksum validation failed for file: %s' % (log_prefix, did_str))
                         logger(logging.DEBUG, 'Local checksum: %s, Rucio checksum: %s' % (local_checksum, rucio_checksum))
-                        trace['clientState'] = 'FAIL_VALIDATE'
+                        trace['clientState'] = FileDownloadState.FAIL_VALIDATE
                         trace['stateReason'] = 'Checksum validation failed: Local checksum: %s, Rucio checksum: %s' % (local_checksum, rucio_checksum)
                 if not success:
                     logger(logging.WARNING, '%sDownload attempt failed. Try %s/%s' % (log_prefix, attempt, retries))
@@ -645,7 +661,7 @@ class DownloadClient:
 
         if not success:
             logger(logging.ERROR, '%sFailed to download file %s' % (log_prefix, did_str))
-            item['clientState'] = 'FAILED'
+            item['clientState'] = FileDownloadState.FAILED
             return item
 
         dest_file_path_iter = iter(dest_file_paths)
@@ -668,9 +684,9 @@ class DownloadClient:
 
         trace['transferStart'] = start_time
         trace['transferEnd'] = end_time
-        trace['clientState'] = 'DONE'
+        trace['clientState'] = FileDownloadState.DONE
         trace['stateReason'] = 'OK'
-        item['clientState'] = 'DONE'
+        item['clientState'] = FileDownloadState.DONE
         self._send_trace(trace)
 
         duration = round(end_time - start_time, 2)
@@ -893,13 +909,13 @@ class DownloadClient:
                 dest_file_path = next(iter(item['dest_file_paths']))
                 if os.path.isfile(dest_file_path):
                     logger(logging.INFO, 'File exists already locally: %s' % file_did_str)
-                    item['clientState'] = 'ALREADY_DONE'
-                    trace['clientState'] = 'ALREADY_DONE'
+                    item['clientState'] = FileDownloadState.ALREADY_DONE
+                    trace['clientState'] = FileDownloadState.ALREADY_DONE
                     self._send_trace(trace)
                 elif len(pfns) == 0:
                     logger(logging.WARNING, 'No available source found for file: %s' % file_did_str)
-                    item['clientState'] = 'FILE_NOT_FOUND'
-                    trace['clientState'] = 'FILE_NOT_FOUND'
+                    item['clientState'] = FileDownloadState.FILE_NOT_FOUND
+                    trace['clientState'] = FileDownloadState.FILE_NOT_FOUND
                     self._send_trace(trace)
                 else:
                     item['trace'] = trace
@@ -956,8 +972,8 @@ class DownloadClient:
                     rucio_checksum = 0 if skip_check else item.get('adler32')
                     local_checksum = 0 if skip_check else adler32(temp_file_path)
                     if str(rucio_checksum).lstrip('0') == str(local_checksum).lstrip('0'):
-                        item['clientState'] = 'DONE'
-                        trace['clientState'] = 'DONE'
+                        item['clientState'] = FileDownloadState.DONE
+                        trace['clientState'] = FileDownloadState.DONE
                         # remove .part ending
                         os.rename(temp_file_path, dest_file_path)
 
@@ -975,13 +991,13 @@ class DownloadClient:
                         os.unlink(temp_file_path)
                         logger(logging.WARNING, 'Checksum validation failed for file: %s' % file_did_str)
                         logger(logging.DEBUG, 'Local checksum: %s, Rucio checksum: %s' % (local_checksum, rucio_checksum))
-                        item['clientState'] = 'FAIL_VALIDATE'
-                        trace['clientState'] = 'FAIL_VALIDATE'
+                        item['clientState'] = FileDownloadState.FAIL_VALIDATE
+                        trace['clientState'] = FileDownloadState.FAIL_VALIDATE
                 else:
                     logger(logging.ERROR, 'Failed to download file: %s' % file_did_str)
                     logger(logging.DEBUG, 'Aria2c status: %s' % status)
-                    item['clientState'] = 'FAILED'
-                    trace['clientState'] = 'DOWNLOAD_ATTEMPT'
+                    item['clientState'] = FileDownloadState.FAILED
+                    trace['clientState'] = FileDownloadState.DOWNLOAD_ATTEMPT
 
                 self._send_trace(trace)
                 del item['trace']
@@ -1539,12 +1555,11 @@ class DownloadClient:
         :raises NoFilesDownloaded:
         :raises NotAllFilesDownloaded:
         """
-        success_states = ['ALREADY_DONE', 'DONE', 'FOUND_IN_PCACHE']
-        # failure_states = ['FILE_NOT_FOUND', 'FAIL_VALIDATE', 'FAILED']
+        success_states = [FileDownloadState.ALREADY_DONE, FileDownloadState.DONE, FileDownloadState.FOUND_IN_PCACHE]
         num_successful = 0
         num_failed = 0
         for item in output_items:
-            clientState = item.get('clientState', 'FAILED')
+            clientState = item.get('clientState', FileDownloadState.FAILED)
             if clientState in success_states:
                 num_successful += 1
             else:

--- a/lib/rucio/tests/test_download.py
+++ b/lib/rucio/tests/test_download.py
@@ -31,6 +31,7 @@ from rucio.common.utils import generate_uuid
 from rucio.core import did as did_core
 from rucio.core import scope as scope_core
 from rucio.core.rse import add_protocol
+from rucio.client.downloadclient import FileDownloadState
 from rucio.rse import rsemanager as rsemgr
 from rucio.rse.protocols.posix import Default as PosixProtocol
 from rucio.tests.common import skip_rse_tests_with_accounts, scope_name_generator, file_generator
@@ -727,3 +728,17 @@ def test_download_exclude_tape(rse_factory, did_factory, download_client):
          TemporaryDirectory() as tmp_dir, \
          pytest.raises(NoFilesDownloaded):
         download_client.download_dids([{'did': did_str, 'base_dir': tmp_dir}])
+
+
+def test_download_states():
+    """ Tests the available download states. """
+    FileDownloadState.PROCESSING
+    FileDownloadState.DOWNLOAD_ATTEMPT
+    FileDownloadState.DONE
+    FileDownloadState.ALREADY_DONE
+    FileDownloadState.FOUND_IN_PCACHE
+    FileDownloadState.FILE_NOT_FOUND
+    FileDownloadState.FAIL_VALIDATE
+    FileDownloadState.FAILED
+
+    assert len(FileDownloadState) == 8


### PR DESCRIPTION
The client state uses strings to store the state. This has the problem that the
evalutation, if a client state is wrong, is done at runtime. Also, it uses the
exception name as state. This is inconsistent, because all available states
should be well defined.

This commit uses an enum for the download client state. This enables checks at
runtime, since all usable states are defined. The values of the enum ensure the
serialization to strings.

It also changes the usage from an exception name as state to the `FAILING`
state. The exception itself is added in the body already.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
