### PR TITLE
Protocols: Create posix.Symlink to create links on download; Fix #5319

### DIFF
--- a/etc/rse_repository.json
+++ b/etc/rse_repository.json
@@ -443,5 +443,31 @@
       }
     },
     "storage_usage_tool": "rucio.rse.protocols.ssh.Default.getSpace"
+  },
+  "MOCK-POSIX-SYMLINK":{
+    "backend_type": "POSIX-SYMLINK",
+    "deterministic": true,
+    "protocols": {
+      "default": "file",
+      "supported": {
+        "file": {
+          "prefix": "/tmp/rucio_rse/",
+          "domains": {
+            "lan": {
+              "read": 1,
+              "write": 1,
+              "delete": 1
+            },
+            "wan": {
+              "read": 1,
+              "write": 1,
+              "delete": 1
+            }
+          },
+          "impl": "rucio.rse.protocols.posix.Symlink"
+        }
+      }
+    },
+    "storage_usage_tool": "rucio.rse.protocols.posix.Symlink.getSpace"
   }
 }


### PR DESCRIPTION
Subclass of the Default POXIS implementation to allow a symlink to be made to the remote location
when issuing at 'get' of the remote file.

Only the get() method is overridden to provide this functionality. Other methods use the default implementation,
which involve using the remote file directly.