### PR TITLE
Documentation: Fix the file headers #5455

### DIFF
--- a/lib/rucio/daemons/common.py
+++ b/lib/rucio/daemons/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright CERN since 2022
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
The `lib/rucio/daemons/common.py` file header was poorly formatted. This came
due to the creation of the file after the PR which fixes all the headers. The
header was on a previous version, since only a rebase was run, not the
`add_header` script itself.  A simple `tools/add_headers` run fixes this issue.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
