### PR TITLE
Documentation: Fix wrongly formatted param doc comments #5547

### DIFF
--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -683,8 +683,8 @@ class UploadClient:
     def _retry_protocol_stat(self, protocol, pfn):
         """
         Try to stat file, on fail try again 1s, 2s, 4s, 8s, 16s, 32s later. Fail is all fail
-        :param protocol     The protocol to use to reach this file
-        :param pfn          Physical file name of the target for the protocol stat
+        :param protocol:     The protocol to use to reach this file
+        :param pfn:          Physical file name of the target for the protocol stat
         """
         retries = config_get_int('client', 'protocol_stat_retries', raise_exception=False, default=6)
         for attempt in range(retries):
@@ -711,9 +711,9 @@ class UploadClient:
     def _create_protocol(self, rse_settings, operation, impl=None, force_scheme=None, domain='wan'):
         """
         Protol construction.
-        :param: rse_settings        rse_settings
-        :param: operation           activity, e.g. read, write, delete etc.
-        :param: force_scheme        custom scheme
+        :param rse_settings:        rse_settings
+        :param operation:           activity, e.g. read, write, delete etc.
+        :param force_scheme:        custom scheme
         :param auth_token: Optionally passing JSON Web Token (OIDC) string for authentication
         """
         try:
@@ -742,7 +742,7 @@ class UploadClient:
             - If it has files, the root folder will be a dataset
             - If it is empty, it does not create anything
 
-        :param: item        dictionary containing all descriptions of the files to upload
+        :param item:        dictionary containing all descriptions of the files to upload
         """
         files = []
         datasets = []

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1564,7 +1564,7 @@ class retry:
     def __init__(self, func, *args, **kwargs):
         '''
         :param func: a method that should be executed with retries
-        :param args parametres of the func
+        :param args: parametres of the func
         :param kwargs: key word arguments of the func
         '''
         self.func, self.args, self.kwargs = func, args, kwargs

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -3821,14 +3821,14 @@ def get_suspicious_files(rse_expression, available_elsewhere, filter_=None, logg
     :param nattempts: The minimum number of replica appearances in the bad_replica DB table from younger_than date. Default value = 0.
     :param rse_expression: The RSE expression where the replicas are located.
     :param filter_: Dictionary of attributes by which the RSE results should be filtered. e.g.: {'availability_write': True}
-    :param: exclude_states: List of states which eliminates replicas from search result if any of the states in the list
+    :param exclude_states: List of states which eliminates replicas from search result if any of the states in the list
                             was declared for a replica since younger_than date. Allowed values
                             = ['B', 'R', 'D', 'L', 'T', 'S'] (meaning 'BAD', 'RECOVERED', 'DELETED', 'LOST', 'TEMPORARY_UNAVAILABLE', 'SUSPICIOUS').
-    :param: available_elsewhere: Default: SuspiciousAvailability["ALL"].value, all suspicious replicas are returned.
+    :param available_elsewhere: Default: SuspiciousAvailability["ALL"].value, all suspicious replicas are returned.
                                  If SuspiciousAvailability["EXIST_COPIES"].value, only replicas that additionally have copies declared as AVAILABLE on at least one other RSE
                                  than the one in the bad_replicas table will be taken into account.
                                  If SuspiciousAvailability["LAST_COPY"].value, only replicas that do not have another copy declared as AVAILABLE on another RSE will be taken into account.
-    :param: is_suspicious: If True, only replicas declared as SUSPICIOUS in bad replicas table will be taken into account. Default value = False.
+    :param is_suspicious: If True, only replicas declared as SUSPICIOUS in bad replicas table will be taken into account. Default value = False.
     :param session: The database session in use. Default value = None.
 
     :returns: a list of replicas:

--- a/lib/rucio/rse/protocols/cache.py
+++ b/lib/rucio/rse/protocols/cache.py
@@ -29,7 +29,7 @@ class Default(protocol.RSEProtocol):
     def __init__(self, protocol_attr, rse_settings, logger=None):
         """ Initializes the object with information about the referred RSE.
 
-            :param props Properties derived from the RSE Repository
+            :param props: Properties derived from the RSE Repository
         """
         super(Default, self).__init__(protocol_attr, rse_settings, logger=logger)
         self.attributes.pop('determinism_type', None)
@@ -60,7 +60,7 @@ class Default(protocol.RSEProtocol):
     def exists(self, pfn):
         """ Checks if the requested file is known by the referred RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :returns: True if the file exists, False if it doesn't
 
@@ -71,7 +71,7 @@ class Default(protocol.RSEProtocol):
     def connect(self):
         """ Establishes the actual connection to the referred RSE.
 
-            :param credentials Provide all necessary information to establish a connection
+            :param credentials: Provide all necessary information to establish a connection
                 to the referred storage system. Some is loaded from the repository inside the
                 RSE class and some must be provided specific for the SFTP protocol like
                 username, password, private_key, private_key_pass, port.
@@ -90,8 +90,8 @@ class Default(protocol.RSEProtocol):
     def get(self, pfn, dest, transfer_timeout=None):
         """ Provides access to files stored inside connected the RSE.
 
-            :param pfn Physical file name of requested file
-            :param dest Name and path of the files when stored at the client
+            :param pfn: Physical file name of requested file
+            :param dest: Name and path of the files when stored at the client
             :param transfer_timeout Transfer timeout (in seconds)
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound
@@ -101,8 +101,8 @@ class Default(protocol.RSEProtocol):
     def put(self, source, target, source_dir=None, transfer_timeout=None):
         """ Allows to store files inside the referred RSE.
 
-            :param source Physical file name
-            :param target Name of the file on the storage system e.g. with prefixed scope
+            :param source: Physical file name
+            :param target: Name of the file on the storage system e.g. with prefixed scope
             :param source_dir Path where the to be transferred files are stored in the local file system
             :param transfer_timeout Transfer timeout (in seconds)
 
@@ -113,7 +113,7 @@ class Default(protocol.RSEProtocol):
     def delete(self, pfn):
         """ Deletes a file from the connected RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :raises ServiceUnavailable, SourceNotFound
         """
@@ -122,7 +122,7 @@ class Default(protocol.RSEProtocol):
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 
-            :param pfn      Current physical file name
+            :param pfn:      Current physical file name
             :param new_pfn  New physical file name
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound

--- a/lib/rucio/rse/protocols/dummy.py
+++ b/lib/rucio/rse/protocols/dummy.py
@@ -29,7 +29,7 @@ class Default(protocol.RSEProtocol):
     def __init__(self, protocol_attr, rse_settings, logger=None):
         """ Initializes the object with information about the referred RSE.
 
-            :param props Properties derived from the RSE Repository
+            :param props: Properties derived from the RSE Repository
         """
         super(Default, self).__init__(protocol_attr, rse_settings, logger=logger)
         self.attributes.pop('determinism_type', None)
@@ -49,7 +49,7 @@ class Default(protocol.RSEProtocol):
     def exists(self, pfn):
         """ Checks if the requested file is known by the referred RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :returns: True if the file exists, False if it doesn't
 
@@ -60,7 +60,7 @@ class Default(protocol.RSEProtocol):
     def connect(self):
         """ Establishes the actual connection to the referred RSE.
 
-            :param credentials Provide all necessary information to establish a connection
+            :param credentials: Provide all necessary information to establish a connection
                 to the referred storage system. Some is loaded from the repository inside the
                 RSE class and some must be provided specific for the SFTP protocol like
                 username, password, private_key, private_key_pass, port.
@@ -79,8 +79,8 @@ class Default(protocol.RSEProtocol):
     def get(self, pfn, dest, transfer_timeout=None):
         """ Provides access to files stored inside connected the RSE.
 
-            :param pfn Physical file name of requested file
-            :param dest Name and path of the files when stored at the client
+            :param pfn: Physical file name of requested file
+            :param dest: Name and path of the files when stored at the client
             :param transfer_timeout Transfer timeout (in seconds)
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound
@@ -90,8 +90,8 @@ class Default(protocol.RSEProtocol):
     def put(self, source, target, source_dir=None, transfer_timeout=None):
         """ Allows to store files inside the referred RSE.
 
-            :param source Physical file name
-            :param target Name of the file on the storage system e.g. with prefixed scope
+            :param source: Physical file name
+            :param target: Name of the file on the storage system e.g. with prefixed scope
             :param source_dir Path where the to be transferred files are stored in the local file system
             :param transfer_timeout Transfer timeout (in seconds)
 
@@ -102,7 +102,7 @@ class Default(protocol.RSEProtocol):
     def delete(self, pfn):
         """ Deletes a file from the connected RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :raises ServiceUnavailable, SourceNotFound
         """
@@ -111,7 +111,7 @@ class Default(protocol.RSEProtocol):
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 
-            :param pfn      Current physical file name
+            :param pfn:      Current physical file name
             :param new_pfn  New physical file name
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -613,7 +613,7 @@ class NoRename(Default):
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 
-            :param pfn      Current physical file name
+            :param pfn:      Current physical file name
             :param new_pfn  New physical file name
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound
@@ -628,7 +628,7 @@ class CLI(Default):
     def __init__(self, protocol_attr, rse_settings, logger=logging.log):
         """ Initializes the object with information about the referred RSE.
 
-            :param props Properties derived from the RSE Repository
+            :param props: Properties derived from the RSE Repository
         """
 
         super(CLI, self).__init__(protocol_attr, rse_settings, logger=logger)

--- a/lib/rucio/rse/protocols/gsiftp.py
+++ b/lib/rucio/rse/protocols/gsiftp.py
@@ -29,7 +29,7 @@ class Default(protocol.RSEProtocol):
     def __init__(self, protocol_attr, rse_settings, logger=None):
         """ Initializes the object with information about the referred RSE.
 
-            :param props Properties derived from the RSE Repository
+            :param props: Properties derived from the RSE Repository
         """
         super(Default, self).__init__(protocol_attr, rse_settings, logger=logger)
 

--- a/lib/rucio/rse/protocols/http_cache.py
+++ b/lib/rucio/rse/protocols/http_cache.py
@@ -30,7 +30,7 @@ class Default(ngarc.Default):
     def __init__(self, protocol_attr, rse_settings, logger=None):
         """ Initializes the object with information about the referred RSE.
 
-            :param props Properties derived from the RSE Repository
+            :param props: Properties derived from the RSE Repository
         """
         super(Default, self).__init__(protocol_attr, rse_settings, logger=logger)
         self.attributes.pop('determinism_type', None)
@@ -61,8 +61,8 @@ class Default(ngarc.Default):
     def put(self, source, target, source_dir=None, transfer_timeout=None):
         """ Allows to store files inside the referred RSE.
 
-            :param source Physical file name
-            :param target Name of the file on the storage system e.g. with prefixed scope
+            :param source: Physical file name
+            :param target: Name of the file on the storage system e.g. with prefixed scope
             :param source_dir Path where the to be transferred files are stored in the local file system
             :param transfer_timeout Transfer timeout (in seconds)
 
@@ -73,7 +73,7 @@ class Default(ngarc.Default):
     def delete(self, pfn):
         """ Deletes a file from the connected RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :raises ServiceUnavailable, SourceNotFound
         """
@@ -82,7 +82,7 @@ class Default(ngarc.Default):
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 
-            :param pfn      Current physical file name
+            :param pfn:      Current physical file name
             :param new_pfn  New physical file name
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound

--- a/lib/rucio/rse/protocols/mock.py
+++ b/lib/rucio/rse/protocols/mock.py
@@ -23,7 +23,7 @@ class Default(protocol.RSEProtocol):
     def __init__(self, protocol_attr, rse_settings, logger=None):
         """ Initializes the object with information about the referred RSE.
 
-            :param props Properties derived from the RSE Repository
+            :param props: Properties derived from the RSE Repository
         """
         super(Default, self).__init__(protocol_attr, rse_settings, logger=logger)
         self.attributes.pop('determinism_type', None)
@@ -43,7 +43,7 @@ class Default(protocol.RSEProtocol):
     def exists(self, pfn):
         """ Checks if the requested file is known by the referred RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :returns: True if the file exists, False if it doesn't
 
@@ -54,7 +54,7 @@ class Default(protocol.RSEProtocol):
     def connect(self):
         """ Establishes the actual connection to the referred RSE.
 
-            :param credentials Provide all necessary information to establish a connection
+            :param credentials: Provide all necessary information to establish a connection
                 to the referred storage system. Some is loaded from the repository inside the
                 RSE class and some must be provided specific for the SFTP protocol like
                 username, password, private_key, private_key_pass, port.
@@ -73,8 +73,8 @@ class Default(protocol.RSEProtocol):
     def get(self, pfn, dest, transfer_timeout=None):
         """ Provides access to files stored inside connected the RSE.
 
-            :param pfn Physical file name of requested file
-            :param dest Name and path of the files when stored at the client
+            :param pfn: Physical file name of requested file
+            :param dest: Name and path of the files when stored at the client
             :param transfer_timeout Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound
@@ -85,8 +85,8 @@ class Default(protocol.RSEProtocol):
     def put(self, source, target, source_dir=None, transfer_timeout=None):
         """ Allows to store files inside the referred RSE.
 
-            :param source Physical file name
-            :param target Name of the file on the storage system e.g. with prefixed scope
+            :param source: Physical file name
+            :param target: Name of the file on the storage system e.g. with prefixed scope
             :param source_dir Path where the to be transferred files are stored in the local file system
             :param transfer_timeout Transfer timeout (in seconds) - dummy
 
@@ -97,7 +97,7 @@ class Default(protocol.RSEProtocol):
     def delete(self, pfn):
         """ Deletes a file from the connected RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :raises ServiceUnavailable, SourceNotFound
         """
@@ -116,7 +116,7 @@ class Default(protocol.RSEProtocol):
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 
-            :param pfn      Current physical file name
+            :param pfn:      Current physical file name
             :param new_pfn  New physical file name
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound

--- a/lib/rucio/rse/protocols/ngarc.py
+++ b/lib/rucio/rse/protocols/ngarc.py
@@ -77,7 +77,7 @@ class Default(protocol.RSEProtocol):
     def exists(self, pfn):
         """ Checks if the requested file is known by the referred RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :returns: True if the file exists, False if it doesn't
 
@@ -140,8 +140,8 @@ class Default(protocol.RSEProtocol):
     def get(self, pfn, dest, transfer_timeout=None):
         """ Provides access to files stored inside connected the RSE.
 
-            :param pfn Physical file name of requested file
-            :param dest Name and path of the files when stored at the client
+            :param pfn: Physical file name of requested file
+            :param dest: Name and path of the files when stored at the client
             :param transfer_timeout Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound
@@ -151,8 +151,8 @@ class Default(protocol.RSEProtocol):
     def put(self, source, target, source_dir=None, transfer_timeout=None):
         """ Allows to store files inside the referred RSE.
 
-            :param source Physical file name
-            :param target Name of the file on the storage system e.g. with prefixed scope
+            :param source: Physical file name
+            :param target: Name of the file on the storage system e.g. with prefixed scope
             :param source_dir Path where the to be transferred files are stored in the local file system
             :param transfer_timeout Transfer timeout (in seconds) - dummy
 
@@ -173,7 +173,7 @@ class Default(protocol.RSEProtocol):
     def delete(self, pfn):
         """ Deletes a file from the connected RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :raises ServiceUnavailable, SourceNotFound
         """
@@ -190,7 +190,7 @@ class Default(protocol.RSEProtocol):
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 
-            :param pfn      Current physical file name
+            :param pfn:      Current physical file name
             :param new_pfn  New physical file name
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound

--- a/lib/rucio/rse/protocols/posix.py
+++ b/lib/rucio/rse/protocols/posix.py
@@ -47,7 +47,7 @@ class Default(protocol.RSEProtocol):
         """
             Establishes the actual connection to the referred RSE.
 
-            :param: credentials needed to establish a connection with the stroage.
+            :param credentials: needed to establish a connection with the stroage.
 
             :raises RSEAccessDenied: if no connection could be established.
         """

--- a/lib/rucio/rse/protocols/rclone.py
+++ b/lib/rucio/rse/protocols/rclone.py
@@ -35,7 +35,7 @@ class Default(protocol.RSEProtocol):
     def __init__(self, protocol_attr, rse_settings, logger=logging.log):
         """ Initializes the object with information about the referred RSE.
 
-            :param props Properties derived from the RSE Repository
+            :param props: Properties derived from the RSE Repository
         """
         super(Default, self).__init__(protocol_attr, rse_settings, logger=logger)
         if len(rse_settings['protocols']) == 1:
@@ -57,7 +57,7 @@ class Default(protocol.RSEProtocol):
     def setuphostname(self, protocols):
         """ Initializes the rclone object with information about protocols in the referred RSE.
 
-            :param protocols Protocols in the RSE
+            :param protocols: Protocols in the RSE
         """
         if protocols['scheme'] in ['scp', 'rsync', 'sftp']:
             self.hostname = 'ssh_rclone_rse'
@@ -144,7 +144,7 @@ class Default(protocol.RSEProtocol):
     def exists(self, pfn):
         """ Checks if the requested file is known by the referred RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :returns: True if the file exists, False if it doesn't
 
@@ -272,8 +272,8 @@ class Default(protocol.RSEProtocol):
     def get(self, pfn, dest, transfer_timeout=None):
         """ Provides access to files stored inside connected the RSE.
 
-            :param pfn Physical file name of requested file
-            :param dest Name and path of the files when stored at the client
+            :param pfn: Physical file name of requested file
+            :param dest: Name and path of the files when stored at the client
             :param transfer_timeout: Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound
@@ -323,7 +323,7 @@ class Default(protocol.RSEProtocol):
         """
             Deletes a file from the connected RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :raises ServiceUnavailable: if some generic error occured in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
@@ -344,7 +344,7 @@ class Default(protocol.RSEProtocol):
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 
-            :param pfn      Current physical file name
+            :param pfn:      Current physical file name
             :param new_pfn  New physical file name
             :raises DestinationNotAccessible: if the destination storage was not accessible.
             :raises ServiceUnavailable: if some generic error occured in the library.

--- a/lib/rucio/rse/protocols/rfio.py
+++ b/lib/rucio/rse/protocols/rfio.py
@@ -38,7 +38,7 @@ class Default(protocol.RSEProtocol):
         """
             Establishes the actual connection to the referred RSE.
 
-            :param: credentials needed to establish a connection with the stroage.
+            :param credentials: needed to establish a connection with the stroage.
 
             :raises RSEAccessDenied: if no connection could be established.
         """

--- a/lib/rucio/rse/protocols/sftp.py
+++ b/lib/rucio/rse/protocols/sftp.py
@@ -49,7 +49,7 @@ class Default(protocol.RSEProtocol):
         """
             Establishes the actual connection to the referred RSE.
 
-            :param: credentials needed to establish a connection with the stroage.
+            :param credentials: needed to establish a connection with the stroage.
 
             :raises RSEAccessDenied: if no connection could be established.
         """

--- a/lib/rucio/rse/protocols/ssh.py
+++ b/lib/rucio/rse/protocols/ssh.py
@@ -28,7 +28,7 @@ class Default(protocol.RSEProtocol):
     def __init__(self, protocol_attr, rse_settings, logger=logging.log):
         """ Initializes the object with information about the referred RSE.
 
-            :param props Properties derived from the RSE Repository
+            :param props: Properties derived from the RSE Repository
         """
         super(Default, self).__init__(protocol_attr, rse_settings, logger=logger)
 
@@ -61,7 +61,7 @@ class Default(protocol.RSEProtocol):
     def exists(self, pfn):
         """ Checks if the requested file is known by the referred RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :returns: True if the file exists, False if it doesn't
 
@@ -188,8 +188,8 @@ class Default(protocol.RSEProtocol):
     def get(self, pfn, dest, transfer_timeout=None):
         """ Provides access to files stored inside connected the RSE.
 
-            :param pfn Physical file name of requested file
-            :param dest Name and path of the files when stored at the client
+            :param pfn: Physical file name of requested file
+            :param dest: Name and path of the files when stored at the client
             :param transfer_timeout: Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound
@@ -244,7 +244,7 @@ class Default(protocol.RSEProtocol):
         """
             Deletes a file from the connected RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :raises ServiceUnavailable: if some generic error occured in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
@@ -265,7 +265,7 @@ class Default(protocol.RSEProtocol):
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 
-            :param pfn      Current physical file name
+            :param pfn:      Current physical file name
             :param new_pfn  New physical file name
             :raises DestinationNotAccessible: if the destination storage was not accessible.
             :raises ServiceUnavailable: if some generic error occured in the library.
@@ -363,8 +363,8 @@ class Rsync(Default):
     def get(self, pfn, dest, transfer_timeout=None):
         """ Provides access to files stored inside connected the RSE.
 
-            :param pfn Physical file name of requested file
-            :param dest Name and path of the files when stored at the client
+            :param pfn: Physical file name of requested file
+            :param dest: Name and path of the files when stored at the client
             :param transfer_timeout: Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound

--- a/lib/rucio/rse/protocols/storm.py
+++ b/lib/rucio/rse/protocols/storm.py
@@ -30,7 +30,7 @@ class Default(protocol.RSEProtocol):
     def __init__(self, protocol_attr, rse_settings, logger=None):
         """ Initializes the object with information about the referred RSE.
 
-            :param props Properties derived from the RSE Repository
+            :param props: Properties derived from the RSE Repository
         """
         super(Default, self).__init__(protocol_attr, rse_settings, logger=logger)
         self.attributes.pop('determinism_type', None)
@@ -72,7 +72,7 @@ class Default(protocol.RSEProtocol):
     def exists(self, pfn):
         """ Checks if the requested file is known by the referred RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :returns: True if the file exists, False if it doesn't
 
@@ -83,7 +83,7 @@ class Default(protocol.RSEProtocol):
     def connect(self):
         """ Establishes the actual connection to the referred RSE.
 
-            :param credentials Provide all necessary information to establish a connection
+            :param credentials: Provide all necessary information to establish a connection
                 to the referred storage system. Some is loaded from the repository inside the
                 RSE class and some must be provided specific for the SFTP protocol like
                 username, password, private_key, private_key_pass, port.
@@ -102,8 +102,8 @@ class Default(protocol.RSEProtocol):
     def get(self, pfn, dest, transfer_timeout=None):
         """ Provides access to files stored inside connected the RSE.
 
-            :param pfn Physical file name of requested file
-            :param dest Name and path of the files when stored at the client
+            :param pfn: Physical file name of requested file
+            :param dest: Name and path of the files when stored at the client
             :param transfer_timeout Transfer timeout (in seconds)
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound
@@ -178,8 +178,8 @@ class Default(protocol.RSEProtocol):
     def put(self, source, target, source_dir=None, transfer_timeout=None):
         """ Allows to store files inside the referred RSE.
 
-            :param source Physical file name
-            :param target Name of the file on the storage system e.g. with prefixed scope
+            :param source: Physical file name
+            :param target: Name of the file on the storage system e.g. with prefixed scope
             :param source_dir Path where the to be transferred files are stored in the local file system
             :param transfer_timeout Transfer timeout (in seconds)
 
@@ -190,7 +190,7 @@ class Default(protocol.RSEProtocol):
     def delete(self, pfn):
         """ Deletes a file from the connected RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :raises ServiceUnavailable, SourceNotFound
         """
@@ -199,7 +199,7 @@ class Default(protocol.RSEProtocol):
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 
-            :param pfn      Current physical file name
+            :param pfn:      Current physical file name
             :param new_pfn  New physical file name
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound

--- a/lib/rucio/rse/protocols/webdav.py
+++ b/lib/rucio/rse/protocols/webdav.py
@@ -149,7 +149,7 @@ class Default(protocol.RSEProtocol):
     def connect(self, credentials={}):
         """ Establishes the actual connection to the referred RSE.
 
-            :param credentials Provides information to establish a connection
+            :param credentials: Provides information to establish a connection
                 to the referred storage system. For WebDAV connections these are
                 ca_cert, cert, auth_type, timeout
 
@@ -224,7 +224,7 @@ class Default(protocol.RSEProtocol):
     def exists(self, pfn):
         """ Checks if the requested file is known by the referred RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :returns: True if the file exists, False if it doesn't
 
@@ -248,8 +248,8 @@ class Default(protocol.RSEProtocol):
     def get(self, pfn, dest='.', transfer_timeout=None):
         """ Provides access to files stored inside connected the RSE.
 
-            :param pfn Physical file name of requested file
-            :param dest Name and path of the files when stored at the client
+            :param pfn: Physical file name of requested file
+            :param dest: Name and path of the files when stored at the client
             :param transfer_timeout: Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound, RSEAccessDenied
@@ -285,8 +285,8 @@ class Default(protocol.RSEProtocol):
     def put(self, source, target, source_dir=None, transfer_timeout=None, progressbar=False):
         """ Allows to store files inside the referred RSE.
 
-            :param source Physical file name
-            :param target Name of the file on the storage system e.g. with prefixed scope
+            :param source: Physical file name
+            :param target: Name of the file on the storage system e.g. with prefixed scope
             :param source_dir Path where the to be transferred files are stored in the local file system
             :param transfer_timeout Transfer timeout (in seconds) - dummy
 
@@ -338,7 +338,7 @@ class Default(protocol.RSEProtocol):
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 
-            :param pfn      Current physical file name
+            :param pfn:      Current physical file name
             :param new_pfn  New physical file name
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound, RSEAccessDenied
@@ -381,7 +381,7 @@ class Default(protocol.RSEProtocol):
     def delete(self, pfn):
         """ Deletes a file from the connected RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :raises ServiceUnavailable, SourceNotFound, RSEAccessDenied, ResourceTemporaryUnavailable
         """
@@ -407,7 +407,7 @@ class Default(protocol.RSEProtocol):
     def mkdir(self, directory):
         """ Internal method to create directories
 
-            :param directory Name of the directory that needs to be created
+            :param directory: Name of the directory that needs to be created
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound, RSEAccessDenied
         """
@@ -431,7 +431,7 @@ class Default(protocol.RSEProtocol):
     def ls(self, filename):
         """ Internal method to list files/directories
 
-            :param filename Name of the directory that needs to be created
+            :param filename: Name of the directory that needs to be created
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound, RSEAccessDenied
         """

--- a/lib/rucio/rse/protocols/xrootd.py
+++ b/lib/rucio/rse/protocols/xrootd.py
@@ -27,7 +27,7 @@ class Default(protocol.RSEProtocol):
     def __init__(self, protocol_attr, rse_settings, logger=logging.log):
         """ Initializes the object with information about the referred RSE.
 
-            :param props Properties derived from the RSE Repository
+            :param props: Properties derived from the RSE Repository
         """
         super(Default, self).__init__(protocol_attr, rse_settings, logger=logger)
 
@@ -57,7 +57,7 @@ class Default(protocol.RSEProtocol):
     def exists(self, pfn):
         """ Checks if the requested file is known by the referred RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :returns: True if the file exists, False if it doesn't
 
@@ -167,7 +167,7 @@ class Default(protocol.RSEProtocol):
     def connect(self):
         """ Establishes the actual connection to the referred RSE.
 
-            :param credentials Provides information to establish a connection
+            :param credentials: Provides information to establish a connection
                 to the referred storage system. For S3 connections these are
                 access_key, secretkey, host_base, host_bucket, progress_meter
                 and skip_existing.
@@ -193,8 +193,8 @@ class Default(protocol.RSEProtocol):
     def get(self, pfn, dest, transfer_timeout=None):
         """ Provides access to files stored inside connected the RSE.
 
-            :param pfn Physical file name of requested file
-            :param dest Name and path of the files when stored at the client
+            :param pfn: Physical file name of requested file
+            :param dest: Name and path of the files when stored at the client
             :param transfer_timeout: Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible, ServiceUnavailable, SourceNotFound
@@ -244,7 +244,7 @@ class Default(protocol.RSEProtocol):
         """
             Deletes a file from the connected RSE.
 
-            :param pfn Physical file name
+            :param pfn: Physical file name
 
             :raises ServiceUnavailable: if some generic error occured in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
@@ -265,7 +265,7 @@ class Default(protocol.RSEProtocol):
     def rename(self, pfn, new_pfn):
         """ Allows to rename a file stored inside the connected RSE.
 
-            :param pfn      Current physical file name
+            :param pfn:      Current physical file name
             :param new_pfn  New physical file name
             :raises DestinationNotAccessible: if the destination storage was not accessible.
             :raises ServiceUnavailable: if some generic error occured in the library.

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -721,8 +721,8 @@ def _retry_protocol_stat(protocol, pfn):
     """
     try to stat file, on fail try again 1s, 2s, 4s, 8s, 16s, 32s later. Fail is all fail
 
-    :param protocol     The protocol to use to reach this file
-    :param pfn          Physical file name of the target for the protocol stat
+    :param protocol:     The protocol to use to reach this file
+    :param pfn:          Physical file name of the target for the protocol stat
     """
     retries = config_get_int('client', 'protocol_stat_retries', raise_exception=False, default=6)
     for attempt in range(retries):


### PR DESCRIPTION
Some function doc comments do not follow the sphinx documentation standard:

- Some are missing the double-point after the parameter name, e.g.
  `:param rse The RSE...`.

- Some have the double-point directly after `:param`, e.g.
  `:param: rse The RSE...`.

Both should be `:param rse: The RSE...`.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
