### PR TITLE
Consistency checks: Fix the project structure #5113

### DIFF
--- a/lib/rucio/daemons/storage/__init__.py
+++ b/lib/rucio/daemons/storage/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/rucio/daemons/storage/consistency/__init__.py
+++ b/lib/rucio/daemons/storage/consistency/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
Python projects use `__init__.py` files to mark directories as part of a
`regular package` [1]. The content of the regular package can get importet by
python via the `import` keyword.

The `storage/consistency` folders both do not contain such files, which makes
them inaccessible to global imports.

[1] https://docs.python.org/3/reference/import.html#regular-packages

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
