### PR TITLE
Dynamically compute container size #5422

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -863,7 +863,7 @@ def stat(args):
         if i > 0:
             print('------')
         scope, name = get_scope(did, client)
-        info = client.get_did(scope=scope, name=name)
+        info = client.get_did(scope=scope, name=name, dynamic_depth='DATASET')
         table = [(k + ':', str(v)) for (k, v) in sorted(info.items())]
         print(tabulate(table, tablefmt='plain', disable_numparse=True))
     return SUCCESS

--- a/lib/rucio/api/did.py
+++ b/lib/rucio/api/did.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from copy import deepcopy
+from typing import TYPE_CHECKING
 
 import rucio.api.permission
 from rucio.common.constants import RESERVED_KEYS
@@ -25,6 +26,10 @@ from rucio.core import did, naming_convention, meta as meta_core
 from rucio.core.rse import get_rse_id
 from rucio.db.sqla.constants import DIDType
 from rucio.db.sqla.session import read_session, stream_session, transactional_session
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+    from sqlalchemy.orm import Session
 
 
 @stream_session
@@ -399,13 +404,15 @@ def scope_list(scope, name=None, recursive=False, vo='def', session=None):
 
 
 @read_session
-def get_did(scope, name, dynamic=False, vo='def', session=None):
+def get_did(scope: str, name: str, dynamic_depth: "Optional[DIDType]" = None, vo: str = 'def', session: "Optional[Session]" = None) -> "Dict[str, Any]":
     """
     Retrieve a single data did.
 
     :param scope: The scope name.
     :param name: The data identifier name.
-    :param dynamic:  Dynamically resolve the bytes and length of the did
+    :param dynamic_depth: the DID type to use as source for estimation of this DIDs length/bytes.
+    If set to None, or to a value which doesn't make sense (ex: requesting depth = CONTAINER for a did of type DATASET)
+    will not compute the size dynamically.
     :param vo: The VO to act on.
     :return did: Dictionary containing {'name', 'scope', 'type'}, Exception otherwise
     :param session: The database session in use.
@@ -413,7 +420,7 @@ def get_did(scope, name, dynamic=False, vo='def', session=None):
 
     scope = InternalScope(scope, vo=vo)
 
-    d = did.get_did(scope=scope, name=name, dynamic=dynamic, session=session)
+    d = did.get_did(scope=scope, name=name, dynamic_depth=dynamic_depth, session=session)
     return api_update_return_dict(d, session=session)
 
 

--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -398,19 +398,24 @@ class DIDClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def get_did(self, scope, name, dynamic=False):
+    def get_did(self, scope, name, dynamic=False, dynamic_depth=None):
         """
         Retrieve a single data identifier.
 
         :param scope: The scope name.
         :param name: The data identifier name.
-        :param dynamic: Calculate sizes dynamically when True
+        :param dynamic_depth: The DID type as string ('FILE'/'DATASET') at which to stop the dynamic
+        length/bytes calculation. If not set, the size will not be computed dynamically.
+        :param dynamic: (Deprecated) same as dynamic_depth = 'FILE'
         """
 
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name)])
-        if dynamic:
-            path += '?dynamic=True'
-        url = build_url(choice(self.list_hosts), path=path)
+        params = {}
+        if dynamic_depth:
+            params['dynamic_depth'] = dynamic_depth
+        elif dynamic:
+            params['dynamic_depth'] = 'FILE'
+        url = build_url(choice(self.list_hosts), path=path, params=params)
         r = self._send_request(url, type_='GET')
         if r.status_code == codes.ok:
             return next(self._load_json_data(r))

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1111,8 +1111,8 @@ class DownloadClient:
             for did in resolved_dids:
                 did_to_input_items.setdefault(DID(did), []).append(item)
 
-                if 'length' in did and not did['length']:
-                    did_with_size = self.client.get_did(scope=did['scope'], name=did['name'], dynamic=True)
+                if 'CONTAINER' in did.get('did_type', '').upper() or ('length' in did and not did['length']):
+                    did_with_size = self.client.get_did(scope=did['scope'], name=did['name'], dynamic_depth='FILE')
                     did['length'] = did_with_size['length']
                     did['bytes'] = did_with_size['bytes']
 

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -1013,7 +1013,7 @@ def repair_rule(rule_id, session=None, logger=logging.log):
         # make the decisison on soft or hard repair.
         hard_repair = False
         if did.did_type != DIDType.FILE:
-            nr_files = rucio.core.did.get_did(scope=rule.scope, name=rule.name, dynamic=True, session=session)['length']
+            nr_files = rucio.core.did.get_did(scope=rule.scope, name=rule.name, dynamic_depth=DIDType.FILE, session=session)['length']
         else:
             nr_files = 1
         if nr_files * rule.copies != (rule.locks_ok_cnt + rule.locks_stuck_cnt + rule.locks_replicating_cnt):
@@ -2976,7 +2976,7 @@ def __create_rule_approval_email(rule, session=None):
     with open('%s/rule_approval_request.tmpl' % config_get('common', 'mailtemplatedir'), 'r') as templatefile:
         template = Template(templatefile.read())
 
-    did = rucio.core.did.get_did(scope=rule.scope, name=rule.name, dynamic=True, session=session)
+    did = rucio.core.did.get_did(scope=rule.scope, name=rule.name, dynamic_depth=DIDType.FILE, session=session)
     rses = [rep['rse_id'] for rep in rucio.core.replica.list_dataset_replicas(scope=rule.scope, name=rule.name, session=session) if rep['state'] == ReplicaState.AVAILABLE]
 
     # RSE occupancy

--- a/lib/rucio/core/rule_grouping.py
+++ b/lib/rucio/core/rule_grouping.py
@@ -1257,7 +1257,7 @@ def apply_rule(did, rule, rses, source_rses, rseselector, session=None, logger=l
             # simply loop over child datasets
             # this is an approximation because ignoring the possibility of file overlap
             for ds_scope, ds_name in datasets:
-                ds = rucio.core.did.get_did(scope=ds_scope, name=ds_name, dynamic=True, session=session)  # this will be retrieved again later on -> could be optimized
+                ds = rucio.core.did.get_did(scope=ds_scope, name=ds_name, dynamic_depth=DIDType.FILE, session=session)  # this will be retrieved again later on -> could be optimized
                 nbytes += ds['bytes']
                 one_rse_coverage = rucio.core.replica.get_RSEcoverage_of_dataset(scope=ds_scope, name=ds_name, session=session)
                 for rse_id, bytes_ in one_rse_coverage.items():
@@ -1273,7 +1273,7 @@ def apply_rule(did, rule, rses, source_rses, rseselector, session=None, logger=l
         for ds_scope, ds_name in datasets:
             # prnt(('processing dataset ',ds_scope, ds_name))
             #
-            ds = rucio.core.did.get_did(scope=ds_scope, name=ds_name, dynamic=True, session=session)
+            ds = rucio.core.did.get_did(scope=ds_scope, name=ds_name, dynamic_depth=DIDType.FILE, session=session)
             ds_length = ds['length']
             ds_bytes = ds['bytes']
             ds_open = ds['open']

--- a/lib/rucio/tests/test_did.py
+++ b/lib/rucio/tests/test_did.py
@@ -110,7 +110,12 @@ class TestDIDCore:
         set_metadata(scope=mock_scope, name=lfn, key='bytes', value=724963577)
         assert get_metadata(scope=mock_scope, name=lfn)['bytes'] == 724963577
 
-    def test_get_did_with_dynamic(self, root_account, rse_factory, did_factory):
+    @pytest.mark.parametrize("file_config_mock", [
+        # Run test twice: with, and without, temp tables
+        {"overrides": [('core', 'use_temp_tables', 'True')]},
+        {"overrides": [('core', 'use_temp_tables', 'False')]},
+    ], indirect=True)
+    def test_get_did_with_dynamic(self, root_account, rse_factory, did_factory, file_config_mock):
         """ DATA IDENTIFIERS (CORE): Get did with dynamic resolve of size"""
         rse_name, rse_id = rse_factory.make_mock_rse()
 

--- a/lib/rucio/tests/test_did.py
+++ b/lib/rucio/tests/test_did.py
@@ -110,24 +110,37 @@ class TestDIDCore:
         set_metadata(scope=mock_scope, name=lfn, key='bytes', value=724963577)
         assert get_metadata(scope=mock_scope, name=lfn)['bytes'] == 724963577
 
-    def test_get_did_with_dynamic(self, vo, mock_scope, root_account, rse_factory):
+    def test_get_did_with_dynamic(self, root_account, rse_factory, did_factory):
         """ DATA IDENTIFIERS (CORE): Get did with dynamic resolve of size"""
-        rse, rse_id = rse_factory.make_mock_rse()
-        tmp_dsn1 = 'dsn_%s' % generate_uuid()
-        tmp_dsn2 = 'dsn_%s' % generate_uuid()
-        tmp_dsn3 = 'dsn_%s' % generate_uuid()
-        tmp_dsn4 = 'dsn_%s' % generate_uuid()
+        rse_name, rse_id = rse_factory.make_mock_rse()
 
-        add_did(scope=mock_scope, name=tmp_dsn1, did_type=DIDType.DATASET, account=root_account)
-        add_replica(rse_id=rse_id, scope=mock_scope, name=tmp_dsn2, bytes_=10, account=root_account)
-        add_replica(rse_id=rse_id, scope=mock_scope, name=tmp_dsn3, bytes_=10, account=root_account)
-        attach_dids(scope=mock_scope, name=tmp_dsn1, dids=[{'scope': mock_scope, 'name': tmp_dsn2}, {'scope': mock_scope, 'name': tmp_dsn3}], account=root_account)
+        # make a dataset with 2 files in it and verify get_did(dynamic) on dataset
+        dataset1 = did_factory.make_dataset()
+        file1 = did_factory.random_did()
+        file2 = did_factory.random_did()
+        add_replica(rse_id=rse_id, bytes_=10, account=root_account, **file1)
+        add_replica(rse_id=rse_id, bytes_=10, account=root_account, **file2)
+        attach_dids(dids=[file1, file2], account=root_account, **dataset1)
+        did1 = get_did(dynamic=True, **dataset1)
+        assert did1['length'] == 2
+        assert did1['bytes'] == 20
 
-        add_did(scope=mock_scope, name=tmp_dsn4, did_type=DIDType.CONTAINER, account=root_account)
-        attach_dids(scope=mock_scope, name=tmp_dsn4, dids=[{'scope': mock_scope, 'name': tmp_dsn1}], account=root_account)
+        # attach dataset to container and verify get_did(dynamic) on container
+        container = did_factory.make_container()
+        attach_dids(dids=[dataset1], account=root_account, **container)
+        did1 = get_did(dynamic=True, **container)
+        assert did1['length'] == 2
+        assert did1['bytes'] == 20
 
-        assert get_did(scope=mock_scope, name=tmp_dsn1, dynamic=True)['bytes'] == 20
-        assert get_did(scope=mock_scope, name=tmp_dsn4, dynamic=True)['bytes'] == 20
+        # make another dataset with one file in it and attach to previously created container
+        dataset2 = did_factory.make_dataset()
+        file3 = did_factory.random_did()
+        add_replica(rse_id=rse_id, bytes_=10, account=root_account, **file3)
+        attach_dids(dids=[dataset2], account=root_account, **container)
+        attach_dids(dids=[file3], account=root_account, **dataset2)
+        did1 = get_did(dynamic=True, **container)
+        assert did1['length'] == 3
+        assert did1['bytes'] == 30
 
     def test_reattach_dids(self, vo, mock_scope, root_account, rse_factory):
         """ DATA IDENTIFIERS (CORE): Repeatedly attach and detach DIDs """

--- a/lib/rucio/tests/test_did.py
+++ b/lib/rucio/tests/test_did.py
@@ -121,14 +121,14 @@ class TestDIDCore:
         add_replica(rse_id=rse_id, bytes_=10, account=root_account, **file1)
         add_replica(rse_id=rse_id, bytes_=10, account=root_account, **file2)
         attach_dids(dids=[file1, file2], account=root_account, **dataset1)
-        did1 = get_did(dynamic=True, **dataset1)
+        did1 = get_did(dynamic_depth=DIDType.FILE, **dataset1)
         assert did1['length'] == 2
         assert did1['bytes'] == 20
 
         # attach dataset to container and verify get_did(dynamic) on container
         container = did_factory.make_container()
         attach_dids(dids=[dataset1], account=root_account, **container)
-        did1 = get_did(dynamic=True, **container)
+        did1 = get_did(dynamic_depth=DIDType.FILE, **container)
         assert did1['length'] == 2
         assert did1['bytes'] == 20
 
@@ -138,9 +138,15 @@ class TestDIDCore:
         add_replica(rse_id=rse_id, bytes_=10, account=root_account, **file3)
         attach_dids(dids=[dataset2], account=root_account, **container)
         attach_dids(dids=[file3], account=root_account, **dataset2)
-        did1 = get_did(dynamic=True, **container)
+        did1 = get_did(dynamic_depth=DIDType.FILE, **container)
         assert did1['length'] == 3
         assert did1['bytes'] == 30
+
+        # if resolve_depth is dataset, the result will be incorrect, but this is by design,
+        # dataset has to be re-evaluated
+        did1 = get_did(dynamic_depth=DIDType.DATASET, **container)
+        assert did1['length'] == 0
+        assert did1['bytes'] == 0
 
     def test_reattach_dids(self, vo, mock_scope, root_account, rse_factory):
         """ DATA IDENTIFIERS (CORE): Repeatedly attach and detach DIDs """


### PR DESCRIPTION
Apply it in two cases: 
- For downloads, we are interested in an exact statistics, so perform the iteration up to the file. 
- When calling "stats" on the container. In this case, only compute it using data from datasets. 

Also add support for temporary tables in get_did when dynamically computing the size. 