### PR TITLE
Metadata: Add additional operators in metadata filter engine for Oracle #5503 

### DIFF
--- a/lib/rucio/core/did_meta_plugins/filter_engine.py
+++ b/lib/rucio/core/did_meta_plugins/filter_engine.py
@@ -397,8 +397,6 @@ class FilterEngine:
                                     expression = oper(json_column[key].as_string(), value)
                             except Exception as e:
                                 raise exception.FilterEngineGenericError(e)
-                            if oper == operator.ne:                                                 # set .ne operator to include NULLs.
-                                expression = or_(expression, json_column[key].is_(None))
                 else:
                     raise exception.FilterEngineGenericError("Requested filter on key without model attribute, but [json_column] not set.")
 

--- a/lib/rucio/core/did_meta_plugins/filter_engine.py
+++ b/lib/rucio/core/did_meta_plugins/filter_engine.py
@@ -359,17 +359,17 @@ class FilterEngine:
                                 continue
                             else:                                                                   # partial match with wildcard == like || notlike
                                 if oper == operator.eq:
-                                    expression = text("json_exists({},'$?(@.{} like \"{}\")')".format(json_column, key, value.replace('*', '%')))
+                                    expression = text("json_exists({},'$?(@.{} like \"{}\")')".format(json_column.key, key, value.replace('*', '%')))
                                 elif oper == operator.ne:
                                     raise exception.FilterEngineGenericError("Oracle implementation does not support this operator.")
                         else:
                             try:
                                 if isinstance(value, (bool)):                                       # bool must be checked first (as bool subclass of int)
-                                    expression = text("json_exists({},'$?(@.{}.boolean() {} \"{}\")')".format(json_column, key, ORACLE_OP_MAP[oper], value))
+                                    expression = text("json_exists({},'$?(@.{}.boolean() {} \"{}\")')".format(json_column.key, key, ORACLE_OP_MAP[oper], value))
                                 elif isinstance(value, (int, float)):
-                                    expression = text("json_exists({},'$?(@.{} {} {})')".format(json_column, key, ORACLE_OP_MAP[oper], value))
+                                    expression = text("json_exists({},'$?(@.{} {} {})')".format(json_column.key, key, ORACLE_OP_MAP[oper], value))
                                 else:
-                                    expression = text("json_exists({},'$?(@.{} {} \"{}\")')".format(json_column, key, ORACLE_OP_MAP[oper], value))
+                                    expression = text("json_exists({},'$?(@.{} {} \"{}\")')".format(json_column.key, key, ORACLE_OP_MAP[oper], value))
                             except Exception as e:
                                 raise exception.FilterEngineGenericError(e)
                     else:

--- a/lib/rucio/core/did_meta_plugins/json_meta.py
+++ b/lib/rucio/core/did_meta_plugins/json_meta.py
@@ -54,7 +54,7 @@ class JSONDidMeta(DidMetaPlugin):
             meta = getattr(row, 'meta')
             return json_lib.loads(meta) if session.bind.dialect.name in ['oracle', 'sqlite'] else meta
         except NoResultFound:
-            raise exception.DataIdentifierNotFound("No generic metadata found for '%(scope)s:%(name)s'" % locals())
+            return {}
 
     def set_metadata(self, scope, name, key, value, recursive=False, session=None):
         self.set_metadata_bulk(scope=scope, name=name, metadata={key: value}, recursive=recursive, session=session)

--- a/lib/rucio/tests/test_filter_engine.py
+++ b/lib/rucio/tests/test_filter_engine.py
@@ -584,7 +584,7 @@ class TestFilterEngineReal(unittest.TestCase):
                 json_column=models.DidMeta.meta)
             dids += [did for did in q.yield_per(5)]
             dids = set(dids)
-            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 2)     # 1, 2
+            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 2)     # 2, 3
 
             dids = []
             q = FilterEngine('testkeyint1 = 1, testkeystr1 = test; testkeyint1 != 1', model_class=models.DidMeta, strict_coerce=False).create_sqla_query(

--- a/lib/rucio/tests/test_filter_engine.py
+++ b/lib/rucio/tests/test_filter_engine.py
@@ -214,7 +214,7 @@ class TestFilterEngineReal(unittest.TestCase):
                 json_column=models.DidMeta.meta)
             dids += [did for did in q.yield_per(5)]
             dids = set(dids)
-            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 2)
+            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 0)
 
     @read_session
     def test_OneSidedInequality(self, session=None):
@@ -425,7 +425,7 @@ class TestFilterEngineReal(unittest.TestCase):
                 json_column=models.DidMeta.meta)
             dids += [did for did in q.yield_per(5)]
             dids = set(dids)
-            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 1)     # 1
+            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 0)     # 0
 
     @read_session
     def test_OrGroups(self, session=None):
@@ -584,7 +584,7 @@ class TestFilterEngineReal(unittest.TestCase):
                 json_column=models.DidMeta.meta)
             dids += [did for did in q.yield_per(5)]
             dids = set(dids)
-            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 3)     # 1, 2, 3
+            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 2)     # 1, 2
 
             dids = []
             q = FilterEngine('testkeyint1 = 1, testkeystr1 = test; testkeyint1 != 1', model_class=models.DidMeta, strict_coerce=False).create_sqla_query(

--- a/lib/rucio/tests/test_filter_engine.py
+++ b/lib/rucio/tests/test_filter_engine.py
@@ -425,7 +425,7 @@ class TestFilterEngineReal(unittest.TestCase):
                 json_column=models.DidMeta.meta)
             dids += [did for did in q.yield_per(5)]
             dids = set(dids)
-            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 0)     # 0
+            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 0)
 
     @read_session
     def test_OrGroups(self, session=None):
@@ -465,7 +465,7 @@ class TestFilterEngineReal(unittest.TestCase):
             additional_model_attributes=[models.DataIdentifier.name])
         dids += [did for did in q.yield_per(5)]
         dids = set(dids)
-        self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 0)     #
+        self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 0)
 
         dids = []
         q = FilterEngine('name = {}; name = {}; name = {}'.format(did_name1, did_name2, did_name3), model_class=models.DataIdentifier).create_sqla_query(
@@ -527,7 +527,7 @@ class TestFilterEngineReal(unittest.TestCase):
                 json_column=models.DidMeta.meta)
             dids += [did for did in q.yield_per(5)]
             dids = set(dids)
-            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 0)     #
+            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 0)
 
             dids = []
             q = FilterEngine('name = {}; name = {}; name = {}'.format(did_name1, did_name2, did_name3), model_class=models.DidMeta, strict_coerce=False).create_sqla_query(

--- a/lib/rucio/tests/test_filter_engine.py
+++ b/lib/rucio/tests/test_filter_engine.py
@@ -595,7 +595,7 @@ class TestFilterEngineReal(unittest.TestCase):
                 json_column=models.DidMeta.meta)
             dids += [did for did in q.yield_per(5)]
             dids = set(dids)
-            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 2)     # 2, 3
+            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 1)     # 3
 
     @read_session
     def test_BackwardsCompatibilityCreatedAfter(self, session=None):

--- a/lib/rucio/tests/test_filter_engine.py
+++ b/lib/rucio/tests/test_filter_engine.py
@@ -204,7 +204,7 @@ class TestFilterEngineReal(unittest.TestCase):
             dids = set(dids)
             self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3), dids)).count(True), 1)
 
-        if session.bind.dialect.name != 'oracle' and json_implemented(session=session):
+        if json_implemented(session=session):
             dids = []
             q = FilterEngine('testkeyint1!=1', model_class=models.DidMeta, strict_coerce=False).create_sqla_query(
                 additional_model_attributes=[
@@ -253,7 +253,7 @@ class TestFilterEngineReal(unittest.TestCase):
 
         # Plugin: JSON
         #
-        if session.bind.dialect.name != 'oracle' and json_implemented(session=session):
+        if json_implemented(session=session):
             did_name = self._create_tmp_DID()
             set_metadata(scope=self.tmp_scope, name=did_name, key='testkeyint1', value=1)
 
@@ -331,7 +331,7 @@ class TestFilterEngineReal(unittest.TestCase):
 
         # Plugin: JSON
         #
-        if session.bind.dialect.name != 'oracle' and json_implemented(session=session):
+        if json_implemented(session=session):
             did_name = self._create_tmp_DID()
             set_metadata(scope=self.tmp_scope, name=did_name, key='testkeyint1', value=1)
 
@@ -396,7 +396,7 @@ class TestFilterEngineReal(unittest.TestCase):
 
         # Plugin: JSON
         #
-        if session.bind.dialect.name != 'oracle' and json_implemented(session=session):
+        if json_implemented(session=session):
             did_name1 = self._create_tmp_DID()
             did_name2 = self._create_tmp_DID()
             did_name3 = self._create_tmp_DID()
@@ -476,7 +476,7 @@ class TestFilterEngineReal(unittest.TestCase):
 
         # Plugin: JSON
         #
-        if session.bind.dialect.name != 'oracle' and json_implemented(session=session):
+        if json_implemented(session=session):
             did_name1 = self._create_tmp_DID()
             did_name2 = self._create_tmp_DID()
             did_name3 = self._create_tmp_DID()
@@ -566,7 +566,7 @@ class TestFilterEngineReal(unittest.TestCase):
 
         # Plugin: JSON
         #
-        if session.bind.dialect.name != 'oracle' and json_implemented(session=session):
+        if json_implemented(session=session):
             did_name1 = self._create_tmp_DID()
             did_name2 = self._create_tmp_DID()
             did_name3 = self._create_tmp_DID()
@@ -688,7 +688,7 @@ class TestFilterEngineReal(unittest.TestCase):
 
         # Plugin: JSON
         #
-        if session.bind.dialect.name != 'oracle' and json_implemented(session=session):
+        if json_implemented(session=session):
             did_name1 = self._create_tmp_DID()
             did_name2 = self._create_tmp_DID()
             did_name3 = self._create_tmp_DID()
@@ -721,27 +721,28 @@ class TestFilterEngineReal(unittest.TestCase):
             dids = set(dids)
             self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3, did_name4, did_name5), dids)).count(True), 4)  # 1, 2, 3, 4
 
-            dids = []
-            q = FilterEngine('testkeystr1 != *anothertest*', model_class=models.DidMeta, strict_coerce=False).create_sqla_query(
-                additional_model_attributes=[
-                    models.DidMeta.scope,
-                    models.DidMeta.name
-                ],
-                json_column=models.DidMeta.meta)
-            dids += [did for did in q.yield_per(5)]
-            dids = set(dids)
-            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3, did_name4, did_name5), dids)).count(True), 2)  # 3, 4
+            if session.bind.dialect.name != 'oracle':
+                dids = []
+                q = FilterEngine('testkeystr1 != *anothertest*', model_class=models.DidMeta, strict_coerce=False).create_sqla_query(
+                    additional_model_attributes=[
+                        models.DidMeta.scope,
+                        models.DidMeta.name
+                    ],
+                    json_column=models.DidMeta.meta)
+                dids += [did for did in q.yield_per(5)]
+                dids = set(dids)
+                self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3, did_name4, did_name5), dids)).count(True), 2)  # 3, 4
 
-            dids = []
-            q = FilterEngine('testkeystr1 != *test*', model_class=models.DidMeta, strict_coerce=False).create_sqla_query(
-                additional_model_attributes=[
-                    models.DidMeta.scope,
-                    models.DidMeta.name
-                ],
-                json_column=models.DidMeta.meta)
-            dids += [did for did in q.yield_per(5)]
-            dids = set(dids)
-            self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3, did_name4, did_name5), dids)).count(True), 0)
+                dids = []
+                q = FilterEngine('testkeystr1 != *test*', model_class=models.DidMeta, strict_coerce=False).create_sqla_query(
+                    additional_model_attributes=[
+                        models.DidMeta.scope,
+                        models.DidMeta.name
+                    ],
+                    json_column=models.DidMeta.meta)
+                dids += [did for did in q.yield_per(5)]
+                dids = set(dids)
+                self.assertEqual(list(map(lambda did: did.name in (did_name1, did_name2, did_name3, did_name4, did_name5), dids)).count(True), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR: 
- Adds support for all metadata operations (except the `not like` one which is not supported) when using Oracle.
- Introduces a change into how to manage cases when querying JSON metadata for nonexistent keys. Up until now, when querying for inequality, e.g. `sample_key != 7`, the engine would return even DIDs that don't have the `sample_key` in their json meta dictionary. This PR assumes all keys to be present, even for inequality comparisons, in order to evaluate the clause and return the DID.
- Fixes #4512 

Implementation references: [1] [2]

[1] https://docs.oracle.com/en/database/oracle/oracle-database/19/adjsn/json-path-expressions.html
[2] https://docs.oracle.com/en/database/oracle/oracle-database/19/adjsn/condition-JSON_EXISTS.html