### PR TITLE
Documentation: Update ISSUE TEMPLATE #5575

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,46 @@
+name: 🐛 Bug Report
+description: Submit a bug report to help us improve
+labels: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing your issue, ask yourself:
+        - Is this clearly a Rucio defect?
+        - Do I have basic ideas about where it goes wrong? (For example, if there are stack traces, are they pointing to one file?)
+        - Could it be because of my own mistakes?
+        - Does an issue about the bug already exist?
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Write down the steps to reproduce the bug. You should start with a fresh installation, or your git repository linked above.
+      placeholder: |
+        1. Step 1...
+        2. Step 2...
+        3. Step 3...
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Rucio Version
+      description: The used Rucio Version.
+      placeholder: "e.g. Client: 1.26.3, Server: 1.28.4"
+
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: Include other relevant details, e.g. about your environment or setup.
+      placeholder: |
+        - Operating System
+        - Is the bug on the client/server side?
+        - ...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,23 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 Documentation
+    url: https://rucio.cern.ch/documentation/
+    about: The Rucio Documentation might give you some information related to the problem.
+  - name: ❓ Question - Ask us
+    url: https://rucio.cern.ch/contact.html
+    about: This issue tracker is not for technical support. Please use one of our dedicated channels, and ask the community for help.
+  - name: 🖋️  Issue related to the Documentation
+    url: https://github.com/rucio/documentation
+    about: If the issue is in or related to the documentation, please open it in the dedicated `rucio/documentation` repository.
+  - name: 🚢 Issue related to the Containers
+    url: https://github.com/rucio/containers
+    about: If the issue is in or related to the containers, please open it in the dedicated `rucio/containers` repository.
+  - name: 📈 Issue related to the Helm Charts
+    url: https://github.com/rucio/helm-charts
+    about: If the issue is in or related to the helm-charts, please open it in the dedicated `rucio/helm-charts` repository.
+  - name: 🔬 Issue related to the Rucio JupyterLab Extension
+    url: https://github.com/rucio/jupyterlab-extension
+    about: If the issue is in or related to the jupyterlab-extension, please open it in the dedicated `rucio/jupyterlab-extension` repository.
+  - name: 📐 Issue related to the Probes
+    url: https://github.com/rucio/probes
+    about: If the issue is in or related to the probes, please open it in the dedicated `rucio/probes` repository.

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,36 @@
+name: 💅 Feature Request
+description: Submit a feature request
+labels: enhancement
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of what the feature is.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Please outline the motivation for the proposal and why it should be implemented. Has this been requested by a lot of users?
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Change
+      description: Please outline the change for the proposal in detail.
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Additional Information
+      description: Please select all conditions that apply.
+      options:
+        - label: The `Core` needs to be changed.
+        - label: A `Daemon` needs to be changed.
+        - label: The `REST API` needs to be changed.
+        - label: The `API layer` needs to be changed.
+        - label: The `Client` needs to be changed.
+        - label: The change is incompatible with old Rucio versions.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-Motivation
-----------
-
-
-
-Modification
-------------
-
-


### PR DESCRIPTION
The new GitHub Issue Forms allow us to create more user-friendly issue
templates. These templates can provide more information to the issuer, as well
as the developer (e.g. specifically asking for the Rucio version used for bugs,
marking breaking changes in features, ...).

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
