### PR TITLE
Transfers: always skip ACTIVE transfers in receiver. Closes #5335

### DIFF
--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -73,9 +73,7 @@ class Receiver(object):
            and 'issuer' in msg['job_metadata'].keys() \
            and str(msg['job_metadata']['issuer']) == str('rucio'):
 
-            if 'job_state' in msg.keys() and (
-                    str(msg['job_state']) != str('ACTIVE')
-                    or str(msg['job_state']) == str('ACTIVE') and 'job_m_replica' in msg.keys() and (str(msg['job_m_replica']).lower() == str('true'))):
+            if 'job_state' in msg.keys() and str(msg['job_state']) != str('ACTIVE'):
                 record_counter('daemons.conveyor.receiver.message_rucio')
 
                 self._perform_request_update(msg)


### PR DESCRIPTION
the job_m_replica flag is for multi-source transfers, so the condition
which I remove makes no sense. We don't want to transition the state
of a multi-source transfer which is still in an ACTIVE state.

While the commit fixes the potential bug from the linked ticket, the
bug didn't occur in production because of a bug in FTS: job_m_replica
was always returned False by fts, even for multi-source transfers.
The FTS bug was already fixed and will be live soon (with the release
of FTS v3.12.0).

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
