### PR TITLE
Testing: Disable non-determined rucio version in autotests #5572

### DIFF
--- a/.github/workflows/imagecache.yml
+++ b/.github/workflows/imagecache.yml
@@ -66,7 +66,9 @@ jobs:
           if echo '{}' | "${{ steps.files.outputs.build_images }}" --version-test 2; then
             # new --branch option not available in older build_images.py revisions
             BUILD_ARGS=("${BUILD_ARGS[@]}" "--branch" "${{ matrix.branch }}")
-          elif [[ "${{ matrix.branch }}" != "master" ]]; then
+          fi
+          if [[ "${{ matrix.branch }}" != "master" ]]; then
+            # The image tag is the same for the different rucio versions. This if ensures, that only the master gets builded. rucio#5572
             echo "::warning::Not building image for branch ${{ matrix.branch }}, because it would overwrite master"
             exit 0
           fi
@@ -134,7 +136,9 @@ jobs:
           if echo '{}' | "${{ steps.files.outputs.build_images }}" --version-test 2; then
             # new --branch option not available in older build_images.py revisions
             BUILD_ARGS=("${BUILD_ARGS[@]}" "--branch" "${{ matrix.branch }}")
-          elif [[ "${{ matrix.branch }}" != "master" ]]; then
+          fi
+          if [[ "${{ matrix.branch }}" != "master" ]]; then
+            # The image tag is the same for the different rucio versions. This if ensures, that only the master gets builded. rucio#5572
             echo "::warning::Not building image for branch ${{ matrix.branch }}, because it would overwrite master"
             exit 0
           fi


### PR DESCRIPTION
The `autotest` docker images get build on a daily basis. There are multiple
images build with different configurations (different OS, Python version, Rucio
version). While the OS and the Python version is encoded in the image tag
(e.g. `ghcr.io/rucio/rucio/rucio-autotest:fedora33-python3.9`), the Rucio
version is not.

We are building four different classes of images every day with various
configurations: `Release-1.23-LTS`, `Release-1.26-LTS`, `Release-1.28`,
`master`. Since the tag does not contain the Rucio version, the image available
online corresponds to the last image uploaded. So the image is up-to-date if the
`master` finished last, but not if some other configuration does.

This is **not** a problem in the `autotest` workflow run, since the image gets
build every time to make up for changes. This, however, is a problem if we have
a process which needs an up-to-date (tracking master) container
(e.g. rucio/documentation#115), since the Rucio and dependency version in the
container is non-deterministic.

There are two possibilities to proceed here:

1. Include the rucio version in the tag. This way, we have up-to-date LTS
  containers as well as one tracking the master. This however rebuilds the
  containers every night, even if the LTS ones are not really used.

2. Only keep the latest project version and don't include the other ones. This
  saves time on a daily basis and only forces a build of the other versions if a
  build is needed. We also don't have to change the `autotest` code.

We decided for the 2. option and skip the build of the other containers.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
