### PR TITLE
Documentation: Change the file header of `.py.mako` files #5597

### DIFF
--- a/lib/rucio/db/sqla/migrate_repo/script.py.mako
+++ b/lib/rucio/db/sqla/migrate_repo/script.py.mako
@@ -1,4 +1,5 @@
-# Copyright 2013-2021 CERN
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,9 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Authors:
-# - John Doe <john.doe@asdf.com>, 2021
 
 ''' ${message} '''
 

--- a/tools/add_header
+++ b/tools/add_header
@@ -292,7 +292,7 @@ class PythonHeaderTemplate(HeaderTemplate):
             # File could not be opened, this makes it automatically invalid
             return False
 
-        return os.path.splitext(file_path)[1] == ".py" or is_file_using_shebag
+        return file_path.endswith(".py") or file_path.endswith(".py.mako") or is_file_using_shebag
 
     def __init__(self, file_path: str):
         super().__init__(file_path)


### PR DESCRIPTION
`.py.mako` files are template files used to generate python files. The
file headers should be treated the same as python ones.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
