### PR TITLE
Clients: Fix various rucio bin's help text formatting #5537

### DIFF
--- a/bin/rucio-abacus-account
+++ b/bin/rucio-abacus-account
@@ -54,7 +54,7 @@ Check account usage again::
   | MOCK  | 211.724 kB | 0.000 B | 0.000 B      |
   +-------+------------+---------+--------------+
 
-    ''')
+    ''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
     parser.add_argument("--threads", action="store", default=1, type=int, help='Concurrency control: total number of threads on this process')
     parser.add_argument("--enable-history", action="store_true", default=False, help='Record account usage into history table every hour.')

--- a/bin/rucio-abacus-rse
+++ b/bin/rucio-abacus-rse
@@ -60,7 +60,7 @@ Check RSE usage again::
       updated_at: 2018-12-03 08:58:33
       source: rucio
   ------
-''')
+''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
     parser.add_argument("--threads", action="store", default=1, type=int, help='Concurrency control: total number of threads on this process')
     parser.add_argument("--enable-history", action="store_true", default=False, help='Record RSE usage into history table every hour.')

--- a/bin/rucio-conveyor-submitter
+++ b/bin/rucio-conveyor-submitter
@@ -78,7 +78,7 @@ Note that attempting the use the ``--vos`` argument when in single-VO mode will 
   $ rucio-conveyor-submitter --run-once --vos abc xyz
   2020-07-29 13:39:37,263 5752    INFO    RSE selection: automatic
   2020-07-29 13:39:37,264 5752    INFO    starting submitter threads
-    ''')
+    ''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--run-once", action="store_true", default=False,
                         help='One iteration only')
     parser.add_argument("--total-threads", action="store", default=1, type=int,

--- a/bin/rucio-conveyor-throttler
+++ b/bin/rucio-conveyor-throttler
@@ -87,7 +87,7 @@ Check transfer requests::
 
 Finally one of the transfer requests got put in the queue and can be picked up by the Conyevor-Submitter daemon to submit the transfer job to the transfertool.
 The other request will have to wait until one of the queued requests is done or until the transfer limit changes.
-''')
+''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--run-once", action="store_true", default=False,
                         help='One iteration only')
     parser.add_argument('--sleep-time', action="store", default=600, type=int,

--- a/bin/rucio-judge-cleaner
+++ b/bin/rucio-judge-cleaner
@@ -73,7 +73,7 @@ Check the replication rules and the replicas::
   session.get_session().query(models.RSEFileAssociation).filter_by(name='file', scope='mock', rse_id=rse_id).first().lock_cnt // 0
 
 The rule we created before was deleted and the replica of the file on RSE MOCK2 got a tombstone because there is no protecting rule anymore.
-    ''')
+    ''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
     parser.add_argument("--threads", action="store", default=1, type=int, help='Concurrency control: total number of threads on this process')
     parser.add_argument('--sleep-time', action="store", default=60, type=int, help='Concurrency control: thread sleep time after each chunk of work')

--- a/bin/rucio-judge-evaluator
+++ b/bin/rucio-judge-evaluator
@@ -119,7 +119,7 @@ Check the replicas for the DID mock:file::
 The DID mock:file has now two replicas with one lock each.
 As the file replica is attached to the dataset and the rule for the dataset specifies another RSE MOCK instead of the upload RSE, it has to be replicated to this RSE.
 Therefor a second replica in state COPYING got created on RSE MOCK.
-    ''')
+    ''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
     parser.add_argument("--threads", action="store", default=1, type=int, help='Concurrency control: total number of threads for this process')
     parser.add_argument('--sleep-time', action="store", default=30, type=int, help='Concurrency control: thread sleep time after each chunk of work')

--- a/bin/rucio-necromancer
+++ b/bin/rucio-necromancer
@@ -100,7 +100,7 @@ Check replicas again::
   |---------+--------+------------+-----------+---------------------------------------------------------|
   | mock    | file   | 149.000 B  |    948240 | MOCK2: file://localhost:1/tmp/rucio_rse/mock/fb/d1/file |
   +---------+--------+------------+-----------+---------------------------------------------------------+
-    ''')
+''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--run-once", action="store_true", default=False, help='Runs one loop iteration')
     parser.add_argument("--threads", action="store", default=1, type=int, help='Concurrency control: number of threads')
     parser.add_argument("--bulk", action="store", default=1000, type=int, help='Bulk control: number of requests per cycle')

--- a/bin/rucio-replica-recoverer
+++ b/bin/rucio-replica-recoverer
@@ -30,7 +30,6 @@ def get_parser():
     Returns the argparse parser.
     """
     parser = argparse.ArgumentParser(description='''
-
 Replica-Recoverer is a daemon that declares suspicious replicas
 that are available on other RSE as bad. Consequently, automatic
 replica recovery is triggered via necromancer daemon,
@@ -228,7 +227,7 @@ Note that attempting the use the ``--vos`` argument when in single-VO mode will 
 
   $ rucio-replica-recoverer --run-once --vos abc xyz
   2020-07-28 15:21:33,349 5488    WARNING Ignoring argument vos, this is only applicable in a multi-VO setup.
-''')  # NOQA: E501
+''', formatter_class=argparse.RawDescriptionHelpFormatter)  # NOQA: E501
     parser.add_argument("--nattempts", action="store", default=10, help='Minimum count of suspicious file replica appearance in bad_replicas table. Default value is 10.')
     parser.add_argument("--younger-than", action="store", default=3, help='Consider all file replicas logged in bad_replicas table since speicified number of younger-than days. Default value is 3.')
     parser.add_argument('--vos', nargs='+', type=str, help='Optional list of VOs to consider. Only used in multi-VO mode.')

--- a/bin/rucio-storage-consistency-actions
+++ b/bin/rucio-storage-consistency-actions
@@ -34,7 +34,7 @@ def get_parser():
     parser = argparse.ArgumentParser(description="The Consistency-Actions daemon is responsible for applying the corrective actions resulting from a consistency-check scan of an RSE.", epilog='''
 Run the daemon::
   $ rucio-storage-consistency-actions --run-once --scope cms --rses T2_US_Purdue T2_US_Nebraska --dark-threshold-percent 2.0 --miss-threshold-percent 1.5 --scanner-files-path /tmp/consistency-dump --sleep-time 10
-    ''')
+''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
     parser.add_argument("--scope", action="store", default=False, type=str,
                         help='Scope of the input files produced by theiCC scanner - e.g.: "cms" ')

--- a/bin/rucio-transmogrifier
+++ b/bin/rucio-transmogrifier
@@ -57,7 +57,7 @@ Check again if there are rules for the DID::
   ID                                ACCOUNT    SCOPE:NAME    STATE[OK/REPL/STUCK]    RSE_EXPRESSION      COPIES  EXPIRES (UTC)    CREATED (UTC)
   --------------------------------  ---------  ------------  ----------------------  ----------------  --------  ---------------  -------------------
   e658f6f47f444326aad624dabef7b785  root       mock:test     OK[0/0/0]               MOCK                     1                   2018-12-03 14:01:19
-    ''')
+    ''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--run-once", action="store_true", default=False, help='Runs one loop iteration')
     parser.add_argument("--threads", action="store", default=1, type=int, help='Concurrency control: number of threads')
     parser.add_argument("--bulk", action="store", default=1000, type=int, help='Bulk control: number of requests per cycle')

--- a/bin/rucio-undertaker
+++ b/bin/rucio-undertaker
@@ -57,7 +57,7 @@ Check if the DID exists::
   | SCOPE:NAME   | [DID TYPE]   |
   |--------------+--------------|
   +--------------+--------------+
-    ''')
+''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
     parser.add_argument("--total-workers", action="store", default=1, type=int, help='Total number of workers')
     parser.add_argument("--chunk-size", action="store", default=5, type=int, help='Chunk size')


### PR DESCRIPTION
By default, `argparse` warps the _description_ and _epilog_ of the help
text. Text, which should be displayed as it is in the code, also gets
wrapped. This is a problem, since it makes it harder to read and
basically impossible to understand code examples.

This commit changes `argparse`s behavior, it displays the lines
correctly now.