### PR TITLE
Replicas: Fix misleading documentation in ReplicaClient.update_replic…

### DIFF
--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -275,13 +275,12 @@ class ReplicaClient(BaseClient):
         :param files: The list of files. This is a list of DIDs like :
             [{'scope': <scope1>, 'name': <name1>, 'state': <state1>}, {'scope': <scope2>, 'name': <name2>, 'state': <state2>}, ...],
             where a state value can be either of:
-            'A' (available)
-            'S' (suspicious)
-            'U' (unavailable)
-            'R' (recovered)
-            'B' (bad)
-            'L' (lost)
-            'D' (deleted)
+              'A' (AVAILABLE)
+              'U' (UNAVAILABLE)
+              'C' (COPYING)
+              'B' (BEING_DELETED)
+              'D' (BAD)
+              'T' (TEMPORARY_UNAVAILABLE)
         :return: True if replica states have been updated successfully, otherwise an exception is raised.
 
         """


### PR DESCRIPTION
…as_state() #5487

The documentation about the available `ReplicaStates` is wrong. It is
mixed with the `BadFilesStatus`. This seems to be a simple mistake, the
`BadFilesStatus` is not used anywhere.

It got introduced in c24ac10ed (Merge pull request #5552 from
rcarpa/patch-5523-circular_reference_containers, 2022-05-30)

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
