### PR TITLE
Testing: Drop the type annotations check for client code #4455

### DIFF
--- a/tools/count_missing_type_annotations_utils.sh
+++ b/tools/count_missing_type_annotations_utils.sh
@@ -46,7 +46,7 @@ create_missing_python_type_annotations_report() {
     # This does not include tests, tools, database and bin files.
     # :param $1: The name of the output file.
 
-    flake8 lib/rucio --exclude tools,lib/rucio/tests,lib/rucio/db --output-file $1 --select ANN || true
+    flake8 lib/rucio --exclude tools,lib/rucio/tests,lib/rucio/db,lib/rucio/client,lib/rucio/common,lib/rucio/rse,bin --output-file $1 --select ANN || true
 }
 
 


### PR DESCRIPTION
The type annotations got introduced because we dropped support for
Python2. While this is true on the server side, we still support Python2
on the client one. Since these type annotations are not part of the
Python2 syntax, we can't introduce them yet.

There are two possibilities:

- Use the Python2 compatible type annotations. These are comments with
  the pre-fix "type: ". While the code would be type-annotated, this has
  some major drawbacks:

  - The syntax should be changed back to the Python3 one, to have a
    consistent style.

  - The comments are ugly and delude the code.

- Don't introduce type annotations in the client code till we drop
  support for Python2. This leaves us without type annotated code for a
  short while.

Option two seems reasonable better, since the support will be dropped in
a short amount of time. Once the Python2 support is dropped, we can
activate the missing type annotations count job again for the client.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
