### PR TITLE
Delete where file does not exist is OK

### DIFF
--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -491,9 +491,12 @@ class Default(protocol.RSEProtocol):
 
         try:
             for path in paths:
-                ret = ctx.unlink(str(path))
-                if ret:
-                    return ret
+                if self.__gfal2_exist(path) == 0:
+                    ret = ctx.unlink(str(path))
+                    if ret:
+                        return ret
+                else:
+                    raise exception.SourceNotFound
             return ret
         except gfal2.GError as error:  # pylint: disable=no-member
             if error.code == errno.ENOENT or 'No such file' in str(error):


### PR DESCRIPTION
Fix #5622 check that a file exists before trying to delete it with GFAL.

CMS has been running with this for years, it's time to try to get it into the release. @nsmith- is the original author
