### PR TITLE
Core & Internals: migrate to pymemcache. Closes #5341

### DIFF
--- a/lib/rucio/common/cache.py
+++ b/lib/rucio/common/cache.py
@@ -12,29 +12,49 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
+import logging
 from dogpile.cache import make_region
 
 from rucio.common.config import config_get
 
+CACHE_URL = config_get('cache', 'url', False, '127.0.0.1:11211', check_config_table=False)
+
+ENABLE_CACHING = True
+_mc_client = None
+try:
+    import pymemcache
+    _mc_client = pymemcache.Client(CACHE_URL, connect_timeout=1, timeout=1)
+    _mc_client.version()
+except (IOError, ImportError):
+    logging.warning("Cannot access memcached at {}. Caching will be disabled".format(CACHE_URL), exc_info=True)
+    ENABLE_CACHING = False
+finally:
+    if _mc_client:
+        _mc_client.close()
+
 
 def make_region_memcached(expiration_time, function_key_generator=None):
     """
-    Make and configure a dogpile.cache.memcached region
+    Make and configure a dogpile.cache.pymemcache region
     """
     if function_key_generator:
         region = make_region(function_key_generator=function_key_generator)
     else:
         region = make_region()
 
-    region.configure(
-        'dogpile.cache.memcached',
-        expiration_time=expiration_time,
-        arguments={
-            'url': config_get('cache', 'url', False, '127.0.0.1:11211', check_config_table=False),
-            'distributed_lock': True,
-            'memcached_expire_time': expiration_time + 60,  # must be bigger than expiration_time
-        }
-    )
+    if ENABLE_CACHING:
+        region.configure(
+            'dogpile.cache.pymemcache',
+            expiration_time=expiration_time,
+            arguments={
+                'url': CACHE_URL,
+                'distributed_lock': True,
+                'memcached_expire_time': expiration_time + 60,  # must be bigger than expiration_time
+            }
+        )
+    else:
+        region.configure('dogpile.cache.null')
 
     return region

--- a/lib/rucio/tests/test_judge_repairer.py
+++ b/lib/rucio/tests/test_judge_repairer.py
@@ -302,7 +302,7 @@ class TestJudgeRepairer(unittest.TestCase):
         rule_repairer(once=True)  # Clean out the repairer
 
         region = make_region().configure(
-            'dogpile.cache.memcached',
+            'dogpile.cache.pymemcache',
             expiration_time=900,
             arguments={'url': config_get('cache', 'url', False, '127.0.0.1:11211'), 'distributed_lock': True}
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # All dependencies needed to run rucio client (and server/daemons) should be defined here
 requests>=2.20.0,<=2.27.1                                   # Python HTTP for Humans.
 urllib3>=1.24.2,<=1.26.8                                    # HTTP library with thread-safe connection pooling, file post, etc.
-dogpile.cache>=0.6.5,<0.7.0; python_version < '3.0'         # Caching API plugins (0.7.0 only Py3 compatible)
-dogpile.cache>=0.6.5,<=1.1.5; python_version >= '3.0'       # Caching API plugins
+dogpile.cache>=0.6.5,<0.7.0; python_version < '3.0'         # Caching API plugins (0.7.0 only Py3 compatible; is used with 'memory' backend in clients)
+dogpile.cache>=1.1.2,<=1.1.5; python_version >= '3.0'       # Caching API plugins (1.1.2 is the first version to support pymemcache)
 tabulate~=0.8.0                                             # Pretty-print tabular data
 six>=1.12.0,<=1.16.0                                        # Python 2 and 3 compatibility utilities
 jsonschema~=3.2.0                                           # For JSON schema validation (Policy modules) (3.2.0 last Python 2.7 module
@@ -23,7 +23,7 @@ python-magic~=0.4.25                                        # dumper_extras; Fil
 # All dependencies needed to run rucio server/daemons should be defined here
 SQLAlchemy==1.4.31                                          # DB backend
 alembic~=1.7.6                                              # Lightweight database migration tool for SQLAlchemy
-python-memcached==1.59                                      # Quick and small memcached client for Python3 (Used by Dogpile)
+pymemcache==3.5.2                                            # A comprehensive, fast, pure-Python memcached client (Used by Dogpile)
 python-dateutil==2.8.2                                      # Extensions to the standard datetime module
 stomp.py==6.1.1                                             # ActiveMQ Messaging Protocol
 statsd==3.3.0                                               # Needed to log into graphite with more than 1 Hz

--- a/setuputil.py
+++ b/setuputil.py
@@ -79,7 +79,7 @@ server_requirements_table = {
         'pysftp',
         'sqlalchemy',
         'alembic',
-        'python-memcached',
+        'pymemcache',
         'python-dateutil',
         'stomp.py',
         'statsd',


### PR DESCRIPTION
Dogpile only started supporting pymemcache in 1.1.2, so increase
the pinned version.

Compared to the python-memcached backend, pymemcache doesn't silently
ignore errors when the backend is not available. As a result, with
pymemcache, rucio raises exceptions when run in an environment
where memcached is not available. Detect this case and explicitly
disable the caching layer.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
