### PR TITLE
Transfers: rapidly mark bulk transfers as FAILED. Closes #4841

### DIFF
--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -573,10 +573,12 @@ class FTS3ApiTransferStatusReport(Fts3TransferStatusReport):
         if file_state_is_final:
             if file_state == FTS_STATE.FINISHED:
                 new_state = RequestState.DONE
-            elif job_state_is_final and file_state == FTS_STATE.FAILED \
-                    and self._is_recoverable_fts_overwrite_error(self.request(session), reason, self._file_metadata):
-                new_state = RequestState.DONE
-            elif job_state_is_final and file_state in (FTS_STATE.FAILED, FTS_STATE.CANCELED):
+            elif file_state == FTS_STATE.FAILED and not self._multi_sources:  # for multi-source transfers we must wait for the job to be in a final state
+                if self._is_recoverable_fts_overwrite_error(self.request(session), reason, self._file_metadata):
+                    new_state = RequestState.DONE
+                else:
+                    new_state = RequestState.FAILED
+            elif job_state_is_final and file_state == FTS_STATE.CANCELED:
                 new_state = RequestState.FAILED
             elif job_state_is_final and file_state == FTS_STATE.NOT_USED:
                 if job_state == FTS_STATE.FINISHED:


### PR DESCRIPTION
In a previous commit related to the linked ticket, we already
implemented an optimization to rapidly mark transfers as DONE
even if the job is not completely finished. This optimization
was useful for bulk transfers. Howether, marking transfers as
FAILED wasn't implemented. We waited for job completion to
perform that state transition.

Implement the state transition, but skip it for the multi-source
transfers: in a multi-source a failed file_state doesn't mean
a failed transfer because other sources can still be tried and
succeed.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
