### PR TITLE
Tests: Fix concurrent file access in add lifetime exception tests #5638

### DIFF
--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -2183,7 +2183,7 @@ class TestBinRucio(unittest.TestCase):
 
     def test_add_lifetime_exception_large_dids_number(self):
         """ CLIENT(USER): Check that exceptions with more than 1k DIDs are supported """
-        filename = get_tmp_dir() + 'lifetime_exception.txt'
+        filename = get_tmp_dir() + 'lifetime_exception_many_dids.txt'
         with open(filename, 'w') as file_:
             for _ in range(2000):
                 file_.write('%s:%s\n' % (self.user, generate_uuid()))


### PR DESCRIPTION
The `test_add_lifetime_exception` and
`test_add_lifetime_exception_large_dids_number` tests use the same
temporary file. When run in parallel, this can lead to nondeterministic
errors in the tests. E.g. a file access after the file is deleted.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
