### PR TITLE
Transfers: set overwrite_hop when relevant. Closes #5570

### DIFF
--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -270,14 +270,19 @@ def bulk_group_transfers(transfer_paths, policy='rule', group_bulk=200, source_s
             # for multihop transfers, all the path is submitted as a separate job
             job_params = _build_job_params(transfer_path[-1], multihop=True)
 
+            overwrite_hop = True
             for transfer in transfer_path[:-1]:
                 hop_params = _build_job_params(transfer, multihop=True)
                 # Only allow overwrite if all transfers in multihop allow it
                 job_params['overwrite'] = hop_params['overwrite'] and job_params['overwrite']
+                # Allow overwrite_hop if all intermediate hops allow it (ignoring the last hop)
+                overwrite_hop = hop_params['overwrite'] and overwrite_hop
                 # Activate bring_online if it was requested by first hop (it is a multihop starting at a tape)
                 # We don't allow multihop via a tape, so bring_online should not be set on any other hop
                 if transfer is transfer_path[0] and hop_params['bring_online']:
                     job_params['bring_online'] = hop_params['bring_online']
+            if not job_params['overwrite'] and overwrite_hop:
+                job_params['overwrite_hop'] = overwrite_hop
 
             group_key = 'multihop_%s' % transfer_path[-1].rws.request_id
             grouped_transfers[group_key] = {'transfers': transfer_path[0:group_bulk], 'job_params': job_params}


### PR DESCRIPTION
FTS supports the "overwrite_hop" option, which tells it
to overwrite any intermediate hop, but not the destination.
This is useful for recovering from a failed multi-hop
transfer towards a tape: when an intermediate hop already
contains a possibly corrupted file from the previous try.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
