### PR TITLE
Replicas: Fix variable name bug in add_bad_dids #5642

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -354,7 +354,7 @@ def add_bad_dids(dids, rse_id, reason, issuer, state=BadFilesStatus.BAD, session
     for did in dids:
         scope = InternalScope(did['scope'], vo=issuer.vo)
         name = did['name']
-        list_replicas.append((scope, name, None))
+        replicas_list.append((scope, name, None))
 
     for scope, name, _, __exists, already_declared, size in __exist_replicas(rse_id=rse_id, replicas=replicas_list, session=session):
         if __exists and not already_declared:


### PR DESCRIPTION
The temporary list of replicas to mark as _BAD_ is not references
correctly. Instead, a function is referenced. This produces an
`AttributeError: 'function' object has no attribute 'append'` exception.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
