### PR TITLE
Testing: use correct httpd rucio configuration in multi-vo tests. #5660

### DIFF
--- a/etc/docker/test/matrix.yml
+++ b/etc/docker/test/matrix.yml
@@ -49,6 +49,7 @@ suites:
       - sqlite
   - id: multi_vo
     RDBMS: postgres14
+    RUCIO_HOME: /opt/rucio/etc/multi_vo/tst
   - id: py37py38
     RDBMS: postgres14
 image_identifier:


### PR DESCRIPTION
This doesn't fully fix the linked issue, because the multi-vo tests are run with to configurations and the second iteration
will still have an incorrect config. 

However, it improves the situation and fixes the test failures for my current did rework

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
