### PR TITLE
Feature 5583 make subscriptions page real time

### DIFF
--- a/lib/rucio/web/ui/static/rucio.js
+++ b/lib/rucio/web/ui/static/rucio.js
@@ -1684,7 +1684,7 @@ RucioClient.prototype.send_trace = function(options) {
 /* --- rucio dumps methods --- */
 
 /* list all subscriptions from dumps */
-RucioClient.prototype.list_subscription_rules_state_from_dumps = function(options) {
+RucioClient.prototype.list_subscription_rules_state_real_time = function(options) {
     check_token();
     // replace root with actual account
     var url = this.url + '/subscriptions/' + options.account + '/Rules/States';

--- a/lib/rucio/web/ui/static/rucio.js
+++ b/lib/rucio/web/ui/static/rucio.js
@@ -1686,14 +1686,16 @@ RucioClient.prototype.send_trace = function(options) {
 /* list all subscriptions from dumps */
 RucioClient.prototype.list_subscription_rules_state_from_dumps = function(options) {
     check_token();
-    var url = this.dumps + '/subscription_states/' + options.date + '/' + options.hour + options.minutes + '.lst';
+    // replace root with actual account
+    var url = this.url + '/subscriptions/' + options.account + '/Rules/States';
     jQuery.ajax({url: url,
-                 headers: {'X-Rucio-Script': this.script},
+                 headers: {...this.headers },
                  async: false,
                  crossDomain: true,
+                 dataType: 'text',
                  success: function(data)
                  {
-                     options.success(data);
+                    options.success(parse_json_stream(data));
                  },
                  error: function(jqXHR, textStatus, errorThrown)
                  {
@@ -1753,6 +1755,7 @@ RucioClient.prototype.get_account_usage_from_dumps = function(options) {
                  }
                 });
 };
+
 
 /* get dbreleases from dumps */
 RucioClient.prototype.get_dbreleases_from_dumps = function(options) {

--- a/lib/rucio/web/ui/static/rucio.js
+++ b/lib/rucio/web/ui/static/rucio.js
@@ -1756,7 +1756,6 @@ RucioClient.prototype.get_account_usage_from_dumps = function(options) {
                 });
 };
 
-
 /* get dbreleases from dumps */
 RucioClient.prototype.get_dbreleases_from_dumps = function(options) {
     var url = this.dumps + '/ddo.json';

--- a/lib/rucio/web/ui/static/subscription.js
+++ b/lib/rucio/web/ui/static/subscription.js
@@ -108,37 +108,29 @@ function create_history(period) {
             date: date,
             hour: hour,
             minutes: minutes,
+            account: chosen_account,
             success: function(data) {
                 var tmp = [0, 0, 0, 0];
-                data = data.split('\n');
-                $.each(data, function(index, value) {
-                    values = value.split('\t');
-                    var acc = values[0];
-                    var name = values[1];
-                    var state = values[2];
-                    var count = parseInt(values[3]);
-                    if (acc != chosen_account) {
+                $.each(data, function(index, value) {                    
+                    var { account, name, state }  = value;
+                    var count = 0;
+                    if("count" in value) {
+                        count = value.count;
+                    }
+                    if (account != chosen_account) {
                         return true;
                     }
                     if (name != chosen_name) {
                         return true;
                     }
-                    if (state == 'O') {
-                        if (count > 0){
-                            tmp[0] = count;
-                    }
-                    } else if (state == 'R') {
-                        if (count > 0){
-                            tmp[1] = count;
-                        }
-                    } else if (state == 'S'){
-                        if (count > 0){
-                            tmp[2] = count;
-                        }
-                    } else if (state == 'U'){
-                        if (count > 0){
-                            tmp[3] = count;
-                        }
+                    if (state == 'OK') {
+                        tmp[0] = count;
+                    } else if (state == 'REPLICATING') {
+                        tmp[1] = count;
+                    } else if (state == 'STUCK'){
+                        tmp[2] = count;
+                    } else if (state == 'SUSPENDED'){
+                        tmp[3] = count;
                     }
                 });
                 ok.push(tmp[0]);

--- a/lib/rucio/web/ui/static/subscription.js
+++ b/lib/rucio/web/ui/static/subscription.js
@@ -104,7 +104,7 @@ function create_history(period) {
         }
 
         categories.push(hour + ":" + minutes);
-        r.list_subscription_rules_state_from_dumps({
+        r.list_subscription_rules_state_real_time({
             date: date,
             hour: hour,
             minutes: minutes,

--- a/lib/rucio/web/ui/static/subscriptions.js
+++ b/lib/rucio/web/ui/static/subscriptions.js
@@ -13,15 +13,14 @@
 
 display_data = function(data, chosen_account, date, hour, minutes) {
     var tmp = {};
-    data = data.split('\n');
     $.each(data, function(index, value) {
-        values = value.split('\t');
-        var acc = values[0];
-        var name = values[1];
-        var state = values[2];
-        var count = parseInt(values[3]);
-        var sub_state = values[4];
-        if (sub_state == 'I') {
+        var { name, state } = value;
+        var sub_state = state;
+        var count = 0;
+        if("count" in value) {
+            count = value.count;
+        }
+        if (sub_state == 'INACTIVE') {
             return;
         }
         if (acc != chosen_account) {
@@ -30,19 +29,19 @@ display_data = function(data, chosen_account, date, hour, minutes) {
         if (!(name in tmp)) {
             tmp[name] = [0, 0, 0, 0];
         }
-        if (state == 'O') {
+        if (state == 'OK') {
             if (count > 0){
                 tmp[name][0] = '<a href="/subscriptions/rules?name=' + name + '&state=O' + '&account=' + chosen_account + '">' + count + '</a>';
             }
-        } else if (state == 'R') {
+        } else if (state == 'REPLICATING') {
             if (count > 0){
                 tmp[name][1] = '<a href="/subscriptions/rules?name=' + name + '&state=R' + '&account=' + chosen_account + '">' + count + '</a>';
             }
-        } else if (state == 'S'){
+        } else if (state == 'STUCK'){
             if (count > 0){
                 tmp[name][2] = '<a href="/subscriptions/rules?name=' + name + '&state=S' + '&account=' + chosen_account + '">' + count + '</a>';
             }
-        } else if (state == 'U'){
+        } else if (state == 'SUSPENDED'){
             if (count > 0){
                 tmp[name][3] = '<a href="/subscriptions/rules?name=' + name + '&state=U' + '&account=' + chosen_account + '">' + count + '</a>';
             }
@@ -107,10 +106,12 @@ retrieve_data = function(chosen_account, try_cnt) {
     }
     date = get_date(try_cnt*10);
 
+    //hard coded to try 6 times over, change to once
     r.list_subscription_rules_state_from_dumps({
         date: date[0],
         hour: date[1],
         minutes: date[2],
+        account: chosen_account,
         success: function(data) {
             if (data.length == 0) {
                 retrieve_data(chosen_account, try_cnt + 1);

--- a/lib/rucio/web/ui/static/subscriptions.js
+++ b/lib/rucio/web/ui/static/subscriptions.js
@@ -100,13 +100,12 @@ get_date = function(period) {
 }
 
 retrieve_data = function(chosen_account, try_cnt) {
-    if (try_cnt > 6) {
+    if (try_cnt > 3) {
         $('#loader').html('<font color="red">Cannot find subscription monitor data for the last hour</font></br>');
         return;
     }
     date = get_date(try_cnt*10);
 
-    //hard coded to try 6 times over, change to once
     r.list_subscription_rules_state_from_dumps({
         date: date[0],
         hour: date[1],

--- a/lib/rucio/web/ui/static/subscriptions.js
+++ b/lib/rucio/web/ui/static/subscriptions.js
@@ -100,7 +100,7 @@ get_date = function(period) {
 }
 
 retrieve_data = function(chosen_account, try_cnt) {
-    if (try_cnt > 3) {
+    if (try_cnt > 2) {
         $('#loader').html('<font color="red">Cannot find subscription monitor data for the last hour</font></br>');
         return;
     }

--- a/lib/rucio/web/ui/static/subscriptions.js
+++ b/lib/rucio/web/ui/static/subscriptions.js
@@ -106,7 +106,7 @@ retrieve_data = function(chosen_account, try_cnt) {
     }
     date = get_date(try_cnt*10);
 
-    r.list_subscription_rules_state_from_dumps({
+    r.list_subscription_rules_state_real_time({
         date: date[0],
         hour: date[1],
         minutes: date[2],


### PR DESCRIPTION
Fixes #5583 

1. Removes dependency on file reading to update subscriptions
2. Hits `subscriptions/<account>/Rules/State` directly to fetch subscriptions
3. Updates retry logic
