### PR TITLE
Patch 5658 oracle container breaks GitHub actions patch pipeline release 1 28

### DIFF
--- a/tools/add_header
+++ b/tools/add_header
@@ -199,8 +199,13 @@ class BashHeaderTemplate(HeaderTemplate):
 
         if len(file_content) == 0:
             return None
+
+        if "#!/bin/sh" in file_content[0]:
+            return file_content[0]
+
         if "#!/bin/bash" in file_content[0]:
             return file_content[0]
+
         return None
 
     @staticmethod

--- a/tools/prepare-commit-msg
+++ b/tools/prepare-commit-msg
@@ -1,4 +1,18 @@
 #!/bin/sh
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 NUMBER=$(git branch | grep '*' | grep 'patch\|feature\|hotfix' | cut -d- -f2)
 if [ -z $NUMBER ]

--- a/tools/test/oracle_setup.sh
+++ b/tools/test/oracle_setup.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #


### PR DESCRIPTION
Same PR as #5663 to fix #5658.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
