### PR TITLE
Core: Fix RSE `supported_checksums` attribute parsing; Fix #5155

### DIFF
--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -19,7 +19,7 @@ import logging
 import traceback
 from io import StringIO
 from re import match
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import sqlalchemy
 from dogpile.cache.api import NO_VALUE
@@ -762,15 +762,16 @@ def get_rse_attributes(rse_id, session=None):
     return result
 
 
-def get_rse_supported_checksums_from_attributes(rse_attributes):
+def get_rse_supported_checksums_from_attributes(rse_attributes: Dict[str, Any]) -> List[str]:
     """
     Parse the RSE attribute defining the checksum supported by the RSE
     :param rse_attributes: attributes retrieved using list_rse_attributes
+    :returns: A list of the names of supported checksums indicated by the specified attributes.
     """
-    return parse_checksum_support_attribute(rse_attributes.get(CHECKSUM_KEY))
+    return parse_checksum_support_attribute(rse_attributes.get(CHECKSUM_KEY, ''))
 
 
-def parse_checksum_support_attribute(checksum_attribute):
+def parse_checksum_support_attribute(checksum_attribute: str) -> List[str]:
     """
     Parse the checksum support RSE attribute.
     :param checksum_attribute: The value of the RSE attribute storing the checksum value
@@ -782,10 +783,12 @@ def parse_checksum_support_attribute(checksum_attribute):
 
     if not checksum_attribute:
         return GLOBALLY_SUPPORTED_CHECKSUMS
+
+    supported_checksum_list = [c.strip() for c in checksum_attribute.split(',') if c.strip()]
+
+    if 'none' in supported_checksum_list:
+        return []
     else:
-        supported_checksum_list = [c.strip() for c in checksum_attribute.split(',') if c.strip()]
-        if 'none' in supported_checksum_list:
-            return []
         return supported_checksum_list
 
 

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -415,14 +415,17 @@ def caches_mock(request):
     from dogpile.cache import make_region
 
     caches_to_mock = []
+    expiration_time = 600
+
     params = __get_fixture_param(request)
     if params:
         caches_to_mock = params.get("caches_to_mock", caches_to_mock)
+        expiration_time = params.get("expiration_time", expiration_time)
 
     with ExitStack() as stack:
         mocked_caches = []
         for module in caches_to_mock:
-            region = make_region().configure('dogpile.cache.memory', expiration_time=600)
+            region = make_region().configure('dogpile.cache.memory', expiration_time=expiration_time)
             stack.enter_context(mock.patch(module, new=region))
             mocked_caches.append(region)
 


### PR DESCRIPTION
The function `rse.py::parse_checksum_support_attribute` misbehaved when
being called with arguments of type `str` instead of the assumed
`list[str]`.

This commit adds explicit type hints to functions related to parsing the
`supported_checksums` attribute, and fixes errors at call sites passing
wrong types.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
