### PR TITLE
Core: Refactor the get_rse_attribute method #5671

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1097,11 +1097,9 @@ def _list_replicas(dataset_clause, file_clause, state_clause, show_pfns,
 
                     # do we need to sign the URLs?
                     if sign_urls and protocol.attributes['scheme'] == 'https':
-                        service = get_rse_attribute('sign_url',
-                                                    rse_id=rse_id,
-                                                    session=session)
-                        if service and isinstance(service, list):
-                            pfn = get_signed_url(rse_id=rse_id, service=service[0], operation='read', url=pfn, lifetime=signature_lifetime)
+                        service = get_rse_attribute(rse_id, 'sign_url', session=session)
+                        if service:
+                            pfn = get_signed_url(rse_id=rse_id, service=service, operation='read', url=pfn, lifetime=signature_lifetime)
 
                     # server side root proxy handling if location is set.
                     # supports root and http destinations
@@ -1111,10 +1109,10 @@ def _list_replicas(dataset_clause, file_clause, state_clause, show_pfns,
 
                         if 'site' in client_location and client_location['site']:
                             # is the RSE site-configured?
-                            rse_site_attr = get_rse_attribute('site', rse_id, session=session)
+                            rse_site_attr = get_rse_attribute(rse_id, 'site', session=session)
                             replica_site = ['']
-                            if isinstance(rse_site_attr, list) and rse_site_attr:
-                                replica_site = rse_site_attr[0]
+                            if rse_site_attr:
+                                replica_site = rse_site_attr
 
                             # does it match with the client? if not, it's an outgoing connection
                             # therefore the internal proxy must be prepended
@@ -1389,7 +1387,7 @@ def __bulk_add_replicas(rse_id, files, account, session=None):
         filter(or_(*condition))
     available_replicas = [dict([(column, getattr(row, column)) for column in row._fields]) for row in query]
 
-    default_tombstone_delay = next(iter(get_rse_attribute('tombstone_delay', rse_id=rse_id, session=session)), None)
+    default_tombstone_delay = get_rse_attribute(rse_id, 'tombstone_delay', session=session)
     default_tombstone = tombstone_from_delay(default_tombstone_delay)
 
     new_replicas = []

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1807,15 +1807,13 @@ def __throttler_request_state(activity, source_rse_id, dest_rse_id, session: "Op
 
 
 def get_supported_transfertools(rse_id: str, session=None) -> "Set[str]":
-    transfertool_attr = get_rse_attribute('transfertool', rse_id=rse_id, session=session)
-    if transfertool_attr:
-        result = set()
-        for attr in transfertool_attr:
-            if attr:
-                assert type(attr) == str
-                # split attribute values by comma
-                for transfertool in filter(bool, map(str.strip, attr.split(sep=','))):
-                    result.add(transfertool)
-        if result:
-            return result
-    return {'fts3', 'globus'}
+    transfertool_attr = get_rse_attribute(rse_id, 'transfertool', session=session)
+
+    if not transfertool_attr:
+        return {'fts3', 'globus'}
+
+    result = set()
+    # split attribute values by comma
+    for transfertool in filter(bool, map(str.strip, transfertool_attr.split(sep=','))):
+        result.add(transfertool)
+    return result

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -293,7 +293,7 @@ class RSEAttributeSmallerCheck(BaseExpressionElement):
         rse_dict = {}
         for rse in rse_list:
             try:
-                if float(get_rse_attribute(key=self.key, rse_id=rse['id'], session=session)[0]) < float(self.value):
+                if float(get_rse_attribute(rse['id'], self.key, session=session)) < float(self.value):
                     rse_dict[rse['id']] = rse
                     output.append(rse['id'])
             except ValueError:
@@ -328,7 +328,7 @@ class RSEAttributeLargerCheck(BaseExpressionElement):
         rse_dict = {}
         for rse in rse_list:
             try:
-                if float(get_rse_attribute(key=self.key, rse_id=rse['id'], session=session)[0]) > float(self.value):
+                if float(get_rse_attribute(rse['id'], self.key, session=session)) > float(self.value):
                     rse_dict[rse['id']] = rse
                     output.append(rse['id'])
             except ValueError:

--- a/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
@@ -62,7 +62,7 @@ total_secondary = 0
 total_total = 0
 global_ratio = float(0)
 for rse in rses:
-    site_name = get_rse_attribute(key='site', rse_id=rse['id'])[0]
+    site_name = get_rse_attribute(rse['id'], 'site')
     rse['groupdisk'] = group_space(site_name)
     rse['primary'] = get_rse_usage(rse_id=rse['id'], source='rucio')[0]['used'] - get_rse_usage(rse_id=rse['id'], source='expired')[0]['used']
     rse['primary'] += rse['groupdisk']

--- a/lib/rucio/daemons/bb8/t2_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/t2_background_rebalance.py
@@ -63,7 +63,7 @@ total_secondary = 0
 total_total = 0
 global_ratio = float(0)
 for rse in rses:
-    site_name = get_rse_attribute(key='site', rse_id=rse['id'])[0]
+    site_name = get_rse_attribute(rse['id'], 'site')
     rse['groupdisk'] = group_space(site_name)
     rse['primary'] = get_rse_usage(rse_id=rse['id'], source='rucio')[0]['used'] - get_rse_usage(rse_id=rse['id'], source='expired')[0]['used']
     rse['primary'] += rse['groupdisk']

--- a/lib/rucio/rse/protocols/globus.py
+++ b/lib/rucio/rse/protocols/globus.py
@@ -41,7 +41,7 @@ class GlobusRSEProtocol(RSEProtocol):
             :param props: Properties of the requested protocol
         """
         super(GlobusRSEProtocol, self).__init__(protocol_attr, rse_settings, logger=logger)
-        self.globus_endpoint_id = get_rse_attribute(key='globus_endpoint_id', rse_id=self.rse.get('id'))
+        self.globus_endpoint_id = get_rse_attribute(self.rse.get('id'), 'globus_endpoint_id')
         self.logger = logger
 
     def lfns2pfns(self, lfns):
@@ -154,7 +154,7 @@ class GlobusRSEProtocol(RSEProtocol):
 
         if self.globus_endpoint_id:
             try:
-                resp = transfer_client.operation_ls(endpoint_id=self.globus_endpoint_id[0], path=filepath)
+                resp = transfer_client.operation_ls(endpoint_id=self.globus_endpoint_id, path=filepath)
                 exists = len([r for r in resp if r['name'] == filename]) > 0
             except TransferAPIError as err:
                 print(err)
@@ -179,7 +179,7 @@ class GlobusRSEProtocol(RSEProtocol):
 
         if self.globus_endpoint_id:
             try:
-                resp = transfer_client.operation_ls(endpoint_id=self.globus_endpoint_id[0], path=path)
+                resp = transfer_client.operation_ls(endpoint_id=self.globus_endpoint_id, path=path)
                 items = resp['DATA']
             except TransferAPIError as err:
                 print(err)
@@ -199,7 +199,7 @@ class GlobusRSEProtocol(RSEProtocol):
         """
         if self.globus_endpoint_id:
             try:
-                delete_response = send_delete_task(endpoint_id=self.globus_endpoint_id[0], path=path, logger=self.logger)
+                delete_response = send_delete_task(endpoint_id=self.globus_endpoint_id, path=path, logger=self.logger)
             except TransferAPIError as err:
                 print(err)
         else:
@@ -219,7 +219,7 @@ class GlobusRSEProtocol(RSEProtocol):
         """
         if self.globus_endpoint_id:
             try:
-                bulk_delete_response = send_bulk_delete_task(endpoint_id=self.globus_endpoint_id[0], pfns=pfns, logger=self.logger)
+                bulk_delete_response = send_bulk_delete_task(endpoint_id=self.globus_endpoint_id, pfns=pfns, logger=self.logger)
             except TransferAPIError as err:
                 self.logger(logging.WARNING, str(err))
         else:

--- a/lib/rucio/tests/test_import_export.py
+++ b/lib/rucio/tests/test_import_export.py
@@ -32,8 +32,8 @@ from rucio.core.exporter import export_data, export_rses
 from rucio.core.identity import add_identity, list_identities, add_account_identity, list_accounts_for_identity
 from rucio.core.importer import import_data, import_rses
 from rucio.core.rse import get_rse_id, get_rse_name, add_rse, get_rse, add_protocol, get_rse_protocols, \
-    list_rse_attributes, get_rse_limits, set_rse_limits, add_rse_attribute, list_rses, export_rse, get_rse_attribute, \
-    del_rse
+    list_rse_attributes, get_rse_limits, set_rse_limits, add_rse_attribute, list_rses, export_rse, del_rse, \
+    get_rse_attribute_without_cache
 from rucio.db.sqla import session, models
 from rucio.db.sqla.constants import RSEType, AccountType, IdentityType, AccountStatus
 from rucio.tests.common import rse_name_generator, headers, auth, hdrdict
@@ -61,8 +61,8 @@ def check_rse(rse_name, test_data, vo='def'):
 def check_protocols(rse, test_data, vo='def'):
     rse_id = get_rse_id(rse=rse, vo=vo)
     protocols = get_rse_protocols(rse_id)
-    assert test_data[rse]['lfn2pfn_algorithm'] == get_rse_attribute('lfn2pfn_algorithm', rse_id=rse_id, use_cache=False)[0]
-    assert test_data[rse]['verify_checksum'] == get_rse_attribute('verify_checksum', rse_id=rse_id, use_cache=False)[0]
+    assert test_data[rse]['lfn2pfn_algorithm'] == get_rse_attribute_without_cache(rse_id, 'lfn2pfn_algorithm')
+    assert test_data[rse]['verify_checksum'] == get_rse_attribute_without_cache(rse_id, 'verify_checksum')
     assert test_data[rse]['availability_write'] == protocols['availability_write']
     assert test_data[rse]['availability_read'] == protocols['availability_read']
     assert test_data[rse]['availability_delete'] == protocols['availability_delete']
@@ -723,13 +723,13 @@ class TestImporterSyncModes(unittest.TestCase):
         import_rses(rses=deepcopy(data['rses']), rse_sync_method='edit', attr_sync_method='append', **self.vo)
 
         # Check that attributes were added for less_attr_rse
-        assert get_rse_attribute('attr2', rse_id=less_attr_rse_id, use_cache=False) == ['test_new']
+        assert get_rse_attribute_without_cache(less_attr_rse_id, 'attr2') == 'test_new'
 
         # Check that attributes were not modified for diff_attr_rse
-        assert get_rse_attribute('attr2', rse_id=diff_attr_rse_id, use_cache=False) == ['test_original']
+        assert get_rse_attribute_without_cache(diff_attr_rse_id, 'attr2') == 'test_original'
 
         # Check that attributes were missing from the json are not deleted
-        assert get_rse_attribute('attr3', rse_id=more_attr_rse_id, use_cache=False) == ['test_original']
+        assert get_rse_attribute_without_cache(more_attr_rse_id, 'attr3') == 'test_original'
 
     def test_import_attributes_edit(self):
         """ IMPORTER (CORE): test import attributes (EDIT mode). """
@@ -780,13 +780,13 @@ class TestImporterSyncModes(unittest.TestCase):
         import_rses(rses=deepcopy(data['rses']), rse_sync_method='edit', attr_sync_method='edit', **self.vo)
 
         # Check that attributes were added for less_attr_rse
-        assert get_rse_attribute('attr2', rse_id=less_attr_rse_id, use_cache=False) == ['test_new']
+        assert get_rse_attribute_without_cache(less_attr_rse_id, 'attr2') == 'test_new'
 
         # Check that attributes were modified for diff_attr_rse
-        assert get_rse_attribute('attr2', rse_id=diff_attr_rse_id, use_cache=False) == ['test_different']
+        assert get_rse_attribute_without_cache(diff_attr_rse_id, 'attr2') == 'test_different'
 
         # Check that attributes that were missing from the json are not deleted
-        assert get_rse_attribute('attr3', rse_id=more_attr_rse_id, use_cache=False) == ['test_original']
+        assert get_rse_attribute_without_cache(more_attr_rse_id, 'attr3') == 'test_original'
 
     def test_import_attributes_hard(self):
         """ IMPORTER (CORE): test import attributes (HARD mode). """
@@ -837,13 +837,13 @@ class TestImporterSyncModes(unittest.TestCase):
         import_rses(rses=deepcopy(data['rses']), rse_sync_method='edit', attr_sync_method='hard', **self.vo)
 
         # Check that attributes were added for less_attr_rse
-        assert get_rse_attribute('attr2', rse_id=less_attr_rse_id, use_cache=False) == ['test_new']
+        assert get_rse_attribute_without_cache(less_attr_rse_id, 'attr2') == 'test_new'
 
         # Check that attributes were modified for diff_attr_rse
-        assert get_rse_attribute('attr2', rse_id=diff_attr_rse_id, use_cache=False) == ['test_different']
+        assert get_rse_attribute_without_cache(diff_attr_rse_id, 'attr2') == 'test_different'
 
         # Check that attributes that were missing from the json are deleted
-        assert get_rse_attribute('attr3', rse_id=more_attr_rse_id, use_cache=False) == []
+        assert get_rse_attribute_without_cache(more_attr_rse_id, 'attr3') is None
 
     def test_import_protocols_append(self):
         """ IMPORTER (CORE): test import protocols (APPEND mode). """


### PR DESCRIPTION
The `get_rse_attribute` method does some things which are unexpected
by a `get` function:

- The return type is `List[Union[bool,str]]`: The function returns a
  list with one element (since it filters for `rse_id` and `key`, both
  construct the primary key of the `RSEAttrAssociation` table) if an
  attribute is found, or an empty list if no attribute is found. It may
  also return a list of all attributes for all rses if `rse_id` is not
  specified or a list with just multiple items with the value `value` if
  `key` and `value` is specified.

- The `value` parameter: This parameter lets the user select all values
  for a specific key, which has the value `value`. This returns a list
  containing the value `value` as often as the `key` - `value` pair
  exists in the table, regardless of the rse. This functionality is
  gladly never used in our code-base.

The following are inconsistencies too:

- The cache: The cache does not conform with non-existing values for
  `rse_id` and `value`.

- The `use_cache` parameter: This parameter toggles an execution branch
  depending on a boolean value. This makes the function more complex
  then it has to be.

The new `get_rse_attribute` function has some improvements:

- It does what it says, it returns **one** rse attribute for a rse. The
  return value `None` clearly communicates that a value does not exist.

- The function is split into two functions: one for a cached and one for
  an un-cached access. This removes the `use_cache` parameter in the
  function.

- The `value` parameter got removed completely. No explanation needed,
  what did it do there in the first place?

- The `rse_id` and `key` are both mandatory now. It makes little sense
  to "get" the rse attribute for a specific key without a rse. This
  case should be handled in a `list_rse_attributes` function.

- The `rse_id` now comes before the `key` parameter. This is logical,
  since we want to get an attribute of a rse and not a rse of an
  attribute.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
