### PR TITLE
Core: Refactor the get_rse_attribute method #5671

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1096,11 +1096,9 @@ def _list_replicas(dataset_clause, file_clause, state_clause, show_pfns,
 
                     # do we need to sign the URLs?
                     if sign_urls and protocol.attributes['scheme'] == 'https':
-                        service = get_rse_attribute('sign_url',
-                                                    rse_id=rse_id,
-                                                    session=session)
-                        if service and isinstance(service, list):
-                            pfn = get_signed_url(rse_id=rse_id, service=service[0], operation='read', url=pfn, lifetime=signature_lifetime)
+                        service = get_rse_attribute(rse_id, 'sign_url', session=session)
+                        if service:
+                            pfn = get_signed_url(rse_id=rse_id, service=service, operation='read', url=pfn, lifetime=signature_lifetime)
 
                     # server side root proxy handling if location is set.
                     # supports root and http destinations
@@ -1109,11 +1107,7 @@ def _list_replicas(dataset_clause, file_clause, state_clause, show_pfns,
                     if domain == 'wan' and protocol.attributes['scheme'] in ['root', 'http', 'https'] and client_location:
 
                         if 'site' in client_location and client_location['site']:
-                            # is the RSE site-configured?
-                            rse_site_attr = get_rse_attribute('site', rse_id, session=session)
-                            replica_site = ['']
-                            if isinstance(rse_site_attr, list) and rse_site_attr:
-                                replica_site = rse_site_attr[0]
+                            replica_site = get_rse_attribute(rse_id, 'site', session=session)
 
                             # does it match with the client? if not, it's an outgoing connection
                             # therefore the internal proxy must be prepended
@@ -1388,7 +1382,7 @@ def __bulk_add_replicas(rse_id, files, account, session=None):
         filter(or_(*condition))
     available_replicas = [dict([(column, getattr(row, column)) for column in row._fields]) for row in query]
 
-    default_tombstone_delay = next(iter(get_rse_attribute('tombstone_delay', rse_id=rse_id, session=session)), None)
+    default_tombstone_delay = get_rse_attribute(rse_id, 'tombstone_delay', session=session)
     default_tombstone = tombstone_from_delay(default_tombstone_delay)
 
     new_replicas = []

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1823,15 +1823,13 @@ def __throttler_request_state(activity, source_rse_id, dest_rse_id, session: "Op
 
 
 def get_supported_transfertools(rse_id: str, session=None) -> "Set[str]":
-    transfertool_attr = get_rse_attribute('transfertool', rse_id=rse_id, session=session)
-    if transfertool_attr:
-        result = set()
-        for attr in transfertool_attr:
-            if attr:
-                assert type(attr) == str
-                # split attribute values by comma
-                for transfertool in filter(bool, map(str.strip, attr.split(sep=','))):
-                    result.add(transfertool)
-        if result:
-            return result
-    return {'fts3', 'globus'}
+    transfertool_attr = get_rse_attribute(rse_id, 'transfertool', session=session)
+
+    if not transfertool_attr:
+        return {'fts3', 'globus'}
+
+    result = set()
+    for transfertool in transfertool_attr.split(sep=','):
+        if transfertool.strip():
+            result.add(transfertool)
+    return result

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -19,9 +19,9 @@ import logging
 import traceback
 from io import StringIO
 from re import match
+from typing import Any, Dict, Optional, Sequence, Union
 
 import sqlalchemy
-import sqlalchemy.orm
 from dogpile.cache.api import NO_VALUE
 from sqlalchemy.exc import DatabaseError, IntegrityError, OperationalError
 from sqlalchemy.orm import aliased, Session
@@ -38,7 +38,6 @@ from rucio.db.sqla import models
 from rucio.db.sqla.constants import (RSEType, ReplicaState)
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
 
-from typing import Any, Dict, Optional, Sequence
 
 REGION = make_region_memcached(expiration_time=900)
 
@@ -681,39 +680,51 @@ def get_rses_with_attribute_value(key, value, lookup_key, vo='def', session=None
 
 
 @read_session
-def get_rse_attribute(key, rse_id=None, value=None, use_cache=True, session=None):
+def _get_rse_attribute_without_cache(rse_id: str, key: str, session: Optional[Session] = None) -> Optional[Union[str, bool]]:
     """
-    Retrieve RSE attribute value.
+    Retrieve RSE attribute value from the database.
 
     :param rse_id: The RSE id.
     :param key: The key for the attribute.
-    :param value: Optionally, the desired value for the attribute.
-    :param use_cache: Boolean to use memcached.
     :param session: The database session in use.
 
-    :returns: A list with RSE attribute values for a Key.
+    :returns: The value for the rse attribute, None if it does not exist.
     """
 
-    result = NO_VALUE
+    value = session.query(models.RSEAttrAssociation.value).filter_by(rse_id=rse_id, key=key).one_or_none()
+
+    if value is None:
+        return None
+
+    return value.value
+
+
+@read_session
+def get_rse_attribute(rse_id: str, key: str, use_cache: bool = True, session: Optional[Session] = None) -> Optional[Union[str, bool]]:
+    """
+    Retrieve RSE attribute value. If it is not cached, look it up in the
+    database. If the value exists and is not cached, it will be added to the
+    cache.
+
+    :param rse_id: The RSE id.
+    :param key: The key for the attribute.
+    :param session: The database session in use.
+
+    :returns: The value for the rse attribute, None if it does not exist.
+    """
+    cache_key = f'rse_attributes_{rse_id}_{key}'
     if use_cache:
-        result = REGION.get('%s-%s-%s' % (key, rse_id, value))
-    if result is NO_VALUE:
+        value = REGION.get(cache_key)
 
-        rse_attrs = []
-        if rse_id:
-            query = session.query(models.RSEAttrAssociation.value).filter_by(rse_id=rse_id, key=key).distinct()
-            if value:
-                query = session.query(models.RSEAttrAssociation.value).filter_by(rse_id=rse_id, key=key, value=value).distinct()
-        else:
-            query = session.query(models.RSEAttrAssociation.value).filter_by(key=key).distinct()
-            if value:
-                query = session.query(models.RSEAttrAssociation.value).filter_by(key=key, value=value).distinct()
-        for attr_value in query:
-            rse_attrs.append(attr_value[0])
-        REGION.set('%s-%s-%s' % (key, rse_id, value), rse_attrs)
-        return rse_attrs
+        if value is not NO_VALUE:
+            return value
 
-    return result
+    value = _get_rse_attribute_without_cache(rse_id, key, session=session)
+
+    if use_cache:
+        REGION.set(cache_key, value)
+
+    return value
 
 
 def get_rse_attributes(rse_id, session=None):
@@ -1084,18 +1095,17 @@ def get_rse_protocols(rse_id, schemes=None, session=None):
     if not _rse:
         raise exception.RSENotFound('RSE with id \'%s\' not found' % rse_id)
 
-    lfn2pfn_algorithms = get_rse_attribute('lfn2pfn_algorithm', rse_id=_rse.id, session=session)
+    lfn2pfn_algorithm = get_rse_attribute(_rse.id, 'lfn2pfn_algorithm', session=session)
     # Resolve LFN2PFN default algorithm as soon as possible.  This way, we can send back the actual
     # algorithm name in response to REST queries.
-    lfn2pfn_algorithm = get_lfn2pfn_algorithm_default()
-    if lfn2pfn_algorithms:
-        lfn2pfn_algorithm = lfn2pfn_algorithms[0]
+    if not lfn2pfn_algorithm:
+        lfn2pfn_algorithm = get_lfn2pfn_algorithm_default()
 
     # Copy verify_checksum from the attributes, later: assume True if not specified
-    verify_checksum = get_rse_attribute('verify_checksum', rse_id=_rse.id, session=session)
+    verify_checksum = get_rse_attribute(_rse.id, 'verify_checksum', session=session)
 
     # Copy sign_url from the attributes
-    sign_url = get_rse_attribute('sign_url', rse_id=_rse.id, session=session)
+    sign_url = get_rse_attribute(_rse.id, 'sign_url', session=session)
 
     info = {'availability_delete': _rse.availability_delete,
             'availability_read': _rse.availability_read,
@@ -1109,9 +1119,9 @@ def get_rse_protocols(rse_id, schemes=None, session=None):
             'qos_class': _rse.qos_class,
             'rse': _rse.rse,
             'rse_type': _rse.rse_type.name,
-            'sign_url': sign_url[0] if sign_url else None,
+            'sign_url': sign_url,
             'staging_area': _rse.staging_area,
-            'verify_checksum': verify_checksum[0] if verify_checksum else True,
+            'verify_checksum': verify_checksum if verify_checksum is not None else True,
             'volatile': _rse.volatile}
 
     for op in utils.rse_supported_protocol_operations():

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -291,7 +291,7 @@ class RSEAttributeSmallerCheck(BaseExpressionElement):
         rse_dict = {}
         for rse in rse_list:
             try:
-                if float(get_rse_attribute(key=self.key, rse_id=rse['id'], session=session)[0]) < float(self.value):
+                if float(get_rse_attribute(rse['id'], self.key, session=session)) < float(self.value):
                     rse_dict[rse['id']] = rse
                     output.append(rse['id'])
             except ValueError:
@@ -326,7 +326,7 @@ class RSEAttributeLargerCheck(BaseExpressionElement):
         rse_dict = {}
         for rse in rse_list:
             try:
-                if float(get_rse_attribute(key=self.key, rse_id=rse['id'], session=session)[0]) > float(self.value):
+                if float(get_rse_attribute(rse['id'], self.key, session=session)) > float(self.value):
                     rse_dict[rse['id']] = rse
                     output.append(rse['id'])
             except ValueError:

--- a/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
@@ -61,7 +61,7 @@ total_secondary = 0
 total_total = 0
 global_ratio = float(0)
 for rse in rses:
-    site_name = get_rse_attribute(key='site', rse_id=rse['id'])[0]
+    site_name = get_rse_attribute(rse['id'], 'site')
     rse['groupdisk'] = group_space(site_name)
     rse['primary'] = get_rse_usage(rse_id=rse['id'], source='rucio')[0]['used'] - get_rse_usage(rse_id=rse['id'], source='expired')[0]['used']
     rse['primary'] += rse['groupdisk']

--- a/lib/rucio/daemons/bb8/t2_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/t2_background_rebalance.py
@@ -61,7 +61,7 @@ total_secondary = 0
 total_total = 0
 global_ratio = float(0)
 for rse in rses:
-    site_name = get_rse_attribute(key='site', rse_id=rse['id'])[0]
+    site_name = get_rse_attribute(rse['id'], 'site')
     rse['groupdisk'] = group_space(site_name)
     rse['primary'] = get_rse_usage(rse_id=rse['id'], source='rucio')[0]['used'] - get_rse_usage(rse_id=rse['id'], source='expired')[0]['used']
     rse['primary'] += rse['groupdisk']

--- a/lib/rucio/rse/protocols/globus.py
+++ b/lib/rucio/rse/protocols/globus.py
@@ -38,7 +38,7 @@ class GlobusRSEProtocol(RSEProtocol):
             :param props: Properties of the requested protocol
         """
         super(GlobusRSEProtocol, self).__init__(protocol_attr, rse_settings, logger=logger)
-        self.globus_endpoint_id = get_rse_attribute(key='globus_endpoint_id', rse_id=self.rse.get('id'))
+        self.globus_endpoint_id = get_rse_attribute(self.rse.get('id'), 'globus_endpoint_id')
         self.logger = logger
 
     def lfns2pfns(self, lfns):
@@ -151,7 +151,7 @@ class GlobusRSEProtocol(RSEProtocol):
 
         if self.globus_endpoint_id:
             try:
-                resp = transfer_client.operation_ls(endpoint_id=self.globus_endpoint_id[0], path=filepath)
+                resp = transfer_client.operation_ls(endpoint_id=self.globus_endpoint_id, path=filepath)
                 exists = len([r for r in resp if r['name'] == filename]) > 0
             except TransferAPIError as err:
                 print(err)
@@ -176,7 +176,7 @@ class GlobusRSEProtocol(RSEProtocol):
 
         if self.globus_endpoint_id:
             try:
-                resp = transfer_client.operation_ls(endpoint_id=self.globus_endpoint_id[0], path=path)
+                resp = transfer_client.operation_ls(endpoint_id=self.globus_endpoint_id, path=path)
                 items = resp['DATA']
             except TransferAPIError as err:
                 print(err)
@@ -196,7 +196,7 @@ class GlobusRSEProtocol(RSEProtocol):
         """
         if self.globus_endpoint_id:
             try:
-                delete_response = send_delete_task(endpoint_id=self.globus_endpoint_id[0], path=path, logger=self.logger)
+                delete_response = send_delete_task(endpoint_id=self.globus_endpoint_id, path=path, logger=self.logger)
             except TransferAPIError as err:
                 print(err)
         else:
@@ -216,7 +216,7 @@ class GlobusRSEProtocol(RSEProtocol):
         """
         if self.globus_endpoint_id:
             try:
-                bulk_delete_response = send_bulk_delete_task(endpoint_id=self.globus_endpoint_id[0], pfns=pfns, logger=self.logger)
+                bulk_delete_response = send_bulk_delete_task(endpoint_id=self.globus_endpoint_id, pfns=pfns, logger=self.logger)
             except TransferAPIError as err:
                 self.logger(logging.WARNING, str(err))
         else:

--- a/lib/rucio/tests/test_import_export.py
+++ b/lib/rucio/tests/test_import_export.py
@@ -30,8 +30,8 @@ from rucio.core.exporter import export_data, export_rses
 from rucio.core.identity import add_identity, list_identities, add_account_identity, list_accounts_for_identity
 from rucio.core.importer import import_data, import_rses
 from rucio.core.rse import get_rse_id, get_rse_name, add_rse, get_rse, add_protocol, get_rse_protocols, \
-    list_rse_attributes, get_rse_limits, set_rse_limits, add_rse_attribute, list_rses, export_rse, get_rse_attribute, \
-    del_rse
+    list_rse_attributes, get_rse_limits, set_rse_limits, add_rse_attribute, list_rses, export_rse, del_rse, \
+    get_rse_attribute
 from rucio.db.sqla import session, models
 from rucio.db.sqla.constants import RSEType, AccountType, IdentityType, AccountStatus
 from rucio.tests.common import rse_name_generator, headers, auth, hdrdict
@@ -61,8 +61,8 @@ def check_rse(rse_name, test_data, vo='def'):
 def check_protocols(rse, test_data, vo='def'):
     rse_id = get_rse_id(rse=rse, vo=vo)
     protocols = get_rse_protocols(rse_id)
-    assert test_data[rse]['lfn2pfn_algorithm'] == get_rse_attribute('lfn2pfn_algorithm', rse_id=rse_id, use_cache=False)[0]
-    assert test_data[rse]['verify_checksum'] == get_rse_attribute('verify_checksum', rse_id=rse_id, use_cache=False)[0]
+    assert test_data[rse]['lfn2pfn_algorithm'] == get_rse_attribute(rse_id, 'lfn2pfn_algorithm', use_cache=False)
+    assert test_data[rse]['verify_checksum'] == get_rse_attribute(rse_id, 'verify_checksum', use_cache=False)
     assert test_data[rse]['availability_write'] == protocols['availability_write']
     assert test_data[rse]['availability_read'] == protocols['availability_read']
     assert test_data[rse]['availability_delete'] == protocols['availability_delete']
@@ -730,13 +730,13 @@ class TestImporterSyncModes(unittest.TestCase):
         import_rses(rses=deepcopy(data['rses']), rse_sync_method='edit', attr_sync_method='append', **self.vo)
 
         # Check that attributes were added for less_attr_rse
-        assert get_rse_attribute('attr2', rse_id=less_attr_rse_id, use_cache=False) == ['test_new']
+        assert get_rse_attribute(less_attr_rse_id, 'attr2', use_cache=False) == 'test_new'
 
         # Check that attributes were not modified for diff_attr_rse
-        assert get_rse_attribute('attr2', rse_id=diff_attr_rse_id, use_cache=False) == ['test_original']
+        assert get_rse_attribute(diff_attr_rse_id, 'attr2', use_cache=False) == 'test_original'
 
         # Check that attributes were missing from the json are not deleted
-        assert get_rse_attribute('attr3', rse_id=more_attr_rse_id, use_cache=False) == ['test_original']
+        assert get_rse_attribute(more_attr_rse_id, 'attr3', use_cache=False) == 'test_original'
 
     def test_import_attributes_edit(self):
         """ IMPORTER (CORE): test import attributes (EDIT mode). """
@@ -787,13 +787,13 @@ class TestImporterSyncModes(unittest.TestCase):
         import_rses(rses=deepcopy(data['rses']), rse_sync_method='edit', attr_sync_method='edit', **self.vo)
 
         # Check that attributes were added for less_attr_rse
-        assert get_rse_attribute('attr2', rse_id=less_attr_rse_id, use_cache=False) == ['test_new']
+        assert get_rse_attribute(less_attr_rse_id, 'attr2', use_cache=False) == 'test_new'
 
         # Check that attributes were modified for diff_attr_rse
-        assert get_rse_attribute('attr2', rse_id=diff_attr_rse_id, use_cache=False) == ['test_different']
+        assert get_rse_attribute(diff_attr_rse_id, 'attr2', use_cache=False) == 'test_different'
 
         # Check that attributes that were missing from the json are not deleted
-        assert get_rse_attribute('attr3', rse_id=more_attr_rse_id, use_cache=False) == ['test_original']
+        assert get_rse_attribute(more_attr_rse_id, 'attr3', use_cache=False) == 'test_original'
 
     def test_import_attributes_hard(self):
         """ IMPORTER (CORE): test import attributes (HARD mode). """
@@ -844,13 +844,13 @@ class TestImporterSyncModes(unittest.TestCase):
         import_rses(rses=deepcopy(data['rses']), rse_sync_method='edit', attr_sync_method='hard', **self.vo)
 
         # Check that attributes were added for less_attr_rse
-        assert get_rse_attribute('attr2', rse_id=less_attr_rse_id, use_cache=False) == ['test_new']
+        assert get_rse_attribute(less_attr_rse_id, 'attr2', use_cache=False) == 'test_new'
 
         # Check that attributes were modified for diff_attr_rse
-        assert get_rse_attribute('attr2', rse_id=diff_attr_rse_id, use_cache=False) == ['test_different']
+        assert get_rse_attribute(diff_attr_rse_id, 'attr2', use_cache=False) == 'test_different'
 
         # Check that attributes that were missing from the json are deleted
-        assert get_rse_attribute('attr3', rse_id=more_attr_rse_id, use_cache=False) == []
+        assert get_rse_attribute(more_attr_rse_id, 'attr3', use_cache=False) is None
 
     def test_import_protocols_append(self):
         """ IMPORTER (CORE): test import protocols (APPEND mode). """


### PR DESCRIPTION
The `get_rse_attribute` method does some things which are unexpected by
a `get` function:

- The return type is `List[Union[bool,str]]`: The function returns a
  list with one element (since it filters for `rse_id` and `key`, both
  construct the primary key of the `RSEAttrAssociation` table) if an
  attribute is found, or an empty list if no attribute is found. It may
  also return a list of all attributes for all rses if `rse_id` is not
  specified or a list with just multiple items with the value `value` if
  `key` and `value` is specified.

- The `value` parameter: This parameter lets the user select all values
  for a specific key, which has the value `value`. This returns a list
  containing the value `value` as often as the `key` - `value` pair
  exists in the table, regardless of the rse. This functionality is
  gladly never used in our code-base.

The following are inconsistencies too:

- The cache: The cache does not conform with non-existing values for
  `rse_id` and `value`.

- The `use_cache` parameter: This parameter toggles an execution branch
  depending on a boolean value. This makes the function more complex
  than it has to be.

The new `get_rse_attribute` function has some improvements:

- It does what it says, it returns **one** rse attribute for a rse. The
  return value `None` clearly communicates that a value does not exist.

- The `value` parameter got removed completely. No explanation needed,
  what did it do there in the first place?

- The `rse_id` and `key` are both mandatory now. It makes little sense
  to "get" the rse attribute for a specific key without a rse. This case
  should be handled in a `list_rse_attributes` function.

- The `rse_id` now comes before the `key` parameter. This is logical,
  since we want to get an attribute of a rse and not a rse of an
  attribute.

The `use_cache` parameter is still present, so the function is
consistent with the rest of the code base.