### PR TITLE
Testing: fix 1.28 integration tests. Close #5679

### DIFF
--- a/etc/rse_repository.json
+++ b/etc/rse_repository.json
@@ -573,7 +573,7 @@
     },
     "storage_usage_tool": "rucio.rse.protocols.xrootd.Default.getSpace"
   },
-  "SSH_DISK":{
+  "SSH-DISK":{
     "backend_type": "SSH",
     "deterministic": true,
     "protocols": {

--- a/lib/rucio/tests/test_rse_protocol_rclone.py
+++ b/lib/rucio/tests/test_rse_protocol_rclone.py
@@ -40,7 +40,7 @@ def load_rse_info(request, containerized_rses):
     rses = [rse for rse in containerized_rses if rse[0] == 'SSH1']
 
     data = load_test_conf_file('rse_repository.json')
-    request.cls.prefix = data['SSH_DISK']['protocols']['supported']['rclone']['prefix']
+    request.cls.prefix = data['SSH-DISK']['protocols']['supported']['rclone']['prefix']
 
     if len(rses) == 0:
         request.cls.rse_id = 'SSH-RSE'

--- a/lib/rucio/tests/test_rse_protocol_rsync.py
+++ b/lib/rucio/tests/test_rse_protocol_rsync.py
@@ -40,9 +40,9 @@ def load_rse_info(request, containerized_rses):
     rses = [rse for rse in containerized_rses if rse[0] == 'SSH1']
 
     data = load_test_conf_file('rse_repository.json')
-    request.cls.prefix = data['SSH_DISK']['protocols']['supported']['rsync']['prefix']
-    request.cls.port = data['SSH_DISK']['protocols']['supported']['rsync']['port']
-    request.cls.sshuser = data['SSH_DISK']['protocols']['supported']['rsync']['extended_attributes']['user']
+    request.cls.prefix = data['SSH-DISK']['protocols']['supported']['rsync']['prefix']
+    request.cls.port = data['SSH-DISK']['protocols']['supported']['rsync']['port']
+    request.cls.sshuser = data['SSH-DISK']['protocols']['supported']['rsync']['extended_attributes']['user']
 
     if len(rses) == 0:
         request.cls.rse_id = 'SSH-RSE'

--- a/lib/rucio/tests/test_rse_protocol_ssh.py
+++ b/lib/rucio/tests/test_rse_protocol_ssh.py
@@ -40,9 +40,9 @@ def load_rse_info(request, containerized_rses):
     rses = [rse for rse in containerized_rses if rse[0] == 'SSH1']
 
     data = load_test_conf_file('rse_repository.json')
-    request.cls.prefix = data['SSH_DISK']['protocols']['supported']['ssh']['prefix']
-    request.cls.port = data['SSH_DISK']['protocols']['supported']['ssh']['port']
-    request.cls.sshuser = data['SSH_DISK']['protocols']['supported']['ssh']['extended_attributes']['user']
+    request.cls.prefix = data['SSH-DISK']['protocols']['supported']['ssh']['prefix']
+    request.cls.port = data['SSH-DISK']['protocols']['supported']['ssh']['port']
+    request.cls.sshuser = data['SSH-DISK']['protocols']['supported']['ssh']['extended_attributes']['user']
 
     if len(rses) == 0:
         request.cls.rse_id = 'SSH-RSE'

--- a/tools/pytest.sh
+++ b/tools/pytest.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #


### PR DESCRIPTION
The integration tests in `release-1.28` branch fail to initialize as seen in [this](https://github.com/rucio/rucio/runs/7068054866?check_suite_focus=true)

This is caused by a missing shebang in the `pytest.sh` script. In master, the integration tests work okay since the shebang was introduced in #5455

The ssh rse protocol integration test also fails in the 1.28 branch due to the renaming of the `SSH_DISK` rse to `SSH-DISK` in [this commit](https://github.com/rucio/rucio/commit/ca50ea00b1da6c0db2bdb0eb47d421b03d22f186).

To fix these:
1. Add a shebang to pytest.sh
2. rename `SSH_DISK` rse in `etc/rse_repository.json` to `SSH-DISK`.

Close #5679 
