### PR TITLE
Deletion: fixed oidc_account getting retrieved as bool #5682

### DIFF
--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -408,7 +408,7 @@ def reaper(rses, include_rses, exclude_rses, vos=None, chunk_size=100, once=Fals
     """
 
     executable = 'reaper'
-    oidc_account = config_get_bool('reaper', 'oidc_account', False, '')
+    oidc_account = config_get('reaper', 'oidc_account', False, 'root')
     oidc_scope = config_get('reaper', 'oidc_scope', False, 'delete')
     oidc_audience = config_get('reaper', 'oidc_audience', False, 'rse')
 


### PR DESCRIPTION
changed from config_get_bool to config_get, and default to root (since this account is the default account that has the IAM admin client sub)

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
