### PR TITLE
Core & Internals: don't log cache warnings. #5656. Closes #5697

### DIFF
--- a/lib/rucio/common/cache.py
+++ b/lib/rucio/common/cache.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 from __future__ import absolute_import
 
-import logging
 from dogpile.cache import make_region
 
 from rucio.common.config import config_get
@@ -32,10 +31,8 @@ try:
         _mc_client = pymemcache.Client(CACHE_URL, connect_timeout=1, timeout=1)
         _mc_client.version()
 except IOError:
-    logging.warning("Cannot connect to memcached at {}. Caching will be disabled".format(CACHE_URL))
     ENABLE_CACHING = False
 except ImportError:
-    logging.warning("Cannot import pymemcache. Caching will be disabled")
     ENABLE_CACHING = False
 finally:
     if _mc_client:


### PR DESCRIPTION
I initially added the warning logs to avoid silent problems with
cache. Unfortunately, it triggered multiple problems:
- clients always print a warning message in some envs
- it overrides the logging level

Until the migration to pymemcache, the cache errors were already
silently ignored, so this is not really a regression.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
