### PR TITLE
Feature 5664 split the availability column into its respective values

### DIFF
--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -29,8 +29,7 @@ from rucio.db.sqla.session import read_session, stream_session, transactional_se
 def add_rse(rse, issuer, vo='def', deterministic=True, volatile=False, city=None, region_code=None,
             country_name=None, continent=None, time_zone=None, ISP=None,
             staging_area=False, rse_type=None, latitude=None, longitude=None, ASN=None,
-            availability_read: Optional[bool] = None, availability_write: Optional[bool] = None,
-            availability_delete: Optional[bool] = None, session=None):
+            availability: Optional[int] = None, session=None):
     """
     Creates a new Rucio Storage Element(RSE).
 
@@ -50,9 +49,7 @@ def add_rse(rse, issuer, vo='def', deterministic=True, volatile=False, city=None
     :param latitude: Latitude coordinate of RSE.
     :param longitude: Longitude coordinate of RSE.
     :param ASN: Access service network.
-    :param availability_read: If the RSE is readable.
-    :param availability_write: If the RSE is writable.
-    :param availability_delete: If the RSE is deletable.
+    :param availability: Availability.
     :param session: The database session in use.
     """
     validate_schema(name='rse', obj=rse, vo=vo)
@@ -63,8 +60,7 @@ def add_rse(rse, issuer, vo='def', deterministic=True, volatile=False, city=None
     return rse_module.add_rse(rse, vo=vo, deterministic=deterministic, volatile=volatile, city=city,
                               region_code=region_code, country_name=country_name, staging_area=staging_area,
                               continent=continent, time_zone=time_zone, ISP=ISP, rse_type=rse_type, latitude=latitude,
-                              longitude=longitude, ASN=ASN, availability_read=availability_read,
-                              availability_write=availability_write, availability_delete=availability_delete, session=session)
+                              longitude=longitude, ASN=ASN, availability=availability, session=session)
 
 
 @read_session

--- a/lib/rucio/core/importer.py
+++ b/lib/rucio/core/importer.py
@@ -51,8 +51,7 @@ def import_rses(rses, rse_sync_method='edit', attr_sync_method='edit', protocol_
                                         city=rse.get('city'), region_code=rse.get('region_code'), country_name=rse.get('country_name'),
                                         staging_area=rse.get('staging_area'), continent=rse.get('continent'), time_zone=rse.get('time_zone'),
                                         ISP=rse.get('ISP'), rse_type=rse.get('rse_type'), latitude=rse.get('latitude'),
-                                        longitude=rse.get('longitude'), ASN=rse.get('ASN'), availability_read=rse.get('availability_read'),
-                                        availability_write=rse.get('availability_write'), availability_delete=rse.get('availability_delete'),
+                                        longitude=rse.get('longitude'), ASN=rse.get('ASN'), availability=rse.get('availability'),
                                         session=session)
 
         new_rses.append(rse_id)

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -762,7 +762,7 @@ def _list_replicas_for_datasets(dataset_clause, state_clause, rse_clause, ignore
                  models.DataIdentifierAssociation.child_name)
 
     if not ignore_availability:
-        replica_query = replica_query.filter(models.RSE.availability_read == true())
+        replica_query = replica_query.filter(models.RSE.availability.in_((4, 5, 6, 7)))
 
     if state_clause is not None:
         replica_query = replica_query.filter(and_(state_clause))
@@ -811,7 +811,7 @@ def _list_replicas_for_constituents(constituent_clause, state_clause, files_wo_r
                  models.ConstituentAssociation.child_name)
 
     if not ignore_availability:
-        constituent_query = constituent_query.filter(models.RSE.availability_read == true())
+        constituent_query = constituent_query.filter(models.RSE.availability.in_((4, 5, 6, 7)))
 
     if state_clause is not None:
         constituent_query = constituent_query.filter(and_(state_clause))
@@ -845,7 +845,7 @@ def _list_replicas_for_files(file_clause, state_clause, files_wo_replica, rse_cl
         ]
 
         if not ignore_availability:
-            filters.append(models.RSE.availability_read == true())
+            filters.append(models.RSE.availability.in_((4, 5, 6, 7)))
 
         if state_clause is not None:
             filters.append(state_clause)
@@ -1449,7 +1449,7 @@ def add_replicas(rse_id, files, account, ignore_availability=True,
     if replica_rse.volatile is True:
         raise exception.UnsupportedOperation('Cannot add replicas on volatile RSE %s ' % (replica_rse.rse))
 
-    if not (replica_rse.availability_write) and not ignore_availability:
+    if not (replica_rse.availability & 2) and not ignore_availability:
         raise exception.ResourceTemporaryUnavailable('%s is temporary unavailable for writing' % replica_rse.rse)
 
     for file in files:
@@ -1550,7 +1550,7 @@ def __delete_replicas(rse_id, files, ignore_availability=True, session=None):
 
     replica_rse = get_rse(rse_id=rse_id, session=session)
 
-    if not replica_rse.availability_delete and not ignore_availability:
+    if not (replica_rse.availability & 1) and not ignore_availability:
         raise exception.ResourceTemporaryUnavailable('%s is temporary unavailable'
                                                      'for deleting' % replica_rse.rse)
     tt_mngr = temp_table_mngr(session)
@@ -2075,7 +2075,7 @@ def __delete_replicas_without_temp_tables(rse_id, files, ignore_availability=Tru
     """
     replica_rse = get_rse(rse_id=rse_id, session=session)
 
-    if not replica_rse.availability_delete and not ignore_availability:
+    if not (replica_rse.availability & 1) and not ignore_availability:
         raise exception.ResourceTemporaryUnavailable('%s is temporary unavailable'
                                                      'for deleting' % replica_rse.rse)
 

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -404,7 +404,7 @@ def list_transfer_requests_and_source_replicas(
     )
 
     if not ignore_availability:
-        sub_requests = sub_requests.where(models.RSE.availability_write == true())
+        sub_requests = sub_requests.where(models.RSE.availability.in_((2, 3, 6, 7)))
 
     if isinstance(older_than, datetime.datetime):
         sub_requests = sub_requests.where(models.Request.requested_at < older_than)

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -19,6 +19,7 @@ import logging
 import traceback
 from io import StringIO
 from re import match
+from typing import Any, Dict, Optional, Sequence
 
 import sqlalchemy
 import sqlalchemy.orm
@@ -32,13 +33,12 @@ import rucio.core.account_counter
 from rucio.common import exception, utils
 from rucio.common.cache import make_region_memcached
 from rucio.common.config import get_lfn2pfn_algorithm_default
-from rucio.common.utils import CHECKSUM_KEY, GLOBALLY_SUPPORTED_CHECKSUMS, Availability
+from rucio.common.utils import CHECKSUM_KEY, GLOBALLY_SUPPORTED_CHECKSUMS
 from rucio.core.rse_counter import add_counter, get_counter
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import (RSEType, ReplicaState)
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
 
-from typing import Any, Dict, Optional, Sequence
 
 REGION = make_region_memcached(expiration_time=900)
 
@@ -162,8 +162,7 @@ RSE_SETTINGS = ["continent", "city", "region_code", "country_name", "time_zone",
 
 @transactional_session
 def add_rse(rse, vo='def', deterministic=True, volatile=False, city=None, region_code=None, country_name=None, continent=None, time_zone=None,
-            ISP=None, staging_area=False, rse_type=RSEType.DISK, longitude=None, latitude=None, ASN=None, availability_read: Optional[bool] = None,
-            availability_write: Optional[bool] = None, availability_delete: Optional[bool] = None, session=None):
+            ISP=None, staging_area=False, rse_type=RSEType.DISK, longitude=None, latitude=None, ASN=None, availability: Optional[int] = 7, session=None):
     """
     Add a rse with the given location name.
 
@@ -182,18 +181,15 @@ def add_rse(rse, vo='def', deterministic=True, volatile=False, city=None, region
     :param latitude: Latitude coordinate of RSE.
     :param longitude: Longitude coordinate of RSE.
     :param ASN: Access service network. Accessed by `locals()`.
-    :param availability_read: If the RSE is readable.
-    :param availability_write: If the RSE is writable.
-    :param availability_delete: If the RSE is deletable.
+    :param availability: Availability.
     :param session: The database session in use.
     """
     if isinstance(rse_type, str):
         rse_type = RSEType(rse_type)
 
     new_rse = models.RSE(rse=rse, vo=vo, deterministic=deterministic, volatile=volatile,
-                         staging_area=staging_area, availability_read=availability_read,
-                         availability_write=availability_write, availability_delete=availability_delete,
-                         rse_type=rse_type, longitude=longitude, latitude=latitude,
+                         staging_area=staging_area, rse_type=rse_type, longitude=longitude,
+                         latitude=latitude, availability=availability,
 
                          # The following fields will be deprecated, they are RSE attributes now.
                          # (Still in the code for backwards compatibility)
@@ -482,6 +478,9 @@ def list_rses(filters={}, session=None):
     """
 
     rse_list = []
+    availability_mask1 = 0
+    availability_mask2 = 7
+    availability_mapping = {'availability_read': 4, 'availability_write': 2, 'availability_delete': 1}
     false_value = False  # To make pep8 checker happy ...
 
     if filters and filters.get('vo'):
@@ -493,14 +492,6 @@ def list_rses(filters={}, session=None):
     if filters:
         if 'availability' in filters and ('availability_read' in filters or 'availability_write' in filters or 'availability_delete' in filters):
             raise exception.InvalidObject('Cannot use availability and read, write, delete filter at the same time.')
-
-        if 'availability' in filters:
-            availability = Availability.from_integer(filters['availability'])
-            filters['availability_read'] = availability.read
-            filters['availability_write'] = availability.write
-            filters['availability_delete'] = availability.delete
-            del filters['availability']
-
         query = session.query(models.RSE).\
             join(models.RSEAttrAssociation, models.RSE.id == models.RSEAttrAssociation.rse_id).\
             filter(models.RSE.deleted == false_value).group_by(models.RSE)
@@ -511,12 +502,28 @@ def list_rses(filters={}, session=None):
                     query = query.filter(getattr(models.RSE, k) == RSEType[v])
                 else:
                     query = query.filter(getattr(models.RSE, k) == v)
+            elif k in ['availability_read', 'availability_write', 'availability_delete']:
+                if v:
+                    availability_mask1 = availability_mask1 | availability_mapping[k]
+                else:
+                    availability_mask2 = availability_mask2 & ~availability_mapping[k]
             else:
                 t = aliased(models.RSEAttrAssociation)
                 query = query.join(t, t.rse_id == models.RSEAttrAssociation.rse_id)
                 query = query.filter(t.key == k,
                                      t.value == v)
+
+        condition1, condition2 = [], []
+        for i in range(0, 8):
+            if i | availability_mask1 == i:
+                condition1.append(models.RSE.availability == i)
+            if i & availability_mask2 == i:
+                condition2.append(models.RSE.availability == i)
+
+        if 'availability' not in filters:
+            query = query.filter(sqlalchemy.and_(sqlalchemy.or_(*condition1), sqlalchemy.or_(*condition2)))
     else:
+
         query = session.query(models.RSE).filter_by(deleted=False).order_by(models.RSE.rse)
 
     if vo:
@@ -1097,9 +1104,13 @@ def get_rse_protocols(rse_id, schemes=None, session=None):
     # Copy sign_url from the attributes
     sign_url = get_rse_attribute('sign_url', rse_id=_rse.id, session=session)
 
-    info = {'availability_delete': _rse.availability_delete,
-            'availability_read': _rse.availability_read,
-            'availability_write': _rse.availability_write,
+    read = True if _rse.availability & 4 else False
+    write = True if _rse.availability & 2 else False
+    delete = True if _rse.availability & 1 else False
+
+    info = {'availability_delete': delete,
+            'availability_read': read,
+            'availability_write': write,
             'credentials': None,
             'deterministic': _rse.deterministic,
             'domain': utils.rse_supported_protocol_domains(),
@@ -1372,6 +1383,7 @@ MUTABLE_RSE_PROPERTIES = {
     'staging_area',
     'qos_class',
     'continent',
+    'availability'
 }
 
 
@@ -1395,22 +1407,26 @@ def update_rse(rse_id: str, parameters: 'Dict[str, Any]', session=None):
         query = session.query(models.RSE).filter_by(id=rse_id).one()
     except sqlalchemy.orm.exc.NoResultFound:
         raise exception.RSENotFound('RSE with ID \'%s\' cannot be found' % rse_id)
+    availability = 0
     rse = query.rse
+    for column in query:
+        if column[0] == 'availability':
+            availability = column[1] or availability
 
     param = {}
-
-    if 'availability' in parameters:
-        availability = Availability.from_integer(parameters['availability'])
-        param['availability_read'] = availability.read
-        param['availability_write'] = availability.write
-        param['availability_delete'] = availability.delete
-        del parameters['availability']
+    availability_mapping = {'availability_read': 4, 'availability_write': 2, 'availability_delete': 1}
 
     for key in parameters:
         if key == 'name' and parameters['name'] != rse:  # Needed due to wrongly setting name in pre1.22.7 clients
             param['rse'] = parameters['name']
-        elif key in MUTABLE_RSE_PROPERTIES - {'name'}:
+        elif key in ['availability_read', 'availability_write', 'availability_delete']:
+            if parameters[key] is True:
+                availability = availability | availability_mapping[key]
+            else:
+                availability = availability & ~availability_mapping[key]
+        elif key in MUTABLE_RSE_PROPERTIES - {'name', 'availability_read', 'availability_write', 'availability_delete'}:
             param[key] = parameters[key]
+    param['availability'] = availability or param['availability']
 
     # handle null-able keys
     for key in parameters:

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -43,7 +43,7 @@ def parse_expression(expression, filter_=None, session=None):
     Parse a RSE expression and return the list of RSE dictionaries.
 
     :param expression:    RSE expression, e.g: 'CERN|BNL'.
-    :param filter_:       Availability filter (dictionary) used for the RSEs. e.g.: {'availability_write': True}
+    :param filter_:        Availability filter (dictionary) used for the RSEs. e.g.: {'availability_write': True}
     :param session:       Database session in use.
     :returns:             A list of rse dictionaries.
     :raises:              InvalidRSEExpression, RSENotFound, RSEWriteBlocked
@@ -96,7 +96,7 @@ def parse_expression(expression, filter_=None, session=None):
     if filter_:
         for rse in vo_result:
             if filter_.get('availability_write', False):
-                if rse.get('availability_write'):
+                if rse.get('availability') & 2:
                     final_result.append(rse)
         if not final_result:
             raise RSEWriteBlocked('RSE excluded; not available for writing.')

--- a/lib/rucio/core/rse_selector.py
+++ b/lib/rucio/core/rse_selector.py
@@ -48,7 +48,7 @@ class RSESelector():
         if weight is not None:
             for rse in rses:
                 attributes = list_rse_attributes(rse_id=rse['id'], session=session)
-                availability_write = True if rse.get('availability_write', True) else False
+                availability_write = True if rse.get('availability', 7) & 2 else False
                 if weight not in attributes:
                     continue  # The RSE does not have the required weight set, therefore it is ignored
                 try:
@@ -62,7 +62,7 @@ class RSESelector():
         else:
             for rse in rses:
                 mock_rse = has_rse_attribute(rse['id'], 'mock', session=session)
-                availability_write = True if rse.get('availability_write', True) else False
+                availability_write = True if rse.get('availability', 7) & 2 else False
                 self.rses.append({'rse_id': rse['id'],
                                   'weight': 1,
                                   'mock_rse': mock_rse,

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -2181,7 +2181,7 @@ def examine_rule(rule_id, session=None):
 
                     for replica in available_replicas:
                         sources.append((get_rse_name(rse_id=replica.rse_id, session=session),
-                                        True if get_rse(rse_id=replica.rse_id, session=session).availability_read else False))
+                                        True if get_rse(rse_id=replica.rse_id, session=session).availability >= 4 else False))
 
                 result['transfers'].append({'scope': lock.scope,
                                             'name': lock.name,

--- a/lib/rucio/daemons/bb8/bb8.py
+++ b/lib/rucio/daemons/bb8/bb8.py
@@ -216,14 +216,14 @@ def run_once(
             "Excluding RSEs as destinations which are not available for write:",
         )
         for des in rses_under_ratio:
-            if not des["availability_write"]:
+            if des["availability"] & 2 == 0:
                 logger(logging.DEBUG, "Excluding %s", des["rse"])
                 rses_under_ratio.remove(des)
         logger(
             logging.DEBUG, "Excluding RSEs as sources which are not available for read:"
         )
         for src in rses_over_ratio:
-            if not src["availability_read"]:
+            if src["availability"] & 4 == 0:
                 logger(logging.DEBUG, "Excluding %s", src["rse"])
                 rses_over_ratio.remove(src)
 

--- a/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
@@ -109,13 +109,13 @@ for src in rses_over_ratio:
 
 print('Excluding RSEs as destinations which are blocklisted:')
 for des in rses_under_ratio:
-    if not (des['availability_read'] and des['availability_write'] and des['availability_delete']):
+    if des['availability'] != 7:
         print('  %s' % (des['rse']))
         rses_under_ratio.remove(des)
 
 print('Excluding RSEs as sources which are blocklisted:')
 for src in rses_over_ratio:
-    if not (src['availability_read'] and src['availability_write'] and src['availability_delete']):
+    if src['availability'] != 7:
         print('  %s' % (src['rse']))
         rses_over_ratio.remove(src)
 

--- a/lib/rucio/daemons/bb8/t2_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/t2_background_rebalance.py
@@ -109,13 +109,13 @@ for src in rses_over_ratio:
 
 print('Excluding RSEs as desetinations which are blocklisted:')
 for des in rses_under_ratio:
-    if not (des['availability_read'] and des['availability_write'] and des['availability_delete']):
+    if des['availability'] != 7:
         print('  %s' % (des['rse']))
         rses_under_ratio.remove(des)
 
 print('Excluding RSEs as sources which are blocklisted:')
 for src in rses_over_ratio:
-    if (src['availability_read'] and src['availability_write'] and src['availability_delete']):
+    if src['availability'] != 7:
         print('  %s' % (src['rse']))
         rses_over_ratio.remove(src)
 

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
@@ -176,7 +176,7 @@ class PlacementAlgorithm:
                 continue
             if rse_attr['type'] != 'DATADISK':
                 continue
-            if not src_rse_info['availability_read']:
+            if src_rse_info['availability'] & 4 == 0:
                 continue
 
             if rep['state'] == ReplicaState.AVAILABLE:
@@ -201,7 +201,7 @@ class PlacementAlgorithm:
                         dst_rse_id = self._sites[dst_site]['rse_id']
                         dst_rse_info = get_rse(rse_id=dst_rse_id)
 
-                        if not dst_rse_info['availability_write']:
+                        if dst_rse_info['availability'] & 2 == 0:
                             continue
 
                         site_added_bytes = sum(self._added_bytes.get_series(dst_rse_id))

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -174,9 +174,9 @@ def run_once(worker_number=0, logger=logging.log, session=None, **kwargs):
         if direction == 'destination' or direction == 'source':
             for rse_id in result_dict:
                 rse_name = result_dict[rse_id]['rse']
-                rse = get_rse(rse_id)
+                availability = get_rse(rse_id).availability
                 # dest_rse is not blocklisted for write or src_rse is not blocklisted for read
-                if (direction == 'destination' and rse.availability_write) or (direction == 'source' and rse.availability_read):
+                if (direction == 'destination' and availability & 2) or (direction == 'source' and availability & 4):
                     if all_activities:
                         __release_all_activities(result_dict[rse_id], direction, rse_name, rse_id, logger=logger, session=session)
                     else:

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -513,7 +513,7 @@ def _run_once(rses_to_process, chunk_size, greedy, scheme,
     tot_needed_free_space = 0
     for rse in rses_to_process:
         # Check if RSE is blocklisted
-        if not rse.columns['availability_write']:
+        if rse.columns['availability'] % 2 == 0:
             logger(logging.DEBUG, 'RSE %s is blocklisted for delete', rse.name)
             continue
         rse.ensure_loaded(load_attributes=True)

--- a/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
+++ b/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
@@ -209,8 +209,8 @@ def declare_suspicious_replicas_bad(once: bool = False, younger_than: int = 3, n
                         logger(logging.DEBUG, '%s', i)
 
                     # RSEs that aren't available shouldn't have suspicious replicas showing up. Skip to next RSE.
-                    if not rse['availability_write'] and ((len(suspicious_replicas_avail_elsewhere) > 0) or (len(suspicious_replicas_last_copy) > 0)):
-                        logger(logging.WARNING, "%s is not available (availability_write: %s), yet it has suspicious replicas. Please investigate. \n", rse_expr, rse['availability_write'])
+                    if (rse['availability'] not in {4, 5, 6, 7}) and ((len(suspicious_replicas_avail_elsewhere) > 0) or (len(suspicious_replicas_last_copy) > 0)):
+                        logger(logging.WARNING, "%s is not available (availability: %s), yet it has suspicious replicas. Please investigate. \n", rse_expr, rse['availability'])
                         continue
 
                     if suspicious_replicas_avail_elsewhere:

--- a/lib/rucio/tests/test_import_export.py
+++ b/lib/rucio/tests/test_import_export.py
@@ -53,9 +53,7 @@ def check_rse(rse_name, test_data, vo='def'):
     assert rse['staging_area'] == test_data[rse_name]['staging_area']
     assert rse['longitude'] == test_data[rse_name]['longitude']
     assert rse['latitude'] == test_data[rse_name]['latitude']
-    assert rse['availability_read'] == test_data[rse_name]['availability_read']
-    assert rse['availability_write'] == test_data[rse_name]['availability_write']
-    assert rse['availability_delete'] == test_data[rse_name]['availability_delete']
+    assert rse['availability'] == test_data[rse_name]['availability']
 
 
 def check_protocols(rse, test_data, vo='def'):
@@ -154,8 +152,7 @@ def importer_example_data(vo):
 
     # RSE 1 that already exists
     example_data.old_rse_1 = rse_name_generator()
-    example_data.old_rse_id_1 = add_rse(example_data.old_rse_1, availability_read=False, availability_write=False, region_code='DE', country_name='DE',
-                                        deterministic=True, volatile=True, staging_area=True, time_zone='Europe', latitude='1', longitude='2', vo=vo)
+    example_data.old_rse_id_1 = add_rse(example_data.old_rse_1, availability=1, region_code='DE', country_name='DE', deterministic=True, volatile=True, staging_area=True, time_zone='Europe', latitude='1', longitude='2', vo=vo)
     add_protocol(example_data.old_rse_id_1, {'scheme': 'scheme1', 'hostname': 'hostname1', 'port': 1000, 'impl': 'TODO'})
     add_protocol(example_data.old_rse_id_1, {'scheme': 'scheme3', 'hostname': 'hostname3', 'port': 1000, 'impl': 'TODO'})
 
@@ -201,9 +198,7 @@ def importer_example_data(vo):
         'rses': {
             example_data.new_rse: {
                 'rse_type': RSEType.TAPE,
-                'availability_read': False,
-                'availability_write': True,
-                'availability_delete': True,
+                'availability': 3,
                 'city': 'NewCity',
                 'region_code': 'CH',
                 'country_name': 'switzerland',
@@ -239,9 +234,7 @@ def importer_example_data(vo):
                 'time_zone': 'Asia',
                 'longitude': 5,
                 'city': 'City',
-                'availability_read': False,
-                'availability_write': True,
-                'availability_delete': False,
+                'availability': 2,
                 'latitude': 10,
                 'protocols': [{
                     'scheme': 'scheme1',
@@ -496,9 +489,7 @@ class TestImporterSyncModes(unittest.TestCase):
             'rses': {
                 new_rse: {
                     'rse_type': RSEType.TAPE,
-                    'availability_read': False,
-                    'availability_write': True,
-                    'availability_delete': True,
+                    'availability': 3,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -534,6 +525,7 @@ class TestImporterSyncModes(unittest.TestCase):
                     'time_zone': 'Europe',
                     'longitude': 2,
                     'city': 'City',
+                    'availability': 1,
                     'latitude': 1,
                     'protocols': [{
                         'scheme': 'scheme1',
@@ -599,9 +591,7 @@ class TestImporterSyncModes(unittest.TestCase):
             'rses': {
                 new_rse: {
                     'rse_type': RSEType.TAPE,
-                    'availability_read': False,
-                    'availability_write': True,
-                    'availability_delete': True,
+                    'availability': 3,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -637,6 +627,7 @@ class TestImporterSyncModes(unittest.TestCase):
                     'time_zone': 'Europe',
                     'longitude': 2,
                     'city': 'City',
+                    'availability': 1,
                     'latitude': 1,
                     'protocols': [{
                         'scheme': 'scheme1',
@@ -874,9 +865,7 @@ class TestImporterSyncModes(unittest.TestCase):
             'rses': {
                 less_prot_rse: {
                     'rse_type': RSEType.TAPE,
-                    'availability_read': False,
-                    'availability_write': True,
-                    'availability_delete': True,
+                    'availability': 3,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -903,9 +892,7 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 diff_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability_read': False,
-                    'availability_write': True,
-                    'availability_delete': True,
+                    'availability': 3,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -924,9 +911,7 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 more_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability_read': False,
-                    'availability_write': True,
-                    'availability_delete': False,
+                    'availability': 2,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -997,9 +982,7 @@ class TestImporterSyncModes(unittest.TestCase):
             'rses': {
                 less_prot_rse: {
                     'rse_type': RSEType.TAPE,
-                    'availability_read': False,
-                    'availability_write': True,
-                    'availability_delete': True,
+                    'availability': 3,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -1026,9 +1009,7 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 diff_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability_read': False,
-                    'availability_write': True,
-                    'availability_delete': True,
+                    'availability': 3,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -1047,9 +1028,7 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 more_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability_read': False,
-                    'availability_write': True,
-                    'availability_delete': False,
+                    'availability': 2,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -1120,9 +1099,7 @@ class TestImporterSyncModes(unittest.TestCase):
             'rses': {
                 less_prot_rse: {
                     'rse_type': RSEType.TAPE,
-                    'availability_read': False,
-                    'availability_write': True,
-                    'availability_delete': True,
+                    'availability': 3,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -1149,9 +1126,7 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 diff_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability_read': False,
-                    'availability_write': True,
-                    'availability_delete': True,
+                    'availability': 3,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -1170,9 +1145,7 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 more_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability_read': False,
-                    'availability_write': True,
-                    'availability_delete': False,
+                    'availability': 2,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',

--- a/lib/rucio/tests/test_rse.py
+++ b/lib/rucio/tests/test_rse.py
@@ -53,9 +53,7 @@ class TestRSECoreApi(unittest.TestCase):
         invalid_rse = 'BLAHBLAH'
         properties = {
             'ASN': 'ASN',
-            'availability_read': False,
-            'availability_write': True,
-            'availability_delete': False,
+            'availability': 2,
             'deterministic': True,
             'volatile': True,
             'city': 'city',
@@ -87,9 +85,7 @@ class TestRSECoreApi(unittest.TestCase):
         assert rse.longitude == properties['longitude']
         assert rse.latitude == properties['latitude']
         assert rse.ASN == properties['ASN']
-        assert rse.availability_read == properties['availability_read']
-        assert rse.availability_write == properties['availability_write']
-        assert rse.availability_delete == properties['availability_delete']
+        assert rse.availability == properties['availability']
         assert not rse_exists(invalid_rse, **self.vo)
 
         with pytest.raises(Duplicate):
@@ -227,9 +223,7 @@ def test_create_rse_success(vo, rest_client, auth_token):
     headers_dict = {'X-Rucio-Type': 'user', 'X-Rucio-Account': 'root'}
     properties = {
         'ASN': 'ASN',
-        'availability_read': False,
-        'availability_write': True,
-        'availability_delete': False,
+        'availability': 2,
         'deterministic': True,
         'volatile': True,
         'city': 'city',
@@ -260,9 +254,7 @@ def test_create_rse_success(vo, rest_client, auth_token):
     assert rse.longitude == properties['longitude']
     assert rse.latitude == properties['latitude']
     assert rse.ASN == properties['ASN']
-    assert rse.availability_read == properties['availability_read']
-    assert rse.availability_write == properties['availability_write']
-    assert rse.availability_delete == properties['availability_delete']
+    assert rse.availability == properties['availability']
 
     response = rest_client.post('/rses/' + rse_name, headers=headers(auth(auth_token), hdrdict(headers_dict)))
     assert response.status_code == 409
@@ -368,9 +360,7 @@ class TestRSEClient(unittest.TestCase):
         rse_name = rse_name_generator()
         properties = {
             'ASN': 'ASN',
-            'availability_read': False,
-            'availability_write': True,
-            'availability_delete': False,
+            'availability': 2,
             'deterministic': True,
             'volatile': True,
             'city': 'city',
@@ -401,9 +391,7 @@ class TestRSEClient(unittest.TestCase):
         assert rse.longitude == properties['longitude']
         assert rse.latitude == properties['latitude']
         assert rse.ASN == properties['ASN']
-        assert rse.availability_read == properties['availability_read']
-        assert rse.availability_write == properties['availability_write']
-        assert rse.availability_delete == properties['availability_delete']
+        assert rse.availability == properties['availability']
 
         with pytest.raises(Duplicate):
             self.client.add_rse(rse_name)


### PR DESCRIPTION
In #5665, the availability column got split into three seperate values.

The production cluster runs different Rucio versions at the same time, which is not respected in #5665. This PR reverts the changes in the code, not the ones in the database, and introduces a new strategy to deal with the backwards compatibility. The new strategy will have three steps:

1. Add the new columns (this PR and #5665). They will be populated with data, but will remain unused for now.
2. Once all instances in the cluster use the version from step (1.), the default column will be changed to the new ones. This will not lose any data and still make the cluster backwards compatible to instances from step (1.).
3. Once all instances in the cluster use the version from step (2.), we delete the old behavior.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
