### PR TITLE
Core: Make the RSE settings backwards compatible #5464

### DIFF
--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -1423,7 +1423,6 @@ def update_rse(rse_id: str, parameters: 'Dict[str, Any]', session=None):
         if has_rse_attribute(rse_id, setting, session=session):
             del_rse_attribute(rse_id, setting, session=session)
         add_rse_attribute(rse_id, setting, param[setting], session=session)
-        del param[setting]
 
     query.update(param)
     if 'rse' in param:


### PR DESCRIPTION
In 8e744b0b5 (Core & Internals: Change unnecessary RSE settings to RSE
attributes #5464, 2022-06-20), the RSE settings got refactored from it's
respective columns into RSE attributes.

Since we run multiple Rucio versions in the prod cluster, new changes
should be backwards compatible. In this case this means that the old RSE
settings columns should be updated, as well as the new corresponding RSE
attributes. While this is the case for `add_rse`, it is not for
`update_rse`. The update function only updates the RSE attribute for the
setting, not the column in the RSE model.

The backwards compatibility allows us to migrate data from the old
columns into RSE attributes at any given moments, which is critical for
the follow up PRs.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
