### PR TITLE
Core: Resolve the config not found exception #5704

### DIFF
--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -57,9 +57,12 @@ def config_get(section, option, raise_exception=True, default=None, clean_cached
     try:
         return extract_function(get_config(), section, option)
     except (ConfigParser.NoOptionError, ConfigParser.NoSectionError, RuntimeError) as err:
-        legacy_config = get_legacy_config(section, option, extract_function)
-        if legacy_config is not None:
-            return legacy_config
+        try:
+            legacy_config = get_legacy_config(section, option, extract_function)
+            if legacy_config is not None:
+                return legacy_config
+        except RuntimeError:
+            pass
 
         from rucio.common.utils import is_client
         client_mode = is_client()


### PR DESCRIPTION
Importing the client without a config file raises a RuntimeError:

```python
>>> from rucio.client import Client
...
RuntimeError: Could not load Rucio configuration file. Rucio looked in
the following paths for a configuration file, in order:
        /opt/rucio/etc/rucio.cfg
```

This should not happen, since the client is configurable after the
construction of the client object.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
