### PR TITLE
Protocols: Migrate WebDAV XML parsing to Python's ElementTree

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ urllib3>=1.24.2,<=1.26.8                                    # HTTP library with 
 dogpile.cache>=1.1.2,<=1.1.5                                # Caching API plugins (1.1.2 is the first version to support pymemcache)
 tabulate~=0.8.0                                             # Pretty-print tabular data
 jsonschema~=3.2.0                                           # For JSON schema validation (Policy modules)
+dataclasses==0.8.0; python_version == '3.6'
 
 # All dependencies needed in extras for rucio client (and server/daemons) should be defined here
 paramiko~=2.10.3                                            # ssh_extras; SSH2 protocol library (also needed in the server) Race condition before 2.10.1 (https://github.com/advisories/GHSA-f8q4-jwww-x3wv)

--- a/setuputil.py
+++ b/setuputil.py
@@ -26,6 +26,7 @@ clients_requirements_table = {
         'dogpile.cache',
         'tabulate',
         'jsonschema',
+        'dataclasses',
     ],
     'ssh': ['paramiko'],
     'kerberos': [


### PR DESCRIPTION
As described in #5700, the parser for the WebDAV server responses had issues with namespace handling. This caused Rucio to misinterpret responses from for instance the Apache DAV module. Changing the implementation to use Python's `xml.etree.ElementTree` fixes this issue.

This PR also includes a fix for #5308, in which Rucio doesn't properly handle DAV servers with path prefixes.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
