### PR TITLE
Database: Set the default availability_* value in the migration #5664

### DIFF
--- a/lib/rucio/db/sqla/migrate_repo/versions/1677d4d803c8_split_rse_availability_into_multiple.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1677d4d803c8_split_rse_availability_into_multiple.py
@@ -18,6 +18,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, drop_column, get_bind
+from sqlalchemy.sql.expression import true
 
 from rucio.db.sqla.types import GUID
 
@@ -42,9 +43,9 @@ def upgrade():
             "rses",
             sa.Column("id", GUID()),
             sa.Column("availability", sa.Integer),
-            sa.Column("availability_read", sa.Boolean),
-            sa.Column("availability_write", sa.Boolean),
-            sa.Column("availability_delete", sa.Boolean),
+            sa.Column("availability_read", sa.Boolean, default=true()),
+            sa.Column("availability_write", sa.Boolean, default=true()),
+            sa.Column("availability_delete", sa.Boolean, default=true()),
             schema=schema,
         )
 


### PR DESCRIPTION
The default value for the Oracle db is `NONE`, even for the boolean
columns. This should be true for every column, to represent the default value 7
from the availability column.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
