### PR TITLE
Database: Set the default availability_* value in the migration Vol 2…

### DIFF
--- a/lib/rucio/db/sqla/migrate_repo/versions/1677d4d803c8_split_rse_availability_into_multiple.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1677d4d803c8_split_rse_availability_into_multiple.py
@@ -35,17 +35,17 @@ def upgrade():
     if context.get_context().dialect.name in ["oracle", "mysql", "postgresql"]:
         schema = context.get_context().version_table_schema if context.get_context().version_table_schema else ""
 
-        add_column("rses", sa.Column("availability_read", sa.Boolean), schema=schema)
-        add_column("rses", sa.Column("availability_write", sa.Boolean), schema=schema)
-        add_column("rses", sa.Column("availability_delete", sa.Boolean), schema=schema)
+        add_column("rses", sa.Column("availability_read", sa.Boolean, server_default=true()), schema=schema)
+        add_column("rses", sa.Column("availability_write", sa.Boolean, server_default=true()), schema=schema)
+        add_column("rses", sa.Column("availability_delete", sa.Boolean, server_default=true()), schema=schema)
 
         RSE = sa.sql.table(
             "rses",
             sa.Column("id", GUID()),
             sa.Column("availability", sa.Integer),
-            sa.Column("availability_read", sa.Boolean, default=true()),
-            sa.Column("availability_write", sa.Boolean, default=true()),
-            sa.Column("availability_delete", sa.Boolean, default=true()),
+            sa.Column("availability_read", sa.Boolean, server_default=true()),
+            sa.Column("availability_write", sa.Boolean, server_default=true()),
+            sa.Column("availability_delete", sa.Boolean, server_default=true()),
             schema=schema,
         )
 


### PR DESCRIPTION
…. #5664

The default value for the Oracle db is `NONE`, even for the boolean
columns. This should be true for every column, to represent the default value 7
from the availability column.

Just setting the models default value is not enough, the column
definition also needs to be updated. Thank you Oracle for noticing,
thanks to myself for being so incompetent.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
