### PR TITLE
Ensure consistent units in Prometheus timer monitoring 

### DIFF
--- a/lib/rucio/common/stopwatch.py
+++ b/lib/rucio/common/stopwatch.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import time
+from typing import Optional
+
+
+class Stopwatch:
+    """Stopwatch to measure time durations.
+
+    Note: The stopwatch is started on initialization.
+    """
+
+    _t_start: float
+    _t_end: Optional[float]
+
+    def __init__(self) -> None:
+        self.restart()
+
+    def _now(self) -> float:
+        # TODO: change to time.monotonic_ns() if python 3.6 support is dropped.
+        return time.monotonic()
+
+    def restart(self) -> None:
+        """Resets and starts the stopwatch."""
+        self._t_start = self._now()
+        self._t_end = None
+
+    def stop(self) -> None:
+        """Stops the stopwatch."""
+        self._t_end = self._now()
+
+    @property
+    def elapsed(self) -> float:
+        """Returns the total number of elapsed seconds."""
+        if self._t_end is None:
+            return self._now() - self._t_start
+        else:
+            return self._t_end - self._t_start
+
+    def __float__(self) -> float:
+        """Returns the total number of elapsed seconds."""
+        return self.elapsed

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -28,7 +28,7 @@ from urllib.parse import urlparse, urlencode
 from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get, get_rse_credentials
 from rucio.common.exception import UnsupportedOperation
-from rucio.core.monitor import record_timer_block
+from rucio.core.monitor import Timer
 
 CREDS_GCS = None
 
@@ -142,7 +142,7 @@ def get_signed_url(rse_id, service, operation, url, lifetime=600):
         else:
             s3op = 'delete_object'
 
-        with record_timer_block('credential.signs3'):
+        with Timer('credential.signs3'):
             s3 = boto3.client('s3', endpoint_url='https://' + host + ':' + port, aws_access_key_id=access_key, aws_secret_access_key=secret_key, config=Config(signature_version=signature_version, region_name=region_name))
 
             signed_url = s3.generate_presigned_url(s3op, Params={'Bucket': bucket, 'Key': key}, ExpiresIn=lifetime)
@@ -178,7 +178,7 @@ def get_signed_url(rse_id, service, operation, url, lifetime=600):
         expires = int(time.time() + lifetime)
 
         # create signed URL
-        with record_timer_block('credential.signswift'):
+        with Timer('credential.signswift'):
             hmac_body = u'%s\n%s\n%s' % (swiftop, expires, components.path)
             # Python 3 hmac only accepts bytes or bytearray
             sig = hmac.new(bytearray(tempurl_key, 'utf-8'), bytearray(hmac_body, 'utf-8'), sha1).hexdigest()

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -17,7 +17,6 @@ import json
 import random
 import subprocess
 import logging
-import time
 import traceback
 from datetime import datetime, timedelta
 from math import floor
@@ -43,11 +42,12 @@ from rucio.common.utils import all_oidc_req_claims_present, build_url, val_to_sp
 from rucio.common import types
 from rucio.core.account import account_exists
 from rucio.core.identity import exist_identity_account, get_default_account
-from rucio.core.monitor import record_counter, record_timer
+from rucio.core.monitor import record_counter, Stopwatch
 from rucio.db.sqla import filter_thread_work
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import IdentityType
 from rucio.db.sqla.session import read_session, transactional_session
+
 
 # worokaround for a bug in pyoidc (as of Dec 2019)
 REQUEST2ENDPOINT['CCAccessTokenRequest'] = 'token_endpoint'
@@ -298,7 +298,7 @@ def get_auth_oidc(account: str, session=None, **kwargs) -> str:
             return None
 
     try:
-        start = time.time()
+        timer = Stopwatch()
         # redirect_url needs to be specified & one of those defined
         # in the Rucio OIDC Client configuration
         redirect_to = "auth/oidc_code"
@@ -346,7 +346,7 @@ def get_auth_oidc(account: str, session=None, **kwargs) -> str:
             auth_url = build_url('https://' + auth_server.netloc, path='{}auth/oidc_redirect'.format(
                 auth_server.path.split('auth/')[0].lstrip('/')), params=access_msg)
 
-        record_timer(name='IdP_authentication.request', time=time.time() - start)
+        timer.record('IdP_authentication.request')
         return auth_url
 
     except Exception as error:
@@ -369,7 +369,7 @@ def get_token_oidc(auth_query_string: str, ip: str = None, session=None):
               (no auto, auto, polling).
     """
     try:
-        start = time.time()
+        timer = Stopwatch()
         parsed_authquery = parse_qs(auth_query_string)
         state = parsed_authquery["state"][0]
         code = parsed_authquery["code"][0]
@@ -476,7 +476,7 @@ def get_token_oidc(auth_query_string: str, ip: str = None, session=None):
                            .update({models.OAuthRequest.access_msg: oauth_req_params.access_msg,
                                     models.OAuthRequest.redirect_msg: new_token['token']})
                 session.commit()
-            record_timer(name='IdP_authorization', time=time.time() - start)
+            timer.record('IdP_authorization')
             if '_polling' in oauth_req_params.access_msg:
                 return {'polling': True}
             elif 'http' in oauth_req_params.access_msg:
@@ -484,7 +484,7 @@ def get_token_oidc(auth_query_string: str, ip: str = None, session=None):
             else:
                 return {'fetchcode': fetchcode}
         else:
-            record_timer(name='IdP_authorization', time=time.time() - start)
+            timer.record('IdP_authorization')
             return {'token': new_token}
 
     except Exception:
@@ -764,7 +764,7 @@ def __exchange_token_oidc(subject_token_object: models.Token, session=None, **kw
     if not grant_type:
         grant_type = EXCHANGE_GRANT_TYPE
     try:
-        start = time.time()
+        timer = Stopwatch()
 
         record_counter(name='IdP_authentication.code_granted')
         oidc_dict = __get_init_oidc_client(token_object=subject_token_object, token_type="subject_token")
@@ -808,7 +808,7 @@ def __exchange_token_oidc(subject_token_object: models.Token, session=None, **kw
         record_counter(name='IdP_authorization.access_token.saved')
         if 'refresh_token' in oidc_tokens:
             record_counter(name='IdP_authorization.refresh_token.saved')
-        record_timer(name='IdP_authorization.token_exchange', time=time.time() - start)
+        timer.record('IdP_authorization.token_exchange')
         return new_token
 
     except Exception:
@@ -968,7 +968,7 @@ def __refresh_token_oidc(token_object: models.Token, session=None):
         constraints. Otherwise, throws an an Exception.
     """
     try:
-        start = time.time()
+        timer = Stopwatch()
         record_counter(name='IdP_authorization.refresh_token.request')
         jwt_row_dict, extra_dict = {}, {}
         jwt_row_dict['account'] = token_object.account
@@ -1025,7 +1025,7 @@ def __refresh_token_oidc(token_object: models.Token, session=None):
         else:
             raise CannotAuthorize("OIDC identity '%s' of the '%s' account is did not " % (token_object.identity, token_object.account)
                                   + "succeed requesting a new access and refresh tokens.")  # NOQA: W503
-        record_timer(name='IdP_authorization.refresh_token', time=time.time() - start)
+        timer.record('IdP_authorization.refresh_token')
         return new_token
 
     except Exception as error:

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -42,7 +42,7 @@ from rucio.common.utils import all_oidc_req_claims_present, build_url, val_to_sp
 from rucio.common import types
 from rucio.core.account import account_exists
 from rucio.core.identity import exist_identity_account, get_default_account
-from rucio.core.monitor import record_counter, Stopwatch
+from rucio.core.monitor import record_counter, Timer
 from rucio.db.sqla import filter_thread_work
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import IdentityType
@@ -298,7 +298,7 @@ def get_auth_oidc(account: str, session=None, **kwargs) -> str:
             return None
 
     try:
-        timer = Stopwatch()
+        timer = Timer()
         # redirect_url needs to be specified & one of those defined
         # in the Rucio OIDC Client configuration
         redirect_to = "auth/oidc_code"
@@ -369,7 +369,7 @@ def get_token_oidc(auth_query_string: str, ip: str = None, session=None):
               (no auto, auto, polling).
     """
     try:
-        timer = Stopwatch()
+        timer = Timer()
         parsed_authquery = parse_qs(auth_query_string)
         state = parsed_authquery["state"][0]
         code = parsed_authquery["code"][0]
@@ -764,7 +764,7 @@ def __exchange_token_oidc(subject_token_object: models.Token, session=None, **kw
     if not grant_type:
         grant_type = EXCHANGE_GRANT_TYPE
     try:
-        timer = Stopwatch()
+        timer = Timer()
 
         record_counter(name='IdP_authentication.code_granted')
         oidc_dict = __get_init_oidc_client(token_object=subject_token_object, token_type="subject_token")
@@ -968,7 +968,7 @@ def __refresh_token_oidc(token_object: models.Token, session=None):
         constraints. Otherwise, throws an an Exception.
     """
     try:
-        timer = Stopwatch()
+        timer = Timer()
         record_counter(name='IdP_authorization.refresh_token.request')
         jwt_row_dict, extra_dict = {}, {}
         jwt_row_dict['account'] = token_object.account

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -52,7 +52,7 @@ from rucio.core import account_counter, rse_counter, request as request_core, tr
 from rucio.core.account import get_account
 from rucio.core.lifetime_exception import define_eol
 from rucio.core.message import add_message
-from rucio.core.monitor import record_timer_block
+from rucio.core.monitor import Timer
 from rucio.core.rse import get_rse_name, list_rse_attributes, get_rse, get_rse_usage
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.rse_selector import RSESelector
@@ -112,9 +112,9 @@ def add_rule(dids, account, copies, rse_expression, grouping, weight, lifetime, 
 
     grouping = {'ALL': RuleGrouping.ALL, 'NONE': RuleGrouping.NONE}.get(grouping, RuleGrouping.DATASET)
 
-    with record_timer_block('rule.add_rule'):
+    with Timer('rule.add_rule'):
         # 1. Resolve the rse_expression into a list of RSE-ids
-        with record_timer_block('rule.add_rule.parse_rse_expression'):
+        with Timer('rule.add_rule.parse_rse_expression'):
             vo = account.vo
             if ignore_availability:
                 rses = parse_expression(rse_expression, filter_={'vo': vo}, session=session)
@@ -148,7 +148,7 @@ def add_rule(dids, account, copies, rse_expression, grouping, weight, lifetime, 
                 source_rses = []
 
         # 2. Create the rse selector
-        with record_timer_block('rule.add_rule.create_rse_selector'):
+        with Timer('rule.add_rule.create_rse_selector'):
             rseselector = RSESelector(account=account, rses=rses, weight=weight, copies=copies, ignore_account_limit=ask_approval or ignore_account_limit, session=session)
 
         expires_at = datetime.utcnow() + timedelta(seconds=lifetime) if lifetime is not None else None
@@ -157,7 +157,7 @@ def add_rule(dids, account, copies, rse_expression, grouping, weight, lifetime, 
 
         for elem in dids:
             # 3. Get the did
-            with record_timer_block('rule.add_rule.get_did'):
+            with Timer('rule.add_rule.get_did'):
                 try:
                     did = session.query(models.DataIdentifier).filter(models.DataIdentifier.scope == elem['scope'],
                                                                       models.DataIdentifier.name == elem['name']).one()
@@ -197,7 +197,7 @@ def add_rule(dids, account, copies, rse_expression, grouping, weight, lifetime, 
             eol_at = define_eol(elem['scope'], elem['name'], rses, session=session)
 
             # 4. Create the replication rule
-            with record_timer_block('rule.add_rule.create_rule'):
+            with Timer('rule.add_rule.create_rule'):
                 meta_json = None
                 if meta is not None:
                     try:
@@ -286,7 +286,7 @@ def add_rule(dids, account, copies, rse_expression, grouping, weight, lifetime, 
                 continue
 
             # 5. Apply the rule
-            with record_timer_block('rule.add_rule.apply_rule'):
+            with Timer('rule.add_rule.apply_rule'):
                 try:
                     apply_rule(did, new_rule, [x['id'] for x in rses], [x['id'] for x in source_rses], rseselector, session=session)
                 except IntegrityError as error:
@@ -336,13 +336,13 @@ def add_rules(dids, rules, session=None, logger=logging.log):
     if any(r.get("copies", 1) <= 0 for r in rules):
         raise InvalidValueForKey("The number of copies for a replication rule should be greater than 0.")
 
-    with record_timer_block('rule.add_rules'):
+    with Timer('rule.add_rules'):
         rule_ids = {}
 
         # 1. Fetch the RSEs from the RSE expression to restrict further queries just on these RSEs
         restrict_rses = []
         all_source_rses = []
-        with record_timer_block('rule.add_rules.parse_rse_expressions'):
+        with Timer('rule.add_rules.parse_rse_expressions'):
             for rule in rules:
                 vo = rule['account'].vo
                 if rule.get('ignore_availability'):
@@ -359,7 +359,7 @@ def add_rules(dids, rules, session=None, logger=logging.log):
 
         for elem in dids:
             # 2. Get the did
-            with record_timer_block('rule.add_rules.get_did'):
+            with Timer('rule.add_rules.get_did'):
                 try:
                     did = session.query(models.DataIdentifier).filter(
                         models.DataIdentifier.scope == elem['scope'],
@@ -398,7 +398,7 @@ def add_rules(dids, rules, session=None, logger=logging.log):
             rule_ids[(elem['scope'], elem['name'])] = []
 
             # 3. Resolve the did into its contents
-            with record_timer_block('rule.add_rules.resolve_dids_to_locks_replicas'):
+            with Timer('rule.add_rules.resolve_dids_to_locks_replicas'):
                 # Get all Replicas, not only the ones interesting for the rse_expression
                 datasetfiles, locks, replicas, source_replicas = __resolve_did_to_locks_and_replicas(did=did,
                                                                                                      nowait=False,
@@ -407,7 +407,7 @@ def add_rules(dids, rules, session=None, logger=logging.log):
                                                                                                      session=session)
 
             for rule in rules:
-                with record_timer_block('rule.add_rules.add_rule'):
+                with Timer('rule.add_rules.add_rule'):
                     # 4. Resolve the rse_expression into a list of RSE-ids
                     vo = rule['account'].vo
                     if rule.get('ignore_availability'):
@@ -447,11 +447,11 @@ def add_rules(dids, rules, session=None, logger=logging.log):
                         source_rses = []
 
                     # 5. Create the RSE selector
-                    with record_timer_block('rule.add_rules.create_rse_selector'):
+                    with Timer('rule.add_rules.create_rse_selector'):
                         rseselector = RSESelector(account=rule['account'], rses=rses, weight=rule.get('weight'), copies=rule['copies'], ignore_account_limit=rule.get('ask_approval', False), session=session)
 
                     # 4. Create the replication rule
-                    with record_timer_block('rule.add_rules.create_rule'):
+                    with Timer('rule.add_rules.create_rule'):
                         grouping = {'ALL': RuleGrouping.ALL, 'NONE': RuleGrouping.NONE}.get(rule.get('grouping'), RuleGrouping.DATASET)
 
                         expires_at = datetime.utcnow() + timedelta(seconds=rule.get('lifetime')) if rule.get('lifetime') is not None else None
@@ -538,7 +538,7 @@ def add_rules(dids, rules, session=None, logger=logging.log):
                         continue
 
                     # 5. Apply the replication rule to create locks, replicas and transfers
-                    with record_timer_block('rule.add_rules.create_locks_replicas_transfers'):
+                    with Timer('rule.add_rules.create_locks_replicas_transfers'):
                         try:
                             __create_locks_replicas_transfers(datasetfiles=datasetfiles,
                                                               locks=locks,
@@ -638,7 +638,7 @@ def inject_rule(rule_id, session=None, logger=logging.log):
         return
 
     # 1. Resolve the rse_expression into a list of RSE-ids
-    with record_timer_block('rule.add_rule.parse_rse_expression'):
+    with Timer('rule.add_rule.parse_rse_expression'):
         vo = rule['account'].vo
         if rule.ignore_availability:
             rses = parse_expression(rule.rse_expression, filter_={'vo': vo}, session=session)
@@ -651,11 +651,11 @@ def inject_rule(rule_id, session=None, logger=logging.log):
             source_rses = []
 
     # 2. Create the rse selector
-    with record_timer_block('rule.add_rule.create_rse_selector'):
+    with Timer('rule.add_rule.create_rse_selector'):
         rseselector = RSESelector(account=rule['account'], rses=rses, weight=rule.weight, copies=rule.copies, ignore_account_limit=rule.ignore_account_limit, session=session)
 
     # 3. Get the did
-    with record_timer_block('rule.add_rule.get_did'):
+    with Timer('rule.add_rule.get_did'):
         try:
             did = session.query(models.DataIdentifier).filter(models.DataIdentifier.scope == rule.scope,
                                                               models.DataIdentifier.name == rule.name).one()
@@ -665,7 +665,7 @@ def inject_rule(rule_id, session=None, logger=logging.log):
             raise InvalidObject(error.args)
 
     # 4. Apply the rule
-    with record_timer_block('rule.add_rule.apply_rule'):
+    with Timer('rule.add_rule.apply_rule'):
         try:
             apply_rule(did, rule, [x['id'] for x in rses], [x['id'] for x in source_rses], rseselector, session=session)
         except IntegrityError as error:
@@ -847,7 +847,7 @@ def delete_rule(rule_id, purge_replicas=None, soft=False, delete_parent=False, n
     :raises:                  UnsupportedOperation if the Rule is locked.
     """
 
-    with record_timer_block('rule.delete_rule'):
+    with Timer('rule.delete_rule'):
         try:
             rule = session.query(models.ReplicationRule)\
                           .filter(models.ReplicationRule.id == rule_id)\
@@ -2403,7 +2403,7 @@ def __evaluate_did_detach(eval_did, session=None, logger=logging.log):
     logger(logging.INFO, "Re-Evaluating did %s:%s for DETACH", eval_did.scope, eval_did.name)
     force_epoch = config_get('rules', 'force_epoch_when_detach', default=False, session=session)
 
-    with record_timer_block('rule.evaluate_did_detach'):
+    with Timer('rule.evaluate_did_detach'):
         # Get all parent DID's
         parent_dids = rucio.core.did.list_all_parent_dids(scope=eval_did.scope, name=eval_did.name, session=session)
 
@@ -2492,13 +2492,13 @@ def __evaluate_did_attach(eval_did, session=None, logger=logging.log):
 
     logger(logging.INFO, "Re-Evaluating did %s:%s for ATTACH", eval_did.scope, eval_did.name)
 
-    with record_timer_block('rule.evaluate_did_attach'):
+    with Timer('rule.evaluate_did_attach'):
         # Get all parent DID's
-        with record_timer_block('rule.evaluate_did_attach.list_parent_dids'):
+        with Timer('rule.evaluate_did_attach.list_parent_dids'):
             parent_dids = rucio.core.did.list_all_parent_dids(scope=eval_did.scope, name=eval_did.name, session=session)
 
         # Get immediate new child DID's
-        with record_timer_block('rule.evaluate_did_attach.list_new_child_dids'):
+        with Timer('rule.evaluate_did_attach.list_new_child_dids'):
             new_child_dids = session.query(models.DataIdentifierAssociation)\
                 .with_hint(models.DataIdentifierAssociation, "INDEX_RS_ASC(contents contents_pk)", 'oracle')\
                 .filter(models.DataIdentifierAssociation.scope == eval_did.scope,
@@ -2507,7 +2507,7 @@ def __evaluate_did_attach(eval_did, session=None, logger=logging.log):
 
         if new_child_dids:
             # Get all unsuspended RR from parents and eval_did
-            with record_timer_block('rule.evaluate_did_attach.get_rules'):
+            with Timer('rule.evaluate_did_attach.get_rules'):
                 rule_clauses = []
                 for did in parent_dids:
                     rule_clauses.append(and_(models.ReplicationRule.scope == did['scope'],
@@ -2522,7 +2522,7 @@ def __evaluate_did_attach(eval_did, session=None, logger=logging.log):
 
             if rules:
                 # Resolve the new_child_dids to its locks
-                with record_timer_block('rule.evaluate_did_attach.resolve_did_to_locks_and_replicas'):
+                with Timer('rule.evaluate_did_attach.resolve_did_to_locks_and_replicas'):
                     # Resolve the rules to possible target rses:
                     possible_rses = []
                     source_rses = []
@@ -2550,7 +2550,7 @@ def __evaluate_did_attach(eval_did, session=None, logger=logging.log):
                                                                                                           session=session)
 
                 # Evaluate the replication rules
-                with record_timer_block('rule.evaluate_did_attach.evaluate_rules'):
+                with Timer('rule.evaluate_did_attach.evaluate_rules'):
                     for rule in rules:
                         rule_locks_ok_cnt_before = rule.locks_ok_cnt
 
@@ -2656,7 +2656,7 @@ def __evaluate_did_attach(eval_did, session=None, logger=logging.log):
                         insert_rule_history(rule=rule, recent=True, longterm=False, session=session)
 
             # Unflage the dids
-            with record_timer_block('rule.evaluate_did_attach.update_did'):
+            with Timer('rule.evaluate_did_attach.update_did'):
                 for did in new_child_dids:
                     did.rule_evaluation = None
 

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -214,7 +214,7 @@ def automatix(sites, inputfile, sleep_time, account, worker_number=1, total_work
         for site in sites:
 
             for retry in range(0, totretries):
-                timer = monitor.Stopwatch()
+                timer = monitor.Timer()
                 tmpdir = tempfile.mkdtemp()
                 logger(logging.INFO, 'Running on site %s', site)
                 dic = choose_element(probabilities, data)

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -214,7 +214,7 @@ def automatix(sites, inputfile, sleep_time, account, worker_number=1, total_work
         for site in sites:
 
             for retry in range(0, totretries):
-                start_time = time()
+                timer = monitor.Stopwatch()
                 tmpdir = tempfile.mkdtemp()
                 logger(logging.INFO, 'Running on site %s', site)
                 dic = choose_element(probabilities, data)
@@ -250,7 +250,7 @@ def automatix(sites, inputfile, sleep_time, account, worker_number=1, total_work
                 if status:
                     monitor.record_counter(name='automatix.addnewdataset.done', delta=1)
                     monitor.record_counter(name='automatix.addnewfile.done', delta=nbfiles)
-                    monitor.record_timer('automatix.datasetinjection', (time() - start_time) * 1000)
+                    timer.record('automatix.datasetinjection')
                     break
                 else:
                     logger(logging.INFO, 'Failed to upload files. Will retry another time (attempt %s/%s)', str(retry + 1), str(totretries))

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -26,7 +26,7 @@ from rucio.common.config import config_get, config_get_int
 from rucio.common.exception import (InvalidRSEExpression, TransferToolTimeout, TransferToolWrongAnswer, RequestNotFound,
                                     DuplicateFileTransferSubmission, VONotFound, DatabaseException)
 from rucio.core import request as request_core, transfer as transfer_core
-from rucio.core.monitor import record_counter, record_timer, Stopwatch
+from rucio.core.monitor import record_counter, record_timer, Timer
 from rucio.core.replica import add_replicas, tombstone_from_delay, update_replica_state
 from rucio.core.request import set_request_state, queue_requests
 from rucio.core.rse import list_rses
@@ -396,7 +396,7 @@ def _submit_transfers(transfertool_obj, transfers, job_params, submitter='submit
     # A eid is returned if the job is properly submitted otherwise an exception is raised
     is_bulk = len(transfers) > 1
     eid = None
-    timer = Stopwatch()
+    timer = Timer()
     state_to_set = RequestState.SUBMISSION_FAILED
     try:
         record_counter('core.request.submit_transfer')

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -23,7 +23,6 @@ import logging
 import os
 import re
 import threading
-import time
 
 from dogpile.cache.api import NoValue
 from sqlalchemy.exc import DatabaseError
@@ -36,7 +35,7 @@ from rucio.common.types import InternalAccount
 from rucio.common.utils import chunks
 from rucio.core import request as request_core, replica as replica_core
 from rucio.core.config import items
-from rucio.core.monitor import record_timer, record_counter
+from rucio.core.monitor import record_counter, record_timer_block, Stopwatch
 from rucio.core.rse import list_rses
 from rucio.daemons.common import run_daemon
 from rucio.db.sqla.constants import RequestState, RequestType, ReplicaState, BadFilesStatus
@@ -55,35 +54,37 @@ def run_once(bulk, db_bulk, suspicious_patterns, retry_protocol_mismatches, hear
 
     try:
         logger(logging.DEBUG, 'Working on activity %s', activity)
-        time1 = time.time()
-        reqs = request_core.get_next(request_type=[RequestType.TRANSFER, RequestType.STAGEIN, RequestType.STAGEOUT],
-                                     state=[RequestState.DONE, RequestState.FAILED,
-                                            RequestState.LOST, RequestState.SUBMITTING,
-                                            RequestState.SUBMISSION_FAILED, RequestState.NO_SOURCES,
-                                            RequestState.ONLY_TAPE_SOURCES, RequestState.MISMATCH_SCHEME],
-                                     limit=db_bulk,
-                                     older_than=datetime.datetime.utcnow(),
-                                     total_workers=total_workers,
-                                     worker_number=worker_number,
-                                     mode_all=True,
-                                     include_dependent=False,
-                                     hash_variable='rule_id')
-        record_timer('daemons.conveyor.finisher.get_next', (time.time() - time1) * 1000)
-        time2 = time.time()
+
+        with record_timer_block('daemons.conveyor.finisher.get_next'):
+            reqs = request_core.get_next(request_type=[RequestType.TRANSFER, RequestType.STAGEIN, RequestType.STAGEOUT],
+                                         state=[RequestState.DONE, RequestState.FAILED,
+                                                RequestState.LOST, RequestState.SUBMITTING,
+                                                RequestState.SUBMISSION_FAILED, RequestState.NO_SOURCES,
+                                                RequestState.ONLY_TAPE_SOURCES, RequestState.MISMATCH_SCHEME],
+                                         limit=db_bulk,
+                                         older_than=datetime.datetime.utcnow(),
+                                         total_workers=total_workers,
+                                         worker_number=worker_number,
+                                         mode_all=True,
+                                         include_dependent=False,
+                                         hash_variable='rule_id')
+
         if reqs:
             logger(logging.DEBUG, 'Updating %i requests for activity %s', len(reqs), activity)
+
+        timer = Stopwatch()
 
         for chunk in chunks(reqs, bulk):
             try:
                 worker_number, total_workers, logger = heartbeat_handler.live()
-                time3 = time.time()
-                __handle_requests(chunk, suspicious_patterns, retry_protocol_mismatches, logger=logger)
-                record_timer('daemons.conveyor.finisher.handle_requests_time', (time.time() - time3) * 1000 / (len(chunk) if chunk else 1))
+                with record_timer_block(('daemons.conveyor.finisher.handle_requests_time', len(chunk) or 1)):
+                    __handle_requests(chunk, suspicious_patterns, retry_protocol_mismatches, logger=logger)
                 record_counter('daemons.conveyor.finisher.handle_requests', delta=len(chunk))
             except Exception as error:
                 logger(logging.WARNING, '%s', str(error))
+
         if reqs:
-            logger(logging.DEBUG, 'Finish to update %s finished requests for activity %s in %s seconds', len(reqs), activity, time.time() - time2)
+            logger(logging.DEBUG, 'Finish to update %s finished requests for activity %s in %s seconds', len(reqs), activity, timer.elapsed)
 
     except (DatabaseException, DatabaseError) as error:
         if re.match('.*ORA-00054.*', error.args[0]) or re.match('.*ORA-00060.*', error.args[0]) or 'ERROR 1205 (HY000)' in error.args[0]:
@@ -224,13 +225,13 @@ def __handle_requests(reqs, suspicious_patterns, retry_protocol_mismatches, logg
             # Standard failure from the transfer tool
             elif req['state'] == RequestState.FAILED:
                 __check_suspicious_files(req, suspicious_patterns, logger=logger)
-                tss = time.time()
+                timer = Stopwatch()
                 try:
                     if request_core.should_retry_request(req, retry_protocol_mismatches):
                         new_req = request_core.requeue_and_archive(req, source_ranking_update=True, retry_protocol_mismatches=retry_protocol_mismatches, logger=logger)
                         # should_retry_request and requeue_and_archive are not in one session,
                         # another process can requeue_and_archive and this one will return None.
-                        record_timer('daemons.conveyor.common.update_request_state.request_requeue_and_archive', (time.time() - tss) * 1000)
+                        timer.record('daemons.conveyor.common.update_request_state.request_requeue_and_archive')
                         logger(logging.WARNING, 'REQUEUED DID %s:%s REQUEST %s AS %s TRY %s' % (req['scope'],
                                                                                                 req['name'],
                                                                                                 req['request_id'],
@@ -252,10 +253,10 @@ def __handle_requests(reqs, suspicious_patterns, retry_protocol_mismatches, logg
                     # To prevent race conditions
                     continue
                 try:
-                    tss = time.time()
+                    timer = Stopwatch()
                     if request_core.should_retry_request(req, retry_protocol_mismatches):
                         new_req = request_core.requeue_and_archive(req, source_ranking_update=False, retry_protocol_mismatches=retry_protocol_mismatches, logger=logger)
-                        record_timer('daemons.conveyor.common.update_request_state.request_requeue_and_archive', (time.time() - tss) * 1000)
+                        timer.record('daemons.conveyor.common.update_request_state.request_requeue_and_archive')
                         logger(logging.WARNING, 'REQUEUED SUBMITTING DID %s:%s REQUEST %s AS %s TRY %s' % (req['scope'],
                                                                                                            req['name'],
                                                                                                            req['request_id'],

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -38,7 +38,7 @@ from rucio.common.types import InternalAccount
 from rucio.common.logging import setup_logging
 from rucio.common.utils import dict_chunks
 from rucio.core import transfer as transfer_core, request as request_core
-from rucio.core.monitor import record_timer_block, record_counter, Stopwatch
+from rucio.core.monitor import Timer, record_counter
 from rucio.db.sqla.constants import RequestState, RequestType
 from rucio.daemons.common import run_daemon
 from rucio.transfertool.fts3 import FTS3Transfertool
@@ -55,7 +55,7 @@ FILTER_TRANSFERTOOL = config_get('conveyor', 'filter_transfertool', False, None)
 def run_once(fts_bulk, db_bulk, older_than, activity_shares, multi_vo, timeout, activity, heartbeat_handler, oidc_account: str):
     worker_number, total_workers, logger = heartbeat_handler.live()
 
-    with record_timer_block('daemons.conveyor.poller.get_next'):
+    with Timer('daemons.conveyor.poller.get_next'):
         logger(logging.DEBUG, 'Start to poll transfers older than %i seconds for activity %s using transfer tool: %s' % (older_than, activity, FILTER_TRANSFERTOOL))
         transfs = request_core.get_next(request_type=[RequestType.TRANSFER, RequestType.STAGEIN, RequestType.STAGEOUT],
                                         state=[RequestState.SUBMITTED],
@@ -251,7 +251,7 @@ def _poll_transfers(transfertool_obj, transfers_by_eid, timeout, logger):
     """
     is_bulk = len(transfers_by_eid) > 1
     try:
-        timer = Stopwatch()
+        timer = Timer()
         logger(logging.INFO, 'Polling %i transfers against %s with timeout %s' % (len(transfers_by_eid), transfertool_obj, timeout))
         resps = transfertool_obj.bulk_query(requests_by_eid=transfers_by_eid, timeout=timeout)
         timer.stop()

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -38,7 +38,7 @@ from rucio.common.types import InternalAccount
 from rucio.common.logging import setup_logging
 from rucio.common.utils import dict_chunks
 from rucio.core import transfer as transfer_core, request as request_core
-from rucio.core.monitor import record_timer, record_counter
+from rucio.core.monitor import record_timer_block, record_counter, Stopwatch
 from rucio.db.sqla.constants import RequestState, RequestType
 from rucio.daemons.common import run_daemon
 from rucio.transfertool.fts3 import FTS3Transfertool
@@ -55,21 +55,19 @@ FILTER_TRANSFERTOOL = config_get('conveyor', 'filter_transfertool', False, None)
 def run_once(fts_bulk, db_bulk, older_than, activity_shares, multi_vo, timeout, activity, heartbeat_handler, oidc_account: str):
     worker_number, total_workers, logger = heartbeat_handler.live()
 
-    start_time = time.time()
-    logger(logging.DEBUG, 'Start to poll transfers older than %i seconds for activity %s using transfer tool: %s' % (older_than, activity, FILTER_TRANSFERTOOL))
-    transfs = request_core.get_next(request_type=[RequestType.TRANSFER, RequestType.STAGEIN, RequestType.STAGEOUT],
-                                    state=[RequestState.SUBMITTED],
-                                    limit=db_bulk,
-                                    older_than=datetime.datetime.utcnow() - datetime.timedelta(seconds=older_than) if older_than else None,
-                                    total_workers=total_workers,
-                                    worker_number=worker_number,
-                                    mode_all=True,
-                                    hash_variable='id',
-                                    activity=activity,
-                                    activity_shares=activity_shares,
-                                    transfertool=FILTER_TRANSFERTOOL)
-
-    record_timer('daemons.conveyor.poller.get_next', (time.time() - start_time) * 1000)
+    with record_timer_block('daemons.conveyor.poller.get_next'):
+        logger(logging.DEBUG, 'Start to poll transfers older than %i seconds for activity %s using transfer tool: %s' % (older_than, activity, FILTER_TRANSFERTOOL))
+        transfs = request_core.get_next(request_type=[RequestType.TRANSFER, RequestType.STAGEIN, RequestType.STAGEOUT],
+                                        state=[RequestState.SUBMITTED],
+                                        limit=db_bulk,
+                                        older_than=datetime.datetime.utcnow() - datetime.timedelta(seconds=older_than) if older_than else None,
+                                        total_workers=total_workers,
+                                        worker_number=worker_number,
+                                        mode_all=True,
+                                        hash_variable='id',
+                                        activity=activity,
+                                        activity_shares=activity_shares,
+                                        transfertool=FILTER_TRANSFERTOOL)
 
     if TRANSFER_TOOL and not FILTER_TRANSFERTOOL:
         # only keep transfers which don't have any transfertool set, or have one equal to TRANSFER_TOOL
@@ -253,12 +251,12 @@ def _poll_transfers(transfertool_obj, transfers_by_eid, timeout, logger):
     """
     is_bulk = len(transfers_by_eid) > 1
     try:
-        tss = time.time()
+        timer = Stopwatch()
         logger(logging.INFO, 'Polling %i transfers against %s with timeout %s' % (len(transfers_by_eid), transfertool_obj, timeout))
         resps = transfertool_obj.bulk_query(requests_by_eid=transfers_by_eid, timeout=timeout)
-        duration = time.time() - tss
-        record_timer('daemons.conveyor.poller.bulk_query_transfers', duration * 1000 / len(transfers_by_eid))
-        logger(logging.DEBUG, 'Polled %s transfer requests status in %s seconds' % (len(transfers_by_eid), duration))
+        timer.stop()
+        timer.record('daemons.conveyor.poller.bulk_query_transfers', divisor=len(transfers_by_eid))
+        logger(logging.DEBUG, 'Polled %s transfer requests status in %s seconds' % (len(transfers_by_eid), timer.elapsed))
     except TransferToolTimeout as error:
         logger(logging.ERROR, str(error))
         return

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -28,7 +28,7 @@ from rucio.common import exception
 from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.logging import setup_logging
 from rucio.common.schema import get_schema_value
-from rucio.core.monitor import MultiCounter, record_timer, Stopwatch
+from rucio.core.monitor import MultiCounter, record_timer, Timer
 from rucio.core.transfer import transfer_path_str
 from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, next_transfers_to_submit
 from rucio.daemons.common import run_daemon
@@ -58,7 +58,7 @@ def run_once(bulk, group_bulk, filter_transfertool, transfertools, ignore_availa
              heartbeat_handler, activity):
     worker_number, total_workers, logger = heartbeat_handler.live()
 
-    timer = Stopwatch()
+    timer = Timer()
     transfers = next_transfers_to_submit(
         total_workers=total_workers,
         worker_number=worker_number,
@@ -97,7 +97,7 @@ def run_once(bulk, group_bulk, filter_transfertool, transfertools, ignore_availa
             continue
 
         transfertool_obj = builder.make_transfertool(logger=logger, **transfertool_kwargs.get(builder.transfertool_class, {}))
-        timer = Stopwatch()
+        timer = Timer()
         logger(logging.DEBUG, 'Starting to group transfers for %s (%s)', activity, transfertool_obj)
         grouped_jobs = transfertool_obj.group_into_submit_jobs(transfer_paths)
         timer.record('daemons.conveyor.transfer_submitter.bulk_group_transfer', divisor=len(transfer_paths) or 1)

--- a/lib/rucio/daemons/oauthmanager/oauthmanager.py
+++ b/lib/rucio/daemons/oauthmanager/oauthmanager.py
@@ -42,7 +42,7 @@ from rucio.common.logging import setup_logging, formatted_logger
 from rucio.common.utils import daemon_sleep
 from rucio.core.authentication import delete_expired_tokens
 from rucio.core.heartbeat import die, live, sanity_check
-from rucio.core.monitor import record_counter, Stopwatch
+from rucio.core.monitor import record_counter, Timer
 from rucio.core.oidc import delete_expired_oauthrequests, refresh_jwt_tokens
 
 GRACEFUL_STOP = threading.Event()
@@ -78,7 +78,7 @@ def OAuthManager(once=False, loop_rate=300, max_rows=100, sleep_time=300):
 
     while not GRACEFUL_STOP.is_set():
         start_time = time.time()
-        timer = Stopwatch()
+        timer = Timer()
         # issuing the heartbeat for a second time to make all workers aware of each other
         heartbeat = live(executable=executable, hostname=socket.gethostname(), pid=os.getpid(), thread=threading.current_thread())
         prepend_str = 'oauth_manager [%i/%i] : ' % (heartbeat['assign_thread'], heartbeat['nr_threads'])

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -155,7 +155,7 @@ def delete_from_storage(heartbeat_handler, hb_payload, replicas, prot, rse_info,
                 if replica['scope'].vo != 'def':
                     deletion_dict['vo'] = replica['scope'].vo
                 logger(logging.DEBUG, 'Deletion ATTEMPT of %s:%s as %s on %s', replica['scope'], replica['name'], replica['pfn'], rse_name)
-                timer = monitor.Stopwatch()
+                timer = monitor.Timer()
                 # For STAGING RSEs, no physical deletion
                 if is_staging:
                     logger(logging.WARNING, 'Deletion STAGING of %s:%s as %s on %s, will only delete the catalog and not do physical deletion', replica['scope'], replica['name'], replica['pfn'], rse_name)
@@ -575,7 +575,7 @@ def _run_once(rses_to_process, chunk_size, greedy, scheme,
         del_start_time = time.time()
         try:
             use_temp_tables = config_get_bool('core', 'use_temp_tables', default=False)
-            with monitor.record_timer_block('reaper.list_unlocked_replicas'):
+            with monitor.Timer('reaper.list_unlocked_replicas'):
                 if only_delete_obsolete:
                     logger(logging.DEBUG, 'Will run list_and_mark_unlocked_replicas on %s. No space needed, will only delete EPOCH tombstoned replicas', rse.name)
                 if use_temp_tables:
@@ -639,7 +639,7 @@ def _run_once(rses_to_process, chunk_size, greedy, scheme,
 
                 # Then finally delete the replicas
                 del_start = time.time()
-                with monitor.record_timer_block('reaper.delete_replicas'):
+                with monitor.Timer('reaper.delete_replicas'):
                     delete_replicas(rse_id=rse.id, files=deleted_files)
                 logger(logging.DEBUG, 'delete_replicas successed on %s : %s replicas in %s seconds', rse.name, len(deleted_files), time.time() - del_start)
                 DELETION_COUNTER.inc(len(deleted_files))

--- a/lib/rucio/daemons/tracer/kronos.py
+++ b/lib/rucio/daemons/tracer/kronos.py
@@ -36,7 +36,7 @@ from rucio.common.stomp_utils import get_stomp_brokers
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.did import touch_dids, list_parent_dids
 from rucio.core.lock import touch_dataset_locks
-from rucio.core.monitor import record_counter, record_timer
+from rucio.core.monitor import record_counter, Stopwatch
 from rucio.core.replica import touch_replica, touch_collection_replicas, declare_bad_file_replicas
 from rucio.core.rse import get_rse_id
 from rucio.db.sqla.constants import DIDType, BadFilesStatus
@@ -269,7 +269,7 @@ class AMQConsumer(object):
         self.__logger(logging.DEBUG, "trying to update replicas: %s", replicas)
 
         try:
-            start_time = time()
+            timer = Stopwatch()
             for replica in replicas:
                 # if touch replica hits a locked row put the trace back into queue for later retry
                 if not touch_replica(replica):
@@ -285,7 +285,7 @@ class AMQConsumer(object):
                         resubmit['vo'] = replica['scope'].vo
                     self.__conn.send(body=jdumps(resubmit), destination=self.__queue, headers={'appversion': 'rucio', 'resubmitted': '1'})
                     record_counter('daemons.tracer.kronos.sent_resubmitted')
-            record_timer('daemons.tracer.kronos.update_atime', (time() - start_time) * 1000)
+            timer.record('daemons.tracer.kronos.update_atime')
         except Exception:
             self.__logger(logging.ERROR, "Cannot update replicas.", exc_info=True)
             record_counter('daemons.tracer.kronos.update_error')

--- a/lib/rucio/daemons/tracer/kronos.py
+++ b/lib/rucio/daemons/tracer/kronos.py
@@ -36,7 +36,7 @@ from rucio.common.stomp_utils import get_stomp_brokers
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.did import touch_dids, list_parent_dids
 from rucio.core.lock import touch_dataset_locks
-from rucio.core.monitor import record_counter, Stopwatch
+from rucio.core.monitor import record_counter, Timer
 from rucio.core.replica import touch_replica, touch_collection_replicas, declare_bad_file_replicas
 from rucio.core.rse import get_rse_id
 from rucio.db.sqla.constants import DIDType, BadFilesStatus
@@ -269,7 +269,7 @@ class AMQConsumer(object):
         self.__logger(logging.DEBUG, "trying to update replicas: %s", replicas)
 
         try:
-            timer = Stopwatch()
+            timer = Timer()
             for replica in replicas:
                 # if touch replica hits a locked row put the trace back into queue for later retry
                 if not touch_replica(replica):

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -249,7 +249,6 @@ def run_once(heartbeat_handler: "HeartbeatHandler", bulk: int, **_kwargs) -> boo
 
     worker_number, total_workers, logger = heartbeat_handler.live()
     dids, subscriptions = [], []
-    tottime = 0
     try:
         #  Get the new DIDs based on the is_new flag
         logger(logging.DEBUG, "Listing new dids")
@@ -310,7 +309,7 @@ def run_once(heartbeat_handler: "HeartbeatHandler", bulk: int, **_kwargs) -> boo
         return must_sleep
 
     results = {}
-    start_time = time.time()
+    timer = monitor.Stopwatch()
     blocklisted_rse_id = [rse["id"] for rse in list_rses({"availability_write": False})]
     identifiers = []
     #  Loop over all the new dids
@@ -667,24 +666,24 @@ def run_once(heartbeat_handler: "HeartbeatHandler", bulk: int, **_kwargs) -> boo
                 }
             )
 
-    time1 = time.time()
-
     #  Mark the DIDs as processed
+    flag_timer = monitor.Stopwatch()
     for identifier in chunks(identifiers, 100):
         _retrial(set_new_dids, identifier, None)
+    logger(logging.DEBUG, "Time to set the new flag : %f" % flag_timer.elapsed)
 
-    logger(logging.DEBUG, "Time to set the new flag : %f" % (time.time() - time1))
-    tottime = time.time() - start_time
+    timer.stop()
+
     for sub in subscriptions:
         update_subscription(
             name=sub["name"],
             account=sub["account"],
             metadata={"last_processed": datetime.now()},
         )
-    logger(logging.INFO, "It took %f seconds to process %i DIDs" % (tottime, len(dids)))
+    logger(logging.INFO, "It took %f seconds to process %i DIDs" % (timer.elapsed, len(dids)))
     logger(logging.DEBUG, "DIDs processed : %s" % (str(dids)))
     monitor.record_counter(name="transmogrifier.job.done", delta=1)
-    monitor.record_timer(name="transmogrifier.job.duration", time=1000 * tottime)
+    timer.record("transmogrifier.job.duration")
     must_sleep = True
     return must_sleep
 

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -309,7 +309,7 @@ def run_once(heartbeat_handler: "HeartbeatHandler", bulk: int, **_kwargs) -> boo
         return must_sleep
 
     results = {}
-    timer = monitor.Stopwatch()
+    timer = monitor.Timer()
     blocklisted_rse_id = [rse["id"] for rse in list_rses({"availability_write": False})]
     identifiers = []
     #  Loop over all the new dids
@@ -667,7 +667,7 @@ def run_once(heartbeat_handler: "HeartbeatHandler", bulk: int, **_kwargs) -> boo
             )
 
     #  Mark the DIDs as processed
-    flag_timer = monitor.Stopwatch()
+    flag_timer = monitor.Timer()
     for identifier in chunks(identifiers, 100):
         _retrial(set_new_dids, identifier, None)
     logger(logging.DEBUG, "Time to set the new flag : %f" % flag_timer.elapsed)

--- a/lib/rucio/tests/test_monitor.py
+++ b/lib/rucio/tests/test_monitor.py
@@ -32,14 +32,15 @@ class TestMonitor:
 
     def test_context_record_timer(self):
         """MONITOR (CORE): Send a timer message to graphite using context """
-        with monitor.record_timer_block('test.context_timer'):
+        with monitor.Timer('test.context_timer'):
             var_a = 2 * 100
             var_a = var_a * 1
 
-        with monitor.record_timer_block(['test.context_timer']):
+        with monitor.Timer('test.context_timer'):
             var_a = 2 * 100
             var_a = var_a * 1
 
-        with monitor.record_timer_block(['test.context_timer', ('test.context_timer_normal10', 10)]):
+        with monitor.Timer('test.context_timer'), \
+                monitor.Timer('test.context_timer_normal10', divisor=10):
             var_a = 2 * 100
             var_a = var_a * 1

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -38,7 +38,7 @@ from rucio.common.utils import APIEncoder, chunks, PREFERRED_CHECKSUM
 from rucio.core.request import get_source_rse, get_transfer_error
 from rucio.core.rse import get_rse_supported_checksums_from_attributes
 from rucio.core.oidc import get_token_for_account_operation
-from rucio.core.monitor import record_counter, Stopwatch, MultiCounter
+from rucio.core.monitor import record_counter, Timer, MultiCounter
 from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder, TransferStatusReport
 from rucio.db.sqla.constants import RequestState
 
@@ -807,7 +807,7 @@ class FTS3Transfertool(Transfertool):
 
         post_result = None
         try:
-            timer = Stopwatch()
+            timer = Timer()
             post_result = requests.post('%s/jobs' % self.external_host,
                                         verify=self.verify,
                                         cert=self.cert,

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -17,7 +17,6 @@ import datetime
 import json
 import functools
 import logging
-import time
 import traceback
 import uuid
 from typing import Any, Callable, Tuple, TYPE_CHECKING
@@ -39,7 +38,7 @@ from rucio.common.utils import APIEncoder, chunks, PREFERRED_CHECKSUM
 from rucio.core.request import get_source_rse, get_transfer_error
 from rucio.core.rse import get_rse_supported_checksums_from_attributes
 from rucio.core.oidc import get_token_for_account_operation
-from rucio.core.monitor import record_counter, record_timer, MultiCounter
+from rucio.core.monitor import record_counter, Stopwatch, MultiCounter
 from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder, TransferStatusReport
 from rucio.db.sqla.constants import RequestState
 
@@ -762,7 +761,6 @@ class FTS3Transfertool(Transfertool):
         :param timeout:      Timeout in seconds.
         :returns:            FTS transfer identifier.
         """
-        start_time = time.time()
         files = []
         for transfer in transfers:
             if isinstance(transfer, dict):
@@ -809,7 +807,7 @@ class FTS3Transfertool(Transfertool):
 
         post_result = None
         try:
-            start_time = time.time()
+            timer = Stopwatch()
             post_result = requests.post('%s/jobs' % self.external_host,
                                         verify=self.verify,
                                         cert=self.cert,
@@ -817,7 +815,7 @@ class FTS3Transfertool(Transfertool):
                                         headers=self.headers,
                                         timeout=timeout)
             labels = {'host': self.__extract_host(self.external_host)}
-            record_timer('transfertool.fts3.submit_transfer.{host}', (time.time() - start_time) * 1000 / len(files), labels=labels)
+            timer.record('transfertool.fts3.submit_transfer.{host}', divisor=len(files), labels=labels)
         except ReadTimeout as error:
             raise TransferToolTimeout(error)
         except json.JSONDecodeError as error:
@@ -841,7 +839,7 @@ class FTS3Transfertool(Transfertool):
 
         if not transfer_id:
             raise TransferToolWrongAnswer('No transfer id returned by %s' % self.external_host)
-        record_timer('core.request.submit_transfers_fts3', (time.time() - start_time) * 1000 / len(transfers))
+        timer.record('core.request.submit_transfers_fts3', divisor=len(transfers))
         return transfer_id
 
     def cancel(self, transfer_ids, timeout=None):

--- a/tools/count_missing_type_annotations_utils.sh
+++ b/tools/count_missing_type_annotations_utils.sh
@@ -46,7 +46,11 @@ create_missing_python_type_annotations_report() {
     # This does not include tests, tools, database and bin files.
     # :param $1: The name of the output file.
 
-    flake8 lib/rucio --exclude tools,lib/rucio/tests,lib/rucio/db,lib/rucio/client,lib/rucio/common,lib/rucio/rse,bin --output-file $1 --select ANN || true
+    flake8 lib/rucio \
+        --ignore=ANN101 \
+        --exclude tools,lib/rucio/tests,lib/rucio/db,lib/rucio/client,lib/rucio/common,lib/rucio/rse,bin \
+        --output-file $1 \
+        --select ANN || true
 }
 
 


### PR DESCRIPTION
This PR aims to make the timer monitoring consistent with regards to recording elapsed seconds vs. milliseconds (#5688). A new `Stopwatch` class is introduced which handles the actual timing, and a new `Timer` class utilizes this stopwatch to replace `record_timer_block` and simplify usage of `record_timer`.

All previous uses of `record_timer` and `record_timer_block` are then checked and refactored if needed to ensure consistent units.

The PR also disables the flake8 warning `ANN101: missing type annotation for self in method`. The `self` argument is not usually typed except in [special cases](https://peps.python.org/pep-0484/#annotating-instance-and-class-methods), so this warning mostly produces noise.