### PR TITLE
Core & Internals: handle empty string in config_get_list. Closes #5720

### DIFF
--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -289,6 +289,8 @@ def __convert_string_to_list(string):
 
     :returns: A list extracted from the string.
     """
+    if not string or not string.strip():
+        return []
     string = string.split(',')
     return [item.strip(' ') for item in string]
 


### PR DESCRIPTION
Intuitively, an empty string should be converted to an empty list,
but the current code returns `['']`.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
