### PR TITLE
Database: Refactor the query result to dict functionality #5722

### DIFF
--- a/lib/rucio/api/subscription.py
+++ b/lib/rucio/api/subscription.py
@@ -22,6 +22,7 @@ from rucio.common.schema import validate_schema
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core import subscription
 from rucio.db.sqla.session import read_session, stream_session, transactional_session
+from rucio.db.sqla.util import result_to_dict
 
 
 SubscriptionRuleState = namedtuple('SubscriptionRuleState', ['account', 'name', 'state', 'count'])
@@ -204,7 +205,7 @@ def list_subscription_rule_states(name=None, account=None, vo='def', session=Non
     subs = subscription.list_subscription_rule_states(name, account, session=session)
     for sub in subs:
         # sub is an immutable Row so return new named tuple with edited entries
-        d = sub._asdict()
+        d = result_to_dict(sub)
         d['account'] = d['account'].external
         yield SubscriptionRuleState(**d)
 

--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -41,7 +41,7 @@ from rucio.core.did_meta_plugins.filter_engine import FilterEngine
 from rucio.db.sqla import models, filter_thread_work
 from rucio.db.sqla.constants import DIDType, DIDReEvaluation, DIDAvailability, RuleState, BadFilesStatus
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
-from rucio.db.sqla.util import temp_table_mngr
+from rucio.db.sqla.util import result_to_dict, temp_table_mngr
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Tuple, Optional, Sequence
@@ -2048,7 +2048,7 @@ def get_files(files, session=None):
 
     rows = []
     for row in session.execute(stmt):
-        file = row._asdict()
+        file = result_to_dict(row)
         rows.append(file)
         if file['availability'] == DIDAvailability.LOST:
             raise exception.UnsupportedOperation('File %s:%s is LOST and cannot be attached' % (file['scope'], file['name']))
@@ -2226,10 +2226,7 @@ def get_metadata_bulk(dids, inherit=False, session=None):
                     or_(*chunk)
                 )
                 for row in session.execute(stmt).scalars():
-                    data = {}
-                    for column in row.__table__.columns:
-                        data[column.name] = getattr(row, column.name)
-                    yield data
+                    yield result_to_dict(row)
         except NoResultFound:
             raise exception.DataIdentifierNotFound('No Data Identifiers found')
 

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -29,6 +29,7 @@ from rucio.core.did_meta_plugins.filter_engine import FilterEngine
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import DIDType
 from rucio.db.sqla.session import stream_session, read_session, transactional_session
+from rucio.db.sqla.util import result_to_dict
 
 
 class DidColumnMeta(DidMetaPlugin):
@@ -51,10 +52,7 @@ class DidColumnMeta(DidMetaPlugin):
         try:
             row = session.query(models.DataIdentifier).filter_by(scope=scope, name=name).\
                 with_hint(models.DataIdentifier, "INDEX(DIDS DIDS_PK)", 'oracle').one()
-            d = {}
-            for column in row.__table__.columns:
-                d[column.name] = getattr(row, column.name)
-            return d
+            return result_to_dict(row)
         except NoResultFound:
             raise exception.DataIdentifierNotFound("Data identifier '%(scope)s:%(name)s' not found" % locals())
 

--- a/lib/rucio/core/naming_convention.py
+++ b/lib/rucio/core/naming_convention.py
@@ -24,6 +24,7 @@ from rucio.common.cache import make_region_memcached
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import KeyType
 from rucio.db.sqla.session import read_session, transactional_session
+from rucio.db.sqla.util import query_to_list_of_dicts
 
 REGION = make_region_memcached(expiration_time=900)
 
@@ -100,7 +101,7 @@ def list_naming_conventions(session=None):
     """
     query = session.query(models.NamingConvention.scope,
                           models.NamingConvention.regexp)
-    return [row._asdict() for row in query]
+    return list(query_to_list_of_dicts(query))
 
 
 @read_session

--- a/lib/rucio/core/subscription.py
+++ b/lib/rucio/core/subscription.py
@@ -30,6 +30,7 @@ from rucio.common.exception import SubscriptionNotFound, SubscriptionDuplicate, 
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import SubscriptionState
 from rucio.db.sqla.session import transactional_session, stream_session, read_session
+from rucio.db.sqla.util import result_to_dict
 
 
 @transactional_session
@@ -275,11 +276,7 @@ def get_subscription_by_id(subscription_id, session=None):
 
     try:
         subscription = session.query(models.Subscription).filter_by(id=subscription_id).one()
-        result = {}
-        for column in subscription.__table__.columns:
-            result[column.name] = getattr(subscription, column.name)
-        return result
-
+        return result_to_dict(subscription)
     except NoResultFound:
         raise SubscriptionNotFound('No subscription with the id %s found' % (subscription_id))
     except StatementError:


### PR DESCRIPTION
Sqlalchemy query results integrate some functionalities to communicate
changes to the database (e.g. update fields when they are updated in the
code). While this is desired and helpful, it is not always needed. If a
dict is passed to an external dependency or returned as write only, the
communication with the database is not needed.

Converting a query result to a dict is not trivial. Calling the `dict`
function on the result returns not just the desired fields, but also
some custom ones from `sqlalchemy` (for now `_sa_instance_state`, maybe
more in the future). To only get the desired ones, iterate over the
model fields of the result and only append them to the resulting dict.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
