### PR TITLE
Transfers: skip missing requests in poller/receiver. Closes #5429

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -696,6 +696,11 @@ def set_request_state(request_id, state, external_id=None, transferred_at=None, 
             update_items['attributes'] = json.dumps(attributes)
 
         request = get_request(request_id, session=session)
+        if not request:
+            # The request was deleted in the meantime. Ignore it.
+            logger(logging.WARNING, "Request %s not found. Cannot set its state to %s", request_id, state)
+            return
+
         if state in [RequestState.FAILED, RequestState.DONE, RequestState.LOST] and (request["external_id"] != external_id):
             logger(logging.ERROR, "Request %s should not be updated to 'Failed' or 'Done' without external transfer_id" % request_id)
         else:

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -506,7 +506,10 @@ class FTS3CompletionMessageTransferStatusReport(Fts3TransferStatusReport):
         transfer_id = self._transfer_id
         if new_state:
             request = self.request(session)
-            if request['external_id'] == transfer_id and request['state'] != new_state:
+            if not request:
+                logger(logging.WARNING, '%s: no request with this id in the database. Skipping. external_id: %s (%s). new_state: %s', request_id, transfer_id, self.external_host, new_state)
+                return
+            if request and request['external_id'] == transfer_id and request['state'] != new_state:
                 src_rse_name, src_rse_id = self._find_used_source_rse(session, logger)
 
                 self._reason = reason
@@ -591,6 +594,9 @@ class FTS3ApiTransferStatusReport(Fts3TransferStatusReport):
         transfer_id = self._transfer_id
         if new_state:
             request = self.request(session)
+            if not request:
+                logger(logging.WARNING, '%s: no request with this id in the database. Skipping. external_id: %s (%s). new_state: %s', request_id, transfer_id, self.external_host, new_state)
+                return
             if request['external_id'] == transfer_id and request['state'] != new_state:
                 src_rse_name, src_rse_id = self._find_used_source_rse(session, logger)
 


### PR DESCRIPTION
If get_request returns an empty result, the request doesn't exist in
the database. This can happen under normal operation if the cleaner
deleted the request in the meantime. So gracefully handle this case
by skipping the request.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
