### PR TITLE
REST & API: Change the `subscriptions` api docs to the OpenApi format…

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -33,18 +33,82 @@ class Subscription(ErrorHandlingMethodView):
     @check_accept_header_wrapper_flask(['application/x-json-stream'])
     def get(self, account=None, name=None):
         """
-        Retrieve a subscription.
-
-        .. :quickref: Subscription; Get subscriptions.
-
-        :param account: The account name.
-        :param name: The subscription name.
-        :resheader Content-Type: application/x-json-stream
-        :status 200: OK.
-        :status 401: Invalid Auth Token.
-        :status 404: Subscription Not Found.
-        :status 406: Not Acceptable.
-        :returns: Line separated list of dictionaries with subscription information.
+        ---
+        summary: Get Subscription
+        description: Retrieve a subscription.
+        tags:
+          - Replicas
+        parameters:
+        - name: account
+          in: path
+          description: The account name.
+          schema:
+            type: string
+          style: simple
+        - name: name
+          in: path
+          description: The subscription name.
+          schema:
+            type: string
+          style: simple
+        responses:
+          200:
+            description: OK
+            content:
+              application/x-json-stream:
+                schema:
+                  description: A list of subscriptions.
+                  type: array
+                  items:
+                    description: A subscription.
+                    type: object
+                    properties:
+                      id:
+                        description: The id of the subscription.
+                        type: string
+                      name:
+                        description: The name of the subscription.
+                        type: string
+                      filter:
+                        description: The filter for the subscription.
+                        type: string
+                      replication_rules:
+                        description: The replication rules for the subscription.
+                        type: string
+                      policyid:
+                        description: The policyid for the subscription.
+                        type: integer
+                      state:
+                        description: The state of the subscription.
+                        type: string
+                        enum: ["A", "I", "N", "U", "B"]
+                      last_processed:
+                        description: The time the subscription was processed last.
+                        type: string
+                        format: date-time
+                      account:
+                        description: The account for the subscription.
+                        type: string
+                      lifetime:
+                        description: The lifetime for the subscription.
+                        type: string
+                        format: date-time
+                      comments:
+                        description: The comments for the subscription.
+                        type: string
+                      retroactive:
+                        description: If the subscription is retroactive.
+                        type: boolean
+                      expired_at:
+                        description: The date-time of the expiration for the subscription.
+                        type: string
+                        format: date-time
+          401:
+            description: Invalid Auth Token
+          404:
+            description: Subscription Not found
+          406:
+            description: Not acceptable
         """
         try:
             def generate(vo):
@@ -57,16 +121,66 @@ class Subscription(ErrorHandlingMethodView):
 
     def put(self, account, name):
         """
-        Update an existing subscription.
-
-        .. :quickref: Subscription; Update a subscription.
-
-        :param account: The account name.
-        :param name: The subscription name.
-        :status 201: Created.
-        :status 400: Cannot decode json parameter list.
-        :status 401: Invalid Auth Token.
-        :status 404: Subscription Not Found.
+        ---
+        summary: Update subscription
+        description: Update an existing subscription.
+        tags:
+          - Replicas
+        parameters:
+        - name: account
+          in: path
+          description: The account name.
+          schema:
+            type: string
+          style: simple
+          required: true
+        - name: name
+          in: path
+          description: The subscription name.
+          schema:
+            type: string
+          style: simple
+          required: true
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - options
+                properties:
+                  options:
+                    description: The values for the new subcription.
+                    type: object
+                    properties:
+                      filter:
+                        description: The filter for the subscription.
+                        type: string
+                      replication_rules:
+                        description: The replication rules for the subscription.
+                        type: string
+                      comments:
+                        description: The comments for the subscription.
+                        type: string
+                      lifetime:
+                        description: The lifetime for the subscription.
+                        type: string
+                        format: date-time
+                      retroactive:
+                        description: If the retroactive is actiavted for a subscription.
+                        type: boolean
+                      priority:
+                        description: The priority/policyid for the subscription. Stored as policyid.
+                        type: integer
+        responses:
+          201:
+            description: OK
+          400:
+            description: Cannot decode json parameter list.
+          401:
+            description: Invalid Auth Token
+          404:
+            description: Not found
         """
         parameters = json_parameters()
         options = param_get(parameters, 'options')
@@ -94,17 +208,83 @@ class Subscription(ErrorHandlingMethodView):
 
     def post(self, account, name):
         """
-        Create a new subscription.
-
-        .. :quickref: Subscription; Create a subscription.
-
-        :param account: The account name.
-        :param name: The subscription name.
-        :status 201: Created.
-        :status 400: Cannot decode json parameter list.
-        :status 401: Invalid Auth Token.
-        :status 404: Subscription Not Found.
-        :returns: ID if newly created subscription.
+        ---
+        summary: Create subscription
+        description: Create a new subscription
+        tags:
+          - Replicas
+        parameters:
+        - name: account
+          in: path
+          description: The account name.
+          schema:
+            type: string
+          style: simple
+          required: true
+        - name: name
+          in: path
+          description: The subscription name.
+          schema:
+            type: string
+          style: simple
+          required: true
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - options
+                properties:
+                  options:
+                    description: The values for the new subcription.
+                    type: object
+                    required:
+                      - filter
+                      - replication_rules
+                      - comments
+                      - lifetime
+                      - retroactive
+                    properties:
+                      filter:
+                        description: The filter for the subscription.
+                        type: string
+                      replication_rules:
+                        description: The replication rules for the subscription.
+                        type: string
+                      comments:
+                        description: The comments for the subscription.
+                        type: string
+                      lifetime:
+                        description: The lifetime for the subscription.
+                        type: string
+                        format: date-time
+                      retroactive:
+                        description: If the retroactive is actiavted for a subscription.
+                        type: boolean
+                      priority:
+                        description: The priority/policyid for the subscription. Stored as policyid.
+                        type: integer
+                      dry_run:
+                        description: The priority/policyid for the subscription. Stored as policyid.
+                        type: boolean
+                        default: false
+        responses:
+          200:
+            description: OK
+            content:
+              application/json:
+                schema:
+                  description: The subscription Id for the new subscription.
+                  type: string
+          400:
+            description: Cannot decode json parameter list.
+          401:
+            description: Invalid Auth Token
+          404:
+            description: Not found
+          406:
+            description: Not acceptable
         """
         parameters = json_parameters()
         options = param_get(parameters, 'options')
@@ -147,17 +327,76 @@ class SubscriptionName(ErrorHandlingMethodView):
     @check_accept_header_wrapper_flask(['application/x-json-stream'])
     def get(self, name=None):
         """
-        Retrieve a subscription by name.
-
-        .. :quickref: SubscriptionName; Get subscriptions by name.
-
-        :param name: The subscription name.
-        :resheader Content-Type: application/x-json-stream
-        :status 200: OK.
-        :status 401: Invalid Auth Token.
-        :status 404: Subscription Not Found.
-        :status 406: Not Acceptable.
-        :returns: Line separated list of dictionaries with subscription information.
+        ---
+        summary: Get Subscription by Name
+        description: Retrieve a subscription by name.
+        tags:
+          - Replicas
+        parameters:
+        - name: account
+          in: path
+          description: The account name.
+          schema:
+            type: string
+          style: simple
+        responses:
+          200:
+            description: OK
+            content:
+              application/x-json-stream:
+                schema:
+                  description: A list of subscriptions.
+                  type: array
+                  items:
+                    description: A subscription.
+                    type: object
+                    properties:
+                      id:
+                        description: The id of the subscription.
+                        type: string
+                      name:
+                        description: The name of the subscription.
+                        type: string
+                      filter:
+                        description: The filter for the subscription.
+                        type: string
+                      replication_rules:
+                        description: The replication rules for the subscription.
+                        type: string
+                      policyid:
+                        description: The policyid for the subscription.
+                        type: integer
+                      state:
+                        description: The state of the subscription.
+                        type: string
+                        enum: ["A", "I", "N", "U", "B"]
+                      last_processed:
+                        description: The time the subscription was processed last.
+                        type: string
+                        format: date-time
+                      account:
+                        description: The account for the subscription.
+                        type: string
+                      lifetime:
+                        description: The lifetime for the subscription.
+                        type: string
+                        format: date-time
+                      comments:
+                        description: The comments for the subscription.
+                        type: string
+                      retroactive:
+                        description: If the subscription is retroactive.
+                        type: boolean
+                      expired_at:
+                        description: The date-time of the expiration for the subscription.
+                        type: string
+                        format: date-time
+          401:
+            description: Invalid Auth Token
+          404:
+            description: Not found
+          406:
+            description: Not acceptable
         """
         try:
             def generate(vo):
@@ -174,19 +413,47 @@ class Rules(ErrorHandlingMethodView):
     @check_accept_header_wrapper_flask(['application/x-json-stream'])
     def get(self, account, name):
         """
-        Return all rules of a given subscription id.
-
-        .. :quickref: Rules; Get subscription rules.
-
-        :param account: The account name.
-        :param name: The subscription name.
-        :resheader Content-Type: application/x-json-stream
-        :status 200: OK.
-        :status 401: Invalid Auth Token.
-        :status 404: Rule Not Found.
-        :status 404: Subscription Not Found.
-        :status 406: Not Acceptable.
-        :returns: Line separated list of dictionaries with rule information.
+        ---
+        summary: Get Replication Rules
+        description: Return all rules of a given subscription id.
+        tags:
+          - Replicas
+        parameters:
+        - name: account
+          in: path
+          description: The account name.
+          schema:
+            type: string
+          style: simple
+          required: true
+        - name: name
+          in: path
+          description: The subscription name.
+          schema:
+            type: string
+          style: simple
+          required: true
+        - name: state
+          in: query
+          description: The subscription state to filter for.
+          schema:
+            type: string
+        responses:
+          200:
+            description: OK
+            content:
+              application/x-json-stream:
+                schema:
+                  description: A list with the associated replication rules.
+                  type: array
+                  items:
+                    description: A subscription rule.
+          401:
+            description: Invalid Auth Token
+          404:
+            description: Rule or Subscription not found
+          406:
+            description: Not acceptable
         """
         state = request.args.get('state', default=None)
         try:
@@ -211,17 +478,55 @@ class States(ErrorHandlingMethodView):
     @check_accept_header_wrapper_flask(['application/x-json-stream'])
     def get(self, account, name=None):
         """
-        Return a summary of the states of all rules of a given subscription id.
-
-        .. :quickref: States; Get subscription rule states.
-
-        :param account: The account name.
-        :param name: The subscription name.
-        :resheader Content-Type: application/x-json-stream
-        :status 200: OK.
-        :status 401: Invalid Auth Token.
-        :status 406: Not Acceptable.
-        :returns: Line separated list of dictionaries with rule information.
+        ---
+        summary: Get states
+        description: Return a summary of the states of all rules of a given subscription id.
+        tags:
+          - Replicas
+        parameters:
+        - name: account
+          in: path
+          description: The account name.
+          schema:
+            type: string
+          style: simple
+          required: true
+        - name: name
+          in: path
+          description: The subscription name.
+          schema:
+            type: string
+          style: simple
+        responses:
+          200:
+            description: OK
+            content:
+              application/x-json-stream:
+                schema:
+                  description: A list of rule states with counts for each subscription.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      account:
+                        description: The account for the subscription.
+                        type: string
+                      name:
+                        description: The name of the subscription.
+                        type: string
+                      state:
+                        description: The state of the rules.
+                        type: string
+                        enums: ["R", "O", "S", "U", "W", "I"]
+                      count:
+                        description: The number of rules with that state.
+                        type: integer
+          401:
+            description: Invalid Auth Token
+          404:
+            description: Not found
+          406:
+            description: Not acceptable
         """
         def generate(vo):
             for row in list_subscription_rule_states(account=account, vo=vo):
@@ -235,17 +540,74 @@ class SubscriptionId(ErrorHandlingMethodView):
     @check_accept_header_wrapper_flask(['application/json'])
     def get(self, subscription_id):
         """
-        Retrieve a subscription matching the given subscription id
-
-        .. :quickref: SubscriptionId; Get a subscription by ID.
-
-        :param subscription_id: The subscription id.
-        :resheader Content-Type: application/json
-        :status 200: OK.
-        :status 401: Invalid Auth Token.
-        :status 404: Subscription Not Found.
-        :status 406: Not Acceptable.
-        :returns: dictionary with subscription information.
+        ---
+        summary: Get Subscription from ID
+        description: Retrieve a subscription matching the given subscription id.
+        tags:
+          - Replicas
+        parameters:
+        - name: subscription_id
+          in: path
+          description: The subscription id.
+          schema:
+            type: string
+          style: simple
+          required: true
+        responses:
+          200:
+            description: OK
+            content:
+              application/json:
+                schema:
+                  description: The subscription.
+                  type: object
+                  properties:
+                    id:
+                      description: The id of the subscription.
+                      type: string
+                    name:
+                      description: The name of the subscription.
+                      type: string
+                    filter:
+                      description: The filter for the subscription.
+                      type: string
+                    replication_rules:
+                      description: The replication rules for the subscription.
+                      type: string
+                    policyid:
+                      description: The policyid for the subscription.
+                      type: integer
+                    state:
+                      description: The state of the subscription.
+                      type: string
+                      enum: ["A", "I", "N", "U", "B"]
+                    last_processed:
+                      description: The time the subscription was processed last.
+                      type: string
+                      format: date-time
+                    account:
+                      description: The account for the subscription.
+                      type: string
+                    lifetime:
+                      description: The lifetime for the subscription.
+                      type: string
+                      format: date-time
+                    comments:
+                      description: The comments for the subscription.
+                      type: string
+                    retroactive:
+                      description: If the subscription is retroactive.
+                      type: boolean
+                    expired_at:
+                      description: The date-time of the expiration for the subscription.
+                      type: string
+                      format: date-time
+          401:
+            description: Invalid Auth Token
+          404:
+            description: Subscription not found
+          406:
+            description: Not acceptable
         """
         try:
             subscription = get_subscription_by_id(subscription_id, vo=request.environ.get('vo'))


### PR DESCRIPTION
… #4992

The Api documentation is obsolete and not displayed correctly. For this sake we
introduce the OpenApi format for our docs. It is way stricter and a commonly
used format.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
