### PR TITLE
Documentation: Rename no_doc parameter #4992

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
@@ -212,12 +212,12 @@ class GlobalAccountLimit(ErrorHandlingMethodView):
         return '', 200
 
 
-def blueprint(no_doc=True):
+def blueprint(with_doc=False):
     bp = Blueprint('accountlimits', __name__, url_prefix='/accountlimits')
 
     local_account_limit_view = LocalAccountLimit.as_view('local_account_limit')
     bp.add_url_rule('/local/<account>/<rse>', view_func=local_account_limit_view, methods=['post', 'delete'])
-    if no_doc:
+    if not with_doc:
         bp.add_url_rule('/<account>/<rse>', view_func=local_account_limit_view, methods=['post', 'delete'])
     global_account_limit_view = GlobalAccountLimit.as_view('global_account_limit')
     bp.add_url_rule('/global/<account>/<rse_expression>', view_func=global_account_limit_view, methods=['post', 'delete'])
@@ -230,5 +230,5 @@ def blueprint(no_doc=True):
 def make_doc():
     """ Only used for sphinx documentation """
     doc_app = Flask(__name__)
-    doc_app.register_blueprint(blueprint(no_doc=False))
+    doc_app.register_blueprint(blueprint(with_doc=True))
     return doc_app

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -1034,7 +1034,7 @@ class GlobalUsage(ErrorHandlingMethodView):
             return generate_http_error_flask(401, error)
 
 
-def blueprint(no_doc=True):
+def blueprint(with_doc=False):
     bp = Blueprint('accounts', __name__, url_prefix='/accounts')
 
     attributes_view = Attributes.as_view('attributes')
@@ -1060,7 +1060,7 @@ def blueprint(no_doc=True):
     usage_view = LocalUsage.as_view('usage')
     bp.add_url_rule('/<account>/usage/local', view_func=usage_view, methods=['get', ])
     bp.add_url_rule('/<account>/usage', view_func=usage_view, methods=['get', ])
-    if no_doc:
+    if not with_doc:
         # for backwards-compatibility
         # rule without trailing slash needs to be added before rule with trailing slash
         bp.add_url_rule('/<account>/usage/', view_func=usage_view, methods=['get', ])
@@ -1072,7 +1072,7 @@ def blueprint(no_doc=True):
     account_parameter_view = AccountParameter.as_view('account_parameter')
     bp.add_url_rule('/<account>', view_func=account_parameter_view, methods=['get', 'put', 'post', 'delete'])
     account_view = Account.as_view('account')
-    if no_doc:
+    if not with_doc:
         # rule without trailing slash needs to be added before rule with trailing slash
         bp.add_url_rule('', view_func=account_view, methods=['get', ])
     bp.add_url_rule('/', view_func=account_view, methods=['get', ])
@@ -1085,5 +1085,5 @@ def blueprint(no_doc=True):
 def make_doc():
     """ Only used for sphinx documentation """
     doc_app = Flask(__name__)
-    doc_app.register_blueprint(blueprint(no_doc=False))
+    doc_app.register_blueprint(blueprint(with_doc=True))
     return doc_app

--- a/lib/rucio/web/rest/flaskapi/v1/credentials.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credentials.py
@@ -165,12 +165,12 @@ class SignURL(ErrorHandlingMethodView):
         return str(result), 200, headers
 
 
-def blueprint(no_doc=True):
+def blueprint(with_doc=False):
     bp = Blueprint('credentials', __name__, url_prefix='/credentials')
 
     signurl_view = SignURL.as_view('signurl')
     bp.add_url_rule('/signurl', view_func=signurl_view, methods=['get', 'options'])
-    if no_doc:
+    if not with_doc:
         # yes, /signur ~= '/signurl?$'
         bp.add_url_rule('/signur', view_func=signurl_view, methods=['get', 'options'])
 
@@ -180,5 +180,5 @@ def blueprint(no_doc=True):
 def make_doc():
     """ Only used for sphinx documentation to add the prefix """
     doc_app = Flask(__name__)
-    doc_app.register_blueprint(blueprint(no_doc=False))
+    doc_app.register_blueprint(blueprint(with_doc=True))
     return doc_app

--- a/lib/rucio/web/rest/flaskapi/v1/dirac.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dirac.py
@@ -97,7 +97,7 @@ class AddFiles(ErrorHandlingMethodView):
         return 'Created', 201
 
 
-def blueprint(no_doc=True):
+def blueprint(with_doc=False):
     bp = Blueprint('dirac', __name__, url_prefix='/dirac')
 
     add_file_view = AddFiles.as_view('addfiles')
@@ -112,5 +112,5 @@ def blueprint(no_doc=True):
 def make_doc():
     """ Only used for sphinx documentation """
     doc_app = Flask(__name__)
-    doc_app.register_blueprint(blueprint(no_doc=False))
+    doc_app.register_blueprint(blueprint(with_doc=True))
     return doc_app

--- a/lib/rucio/web/rest/flaskapi/v1/export.py
+++ b/lib/rucio/web/rest/flaskapi/v1/export.py
@@ -56,11 +56,11 @@ class Export(ErrorHandlingMethodView):
         return Response(render_json(**export_data(issuer=request.environ.get('issuer'), distance=distance, vo=request.environ.get('vo'))), content_type='application/json')
 
 
-def blueprint(no_doc=True):
+def blueprint(with_doc=False):
     bp = Blueprint('export', __name__, url_prefix='/export')
 
     export_view = Export.as_view('scope')
-    if no_doc:
+    if not with_doc:
         # rule without trailing slash needs to be added before rule with trailing slash
         bp.add_url_rule('', view_func=export_view, methods=['get', ])
     bp.add_url_rule('/', view_func=export_view, methods=['get', ])
@@ -73,5 +73,5 @@ def blueprint(no_doc=True):
 def make_doc():
     """ Only used for sphinx documentation to add the prefix """
     doc_app = Flask(__name__)
-    doc_app.register_blueprint(blueprint(no_doc=False))
+    doc_app.register_blueprint(blueprint(with_doc=True))
     return doc_app

--- a/lib/rucio/web/rest/flaskapi/v1/import.py
+++ b/lib/rucio/web/rest/flaskapi/v1/import.py
@@ -129,11 +129,11 @@ class Import(ErrorHandlingMethodView):
         return 'Created', 201
 
 
-def blueprint(no_doc=True):
+def blueprint(with_doc=False):
     bp = Blueprint('import', __name__, url_prefix='/import')
 
     import_view = Import.as_view('scope')
-    if no_doc:
+    if not with_doc:
         # rule without trailing slash needs to be added before rule with trailing slash
         bp.add_url_rule('', view_func=import_view, methods=['post', ])
     bp.add_url_rule('/', view_func=import_view, methods=['post', ])
@@ -146,5 +146,5 @@ def blueprint(no_doc=True):
 def make_doc():
     """ Only used for sphinx documentation to add the prefix """
     doc_app = Flask(__name__)
-    doc_app.register_blueprint(blueprint(no_doc=False))
+    doc_app.register_blueprint(blueprint(with_doc=True))
     return doc_app

--- a/lib/rucio/web/rest/flaskapi/v1/ping.py
+++ b/lib/rucio/web/rest/flaskapi/v1/ping.py
@@ -69,11 +69,11 @@ class Ping(ErrorHandlingMethodView):
         return response
 
 
-def blueprint(no_doc=True):
+def blueprint(with_doc=False):
     bp = Blueprint('ping', __name__, url_prefix='/ping')
 
     ping_view = Ping.as_view('ping')
-    if no_doc:
+    if not with_doc:
         # rule without trailing slash needs to be added before rule with trailing slash
         bp.add_url_rule('', view_func=ping_view, methods=['get', ])
     bp.add_url_rule('/', view_func=ping_view, methods=['get', ])
@@ -85,5 +85,5 @@ def blueprint(no_doc=True):
 def make_doc():
     """ Only used for sphinx documentation to add the prefix """
     doc_app = Flask(__name__)
-    doc_app.register_blueprint(blueprint(no_doc=False))
+    doc_app.register_blueprint(blueprint(with_doc=True))
     return doc_app

--- a/lib/rucio/web/rest/flaskapi/v1/redirect.py
+++ b/lib/rucio/web/rest/flaskapi/v1/redirect.py
@@ -344,14 +344,14 @@ class HeaderRedirector(ErrorHandlingMethodView):
             return generate_http_error_flask(404, error, headers=headers)
 
 
-def blueprint(no_doc=True):
+def blueprint(with_doc=False):
     bp = Blueprint('redirect', __name__, url_prefix='/redirect')
 
     metalink_redirector_view = MetaLinkRedirector.as_view('metalink_redirector')
     bp.add_url_rule('/<path:scope_name>/metalink', view_func=metalink_redirector_view, methods=['get', ])
     header_redirector_view = HeaderRedirector.as_view('header_redirector')
     bp.add_url_rule('/<path:scope_name>', view_func=header_redirector_view, methods=['get', ])
-    if no_doc:
+    if not with_doc:
         bp.add_url_rule('/<path:scope_name>/', view_func=header_redirector_view, methods=['get', ])
 
     return bp
@@ -360,5 +360,5 @@ def blueprint(no_doc=True):
 def make_doc():
     """ Only used for sphinx documentation """
     doc_app = Flask(__name__)
-    doc_app.register_blueprint(blueprint(no_doc=False))
+    doc_app.register_blueprint(blueprint(with_doc=True))
     return doc_app

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -1717,13 +1717,13 @@ class Tombstone(ErrorHandlingMethodView):
         return 'Created', 201
 
 
-def blueprint(no_doc=True):
+def blueprint(with_doc=False):
     bp = Blueprint('replicas', __name__, url_prefix='/replicas')
 
     list_replicas_view = ListReplicas.as_view('list_replicas')
     bp.add_url_rule('/list', view_func=list_replicas_view, methods=['post', ])
     replicas_view = Replicas.as_view('replicas')
-    if no_doc:
+    if not with_doc:
         # rule without trailing slash needs to be added before rule with trailing slash
         bp.add_url_rule('', view_func=replicas_view, methods=['post', 'put', 'delete'])
     bp.add_url_rule('/', view_func=replicas_view, methods=['post', 'put', 'delete'])
@@ -1752,7 +1752,7 @@ def blueprint(no_doc=True):
     set_tombstone_view = Tombstone.as_view('set_tombstone')
     bp.add_url_rule('/tombstone', view_func=set_tombstone_view, methods=['post', ])
 
-    if no_doc:
+    if not with_doc:
         bp.add_url_rule('/list/', view_func=list_replicas_view, methods=['post', ])
         bp.add_url_rule('/suspicious/', view_func=suspicious_replicas_view, methods=['get', 'post'])
         bp.add_url_rule('/bad/states/', view_func=bad_replicas_states_view, methods=['get', ])
@@ -1775,5 +1775,5 @@ def blueprint(no_doc=True):
 def make_doc():
     """ Only used for sphinx documentation """
     doc_app = Flask(__name__)
-    doc_app.register_blueprint(blueprint(no_doc=False))
+    doc_app.register_blueprint(blueprint(with_doc=True))
     return doc_app


### PR DESCRIPTION
Flask differentiates between calls with and without a trailing slash in the
url. We have some Rest Api Endpoints (e.g. `/<account>/usage/`), where it is
important to differentiate. To not include these calls in the docs twice, the
`no_doc` parameter was introduced. It is `True` when the docs should not be
generated, `False` otherwise.

Since the parameter contains a negation in the word itself, it is hard to
understand what behavior is meant when the parameter is set. Renaming the
variable without the negation makes the logic more understandable.
