### PR TITLE
Core: Fix rse update availability can't be set to all false #5744

### DIFF
--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -1431,7 +1431,9 @@ def update_rse(rse_id: str, parameters: 'Dict[str, Any]', session=None):
                 availability = availability & ~availability_mapping[key]
         elif key in MUTABLE_RSE_PROPERTIES - {'name', 'availability_read', 'availability_write', 'availability_delete'}:
             param[key] = parameters[key]
-    param['availability'] = availability or param['availability']
+
+    if 'availability' not in param:
+        param['availability'] = availability
 
     if 'availability' in param:
         availability_values = Availability.from_integer(param['availability'])

--- a/lib/rucio/tests/test_rse.py
+++ b/lib/rucio/tests/test_rse.py
@@ -437,6 +437,13 @@ class TestRSEClient(unittest.TestCase):
         with pytest.raises(ResourceTemporaryUnavailable):
             replica_client.add_replicas(rse=renamed_rse, files=files2, ignore_availability=False)
 
+    def test_update_rse_availability_all_false(self):
+        """ RSE (CLIENTS): update rse should be able to set all availability options to False."""
+        rse = rse_name_generator()
+        ret = self.client.add_rse(rse)
+        assert ret
+        self.client.update_rse(rse, {"availability_read": False, "availability_write": False, "availability_delete": False})
+
     def test_list_rses(self):
         """ RSE (CLIENTS): try to list rses."""
         rse_list = [rse_name_generator() for i in range(5)]


### PR DESCRIPTION
The `availability` attribute of an rse should be variable. `update_rse`
is the core function to do that. While updating the `availability` to a
non-zero value (at least one of `availability_{read,write,delete}` is
`True`) works, updating it to zero does not.

This comes due to an invalid check in line 1434, introduced in 8b033b393
(Core & Internals: Throw an exception on wrong RSE update option #5491,
2022-05-03). The variable `availability` is set to zero, which is a
valid entry in this case. The check in line 1434 however tries to use
the `availability` property of `param`, which does not exist.  This
check was introduced to also account for the direct update of the
`availability` from a number, not through the individual booleans. This
is needed for the `import_rses` in the importer.

This commit changes the priority to the following and thus gets rid of
the exception:

1. The availability number stored in the availability field

2. The individual availability values

3. The default value

We can not guarantee that only one of `availability` and
`availability_{read,write,delete}` should be updated since the recent
introduction of the `availability_{read,write,delete}` columns in the
RSE model. The importer takes all of the columns and tries to update
them.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
