### PR TITLE
Add the Pyright type checker

### DIFF
--- a/.github/actions/checkout_ancestor_commit/action.yaml
+++ b/.github/actions/checkout_ancestor_commit/action.yaml
@@ -16,9 +16,9 @@ inputs:
       `repository_owner/repository_name` of the repository containing the
       reference commit. For example, rucio/rucio.
     default: rucio/rucio
-  files_to_copy:
+  paths_to_copy:
     description: >-
-      Necessary files to copy (e.g. scripts, configurations, ...) to run code in
+      Necessary paths to copy (e.g. scripts, configurations, ...) to run code in
       the older version of the project. This is for the case an ancestor commit
       gets checked out wich does not contain the required files.
 
@@ -45,19 +45,19 @@ runs:
         FORK_POINT=$(git merge-base $COMMON_ANCESTOR_REPO/${{ inputs.ref }} HEAD)
         echo "The fork point of the current branch with the master is $FORK_POINT"
 
-        echo "Backup all specified files since they could be changed."
+        echo "Backup all specified paths since they could be changed."
         IFS=$'\n'
-        FILES_TO_COPY=$'.github/actions/checkout_ancestor_commit/action.yaml\n${{ inputs.files_to_copy }}'
-        for f in $FILES_TO_COPY; do
+        PATHS_TO_COPY=$'.github/actions/checkout_ancestor_commit/action.yaml\n${{ inputs.paths_to_copy }}'
+        for f in $PATHS_TO_COPY; do
           mkdir -p ../tmp/$(dirname $f)
-          cp $f ../tmp/$f
+          cp --recursive $f ../tmp/$f
         done
 
         echo "Checking out the fork point"
         git checkout $FORK_POINT
 
-        echo "Restore backed up files."
-        for f in $FILES_TO_COPY; do
+        echo "Restore backed up paths."
+        for f in $PATHS_TO_COPY; do
           mkdir -p $(dirname $f)
-          cp ../tmp/$f $f
+          cp --recursive ../tmp/$f $f
         done

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout ancestor commit with rucio/master
         uses: ./.github/actions/checkout_ancestor_commit
         with:
-          files_to_copy: |
+          paths_to_copy: |
             tools/count_missing_type_annotations.sh
             tools/count_missing_type_annotations_utils.sh
       - name: Count initial number of missing type annotations

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -71,6 +71,40 @@ jobs:
             echo "[2] https://codimd.web.cern.ch/6-SU3cTpQSWRK6FHkM7mAA#"
             exit 1
           fi
+  python_pyright:
+    name: Python type check (Pyright)
+    runs-on: ubuntu-latest
+    env:
+      PYRIGHT_CURRENT_REPORT: ../pyright_current_report.json
+      PYRIGHT_ANCESTOR_REPORT: ../pyright_ancestor_report.json
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y npm
+          npm install --global pyright
+      - name: Make pyright report of current commit
+        run: |
+          tools/run_pyright.sh generate ${{ env.PYRIGHT_CURRENT_REPORT }}
+      - name: Show the current Pyright report
+        run: cat ${{ env.PYRIGHT_CURRENT_REPORT }}
+      - name: Checkout ancestor commit with rucio/master
+        uses: ./.github/actions/checkout_ancestor_commit
+        with:
+          paths_to_copy: |
+            pyrightconfig.json
+            tools/run_pyright.sh
+            tools/run_pyright/
+      - name: Make pyright report of ancestor commit
+        run: |
+          tools/run_pyright.sh generate ${{ env.PYRIGHT_ANCESTOR_REPORT }}
+      - name: Show the ancestor Pyright report
+        run: cat ${{ env.PYRIGHT_ANCESTOR_REPORT }}
+      - name: Compare reports
+        run: |
+          tools/run_pyright.sh compare --Werror \
+            ${{ env.PYRIGHT_ANCESTOR_REPORT }} \
+            ${{ env.PYRIGHT_CURRENT_REPORT }}
   setup:
     if: github.repository_owner == 'rucio' || github.event_name != 'schedule'
     runs-on: ubuntu-latest

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,8 @@
+{
+    "include": [
+        "lib"
+    ],
+    "pythonVersion": "3.6",
+    "typeCheckingMode": "basic",
+    "useLibraryCodeForTypes": true
+}

--- a/tools/run_pyright.sh
+++ b/tools/run_pyright.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPTDIR="$(dirname "$0")"
+PYTHONIOENCODING=utf8 \
+    PYTHONPATH="$SCRIPTDIR" \
+    python3 -m run_pyright "$@"

--- a/tools/run_pyright/__init__.py
+++ b/tools/run_pyright/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tools/run_pyright/__main__.py
+++ b/tools/run_pyright/__main__.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from argparse import ArgumentParser
+
+from . import generate
+from . import compare
+
+
+def parse_arguments():
+    parser = ArgumentParser('tools/run_pyright.sh', description="Generate and compare Pyright typing reports.")
+    subparser = parser.add_subparsers(dest='command')
+    subparser.required = True
+
+    parse_generate = subparser.add_parser('generate')
+    generate.setup_parser(parse_generate)
+
+    parse_compare = subparser.add_parser('compare')
+    compare.setup_parser(parse_compare)
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    exit_code = args.func(args)
+    sys.exit(exit_code)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/run_pyright/compare.py
+++ b/tools/run_pyright/compare.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from argparse import ArgumentParser, Namespace
+from collections import Counter
+from pathlib import Path
+from typing import List, Tuple
+
+from .models import Report, ReportDiagnostic, ReportDiagnosticWithoutRange, Severity
+from .utils import group_by, load_json
+
+
+def setup_parser(parser: ArgumentParser) -> None:
+    parser.description = """
+    Compares two Pyright reports and outputs newly introduced warnings and errors.
+
+    If new errors are introduced (or warnings with --Werror) the exit code is 2,
+    otherwise 0.
+    """
+    parser.add_argument('old', type=Path, help='First report of comparison.')
+    parser.add_argument('new', type=Path, help='Second report of comparison.')
+    parser.add_argument('--Werror', action='store_true', help='Treat warnings as errors.')
+    parser.set_defaults(func=compare)
+
+
+def compare(args: Namespace) -> int:
+    """Compares two reports to find new warnings and errors."""
+    old_report = Report.from_dict(load_json(args.old))
+    new_report = Report.from_dict(load_json(args.new))
+    new_diagnostics = _compare_reports(new_report, old_report)
+
+    print_regressions(new_diagnostics, new_report)
+
+    num_errors = sum(count for err, count in new_diagnostics if err.severity == Severity.ERROR)
+    num_warnings = sum(count for err, count in new_diagnostics if err.severity == Severity.WARNING)
+
+    print('Summary:')
+    print(f'    {num_errors} new errors.')
+    print(f'    {num_warnings} new warnings.')
+
+    if args.Werror:
+        num_errors += num_warnings
+
+    return 2 if num_errors else 0
+
+
+def _compare_reports(new_report: Report, old_report: Report):
+    """Counts instances of each diagnostic and returns those which have increased in the latest report."""
+    old_count = Counter(map(ReportDiagnostic.without_range, old_report.diagnostics))
+    new_count = Counter(map(ReportDiagnostic.without_range, new_report.diagnostics))
+
+    diff = new_count
+    diff.subtract(old_count)
+
+    new_diagnostics = [(err, count) for err, count in diff.most_common() if count > 0]
+    return new_diagnostics
+
+
+def _indent(text: str, prefix: str) -> str:
+    """Prepends `prefix` to each line in `text` except the first."""
+    return text.replace('\n', '\n' + prefix)
+
+
+def print_regressions(collection: List[Tuple[ReportDiagnosticWithoutRange, int]], report: Report) -> None:
+    """Takes the output of `_compare_reports` and prints it in a human-readable way."""
+    all_problems = group_by(report.diagnostics, key=lambda elem: elem.without_range())
+    diagnostics_by_file = group_by(collection, key=lambda elem: elem[0].file)
+
+    for file, diagnostics in diagnostics_by_file.items():
+        num_diagnostics = sum(count for _, count in diagnostics)
+        print(f'Found {num_diagnostics} new problems in {file}')
+        for diagnostic, count in diagnostics:
+            candidate_line_list: List[str] = []
+            for candidate in all_problems.get(diagnostic, []):
+                if candidate.range_start_line == candidate.range_end_line:
+                    candidate_line_list.append(f'{candidate.range_start_line+1}')
+                else:
+                    candidate_line_list.append(f'{candidate.range_start_line+1}-{candidate.range_end_line+1}')
+
+            prefix = f'  - {count} {diagnostic.severity.value}s with message'
+            message = _indent(diagnostic.message, ' ' * (len(prefix) + 4))
+            candidate_lines = ', '.join(candidate_line_list)
+
+            print(f'{prefix} """{message}""".')
+            print(f'    Candidates: line {candidate_lines}')

--- a/tools/run_pyright/generate.py
+++ b/tools/run_pyright/generate.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+import json
+import subprocess
+import sys
+
+from .models import ReportDict, Report
+from .utils import save_json
+
+
+PATHS = (
+    'lib/',
+)
+
+
+def setup_parser(parser: ArgumentParser) -> None:
+    parser.description = """
+    Invokes Pyright to generate a report of current typing errors and warnings.
+    """
+    parser.add_argument('out', type=Path, help='Store the Pyright report at this path.')
+    parser.set_defaults(func=generate)
+
+
+def generate(args: Namespace) -> int:
+    """Generate a Pyright report and save it at the specified path."""
+    reportdict = _run_pyright()
+
+    save_json(args.out, reportdict)
+
+    report = Report.from_dict(reportdict)
+
+    print('Summary:')
+    print(f'    {report.summary.num_files} files checked.')
+    print(f'    {report.summary.num_errors} errors.')
+    print(f'    {report.summary.num_warnings} warnings.')
+    print(f'    {report.summary.num_information} notes.')
+    print(f'    Duration: {report.summary.time_seconds:.1f} seconds.')
+
+    return 0
+
+
+def _run_pyright() -> ReportDict:
+    """Runs the pyright type-checker and returns its output as json."""
+    cmdline = ['pyright', '--outputjson', *PATHS]
+    try:
+        process = subprocess.run(cmdline, stdout=subprocess.PIPE)
+        return json.loads(process.stdout)
+    except FileNotFoundError as ex:
+        print('Error running pyright.'
+              ' This could be due to pyright not being installed on your system,'
+              ' in which case it may be installed using `npm install --global pyright`.\n'
+              'Additional details:', ex,
+              file=sys.stderr)
+        sys.exit(1)

--- a/tools/run_pyright/models.py
+++ b/tools/run_pyright/models.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from typing import Any, Dict, List
+from dataclasses import dataclass
+
+
+ReportDict = Dict[str, Any]
+
+
+class Severity(Enum):
+    INFORMATION = 'information'
+    WARNING = 'warning'
+    ERROR = 'error'
+
+
+@dataclass(frozen=True)
+class ReportDiagnosticWithoutRange:
+    severity: Severity
+    file: str
+    rule: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ReportDiagnostic:
+    severity: Severity
+    file: str
+    rule: str
+    message: str
+    range_start_line: int
+    range_start_char: int
+    range_end_line: int
+    range_end_char: int
+
+    @classmethod
+    def from_dict(cls, obj: Dict[str, Any]):
+        return cls(
+            severity=Severity(obj['severity']),
+            file=obj['file'],
+            rule=obj['rule'],
+            message=obj['message'],
+            range_start_line=obj['range']['start']['line'],
+            range_start_char=obj['range']['start']['character'],
+            range_end_line=obj['range']['end']['line'],
+            range_end_char=obj['range']['end']['character'],
+        )  # type: ignore
+
+    def without_range(self) -> ReportDiagnosticWithoutRange:
+        return ReportDiagnosticWithoutRange(
+            self.severity, self.file, self.rule, self.message
+        )  # type: ignore
+
+
+@dataclass
+class ReportSummary:
+    num_files: int
+    num_errors: int
+    num_warnings: int
+    num_information: int
+    time_seconds: float
+
+    @classmethod
+    def from_dict(cls, obj: Dict[str, Any]):
+        return cls(
+            num_files=obj['filesAnalyzed'],
+            num_errors=obj['errorCount'],
+            num_warnings=obj['warningCount'],
+            num_information=obj['informationCount'],
+            time_seconds=obj['timeInSec']
+        )
+
+
+@dataclass
+class Report:
+    summary: ReportSummary
+    diagnostics: List[ReportDiagnostic]
+
+    @classmethod
+    def from_dict(cls, obj: ReportDict):
+        return cls(
+            summary=ReportSummary.from_dict(obj['summary']),
+            diagnostics=list(map(ReportDiagnostic.from_dict, obj['generalDiagnostics'])),
+        )

--- a/tools/run_pyright/utils.py
+++ b/tools/run_pyright/utils.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+from typing import Any, TypeVar, Iterable, Callable, Dict, List
+
+from .models import ReportDict
+
+
+_T = TypeVar('_T')
+_K = TypeVar('_K')
+
+
+def group_by(iterable: Iterable[_T], key: Callable[[_T], _K]) -> Dict[_K, List[_T]]:
+    result: Dict[_K, List[_T]] = {}
+    for elem in iterable:
+        k = key(elem)
+        result.setdefault(k, []).append(elem)
+    return result
+
+
+def load_json(path: Path) -> ReportDict:
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def save_json(path: Path, data: Dict[str, Any]) -> None:
+    with open(path, 'w') as file:
+        json.dump(data, file, indent=4)
+        file.write('\n')


### PR DESCRIPTION
This PR introduces tooling for the Pyright Python type checker, usable both as a local tool during development, and also integrated into the CI pipeline.

The CI check works in a similar way to the current `flake8-annotations` check, in that it compares the number of typing errors before and after applying an incoming pull request. However, the existing check only counts the number of missing annotations, which does not help in ensuring correctness of the annotations. For instance, [this parameter](https://github.com/rucio/rucio/blob/58efd21b5e21182df80bef3dbe8befa636e440b8/lib/rucio/core/transfer.py#L581) should probably not be a `List[str]`, but a `str`, which Pyright rightly notices in the function body.

The CI check prevents new PRs from increasing the error count. The check also attempts to intelligently recognize where the new errors were introduced, to help the developer find their mistakes more easily. However, this could cause a disruption in other developers' workflow, so maybe some guidelines for how strictly we adhere to the CI result should be developed. Pyright's config can also be modified to be more relaxed if it proves to be too noisy. 

Pyright was chosen due to the relative ease of configuring it and processing its output compared to MyPy. Other issues like MyPy limiting the amount of output in case of too many errors also led to the PR focusing on Pyright (though this issue could maybe be resolved by passing the `--soft-error-limit N` flag to MyPy).

Another benefit of Pyright (that could just as well be present in other type checkers - I didn't look) is the ability to integrate it into your IDE of choice through the Language Server Protocol. I know at least VSCode has seamless integration when using the [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) extension, which greatly improves the developer experience by highlighting errors immediately, without having to wait for the CI check to run.

As a follow-up to this PR, I want to gradually improve type annotations and correctness throughout the codebase. Pyright reports numerous issues, some of which could be bugs that need fixing.

Closes #5727 