### PR TITLE
Daemons: fix dark reaper heartbeat readable length

### DIFF
--- a/lib/rucio/core/heartbeat.py
+++ b/lib/rucio/core/heartbeat.py
@@ -118,7 +118,7 @@ def live(executable, hostname, pid, thread=None, older_than=600, hash_executable
         .update({'updated_at': datetime.datetime.utcnow(), 'payload': payload})
     if not rowcount:
         Heartbeats(executable=hash_executable,
-                   readable=executable,
+                   readable=executable[:Heartbeats.readable.property.columns[0].type.length],
                    hostname=hostname,
                    pid=pid,
                    thread_id=thread_id,

--- a/lib/rucio/daemons/reaper/dark_reaper.py
+++ b/lib/rucio/daemons/reaper/dark_reaper.py
@@ -20,6 +20,7 @@ Dark Reaper is a daemon to manage quarantined file deletion.
 import functools
 import logging
 import random
+import sys
 import threading
 import time
 import traceback
@@ -61,7 +62,7 @@ def reaper(
 ):
     executable = 'dark-reaper'
     if rses:
-        executable += ' --rses ' + ''.join(rses)
+        executable += ' '.join(sys.argv[1:])
     logger_prefix = 'dark-reaper'
     run_daemon(
         once=once,


### PR DESCRIPTION
The bug was introduced in #5742.

Perform two fixes: 1) put the command line arguments in the executable
rather than the resolved list of RSEs. This shouldn't change much.
The RSE list is only resolved on startup.
2) limit the length of the readable to the column length.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
