### PR TITLE
Rules: Provide more feedback on StatementErrors #5766

### DIFF
--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -1317,8 +1317,8 @@ def update_rule(rule_id, options, session=None):
             raise error
     except NoResultFound:
         raise RuleNotFound('No rule with the id %s found' % (rule_id))
-    except StatementError:
-        raise RucioException('Badly formatted rule id (%s)' % (rule_id))
+    except StatementError as e:
+        raise RucioException(f"A StatementError occurred while processing rule {rule_id}") from e
 
 
 @transactional_session


### PR DESCRIPTION
It is falsely assumed that the `StatementError` in `update_rule` is
always coming from a badly formatted rule id. It is an error that
occurred during execution of a SQL statement.

We pass more information to the caller to provide a better context of
the error. This makes the debugging for non-statement related errors
easier.
