### PR TITLE
Transfers: gracefully skip missing sources in poller/receiver

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1835,6 +1835,7 @@ def get_source_rse(request_id, src_url, session=None, logger=logging.log):
             return None, None
 
         sources = get_sources(request_id, session=session)
+        sources = sources or []
         for source in sources:
             if source['url'] == src_url:
                 src_rse_id = source['rse_id']


### PR DESCRIPTION
The only difference is that the "except" block will not be triggered
and the stack-trace will not be included in the log message.

On the couple of cases I investigated, the missing sources were due to
the poller working on a request which is handled by receiver+finisher
in the meantime.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
