### PR TITLE
Core & Internals: enforce policy package supported version #5652

### DIFF
--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1059,3 +1059,13 @@ class MetadataSchemaMismatchError(RucioException):
         super(MetadataSchemaMismatchError, self).__init__(*args, **kwargs)
         self._message = 'The external table does not match the expected table schema.'
         self.error_code = 102
+
+
+class PolicyPackageVersionError(RucioException):
+    """
+    Policy package is not compatible with this version of Rucio.
+    """
+    def __init__(self, package, *args, **kwargs):
+        super(PolicyPackageVersionError, self).__init__(*args, **kwargs)
+        self._message = 'Policy package %s is not compatible with this Rucio version' % package
+        self.error_code = 103

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -18,6 +18,7 @@ from os import environ
 from configparser import NoOptionError, NoSectionError
 
 from rucio.common import config, exception
+from rucio.common.utils import check_policy_package_version
 
 import importlib
 
@@ -41,9 +42,11 @@ if not multivo:
     if config.config_has_section('policy'):
         try:
             if 'RUCIO_POLICY_PACKAGE' in environ:
-                POLICY = environ['RUCIO_POLICY_PACKAGE'] + ".schema"
+                POLICY = environ['RUCIO_POLICY_PACKAGE']
             else:
-                POLICY = config.config_get('policy', 'package', check_config_table=False) + ".schema"
+                POLICY = config.config_get('policy', 'package', check_config_table=False)
+            check_policy_package_version(POLICY)
+            POLICY = POLICY + ".schema"
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             try:
@@ -69,9 +72,11 @@ def load_schema_for_vo(vo):
         try:
             env_name = 'RUCIO_POLICY_PACKAGE_' + vo.upper()
             if env_name in environ:
-                POLICY = environ[env_name] + ".schema"
+                POLICY = environ[env_name]
             else:
-                POLICY = config.config_get('policy', 'package-' + vo, check_config_table=False) + ".schema"
+                POLICY = config.config_get('policy', 'package-' + vo, check_config_table=False)
+            check_policy_package_version(POLICY)
+            POLICY = POLICY + ".schema"
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             try:

--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -17,6 +17,7 @@ from os import environ
 
 from configparser import NoOptionError, NoSectionError
 from rucio.common import config, exception
+from rucio.common.utils import check_policy_package_version
 
 import importlib
 
@@ -48,9 +49,11 @@ if not multivo:
     if config.config_has_section('policy'):
         try:
             if 'RUCIO_POLICY_PACKAGE' in environ:
-                POLICY = environ['RUCIO_POLICY_PACKAGE'] + ".permission"
+                POLICY = environ['RUCIO_POLICY_PACKAGE']
             else:
-                POLICY = config.config_get('policy', 'package', check_config_table=False) + ".permission"
+                POLICY = config.config_get('policy', 'package', check_config_table=False)
+            check_policy_package_version(POLICY)
+            POLICY = POLICY + ".permission"
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             POLICY = 'rucio.core.permission.' + FALLBACK_POLICY.lower()
@@ -71,9 +74,11 @@ def load_permission_for_vo(vo):
         try:
             env_name = 'RUCIO_POLICY_PACKAGE_' + vo.upper()
             if env_name in environ:
-                POLICY = environ[env_name] + ".permission"
+                POLICY = environ[env_name]
             else:
-                POLICY = config.config_get('policy', 'package-' + vo) + ".permission"
+                POLICY = config.config_get('policy', 'package-' + vo)
+            check_policy_package_version(POLICY)
+            POLICY = POLICY + ".permission"
         except (NoOptionError, NoSectionError):
             # fall back to old system for now
             try:


### PR DESCRIPTION
This pull request checks the supported version field of the policy package and throws an exception if it is not compatible with the Rucio version.

I am not sure where would be best to store the `first_compatible_version` value. It will need to be updated every time the interface between Rucio and the policy package changes (for example, when the session argument was added to the permissions code recently). I don't know what is the best way to ensure this doesn't get forgotten, but I am open to suggestions.