### PR TITLE
Transfers: fix marking multi-source as failed. Closes #5780

### DIFF
--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -573,7 +573,8 @@ class FTS3ApiTransferStatusReport(Fts3TransferStatusReport):
         if file_state_is_final:
             if file_state == FTS_STATE.FINISHED:
                 new_state = RequestState.DONE
-            elif file_state == FTS_STATE.FAILED and not self._multi_sources:  # for multi-source transfers we must wait for the job to be in a final state
+            elif file_state == FTS_STATE.FAILED and job_state == FTS_STATE.FAILED or \
+                    file_state == FTS_STATE.FAILED and not self._multi_sources:  # for multi-source transfers we must wait for the job to be in a final state
                 if self._is_recoverable_fts_overwrite_error(self.request(session), reason, self._file_metadata):
                     new_state = RequestState.DONE
                 else:


### PR DESCRIPTION
The issue is that none of the conditions were matched for a failed
multi-source transfer. So it was never transitioned. The bug was
introduced in 1.29

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
