### PR TITLE
Replicas: list_replicas() optimization #5779

### DIFF
--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -200,20 +200,9 @@ def list_replicas(dids, schemes=None, unavailable=False, request_id=None,
                                      client_location=client_location, domain=domain,
                                      sign_urls=sign_urls, signature_lifetime=signature_lifetime,
                                      resolve_archives=resolve_archives, resolve_parents=resolve_parents,
-                                     nrandom=nrandom, updated_after=updated_after, session=session)
+                                     nrandom=nrandom, updated_after=updated_after, by_rse_name=True, session=session)
 
     for rep in replicas:
-        # 'rses' and 'states' use rse_id as the key. This needs updating to be rse.
-        keys = ['rses', 'states']
-        for k in keys:
-            old_dict = rep.get(k, None)
-            if old_dict is not None:
-                new_dict = {}
-                for rse_id in old_dict:
-                    rse = get_rse_name(rse_id=rse_id, session=session) if rse_id is not None else None
-                    new_dict[rse] = old_dict[rse_id]
-                rep[k] = new_dict
-
         rep['scope'] = rep['scope'].external
         if 'parents' in rep:
             new_parents = []

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -106,6 +106,7 @@ class ReplicaClient(BaseClient):
 
         :param dids: The list of data identifiers (DIDs) like :
             [{'scope': <scope1>, 'name': <name1>}, {'scope': <scope2>, 'name': <name2>}, ...]
+            each dictionary may also contain "type":"FILE" to speed up the query on the server side
         :param schemes: A list of schemes to filter the replicas. (e.g. file, http, ...)
         :param ignore_availability: Also include replicas from blocked RSEs into the list
         :param metalink: ``False`` (default) retrieves as JSON,

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -520,6 +520,9 @@ class ListReplicas(ErrorHandlingMethodView):
                         name:
                           description: The name of the did.
                           type: string
+                        type:
+                          description: DID type. If it is "FILE", the query can be optimized. Other values are ignored for now.
+                          type: string
                   schemes:
                     description: A list of schemes to filter the replicas.
                     type: array


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Optimize list_replicas():
1. Do not call get_rse_name() twice for each replica in the request. Use RSE names returned by core.list_replicas.
2. Document passing "type":"FILE" as a way to bypass DID resolution