### PR TITLE
Fix usages of `datetime.now()` instead of `datetime.utcnow()`

### DIFF
--- a/bin/rucio-auditor
+++ b/bin/rucio-auditor
@@ -121,7 +121,7 @@ def main(args):
 
     try:
         while all(p.is_alive() for p in procs):
-            while last_run_month == datetime.now().month:
+            while last_run_month == datetime.utcnow().month:
                 time.sleep(60 * 60 * 24)
 
             for rse in rses:

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -3974,7 +3974,7 @@ def get_suspicious_files(rse_expression, available_elsewhere, filter_=None, logg
     if not isinstance(nattempts, int):
         nattempts = 0
     if not isinstance(younger_than, datetime):
-        younger_than = datetime.now() - timedelta(days=10)
+        younger_than = datetime.utcnow() - timedelta(days=10)
 
     # assembling exclude_states_clause
     exclude_states_clause = []

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1246,7 +1246,7 @@ def release_waiting_requests_per_deadline(rse_id=None, deadline=1, session=None)
             grouped_requests_subquery.c.scope,
             grouped_requests_subquery.c.oldest_requested_at
         ).where(
-            grouped_requests_subquery.c.oldest_requested_at < datetime.datetime.now() - datetime.timedelta(hours=deadline)
+            grouped_requests_subquery.c.oldest_requested_at < datetime.datetime.utcnow() - datetime.timedelta(hours=deadline)
         ).subquery()
 
         old_requests_subquery = select(

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -172,7 +172,7 @@ def generate_didname(metadata, dsn, did_type):
     file_name = ''
     for field in fields:
         if field == 'date':
-            field_str = str(datetime.now().date())
+            field_str = str(datetime.utcnow().date())
         elif field == 'did_prefix':
             field_str = did_prefix
         elif field == 'dsn':

--- a/lib/rucio/daemons/badreplicas/minos.py
+++ b/lib/rucio/daemons/badreplicas/minos.py
@@ -132,7 +132,7 @@ def __update_temporary_unavailable(chunk: list, reason: str, expires_at: datetim
                 logger(logging.INFO, '%s is in unavailable state. Will be removed from the list of bad PFNs', str(rep['pfn']))
                 bulk_delete_bad_pfns(pfns=[rep['pfn']], session=None)
             # If the expiration date of the TEMPORARY_UNAVAILABLE is in the past, it is removed from the bad PFNs table
-            elif expires_at < datetime.now():
+            elif expires_at < datetime.utcnow():
                 logger(logging.INFO, 'PFN %s expiration time (%s) is older than now and is not in unavailable state. Removing the PFNs from bad_pfns', str(rep['pfn']), expires_at)
                 bulk_delete_bad_pfns(pfns=[rep['pfn']], session=None)
             # Else update everything in the same transaction

--- a/lib/rucio/daemons/bb8/common.py
+++ b/lib/rucio/daemons/bb8/common.py
@@ -303,7 +303,7 @@ def list_rebalance_rule_candidates(rse_id, mode=None, session=None):
         expiration_time=3600,
     )
     if min_created_days > 0:
-        min_created_days = datetime.now() - timedelta(days=min_created_days)
+        min_created_days = datetime.utcnow() - timedelta(days=min_created_days)
         rule_clause.append(models.ReplicationRule.created_at < min_created_days)
 
     # Only move rules which are owned by <allowed_accounts> (coma separated accounts, e.g. panda,root,ddmadmin,jdoe)

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -326,7 +326,7 @@ def __create_missing_replicas_and_requests(
                         'request_type': rws.request_type,
                         'retry_count': rws.retry_count,
                         'account': rws.account,
-                        'requested_at': datetime.datetime.now()}
+                        'requested_at': datetime.datetime.utcnow()}
         if rws.transfertool:
             req_to_queue['transfertool'] = rws.transfertool
         new_req = queue_requests(requests=[req_to_queue], session=session)

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -664,7 +664,7 @@ def run_once(heartbeat_handler: "HeartbeatHandler", bulk: int, **_kwargs) -> boo
         update_subscription(
             name=sub["name"],
             account=sub["account"],
-            metadata={"last_processed": datetime.now()},
+            metadata={"last_processed": datetime.utcnow()},
         )
     logger(
         logging.INFO,

--- a/lib/rucio/tests/test_api_external_representation.py
+++ b/lib/rucio/tests/test_api_external_representation.py
@@ -279,7 +279,7 @@ class TestApiExternalRepresentation(unittest.TestCase):
             'account': self.account_name,
             'rule_id': generate_uuid(),
             'retry_count': 1,
-            'requested_at': datetime.now(),
+            'requested_at': datetime.utcnow(),
             'attributes': {
                 'activity': 'Functional Test',
                 'bytes': 10,

--- a/lib/rucio/tests/test_auditor_hdfs.py
+++ b/lib/rucio/tests/test_auditor_hdfs.py
@@ -56,7 +56,7 @@ class TestReplicaFromHDFS(unittest.TestCase):
         mock_hdfs_get.return_value = FakeHDFSGet(files)
         merged_file_path = hdfs.ReplicaFromHDFS.download(
             'FAKE_RSE',
-            datetime.now(),
+            datetime.utcnow(),
             cache_dir=self.work_dir,
         )
 
@@ -73,7 +73,7 @@ class TestReplicaFromHDFS(unittest.TestCase):
         mock_hdfs_get.return_value = FakeHDFSGet(files)
         merged_file_path = hdfs.ReplicaFromHDFS.download(
             'FAKE_RSE',
-            datetime.now(),
+            datetime.utcnow(),
             cache_dir=self.work_dir,
             buffer_size=2,
         )

--- a/lib/rucio/tests/test_belleii.py
+++ b/lib/rucio/tests/test_belleii.py
@@ -65,7 +65,7 @@ def test_dirac_addfile(rse_factory, did_factory, root_account, did_client, dirac
         rules = [rule for rule in did_client.list_did_rules(scope, name)]
         assert len(rules) == 1
         assert rules[0]['rse_expression'] == rse1
-        assert datetime.now() - rules[0]['expires_at'] < timedelta(hours=24)
+        assert datetime.utcnow() - rules[0]['expires_at'] < timedelta(hours=24)
 
 
 @skip_non_belleii

--- a/lib/rucio/tests/test_clients.py
+++ b/lib/rucio/tests/test_clients.py
@@ -165,7 +165,7 @@ class TestBaseClient(unittest.TestCase):
             del invocations[:]
             client._send_request(server.base_url)  # noqa
         # The client did back-off multiple times before succeeding: 2 * 0.25s (authentication) + 2 * 0.25s (request) = 1s
-        assert datetime.now() - start_time > timedelta(seconds=0.9)
+        assert datetime.utcnow() - start_time > timedelta(seconds=0.9)
 
 
 class TestRucioClients(unittest.TestCase):

--- a/lib/rucio/tests/test_conveyor.py
+++ b/lib/rucio/tests/test_conveyor.py
@@ -750,7 +750,7 @@ def test_stager(rse_factory, did_factory, root_account, replica_client):
                                            'request_type': RequestType.STAGEIN,
                                            'retry_count': 0,
                                            'account': root_account,
-                                           'requested_at': datetime.now()}])
+                                           'requested_at': datetime.utcnow()}])
     stager(once=True, rses=[{'id': rse_id} for rse_id in all_rses])
 
     replica = __wait_for_replica_transfer(dst_rse_id=dst_rse_id, max_wait_seconds=2 * MAX_POLL_WAIT_SECONDS, **did)

--- a/lib/rucio/tests/test_filter_engine.py
+++ b/lib/rucio/tests/test_filter_engine.py
@@ -599,7 +599,7 @@ class TestFilterEngineReal(unittest.TestCase):
 
     @read_session
     def test_BackwardsCompatibilityCreatedAfter(self, session=None):
-        before = datetime.strftime(datetime.now() - timedelta(seconds=1), "%Y-%m-%dT%H:%M:%S.%fZ")  # w/ -1s buffer
+        before = datetime.strftime(datetime.utcnow() - timedelta(seconds=1), "%Y-%m-%dT%H:%M:%S.%fZ")  # w/ -1s buffer
         did_name = self._create_tmp_DID()
 
         dids = []
@@ -611,7 +611,7 @@ class TestFilterEngineReal(unittest.TestCase):
     @read_session
     def test_BackwardsCompatibilityCreatedBefore(self, session=None):
         did_name = self._create_tmp_DID()
-        after = datetime.strftime(datetime.now() + timedelta(seconds=1), "%Y-%m-%dT%H:%M:%S.%fZ")  # w/ +1s buffer
+        after = datetime.strftime(datetime.utcnow() + timedelta(seconds=1), "%Y-%m-%dT%H:%M:%S.%fZ")  # w/ +1s buffer
 
         dids = []
         q = FilterEngine('created_before={}'.format(after), model_class=models.DataIdentifier).create_sqla_query(additional_model_attributes=[models.DataIdentifier.name])

--- a/lib/rucio/tests/test_lifetime.py
+++ b/lib/rucio/tests/test_lifetime.py
@@ -40,8 +40,8 @@ def test_lifetime_creation_core(root_account, rse_factory, mock_scope, did_facto
     """
     nb_datatype = 3
     nb_datasets = 2 * nb_datatype
-    yesterday = datetime.now() - timedelta(days=1)
-    tomorrow = datetime.now() + timedelta(days=1)
+    yesterday = datetime.utcnow() - timedelta(days=1)
+    tomorrow = datetime.utcnow() + timedelta(days=1)
     rse, rse_id = rse_factory.make_posix_rse()
     datasets = [did_factory.make_dataset() for _ in range(nb_datasets)]
     metadata = [str(uuid()) for _ in range(nb_datatype)]
@@ -64,19 +64,19 @@ def test_lifetime_creation_core(root_account, rse_factory, mock_scope, did_facto
         pass
 
     with pytest.raises(UnsupportedOperation):
-        add_exception(datasets, root_account, pattern='wekhewfk', comments='This is a comment', expires_at=datetime.now())
+        add_exception(datasets, root_account, pattern='wekhewfk', comments='This is a comment', expires_at=datetime.utcnow())
 
     # Test with cutoff_date wrongly defined
     config_core.set(section='lifetime_model', option='cutoff_date', value='wrong_value')
     config_core.get(section='lifetime_model', option='cutoff_date', default=None, use_cache=False)
     with pytest.raises(UnsupportedOperation):
-        add_exception(datasets, root_account, pattern='wekhewfk', comments='This is a comment', expires_at=datetime.now())
+        add_exception(datasets, root_account, pattern='wekhewfk', comments='This is a comment', expires_at=datetime.utcnow())
 
     # Test with cutoff_date properly defined
     tomorrow = tomorrow.strftime('%Y-%m-%d')
     config_core.set(section='lifetime_model', option='cutoff_date', value=tomorrow)
     config_core.get(section='lifetime_model', option='cutoff_date', default=None, use_cache=False)
-    result = add_exception(datasets, root_account, pattern='wekhewfk', comments='This is a comment', expires_at=datetime.now())
+    result = add_exception(datasets, root_account, pattern='wekhewfk', comments='This is a comment', expires_at=datetime.utcnow())
 
     # Check if the Not Existing DIDs are identified
     result_unknown = [(entry['scope'], entry['name']) for entry in result['unknown']]
@@ -108,7 +108,7 @@ def test_lifetime_truncate_expiration(root_account, rse_factory, mock_scope, did
     Test the duration of a lifetime exception is truncated if max_extension is defined
     """
     nb_datasets = 2
-    today = datetime.now()
+    today = datetime.utcnow()
     yesterday = today - timedelta(days=1)
     tomorrow = today + timedelta(days=1)
     next_year = today + timedelta(days=365)
@@ -143,8 +143,8 @@ def test_lifetime_creation_client(root_account, rse_factory, mock_scope, did_fac
     """
     nb_datatype = 3
     nb_datasets = 2 * nb_datatype
-    yesterday = datetime.now() - timedelta(days=1)
-    tomorrow = datetime.now() + timedelta(days=1)
+    yesterday = datetime.utcnow() - timedelta(days=1)
+    tomorrow = datetime.utcnow() + timedelta(days=1)
     rse, rse_id = rse_factory.make_posix_rse()
     datasets = [did_factory.make_dataset() for _ in range(nb_datasets)]
     metadata = [str(uuid()) for _ in range(nb_datatype)]
@@ -170,19 +170,19 @@ def test_lifetime_creation_client(root_account, rse_factory, mock_scope, did_fac
     for dataset in datasets:
         client_datasets.append({'scope': dataset['scope'].external, 'name': dataset['name'], 'did_type': 'DATASET'})
     with pytest.raises(UnsupportedOperation):
-        rucio_client.add_exception(client_datasets, account='root', pattern='wekhewfk', comments='This is a comment', expires_at=datetime.now())
+        rucio_client.add_exception(client_datasets, account='root', pattern='wekhewfk', comments='This is a comment', expires_at=datetime.utcnow())
 
     # Test with cutoff_date wrongly defined
     config_core.set(section='lifetime_model', option='cutoff_date', value='wrong_value')
     config_core.get(section='lifetime_model', option='cutoff_date', default=None, use_cache=False)
     with pytest.raises(UnsupportedOperation):
-        rucio_client.add_exception(client_datasets, account='root', pattern='wekhewfk', comments='This is a comment', expires_at=datetime.now())
+        rucio_client.add_exception(client_datasets, account='root', pattern='wekhewfk', comments='This is a comment', expires_at=datetime.utcnow())
 
     # Test with cutoff_date properly defined
     tomorrow = tomorrow.strftime('%Y-%m-%d')
     config_core.set(section='lifetime_model', option='cutoff_date', value=tomorrow)
     config_core.get(section='lifetime_model', option='cutoff_date', default=None, use_cache=False)
-    result = rucio_client.add_exception(client_datasets, account='root', pattern='wekhewfk', comments='This is a comment', expires_at=datetime.now())
+    result = rucio_client.add_exception(client_datasets, account='root', pattern='wekhewfk', comments='This is a comment', expires_at=datetime.utcnow())
 
     # Check if the Not Existing DIDs are identified
     result_unknown = [(entry['scope'], entry['name']) for entry in result['unknown']]
@@ -219,8 +219,8 @@ def test_atropos(root_account, rse_factory, mock_scope, did_factory, rucio_clien
     """
     Test the behaviour of atropos
     """
-    today = datetime.now()
-    check_date = datetime.now() + timedelta(days=365)
+    today = datetime.utcnow()
+    check_date = datetime.utcnow() + timedelta(days=365)
     check_date = check_date.isoformat().split('T')[0]
 
     # Define a policy
@@ -231,7 +231,7 @@ def test_atropos(root_account, rse_factory, mock_scope, did_factory, rucio_clien
         json.dump(lifetime_policy, outfile)
     REGION.invalidate()
     nb_datasets = 2
-    today = datetime.now()
+    today = datetime.utcnow()
     rse, rse_id = rse_factory.make_posix_rse()
     datasets = [did_factory.make_dataset() for _ in range(nb_datasets)]
     rules = list()

--- a/lib/rucio/tests/test_replica_recoverer.py
+++ b/lib/rucio/tests/test_replica_recoverer.py
@@ -142,7 +142,7 @@ class TestReplicaRecoverer(unittest.TestCase):
                 assert (self.rse4recovery_id in replica['states']) is False
 
         # Checking if self.tmp_file2 and self.tmp_file6 were declared as 'BAD'
-        self.from_date = datetime.now() - timedelta(days=1)
+        self.from_date = datetime.utcnow() - timedelta(days=1)
         bad_replicas_list = list_bad_replicas_status(rse_id=self.rse4suspicious_id, younger_than=self.from_date, **self.vo)
         bad_checklist = [(badf['name'], badf['rse_id'], badf['state']) for badf in bad_replicas_list]
 

--- a/lib/rucio/tests/test_request.py
+++ b/lib/rucio/tests/test_request.py
@@ -79,7 +79,7 @@ def test_queue_requests_state(vo, use_preparer):
         'scope': scope,
         'rule_id': generate_uuid(),
         'retry_count': 1,
-        'requested_at': datetime.now().replace(year=2015),
+        'requested_at': datetime.utcnow().replace(year=2015),
         'attributes': {
             'activity': user_activity,
             'bytes': 10,
@@ -95,7 +95,7 @@ def test_queue_requests_state(vo, use_preparer):
         'scope': scope,
         'rule_id': generate_uuid(),
         'retry_count': 1,
-        'requested_at': datetime.now().replace(year=2015),
+        'requested_at': datetime.utcnow().replace(year=2015),
         'attributes': {
             'activity': 'unknown',
             'bytes': 10,
@@ -111,7 +111,7 @@ def test_queue_requests_state(vo, use_preparer):
         'scope': scope,
         'rule_id': generate_uuid(),
         'retry_count': 1,
-        'requested_at': datetime.now().replace(year=2015),
+        'requested_at': datetime.utcnow().replace(year=2015),
         'attributes': {
             'activity': user_activity,
             'bytes': 10,

--- a/lib/rucio/tests/test_throttler.py
+++ b/lib/rucio/tests/test_throttler.py
@@ -59,7 +59,7 @@ def _add_test_replicas_and_request(request_configs, vo=None, scope=None, account
             'scope': scope,
             'retry_count': 1,
             'rule_id': generate_uuid(),
-            'requested_at': datetime.now(),
+            'requested_at': datetime.utcnow(),
             'account': account,
             'attributes': {
                 'activity': 'User Subscription',
@@ -133,19 +133,19 @@ class TestThrottlerGroupedFIFO(unittest.TestCase):
                 {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2000),
+                    'requested_at': datetime.utcnow().replace(year=2000),
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2021),  # requested after the request below but small enough for max_volume check
+                    'requested_at': datetime.utcnow().replace(year=2021),  # requested after the request below but small enough for max_volume check
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                     'attributes': {'bytes': 3000},
                 },
             ]
@@ -298,8 +298,8 @@ class TestThrottlerFIFO(unittest.TestCase):
         name1, name2 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2018)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2018)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
         self.db_session.query(models.RSETransferLimit).delete()
@@ -322,7 +322,7 @@ class TestThrottlerFIFO(unittest.TestCase):
         name1, = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2018)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2018)},
             ]
         )
         preparer.run_once(session=self.db_session, logger=print)
@@ -345,8 +345,8 @@ class TestThrottlerFIFO(unittest.TestCase):
         name1, name2 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2018)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2018)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
         preparer.run_once(session=self.db_session, logger=print)
@@ -368,8 +368,8 @@ class TestThrottlerFIFO(unittest.TestCase):
         name1, name2 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2018)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2018)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
         self.db_session.commit()
@@ -422,17 +422,17 @@ class TestThrottlerFIFOSRCACT:
                 {
                     'source_rse_id': source_rse_id,
                     'dest_rse_id': dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2018),
+                    'requested_at': datetime.utcnow().replace(year=2018),
                     'attributes': {'activity': self.user_activity},
                 }, {
                     'source_rse_id': source_rse_id,
                     'dest_rse_id': dest_rse_id2,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                     'attributes': {'activity': self.user_activity},
                 }, {
                     'source_rse_id': source_rse_id,
                     'dest_rse_id': dest_rse_id3,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                     'attributes': {'activity': self.user_activity2},
                 },
             ]
@@ -503,8 +503,8 @@ class TestThrottlerFIFOSRCALLACT(unittest.TestCase):
         name1, name2 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2018)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2018)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
         preparer.run_once(session=self.db_session, logger=print)
@@ -580,17 +580,17 @@ class TestThrottlerFIFODESTALLACT(unittest.TestCase):
                 {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2018),
+                    'requested_at': datetime.utcnow().replace(year=2018),
                     'attributes': {'activity': self.user_activity},
                 }, {
                     'source_rse_id': self.source_rse_id2,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                     'attributes': {'activity': self.user_activity2},
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id2,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                     'attributes': {'activity': self.user_activity2},
                 },
             ]
@@ -667,22 +667,22 @@ class TestThrottlerGroupedFIFOSRCALLACT(unittest.TestCase):
                 {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2000),
+                    'requested_at': datetime.utcnow().replace(year=2000),
                     'attributes': {'activity': self.user_activity},
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id_2,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                     'attributes': {'activity': self.all_activities},
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2021),
+                    'requested_at': datetime.utcnow().replace(year=2021),
                     'attributes': {'activity': self.all_activities},
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id_2,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                     'attributes': {'activity': self.all_activities},
                 },
             ]
@@ -781,17 +781,17 @@ class TestRequestCoreRelease(unittest.TestCase):
                 {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2015),
+                    'requested_at': datetime.utcnow().replace(year=2015),
                     'attributes': {'bytes': 8},
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                     'attributes': {'bytes': 2},
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2000),
+                    'requested_at': datetime.utcnow().replace(year=2000),
                     'attributes': {'bytes': 10},
                 },
             ]
@@ -822,22 +822,22 @@ class TestRequestCoreRelease(unittest.TestCase):
                 {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2015),
+                    'requested_at': datetime.utcnow().replace(year=2015),
                     'attributes': {'bytes': 6},
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                     'attributes': {'bytes': 2},
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2000),
+                    'requested_at': datetime.utcnow().replace(year=2000),
                     'attributes': {'bytes': 10},
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2030),
+                    'requested_at': datetime.utcnow().replace(year=2030),
                     'attributes': {'bytes': 2},
                 },
             ]
@@ -870,7 +870,7 @@ class TestRequestCoreRelease(unittest.TestCase):
         name1, = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2015)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2015)},
             ]
         )
         preparer.run_once(session=self.db_session, logger=print)
@@ -892,7 +892,7 @@ class TestRequestCoreRelease(unittest.TestCase):
         name, = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2015)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2015)},
             ]
         )
 
@@ -908,7 +908,7 @@ class TestRequestCoreRelease(unittest.TestCase):
         name, = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2015)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2015)},
             ]
         )
         dataset_name = generate_uuid()
@@ -926,11 +926,11 @@ class TestRequestCoreRelease(unittest.TestCase):
         name1, name2, name3, name4, name5 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2000)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2015)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2010)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2018)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2000)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2015)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2010)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2018)},
             ]
         )
         dataset_1_name = generate_uuid()
@@ -960,11 +960,11 @@ class TestRequestCoreRelease(unittest.TestCase):
         name1, name2, name3, name4 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2000)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2000)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
                 # 2021: requested after the request below but small enough for max_volume check
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2021)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020), 'attributes': {'bytes': 3000}},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2021)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020), 'attributes': {'bytes': 3000}},
             ]
         )
         dataset_1_name = generate_uuid()
@@ -998,10 +998,10 @@ class TestRequestCoreRelease(unittest.TestCase):
         name1, name2, name3, name4 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2000)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020), 'attributes': {'bytes': 2}},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2000)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020), 'attributes': {'bytes': 2}},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
         dataset_1_name = generate_uuid()
@@ -1030,8 +1030,8 @@ class TestRequestCoreRelease(unittest.TestCase):
         name1, name2 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now() - timedelta(hours=2)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now()},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow() - timedelta(hours=2)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow()},
             ]
         )
 
@@ -1052,8 +1052,8 @@ class TestRequestCoreRelease(unittest.TestCase):
         name1, name2 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2018)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2018)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
         preparer.run_once(session=self.db_session, logger=print)
@@ -1074,21 +1074,21 @@ class TestRequestCoreRelease(unittest.TestCase):
                 {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2018),
+                    'requested_at': datetime.utcnow().replace(year=2018),
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                     'attributes': {'activity': 'ignore'},
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2020),
+                    'requested_at': datetime.utcnow().replace(year=2020),
                     'account': InternalAccount('jdoe', **self.vo),
                 }, {
                     'source_rse_id': self.source_rse_id,
                     'dest_rse_id': self.dest_rse_id,
-                    'requested_at': datetime.now().replace(year=2020),  # requested latest but account and activity are correct
+                    'requested_at': datetime.utcnow().replace(year=2020),  # requested latest but account and activity are correct
                 },
             ]
         )
@@ -1109,8 +1109,8 @@ class TestRequestCoreRelease(unittest.TestCase):
         name1, name2 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2018)},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now().replace(year=2020)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2018)},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
         preparer.run_once(session=self.db_session, logger=print)
@@ -1130,8 +1130,8 @@ class TestRequestCoreRelease(unittest.TestCase):
         name1, name2 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now() - two_hours},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now()},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow() - two_hours},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow()},
             ]
         )
         preparer.run_once(session=self.db_session, logger=print)
@@ -1146,9 +1146,9 @@ class TestRequestCoreRelease(unittest.TestCase):
         name1, name2, name3 = _add_test_replicas_and_request(
             vo=self.vo, scope=self.scope, account=self.account, session=self.db_session,
             request_configs=[
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now() - two_hours},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now()},
-                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.now()},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow() - two_hours},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow()},
+                {'source_rse_id': self.source_rse_id, 'dest_rse_id': self.dest_rse_id, 'requested_at': datetime.utcnow()},
             ]
         )
         dataset_name = generate_uuid()

--- a/lib/rucio/transfertool/globus_library.py
+++ b/lib/rucio/transfertool/globus_library.py
@@ -101,7 +101,7 @@ def bulk_submit_xfer(submitjob, recursive=False, logger=logging.log):
     tc = TransferClient(authorizer=authorizer)
 
     # make job_label for task a timestamp
-    now = datetime.datetime.now()
+    now = datetime.datetime.utcnow()
     job_label = now.strftime('%Y%m%d%H%M%s')
 
     # retrieve globus_task_deadline value to enforce time window to complete transfers


### PR DESCRIPTION
According to the [Rucio Documentation](https://rucio.cern.ch/documentation/developing_with_rucio/#date-format) the server should treat all naive datetime objects as UTC.  Unfortunately, `datetime.now()` was used extensively, which returns the server's local time instead of UTC time. This could for instance cause rules to expire some hours too late or early.

This commit replaces many calls to `datetime.now` with calls to `datetime.utcnow`. Some calls to `datetime.now` are left behind, these are in most cases used for measuring elapsed time, though some are also left where they concern file modification times, which are in the local time zone.

The PR contains three commits, the last two of which are somewhat unrelated changes which could be 1) squashed into the main commit or 2) moved to separate PRs if desired.