### PR TITLE
Transfers: don't skip intermediate hop CO messages from FTS. Fix #5792

### DIFF
--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -71,7 +71,7 @@ class Receiver(object):
            and 'issuer' in msg['job_metadata'].keys() \
            and str(msg['job_metadata']['issuer']) == str('rucio'):
 
-            if 'job_state' in msg.keys() and str(msg['job_state']) != str('ACTIVE'):
+            if 'job_state' in msg.keys() and (str(msg['job_state']) != str('ACTIVE') or msg.get('job_multihop', False) is True):
                 record_counter('daemons.conveyor.receiver.message_rucio')
 
                 self._perform_request_update(msg)


### PR DESCRIPTION
The last major FTS release started to correctly fill "job_state"
for those messages as "ACTIVE". This is a behavioral change which
makes rucio skip those messages.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
