### PR TITLE
Testing: fix bootstrap_tests, remote_dbs test_suites, influx elastic test containers #5696

### DIFF
--- a/etc/docker/test/matrix.yml
+++ b/etc/docker/test/matrix.yml
@@ -4,6 +4,9 @@ dists:
       python:
         - "3.6"
         - "3.7"
+    deny:
+      suites:
+        - sqlite
   - id: fedora32
     allow:
       python:

--- a/etc/docker/test/matrix.yml
+++ b/etc/docker/test/matrix.yml
@@ -47,6 +47,8 @@ suites:
       - oracle
       - mysql8
       - postgres14
+    services:
+      - influxdb_elastic
   - id: sqlite
     RDBMS:
       - sqlite

--- a/etc/docker/test/matrix_nightly.yml
+++ b/etc/docker/test/matrix_nightly.yml
@@ -4,6 +4,9 @@ dists:
       python:
         - "3.6"
         - "3.7"
+    deny:
+      suites:
+        - sqlite
   - id: fedora32
     allow:
       python:

--- a/etc/docker/test/matrix_nightly.yml
+++ b/etc/docker/test/matrix_nightly.yml
@@ -27,13 +27,18 @@ suites:
     RUN_HTTPD: false
   - id: client
     RDBMS: sqlite
-  - id: all
+  - id: remote_dbs
     RDBMS:
       - oracle
       - mysql8
       - postgres14
+    services:
+      - influxdb_elastic
+  - id: sqlite
+    RDBMS:
       - sqlite
   - id: multi_vo
     RDBMS: postgres14
+    RUCIO_HOME: /opt/rucio/etc/multi_vo/tst
 image_identifier:
   - autotest

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -20,6 +20,7 @@ import os
 import tempfile
 from random import choice
 from string import ascii_uppercase
+import requests
 
 import pytest
 
@@ -35,6 +36,27 @@ skip_multivo = pytest.mark.skipif('SUITE' in os.environ and os.environ['SUITE'] 
 skip_non_belleii = pytest.mark.skipif(not ('POLICY' in os.environ and os.environ['POLICY'] == 'belleii'),
                                       reason="specific belleii tests")
 
+def is_influxdb_available():
+    """Return True if influxdb is available, else return False."""
+    try:
+        response = requests.get('http://localhost:8086/ping')
+        if response.status_code == 204:
+            return True
+    except requests.exceptions.ConnectionError:
+        print('InfluxDB is not running at localhost:8086')
+        return False
+
+def is_elasticsearch_available():
+    """Return True if elasticsearch is available, else return False."""
+    try:
+        response = requests.get('http://localhost:9200/')
+        if response.status_code == 200:
+            return True
+    except requests.exceptions.ConnectionError:
+        print('Elasticsearch is not running at localhost:9200')
+        return False
+
+skip_missing_elasticsearch_influxdb_in_env = pytest.mark.skipif(not (is_influxdb_available() and is_elasticsearch_available()), reason='influxdb is not available')
 
 def get_long_vo():
     """ Get the VO name from the config file for testing.

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -36,6 +36,7 @@ skip_multivo = pytest.mark.skipif('SUITE' in os.environ and os.environ['SUITE'] 
 skip_non_belleii = pytest.mark.skipif(not ('POLICY' in os.environ and os.environ['POLICY'] == 'belleii'),
                                       reason="specific belleii tests")
 
+
 def is_influxdb_available():
     """Return True if influxdb is available, else return False."""
     try:
@@ -45,6 +46,7 @@ def is_influxdb_available():
     except requests.exceptions.ConnectionError:
         print('InfluxDB is not running at localhost:8086')
         return False
+
 
 def is_elasticsearch_available():
     """Return True if elasticsearch is available, else return False."""
@@ -56,7 +58,9 @@ def is_elasticsearch_available():
         print('Elasticsearch is not running at localhost:9200')
         return False
 
+
 skip_missing_elasticsearch_influxdb_in_env = pytest.mark.skipif(not (is_influxdb_available() and is_elasticsearch_available()), reason='influxdb is not available')
+
 
 def get_long_vo():
     """ Get the VO name from the config file for testing.

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -39,7 +39,7 @@ class TestBinRucio(unittest.TestCase):
     def conf_vo(self):
         self.vo = {}
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            if environ.get('SUITE', 'all') != 'client':
+            if environ.get('SUITE', 'remote_dbs') != 'client':
                 # Server test, we can use short VO via DB for internal tests
                 from rucio.tests.common_server import get_vo
                 self.vo = {'vo': get_vo()}
@@ -344,7 +344,7 @@ class TestBinRucio(unittest.TestCase):
 
         # removing replica -> file on RSE should be overwritten
         # (simulating an upload error, where a part of the file is uploaded but the replica is not registered)
-        if environ.get('SUITE', 'all') != 'client':
+        if environ.get('SUITE', 'remote_dbs') != 'client':
             from rucio.db.sqla import session, models
             db_session = session.get_session()
             internal_scope = InternalScope(self.user, **self.vo)

--- a/lib/rucio/tests/test_hermes.py
+++ b/lib/rucio/tests/test_hermes.py
@@ -28,7 +28,7 @@ import time
 from rucio.common.config import config_get
 from rucio.core.message import add_message, retrieve_messages, truncate_messages
 from rucio.daemons.hermes import hermes, hermes2
-from rucio.tests.common import rse_name_generator
+from rucio.tests.common import rse_name_generator, skip_missing_elasticsearch_influxdb_in_env
 
 
 class MyListener(object):
@@ -51,6 +51,7 @@ class MyListener(object):
         self.messages.append(loads(message))
 
 
+@skip_missing_elasticsearch_influxdb_in_env
 @pytest.mark.noparallel(reason="fails when run in parallel")
 @pytest.mark.parametrize(
     "core_config_mock",
@@ -101,6 +102,7 @@ def test_hermes(core_config_mock, caches_mock):
 
 
 @pytest.mark.noparallel(reason="fails when run in parallel")
+@skip_missing_elasticsearch_influxdb_in_env
 @pytest.mark.parametrize(
     "core_config_mock",
     [

--- a/tools/bootstrap_tests.py
+++ b/tools/bootstrap_tests.py
@@ -64,6 +64,7 @@ def belleii_bootstrap(client):
             except Exception as err:
                 print(err)
 
+
 def is_influxdb_available():
     try:
         response = requests.get('http://localhost:8086/ping')
@@ -72,6 +73,7 @@ def is_influxdb_available():
     except requests.exceptions.ConnectionError:
         print('InfluxDB is not running at localhost:8086')
         return False
+
 
 def create_influxdb_database():
     response = requests.get('http://localhost:8086/api/v2/buckets?org=rucio', headers={'Authorization': 'Token mytoken'})

--- a/tools/bootstrap_tests.py
+++ b/tools/bootstrap_tests.py
@@ -64,6 +64,14 @@ def belleii_bootstrap(client):
             except Exception as err:
                 print(err)
 
+def is_influxdb_available():
+    try:
+        response = requests.get('http://localhost:8086/ping')
+        if response.status_code == 204:
+            return True
+    except requests.exceptions.ConnectionError:
+        print('InfluxDB is not running at localhost:8086')
+        return False
 
 def create_influxdb_database():
     response = requests.get('http://localhost:8086/api/v2/buckets?org=rucio', headers={'Authorization': 'Token mytoken'})
@@ -148,6 +156,7 @@ if __name__ == '__main__':
     if os.getenv('POLICY') == 'belleii':
         belleii_bootstrap(client)
 
-    response = create_influxdb_database()
-    if response.status_code != 201:
-        print('Failed to create rucio database in influxDB : %s' % response.text)
+    if is_influxdb_available():
+        response = create_influxdb_database()
+        if response.status_code != 201:
+            print('Failed to create rucio database in influxDB : %s' % response.text)

--- a/tools/test/before_script.sh
+++ b/tools/test/before_script.sh
@@ -30,9 +30,7 @@ RESTART_HTTPD=0
 if [ $RDBMS == "oracle" ]; then
     CON_ORACLE=$(docker $CONTAINER_RUNTIME_ARGS run --no-healthcheck -d $CONTAINER_RUN_ARGS -e processes=1000 -e sessions=1105 -e transactions=1215 -e ORACLE_ALLOW_REMOTE=true -e ORACLE_PASSWORD=oracle -e ORACLE_DISABLE_ASYNCH_IO=true docker.io/gvenzl/oracle-xe:18.4.0)
     docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS docker.io/webcenter/activemq:latest
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e DOCKER_INFLUXDB_INIT_MODE=setup -e DOCKER_INFLUXDB_INIT_USERNAME=myusername -e DOCKER_INFLUXDB_INIT_PASSWORD=passwordpasswordpassword -e DOCKER_INFLUXDB_INIT_ORG=rucio -e DOCKER_INFLUXDB_INIT_BUCKET=rucio -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken influxdb:latest
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e discovery.type=single-node docker.elastic.co/elasticsearch/elasticsearch:6.4.2
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 oracle activemq influxdb elasticsearch >> /etc/hosts'
+    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 oracle activemq >> /etc/hosts'
     docker $CONTAINER_RUNTIME_ARGS cp tools/test/oracle_setup.sh ${CON_ORACLE}:/
     date
     ORACLE_STARTUP_STRING="DATABASE IS READY TO USE"
@@ -57,9 +55,7 @@ if [ $RDBMS == "oracle" ]; then
 elif [ $RDBMS == "mysql5" ]; then
     CON_MYSQL=$(docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e MYSQL_ROOT_PASSWORD=secret -e MYSQL_ROOT_HOST=% docker.io/mysql/mysql-server:5.7)
     docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS docker.io/webcenter/activemq:latest
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e DOCKER_INFLUXDB_INIT_MODE=setup -e DOCKER_INFLUXDB_INIT_USERNAME=myusername -e DOCKER_INFLUXDB_INIT_PASSWORD=passwordpasswordpassword -e DOCKER_INFLUXDB_INIT_ORG=rucio -e DOCKER_INFLUXDB_INIT_BUCKET=rucio -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken influxdb:latest
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e discovery.type=single-node docker.elastic.co/elasticsearch/elasticsearch:6.4.2
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 mysql5 activemq influxdb elasticsearch >> /etc/hosts'
+    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 mysql5 activemq >> /etc/hosts'
 
     date
     for i in {1..30}; do
@@ -79,9 +75,7 @@ elif [ $RDBMS == "mysql5" ]; then
 elif [ $RDBMS == "mysql8" ]; then
     CON_MYSQL=$(docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e MYSQL_ROOT_PASSWORD=secret -e MYSQL_ROOT_HOST=% docker.io/mysql/mysql-server:8.0 --default-authentication-plugin=mysql_native_password --character-set-server=latin1)
     docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS docker.io/webcenter/activemq:latest
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e DOCKER_INFLUXDB_INIT_MODE=setup -e DOCKER_INFLUXDB_INIT_USERNAME=myusername -e DOCKER_INFLUXDB_INIT_PASSWORD=passwordpasswordpassword -e DOCKER_INFLUXDB_INIT_ORG=rucio -e DOCKER_INFLUXDB_INIT_BUCKET=rucio -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken influxdb:latest
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e discovery.type=single-node docker.elastic.co/elasticsearch/elasticsearch:6.4.2
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 mysql8 activemq influxdb elasticsearch >> /etc/hosts'
+    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 mysql8 activemq >> /etc/hosts'
 
     date
     for i in {1..30}; do
@@ -101,9 +95,7 @@ elif [ $RDBMS == "mysql8" ]; then
 elif [ $RDBMS == "postgres14" ]; then
     CON_POSTGRES=$(docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e POSTGRES_PASSWORD=secret docker.io/postgres:14 -c 'max_connections=300')
     docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS docker.io/webcenter/activemq:latest
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e DOCKER_INFLUXDB_INIT_MODE=setup -e DOCKER_INFLUXDB_INIT_USERNAME=myusername -e DOCKER_INFLUXDB_INIT_PASSWORD=passwordpasswordpassword -e DOCKER_INFLUXDB_INIT_ORG=rucio -e DOCKER_INFLUXDB_INIT_BUCKET=rucio -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken influxdb:latest
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e discovery.type=single-node docker.elastic.co/elasticsearch/elasticsearch:6.4.2
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 postgres14 activemq influxdb elasticsearch >> /etc/hosts'
+    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 postgres14 activemq >> /etc/hosts'
 
     date
     for i in {1..30}; do
@@ -128,9 +120,7 @@ elif [ $RDBMS == "postgres14" ]; then
 
 elif [ $RDBMS == "sqlite" ]; then
     docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS docker.io/webcenter/activemq:latest
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e DOCKER_INFLUXDB_INIT_MODE=setup -e DOCKER_INFLUXDB_INIT_USERNAME=myusername -e DOCKER_INFLUXDB_INIT_PASSWORD=passwordpasswordpassword -e DOCKER_INFLUXDB_INIT_ORG=rucio -e DOCKER_INFLUXDB_INIT_BUCKET=rucio -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken influxdb:latest
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e discovery.type=single-node docker.elastic.co/elasticsearch/elasticsearch:6.4.2
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 activemq influxdb elasticsearch >> /etc/hosts'
+    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 activemq >> /etc/hosts'
 
     docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO cp /usr/local/src/rucio/etc/docker/test/extra/rucio_sqlite.cfg /opt/rucio/etc/rucio.cfg
     docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO cp /usr/local/src/rucio/etc/docker/test/extra/alembic_sqlite.ini /opt/rucio/etc/alembic.ini
@@ -139,6 +129,12 @@ fi
 
 if [ "$RESTART_HTTPD" == "1" ]; then
     docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO httpd -k restart
+fi
+
+if [ "$SERVICES" == "influxdb_elastic" ]; then
+docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e DOCKER_INFLUXDB_INIT_MODE=setup -e DOCKER_INFLUXDB_INIT_USERNAME=myusername -e DOCKER_INFLUXDB_INIT_PASSWORD=passwordpasswordpassword -e DOCKER_INFLUXDB_INIT_ORG=rucio -e DOCKER_INFLUXDB_INIT_BUCKET=rucio -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken influxdb:latest
+docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e discovery.type=single-node docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 influxdb elasticsearch >> /etc/hosts'
 fi
 
 docker $CONTAINER_RUNTIME_ARGS ps -a

--- a/tools/test/matrix_parser.py
+++ b/tools/test/matrix_parser.py
@@ -22,7 +22,7 @@ import typing
 
 import yaml
 
-mapping = {'dists': 'DIST', 'python': 'PYTHON', 'suites': 'SUITE', 'image_identifier': 'IMAGE_IDENTIFIER'}
+mapping = {'dists': 'DIST', 'python': 'PYTHON', 'suites': 'SUITE', 'image_identifier': 'IMAGE_IDENTIFIER', 'services': 'SERVICES'}
 
 
 def extract_mapped_list(inp: typing.Dict):

--- a/tools/test/test.sh
+++ b/tools/test/test.sh
@@ -54,7 +54,7 @@ elif [[ "$SUITE" =~ ^client.* ]]; then
         tools/test/check_syntax.sh
     fi
 
-elif [ "$SUITE" == "all" ]; then
+elif [ "$SUITE" == "remote_dbs" ] || [ "$SUITE" == "sqlite" ]; then
     tools/run_tests_docker.sh
 
 elif [ "$SUITE" == "multi_vo" ]; then


### PR DESCRIPTION
Your highness @bziemons, @rcarpa, please find for your noble consideration, this PR that addresses the following:

- The test suite 'all' was split into `remote_dbs` and `sqlite`. The required changes have been propogated to matrix_nightly.yaml and test.sh to initialize the test environment

- A 'services' statement has been introduced in the test matrix to specify additional services required by the test suites.

- A new `service` called `influxdb_elastic` has been added to matrix.yml and matrix_nightly.yaml

- A new `skipif` condition is defined to execute a test only when `influxdb_elastic` services are present

- test_hermes will only execute if elastic search and influxdb are present in the runtime environment on ports 8086 and 9200 respectively

- bootstrap_tests.py will only initialize influxdb if an influxdb instance is reachable on port 8086. This should fix the connection errors in cases where influxdb is not available.

- remove test suite `all` from `test_rucio_bin` #5712
- disable sqlite for centos7 in matrix.yml and matrix_nightly.yml #5696


