### PR TITLE
Transfer queued message does not include the correct services : Closes #5772

### DIFF
--- a/lib/rucio/core/message.py
+++ b/lib/rucio/core/message.py
@@ -15,6 +15,8 @@
 
 import json
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import or_, delete, update
 from sqlalchemy.exc import IntegrityError
 
@@ -26,9 +28,16 @@ from rucio.db.sqla import filter_thread_work
 from rucio.db.sqla.models import Message, MessageHistory
 from rucio.db.sqla.session import transactional_session
 
+if TYPE_CHECKING:
+    from typing import Any, Dict, List, Optional
+    from sqlalchemy.orm import Session
+
+    MessageType = Dict[str, Any]
+    MessagesListType = List[MessageType]
+
 
 @transactional_session
-def add_messages(messages, session=None):
+def add_messages(messages: "MessagesListType", session: "Optional[Session]" = None) -> None:
     """
     Add a list of messages to be submitted asynchronously to a message broker.
 
@@ -70,7 +79,7 @@ def add_messages(messages, session=None):
 
 
 @transactional_session
-def add_message(event_type, payload, session=None):
+def add_message(event_type: str, payload: dict, session: "Optional[Session]" = None) -> None:
     """
     Add a message to be submitted asynchronously to a message broker.
 
@@ -84,8 +93,13 @@ def add_message(event_type, payload, session=None):
 
 
 @transactional_session
-def retrieve_messages(bulk=1000, thread=None, total_threads=None, event_type=None,
-                      lock=False, old_mode=True, session=None):
+def retrieve_messages(bulk: int = 1000,
+                      thread: "Optional[int]" = None,
+                      total_threads: "Optional[int]" = None,
+                      event_type: "Optional[str]" = None,
+                      lock: bool = False,
+                      old_mode: bool = True,
+                      session: "Optional[Session]" = None) -> "MessagesListType":
     """
     Retrieve up to $bulk messages.
 
@@ -161,7 +175,7 @@ def retrieve_messages(bulk=1000, thread=None, total_threads=None, event_type=Non
 
 
 @transactional_session
-def delete_messages(messages, session=None):
+def delete_messages(messages: "MessagesListType", session: "Optional[Session]" = None) -> None:
     """
     Delete all messages with the given IDs, and archive them to the history.
 
@@ -187,7 +201,7 @@ def delete_messages(messages, session=None):
 
 
 @transactional_session
-def truncate_messages(session=None):
+def truncate_messages(session: "Optional[Session]" = None) -> None:
     """
     Delete all stored messages. This is for internal purposes only.
 
@@ -201,7 +215,7 @@ def truncate_messages(session=None):
 
 
 @transactional_session
-def update_messages_services(messages, services, session=None):
+def update_messages_services(messages: "MessagesListType", services: str, session: "Optional[Session]" = None) -> None:
     """
     Update the services for all messages with the given IDs.
 

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -30,7 +30,7 @@ from rucio.common.config import config_get_bool, config_get
 from rucio.common.exception import RequestNotFound, RucioException, UnsupportedOperation
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid, chunks, get_parsed_throttler_mode
-from rucio.core.message import add_message
+from rucio.core.message import add_message, add_messages
 from rucio.core.monitor import record_counter, record_timer
 from rucio.core.rse import get_rse_name, get_rse_vo, get_rse_transfer_limits, get_rse_attribute, RseData
 from rucio.db.sqla import models, filter_thread_work
@@ -313,7 +313,7 @@ def queue_requests(requests, session=None, logger=logging.log):
                    'queued_at': str(datetime.datetime.utcnow())}
 
         messages.append({'event_type': transfer_status,
-                         'payload': json.dumps(payload)})
+                         'payload': payload})
 
     for requests_chunk in chunks(new_requests, 1000):
         session.bulk_insert_mappings(models.Request, requests_chunk)
@@ -321,8 +321,7 @@ def queue_requests(requests, session=None, logger=logging.log):
     for sources_chunk in chunks(sources, 1000):
         session.bulk_insert_mappings(models.Source, sources_chunk)
 
-    for messages_chunk in chunks(messages, 1000):
-        session.bulk_insert_mappings(models.Message, messages_chunk)
+    add_messages(messages, session=session)
 
     return new_requests
 

--- a/lib/rucio/tests/test_message.py
+++ b/lib/rucio/tests/test_message.py
@@ -16,7 +16,8 @@
 import pytest
 
 from rucio.common.exception import InvalidObject
-from rucio.core.message import add_message, retrieve_messages, delete_messages, truncate_messages
+from rucio.common.utils import generate_uuid
+from rucio.core.message import add_message, add_messages, retrieve_messages, delete_messages, truncate_messages
 
 
 @pytest.mark.noparallel(reason='fails when run in parallel')
@@ -48,35 +49,44 @@ def test_add_message(core_config_mock, caches_mock):
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
     'rucio.core.config.REGION',
 ]}], indirect=True)
-def test_pop_messages(core_config_mock, caches_mock):
-    """ MESSAGE (CORE): Test retrieve and delete messages """
+def test_bulk_insert_and_pop_messages(core_config_mock, caches_mock):
+    """ MESSAGE (CORE): Test bulk insert, retrieve and delete messages """
 
     truncate_messages()
     list_messages = []
+    messages = []
     for cnt in range(10):
-        add_message(event_type='TEST', payload={'foo': True,
-                                                'monty': 'python',
-                                                'number': cnt})
-        list_messages.append((cnt, 'influx'))
-        list_messages.append((cnt, 'activemq'))
-        list_messages.append((cnt, 'elastic'))
+        messages.append(
+            {
+                "event_type": generate_uuid()[:10],
+                "payload": {"foo": True, "monty": "python", "number": cnt},
+            }
+        )
+    add_messages(messages)
 
-    messages = retrieve_messages(30)
+    list_messages = retrieve_messages(40)
+    assert len(list_messages) == 30
     to_delete = []
     for message in messages:
-        assert isinstance(message['payload'], dict)
-        assert message['payload']['foo'] is True
-        assert message['payload']['monty'] == 'python'
-        assert message['payload']['number'] in list(range(10))
-        to_delete.append({'id': message['id'],
-                          'created_at': message['created_at'],
-                          'updated_at': message['created_at'],
-                          'payload': str(message['payload']),
-                          'event_type': message['event_type']})
-        list_messages.remove((message['payload']['number'], message['services']))
-
-    assert list_messages == []
-
+        filtered_messages = [msg for msg in list_messages if msg['event_type'] == message['event_type']]
+        assert len(filtered_messages) == 3
+        services = ['influx', 'activemq', 'elastic']
+        for msg in filtered_messages:
+            assert isinstance(msg['payload'], dict)
+            assert msg['payload']['foo'] is True
+            assert msg['payload']['monty'] == 'python'
+            assert msg['payload']['number'] in list(range(10))
+            assert msg['services'] in services
+            services.remove(msg['services'])
+            to_delete.append(
+                {
+                    "id": msg["id"],
+                    "created_at": msg["created_at"],
+                    "updated_at": msg["created_at"],
+                    "payload": str(msg["payload"]),
+                    "event_type": msg["event_type"],
+                }
+            )
     delete_messages(to_delete)
 
     assert retrieve_messages() == []


### PR DESCRIPTION
This patch introduce a new bulk `add_messages` method to replace the `bulk_insert_mappings` into `Messages` used in `queue_requests`. Closes #5772
In addition 2 extra tests are added to check that handling of jumbo payload is done properly and that submission to non supported services will break.