### PR TITLE
testing: enable py37py38 tests #5349

### DIFF
--- a/tools/test/test.sh
+++ b/tools/test/test.sh
@@ -54,7 +54,7 @@ elif [[ "$SUITE" =~ ^client.* ]]; then
         tools/test/check_syntax.sh
     fi
 
-elif [ "$SUITE" == "remote_dbs" ] || [ "$SUITE" == "sqlite" ]; then
+elif [ "$SUITE" == "remote_dbs" ] || [ "$SUITE" == "sqlite" ] || [ "$SUITE" == "py37py38" ]; then
     tools/run_tests_docker.sh
 
 elif [ "$SUITE" == "multi_vo" ]; then


### PR DESCRIPTION
In https://github.com/rucio/rucio/pull/5350 , `py3738` test suite was added but it was not enabled.
This PR initializes and runs tests for `py3738` test suite
