### PR TITLE
Testing: Improve manually running autotests; #4047

### DIFF
--- a/etc/docker/dev/docker-compose-storage-externalmetadata.yml
+++ b/etc/docker/dev/docker-compose-storage-externalmetadata.yml
@@ -124,7 +124,7 @@ services:
     image: docker.io/mongo:5.0
     network_mode: "service:rucio"
   influxdb:
-    image: influxdb:latest
+    image: docker.io/influxdb:latest
     network_mode: "service:rucio"
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     image: docker.io/graphiteapp/graphite-statsd
     network_mode: "service:rucio"
   influxdb:
-    image: influxdb:latest
+    image: docker.io/influxdb:latest
     network_mode: "service:rucio"
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup

--- a/etc/docker/test/matrix.yml
+++ b/etc/docker/test/matrix.yml
@@ -16,14 +16,7 @@ dists:
       python:
         - "3.9"
 python:
-  - id: "3.6"
-    allow:
-      suites:
-        - syntax
-        - docs
-        - client_syntax
-        - remote_dbs
-        - multi_vo
+  - "3.6"
   - id: "3.7"
     allow:
       suites:

--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -45,7 +45,7 @@ class TestBinRucio:
     def conf_vo(self):
         self.vo = {}
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-            if environ.get('SUITE', 'remote_dbs') != 'client':
+            if 'SUITE' not in environ or environ['SUITE'] != 'client':
                 # Server test, we can use short VO via DB for internal tests
                 from rucio.tests.common_server import get_vo
                 self.vo = {'vo': get_vo()}
@@ -353,7 +353,7 @@ class TestBinRucio:
 
         # removing replica -> file on RSE should be overwritten
         # (simulating an upload error, where a part of the file is uploaded but the replica is not registered)
-        if environ.get('SUITE', 'remote_dbs') != 'client':
+        if 'SUITE' not in environ or environ['SUITE'] != 'client':
             from rucio.db.sqla import session, models
             db_session = session.get_session()
             internal_scope = InternalScope(self.user, **self.vo)

--- a/tools/run_autotests.sh
+++ b/tools/run_autotests.sh
@@ -16,37 +16,6 @@
 
 set -euo pipefail
 IFS=$'\n\t'
+DONKEY_RIDER="$(dirname "$0")/test/donkeyrider.py"
 
-USE_PODMAN=${USE_PODMAN-}
-if [ -z "$USE_PODMAN" ]; then
-    if [ -x /usr/bin/podman -a ! -x /usr/bin/docker ] || grep -q /usr/bin/podman /usr/bin/docker; then
-        echo "Detected podman environment"
-        export USE_PODMAN=1
-    fi
-fi
-
-PARALLEL_AUTOTESTS=${PARALLEL_AUTOTESTS-}
-if [ "x$PARALLEL_AUTOTESTS" != "xfalse" -a "x$PARALLEL_AUTOTESTS" != "x0" ]; then
-    echo "Tests will run in parallel"
-    export PARALLEL_AUTOTESTS=1
-fi
-
-# fetch project directory relatively to this file
-PROJECT_DIR="$(dirname $0)/.."
-MATRIX_FILE=${1:-"$PROJECT_DIR/etc/docker/test/matrix.yml"}
-
-MATRIX=`"$PROJECT_DIR/tools/test/matrix_parser.py" < $MATRIX_FILE`
-if [ -z "$MATRIX" ]; then
-    echo "Matrix could not be determined"
-    exit 1
-fi
-
-IMAGES=`echo $MATRIX | nice "$PROJECT_DIR/tools/test/build_images.py" "$PROJECT_DIR/etc/docker/test"`
-if [ -z "$IMAGES" ]; then
-    echo "Images could not be built"
-    exit 1
-fi
-
-RUN_TESTS_JSON="{\"matrix\": $MATRIX, \"images\": $IMAGES}"
-echo "$RUN_TESTS_JSON"
-echo "$RUN_TESTS_JSON" | nice "$PROJECT_DIR/tools/test/run_tests.py"
+exec "${DONKEY_RIDER}" "$@"

--- a/tools/test/before_script.sh
+++ b/tools/test/before_script.sh
@@ -28,39 +28,32 @@ echo
 RESTART_HTTPD=0
 
 if [ $RDBMS == "oracle" ]; then
-    CON_ORACLE=$(docker $CONTAINER_RUNTIME_ARGS run --no-healthcheck -d $CONTAINER_RUN_ARGS -e processes=1000 -e sessions=1105 -e transactions=1215 -e ORACLE_ALLOW_REMOTE=true -e ORACLE_PASSWORD=oracle -e ORACLE_DISABLE_ASYNCH_IO=true docker.io/gvenzl/oracle-xe:18.4.0)
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS docker.io/webcenter/activemq:latest
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 oracle activemq >> /etc/hosts'
-    docker $CONTAINER_RUNTIME_ARGS cp tools/test/oracle_setup.sh ${CON_ORACLE}:/
+    docker $CONTAINER_RUNTIME_ARGS cp tools/test/oracle_setup.sh ${CON_DB}:/
     date
     ORACLE_STARTUP_STRING="DATABASE IS READY TO USE"
     for i in {1..60}; do
         sleep 2
-        cont=$(bash -c 'docker '"$CONTAINER_RUNTIME_ARGS"' logs '"$CON_ORACLE"' | grep "'"$ORACLE_STARTUP_STRING"'" | wc -l')
+        cont=$(bash -c 'docker '"$CONTAINER_RUNTIME_ARGS"' logs '"$CON_DB"' | grep "'"$ORACLE_STARTUP_STRING"'" | wc -l')
         [ "$cont" -eq "1" ] && break
     done
     date
     if [ "$cont" -ne "1" ]; then
         echo "Oracle did not start up in time."
-        docker $CONTAINER_RUNTIME_ARGS logs $CON_ORACLE || true
+        docker $CONTAINER_RUNTIME_ARGS logs $CON_DB || true
         exit 1
     fi
     sleep 3
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_ORACLE /oracle_setup.sh
+    docker $CONTAINER_RUNTIME_ARGS exec $CON_DB /oracle_setup.sh
     sleep 3
     docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO cp /usr/local/src/rucio/etc/docker/test/extra/rucio_oracle.cfg /opt/rucio/etc/rucio.cfg
     docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO cp /usr/local/src/rucio/etc/docker/test/extra/alembic_oracle.ini /opt/rucio/etc/alembic.ini
     RESTART_HTTPD=1
 
 elif [ $RDBMS == "mysql5" ]; then
-    CON_MYSQL=$(docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e MYSQL_ROOT_PASSWORD=secret -e MYSQL_ROOT_HOST=% docker.io/mysql/mysql-server:5.7)
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS docker.io/webcenter/activemq:latest
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 mysql5 activemq >> /etc/hosts'
-
     date
     for i in {1..30}; do
         sleep 2
-        cont=$(bash -c 'ping=`docker '"$CONTAINER_RUNTIME_ARGS"' exec '"$CON_MYSQL"' mysqladmin --user=root --password=secret ping`; echo $ping 1>&2; echo $ping | grep "mysqld is alive" 1>&2; echo $?')
+        cont=$(bash -c 'ping=`docker '"$CONTAINER_RUNTIME_ARGS"' exec '"$CON_DB"' mysqladmin --user=root --password=secret ping`; echo $ping 1>&2; echo $ping | grep "mysqld is alive" 1>&2; echo $?')
         [ "$cont" -eq "0" ] && break
     done
     date
@@ -73,14 +66,10 @@ elif [ $RDBMS == "mysql5" ]; then
     RESTART_HTTPD=1
 
 elif [ $RDBMS == "mysql8" ]; then
-    CON_MYSQL=$(docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e MYSQL_ROOT_PASSWORD=secret -e MYSQL_ROOT_HOST=% docker.io/mysql/mysql-server:8.0 --default-authentication-plugin=mysql_native_password --character-set-server=latin1)
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS docker.io/webcenter/activemq:latest
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 mysql8 activemq >> /etc/hosts'
-
     date
     for i in {1..30}; do
         sleep 4
-        cont=$(bash -c 'ping=`docker '"$CONTAINER_RUNTIME_ARGS"' exec '"$CON_MYSQL"' mysqladmin --user=root --password=secret ping`; echo $ping 1>&2; echo $ping | grep "mysqld is alive" 1>&2; echo $?')
+        cont=$(bash -c 'ping=`docker '"$CONTAINER_RUNTIME_ARGS"' exec '"$CON_DB"' mysqladmin --user=root --password=secret ping`; echo $ping 1>&2; echo $ping | grep "mysqld is alive" 1>&2; echo $?')
         [ "$cont" -eq "0" ] && break
     done
     date
@@ -93,14 +82,10 @@ elif [ $RDBMS == "mysql8" ]; then
     RESTART_HTTPD=1
 
 elif [ $RDBMS == "postgres14" ]; then
-    CON_POSTGRES=$(docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e POSTGRES_PASSWORD=secret docker.io/postgres:14 -c 'max_connections=300')
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS docker.io/webcenter/activemq:latest
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 postgres14 activemq >> /etc/hosts'
-
     date
     for i in {1..30}; do
         sleep 1
-        cont=$(bash -c 'docker '"$CONTAINER_RUNTIME_ARGS"' exec '"$CON_POSTGRES"' pg_isready 1>&2; echo $?')
+        cont=$(bash -c 'docker '"$CONTAINER_RUNTIME_ARGS"' exec '"$CON_DB"' pg_isready 1>&2; echo $?')
         [ "$cont" -eq "0" ] && break
     done
     date
@@ -119,9 +104,6 @@ elif [ $RDBMS == "postgres14" ]; then
     RESTART_HTTPD=1
 
 elif [ $RDBMS == "sqlite" ]; then
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS docker.io/webcenter/activemq:latest
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 activemq >> /etc/hosts'
-
     docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO cp /usr/local/src/rucio/etc/docker/test/extra/rucio_sqlite.cfg /opt/rucio/etc/rucio.cfg
     docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO cp /usr/local/src/rucio/etc/docker/test/extra/alembic_sqlite.ini /opt/rucio/etc/alembic.ini
     RESTART_HTTPD=1
@@ -129,12 +111,6 @@ fi
 
 if [ "$RESTART_HTTPD" == "1" ]; then
     docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO httpd -k restart
-fi
-
-if [ "$SERVICES" == "influxdb_elastic" ]; then
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e DOCKER_INFLUXDB_INIT_MODE=setup -e DOCKER_INFLUXDB_INIT_USERNAME=myusername -e DOCKER_INFLUXDB_INIT_PASSWORD=passwordpasswordpassword -e DOCKER_INFLUXDB_INIT_ORG=rucio -e DOCKER_INFLUXDB_INIT_BUCKET=rucio -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken docker.io/influxdb:latest
-    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e discovery.type=single-node docker.elastic.co/elasticsearch/elasticsearch:6.4.2
-    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 influxdb elasticsearch >> /etc/hosts'
 fi
 
 docker $CONTAINER_RUNTIME_ARGS ps -a

--- a/tools/test/before_script.sh
+++ b/tools/test/before_script.sh
@@ -132,9 +132,9 @@ if [ "$RESTART_HTTPD" == "1" ]; then
 fi
 
 if [ "$SERVICES" == "influxdb_elastic" ]; then
-docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e DOCKER_INFLUXDB_INIT_MODE=setup -e DOCKER_INFLUXDB_INIT_USERNAME=myusername -e DOCKER_INFLUXDB_INIT_PASSWORD=passwordpasswordpassword -e DOCKER_INFLUXDB_INIT_ORG=rucio -e DOCKER_INFLUXDB_INIT_BUCKET=rucio -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken influxdb:latest
-docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e discovery.type=single-node docker.elastic.co/elasticsearch/elasticsearch:6.4.2
-docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 influxdb elasticsearch >> /etc/hosts'
+    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e DOCKER_INFLUXDB_INIT_MODE=setup -e DOCKER_INFLUXDB_INIT_USERNAME=myusername -e DOCKER_INFLUXDB_INIT_PASSWORD=passwordpasswordpassword -e DOCKER_INFLUXDB_INIT_ORG=rucio -e DOCKER_INFLUXDB_INIT_BUCKET=rucio -e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken docker.io/influxdb:latest
+    docker $CONTAINER_RUNTIME_ARGS run -d $CONTAINER_RUN_ARGS -e discovery.type=single-node docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+    docker $CONTAINER_RUNTIME_ARGS exec $CON_RUCIO sh -c 'echo 127.0.0.1 influxdb elasticsearch >> /etc/hosts'
 fi
 
 docker $CONTAINER_RUNTIME_ARGS ps -a

--- a/tools/test/build_images.py
+++ b/tools/test/build_images.py
@@ -74,7 +74,6 @@ def build_images(matrix, script_args):
                 args = ('docker', 'pull', imagetag)
                 print("Running", " ".join(args), file=sys.stderr, flush=True)
                 subprocess.run(args, stdout=sys.stderr, check=False)
-                cache_args = ('--cache-from', imagetag)
 
             # add image to output
             images[imagetag] = {DIST_KEY: dist, **buildargs._asdict()}

--- a/tools/test/donkeyrider.py
+++ b/tools/test/donkeyrider.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import signal
+import sys
+
+stop = False
+
+
+def shutdown(signum, frame):
+    global stop
+    stop = True
+    print("Caught", signal.Signals(signum).name + ". Stopping..", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    if 'USE_PODMAN' not in os.environ or os.environ['USE_PODMAN'] == "":
+        docker_executable = shutil.which("docker")
+        podman_executable = shutil.which("podman")
+        if docker_executable and podman_executable:
+            with open(docker_executable, 'br') as fhandle:
+                if podman_executable.encode() in fhandle.read():
+                    os.environ['USE_PODMAN'] = "1"
+        elif docker_executable:
+            os.environ['USE_PODMAN'] = "0"
+        elif podman_executable:
+            os.environ['USE_PODMAN'] = "1"
+        else:
+            print("No compatible container executable (podman/docker) found! Exiting..", file=sys.stderr)
+            sys.exit(1)
+
+    if 'PARALLEL_AUTOTESTS' not in os.environ or (os.environ['PARALLEL_AUTOTESTS'] not in ['false', '0']):
+        print("Tests will run in parallel", file=sys.stderr)
+        os.environ['PARALLEL_AUTOTESTS'] = "1"
+
+    project_dir = os.path.abspath(os.path.join(os.path.abspath(os.path.dirname(__file__)), "../.."))
+    print("Detected project directory", project_dir, file=sys.stderr)
+
+    if len(sys.argv) > 1:
+        matrix_file = sys.argv[1]
+    else:
+        matrix_file = os.path.join(project_dir, "etc/docker/test/matrix.yml")
+    print("Using test matrix from file", matrix_file, file=sys.stderr)
+
+    # make sure the following imports work
+    sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+
+    # matrix parsing
+
+    from matrix_parser import parse_matrix
+
+    with open(matrix_file, 'r') as fhandle:
+        test_matrix = parse_matrix(fhandle)
+
+    if not test_matrix:
+        print("Matrix could not be determined", file=sys.stderr)
+        sys.exit(1)
+
+    # image building
+
+    from build_images import build_main
+
+    images = build_main(test_matrix, ["--download-only", os.path.join(project_dir, "etc/docker/test")])
+
+    if not images:
+        print("Images could not be built", file=sys.stderr)
+
+    # test running
+
+    from run_tests import run_tests
+
+    run_tests(test_matrix, images)
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+    main()

--- a/tools/test/matrix_parser.py
+++ b/tools/test/matrix_parser.py
@@ -49,7 +49,7 @@ def readobj(key: str, val: typing.Dict, denylist: typing.List, allowlist: typing
         del val["deny"]
     if "allow" in val:
         allowlist.append({"key": mapping.get(key, key), "value": itemid,
-                        "allowed": extract_mapped_list(val["allow"])})
+                          "allowed": extract_mapped_list(val["allow"])})
         del val["allow"]
 
     if len(val.keys()) == 0:
@@ -58,8 +58,8 @@ def readobj(key: str, val: typing.Dict, denylist: typing.List, allowlist: typing
         return itemid, val
 
 
-def main():
-    input_conf = dict(yaml.safe_load(sys.stdin))
+def parse_matrix(fhandle) -> "typing.List":
+    input_conf = dict(yaml.safe_load(fhandle))
     denylist = []
     allowlist = []
     mappedkeyvalues = {mapping.get(key, key): [readobj(key, val, denylist, allowlist) for val in input_conf[key]]
@@ -94,7 +94,13 @@ def main():
                                                   denylist)),
                            product_dicts)
 
-    print(json.dumps(list(product_dicts)), file=sys.stdout)
+    return list(product_dicts)
+
+
+def main():
+    """Use stdin and stdout by default"""
+    product_dicts = parse_matrix(sys.stdin)
+    print(json.dumps(product_dicts), file=sys.stdout)
 
 
 if __name__ == "__main__":

--- a/tools/test/suites.py
+++ b/tools/test/suites.py
@@ -1,0 +1,264 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import itertools
+import subprocess
+import sys
+import typing
+from typing import Tuple, Optional, Dict, List
+
+DEFAULT_TIMEOUT = 10
+DEFAULT_DB_TIMEOUT = 27
+
+
+def run(*args, check=True, return_stdout=False, env=None) -> typing.Union[typing.NoReturn, io.TextIOBase]:
+    kwargs = {'check': check, 'stdout': sys.stderr, 'stderr': subprocess.STDOUT}
+    if env is not None:
+        kwargs['env'] = env
+    if return_stdout:
+        kwargs['stderr'] = sys.stderr
+        kwargs['stdout'] = subprocess.PIPE
+    args = [str(a) for a in args]
+    print("** Running", " ".join(map(lambda a: repr(a) if ' ' in a else a, args)), kwargs, file=sys.stderr, flush=True)
+    proc = subprocess.run(args, **kwargs)
+    if return_stdout:
+        return proc.stdout
+
+
+def env_args(caseenv):
+    environment_args = list(itertools.chain(*map(lambda x: ('--env', f'{x[0]}={x[1]}'), caseenv.items())))
+    environment_args.append('--env')
+    environment_args.append('GITHUB_ACTIONS')
+    return environment_args
+
+
+class Container:
+    def __init__(
+        self,
+        image: "str",
+        *args,
+        runtime_args: "Optional[List[str]]" = None,
+        run_args: "Optional[List[str]]" = None,
+        environment: "Optional[Dict[str, str]]" = None,
+        stop_timeout: int = DEFAULT_TIMEOUT,
+    ):
+        if runtime_args is None:
+            runtime_args = []
+        self.runtime_args = runtime_args
+        if run_args is None:
+            run_args = []
+        if environment is None:
+            environment = {}
+        self.stop_timeout = stop_timeout
+        self.args = ['docker', *runtime_args, 'run', '--detach', *run_args, *(env_args(environment)), image, *args]
+        self.cid = None
+
+    def __enter__(self):
+        stdout = run(*self.args, return_stdout=True)
+        self.cid = stdout.decode().strip()
+        if not self.cid:
+            raise RuntimeError("Could not determine container id after starting the container")
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        run('docker', *self.runtime_args, 'stop', f'--time={self.stop_timeout}', self.cid, check=False)
+        run('docker', *self.runtime_args, 'rm', '--force', '--volumes', self.cid, check=False)
+
+    def wait(self):
+        run('docker', *self.runtime_args, 'wait', self.cid, check=False)
+
+
+class CumulativeContextManager:
+    def __init__(self, *context_managers):
+        self.context_managers = context_managers
+
+    def __enter__(self):
+        for mgr in self.context_managers:
+            mgr.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for mgr in self.context_managers:
+            mgr.__exit__(exc_type, exc_val, exc_tb)
+
+
+class OracleDB(Container):
+    def __init__(
+        self,
+        runtime_args: "Optional[Tuple[str]]" = None,
+        run_args: "Optional[Tuple[str]]" = None,
+        environment: "Optional[Dict[str, str]]" = None,
+        stop_timeout: int = DEFAULT_DB_TIMEOUT,
+    ):
+        if run_args is None:
+            run_args = tuple()
+        run_args = ("--no-healthcheck",) + run_args
+        if environment is None:
+            environment = dict()
+        environment['processes'] = "1000"
+        environment["sessions"] = "1105"
+        environment["transactions"] = "1215"
+        environment["ORACLE_ALLOW_REMOTE"] = "true"
+        environment["ORACLE_PASSWORD"] = "oracle"
+        environment["ORACLE_DISABLE_ASYNCH_IO"] = "true"
+        super(OracleDB, self).__init__(
+            "docker.io/gvenzl/oracle-xe:18.4.0",
+            runtime_args=runtime_args,
+            run_args=run_args,
+            environment=environment,
+            stop_timeout=stop_timeout,
+        )
+
+
+class MySQL5(Container):
+    def __init__(
+        self,
+        runtime_args: "Optional[Tuple[str]]" = None,
+        run_args: "Optional[Tuple[str]]" = None,
+        environment: "Optional[Dict[str, str]]" = None,
+        stop_timeout: int = DEFAULT_DB_TIMEOUT,
+    ):
+        if environment is None:
+            environment = dict()
+        environment["MYSQL_ROOT_PASSWORD"] = "secret"
+        environment["MYSQL_ROOT_HOST"] = "%"
+        super(MySQL5, self).__init__(
+            "docker.io/mysql/mysql-server:5.7",
+            runtime_args=runtime_args,
+            run_args=run_args,
+            environment=environment,
+            stop_timeout=stop_timeout,
+        )
+
+
+class MySQL8(Container):
+    def __init__(
+        self,
+        runtime_args: "Optional[Tuple[str]]" = None,
+        run_args: "Optional[Tuple[str]]" = None,
+        environment: "Optional[Dict[str, str]]" = None,
+        stop_timeout: int = DEFAULT_DB_TIMEOUT,
+    ):
+        if environment is None:
+            environment = dict()
+        environment["MYSQL_ROOT_PASSWORD"] = "secret"
+        environment["MYSQL_ROOT_HOST"] = "%"
+        super(MySQL8, self).__init__(
+            "docker.io/mysql/mysql-server:8.0",
+            "--default-authentication-plugin=mysql_native_password",
+            "--character-set-server=latin1",
+            runtime_args=runtime_args,
+            run_args=run_args,
+            environment=environment,
+            stop_timeout=stop_timeout,
+        )
+
+
+class Postgres14(Container):
+    def __init__(
+        self,
+        runtime_args: "Optional[Tuple[str]]" = None,
+        run_args: "Optional[Tuple[str]]" = None,
+        environment: "Optional[Dict[str, str]]" = None,
+        stop_timeout: int = DEFAULT_DB_TIMEOUT,
+    ):
+        if environment is None:
+            environment = dict()
+        environment["POSTGRES_PASSWORD"] = "secret"
+        super(Postgres14, self).__init__(
+            "docker.io/postgres:14",
+            "-c", "max_connections=300",
+            runtime_args=runtime_args,
+            run_args=run_args,
+            environment=environment,
+            stop_timeout=stop_timeout,
+        )
+
+
+class ActiveMQ(Container):
+    def __init__(
+        self,
+        runtime_args: "Optional[Tuple[str]]" = None,
+        run_args: "Optional[Tuple[str]]" = None,
+        environment: "Optional[Dict[str, str]]" = None,
+        stop_timeout: int = DEFAULT_DB_TIMEOUT,
+    ):
+        super(ActiveMQ, self).__init__(
+            "docker.io/webcenter/activemq:latest",
+            runtime_args=runtime_args,
+            run_args=run_args,
+            environment=environment,
+            stop_timeout=stop_timeout,
+        )
+
+
+class InfluxDB(Container):
+    def __init__(
+        self,
+        runtime_args: "Optional[Tuple[str]]" = None,
+        run_args: "Optional[Tuple[str]]" = None,
+        environment: "Optional[Dict[str, str]]" = None,
+        stop_timeout: int = DEFAULT_DB_TIMEOUT,
+    ):
+        if environment is None:
+            environment = dict()
+        environment["DOCKER_INFLUXDB_INIT_MODE"] = "setup"
+        environment["DOCKER_INFLUXDB_INIT_USERNAME"] = "myusername"
+        environment["DOCKER_INFLUXDB_INIT_PASSWORD"] = "passwordpasswordpassword"
+        environment["DOCKER_INFLUXDB_INIT_ORG"] = "rucio"
+        environment["DOCKER_INFLUXDB_INIT_BUCKET"] = "rucio"
+        environment["DOCKER_INFLUXDB_INIT_ADMIN_TOKEN"] = "mytoken"
+        super(InfluxDB, self).__init__(
+            "docker.io/influxdb:latest",
+            runtime_args=runtime_args,
+            run_args=run_args,
+            environment=environment,
+            stop_timeout=stop_timeout,
+        )
+
+
+class Elasticsearch(Container):
+    def __init__(
+        self,
+        runtime_args: "Optional[Tuple[str]]" = None,
+        run_args: "Optional[Tuple[str]]" = None,
+        environment: "Optional[Dict[str, str]]" = None,
+        stop_timeout: int = DEFAULT_DB_TIMEOUT,
+    ):
+        if environment is None:
+            environment = dict()
+        environment["discovery.type"] = "single-node"
+        super(Elasticsearch, self).__init__(
+            "docker.elastic.co/elasticsearch/elasticsearch:6.4.2",
+            runtime_args=runtime_args,
+            run_args=run_args,
+            environment=environment,
+            stop_timeout=stop_timeout,
+        )
+
+
+rdbms_container: Dict[str, typing.Any] = {
+    "oracle": OracleDB,
+    "mysql5": MySQL5,
+    "mysql8": MySQL8,
+    "postgres14": Postgres14,
+    "sqlite": None,
+}
+services = {
+    'default': [ActiveMQ],
+    'influxdb_elastic': [ActiveMQ, InfluxDB, Elasticsearch],
+}
+service_hostnames = ['activemq', 'influxdb', 'elasticsearch'] + list(rdbms_container.keys())

--- a/tools/test/test.sh
+++ b/tools/test/test.sh
@@ -55,7 +55,11 @@ elif [[ "$SUITE" =~ ^client.* ]]; then
     fi
 
 elif [ "$SUITE" == "remote_dbs" ] || [ "$SUITE" == "sqlite" ] || [ "$SUITE" == "py37py38" ]; then
-    tools/run_tests_docker.sh
+    if [ -n "$TESTS" ]; then
+        tools/run_tests_docker.sh -p
+    else
+        tools/run_tests_docker.sh
+    fi
 
 elif [ "$SUITE" == "multi_vo" ]; then
     tools/run_multi_vo_tests_docker.sh
@@ -64,6 +68,6 @@ elif [ "$SUITE" == "votest" ]; then
     RUCIO_HOME=/opt/rucio
     VOTEST_HELPER=$RUCIO_HOME/tools/test/votest_helper.py
     VOTEST_CONFIG_FILE=$RUCIO_HOME/etc/docker/test/matrix_policy_package_tests.yml
-    TESTS=$(python $VOTEST_HELPER --vo $POLICY --tests --file $VOTEST_CONFIG_FILE)
-    tools/run_tests_docker.sh -p $TESTS
+    export TESTS=$(python $VOTEST_HELPER --vo $POLICY --tests --file $VOTEST_CONFIG_FILE)
+    tools/run_tests_docker.sh -p
 fi


### PR DESCRIPTION
- Testing: Move tools/run_autotest.sh to donkeyrider.py
- Testing: Cleanup additional containers on termination
- Testing: Enable filtering of test cases
- Testing: Remove --cache-from argument as it works differently nowadays.
  With docker, this needs --build-arg BUILDKIT_INLINE_CACHE=1 and with podman it only works with images built with --cache-to beforehand.

Example usage: `tools/run_autotests.sh --build -s remote_dbs --db postgres14 -d centos7 -f test_replica.py::TestReplicaCore`

I will also update the documentation on https://github.com/rucio/documentation/blob/main/docs/contributing.md

Fixes #4047 

For Your Eminence, @maany to review.