### PR TITLE
Documentation: Add a logo to the REST API docs #4992

### DIFF
--- a/tools/generate_rest_api_doc.py
+++ b/tools/generate_rest_api_doc.py
@@ -101,6 +101,11 @@ spec = APISpec(
             "name": "Apache 2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
         },
+        "x-logo": {
+            "url": "http://rucio.cern.ch/documentation/img/rucio_horizontaled_black_cropped.svg",
+            "backgroundColor": "#FFFFFF",
+            "altText": "Rucio logo"
+        },
     },
 )
 


### PR DESCRIPTION
The REST API docs should use the awesome Rucio logo.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
