### PR TITLE
 Reaper not processing all Epoch tombstone replicas when no space is needed : Closes #5816 

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -2715,7 +2715,7 @@ def list_and_mark_unlocked_replicas(limit, bytes_=None, rse_id=None, delay_secon
         )
 
         for scope, name, path, bytes_, tombstone, state, datatype in session.execute(stmt):
-            if len(rows) >= limit or (needed_space is not None and total_bytes > needed_space):
+            if len(rows) >= limit or (not only_delete_obsolete and needed_space is not None and total_bytes > needed_space):
                 break
             if state != ReplicaState.UNAVAILABLE:
                 total_bytes += bytes_
@@ -2723,7 +2723,7 @@ def list_and_mark_unlocked_replicas(limit, bytes_=None, rse_id=None, delay_secon
             rows.append({'scope': scope, 'name': name, 'path': path,
                          'bytes': bytes_, 'tombstone': tombstone,
                          'state': state, 'datatype': datatype})
-        if len(rows) >= limit or (needed_space is not None and total_bytes > needed_space):
+        if len(rows) >= limit or (not only_delete_obsolete and needed_space is not None and total_bytes > needed_space):
             break
 
     if rows:
@@ -2800,7 +2800,7 @@ def list_and_mark_unlocked_replicas_no_temp_table(limit, bytes_=None, rse_id=Non
             if tombstone != OBSOLETE and only_delete_obsolete:
                 break
 
-            if needed_space is not None and total_bytes > needed_space:
+            if not only_delete_obsolete and needed_space is not None and total_bytes > needed_space:
                 break
 
             if state != ReplicaState.UNAVAILABLE:
@@ -2827,7 +2827,7 @@ def list_and_mark_unlocked_replicas_no_temp_table(limit, bytes_=None, rse_id=Non
                 if tombstone != OBSOLETE and only_delete_obsolete:
                     break
 
-                if needed_space is not None and total_bytes > needed_space:
+                if not only_delete_obsolete and needed_space is not None and total_bytes > needed_space:
                     break
 
                 if state != ReplicaState.UNAVAILABLE:

--- a/lib/rucio/tests/test_reaper.py
+++ b/lib/rucio/tests/test_reaper.py
@@ -428,7 +428,6 @@ def test_archive_of_deleted_dids(vo, did_factory, root_account, core_config_mock
     rse_core.set_rse_limits(rse_id=rse_id, name='MinFreeSpace', value=50 * file_size)
     assert len(list(replica_core.list_replicas(dids=dids, rse_expression=rse_name))) == nb_files
 
-    # Check first if the reaper does not delete anything if no space is needed
     reaper_cache_region.invalidate()
     rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=nb_files * file_size, free=323000000000)
     reaper(once=True, rses=[], include_rses=rse_name, exclude_rses=None, greedy=True)


### PR DESCRIPTION
 Reaper not processing all Epoch tombstone replicas when no space is needed #5816 

The problem is related to the variable `needed_space` in `list_and_mark_unlocked_replicas_no_temp_table` and `list_and_mark_unlocked_replicas`. The tests on this variable are set as `if needed_space is not None and total_bytes > needed_space`, but in the case no space is needed needed_space=0, the loop will exist after the first replica, even though there are still many `EPOCH` tombstone replicas to delete.