### PR TITLE
Core: Fix usage of unused parameter `younger_than` in `core/replica.py` #5847

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -3974,7 +3974,7 @@ def get_suspicious_files(rse_expression, available_elsewhere, filter_=None, logg
     if not isinstance(nattempts, int):
         nattempts = 0
     if not isinstance(younger_than, datetime):
-        younger_than = datetime.now() - timedelta(days=10)
+        younger_than = datetime.now() - timedelta(days=younger_than if younger_than is not None else 10)
 
     # assembling exclude_states_clause
     exclude_states_clause = []


### PR DESCRIPTION
The `younger_than` parameter was not used in case it is not a datetime.
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
