### PR TITLE
feature 4992 resolve rest api doc problems

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -513,6 +513,8 @@ class Account(ErrorHandlingMethodView):
                       email:
                         description: The email.
                         type: string
+          401:
+            description: Invalid Auth Token
         """
 
         def generate(_filter, vo):

--- a/lib/rucio/web/rest/flaskapi/v1/archives.py
+++ b/lib/rucio/web/rest/flaskapi/v1/archives.py
@@ -52,19 +52,19 @@ class Archive(ErrorHandlingMethodView):
                     properties:
                       scope:
                         description: The scope of the did.
-                        type: str
+                        type: string
                       name:
                         description: The name of the did.
-                        type: str
+                        type: string
                       bytes:
                         description: The number of bytes.
                         type: int
                       adler32:
                         description: The adler32 checksum.
-                        type: str
+                        type: string
                       md5:
                         description: The md5 checksum.
-                        type: str
+                        type: string
           400:
             description: Invalid value
           406:

--- a/lib/rucio/web/rest/flaskapi/v1/archives.py
+++ b/lib/rucio/web/rest/flaskapi/v1/archives.py
@@ -58,7 +58,7 @@ class Archive(ErrorHandlingMethodView):
                         type: string
                       bytes:
                         description: The number of bytes.
-                        type: int
+                        type: integer
                       adler32:
                         description: The adler32 checksum.
                         type: string

--- a/lib/rucio/web/rest/flaskapi/v1/credentials.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credentials.py
@@ -44,14 +44,40 @@ class SignURL(ErrorHandlingMethodView):
 
     def options(self):
         """
-        Allow cross-site scripting. Explicit for Authentication.
-
-        :resheader Access-Control-Allow-Origin:
-        :resheader Access-Control-Allow-Headers:
-        :resheader Access-Control-Allow-Methods:
-        :resheader Access-Control-Allow-Credentials:
-        :resheader Access-Control-Expose-Headers:
-        :status 200: OK
+        ---
+        summary: Cross-Site Scripting
+        description: Allow cross-site scripting. Explicit for Authentication.
+        tags:
+          - Credentials
+        responses:
+          200:
+            description: OK
+            headers:
+              Access-Control-Allow-Origin:
+                schema:
+                  type: string
+                description: The http origin.
+              Access-Control-Allow-Headers:
+                schema:
+                  type: string
+                description: The http access controll request headers.
+              Access-Control-Allow-Methods:
+                schema:
+                  type: string
+                  enum: ['*']
+                description: The allowed methods.
+              Access-Control-Allow-Credentials:
+                schema:
+                  type: string
+                  enum: ['true']
+                description: If credentials are allowed.
+              Access-Control-Expose-Headers:
+                schema:
+                  type: string
+                  enum: ['X-Rucio-Auth-Token']
+                description: The exposed access controll header.
+          404:
+            description: Not found
         """
         return '', 200, self.get_headers()
 

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -1309,7 +1309,7 @@ class Meta(ErrorHandlingMethodView):
           description: The plugin to use.
           schema:
             type: string
-          default: DID_COLUMN
+            default: DID_COLUMN
         responses:
           200:
             description: OK
@@ -1355,7 +1355,7 @@ class Meta(ErrorHandlingMethodView):
           content:
             'application/json':
               schema:
-                type:
+                type: object
                 required:
                 - meta
                 properties:
@@ -1485,13 +1485,13 @@ class SingleMeta(ErrorHandlingMethodView):
           content:
             'application/json':
               schema:
-                type:
+                type: object
                 required:
                 - value
                 properties:
                   value:
                     description: The value to set.
-                    type: AnyValue
+                    type: object
         responses:
           201:
             description: Created
@@ -1667,7 +1667,7 @@ class BulkMeta(ErrorHandlingMethodView):
           content:
             'application/x-json-stream':
               schema:
-                type:
+                type: object
                 required:
                 - dids
                 properties:
@@ -2155,7 +2155,7 @@ class Follow(ErrorHandlingMethodView):
           content:
             'application/json':
               schema:
-                type:
+                type: object
                 required:
                 - account
                 properties:

--- a/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
+++ b/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
@@ -61,7 +61,7 @@ class Heartbeat(ErrorHandlingMethodView):
         requestBody:
           content:
             'application/json':
-              shema:
+              schema:
                 type: object
                 required:
                 - bytes

--- a/lib/rucio/web/rest/flaskapi/v1/locks.py
+++ b/lib/rucio/web/rest/flaskapi/v1/locks.py
@@ -89,7 +89,7 @@ class LockByRSE(ErrorHandlingMethodView):
                         type: integer
                       bytes:
                         description: The bytes limit for the lock.
-                        type: integere
+                        type: integer
                       accessed_at:
                         description: The last time is was accessed.
                         type: string
@@ -186,7 +186,7 @@ class LocksByScopeName(ErrorHandlingMethodView):
                         type: integer
                       bytes:
                         description: The bytes limit for the lock.
-                        type: integere
+                        type: integer
                       accessed_at:
                         description: The last time is was accessed.
                         type: string
@@ -299,7 +299,7 @@ class DatasetLocksForDids(ErrorHandlingMethodView):
                         type: integer
                       bytes:
                         description: The bytes limit for the lock.
-                        type: integere
+                        type: integer
                       accessed_at:
                         description: The last time is was accessed.
                         type: string

--- a/lib/rucio/web/rest/flaskapi/v1/meta.py
+++ b/lib/rucio/web/rest/flaskapi/v1/meta.py
@@ -166,7 +166,7 @@ class Values(ErrorHandlingMethodView):
           content:
             application/json:
               schema:
-                type:
+                type: object
                 required:
                 - value
                 properties:

--- a/lib/rucio/web/rest/flaskapi/v1/ping.py
+++ b/lib/rucio/web/rest/flaskapi/v1/ping.py
@@ -58,7 +58,7 @@ class Ping(ErrorHandlingMethodView):
                   type: object
                   properties:
                     version:
-                      descripption: The server version.
+                      description: The server version.
                       type: string
           406:
             description: Not acceptable

--- a/lib/rucio/web/rest/flaskapi/v1/redirect.py
+++ b/lib/rucio/web/rest/flaskapi/v1/redirect.py
@@ -251,6 +251,8 @@ class HeaderRedirector(ErrorHandlingMethodView):
           style: simple
           required: false
         responses:
+          200:
+            description: OK
           303:
             description: OK
             content:

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -1096,7 +1096,7 @@ class BadReplicasStates(ErrorHandlingMethodView):
                   description: A list of all result replicas.
                   type: array
                   items:
-                    oneof:
+                    oneOf:
                       - type: object
                         properties:
                           scope:

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -770,10 +770,10 @@ class ReplicasDIDs(ErrorHandlingMethodView):
                       properties:
                         scope:
                           description: The scope of the DID.
-                          type: str
+                          type: string
                         name:
                           description: The name of the DID.
-                          type: str
+                          type: string
           400:
             description: Cannot decode json parameter list.
           401:

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -62,7 +62,7 @@ class RequestGet(ErrorHandlingMethodView):
                   properties:
                     id:
                       description: The id of the request.
-                      type: strig
+                      type: string
                     request_type:
                       description: The request type.
                       type: string
@@ -227,7 +227,7 @@ class RequestHistoryGet(ErrorHandlingMethodView):
                   properties:
                     id:
                       description: The id of the request.
-                      type: strig
+                      type: string
                     request_type:
                       description: The request type.
                       type: string
@@ -424,7 +424,7 @@ class RequestList(ErrorHandlingMethodView):
                     properties:
                       id:
                         description: The id of the request.
-                        type: strig
+                        type: string
                       request_type:
                         description: The request type.
                         type: string
@@ -660,7 +660,7 @@ class RequestHistoryList(ErrorHandlingMethodView):
                     properties:
                       id:
                         description: The id of the request.
-                        type: strig
+                        type: string
                       request_type:
                         description: The request type.
                         type: string

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -639,13 +639,13 @@ class RequestHistoryList(ErrorHandlingMethodView):
           description: The offset of the list.
           schema:
             type: integer
-          default: 0
+            default: 0
         - name: limit
           in: query
           description: The maximum number of items to return.
           schema:
             type: integer
-          default: 100
+            default: 100
         responses:
           200:
             description: OK

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -198,10 +198,10 @@ class RSE(ErrorHandlingMethodView):
                     enum: ["DISK", "TAPE"]
                   latitute:
                     description: The latitute of the RSE.
-                    type: float
+                    type: number
                   longitude:
                     description: The longitude of the RSE.
-                    type: float
+                    type: number
                   ASN:
                     description: The access service network of the RSE.
                     type: string
@@ -316,10 +316,10 @@ class RSE(ErrorHandlingMethodView):
                     enum: ["DISK", "TAPE"]
                   latitute:
                     description: The latitute of the RSE.
-                    type: float
+                    type: number
                   longitude:
                     description: The longitude of the RSE.
-                    type: float
+                    type: number
         responses:
           201:
             description: OK
@@ -410,10 +410,10 @@ class RSE(ErrorHandlingMethodView):
                       enum: ["DISK", "TAPE"]
                     latitute:
                       description: The latitute of the RSE.
-                      type: float
+                      type: number
                     longitude:
                       description: The longitude of the RSE.
-                      type: float
+                      type: number
                     ASN:
                       description: The access service network of the RSE.
                       type: string

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -761,7 +761,7 @@ class LFNS2PFNS(ErrorHandlingMethodView):
     """ Translate one-or-more LFNs to corresponding PFNs. """
 
     @check_accept_header_wrapper_flask(['application/json'])
-    def get(self, rse, scheme=None):
+    def get(self, rse):
         """
         ---
         summary: Translate LFNs to PFNs
@@ -775,13 +775,6 @@ class LFNS2PFNS(ErrorHandlingMethodView):
           schema:
             type: string
           style: simple
-        - name: schema
-          in: path
-          description: The protocol identifier.
-          schema:
-            type: string
-          style: simple
-          required: False
         - name: lfn
           in: query
           description: The lfns of the request.

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -721,6 +721,9 @@ class ProtocolList(ErrorHandlingMethodView):
                                     description: The delete value of the lan protocol.
                                     type: integer
                               wan:
+                                description: The wan domain
+                                type: object
+                                properties:
                                   read:
                                     description: The read value of the wan protocol.
                                     type: integer
@@ -1054,6 +1057,9 @@ class Protocol(ErrorHandlingMethodView):
                                     description: The delete value of the lan protocol.
                                     type: integer
                               wan:
+                                description: The wan domain
+                                type: object
+                                properties:
                                   read:
                                     description: The read value of the wan protocol.
                                     type: integer
@@ -1215,6 +1221,9 @@ class Protocol(ErrorHandlingMethodView):
                                     description: The delete value of the lan protocol.
                                     type: integer
                               wan:
+                                description: The wan domain
+                                type: object
+                                properties:
                                   read:
                                     description: The read value of the wan protocol.
                                     type: integer

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -252,7 +252,7 @@ class AllRule(ErrorHandlingMethodView):
                     items:
                       type: string
                   account:
-                    descipriton: The account of the issuer.
+                    description: The account of the issuer.
                     type: string
                   copies:
                     description: The number of replicas.
@@ -622,7 +622,7 @@ class RuleHistory(ErrorHandlingMethodView):
                         description: The date of the update.
                       state:
                         type: string
-                        descipriton: The state of the update.
+                        description: The state of the update.
                       locks_ok_cnt:
                         type: integer
                         description: The number of locks which are ok.
@@ -688,10 +688,10 @@ class RuleHistoryFull(ErrorHandlingMethodView):
                         description: The rse expression.
                       state:
                         type: string
-                        descipriton: The state of the update.
+                        description: The state of the update.
                       account:
                         type: string
-                        descipriton: The account who initiated the change.
+                        description: The account who initiated the change.
                       locks_ok_cnt:
                         type: integer
                         description: The number of locks which are ok.

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -517,7 +517,7 @@ class States(ErrorHandlingMethodView):
                       state:
                         description: The state of the rules.
                         type: string
-                        enums: ["R", "O", "S", "U", "W", "I"]
+                        enum: ["R", "O", "S", "U", "W", "I"]
                       count:
                         description: The number of rules with that state.
                         type: integer

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -333,9 +333,9 @@ class SubscriptionName(ErrorHandlingMethodView):
         tags:
           - Replicas
         parameters:
-        - name: account
+        - name: name
           in: path
-          description: The account name.
+          description: The subscription name.
           schema:
             type: string
           style: simple

--- a/tools/test/check_rest_api_documentation.sh
+++ b/tools/test/check_rest_api_documentation.sh
@@ -34,6 +34,4 @@ fi
 command_exists "node"
 command_exists "npx"
 
-npx @redocly/openapi-cli lint $1 || true
-echo "We are ignoring the result of the OpenApi lint for now, since not every file is migrated."
-echo "TODO: Fix all linter erros and delete the default true configuration"
+npx @redocly/openapi-cli lint $1

--- a/tools/test/check_rest_api_documentation.sh
+++ b/tools/test/check_rest_api_documentation.sh
@@ -16,6 +16,8 @@
 
 set -eo pipefail
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 
 command_exists() {
     # check if command exists and fail otherwise
@@ -34,4 +36,4 @@ fi
 command_exists "node"
 command_exists "npx"
 
-npx @redocly/openapi-cli lint $1
+npx @redocly/cli lint --config "$SCRIPT_DIR/redocly.yaml" $1

--- a/tools/test/redocly.yaml
+++ b/tools/test/redocly.yaml
@@ -10,3 +10,5 @@ styleguide:
       severity: off
     no-path-trailing-slash:
       severity: off
+    no-identical-paths:
+      severity: off

--- a/tools/test/redocly.yaml
+++ b/tools/test/redocly.yaml
@@ -8,3 +8,5 @@ styleguide:
       severity: off
     no-ambiguous-paths:
       severity: off
+    no-path-trailing-slash:
+      severity: off

--- a/tools/test/redocly.yaml
+++ b/tools/test/redocly.yaml
@@ -1,0 +1,8 @@
+styleguide:
+  extends:
+    - recommended
+  rules:
+    operation-operationId:
+      severity: off
+    no-empty-servers:
+      severity: off

--- a/tools/test/redocly.yaml
+++ b/tools/test/redocly.yaml
@@ -6,3 +6,5 @@ styleguide:
       severity: off
     no-empty-servers:
       severity: off
+    no-ambiguous-paths:
+      severity: off


### PR DESCRIPTION
- Documentation: Activate the Rest Api Doc linter #4992
- Documentation: Change the float OpenApi type #4992
- Documentation: Fix typos in the Rest Api Docs #4992
- Documentation: Remove the `scheme` parameter in the Rest Api lfns2pfns #4992
- Documentation: Add a 4xx response to the list accounts endpoint #4992
- Documentation: Rename the docs for the name parameter in subscriptions #4992
- Documentation: Add one 200 response code #4992
- Documentation: Skip the server definition in the Rest Api Doc #4992
- Documentation: Resolve minor errors in the Rest Api Doc #4992
- Documentation: Disable no-ambiguous-paths rule in the Rest Api Doc #4992
- Documentation: Disable the no-path-trailing-slash rule in the Rest Api Doc #4992
- Documentation: Deactivate identical path rule in the Rest Api Doc #4992
- Documentation: Add the credentials options Rest Api Doc #4992

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
