### PR TITLE
Transfers: move path computation to preparer. #5805

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -40,11 +40,7 @@ from rucio.db.sqla.util import temp_table_mngr
 RequestAndState = namedtuple('RequestAndState', ['request_id', 'request_state'])
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Iterator, Union
-
-    RequestResult = Dict[str, Any]
-    RequestResultOrState = Union[RequestResult, RequestAndState]
-    RowIterator = Iterator[RequestResult]
+    from typing import Any, Dict, List, Optional, Union
 
 """
 The core request.py is specifically for handling requests.
@@ -66,8 +62,26 @@ class RequestSource:
 
 
 class RequestWithSources:
-    def __init__(self, id_, request_type, rule_id, scope, name, md5, adler32, byte_count, activity, attributes,
-                 previous_attempt_id, dest_rse_data, account, retry_count, priority, transfertool, requested_at=None):
+    def __init__(
+            self,
+            id_: "Optional[str]",
+            request_type: RequestType,
+            rule_id: "Optional[str]",
+            scope: InternalScope,
+            name: str,
+            md5: str,
+            adler32: str,
+            byte_count: int,
+            activity: str,
+            attributes: "Union[str, None, Dict[str, Any]]",
+            previous_attempt_id: "Optional[str]",
+            dest_rse_data: RseData,
+            account: InternalAccount,
+            retry_count: int,
+            priority: int,
+            transfertool: str,
+            requested_at: "Optional[datetime.datetime]" = None,
+    ):
 
         self.request_id = id_
         self.request_type = request_type
@@ -88,8 +102,8 @@ class RequestWithSources:
         self.transfertool = transfertool
         self.requested_at = requested_at if requested_at else datetime.datetime.utcnow()
 
-        self.sources = []
-        self.requested_source = None
+        self.sources: "List[RequestSource]" = []
+        self.requested_source: "Optional[RequestSource]" = None
 
     def __str__(self):
         return "{}({}:{})".format(self.request_id, self.scope, self.name)

--- a/lib/rucio/core/topology.py
+++ b/lib/rucio/core/topology.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import itertools
+from typing import TYPE_CHECKING
+
+from dogpile.cache.api import NoValue
+from sqlalchemy import select, false
+
+from rucio.common.utils import PriorityQueue
+from rucio.common.cache import make_region_memcached
+from rucio.common.config import config_get_int
+from rucio.common.exception import NoDistance, RSEProtocolNotSupported
+from rucio.core.rse import RseCollection
+from rucio.db.sqla import models
+from rucio.db.sqla.session import transactional_session
+from rucio.rse import rsemanager as rsemgr
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, List, Optional, Union
+    from sqlalchemy.orm import Session
+
+REGION = make_region_memcached(expiration_time=600)
+
+
+class Topology:
+    """
+    Helper private class used to dynamically load and cache the rse information
+    """
+    def __init__(self, rse_collection: "RseCollection"):
+        self.rse_collection = rse_collection
+
+    @transactional_session
+    def search_shortest_paths(
+            self,
+            source_rse_ids: "List[str]",
+            dest_rse_id: "List[str]",
+            operation_src: str,
+            operation_dest: str,
+            domain: str,
+            multihop_rses: "List[str]",
+            limit_dest_schemes: "Union[str, List[str]]",
+            inbound_links_by_node: "Optional[Dict[str, Dict[str, str]]]" = None,
+            session: "Optional[Session]" = None
+    ) -> "Dict[str, List[Dict[str, Any]]]":
+        """
+        Find the shortest paths from multiple sources towards dest_rse_id.
+        Does a Backwards Dijkstra's algorithm: start from destination and follow inbound links towards the sources.
+        If multihop is disabled, stop after analysing direct connections to dest_rse. Otherwise, stops when all
+        sources where found or the graph was traversed in integrality.
+
+        The inbound links retrieved from the database can be accumulated into the inbound_links_by_node, passed
+        from the calling context. To be able to reuse them.
+        """
+        HOP_PENALTY = config_get_int('transfers', 'hop_penalty', default=10, session=session)  # Penalty to be applied to each further hop
+
+        self.rse_collection.ensure_loaded(itertools.chain(source_rse_ids, [dest_rse_id], multihop_rses),
+                                          load_attributes=True, load_info=True, session=session)
+        if multihop_rses:
+            # Filter out island source RSEs
+            sources_to_find = {rse_id for rse_id in source_rse_ids if _load_outgoing_distances_node(rse_id=rse_id, session=session)}
+        else:
+            sources_to_find = set(source_rse_ids)
+
+        next_hop = {dest_rse_id: {'cumulated_distance': 0}}
+        priority_q = PriorityQueue()
+
+        remaining_sources = copy.copy(sources_to_find)
+        priority_q[dest_rse_id] = 0
+        while priority_q:
+            current_node = priority_q.pop()
+
+            if current_node in remaining_sources:
+                remaining_sources.remove(current_node)
+            if not remaining_sources:
+                # We found the shortest paths to all desired sources
+                break
+
+            current_distance = next_hop[current_node]['cumulated_distance']
+            inbound_links = _load_inbound_distances_node(rse_id=current_node)
+            if inbound_links_by_node is not None:
+                inbound_links_by_node[current_node] = inbound_links
+            for adjacent_node, link_distance in sorted(inbound_links.items(),
+                                                       key=lambda item: 0 if item[0] in sources_to_find else 1):
+                if link_distance is None:
+                    continue
+
+                if adjacent_node not in remaining_sources and adjacent_node not in multihop_rses:
+                    continue
+
+                try:
+                    hop_penalty = int(self.rse_collection[adjacent_node].attributes.get('hop_penalty', HOP_PENALTY))
+                except ValueError:
+                    hop_penalty = HOP_PENALTY
+                new_adjacent_distance = current_distance + link_distance + hop_penalty
+                if next_hop.get(adjacent_node, {}).get('cumulated_distance', 9999) <= new_adjacent_distance:
+                    continue
+
+                try:
+                    matching_scheme = rsemgr.find_matching_scheme(
+                        rse_settings_src=self.rse_collection[adjacent_node].info,
+                        rse_settings_dest=self.rse_collection[current_node].info,
+                        operation_src=operation_src,
+                        operation_dest=operation_dest,
+                        domain=domain,
+                        scheme=limit_dest_schemes if adjacent_node == dest_rse_id and limit_dest_schemes else None
+                    )
+                    next_hop[adjacent_node] = {
+                        'source_rse_id': adjacent_node,
+                        'dest_rse_id': current_node,
+                        'source_scheme': matching_scheme[1],
+                        'dest_scheme': matching_scheme[0],
+                        'source_scheme_priority': matching_scheme[3],
+                        'dest_scheme_priority': matching_scheme[2],
+                        'hop_distance': link_distance,
+                        'cumulated_distance': new_adjacent_distance,
+                    }
+                    priority_q[adjacent_node] = new_adjacent_distance
+                except RSEProtocolNotSupported:
+                    if next_hop.get(adjacent_node) is None:
+                        next_hop[adjacent_node] = {}
+
+            if not multihop_rses:
+                # Stop after the first iteration, which finds direct connections to destination
+                break
+
+        paths = {}
+        for rse_id in source_rse_ids:
+            hop = next_hop.get(rse_id)
+            if hop is None:
+                continue
+
+            path = []
+            while hop.get('dest_rse_id'):
+                path.append(hop)
+                hop = next_hop.get(hop['dest_rse_id'])
+            paths[rse_id] = path
+        return paths
+
+
+@transactional_session
+def get_hops(source_rse_id, dest_rse_id, multihop_rses=None, limit_dest_schemes=None, session=None):
+    """
+    Get a list of hops needed to transfer date from source_rse_id to dest_rse_id.
+    Ideally, the list will only include one item (dest_rse_id) since no hops are needed.
+    :param source_rse_id:       Source RSE id of the transfer.
+    :param dest_rse_id:         Dest RSE id of the transfer.
+    :param multihop_rses:       List of RSE ids that can be used for multihop. If empty, multihop is disabled.
+    :param limit_dest_schemes:  List of destination schemes the matching scheme algorithm should be limited to for a single hop.
+    :returns:                   List of hops in the format [{'source_rse_id': source_rse_id, 'source_scheme': 'srm', 'source_scheme_priority': N, 'dest_rse_id': dest_rse_id, 'dest_scheme': 'srm', 'dest_scheme_priority': N}]
+    :raises:                    NoDistance
+    """
+    if not limit_dest_schemes:
+        limit_dest_schemes = []
+
+    if not multihop_rses:
+        multihop_rses = []
+
+    topology = Topology(RseCollection())
+    shortest_paths = topology.search_shortest_paths(source_rse_ids=[source_rse_id], dest_rse_id=dest_rse_id,
+                                                    operation_src='third_party_copy_read', operation_dest='third_party_copy_write',
+                                                    domain='wan', multihop_rses=multihop_rses,
+                                                    limit_dest_schemes=limit_dest_schemes, session=session)
+
+    result = REGION.get('get_hops_dist_%s_%s_%s' % (str(source_rse_id), str(dest_rse_id), ''.join(sorted(limit_dest_schemes))))
+    if not isinstance(result, NoValue):
+        return result
+
+    path = shortest_paths.get(source_rse_id)
+    if path is None:
+        raise NoDistance()
+
+    if not path:
+        raise RSEProtocolNotSupported()
+
+    REGION.set('get_hops_dist_%s_%s_%s' % (str(source_rse_id), str(dest_rse_id), ''.join(sorted(limit_dest_schemes))), path)
+    return path
+
+
+@transactional_session
+def _load_outgoing_distances_node(rse_id, session=None):
+    """
+    Loads the outgoing edges of the distance graph for one node.
+    :param rse_id:    RSE id to load the edges for.
+    :param session:   The DB Session to use.
+    :returns:         Dictionary based graph object.
+    """
+
+    result = REGION.get('outgoing_edges_%s' % str(rse_id))
+    if isinstance(result, NoValue):
+        outgoing_edges = {}
+        stmt = select(
+            models.Distance
+        ).join(
+            models.RSE,
+            models.RSE.id == models.Distance.dest_rse_id
+        ).where(
+            models.Distance.src_rse_id == rse_id,
+            models.RSE.deleted == false()
+        )
+        for distance in session.execute(stmt).scalars():
+            if distance.ranking is None:
+                continue
+            ranking = distance.ranking if distance.ranking >= 0 else 0
+            outgoing_edges[distance.dest_rse_id] = ranking
+        REGION.set('outgoing_edges_%s' % str(rse_id), outgoing_edges)
+        result = outgoing_edges
+    return result
+
+
+@transactional_session
+def _load_inbound_distances_node(rse_id, session=None):
+    """
+    Loads the inbound edges of the distance graph for one node.
+    :param rse_id:    RSE id to load the edges for.
+    :param session:   The DB Session to use.
+    :returns:         Dictionary based graph object.
+    """
+
+    result = REGION.get('inbound_edges_%s' % str(rse_id))
+    if isinstance(result, NoValue):
+        inbound_edges = {}
+        stmt = select(
+            models.Distance
+        ).join(
+            models.RSE,
+            models.RSE.id == models.Distance.src_rse_id
+        ).where(
+            models.Distance.dest_rse_id == rse_id,
+            models.RSE.deleted == false()
+        )
+        for distance in session.execute(stmt).scalars():
+            if distance.ranking is None:
+                continue
+            ranking = distance.ranking if distance.ranking >= 0 else 0
+            inbound_edges[distance.src_rse_id] = ranking
+        REGION.set('inbound_edges_%s' % str(rse_id), inbound_edges)
+        result = inbound_edges
+    return result

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1098,13 +1098,21 @@ def prepare_transfers(
         transfertool = None
         rws = candidate_paths[0][-1].rws
 
-        dest_rse_transfertools = get_supported_transfertools(rws.dest_rse, session=session)
         for candidate_path in candidate_paths:
             source = candidate_path[0].src
-            src_rse_transfertools = get_supported_transfertools(source.rse, session=session)
-            common_transfertools = dest_rse_transfertools.intersection(src_rse_transfertools)
-            if common_transfertools:
+            all_hops_ok = True
+            transfertool = None
+            for hop in candidate_path:
+                src_rse_transfertools = get_supported_transfertools(hop.src.rse, session=session)
+                dst_rse_transfertools = get_supported_transfertools(hop.dst.rse, session=session)
+                common_transfertools = dst_rse_transfertools.intersection(src_rse_transfertools)
+                if not common_transfertools:
+                    all_hops_ok = False
+                    break
+                # We need the last hop transfertool
                 transfertool = 'fts3' if 'fts3' in common_transfertools else common_transfertools.pop()
+
+            if all_hops_ok and transfertool:
                 selected_source = source
                 break
 

--- a/lib/rucio/daemons/common.py
+++ b/lib/rucio/daemons/common.py
@@ -48,7 +48,7 @@ class HeartbeatHandler:
         self.hb_thread = threading.current_thread()
         self.logger_id = hashlib.sha1(f'{self.hostname}:{self.pid}:{self.hb_thread}'.encode('utf-8')).hexdigest()[:7]
 
-        self.logger = None
+        self.logger = logging.log
         self.last_heart_beat = None
         self.last_time = None
         self.last_payload = None
@@ -70,6 +70,7 @@ class HeartbeatHandler:
         """
         if force_renew \
                 or not self.last_time \
+                or not self.last_heart_beat \
                 or self.last_time < datetime.datetime.now() - datetime.timedelta(seconds=self.renewal_interval) \
                 or self.last_payload != payload:
             if self.older_than:

--- a/lib/rucio/daemons/conveyor/preparer.py
+++ b/lib/rucio/daemons/conveyor/preparer.py
@@ -124,6 +124,7 @@ def run_once(bulk: int = 100, heartbeat_handler: "Optional[HeartbeatHandler]" = 
             topology=topology,
             requests_with_sources=list(requests_with_sources.values()),
             admin_accounts=admin_accounts,
+            preparer_mode=True,
             logger=logger,
             session=session,
         )

--- a/lib/rucio/daemons/conveyor/preparer.py
+++ b/lib/rucio/daemons/conveyor/preparer.py
@@ -23,7 +23,8 @@ import rucio.db.sqla.util
 from rucio.common import exception
 from rucio.common.exception import RucioException
 from rucio.common.logging import setup_logging
-from rucio.core.request import prepare_requests, list_transfer_requests_and_source_replicas
+from rucio.core.request import set_requests_state_if_possible
+from rucio.core.transfer import get_transfer_paths, prepare_transfers
 from rucio.db.sqla.constants import RequestState
 from rucio.daemons.common import run_daemon
 
@@ -107,27 +108,42 @@ def run_once(bulk: int = 100, heartbeat_handler: "Optional[HeartbeatHandler]" = 
         worker_number, total_workers, logger = 0, 0, logging.log
 
     start_time = time()
-    requests_with_sources = []
+    requests_handled = 0
     try:
-        requests_with_sources = list_transfer_requests_and_source_replicas(
+        ret = get_transfer_paths(
             total_workers=total_workers,
             worker_number=worker_number,
             limit=bulk,
             request_state=RequestState.PREPARING,
             session=session
         )
-        if not requests_with_sources:
+        requests_handled = sum(len(i) for i in ret)
+        if not requests_handled:
             updated_msg = 'had nothing to do'
         else:
-            count = prepare_requests(requests_with_sources=requests_with_sources, logger=logger, session=session)
-            updated_msg = f'updated {count}/{bulk} requests'
+            candidate_paths, reqs_no_source, reqs_scheme_mismatch, reqs_only_tape_source, _ = ret
+            updated_reqs, reqs_no_transfertool = prepare_transfers(candidate_paths, logger=logger, session=session)
+            updated_msg = f'updated {len(updated_reqs)}/{bulk} requests'
+
+            if reqs_no_transfertool:
+                logger(logging.INFO, "Ignoring request because of unsupported transfertool: %s", reqs_no_transfertool)
+            reqs_no_source.update(reqs_no_transfertool)
+            if reqs_no_source:
+                logger(logging.INFO, "Marking requests as no-sources: %s", reqs_no_source)
+                set_requests_state_if_possible(reqs_no_source, RequestState.NO_SOURCES, logger=logger)
+            if reqs_only_tape_source:
+                logger(logging.INFO, "Marking requests as only-tape-sources: %s", reqs_only_tape_source)
+                set_requests_state_if_possible(reqs_only_tape_source, RequestState.ONLY_TAPE_SOURCES, logger=logger)
+            if reqs_scheme_mismatch:
+                logger(logging.INFO, "Marking requests as scheme-mismatch: %s", reqs_scheme_mismatch)
+                set_requests_state_if_possible(reqs_scheme_mismatch, RequestState.MISMATCH_SCHEME, logger=logger)
     except RucioException:
         logger(logging.ERROR, 'errored with a RucioException, retrying later', exc_info=True)
         updated_msg = 'errored'
     logger(logging.INFO, '%s, taking %.3f seconds' % (updated_msg, time() - start_time))
 
     must_sleep = False
-    if len(requests_with_sources) < bulk / 2:
-        logger(logging.INFO, "Only %s transfers, which is less than half of the bulk %s", len(requests_with_sources), bulk)
+    if requests_handled < bulk / 2:
+        logger(logging.INFO, "Only %s transfers, which is less than half of the bulk %s", requests_handled, bulk)
         must_sleep = True
     return must_sleep

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -299,6 +299,24 @@ def scope_factory():
 
 
 @pytest.fixture
+def tag_factory(function_scope_prefix):
+
+    import string
+    import random
+
+    class _Factory:
+        def __init__(self):
+            self.prefix = f'{function_scope_prefix}-{"".join(random.choice(string.ascii_uppercase) for _ in range(6))}'
+            self.index = 0
+
+        def new_tag(self):
+            self.index += 1
+            return f'{self.prefix}-{self.index}'
+
+    return _Factory()
+
+
+@pytest.fixture
 def db_session():
     from rucio.db.sqla import session
 

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -16,6 +16,7 @@
 import traceback
 import re
 import functools
+from os import environ
 from random import choice
 from string import ascii_uppercase
 
@@ -58,8 +59,14 @@ def function_scope_prefix(request, class_scope_prefix):
 
 @pytest.fixture(scope='session')
 def vo():
-    from rucio.tests.common_server import get_vo
-    return get_vo()
+    if environ.get('SUITE', 'remote_dbs') != 'client':
+        # Server test, we can use short VO via DB for internal tests
+        from rucio.tests.common_server import get_vo
+        return get_vo()
+    else:
+        # Client-only test, only use config with no DB config
+        from rucio.tests.common import get_long_vo
+        return get_long_vo()
 
 
 @pytest.fixture(scope='session')

--- a/lib/rucio/tests/conftest.py
+++ b/lib/rucio/tests/conftest.py
@@ -317,7 +317,7 @@ def tag_factory(function_scope_prefix):
 
 
 @pytest.fixture
-def db_session():
+def db_session(did_factory, rse_factory):
     from rucio.db.sqla import session
 
     db_session = session.get_session()

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -75,11 +75,14 @@ class TemporaryRSEFactory:
         else:
             rse_id = rse_core.add_rse(rse_name, vo=self.vo, **(add_rse_kwargs or {}))
         if scheme and protocol_impl:
+            prefix = '/test_%s/' % rse_id
+            if protocol_impl == 'rucio.rse.protocols.posix.Default':
+                prefix = '/tmp/rucio_rse/test_%s/' % rse_id
             protocol_parameters = {
                 'scheme': scheme,
                 'hostname': '%s.cern.ch' % rse_id,
                 'port': 0,
-                'prefix': '/test_%s/' % rse_id,
+                'prefix': prefix,
                 'impl': protocol_impl,
                 'domains': {
                     'wan': {

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -274,7 +274,7 @@ def test_source_avoid_deletion(caches_mock, core_config_mock, rse_factory, did_f
 ]}], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
     'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by rse expression
-    'rucio.core.transfer.REGION_SHORT',
+    'rucio.core.topology.REGION',
 ]}], indirect=True)
 def test_ignore_availability(rse_factory, did_factory, root_account, core_config_mock, caches_mock):
 

--- a/lib/rucio/tests/test_judge_cleaner.py
+++ b/lib/rucio/tests/test_judge_cleaner.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
 import pytest
 
 from rucio.common.config import config_get_bool
@@ -23,7 +21,7 @@ from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account_limit import set_local_account_limit
 from rucio.core.did import add_did, attach_dids
 from rucio.core.lock import get_replica_locks
-from rucio.core.rse import add_rse_attribute, get_rse_id
+from rucio.core.rse import add_rse_attribute
 from rucio.core.rule import add_rule, update_rule
 from rucio.daemons.judge.cleaner import rule_cleaner
 from rucio.db.sqla.constants import DIDType
@@ -31,8 +29,14 @@ from rucio.tests.common_server import get_vo
 from rucio.tests.test_rule import create_files, tag_generator
 
 
+@pytest.fixture(scope="class")
+def setup_class(request, rse_factory_unittest):
+    request.cls.setUpClass()
+
+
 @pytest.mark.noparallel(reason='uses pre-defined RSE, sets account limits, adds global rse attributes')
-class TestJudgeCleaner(unittest.TestCase):
+@pytest.mark.usefixtures("setup_class")
+class TestJudgeCleaner:
 
     @classmethod
     def setUpClass(cls):
@@ -42,15 +46,10 @@ class TestJudgeCleaner(unittest.TestCase):
             cls.vo = {}
 
         # Add test RSE
-        cls.rse1 = 'MOCK'
-        cls.rse3 = 'MOCK3'
-        cls.rse4 = 'MOCK4'
-        cls.rse5 = 'MOCK5'
-
-        cls.rse1_id = get_rse_id(rse=cls.rse1, **cls.vo)
-        cls.rse3_id = get_rse_id(rse=cls.rse3, **cls.vo)
-        cls.rse4_id = get_rse_id(rse=cls.rse4, **cls.vo)
-        cls.rse5_id = get_rse_id(rse=cls.rse5, **cls.vo)
+        cls.rse1, cls.rse1_id = cls.rse_factory.make_mock_rse()
+        cls.rse3, cls.rse3_id = cls.rse_factory.make_mock_rse()
+        cls.rse4, cls.rse4_id = cls.rse_factory.make_mock_rse()
+        cls.rse5, cls.rse5_id = cls.rse_factory.make_mock_rse()
 
         # Add Tags
         cls.T1 = tag_generator()

--- a/lib/rucio/tests/test_judge_evaluator.py
+++ b/lib/rucio/tests/test_judge_evaluator.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
 import pytest
 
 from rucio.common.config import config_get_bool
@@ -24,7 +22,7 @@ from rucio.core.account import get_usage
 from rucio.core.account_limit import set_local_account_limit
 from rucio.core.did import add_did, attach_dids, detach_dids
 from rucio.core.lock import get_replica_locks, get_dataset_locks
-from rucio.core.rse import add_rse_attribute, get_rse_id
+from rucio.core.rse import add_rse_attribute
 from rucio.core.rule import add_rule, get_rule
 from rucio.daemons.abacus.account import account_update
 from rucio.daemons.judge.evaluator import re_evaluator
@@ -35,8 +33,14 @@ from rucio.tests.common_server import get_vo
 from rucio.tests.test_rule import create_files, tag_generator
 
 
+@pytest.fixture(scope="class")
+def setup_class(request, rse_factory_unittest):
+    request.cls.setUpClass()
+
+
 @pytest.mark.noparallel(reason='sets account limits, adds global rse attributes')
-class TestJudgeEvaluator(unittest.TestCase):
+@pytest.mark.usefixtures("setup_class")
+class TestJudgeEvaluator:
 
     @classmethod
     def setUpClass(cls):
@@ -52,15 +56,10 @@ class TestJudgeEvaluator(unittest.TestCase):
         __cleanup_updated_dids()
 
         # Add test RSE
-        cls.rse1 = 'MOCK'
-        cls.rse3 = 'MOCK3'
-        cls.rse4 = 'MOCK4'
-        cls.rse5 = 'MOCK5'
-
-        cls.rse1_id = get_rse_id(rse=cls.rse1, **cls.vo)
-        cls.rse3_id = get_rse_id(rse=cls.rse3, **cls.vo)
-        cls.rse4_id = get_rse_id(rse=cls.rse4, **cls.vo)
-        cls.rse5_id = get_rse_id(rse=cls.rse5, **cls.vo)
+        cls.rse1, cls.rse1_id = cls.rse_factory.make_mock_rse()
+        cls.rse3, cls.rse3_id = cls.rse_factory.make_mock_rse()
+        cls.rse4, cls.rse4_id = cls.rse_factory.make_mock_rse()
+        cls.rse5, cls.rse5_id = cls.rse_factory.make_mock_rse()
 
         # Add Tags
         cls.T1 = tag_generator()

--- a/lib/rucio/tests/test_judge_injector.py
+++ b/lib/rucio/tests/test_judge_injector.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 from datetime import datetime, timedelta
 
 import pytest
@@ -25,7 +24,7 @@ from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account_limit import set_local_account_limit
 from rucio.core.did import add_did, attach_dids
 from rucio.core.lock import get_replica_locks
-from rucio.core.rse import add_rse_attribute, get_rse_id
+from rucio.core.rse import add_rse_attribute
 from rucio.core.rule import add_rule, get_rule, approve_rule, deny_rule, list_rules
 from rucio.daemons.judge.injector import rule_injector
 from rucio.db.sqla.constants import DIDType, RuleState
@@ -35,8 +34,14 @@ from rucio.tests.common_server import get_vo
 from rucio.tests.test_rule import create_files, tag_generator
 
 
+@pytest.fixture(scope="class")
+def setup_class(request, rse_factory_unittest):
+    request.cls.setUpClass()
+
+
 @pytest.mark.noparallel(reason='uses pre-defined RSE, sets account limits, adds global rse attributes')
-class TestJudgeEvaluator(unittest.TestCase):
+@pytest.mark.usefixtures("setup_class")
+class TestJudgeEvaluator:
 
     @classmethod
     def setUpClass(cls):
@@ -46,15 +51,10 @@ class TestJudgeEvaluator(unittest.TestCase):
             cls.vo = {}
 
         # Add test RSE
-        cls.rse1 = 'MOCK'
-        cls.rse3 = 'MOCK3'
-        cls.rse4 = 'MOCK4'
-        cls.rse5 = 'MOCK5'
-
-        cls.rse1_id = get_rse_id(rse=cls.rse1, **cls.vo)
-        cls.rse3_id = get_rse_id(rse=cls.rse3, **cls.vo)
-        cls.rse4_id = get_rse_id(rse=cls.rse4, **cls.vo)
-        cls.rse5_id = get_rse_id(rse=cls.rse5, **cls.vo)
+        cls.rse1, cls.rse1_id = cls.rse_factory.make_mock_rse()
+        cls.rse3, cls.rse3_id = cls.rse_factory.make_mock_rse()
+        cls.rse4, cls.rse4_id = cls.rse_factory.make_mock_rse()
+        cls.rse5, cls.rse5_id = cls.rse_factory.make_mock_rse()
 
         # Add Tags
         cls.T1 = tag_generator()

--- a/lib/rucio/tests/test_judge_repairer.py
+++ b/lib/rucio/tests/test_judge_repairer.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import itertools
-import unittest
 from hashlib import sha256
 
 import pytest
@@ -30,7 +29,7 @@ from rucio.core.lock import successful_transfer, failed_transfer, get_replica_lo
 from rucio.core.replica import get_replica
 from rucio.core.request import cancel_request_did
 from rucio.core.transfer import cancel_transfers
-from rucio.core.rse import add_rse_attribute, add_rse, update_rse, get_rse_id
+from rucio.core.rse import add_rse_attribute, add_rse, update_rse
 from rucio.core.rule import get_rule, add_rule
 from rucio.daemons.judge.evaluator import re_evaluator
 from rucio.daemons.judge.repairer import rule_repairer
@@ -42,9 +41,15 @@ from rucio.tests.common_server import get_vo
 from rucio.tests.test_rule import create_files, tag_generator
 
 
+@pytest.fixture(scope="class")
+def setup_class(request, rse_factory_unittest):
+    request.cls.setUpClass()
+
+
 @pytest.mark.dirty
 @pytest.mark.noparallel(reason='uses pre-defined rses, sets rse attributes, sets account limits')
-class TestJudgeRepairer(unittest.TestCase):
+@pytest.mark.usefixtures("setup_class")
+class TestJudgeRepairer:
 
     @classmethod
     def setUpClass(cls):
@@ -54,15 +59,10 @@ class TestJudgeRepairer(unittest.TestCase):
             cls.vo = {}
 
         # Add test RSE
-        cls.rse1 = 'MOCK'
-        cls.rse3 = 'MOCK3'
-        cls.rse4 = 'MOCK4'
-        cls.rse5 = 'MOCK5'
-
-        cls.rse1_id = get_rse_id(rse=cls.rse1, **cls.vo)
-        cls.rse3_id = get_rse_id(rse=cls.rse3, **cls.vo)
-        cls.rse4_id = get_rse_id(rse=cls.rse4, **cls.vo)
-        cls.rse5_id = get_rse_id(rse=cls.rse5, **cls.vo)
+        cls.rse1, cls.rse1_id = cls.rse_factory.make_mock_rse()
+        cls.rse3, cls.rse3_id = cls.rse_factory.make_mock_rse()
+        cls.rse4, cls.rse4_id = cls.rse_factory.make_mock_rse()
+        cls.rse5, cls.rse5_id = cls.rse_factory.make_mock_rse()
 
         # Add Tags
         cls.T1 = tag_generator()

--- a/lib/rucio/tests/test_multi_vo.py
+++ b/lib/rucio/tests/test_multi_vo.py
@@ -120,7 +120,7 @@ class TestVOCoreAPI(unittest.TestCase):
         rse_id = add_rse(rse_name, 'root', **self.vo)
 
         add_replica(rse_id=rse_id, scope=scope, name=dataset, bytes_=10, account=account)
-        rule_id = add_rule(dids=[{'scope': scope, 'name': dataset}], account=account, copies=1, rse_expression='MOCK', grouping='NONE', weight='fakeweight', lifetime=None, locked=False, subscription_id=None)[0]
+        rule_id = add_rule(dids=[{'scope': scope, 'name': dataset}], account=account, copies=1, rse_expression='MOCK', grouping='NONE', weight=None, lifetime=None, locked=False, subscription_id=None)[0]
 
         with pytest.raises(AccessDenied):
             delete_replication_rule(rule_id=rule_id, purge_replicas=False, issuer='root', **self.new_vo)

--- a/lib/rucio/tests/test_preparer.py
+++ b/lib/rucio/tests/test_preparer.py
@@ -88,7 +88,7 @@ def test_listing_preparing_transfers(mock_request):
     req_sources = list_transfer_requests_and_source_replicas(request_state=RequestState.PREPARING)
 
     assert len(req_sources) != 0
-    found_requests = list(filter(lambda rws: rws.request_id == mock_request['id'], req_sources))
+    found_requests = list(filter(lambda rws: rws.request_id == mock_request['id'], req_sources.values()))
     assert len(found_requests) == 1
 
 

--- a/lib/rucio/tests/test_preparer.py
+++ b/lib/rucio/tests/test_preparer.py
@@ -13,292 +13,181 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
 
 import pytest
 
-from rucio.common.types import InternalScope, InternalAccount
-from rucio.common.utils import generate_uuid
-from rucio.core import config as rucio_config
-from rucio.core.did import add_did, delete_dids
 from rucio.core.distance import get_distances, add_distance
-from rucio.core.replica import add_replicas, delete_replicas
-from rucio.core.request import get_supported_transfertools, list_transfer_requests_and_source_replicas
-from rucio.core.rse import set_rse_transfer_limits, add_rse, del_rse, add_rse_attribute
+from rucio.core.replica import add_replicas
+from rucio.core.request import list_transfer_requests_and_source_replicas
+from rucio.core.transfer import get_supported_transfertools
+from rucio.core.rse import set_rse_transfer_limits, add_rse_attribute, RseData
 from rucio.daemons.conveyor import preparer
 from rucio.db.sqla import models
-from rucio.db.sqla.constants import RequestState, DIDType
-from rucio.db.sqla.session import get_session
-from rucio.tests.common import rse_name_generator
-
-if TYPE_CHECKING:
-    from typing import Optional, Callable
-    from sqlalchemy.orm import Session
-
-
-class GeneratedRSE:
-    def __init__(
-        self,
-        vo: str,
-        db_session: "Session",
-        setup_func: "Optional[Callable]" = None,
-        teardown_func: "Optional[Callable]" = None,
-    ):
-        self.vo = vo
-        self.db_session = db_session
-        self.setup = setup_func
-        self.teardown = teardown_func
-        self.name = rse_name_generator()
-        self.rse_id: "Optional[str]" = None
-
-    def __enter__(self):
-        self.rse_id = add_rse(self.name, vo=self.vo, session=self.db_session)
-        if self.setup:
-            self.setup(self)
-        self.db_session.commit()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        del_rse(rse_id=self.rse_id, session=self.db_session)
-        if self.teardown:
-            self.teardown(self)
-        self.db_session.commit()
-
-
-class GeneratedRequest:
-    def __init__(
-        self,
-        scope: "InternalScope",
-        name: str,
-        dest_rse_id: str,
-        account: "InternalAccount",
-        db_session: "Session",
-        setup_func: "Optional[Callable]" = None,
-        teardown_func: "Optional[Callable]" = None,
-    ):
-        self.db_session = db_session
-        self.setup = setup_func
-        self.teardown = teardown_func
-        self.db_object = models.Request(
-            state=RequestState.PREPARING,
-            scope=scope,
-            name=name,
-            dest_rse_id=dest_rse_id,
-            account=account,
-        )
-
-    def __enter__(self):
-        self.db_object.save(session=self.db_session)
-        if self.setup:
-            self.setup(self)
-        self.db_session.commit()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.db_object.delete(session=self.db_session)
-        if self.teardown:
-            self.teardown(self)
-        self.db_session.commit()
+from rucio.db.sqla.constants import RequestState
 
 
 @pytest.fixture
-def db_session():
-    db_session = get_session()
-    yield db_session
-    db_session.rollback()
+def dest_rse(vo, rse_factory):
+    rse_name, rse_id = rse_factory.make_mock_rse()
+    yield {'name': rse_name, 'id': rse_id}
 
 
 @pytest.fixture
-def dest_rse(vo, db_session):
-    with GeneratedRSE(vo=vo, db_session=db_session) as generated_rse:
-        yield {'name': generated_rse.name, 'id': generated_rse.rse_id}
+def source_rse(vo, rse_factory, dest_rse):
+    rse_name, rse_id = rse_factory.make_mock_rse()
+    add_distance(rse_id, dest_rse['id'], ranking=5)
+    yield {'name': rse_name, 'id': rse_id}
 
 
 @pytest.fixture
-def source_rse(vo, dest_rse, db_session):
-    def setup(rse):
-        add_distance(rse.rse_id, dest_rse['id'], ranking=5, session=rse.db_session)
-
-    with GeneratedRSE(vo=vo, db_session=db_session, setup_func=setup) as generated_rse:
-        yield {'name': generated_rse.name, 'id': generated_rse.rse_id}
+def file(vo, did_factory):
+    did = did_factory.random_file_did()
+    return {'scope': did['scope'], 'name': did['name'], 'bytes': 1, 'adler32': 'deadbeef'}
 
 
 @pytest.fixture
-def file(vo):
-    scope = InternalScope(scope='mock', vo=vo)
-    name = generate_uuid()
-    return {'scope': scope, 'name': name, 'bytes': 1, 'adler32': 'deadbeef'}
+def dataset(db_session, did_factory, vo):
+    return did_factory.make_dataset()
 
 
 @pytest.fixture
-def dataset(db_session, vo):
-    scope = InternalScope(scope='mock', vo=vo)
-    name = generate_uuid()
-    account = InternalAccount('root', vo=vo)
+def mock_request(db_session, vo, source_rse, dest_rse, file, root_account):
+    add_replicas(rse_id=source_rse['id'], files=[file], account=root_account, session=db_session)
 
-    kwargs = {'scope': scope, 'name': name, 'did_type': DIDType.DATASET, 'account': account}
-    add_did(**kwargs, session=db_session)
-    db_session.commit()
-
-    yield kwargs
-
-    del kwargs['account']
-    kwargs['purge_replicas'] = True
-    delete_dids(dids=[kwargs], account=account)
-    db_session.commit()
-
-
-@pytest.fixture
-def mock_request(db_session, vo, source_rse, dest_rse, file):
-    account = InternalAccount('root', vo=vo)
-
-    def teardown(req):
-        delete_replicas(rse_id=source_rse['id'], files=[file], session=req.db_session)
-
-    add_replicas(rse_id=source_rse['id'], files=[file], account=account, session=db_session)
-    with GeneratedRequest(
+    request = models.Request(
+        state=RequestState.PREPARING,
         scope=file['scope'],
         name=file['name'],
         dest_rse_id=dest_rse['id'],
-        account=account,
-        db_session=db_session,
-        teardown_func=teardown,
-    ) as rucio_request:
-        yield rucio_request.db_object
+        account=root_account,
+    )
+    request.save(session=db_session)
+    request_dict = request.to_dict()
+    db_session.commit()
+    db_session.expunge(request)
+    yield request_dict
 
 
 @pytest.fixture
-def mock_request_no_source(db_session, dest_rse, dataset):
-    with GeneratedRequest(
+def mock_request_no_source(db_session, dest_rse, dataset, root_account):
+    request = models.Request(
+        state=RequestState.PREPARING,
         scope=dataset['scope'],
         name=dataset['name'],
         dest_rse_id=dest_rse['id'],
-        account=dataset['account'],
-        db_session=db_session,
-    ) as rucio_request:
-        yield rucio_request.db_object
-
-
-@pytest.fixture
-def dest_throttler(db_session, mock_request):
-    rucio_config.set('throttler', 'mode', 'DEST_PER_ACT', session=db_session)
-    set_rse_transfer_limits(
-        mock_request.dest_rse_id,
-        activity=mock_request.activity,
-        max_transfers=1,
-        strategy='fifo',
-        session=db_session,
+        account=root_account,
     )
+    request.save(session=db_session)
+    request_dict = request.to_dict()
     db_session.commit()
-
-    yield
-
-    db_session.query(models.RSETransferLimit).filter_by(rse_id=mock_request.dest_rse_id).delete()
-    rucio_config.remove_option("throttler", "mode", session=db_session)
-    db_session.commit()
+    db_session.expunge(request)
+    yield request_dict
 
 
-def test_listing_preparing_transfers(db_session, mock_request):
-    req_sources = list_transfer_requests_and_source_replicas(request_state=RequestState.PREPARING, session=db_session)
+def test_listing_preparing_transfers(mock_request):
+    req_sources = list_transfer_requests_and_source_replicas(request_state=RequestState.PREPARING)
 
     assert len(req_sources) != 0
-    found_requests = list(filter(lambda rws: rws.request_id == mock_request.id, req_sources))
+    found_requests = list(filter(lambda rws: rws.request_id == mock_request['id'], req_sources))
     assert len(found_requests) == 1
 
 
-@pytest.mark.noparallel(reason='changes global configuration value')
-@pytest.mark.usefixtures("dest_throttler")
-def test_preparer_setting_request_state_waiting(db_session, mock_request):
-    preparer.run_once(session=db_session, logger=print)
-    db_session.commit()
+@pytest.mark.noparallel(reason='uses preparer')
+@pytest.mark.parametrize("core_config_mock", [{"table_content": [
+    ('throttler', 'mode', 'DEST_PER_ACT')
+]}], indirect=True)
+def test_preparer_setting_request_state_waiting(db_session, mock_request, core_config_mock):
+    set_rse_transfer_limits(
+        mock_request['dest_rse_id'],
+        activity=mock_request['activity'],
+        max_transfers=1,
+        strategy='fifo',
+    )
 
-    updated_mock_request = db_session.query(models.Request).filter_by(id=mock_request.id).one()  # type: models.Request
+    preparer.run_once(logger=print)
+
+    updated_mock_request = db_session.query(models.Request).filter_by(id=mock_request['id']).one()  # type: models.Request
 
     assert updated_mock_request.state == RequestState.WAITING
 
 
+@pytest.mark.noparallel(reason='uses preparer')
 def test_preparer_setting_request_state_queued(db_session, mock_request):
-    preparer.run_once(session=db_session, logger=print)
-    db_session.commit()
+    preparer.run_once(logger=print)
 
-    updated_mock_request = db_session.query(models.Request).filter_by(id=mock_request.id).one()  # type: models.Request
+    updated_mock_request = db_session.query(models.Request).filter_by(id=mock_request['id']).one()  # type: models.Request
 
     assert updated_mock_request.state == RequestState.QUEUED
 
 
+@pytest.mark.noparallel(reason='uses preparer')
 def test_preparer_setting_request_source(db_session, vo, source_rse, mock_request):
-    preparer.run_once(session=db_session, logger=print)
-    db_session.commit()
+    preparer.run_once(logger=print)
 
-    updated_mock_request = db_session.query(models.Request).filter_by(id=mock_request.id).one()  # type: models.Request
+    updated_mock_request = db_session.query(models.Request).filter_by(id=mock_request['id']).one()  # type: models.Request
 
     assert updated_mock_request.state == RequestState.QUEUED
     assert updated_mock_request.source_rse_id == source_rse['id']
 
 
+@pytest.mark.noparallel(reason='uses preparer')
 def test_preparer_for_request_without_source(db_session, mock_request_no_source):
-    preparer.run_once(session=db_session, logger=print)
-    db_session.commit()
+    preparer.run_once(logger=print)
 
     updated_mock_request: "models.Request" = (
-        db_session.query(models.Request).filter_by(id=mock_request_no_source.id).one()
+        db_session.query(models.Request).filter_by(id=mock_request_no_source['id']).one()
     )
 
     assert updated_mock_request.state == RequestState.NO_SOURCES
 
 
+@pytest.mark.noparallel(reason='uses preparer')
 def test_preparer_for_request_without_matching_transfertool_source(db_session, source_rse, dest_rse, mock_request):
-    add_rse_attribute(source_rse['id'], 'transfertool', 'fts3', session=db_session)
-    add_rse_attribute(dest_rse['id'], 'transfertool', 'globus', session=db_session)
-    db_session.commit()
+    add_rse_attribute(source_rse['id'], 'transfertool', 'fts3')
+    add_rse_attribute(dest_rse['id'], 'transfertool', 'globus')
 
     from rucio.core.rse import REGION
 
     REGION.invalidate()
 
-    preparer.run_once(session=db_session, logger=print)
-    db_session.commit()
+    preparer.run_once(logger=print)
 
-    updated_mock_request = db_session.query(models.Request).filter_by(id=mock_request.id).one()  # type: models.Request
+    db_session.expunge_all()
+    updated_mock_request = db_session.query(models.Request).filter_by(id=mock_request['id']).one()  # type: models.Request
 
     assert updated_mock_request.state == RequestState.NO_SOURCES
 
 
-@pytest.mark.xfail(reason='fails when run in parallel')
-def test_two_sources_one_destination(db_session, vo, file, mock_request):
-    def setup(rse):
-        add_distance(rse.rse_id, mock_request.dest_rse_id, ranking=2, session=rse.db_session)
-        add_replicas(rse_id=rse.rse_id, files=[file], account=mock_request.account, session=rse.db_session)
+@pytest.mark.noparallel(reason='uses preparer')
+def test_two_sources_one_destination(rse_factory, source_rse, db_session, vo, file, mock_request):
+    _, source_rse2_id = rse_factory.make_mock_rse()
+    add_distance(source_rse2_id, mock_request['dest_rse_id'], ranking=2)
+    add_replicas(rse_id=source_rse2_id, files=[file], account=mock_request['account'])
 
-    with GeneratedRSE(vo=vo, db_session=db_session, setup_func=setup) as source2_rse:
-        src1_distance, src2_distance = (
-            get_distances(
-                src_rse_id=src_rse,
-                dest_rse_id=mock_request.dest_rse_id,
-                session=db_session,
-            )
-            for src_rse in (mock_request.source_rse_id, source2_rse.rse_id)
+    src1_distance, src2_distance = (
+        get_distances(
+            src_rse_id=src_rse,
+            dest_rse_id=mock_request['dest_rse_id'],
         )
+        for src_rse in (source_rse['id'], source_rse2_id)
+    )
+    assert src1_distance and len(src1_distance) == 1 and src1_distance[0]['ranking'] == 5
+    assert src2_distance and len(src2_distance) == 1 and src2_distance[0]['ranking'] == 2
 
-        assert src1_distance and len(src1_distance) == 1 and src1_distance[0]['ranking'] == 5
-        assert src2_distance and len(src2_distance) == 1 and src2_distance[0]['ranking'] == 2
+    preparer.run_once(logger=print)
 
-        preparer.run_once(session=db_session, logger=print)
-        db_session.commit()
+    db_session.expunge_all()
+    updated_mock_request = (
+        db_session.query(models.Request).filter_by(id=mock_request['id']).one()
+    )  # type: models.Request
 
-        updated_mock_request = (
-            db_session.query(models.Request).filter_by(id=mock_request.id).one()
-        )  # type: models.Request
-
-        assert updated_mock_request.state == RequestState.QUEUED
-        assert updated_mock_request.source_rse_id == source2_rse.rse_id  # distance 2 < 5
-
-        delete_replicas(rse_id=source2_rse.rse_id, files=[file], session=db_session)
+    assert updated_mock_request.state == RequestState.QUEUED
+    assert updated_mock_request.source_rse_id == source_rse2_id  # distance 2 < 5
 
 
-def test_get_supported_transfertools_default(vo, db_session):
-    with GeneratedRSE(vo=vo, db_session=db_session) as generated_rse:
-        transfertools = get_supported_transfertools(rse_id=generated_rse.rse_id, session=db_session)
+def test_get_supported_transfertools_default(vo, rse_factory):
+    rse_name, rse_id = rse_factory.make_mock_rse()
+    transfertools = get_supported_transfertools(rse_data=RseData(rse_id))
 
     assert len(transfertools) == 2
     assert 'fts3' in transfertools

--- a/lib/rucio/tests/test_transfer.py
+++ b/lib/rucio/tests/test_transfer.py
@@ -19,8 +19,9 @@ from concurrent.futures import ThreadPoolExecutor
 from rucio.common.exception import NoDistance
 from rucio.core.distance import add_distance
 from rucio.core.replica import add_replicas
-from rucio.core.transfer import get_transfer_paths
-from rucio.core.topology import get_hops
+from rucio.core.request import list_transfer_requests_and_source_replicas
+from rucio.core.transfer import build_transfer_paths
+from rucio.core.topology import get_hops, Topology
 from rucio.core import rule as rule_core
 from rucio.core import request as request_core
 from rucio.core import rse as rse_core
@@ -360,7 +361,8 @@ def test_fk_error_on_source_creation(rse_factory, did_factory, root_account):
     add_replicas(rse_id=src_rse_id, files=[file], account=root_account)
     rule_core.add_rule(dids=[did], account=root_account, copies=1, rse_expression=dst_rse, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
 
-    requests, *_ = get_transfer_paths(rses=[src_rse_id, dst_rse_id])
+    requests_by_id = list_transfer_requests_and_source_replicas(rses=[src_rse_id, dst_rse_id])
+    requests, *_ = build_transfer_paths(topology=Topology.create_from_config(), requests_with_sources=requests_by_id.values())
     request_id, [transfer_path] = next(iter(requests.items()))
 
     transfer_path[0].rws.request_id = generate_uuid()

--- a/lib/rucio/tests/test_transfer.py
+++ b/lib/rucio/tests/test_transfer.py
@@ -74,7 +74,7 @@ def test_get_hops(rse_factory):
     _, rse4_id = rse_factory.make_mock_rse()
     _, rse5_id = rse_factory.make_mock_rse()
     _, rse6_id = rse_factory.make_mock_rse()
-    all_rses = [rse0_id, rse1_id, rse2_id, rse3_id, rse4_id, rse5_id, rse6_id]
+    all_rses = {rse0_id, rse1_id, rse2_id, rse3_id, rse4_id, rse5_id, rse6_id}
 
     add_distance(rse1_id, rse3_id, ranking=40)
     add_distance(rse1_id, rse2_id, ranking=10)
@@ -114,7 +114,7 @@ def test_get_hops(rse_factory):
 
     # No multihop rses given, multihop disabled
     with pytest.raises(NoDistance):
-        get_hops(source_rse_id=rse3_id, dest_rse_id=rse2_id, multihop_rses=[])
+        get_hops(source_rse_id=rse3_id, dest_rse_id=rse2_id, multihop_rses=set())
 
     # The shortest multihop path will be computed
     [hop1, hop2] = get_hops(source_rse_id=rse3_id, dest_rse_id=rse2_id, multihop_rses=all_rses)
@@ -124,7 +124,7 @@ def test_get_hops(rse_factory):
     assert hop2['dest_rse_id'] == rse2_id
 
     # multihop_rses doesn't contain the RSE needed for the shortest path. Return a longer path
-    [hop1, hop2] = get_hops(source_rse_id=rse1_id, dest_rse_id=rse4_id, multihop_rses=[rse3_id])
+    [hop1, hop2] = get_hops(source_rse_id=rse1_id, dest_rse_id=rse4_id, multihop_rses={rse3_id})
     assert hop1['source_rse_id'] == rse1_id
     assert hop1['dest_rse_id'] == rse3_id
     assert hop2['source_rse_id'] == rse3_id

--- a/lib/rucio/tests/test_transfer.py
+++ b/lib/rucio/tests/test_transfer.py
@@ -19,7 +19,8 @@ from concurrent.futures import ThreadPoolExecutor
 from rucio.common.exception import NoDistance
 from rucio.core.distance import add_distance
 from rucio.core.replica import add_replicas
-from rucio.core.transfer import get_hops, get_transfer_paths
+from rucio.core.transfer import get_transfer_paths
+from rucio.core.topology import get_hops
 from rucio.core import rule as rule_core
 from rucio.core import request as request_core
 from rucio.core import rse as rse_core


### PR DESCRIPTION
Preparer is the one taking decisions about transfertools to use and throttling requests, but it had a very simplistic logic for doing that. As a result, we already had cases when a wrong transfertool was selected for submission. This can also result in incorrectly throttling a request.

This PR moves path computation to preparer, allowing it to select a source_rse_id with almost the same intelligence as submitter has. To avoid un-necessary double computation of paths, we simplify the submitter: if source_rse_id is set in the request (which should only be the case in "queued" transfers if they passed through preparer), submitter performs a simplified workflow on them. When preparer is not used, the behavior of submitter is unchanged. 
