### PR TITLE
Core & Internals: Split RSE availability column Part 2 #5664

### DIFF
--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -29,7 +29,8 @@ from rucio.db.sqla.session import read_session, stream_session, transactional_se
 def add_rse(rse, issuer, vo='def', deterministic=True, volatile=False, city=None, region_code=None,
             country_name=None, continent=None, time_zone=None, ISP=None,
             staging_area=False, rse_type=None, latitude=None, longitude=None, ASN=None,
-            availability: Optional[int] = None, session=None):
+            availability_read: Optional[bool] = None, availability_write: Optional[bool] = None,
+            availability_delete: Optional[bool] = None, session=None):
     """
     Creates a new Rucio Storage Element(RSE).
 
@@ -49,7 +50,9 @@ def add_rse(rse, issuer, vo='def', deterministic=True, volatile=False, city=None
     :param latitude: Latitude coordinate of RSE.
     :param longitude: Longitude coordinate of RSE.
     :param ASN: Access service network.
-    :param availability: Availability.
+    :param availability_read: If the RSE is readable.
+    :param availability_write: If the RSE is writable.
+    :param availability_delete: If the RSE is deletable.
     :param session: The database session in use.
     """
     validate_schema(name='rse', obj=rse, vo=vo)
@@ -60,7 +63,8 @@ def add_rse(rse, issuer, vo='def', deterministic=True, volatile=False, city=None
     return rse_module.add_rse(rse, vo=vo, deterministic=deterministic, volatile=volatile, city=city,
                               region_code=region_code, country_name=country_name, staging_area=staging_area,
                               continent=continent, time_zone=time_zone, ISP=ISP, rse_type=rse_type, latitude=latitude,
-                              longitude=longitude, ASN=ASN, availability=availability, session=session)
+                              longitude=longitude, ASN=ASN, availability_read=availability_read,
+                              availability_write=availability_write, availability_delete=availability_delete, session=session)
 
 
 @read_session

--- a/lib/rucio/core/importer.py
+++ b/lib/rucio/core/importer.py
@@ -51,7 +51,8 @@ def import_rses(rses, rse_sync_method='edit', attr_sync_method='edit', protocol_
                                         city=rse.get('city'), region_code=rse.get('region_code'), country_name=rse.get('country_name'),
                                         staging_area=rse.get('staging_area'), continent=rse.get('continent'), time_zone=rse.get('time_zone'),
                                         ISP=rse.get('ISP'), rse_type=rse.get('rse_type'), latitude=rse.get('latitude'),
-                                        longitude=rse.get('longitude'), ASN=rse.get('ASN'), availability=rse.get('availability'),
+                                        longitude=rse.get('longitude'), ASN=rse.get('ASN'), availability_read=rse.get('availability_read'),
+                                        availability_write=rse.get('availability_write'), availability_delete=rse.get('availability_delete'),
                                         session=session)
 
         new_rses.append(rse_id)

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1099,7 +1099,7 @@ def _list_replicas_with_temp_tables(
         )
 
         if not ignore_availability:
-            stmt = stmt.where(models.RSE.availability.in_((4, 5, 6, 7)))
+            stmt = stmt.where(models.RSE.availability_read == true())
 
         if updated_after:
             stmt = stmt.where(models.RSEFileAssociation.updated_at >= updated_after)
@@ -1562,7 +1562,7 @@ def add_replicas(rse_id, files, account, ignore_availability=True,
     if replica_rse.volatile is True:
         raise exception.UnsupportedOperation('Cannot add replicas on volatile RSE %s ' % (replica_rse.rse))
 
-    if not (replica_rse.availability & 2) and not ignore_availability:
+    if not replica_rse.availability_write and not ignore_availability:
         raise exception.ResourceTemporaryUnavailable('%s is temporary unavailable for writing' % replica_rse.rse)
 
     for file in files:
@@ -1663,7 +1663,7 @@ def __delete_replicas(rse_id, files, ignore_availability=True, session=None):
 
     replica_rse = get_rse(rse_id=rse_id, session=session)
 
-    if not (replica_rse.availability & 1) and not ignore_availability:
+    if not replica_rse.availability_delete and not ignore_availability:
         raise exception.ResourceTemporaryUnavailable('%s is temporary unavailable'
                                                      'for deleting' % replica_rse.rse)
     tt_mngr = temp_table_mngr(session)
@@ -2188,7 +2188,7 @@ def __delete_replicas_without_temp_tables(rse_id, files, ignore_availability=Tru
     """
     replica_rse = get_rse(rse_id=rse_id, session=session)
 
-    if not (replica_rse.availability & 1) and not ignore_availability:
+    if not replica_rse.availability_delete and not ignore_availability:
         raise exception.ResourceTemporaryUnavailable('%s is temporary unavailable'
                                                      'for deleting' % replica_rse.rse)
 
@@ -4263,7 +4263,7 @@ def _list_replicas_for_datasets_wo_temp_tables(dataset_clause, state_clause, rse
                  models.DataIdentifierAssociation.child_name)
 
     if not ignore_availability:
-        replica_query = replica_query.filter(models.RSE.availability.in_((4, 5, 6, 7)))
+        replica_query = replica_query.filter(models.RSE.availability_read == true())
 
     if state_clause:
         replica_query = replica_query.filter(and_(state_clause))
@@ -4312,7 +4312,7 @@ def _list_replicas_for_constituents_wo_temp_tables(constituent_clause, state_cla
                  models.ConstituentAssociation.child_name)
 
     if not ignore_availability:
-        constituent_query = constituent_query.filter(models.RSE.availability.in_((4, 5, 6, 7)))
+        constituent_query = constituent_query.filter(models.RSE.availability_read == true())
 
     if state_clause is not None:
         constituent_query = constituent_query.filter(and_(state_clause))
@@ -4346,7 +4346,7 @@ def _list_replicas_for_files_wo_temp_tables(file_clause, state_clause, files_wo_
         ]
 
         if not ignore_availability:
-            filters.append(models.RSE.availability.in_((4, 5, 6, 7)))
+            filters.append(models.RSE.availability_read == true())
 
         if state_clause is not None:
             filters.append(state_clause)

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -404,7 +404,7 @@ def list_transfer_requests_and_source_replicas(
     )
 
     if not ignore_availability:
-        sub_requests = sub_requests.where(models.RSE.availability.in_((2, 3, 6, 7)))
+        sub_requests = sub_requests.where(models.RSE.availability_read == true())
 
     if isinstance(older_than, datetime.datetime):
         sub_requests = sub_requests.where(models.Request.requested_at < older_than)

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -159,7 +159,8 @@ class RseData:
 
 @transactional_session
 def add_rse(rse, vo='def', deterministic=True, volatile=False, city=None, region_code=None, country_name=None, continent=None, time_zone=None,
-            ISP=None, staging_area=False, rse_type=RSEType.DISK, longitude=None, latitude=None, ASN=None, availability: Optional[int] = 7, session=None):
+            ISP=None, staging_area=False, rse_type=RSEType.DISK, longitude=None, latitude=None, ASN=None, availability_read: Optional[bool] = None,
+            availability_write: Optional[bool] = None, availability_delete: Optional[bool] = None, session=None):
     """
     Add a rse with the given location name.
 
@@ -178,7 +179,6 @@ def add_rse(rse, vo='def', deterministic=True, volatile=False, city=None, region
     :param latitude: Latitude coordinate of RSE.
     :param longitude: Longitude coordinate of RSE.
     :param ASN: Access service network. Accessed by `locals()`.
-    :param availability: Availability.
     :param availability_read: If the RSE is readable.
     :param availability_write: If the RSE is writable.
     :param availability_delete: If the RSE is deletable.
@@ -187,11 +187,11 @@ def add_rse(rse, vo='def', deterministic=True, volatile=False, city=None, region
     if isinstance(rse_type, str):
         rse_type = RSEType(rse_type)
 
-    availability_values = Availability.from_integer(availability)
+    availability = Availability(availability_read, availability_write, availability_delete).integer
     new_rse = models.RSE(rse=rse, vo=vo, deterministic=deterministic, volatile=volatile,
                          staging_area=staging_area, rse_type=rse_type, longitude=longitude,
-                         latitude=latitude, availability=availability, availability_read=availability_values.read,
-                         availability_write=availability_values.write, availability_delete=availability_values.delete,
+                         latitude=latitude, availability=availability, availability_read=availability_read,
+                         availability_write=availability_write, availability_delete=availability_delete,
 
                          # The following fields will be deprecated, they are RSE attributes now.
                          # (Still in the code for backwards compatibility)
@@ -480,9 +480,6 @@ def list_rses(filters={}, session=None):
     """
 
     rse_list = []
-    availability_mask1 = 0
-    availability_mask2 = 7
-    availability_mapping = {'availability_read': 4, 'availability_write': 2, 'availability_delete': 1}
     false_value = False  # To make pep8 checker happy ...
 
     if filters and filters.get('vo'):
@@ -494,6 +491,14 @@ def list_rses(filters={}, session=None):
     if filters:
         if 'availability' in filters and ('availability_read' in filters or 'availability_write' in filters or 'availability_delete' in filters):
             raise exception.InvalidObject('Cannot use availability and read, write, delete filter at the same time.')
+
+        if 'availability' in filters:
+            availability = Availability.from_integer(filters['availability'])
+            filters['availability_read'] = availability.read
+            filters['availability_write'] = availability.write
+            filters['availability_delete'] = availability.delete
+            del filters['availability']
+
         query = session.query(models.RSE).\
             join(models.RSEAttrAssociation, models.RSE.id == models.RSEAttrAssociation.rse_id).\
             filter(models.RSE.deleted == false_value).group_by(models.RSE)
@@ -504,28 +509,13 @@ def list_rses(filters={}, session=None):
                     query = query.filter(getattr(models.RSE, k) == RSEType[v])
                 else:
                     query = query.filter(getattr(models.RSE, k) == v)
-            elif k in ['availability_read', 'availability_write', 'availability_delete']:
-                if v:
-                    availability_mask1 = availability_mask1 | availability_mapping[k]
-                else:
-                    availability_mask2 = availability_mask2 & ~availability_mapping[k]
             else:
                 t = aliased(models.RSEAttrAssociation)
                 query = query.join(t, t.rse_id == models.RSEAttrAssociation.rse_id)
                 query = query.filter(t.key == k,
                                      t.value == v)
 
-        condition1, condition2 = [], []
-        for i in range(0, 8):
-            if i | availability_mask1 == i:
-                condition1.append(models.RSE.availability == i)
-            if i & availability_mask2 == i:
-                condition2.append(models.RSE.availability == i)
-
-        if 'availability' not in filters:
-            query = query.filter(sqlalchemy.and_(sqlalchemy.or_(*condition1), sqlalchemy.or_(*condition2)))
     else:
-
         query = session.query(models.RSE).filter_by(deleted=False).order_by(models.RSE.rse)
 
     if vo:
@@ -1120,13 +1110,9 @@ def get_rse_protocols(rse_id, schemes=None, session=None):
     # Copy sign_url from the attributes
     sign_url = get_rse_attribute(_rse.id, 'sign_url', session=session)
 
-    read = True if _rse.availability & 4 else False
-    write = True if _rse.availability & 2 else False
-    delete = True if _rse.availability & 1 else False
-
-    info = {'availability_delete': delete,
-            'availability_read': read,
-            'availability_write': write,
+    info = {'availability_delete': _rse.availability_delete,
+            'availability_read': _rse.availability_read,
+            'availability_write': _rse.availability_write,
             'credentials': None,
             'deterministic': _rse.deterministic,
             'domain': utils.rse_supported_protocol_domains(),
@@ -1423,34 +1409,21 @@ def update_rse(rse_id: str, parameters: 'Dict[str, Any]', session=None):
         query = session.query(models.RSE).filter_by(id=rse_id).one()
     except sqlalchemy.orm.exc.NoResultFound:
         raise exception.RSENotFound('RSE with ID \'%s\' cannot be found' % rse_id)
-    availability = 0
     rse = query.rse
-    for column in query:
-        if column[0] == 'availability':
-            availability = column[1] or availability
 
     param = {}
-    availability_mapping = {'availability_read': 4, 'availability_write': 2, 'availability_delete': 1}
+
+    if 'availability' in parameters:
+        availability = Availability.from_integer(parameters['availability'])
+        param['availability_read'] = availability.read
+        param['availability_write'] = availability.write
+        param['availability_delete'] = availability.delete
 
     for key in parameters:
         if key == 'name' and parameters['name'] != rse:  # Needed due to wrongly setting name in pre1.22.7 clients
             param['rse'] = parameters['name']
-        elif key in ['availability_read', 'availability_write', 'availability_delete']:
-            if parameters[key] is True:
-                availability = availability | availability_mapping[key]
-            else:
-                availability = availability & ~availability_mapping[key]
-        elif key in MUTABLE_RSE_PROPERTIES - {'name', 'availability_read', 'availability_write', 'availability_delete'}:
+        elif key in MUTABLE_RSE_PROPERTIES - {'name'}:
             param[key] = parameters[key]
-
-    if 'availability' not in param:
-        param['availability'] = availability
-
-    if 'availability' in param:
-        availability_values = Availability.from_integer(param['availability'])
-        param['availability_read'] = availability_values.read
-        param['availability_write'] = availability_values.write
-        param['availability_delete'] = availability_values.delete
 
     # handle null-able keys
     for key in parameters:

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -43,7 +43,7 @@ def parse_expression(expression, filter_=None, session=None):
     Parse a RSE expression and return the list of RSE dictionaries.
 
     :param expression:    RSE expression, e.g: 'CERN|BNL'.
-    :param filter_:        Availability filter (dictionary) used for the RSEs. e.g.: {'availability_write': True}
+    :param filter_:       Availability filter (dictionary) used for the RSEs. e.g.: {'availability_write': True}
     :param session:       Database session in use.
     :returns:             A list of rse dictionaries.
     :raises:              InvalidRSEExpression, RSENotFound, RSEWriteBlocked
@@ -96,7 +96,7 @@ def parse_expression(expression, filter_=None, session=None):
     if filter_:
         for rse in vo_result:
             if filter_.get('availability_write', False):
-                if rse.get('availability') & 2:
+                if rse.get('availability_write'):
                     final_result.append(rse)
         if not final_result:
             raise RSEWriteBlocked('RSE excluded; not available for writing.')

--- a/lib/rucio/core/rse_selector.py
+++ b/lib/rucio/core/rse_selector.py
@@ -48,7 +48,7 @@ class RSESelector():
         if weight is not None:
             for rse in rses:
                 attributes = list_rse_attributes(rse_id=rse['id'], session=session)
-                availability_write = True if rse.get('availability', 7) & 2 else False
+                availability_write = True if rse.get('availability_write', True) else False
                 if weight not in attributes:
                     continue  # The RSE does not have the required weight set, therefore it is ignored
                 try:
@@ -62,7 +62,7 @@ class RSESelector():
         else:
             for rse in rses:
                 mock_rse = has_rse_attribute(rse['id'], 'mock', session=session)
-                availability_write = True if rse.get('availability', 7) & 2 else False
+                availability_write = True if rse.get('availability_write', True) else False
                 self.rses.append({'rse_id': rse['id'],
                                   'weight': 1,
                                   'mock_rse': mock_rse,

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -2198,7 +2198,7 @@ def examine_rule(rule_id, session=None):
 
                     for replica in available_replicas:
                         sources.append((get_rse_name(rse_id=replica.rse_id, session=session),
-                                        True if get_rse(rse_id=replica.rse_id, session=session).availability >= 4 else False))
+                                        True if get_rse(rse_id=replica.rse_id, session=session).availability_read else False))
 
                 result['transfers'].append({'scope': lock.scope,
                                             'name': lock.name,

--- a/lib/rucio/daemons/bb8/bb8.py
+++ b/lib/rucio/daemons/bb8/bb8.py
@@ -216,14 +216,14 @@ def run_once(
             "Excluding RSEs as destinations which are not available for write:",
         )
         for des in rses_under_ratio:
-            if des["availability"] & 2 == 0:
+            if not des["availability_write"]:
                 logger(logging.DEBUG, "Excluding %s", des["rse"])
                 rses_under_ratio.remove(des)
         logger(
             logging.DEBUG, "Excluding RSEs as sources which are not available for read:"
         )
         for src in rses_over_ratio:
-            if src["availability"] & 4 == 0:
+            if not src["availability_read"]:
                 logger(logging.DEBUG, "Excluding %s", src["rse"])
                 rses_over_ratio.remove(src)
 

--- a/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
@@ -109,13 +109,13 @@ for src in rses_over_ratio:
 
 print('Excluding RSEs as destinations which are blocklisted:')
 for des in rses_under_ratio:
-    if des['availability'] != 7:
+    if not (des['availability_read'] and des['availability_write'] and des['availability_delete']):
         print('  %s' % (des['rse']))
         rses_under_ratio.remove(des)
 
 print('Excluding RSEs as sources which are blocklisted:')
 for src in rses_over_ratio:
-    if src['availability'] != 7:
+    if not (src['availability_read'] and src['availability_write'] and src['availability_delete']):
         print('  %s' % (src['rse']))
         rses_over_ratio.remove(src)
 

--- a/lib/rucio/daemons/bb8/t2_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/t2_background_rebalance.py
@@ -109,13 +109,13 @@ for src in rses_over_ratio:
 
 print('Excluding RSEs as desetinations which are blocklisted:')
 for des in rses_under_ratio:
-    if des['availability'] != 7:
+    if not (des['availability_read'] and des['availability_write'] and des['availability_delete']):
         print('  %s' % (des['rse']))
         rses_under_ratio.remove(des)
 
 print('Excluding RSEs as sources which are blocklisted:')
 for src in rses_over_ratio:
-    if src['availability'] != 7:
+    if not (src['availability_read'] and src['availability_write'] and src['availability_delete']):
         print('  %s' % (src['rse']))
         rses_over_ratio.remove(src)
 

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
@@ -176,7 +176,7 @@ class PlacementAlgorithm:
                 continue
             if rse_attr['type'] != 'DATADISK':
                 continue
-            if src_rse_info['availability'] & 4 == 0:
+            if not src_rse_info['availability_read']:
                 continue
 
             if rep['state'] == ReplicaState.AVAILABLE:
@@ -201,7 +201,7 @@ class PlacementAlgorithm:
                         dst_rse_id = self._sites[dst_site]['rse_id']
                         dst_rse_info = get_rse(rse_id=dst_rse_id)
 
-                        if dst_rse_info['availability'] & 2 == 0:
+                        if not dst_rse_info['availability_write']:
                             continue
 
                         site_added_bytes = sum(self._added_bytes.get_series(dst_rse_id))

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -179,9 +179,9 @@ def run_once(worker_number=0, logger=logging.log, session=None, **kwargs):
         if direction == 'destination' or direction == 'source':
             for rse_id in result_dict:
                 rse_name = result_dict[rse_id]['rse']
-                availability = get_rse(rse_id).availability
+                rse = get_rse(rse_id)
                 # dest_rse is not blocklisted for write or src_rse is not blocklisted for read
-                if (direction == 'destination' and availability & 2) or (direction == 'source' and availability & 4):
+                if (direction == 'destination' and rse.availability_write) or (direction == 'source' and rse.availability_read):
                     if all_activities:
                         __release_all_activities(result_dict[rse_id], direction, rse_name, rse_id, logger=logger, session=session)
                     else:

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -514,7 +514,7 @@ def _run_once(rses_to_process, chunk_size, greedy, scheme,
     tot_needed_free_space = 0
     for rse in rses_to_process:
         # Check if RSE is blocklisted
-        if rse.columns['availability'] % 2 == 0:
+        if not rse.columns['availability_write']:
             logger(logging.DEBUG, 'RSE %s is blocklisted for delete', rse.name)
             continue
         rse.ensure_loaded(load_attributes=True)

--- a/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
+++ b/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
@@ -209,8 +209,8 @@ def declare_suspicious_replicas_bad(once: bool = False, younger_than: int = 3, n
                         logger(logging.DEBUG, '%s', i)
 
                     # RSEs that aren't available shouldn't have suspicious replicas showing up. Skip to next RSE.
-                    if (rse['availability'] not in {4, 5, 6, 7}) and ((len(suspicious_replicas_avail_elsewhere) > 0) or (len(suspicious_replicas_last_copy) > 0)):
-                        logger(logging.WARNING, "%s is not available (availability: %s), yet it has suspicious replicas. Please investigate. \n", rse_expr, rse['availability'])
+                    if not rse['availability_read'] and ((len(suspicious_replicas_avail_elsewhere) > 0) or (len(suspicious_replicas_last_copy) > 0)):
+                        logger(logging.WARNING, "%s is not available (availability_read: %s), yet it has suspicious replicas. Please investigate. \n", rse_expr, rse['availability_read'])
                         continue
 
                     if suspicious_replicas_avail_elsewhere:

--- a/lib/rucio/tests/test_import_export.py
+++ b/lib/rucio/tests/test_import_export.py
@@ -53,7 +53,9 @@ def check_rse(rse_name, test_data, vo='def'):
     assert rse['staging_area'] == test_data[rse_name]['staging_area']
     assert rse['longitude'] == test_data[rse_name]['longitude']
     assert rse['latitude'] == test_data[rse_name]['latitude']
-    assert rse['availability'] == test_data[rse_name]['availability']
+    assert rse['availability_read'] == test_data[rse_name]['availability_read']
+    assert rse['availability_write'] == test_data[rse_name]['availability_write']
+    assert rse['availability_delete'] == test_data[rse_name]['availability_delete']
 
 
 def check_protocols(rse, test_data, vo='def'):
@@ -152,7 +154,8 @@ def importer_example_data(vo):
 
     # RSE 1 that already exists
     example_data.old_rse_1 = rse_name_generator()
-    example_data.old_rse_id_1 = add_rse(example_data.old_rse_1, availability=1, region_code='DE', country_name='DE', deterministic=True, volatile=True, staging_area=True, time_zone='Europe', latitude='1', longitude='2', vo=vo)
+    example_data.old_rse_id_1 = add_rse(example_data.old_rse_1, availability_read=False, availability_write=False, region_code='DE', country_name='DE',
+                                        deterministic=True, volatile=True, staging_area=True, time_zone='Europe', latitude='1', longitude='2', vo=vo)
     add_protocol(example_data.old_rse_id_1, {'scheme': 'scheme1', 'hostname': 'hostname1', 'port': 1000, 'impl': 'TODO'})
     add_protocol(example_data.old_rse_id_1, {'scheme': 'scheme3', 'hostname': 'hostname3', 'port': 1000, 'impl': 'TODO'})
 
@@ -198,7 +201,9 @@ def importer_example_data(vo):
         'rses': {
             example_data.new_rse: {
                 'rse_type': RSEType.TAPE,
-                'availability': 3,
+                'availability_read': False,
+                'availability_write': True,
+                'availability_delete': True,
                 'city': 'NewCity',
                 'region_code': 'CH',
                 'country_name': 'switzerland',
@@ -234,7 +239,9 @@ def importer_example_data(vo):
                 'time_zone': 'Asia',
                 'longitude': 5,
                 'city': 'City',
-                'availability': 2,
+                'availability_read': False,
+                'availability_write': True,
+                'availability_delete': False,
                 'latitude': 10,
                 'protocols': [{
                     'scheme': 'scheme1',
@@ -865,7 +872,9 @@ class TestImporterSyncModes(unittest.TestCase):
             'rses': {
                 less_prot_rse: {
                     'rse_type': RSEType.TAPE,
-                    'availability': 3,
+                    'availability_read': False,
+                    'availability_write': True,
+                    'availability_delete': True,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -892,7 +901,9 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 diff_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability': 3,
+                    'availability_read': False,
+                    'availability_write': True,
+                    'availability_delete': True,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -911,7 +922,9 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 more_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability': 2,
+                    'availability_read': False,
+                    'availability_write': True,
+                    'availability_delete': False,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -982,7 +995,9 @@ class TestImporterSyncModes(unittest.TestCase):
             'rses': {
                 less_prot_rse: {
                     'rse_type': RSEType.TAPE,
-                    'availability': 3,
+                    'availability_read': False,
+                    'availability_write': True,
+                    'availability_delete': True,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -1009,7 +1024,9 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 diff_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability': 3,
+                    'availability_read': False,
+                    'availability_write': True,
+                    'availability_delete': True,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -1028,7 +1045,9 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 more_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability': 2,
+                    'availability_read': False,
+                    'availability_write': True,
+                    'availability_delete': False,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -1099,7 +1118,9 @@ class TestImporterSyncModes(unittest.TestCase):
             'rses': {
                 less_prot_rse: {
                     'rse_type': RSEType.TAPE,
-                    'availability': 3,
+                    'availability_read': False,
+                    'availability_write': True,
+                    'availability_delete': True,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -1126,7 +1147,9 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 diff_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability': 3,
+                    'availability_read': False,
+                    'availability_write': True,
+                    'availability_delete': True,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',
@@ -1145,7 +1168,9 @@ class TestImporterSyncModes(unittest.TestCase):
                 },
                 more_prot_rse: {
                     'rse_type': RSEType.DISK,
-                    'availability': 2,
+                    'availability_read': False,
+                    'availability_write': True,
+                    'availability_delete': False,
                     'city': 'NewCity',
                     'region_code': 'CH',
                     'country_name': 'switzerland',

--- a/lib/rucio/tests/test_rse.py
+++ b/lib/rucio/tests/test_rse.py
@@ -51,7 +51,9 @@ class TestRSECoreApi:
         invalid_rse = 'BLAHBLAH'
         properties = {
             'ASN': 'ASN',
-            'availability': 2,
+            'availability_read': False,
+            'availability_write': True,
+            'availability_delete': False,
             'deterministic': True,
             'volatile': True,
             'city': 'city',
@@ -83,7 +85,9 @@ class TestRSECoreApi:
         assert rse.longitude == properties['longitude']
         assert rse.latitude == properties['latitude']
         assert rse.ASN == properties['ASN']
-        assert rse.availability == properties['availability']
+        assert rse.availability_read == properties['availability_read']
+        assert rse.availability_write == properties['availability_write']
+        assert rse.availability_delete == properties['availability_delete']
         assert not rse_exists(invalid_rse, vo=vo)
 
         with pytest.raises(Duplicate):
@@ -255,7 +259,9 @@ def test_create_rse_success(vo, rest_client, auth_token):
     headers_dict = {'X-Rucio-Type': 'user', 'X-Rucio-Account': 'root'}
     properties = {
         'ASN': 'ASN',
-        'availability': 2,
+        'availability_read': False,
+        'availability_write': True,
+        'availability_delete': False,
         'deterministic': True,
         'volatile': True,
         'city': 'city',
@@ -286,7 +292,9 @@ def test_create_rse_success(vo, rest_client, auth_token):
     assert rse.longitude == properties['longitude']
     assert rse.latitude == properties['latitude']
     assert rse.ASN == properties['ASN']
-    assert rse.availability == properties['availability']
+    assert rse.availability_read == properties['availability_read']
+    assert rse.availability_write == properties['availability_write']
+    assert rse.availability_delete == properties['availability_delete']
 
     response = rest_client.post('/rses/' + rse_name, headers=headers(auth(auth_token), hdrdict(headers_dict)))
     assert response.status_code == 409
@@ -383,7 +391,9 @@ class TestRSEClient:
         rse_name = rse_name_generator()
         properties = {
             'ASN': 'ASN',
-            'availability': 2,
+            'availability_read': False,
+            'availability_write': True,
+            'availability_delete': False,
             'deterministic': True,
             'volatile': True,
             'city': 'city',
@@ -414,7 +424,9 @@ class TestRSEClient:
         assert rse.longitude == properties['longitude']
         assert rse.latitude == properties['latitude']
         assert rse.ASN == properties['ASN']
-        assert rse.availability == properties['availability']
+        assert rse.availability_read == properties['availability_read']
+        assert rse.availability_write == properties['availability_write']
+        assert rse.availability_delete == properties['availability_delete']
 
         with pytest.raises(Duplicate):
             rucio_client.add_rse(rse_name)

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -25,7 +25,7 @@ from rucio.api.rse import add_rse, update_rse, list_rses, del_rse, add_rse_attri
 from rucio.common.exception import Duplicate, AccessDenied, RSENotFound, RSEOperationNotSupported, \
     RSEProtocolNotSupported, InvalidObject, RSEProtocolDomainNotSupported, RSEProtocolPriorityError, \
     InvalidRSEExpression, RSEAttributeNotFound, CounterNotFound, InvalidPath, ReplicaNotFound, InputValidationError
-from rucio.common.utils import render_json, APIEncoder
+from rucio.common.utils import Availability, render_json, APIEncoder
 from rucio.rse import rsemanager
 from rucio.web.rest.flaskapi.v1.common import request_auth_env, response_headers, check_accept_header_wrapper_flask, \
     try_stream, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
@@ -110,6 +110,16 @@ class RSEs(ErrorHandlingMethodView):
                       availability:
                         description: The availability of the rse.
                         type: integer
+                        deprecated: true
+                      availability_read:
+                        description: If the RSE is readable.
+                        type: integer
+                      availability_write:
+                        description: If the RSE is writable.
+                        type: integer
+                      availability_delete:
+                        description: If the RSE is deletable.
+                        type: integer
                       usage:
                         description: The usage of the rse.
                         type: integer
@@ -137,6 +147,7 @@ class RSEs(ErrorHandlingMethodView):
         else:
             def generate(vo):
                 for rse in list_rses(vo=vo):
+                    rse['availability'] = Availability(rse['availability_read'], rse['availability_write'], rse['availability_delete']).integer
                     yield render_json(**rse) + '\n'
 
             return try_stream(generate(vo=request.environ.get('vo')))
@@ -208,6 +219,16 @@ class RSE(ErrorHandlingMethodView):
                   availability:
                     description: The availability of the RSE.
                     type: integer
+                    deprecated: true
+                  availability_read:
+                    description: If the RSE is readable.
+                    type: boolean
+                  availability_write:
+                    description: If the RSE is writable.
+                    type: boolean
+                  availability_delete:
+                    description: If the RSE is deletable.
+                    type: boolean
         responses:
           201:
             description: OK
@@ -239,12 +260,25 @@ class RSE(ErrorHandlingMethodView):
             'latitude': None,
             'longitude': None,
             'ASN': None,
-            'availability': None,
+            'availability_read': None,
+            'availability_write': None,
+            'availability_delete': None,
         }
         if request.get_data(as_text=True):
             parameters = json_parameters()
+
+            if "availability" in parameters and ("availability_read" in parameters or "availability_write" in parameters or "availability_delete" in parameters):
+                return generate_http_error_flask(422, InputValidationError("'availability' can not be specified with 'availability_read', 'availability_write' or 'availability_delete'"))  # noqa: E501
+
+            if "availability" in parameters:
+                availability = Availability.from_integer(parameters["availability"])
+                kwargs["availability_read"] = availability.read
+                kwargs["availability_write"] = availability.write
+                kwargs["availability_delete"] = availability.delete
+
             for keyword in kwargs.keys():
                 kwargs[keyword] = param_get(parameters, keyword, default=kwargs[keyword])
+
         kwargs['issuer'] = request.environ.get('issuer')
         kwargs['vo'] = request.environ.get('vo')
         try:
@@ -280,7 +314,7 @@ class RSE(ErrorHandlingMethodView):
               schema:
                 type: object
                 properties:
-                  availability_raed:
+                  availability_read:
                     description: The vailability of the RSE.
                     type: boolean
                   availability_write:
@@ -420,6 +454,15 @@ class RSE(ErrorHandlingMethodView):
                     availability:
                       description: The availability of the RSE.
                       type: integer
+                      deprecated: true
+                    availability_read:
+                      description: If the RSE is readable.
+                      type: integer
+                    availability_write:
+                      description: If the RSE is writable.
+                      type: integer
+                    availability_delete:
+                      description: If the RSE is deletable.
           401:
             description: Invalid Auth Token
           404:
@@ -428,8 +471,9 @@ class RSE(ErrorHandlingMethodView):
             description: Not acceptable
         """
         try:
-            rse_prop = get_rse(rse=rse, vo=request.environ.get('vo'))
-            return Response(render_json(**rse_prop), content_type="application/json")
+            rse = get_rse(rse=rse, vo=request.environ.get('vo'))
+            rse['availability'] = Availability(rse['availability_read'], rse['availability_write'], rse['availability_delete']).integer
+            return Response(render_json(**rse), content_type="application/json")
         except RSENotFound as error:
             return generate_http_error_flask(404, error)
 


### PR DESCRIPTION
The rse availability columns are created respectively. Since all
instances are migrated now, we can switch to the new method as the
deafult. This concludes part 2 of the three step plan:

1. Add the new columns to the database and write the data to it, don't
   read from it. This creates the new columns, and fills them with
   intact data.

2. After all instances use the new version, use the new columns.

3. After all instances use the new column, delete the old one.
