### PR TITLE
Tools: Disable the type-checker for tests and db #5750

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -2,6 +2,10 @@
     "include": [
         "lib"
     ],
+    "exclude": [
+        "lib/rucio/db",
+        "lib/rucio/tests",
+    ],
     "pythonVersion": "3.6",
     "typeCheckingMode": "basic",
     "useLibraryCodeForTypes": true


### PR DESCRIPTION
The type-checker currently tests the entire repository. While this is
desired, it can get tedious to write tests and db migrations. This
commit disables the type-checker for the tests and database-migrations,
to not discurrage developers from writing them.
