### PR TITLE
Added force flag to ignore existing replica state in the bad_replicas table

### DIFF
--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -41,46 +41,43 @@ class ReplicaClient(BaseClient):
         if (rse is None) == (rse_id is None):
             raise ValueError("Either RSE name or RSE id must be specified, but not both")
 
-        data = {'rse': rse, 'rse_id': rse_id, 'replicas': replicas}
         url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, 'quarantine']))
         headers = {}
-        r = self._send_request(url, headers=headers, type_='POST', data=dumps(data))
-        if r.status_code // 100 != 2:
-            exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
-            raise exc_cls(exc_msg)
+        chunk_size = 1000
+        for i in range(0, len(replicas), chunk_size):
+            chunk = replicas[i:i + chunk_size]
+            data = {'rse': rse, 'rse_id': rse_id, 'replicas': chunk}
+            r = self._send_request(url, headers=headers, type_='POST', data=dumps(data))
+            if r.status_code // 100 != 2:
+                exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+                raise exc_cls(exc_msg)
 
-    def declare_bad_file_replicas(self, replicas, reason):
+    def declare_bad_file_replicas(self, replicas, reason, force=False):
         """
         Declare a list of bad replicas.
 
         :param replicas: Either a list of PFNs (string) or a list of dicts {'scope': <scope>, 'name': <name>, 'rse_id': <rse_id> or 'rse': <rse_name>}
         :param reason: The reason of the loss.
+        :param force: boolean, tell the serrver to ignore existing replica status in the bad_replicas table. Default: False
+        :returns: Dictionary {"rse_name": ["did: error",...]} - list of strings for DIDs failed to declare, by RSE
         """
-        data = {'reason': reason, 'replicas': replicas}
+
+        out = {}    # {rse: ["did: error text",...]}
         url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, 'bad']))
         headers = {}
-        r = self._send_request(url, headers=headers, type_='POST', data=dumps(data))
-        if r.status_code == codes.created:
-            return loads(r.text)
-        exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
-        raise exc_cls(exc_msg)
-
-    def declare_bad_did_replicas(self, rse, dids, reason):
-        """
-        Declare a list of bad replicas.
-
-        :param rse: The RSE where the bad replicas reside
-        :param dids: The DIDs of the bad replicas
-        :param reason: The reason of the loss.
-        """
-        data = {'reason': reason, 'rse': rse, 'dids': dids}
-        url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, 'bad/dids']))
-        headers = {}
-        r = self._send_request(url, headers=headers, type_='POST', data=dumps(data))
-        if r.status_code == codes.created:
-            return loads(r.text)
-        exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
-        raise exc_cls(exc_msg)
+        chunk_size = 1000
+        for i in range(0, len(replicas), chunk_size):
+            chunk = replicas[i:i + chunk_size]
+            data = {'reason': reason, 'replicas': chunk, 'force': force}
+            r = self._send_request(url, headers=headers, type_='POST', data=dumps(data))
+            if r.status_code not in (codes.created, codes.ok):
+                exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+                raise exc_cls(exc_msg)
+            chunk_result = loads(r.text)
+            if chunk_result:
+                for rse, lst in chunk_result.items():
+                    out.setdefault(rse, []).extend(lst)
+        return out
 
     def declare_suspicious_file_replicas(self, pfns, reason):
         """

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -242,7 +242,7 @@ def list_bad_replicas_status(state=BadFilesStatus.BAD, rse_id=None, younger_than
 
 
 @transactional_session
-def __declare_bad_file_replicas(pfns, rse_id, reason, issuer, status=BadFilesStatus.BAD, scheme='srm', session=None):
+def __declare_bad_file_replicas(pfns, rse_id, reason, issuer, status=BadFilesStatus.BAD, scheme='srm', force=False, session=None):
     """
     Declare a list of bad replicas.
 
@@ -252,6 +252,7 @@ def __declare_bad_file_replicas(pfns, rse_id, reason, issuer, status=BadFilesSta
     :param issuer: The issuer account.
     :param status: Either BAD or SUSPICIOUS.
     :param scheme: The scheme of the PFNs.
+    :param force: boolean, if declaring BAD replica, ignore existing replica status in the bad_replicas table. Default: False
     :param session: The database session in use.
     """
     unknown_replicas = []
@@ -303,10 +304,15 @@ def __declare_bad_file_replicas(pfns, rse_id, reason, issuer, status=BadFilesSta
         replicas_list.append((scope, name, path))
 
     for scope, name, path, __exists, already_declared, size in __exist_replicas(rse_id=rse_id, replicas=replicas_list, session=session):
-        if __exists and ((status == BadFilesStatus.BAD and not already_declared) or status == BadFilesStatus.SUSPICIOUS):
+        if __exists and \
+                (
+                    status == BadFilesStatus.BAD and (force or not already_declared)
+                    or status == BadFilesStatus.SUSPICIOUS
+                ):
             declared_replicas.append({'scope': scope, 'name': name, 'rse_id': rse_id, 'state': ReplicaState.BAD})
-            new_bad_replica = models.BadReplicas(scope=scope, name=name, rse_id=rse_id, reason=reason, state=status, account=issuer, bytes=size)
-            new_bad_replica.save(session=session, flush=False)
+            if not already_declared:
+                new_bad_replica = models.BadReplicas(scope=scope, name=name, rse_id=rse_id, reason=reason, state=status, account=issuer, bytes=size)
+                new_bad_replica.save(session=session, flush=False)
         else:
             if already_declared:
                 unknown_replicas.append('%s %s' % (path_pfn_dict.get(path, '%s:%s' % (scope, name)), 'Already declared'))
@@ -390,7 +396,7 @@ def add_bad_dids(dids, rse_id, reason, issuer, state=BadFilesStatus.BAD, session
 
 
 @transactional_session
-def declare_bad_file_replicas(replicas, reason, issuer, status=BadFilesStatus.BAD, session=None):
+def declare_bad_file_replicas(replicas, reason, issuer, status=BadFilesStatus.BAD, force=False, session=None):
     """
     Declare a list of bad replicas.
 
@@ -398,8 +404,9 @@ def declare_bad_file_replicas(replicas, reason, issuer, status=BadFilesStatus.BA
     :param reason: The reason of the loss.
     :param issuer: The issuer account.
     :param status: The status of the file (SUSPICIOUS or BAD).
+    :param force: boolean, if declaring BAD replica, ignore existing replica status in the bad_replicas table. Default: False
     :param session: The database session in use.
-    :returns: Dictionary {rse_id -> [reploicas failed to declare]}
+    :returns: Dictionary {rse_id -> [replicas failed to declare with errors]}
     """
     unknown_replicas = {}
     if replicas:
@@ -416,7 +423,9 @@ def declare_bad_file_replicas(replicas, reason, issuer, status=BadFilesStatus.BA
                 rse_id = replica['rse_id']
                 files_to_declare.setdefault(rse_id, []).append(replica)
         for rse_id in files_to_declare:
-            notdeclared = __declare_bad_file_replicas(files_to_declare[rse_id], rse_id, reason, issuer, status=status, scheme=scheme, session=session)
+            notdeclared = __declare_bad_file_replicas(files_to_declare[rse_id], rse_id, reason, issuer,
+                                                      status=status, scheme=scheme,
+                                                      force=force, session=session)
             if notdeclared:
                 unknown_replicas[rse_id] = notdeclared
     return unknown_replicas

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -812,6 +812,9 @@ class BadReplicas(ErrorHandlingMethodView):
             application/json:
               schema:
                 type: object
+                required:
+                  - replicas
+                  - reason
                 properties:
                   replicas:
                     description: The list of pfns or list of dicts with "scope", "name", "rse_id"/"rse"
@@ -821,6 +824,9 @@ class BadReplicas(ErrorHandlingMethodView):
                   reason:
                     description: The reason for the declaration.
                     type: string
+                  force:
+                    description: If true, ignore existing replica status in the bad_replicas table.
+                    type: boolean
         responses:
           201:
             description: OK
@@ -839,9 +845,12 @@ class BadReplicas(ErrorHandlingMethodView):
         parameters = json_parameters()
         replicas = param_get(parameters, 'replicas', default=[])
         reason = param_get(parameters, 'reason', default=None)
+        force = param_get(parameters, 'force', default=False)
 
         try:
-            not_declared_files = declare_bad_file_replicas(replicas, reason=reason, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+            not_declared_files = declare_bad_file_replicas(replicas, reason=reason, 
+                                                            issuer=request.environ.get('issuer'), vo=request.environ.get('vo'),
+                                                            force=force)
             return not_declared_files, 201
         except AccessDenied as error:
             return generate_http_error_flask(401, error)


### PR DESCRIPTION
Added force flag to ignore existing bad_replicas file state when declaring bad file replicas

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
