### PR TITLE
Replicas: Added force flag to declare_bad_file_replicas #5392

### DIFF
--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -90,6 +90,17 @@ codes = {
 DATE_FORMAT = '%a, %d %b %Y %H:%M:%S UTC'
 
 
+def invert_dict(d):
+    """
+    Invert the dictionary.
+    CAUTION: this function is not deterministic unless the input dictionary is one-to-one mapping.
+
+    :param d: source dictionary
+    :returns: dictionary {value: key for key, value in d.items()}
+    """
+    return {value: key for key, value in d.items()}
+
+
 def dids_as_dicts(did_list):
     """
     Converts list of DIDs to list of dictionaries

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -821,6 +821,9 @@ class BadReplicas(ErrorHandlingMethodView):
                   reason:
                     description: The reason for the declaration.
                     type: string
+                  force:
+                    description: If true, ignore existing replica status in the bad_replicas table.
+                    type: boolean
         responses:
           201:
             description: OK
@@ -839,9 +842,12 @@ class BadReplicas(ErrorHandlingMethodView):
         parameters = json_parameters()
         replicas = param_get(parameters, 'replicas', default=[])
         reason = param_get(parameters, 'reason', default=None)
+        force = param_get(parameters, 'force', default=False)
 
         try:
-            not_declared_files = declare_bad_file_replicas(replicas, reason=reason, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+            not_declared_files = declare_bad_file_replicas(replicas, reason=reason,
+                                                           issuer=request.environ.get('issuer'), vo=request.environ.get('vo'),
+                                                           force=force)
             return not_declared_files, 201
         except AccessDenied as error:
             return generate_http_error_flask(401, error)


### PR DESCRIPTION
Implemented the "force" flag to ignore the replica status in the bad_replicas table
Chunk large requests to declare bad replicas and quarantine dark replicas by 1000 files
Avoid unneeded calls to translate RSE id to RSE name
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
