### PR TITLE
Tests: Resolve flaky Automatix test

### DIFF
--- a/lib/rucio/tests/test_automatix.py
+++ b/lib/rucio/tests/test_automatix.py
@@ -15,12 +15,13 @@
 
 import json
 import os
+from random import choice
+from string import ascii_uppercase
 import tempfile
 
 import pytest
 
 from rucio.common.config import config_add_section, config_has_section, config_set, config_remove_option
-from rucio.common.utils import generate_uuid
 from rucio.common.types import InternalScope
 from rucio.core.did import list_dids, list_files
 from rucio.core.scope import add_scope
@@ -49,8 +50,7 @@ def test_automatix(vo, root_account, rse_factory):
         config_set("automatix", "did_prefix", "/belle/ddm/tests")
         config_set("automatix", "separator", "/")
 
-    project = generate_uuid()
-    project = project[:8]
+    project = ''.join(choice(ascii_uppercase) for _ in range(8))
     test_dict = {
         "type1": {
             "probability": 100,


### PR DESCRIPTION
Since 709308295 (Improvements of automatix daemon : Closes #5616, #5617
(#5621), 2022-09-02), the `test_automatix` test fails infrequently. The
error message provided suggests, that the `project` variable sometimes
get converted to an integer:

```
=================================== FAILURES ===================================
________________________________ test_automatix ________________________________
[gw1] linux -- Python 3.6.8 /usr/bin/python
/usr/local/lib64/python3.6/site-packages/sqlalchemy/engine/base.py:1803: in _execute_context
    cursor, statement, parameters, context
/usr/local/lib64/python3.6/site-packages/sqlalchemy/engine/default.py:732: in do_execute
    cursor.execute(statement, parameters)
E   psycopg2.errors.UndefinedFunction: operator does not exist: character varying = integer
E   LINE 3: WHERE dev.dids.project = 17420750 AND dev.dids.did_type = 'C...
E                                  ^
E   HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
```

The `project` variable used is initialized via the first 8 characters of
a random uuid4 string. This string contains hexadecimal values, which
can lead to a string with the 8 first characters being just integers.
The probability for that with `(10 / 16) ^ 8 = 2.33%` (if we asume a
uniform distribution) is fairly low, however, we run the tests quite
frequently. This thus is a vaiable candidate for the error.

The `filter_engine` used in `list_dids` is responsible for converting
the string to an int. This is desired for now. Postgres is the only
engine which does not provide a functionality to compare a string and an
integer.

Using a string which does not automatically gets converted to an integer
solves the problem.
