### PR TITLE
CI: Disable the type checker for actions with no parent #5727

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           python3 tools/add_header --dry-run --disable-progress-bar
   python_annotations:
+    if: ${{ !startsWith(github.base_ref, 'release') && github.event_name != 'schedule' }}
     name: Check Python Type Annotations
     runs-on: ubuntu-latest
     env:
@@ -72,6 +73,7 @@ jobs:
             exit 1
           fi
   python_pyright:
+    if: ${{ !startsWith(github.base_ref, 'release') && github.event_name != 'schedule' }}
     name: Python type check (Pyright)
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
The type checker needs a base version to compare the current changes
to. Since the schedule actions does not provide such an attribute, we
should disable it.

The release branch is altered quite heavily from master, comparing it
agains the last mutual state results to many differences. Since
"in-between" commits which alter the types of different functions might
be missing we should disable it in general.
