### PR TITLE
Feature 5727 disable workflow run on release branches

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -21,7 +21,10 @@ jobs:
         run: |
           python3 tools/add_header --dry-run --disable-progress-bar
   python_annotations:
-    if: ${{ !startsWith(github.base_ref, 'release') && github.event_name != 'schedule' }}
+    if: |
+      !startsWith(github.ref_name, 'release')
+      && !startsWith(github.base_ref, 'release')
+      && github.event_name != 'schedule'
     name: Check Python Type Annotations
     runs-on: ubuntu-latest
     env:
@@ -73,7 +76,10 @@ jobs:
             exit 1
           fi
   python_pyright:
-    if: ${{ !startsWith(github.base_ref, 'release') && github.event_name != 'schedule' }}
+    if: |
+      !startsWith(github.ref_name, 'release')
+      && !startsWith(github.base_ref, 'release')
+      && github.event_name != 'schedule'
     name: Python type check (Pyright)
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -25,6 +25,7 @@ jobs:
       !startsWith(github.ref_name, 'release')
       && !startsWith(github.base_ref, 'release')
       && github.event_name != 'schedule'
+      && github.ref_type != 'tag'
     name: Check Python Type Annotations
     runs-on: ubuntu-latest
     env:
@@ -80,6 +81,7 @@ jobs:
       !startsWith(github.ref_name, 'release')
       && !startsWith(github.base_ref, 'release')
       && github.event_name != 'schedule'
+      && github.ref_type != 'tag'
     name: Python type check (Pyright)
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This commit refines the GitHub Action rules for the type annotation and type checker. The new rules are:

| Type | Will the type Annotation check and the type checker run? |
|--|--|
| "Normal" PR to the master branch| :heavy_check_mark:  |
| PR to a release branch | :x:  |
| Commit to the master branch | :heavy_check_mark: |
| Commit to a release branch | :x: |
| On schedule | :x: |
| On tag | :x: |
