### PR TITLE
Remove the local file in `test_download_dataset` before download #5887

### DIFF
--- a/lib/rucio/tests/test_bin_rucio.py
+++ b/lib/rucio/tests/test_bin_rucio.py
@@ -1039,6 +1039,9 @@ class TestBinRucio:
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
+
+        os.remove(tmp_file1)
+
         # download dataset
         cmd = 'rucio -v download --dir /tmp {0}'.format(tmp_dataset)  # triming '/tmp/' from filename
         print(self.marker + cmd)


### PR DESCRIPTION
The local created file in `test_download_dataset`, which gets uploaded, is not
removed before the download. This results in a failing test, since it is cached
and thus does not need to be downloaded.
