### PR TITLE
Core & Internals: lazy account_usage counter creation. Closes #5914

### DIFF
--- a/lib/rucio/core/account.py
+++ b/lib/rucio/core/account.py
@@ -57,8 +57,6 @@ def add_account(account, type_, email, session=None):
         new_account.save(session=session)
     except IntegrityError:
         raise exception.Duplicate('Account ID \'%s\' already exists!' % account)
-    # Create the account counters for this account
-    rucio.core.account_counter.create_counters_for_new_account(account=account, session=session)
 
 
 @read_session

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -28,7 +28,6 @@ from sqlalchemy.orm import aliased, Session
 from sqlalchemy.orm.exc import FlushError
 from sqlalchemy.sql.expression import or_, false, func, case, select
 
-import rucio.core.account_counter
 from rucio.common import exception, utils
 from rucio.common.cache import make_region_memcached
 from rucio.common.config import get_lfn2pfn_algorithm_default
@@ -264,9 +263,6 @@ def add_rse(rse, vo='def', deterministic=True, volatile=False, city=None, region
 
     # Add counter to monitor the space usage
     add_counter(rse_id=new_rse.id, session=session)
-
-    # Add account counter
-    rucio.core.account_counter.create_counters_for_new_rse(rse_id=new_rse.id, session=session)
 
     return new_rse.id
 

--- a/lib/rucio/db/sqla/util.py
+++ b/lib/rucio/db/sqla/util.py
@@ -37,7 +37,6 @@ from rucio.common.config import config_get, config_get_list
 from rucio.common.schema import get_schema_value
 from rucio.common.types import InternalAccount
 from rucio.common.utils import generate_uuid
-from rucio.core.account_counter import create_counters_for_new_account
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import AccountStatus, AccountType, IdentityType
 from rucio.db.sqla.session import get_engine, get_session, get_dump_engine
@@ -136,11 +135,9 @@ def create_base_vo():
     s.commit()
 
 
-def create_root_account(create_counters=True):
+def create_root_account():
     """
     Inserts the default root account to an existing database. Make sure to change the default password later.
-
-    :param create_counters: If True, create counters for the new account at existing RSEs.
     """
 
     multi_vo = bool(config_get('common', 'multi_vo', False, False))
@@ -199,10 +196,6 @@ def create_root_account(create_counters=True):
     # SSH authentication
     identity4 = models.Identity(identity=ssh_id, identity_type=IdentityType.SSH, email=ssh_email)
     iaa4 = models.IdentityAccountAssociation(identity=identity4.identity, identity_type=identity4.identity_type, account=account.account, is_default=True)
-
-    # Account counters
-    if create_counters:
-        create_counters_for_new_account(account=account.account, session=s)
 
     # Apply
     for identity in [identity1, identity2, identity3, identity4]:

--- a/tools/convert_database_vo.py
+++ b/tools/convert_database_vo.py
@@ -299,7 +299,7 @@ def convert_to_mvo(new_vo, description, email, create_super_root=False, commit_c
     success = rename_vo('def', new_vo, insert_new_vo=insert_new_vo, description=description, email=email,
                         commit_changes=commit_changes, skip_history=skip_history)
     if create_super_root and success:
-        create_root_account(create_counters=False)
+        create_root_account()
     s.close()
 
 


### PR DESCRIPTION
Until this commit, whenever an RSE or an account was created, the
account_usage table was pre-filled with empty counters to maintain
the cartesian product between the account and rse tables.
This means that most counters are empty. In atlas, only 0.5% of
them has a non-empty value.

This commit re-works the workflow to not fill the table with empty
counters and consider missing rows as a counter with value `0`.

The primary sponsor for this change are the unit tests, where we create
and teardown test accounts and RSEs quite frequently.