### PR TITLE
Core & Internals: get rid of the retrying dependency. Closes #5344

### DIFF
--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -25,7 +25,6 @@ from abc import abstractmethod
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, Iterable, Optional
-from retrying import retry
 from threading import Lock
 
 from prometheus_client import start_http_server, Counter, Gauge, Histogram, REGISTRY, CollectorRegistry, generate_latest, values, multiprocess
@@ -33,6 +32,7 @@ from statsd import StatsClient
 
 from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.stopwatch import Stopwatch
+from rucio.common.utils import retrying
 
 PROMETHEUS_MULTIPROC_DIR = os.environ.get('PROMETHEUS_MULTIPROC_DIR', os.environ.get('prometheus_multiproc_dir', None))
 
@@ -118,9 +118,9 @@ def cleanup_old_prometheus_files(logger=logging.log):
         _cleanup_old_prometheus_files(path, file_pattern='*.db', cleanup_delay=timedelta(days=7).total_seconds(), logger=logger)
 
 
-@retry(retry_on_exception=lambda _: True,
-       wait_fixed=500,
-       stop_max_attempt_number=2)
+@retrying(retry_on_exception=lambda _: True,
+          wait_fixed=500,
+          stop_max_attempt_number=2)
 def generate_prometheus_metrics():
     cleanup_old_prometheus_files()
 

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -18,7 +18,6 @@ import sys
 
 from functools import wraps
 from inspect import isgeneratorfunction
-from retrying import retry
 from threading import Lock
 from os.path import basename
 
@@ -30,6 +29,7 @@ from sqlalchemy.pool import QueuePool, SingletonThreadPool, NullPool
 
 from rucio.common.config import config_get
 from rucio.common.exception import RucioException, DatabaseException, InputValidationError
+from rucio.common.utils import retrying
 from rucio.common.extra import import_extras
 
 EXTRA_MODULES = import_extras(['MySQLdb', 'pymysql'])
@@ -293,10 +293,9 @@ def read_session(function):
     This is useful if only SELECTs and the like are being done; anything involving
     INSERTs, UPDATEs etc should use transactional_session.
     '''
-    @retry(retry_on_exception=retry_if_db_connection_error,
-           wait_fixed=500,
-           stop_max_attempt_number=2,
-           wrap_exception=False)
+    @retrying(retry_on_exception=retry_if_db_connection_error,
+              wait_fixed=500,
+              stop_max_attempt_number=2)
     @wraps(function)
     def new_funct(*args, **kwargs):
         if isgeneratorfunction(function):
@@ -335,10 +334,9 @@ def stream_session(function):
     This is useful if only SELECTs and the like are being done; anything involving
     INSERTs, UPDATEs etc should use transactional_session.
     '''
-    @retry(retry_on_exception=retry_if_db_connection_error,
-           wait_fixed=500,
-           stop_max_attempt_number=2,
-           wrap_exception=False)
+    @retrying(retry_on_exception=retry_if_db_connection_error,
+              wait_fixed=500,
+              stop_max_attempt_number=2)
     @wraps(function)
     def new_funct(*args, **kwargs):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ stomp.py==6.1.1                                             # ActiveMQ Messaging
 statsd==3.3.0                                               # Needed to log into graphite with more than 1 Hz
 geoip2==4.5.0                                               # GeoIP2 API (for IPv6 support)
 google-auth==2.6.0                                          # Google authentication library for Python
-retrying==1.3.3                                             # general-purpose retrying library to simplify the task of adding retry behavior to just about anything
 redis==4.1.4                                                # Python client for Redis key-value store
 Flask==2.0.3                                                # Python web framework
 oic==1.3.0                                                  # for authentication via OpenID Connect protocol

--- a/setuputil.py
+++ b/setuputil.py
@@ -74,7 +74,6 @@ server_requirements_table = {
         'statsd',
         'geoip2',
         'google-auth',
-        'retrying',
         'redis',
         'flask',
         'oic',


### PR DESCRIPTION
It doesn't install anymore on python 3.10.

Implement a very minimalist decorator which re-implements only the parts of that library which were used by rucio.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
