### PR TITLE
Core: Protect against protocol invalid read_wan and _lan priorities Fix: #4237

### DIFF
--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -1095,7 +1095,10 @@ def add_protocol(rse_id, parameter, session=None):
                 if op not in utils.rse_supported_protocol_operations():
                     raise exception.RSEOperationNotSupported('Operation \'%s\' not defined in schema.' % (op))
                 op_name = op if op.startswith('third_party_copy') else ''.join([op, '_', s]).lower()
-                if parameter['domains'][s][op] < 0:
+                try:
+                    if parameter['domains'][s][op] < 0:
+                        raise exception.RSEProtocolPriorityError('The provided priority (%s)for operation \'%s\' in domain \'%s\' is not supported.' % (parameter['domains'][s][op], op, s))
+                except TypeError:
                     raise exception.RSEProtocolPriorityError('The provided priority (%s)for operation \'%s\' in domain \'%s\' is not supported.' % (parameter['domains'][s][op], op, s))
                 parameter[op_name] = parameter['domains'][s][op]
         del parameter['domains']


### PR DESCRIPTION
this PR consists of an extension to the test in `test_replica.py::TestReplicaCore::test_list_replica_with_schemes` and an additional try/except in `rse.py::add_protocol` which checks for `TypeError`

