### PR TITLE
Protocols: Add support for S3 virtual hosted buckets #5451 

### DIFF
--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -128,12 +128,14 @@ def get_signed_url(rse_id, service, operation, url, lifetime=600):
                 raise UnsupportedOperation('Not a valid Path-Style S3 URL')
             bucket = pathcomponents[1]
             key = '/'.join(pathcomponents[2:])
-        else:
+        elif s3_url_style == "virtual":
             hostcomponents = host.split('.')
             bucket = hostcomponents[0]
             if len(pathcomponents) < 2:
                 raise UnsupportedOperation('Not a valid Virtual-Style S3 URL')
             key = '/'.join(pathcomponents[1:])
+        else:
+            raise UnsupportedOperation('Not a valid RSE S3 URL style (allowed values: path|virtual)')
 
         # remove port number from host if present
         colon = host.find(':')

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -131,6 +131,8 @@ def get_signed_url(rse_id, service, operation, url, lifetime=600):
         else:
             hostcomponents = host.split('.')
             bucket = hostcomponents[0]
+            if len(pathcomponents) < 2:
+                raise UnsupportedOperation('Not a valid Virtual-Style S3 URL')
             key = '/'.join(pathcomponents[1:])
 
         # remove port number from host if present

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -29,6 +29,7 @@ from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get, get_rse_credentials
 from rucio.common.exception import UnsupportedOperation
 from rucio.core.monitor import MetricManager
+from rucio.core.rse import get_rse_attribute
 
 CREDS_GCS = None
 
@@ -108,14 +109,29 @@ def get_signed_url(rse_id, service, operation, url, lifetime=600):
                                                                                  signature)
 
     elif service == 's3':
+
+        # get RSE S3 URL style (path or virtual)
+        # path-style: https://s3.region-code.amazonaws.com/bucket-name/key-name
+        # virtual-style: https://bucket-name.s3.region-code.amazonaws.com/key-name
+        s3_url_style = get_rse_attribute(rse_id, 's3_url_style')
+
+        # no S3 URL style specified, assume path-style
+        if s3_url_style is None:
+            s3_url_style = "path"
+
         # split URL to get hostname, bucket and key
         components = urlparse(url)
         host = components.netloc
         pathcomponents = components.path.split('/')
-        if len(pathcomponents) < 3:
-            raise UnsupportedOperation('Not a valid S3 URL')
-        bucket = pathcomponents[1]
-        key = '/'.join(pathcomponents[2:])
+        if s3_url_style == "path":
+            if len(pathcomponents) < 3:
+                raise UnsupportedOperation('Not a valid Path-Style S3 URL')
+            bucket = pathcomponents[1]
+            key = '/'.join(pathcomponents[2:])
+        else:
+            hostcomponents = host.split('.')
+            bucket = hostcomponents[0]
+            key = '/'.join(pathcomponents[1:])
 
         # remove port number from host if present
         colon = host.find(':')
@@ -144,7 +160,14 @@ def get_signed_url(rse_id, service, operation, url, lifetime=600):
             s3op = 'delete_object'
 
         with METRICS.timer('signs3'):
-            s3 = boto3.client('s3', endpoint_url='https://' + host + ':' + port, aws_access_key_id=access_key, aws_secret_access_key=secret_key, config=Config(signature_version=signature_version, region_name=region_name))
+
+            s3 = boto3.client(service_name='s3',
+                              endpoint_url='https://' + host + ':' + port,
+                              aws_access_key_id=access_key,
+                              aws_secret_access_key=secret_key,
+                              config=Config(signature_version=signature_version,
+                                            region_name=region_name,
+                                            s3={"addressing_style": s3_url_style}))
 
             signed_url = s3.generate_presigned_url(s3op, Params={'Bucket': bucket, 'Key': key}, ExpiresIn=lifetime)
 

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -186,6 +186,8 @@ def job_params_for_fts_transfer(transfer, bring_online, default_lifetime, archiv
 
     strict_copy = transfer.dst.rse.attributes.get('strict_copy', False)
     archive_timeout = transfer.dst.rse.attributes.get('archive_timeout', None)
+    src_rse_s3_url_style = transfer.src.rse.attributes.get('s3_url_style', None)
+    dst_rse_s3_url_style = transfer.dst.rse.attributes.get('s3_url_style', None)
 
     verify_checksum, _checksum_to_use = _checksum_validation_strategy(transfer, logger=logger)
 
@@ -212,6 +214,15 @@ def job_params_for_fts_transfer(transfer, bring_online, default_lifetime, archiv
     if transfer.use_ipv4:
         job_params['ipv4'] = True
         job_params['ipv6'] = False
+    
+    # assume s3alternate True (path-style URL S3 RSEs)
+    job_params['s3alternate'] = True
+    if src_rse_s3_url_style:
+        if src_rse_s3_url_style == "virtual":
+            job_params['s3alternate'] = False
+    if dst_rse_s3_url_style:
+        if dst_rse_s3_url_style == "virtual":
+            job_params['s3alternate'] = False
 
     if archive_timeout and transfer.dst.rse.is_tape():
         try:

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -218,10 +218,10 @@ def job_params_for_fts_transfer(transfer, bring_online, default_lifetime, archiv
     # assume s3alternate True (path-style URL S3 RSEs)
     job_params['s3alternate'] = True
     if src_rse_s3_url_style:
-        if src_rse_s3_url_style == "virtual":
+        if src_rse_s3_url_style == "host":
             job_params['s3alternate'] = False
     if dst_rse_s3_url_style:
-        if dst_rse_s3_url_style == "virtual":
+        if dst_rse_s3_url_style == "host":
             job_params['s3alternate'] = False
 
     if archive_timeout and transfer.dst.rse.is_tape():

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -214,7 +214,7 @@ def job_params_for_fts_transfer(transfer, bring_online, default_lifetime, archiv
     if transfer.use_ipv4:
         job_params['ipv4'] = True
         job_params['ipv6'] = False
-    
+
     # assume s3alternate True (path-style URL S3 RSEs)
     job_params['s3alternate'] = True
     if src_rse_s3_url_style:


### PR DESCRIPTION
This PR adds support for S3 virtual-hosted buckets.
Some actual testing with an S3 resource is needed to validate the changes.

Many thanks to @rcarpa for helping me in part of this PR.

Refs:
https://fts3-docs.web.cern.ch/fts3-docs/fts-rest/docs/bulk.html#parameters
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client
https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.generate_presigned_url
https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-presigned-urls.html

P.S.

This PR does not contribute to the necessary `https -> s3s` protocol translation that is needed for FTS.
My understanding is that this functionality is already present in the following methods:
https://github.com/rucio/rucio/blob/408ec623d1cfe5f2e7f6c9e085a00f886234eae7/lib/rucio/core/transfer.py#L165
https://github.com/rucio/rucio/blob/408ec623d1cfe5f2e7f6c9e085a00f886234eae7/lib/rucio/core/transfer.py#L191
