### PR TITLE
Subscription : Add the possibility to reevaluate subscription when a dataset is closed : Closes #5926

### DIFF
--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -2734,6 +2734,7 @@ def set_status(scope, name, session=None, **kwargs):
     :param kwargs:  Keyword arguments of the form status_name=value.
     """
     statuses = ['open', ]
+    reevaluate_dids_at_close = config_get_bool('subscriptions', 'reevaluate_dids_at_close', raise_exception=False, default=False, session=session)
 
     update_stmt = update(
         models.DataIdentifier
@@ -2784,6 +2785,10 @@ def set_status(scope, name, session=None, **kwargs):
                     message['vo'] = scope.vo
 
                 add_message('CLOSE', message, session=session)
+                if reevaluate_dids_at_close:
+                    set_new_dids(dids=[{'scope': scope, 'name': name}],
+                                 new_flag=True,
+                                 session=session)
 
             else:
                 # Set status to open only for privileged accounts

--- a/lib/rucio/tests/test_judge_repairer.py
+++ b/lib/rucio/tests/test_judge_repairer.py
@@ -179,7 +179,7 @@ class TestJudgeRepairer:
         attach_dids(scope, dataset, files, self.jdoe)
 
         # Fake judge
-        re_evaluator(once=True)
+        re_evaluator(once=True, did_limit=10000)
 
         # Check if the Locks are created properly
         for file in files:


### PR DESCRIPTION
Subscription : Add the possibility to reevaluate subscription when a dataset is closed : Closes #5926

This introduces the possibility to automatically set the `is_new flag` to True when a collection (dataset or container) is closed. 