### PR TITLE
Fix unit tests for non atlas policies round 2/3 : Closes #5839

### DIFF
--- a/etc/docker/test/matrix_policy_package_tests.yml
+++ b/etc/docker/test/matrix_policy_package_tests.yml
@@ -151,6 +151,8 @@ belleii:
       - rucio_tests/test_permission.py
       - rucio_tests/test_curl.py
       - rucio_tests/test_rse.py
+      - rucio_tests/test_rule.py
+      - rucio_tests/test_dataset_replicas.py
     deny:
       - rucio_tests/test_rse_protocol_ssh.py
       - rucio_tests/test_redirect.py
@@ -159,10 +161,8 @@ belleii:
       - rucio_tests/test_bb8.py
       - rucio_tests/test_rse_lfn2path.py
       - rucio_tests/test_s3.py
-      - rucio_tests/test_rule.py
       - rucio_tests/test_multi_vo.py
       - rucio_tests/test_naming_convention.py
-      - rucio_tests/test_dataset_replicas.py
       - rucio_tests/test_did_meta_plugins.py
       - rucio_tests/test_bin_rucio.py
       - rucio_tests/test_boolean.py

--- a/etc/docker/test/matrix_policy_package_tests.yml
+++ b/etc/docker/test/matrix_policy_package_tests.yml
@@ -153,19 +153,18 @@ belleii:
       - rucio_tests/test_rse.py
       - rucio_tests/test_rule.py
       - rucio_tests/test_dataset_replicas.py
-    deny:
+      - rucio_tests/test_did_meta_plugins.py
+      - rucio_tests/test_boolean.py
       - rucio_tests/test_rse_protocol_ssh.py
-      - rucio_tests/test_redirect.py
-      - rucio_tests/test_credential.py
-      - rucio_tests/test_bad_replica.py
-      - rucio_tests/test_bb8.py
       - rucio_tests/test_rse_lfn2path.py
-      - rucio_tests/test_s3.py
+      - rucio_tests/test_credential.py
+      - rucio_tests/test_bb8.py
+    deny:
+      - rucio_tests/test_redirect.py
+      - rucio_tests/test_bad_replica.py
       - rucio_tests/test_multi_vo.py
       - rucio_tests/test_naming_convention.py
-      - rucio_tests/test_did_meta_plugins.py
       - rucio_tests/test_bin_rucio.py
-      - rucio_tests/test_boolean.py
       - rucio_tests/test_auditor_hdfs.py
   rdbms:
     - postgres14

--- a/lib/rucio/tests/test_credential.py
+++ b/lib/rucio/tests/test_credential.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import os
 
+import unittest
 import pytest
 
 from rucio.client import client
@@ -122,6 +123,7 @@ class TestCredential(unittest.TestCase):
         assert value == expected
 
     @pytest.mark.noparallel(reason='fails when run in parallel')
+    @pytest.mark.skipif(os.environ.get('POLICY') != 'atlas', reason='Test ATLAS hash convention')
     def test_list_replicas_sign_url(self):
         """ CREDENTIAL: List replicas for an RSE where signature is enabled """
 

--- a/lib/rucio/tests/test_did_meta_plugins.py
+++ b/lib/rucio/tests/test_did_meta_plugins.py
@@ -25,7 +25,7 @@ from rucio.core.did_meta_plugins import list_dids, get_metadata, set_metadata
 from rucio.core.did_meta_plugins.mongo_meta import MongoDidMeta
 from rucio.core.did_meta_plugins.postgres_meta import ExternalPostgresJSONDidMeta
 from rucio.db.sqla.util import json_implemented
-from rucio.tests.common import skip_rse_tests_with_accounts
+from rucio.tests.common import skip_rse_tests_with_accounts, did_name_generator
 
 
 def skip_without_json():
@@ -38,7 +38,7 @@ class TestDidMetaDidColumn:
     @pytest.mark.dirty
     def test_add_did_meta(self, mock_scope, root_account):
         """ DID Meta (Hardcoded): Add did meta """
-        did_name = 'mock_did_%s' % generate_uuid()
+        did_name = did_name_generator('dataset')
         add_did(scope=mock_scope, name=did_name, did_type='DATASET', account=root_account)
         set_metadata(scope=mock_scope, name=did_name, key='project', value='data12_8TeV')
         assert get_metadata(scope=mock_scope, name=did_name)['project'] == 'data12_8TeV'
@@ -46,7 +46,7 @@ class TestDidMetaDidColumn:
     @pytest.mark.dirty
     def test_get_did_meta(self, mock_scope, root_account):
         """ DID Meta (Hardcoded): Get did meta """
-        did_name = 'mock_did_%s' % generate_uuid()
+        did_name = did_name_generator('dataset')
         dataset_meta = {'project': 'data12_8TeV'}
         add_did(scope=mock_scope, name=did_name, did_type='DATASET', meta=dataset_meta, account=root_account)
         assert get_metadata(scope=mock_scope, name=did_name)['project'] == 'data12_8TeV'
@@ -55,7 +55,7 @@ class TestDidMetaDidColumn:
     def test_list_did_meta(self, mock_scope, root_account):
         """ DID Meta (Hardcoded): List did meta """
         dsns = []
-        tmp_dsn1 = 'dsn_%s' % generate_uuid()
+        tmp_dsn1 = did_name_generator('dataset')
 
         dsns.append(tmp_dsn1)
 
@@ -69,12 +69,12 @@ class TestDidMetaDidColumn:
 
         add_did(scope=mock_scope, name=tmp_dsn1, did_type="DATASET", account=root_account, meta=dataset_meta)
 
-        tmp_dsn2 = 'dsn_%s' % generate_uuid()
+        tmp_dsn2 = did_name_generator('dataset')
         dsns.append(tmp_dsn2)
         dataset_meta['run_number'] = 400001
         add_did(scope=mock_scope, name=tmp_dsn2, did_type="DATASET", account=root_account, meta=dataset_meta)
 
-        tmp_dsn3 = 'dsn_%s' % generate_uuid()
+        tmp_dsn3 = did_name_generator('dataset')
         dsns.append(tmp_dsn3)
         dataset_meta['stream_name'] = 'physics_Egamma'
         dataset_meta['datatype'] = 'NTUP_SMWZ'
@@ -114,7 +114,7 @@ class TestDidMetaJSON:
         """ DID Meta (JSON): Add did meta """
         skip_without_json()
 
-        did_name = 'mock_did_%s' % generate_uuid()
+        did_name = did_name_generator('dataset')
         meta_key = 'my_key_%s' % generate_uuid()
         meta_value = 'my_value_%s' % generate_uuid()
         add_did(scope=mock_scope, name=did_name, did_type='DATASET', account=root_account)
@@ -126,7 +126,7 @@ class TestDidMetaJSON:
         """ DID Meta (JSON): Get did meta """
         skip_without_json()
 
-        did_name = 'mock_did_%s' % generate_uuid()
+        did_name = did_name_generator('dataset')
         meta_key = 'my_key_%s' % generate_uuid()
         meta_value = 'my_value_%s' % generate_uuid()
         add_did(scope=mock_scope, name=did_name, did_type='DATASET', account=root_account)
@@ -143,19 +143,19 @@ class TestDidMetaJSON:
         meta_value1 = 'my_value_%s' % generate_uuid()
         meta_value2 = 'my_value_%s' % generate_uuid()
 
-        tmp_dsn1 = 'dsn_%s' % generate_uuid()
+        tmp_dsn1 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn1, did_type="DATASET", account=root_account)
         set_metadata(scope=mock_scope, name=tmp_dsn1, key=meta_key1, value=meta_value1)
 
-        tmp_dsn2 = 'dsn_%s' % generate_uuid()
+        tmp_dsn2 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn2, did_type="DATASET", account=root_account)
         set_metadata(scope=mock_scope, name=tmp_dsn2, key=meta_key1, value=meta_value2)
 
-        tmp_dsn3 = 'dsn_%s' % generate_uuid()
+        tmp_dsn3 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn3, did_type="DATASET", account=root_account)
         set_metadata(scope=mock_scope, name=tmp_dsn3, key=meta_key2, value=meta_value1)
 
-        tmp_dsn4 = 'dsn_%s' % generate_uuid()
+        tmp_dsn4 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn4, did_type="DATASET", account=root_account)
         set_metadata(scope=mock_scope, name=tmp_dsn4, key=meta_key1, value=meta_value1)
         set_metadata(scope=mock_scope, name=tmp_dsn4, key=meta_key2, value=meta_value2)
@@ -210,7 +210,7 @@ class TestDidMetaMongo:
     def test_set_get_metadata(self, mock_scope, root_account, mongo_meta):
         """ DID Meta (MONGO): Get/set did meta """
 
-        did_name = 'mock_did_%s' % generate_uuid()
+        did_name = did_name_generator('dataset')
         meta_key = 'my_key_%s' % generate_uuid()
         meta_value = 'my_value_%s' % generate_uuid()
         add_did(scope=mock_scope, name=did_name, did_type='DATASET', account=root_account)
@@ -226,19 +226,19 @@ class TestDidMetaMongo:
         meta_value1 = 'my_value_%s' % generate_uuid()
         meta_value2 = 'my_value_%s' % generate_uuid()
 
-        tmp_dsn1 = 'dsn_%s' % generate_uuid()
+        tmp_dsn1 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn1, did_type="DATASET", account=root_account)
         mongo_meta.set_metadata(scope=mock_scope, name=tmp_dsn1, key=meta_key1, value=meta_value1)
 
-        tmp_dsn2 = 'dsn_%s' % generate_uuid()
+        tmp_dsn2 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn2, did_type="DATASET", account=root_account)
         mongo_meta.set_metadata(scope=mock_scope, name=tmp_dsn2, key=meta_key1, value=meta_value2)
 
-        tmp_dsn3 = 'dsn_%s' % generate_uuid()
+        tmp_dsn3 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn3, did_type="DATASET", account=root_account)
         mongo_meta.set_metadata(scope=mock_scope, name=tmp_dsn3, key=meta_key2, value=meta_value1)
 
-        tmp_dsn4 = 'dsn_%s' % generate_uuid()
+        tmp_dsn4 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn4, did_type="DATASET", account=root_account)
         mongo_meta.set_metadata(scope=mock_scope, name=tmp_dsn4, key=meta_key1, value=meta_value1)
         mongo_meta.set_metadata(scope=mock_scope, name=tmp_dsn4, key=meta_key2, value=meta_value2)
@@ -302,7 +302,7 @@ class TestDidMetaExternalPostgresJSON:
     def test_set_get_metadata(self, mock_scope, root_account, postgres_json_meta):
         """ DID Meta (POSTGRES_JSON): Get/set did meta """
 
-        did_name = 'mock_did_%s' % generate_uuid()
+        did_name = did_name_generator('dataset')
         meta_key = 'my_key_%s' % generate_uuid()
         meta_value = 'my_value_%s' % generate_uuid()
         add_did(scope=mock_scope, name=did_name, did_type='DATASET', account=root_account)
@@ -318,19 +318,19 @@ class TestDidMetaExternalPostgresJSON:
         meta_value1 = 'my_value_%s' % generate_uuid()
         meta_value2 = 'my_value_%s' % generate_uuid()
 
-        tmp_dsn1 = 'dsn_%s' % generate_uuid()
+        tmp_dsn1 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn1, did_type="DATASET", account=root_account)
         postgres_json_meta.set_metadata(scope=mock_scope, name=tmp_dsn1, key=meta_key1, value=meta_value1)
 
-        tmp_dsn2 = 'dsn_%s' % generate_uuid()
+        tmp_dsn2 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn2, did_type="DATASET", account=root_account)
         postgres_json_meta.set_metadata(scope=mock_scope, name=tmp_dsn2, key=meta_key1, value=meta_value2)
 
-        tmp_dsn3 = 'dsn_%s' % generate_uuid()
+        tmp_dsn3 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn3, did_type="DATASET", account=root_account)
         postgres_json_meta.set_metadata(scope=mock_scope, name=tmp_dsn3, key=meta_key2, value=meta_value1)
 
-        tmp_dsn4 = 'dsn_%s' % generate_uuid()
+        tmp_dsn4 = did_name_generator('dataset')
         add_did(scope=mock_scope, name=tmp_dsn4, did_type="DATASET", account=root_account)
         postgres_json_meta.set_metadata(scope=mock_scope, name=tmp_dsn4, key=meta_key1, value=meta_value1)
         postgres_json_meta.set_metadata(scope=mock_scope, name=tmp_dsn4, key=meta_key2, value=meta_value2)
@@ -373,7 +373,7 @@ class TestDidMetaClient:
     @pytest.mark.dirty
     def test_set_metadata(self, mock_scope, did_client, db_session):
         """ META (CLIENTS) : Adds a fully set json column to a did, updates if some keys present """
-        tmp_name = 'name_%s' % generate_uuid()
+        tmp_name = did_name_generator('dataset')
         scope = mock_scope.external
         did_client.add_did(scope=scope, name=tmp_name, did_type="DATASET")
 
@@ -403,7 +403,7 @@ class TestDidMetaClient:
         """ META (CLIENTS) : Deletes metadata key """
         skip_without_json()
         scope = mock_scope.external
-        tmp_name = 'name_%s' % generate_uuid()
+        tmp_name = did_name_generator('dataset')
         did_client.add_did(scope=scope, name=tmp_name, did_type="DATASET")
 
         value1 = "value_" + str(generate_uuid())
@@ -426,7 +426,7 @@ class TestDidMetaClient:
     @pytest.mark.dirty
     def test_get_metadata(self, mock_scope, did_client, db_session):
         """ META (CLIENTS) : Gets all metadata for the given did """
-        tmp_name = 'name_%s' % generate_uuid()
+        tmp_name = did_name_generator('dataset')
         scope = mock_scope.external
         did_client.add_did(scope=scope, name=tmp_name, did_type="DATASET")
 
@@ -463,7 +463,7 @@ class TestDidMetaClient:
         # Test did Columns use case
         dsns = []
         tmp_scope = 'mock'
-        tmp_dsn1 = 'dsn_%s' % generate_uuid()
+        tmp_dsn1 = did_name_generator('dataset')
         dsns.append(tmp_dsn1)
 
         dataset_meta = {'project': 'data12_8TeV',
@@ -474,12 +474,12 @@ class TestDidMetaClient:
                         'version': 'f392_m920',
                         }
         did_client.add_dataset(scope=tmp_scope, name=tmp_dsn1, meta=dataset_meta)
-        tmp_dsn2 = 'dsn_%s' % generate_uuid()
+        tmp_dsn2 = did_name_generator('dataset')
         dsns.append(tmp_dsn2)
         dataset_meta['run_number'] = 400001
         did_client.add_dataset(scope=tmp_scope, name=tmp_dsn2, meta=dataset_meta)
 
-        tmp_dsn3 = 'dsn_%s' % generate_uuid()
+        tmp_dsn3 = did_name_generator('dataset')
         dsns.append(tmp_dsn3)
         dataset_meta['stream_name'] = 'physics_Egamma'
         dataset_meta['datatype'] = 'NTUP_SMWZ'
@@ -510,10 +510,10 @@ class TestDidMetaClient:
 
         # Test JSON use case
         if json_implemented(session=db_session):
-            did1 = 'name_%s' % generate_uuid()
-            did2 = 'name_%s' % generate_uuid()
-            did3 = 'name_%s' % generate_uuid()
-            did4 = 'name_%s' % generate_uuid()
+            did1 = did_name_generator('dataset')
+            did2 = did_name_generator('dataset')
+            did3 = did_name_generator('dataset')
+            did4 = did_name_generator('dataset')
 
             key1 = 'key_1_%s' % generate_uuid()
             key2 = 'key_2_%s' % generate_uuid()
@@ -597,7 +597,7 @@ class TestDidMetaClient:
 
 @pytest.fixture
 def testdid(vo, file_config_mock, mock_scope, root_account):
-    did_name = 'testdid_%s' % generate_uuid()
+    did_name = did_name_generator('dataset')
     didtype = 'DATASET'
 
     add_did(scope=mock_scope, name=did_name, did_type=didtype, account=root_account)

--- a/lib/rucio/tests/test_judge_repairer.py
+++ b/lib/rucio/tests/test_judge_repairer.py
@@ -22,7 +22,6 @@ from dogpile.cache import make_region
 from rucio.common.config import config_get
 from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
-from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account_limit import set_local_account_limit
 from rucio.core.did import add_did, attach_dids
 from rucio.core.lock import successful_transfer, failed_transfer, get_replica_locks
@@ -36,7 +35,7 @@ from rucio.daemons.judge.repairer import rule_repairer
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import DIDType, RuleState, ReplicaState
 from rucio.db.sqla.session import get_session
-from rucio.tests.common import rse_name_generator
+from rucio.tests.common import rse_name_generator, did_name_generator
 from rucio.tests.common_server import get_vo
 from rucio.tests.test_rule import create_files, tag_generator
 
@@ -97,7 +96,7 @@ class TestJudgeRepairer:
         rule_repairer(once=True)  # Clean out the repairer
         scope = InternalScope('mock', **self.vo)
         files = create_files(3, scope, self.rse4_id, bytes_=100)
-        dataset = 'dataset_' + str(uuid())
+        dataset = did_name_generator('dataset')
         add_did(scope, dataset, DIDType.DATASET, self.jdoe)
         attach_dids(scope, dataset, files, self.jdoe)
 
@@ -124,7 +123,7 @@ class TestJudgeRepairer:
         rule_repairer(once=True)  # Clean out the repairer
         scope = InternalScope('mock', **self.vo)
         files = create_files(4, scope, self.rse4_id, bytes_=100)
-        dataset = 'dataset_' + str(uuid())
+        dataset = did_name_generator('dataset')
         add_did(scope, dataset, DIDType.DATASET, self.jdoe)
         attach_dids(scope, dataset, files, self.jdoe)
 
@@ -148,7 +147,7 @@ class TestJudgeRepairer:
         rule_repairer(once=True)  # Clean out the repairer
         scope = InternalScope('mock', **self.vo)
         files = create_files(4, scope, self.rse4_id, bytes_=100)
-        dataset = 'dataset_' + str(uuid())
+        dataset = did_name_generator('dataset')
         add_did(scope, dataset, DIDType.DATASET, self.jdoe)
         attach_dids(scope, dataset, files, self.jdoe)
 
@@ -170,7 +169,7 @@ class TestJudgeRepairer:
         """ JUDGE EVALUATOR: Test the judge when a rule gets STUCK from re_evaluating and there are missing locks"""
         scope = InternalScope('mock', **self.vo)
         files = create_files(3, scope, self.rse4_id)
-        dataset = 'dataset_' + str(uuid())
+        dataset = did_name_generator('dataset')
         add_did(scope, dataset, DIDType.DATASET, self.jdoe)
 
         # Add a first rule to the DS
@@ -179,7 +178,7 @@ class TestJudgeRepairer:
         attach_dids(scope, dataset, files, self.jdoe)
 
         # Fake judge
-        re_evaluator(once=True)
+        re_evaluator(once=True, did_limit=10000)
 
         # Check if the Locks are created properly
         for file in files:
@@ -208,7 +207,7 @@ class TestJudgeRepairer:
         """ JUDGE EVALUATOR: Test the judge when a with two rules with source_replica_expression"""
         scope = InternalScope('mock', **self.vo)
         files = create_files(3, scope, self.rse4_id)
-        dataset = 'dataset_' + str(uuid())
+        dataset = did_name_generator('dataset')
         add_did(scope, dataset, DIDType.DATASET, self.jdoe)
         attach_dids(scope, dataset, files, self.jdoe)
 
@@ -243,7 +242,7 @@ class TestJudgeRepairer:
         rule_repairer(once=True)  # Clean out the repairer
         scope = InternalScope('mock', **self.vo)
         files = create_files(4, scope, self.rse4_id, bytes_=100)
-        dataset = 'dataset_' + str(uuid())
+        dataset = did_name_generator('dataset')
         add_did(scope, dataset, DIDType.DATASET, self.jdoe)
         attach_dids(scope, dataset, files, self.jdoe)
 
@@ -274,7 +273,7 @@ class TestJudgeRepairer:
         rule_repairer(once=True)  # Clean out the repairer
         scope = InternalScope('mock', **self.vo)
         files = create_files(4, scope, self.rse4_id, bytes_=100)
-        dataset = 'dataset_' + str(uuid())
+        dataset = did_name_generator('dataset')
         add_did(scope, dataset, DIDType.DATASET, self.jdoe)
         attach_dids(scope, dataset, files, self.jdoe)
 
@@ -315,7 +314,7 @@ class TestJudgeRepairer:
         for grouping, ignore_availability in itertools.product(["NONE", "DATASET", "ALL"], [True, False]):
             scope = InternalScope('mock', **self.vo)
             files = create_files(1, scope, self.rse4_id, bytes_=100)
-            dataset = 'dataset_' + str(uuid())
+            dataset = did_name_generator('dataset')
             add_did(scope, dataset, DIDType.DATASET, self.jdoe)
             attach_dids(scope, dataset, files, self.jdoe)
 

--- a/lib/rucio/tests/test_rse_lfn2path.py
+++ b/lib/rucio/tests/test_rse_lfn2path.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import os
 
+import unittest
 import pytest
 
 from rucio.common import config
@@ -46,6 +47,7 @@ class TestDeterministicTranslation(unittest.TestCase):
         self.create_translator()
         assert self.translator.path("foo", "bar") == "foo/4e/99/bar"
 
+    @pytest.mark.skipif(os.environ.get('POLICY') != 'atlas', reason='Test ATLAS hash convention')
     def test_default_hash(self):
         """LFN2PFN: Translate to path using default algorithm (Success)"""
         assert self.translator.path("foo", "bar") == "foo/4e/99/bar"
@@ -56,6 +58,7 @@ class TestDeterministicTranslation(unittest.TestCase):
         self.create_translator()
         assert self.translator.path("foo", "bar") == "foo/bar"
 
+    @pytest.mark.skipif(os.environ.get('POLICY') != 'atlas', reason='Test ATLAS hash convention')
     def test_user_scope(self):
         """LFN2PFN: Test special user scope rules (Success)"""
         assert self.translator.path("user.foo", "bar") == "user/foo/13/7f/bar"

--- a/lib/rucio/tests/test_rule.py
+++ b/lib/rucio/tests/test_rule.py
@@ -28,6 +28,7 @@ from rucio.common.exception import (RuleNotFound, AccessDenied, InsufficientAcco
                                     RSEOverQuota, RuleReplaceFailed, ManualRuleApprovalBlocked, InputValidationError,
                                     UnsupportedOperation, InvalidValueForKey)
 from rucio.common.policy import get_policy
+from rucio.common.schema import get_schema_value
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account import add_account_attribute, get_usage
@@ -1166,12 +1167,13 @@ class TestClient:
 
     def test_add_rule(self, mock_scope, did_factory, jdoe_account):
         """ REPLICATION RULE (CLIENT): Add a replication rule and list full history """
+        activity = get_schema_value('ACTIVITY')['enum'][0]
         files = create_files(3, mock_scope, self.rse1_id)
         dataset = did_factory.random_dataset_did()
         add_did(did_type=DIDType.DATASET, account=jdoe_account, **dataset)
         attach_dids(dids=files, account=jdoe_account, **dataset)
 
-        ret = self.rule_client.add_replication_rule(dids=[{'scope': mock_scope.external, 'name': dataset['name']}], account='jdoe', copies=2, rse_expression=self.T1, grouping='NONE')
+        ret = self.rule_client.add_replication_rule(dids=[{'scope': mock_scope.external, 'name': dataset['name']}], account='jdoe', copies=2, rse_expression=self.T1, grouping='NONE', activity=activity)
         assert isinstance(ret, list)
 
         rep_rules = [rep_rule for rep_rule in self.rule_client.list_replication_rule_full_history(mock_scope.external, dataset['name'])]
@@ -1211,23 +1213,25 @@ class TestClient:
 
     def test_get_rule(self, mock_scope, did_factory, jdoe_account):
         """ REPLICATION RULE (CLIENT): Get Replication Rule by id """
+        activity = get_schema_value('ACTIVITY')['enum'][0]
         files = create_files(3, mock_scope, self.rse1_id)
         dataset = did_factory.random_dataset_did()
         add_did(did_type=DIDType.DATASET, account=jdoe_account, **dataset)
         attach_dids(dids=files, account=jdoe_account, **dataset)
 
-        ret = self.rule_client.add_replication_rule(dids=[{'scope': mock_scope.external, 'name': dataset['name']}], account='jdoe', copies=2, rse_expression=self.T1, grouping='NONE')
+        ret = self.rule_client.add_replication_rule(dids=[{'scope': mock_scope.external, 'name': dataset['name']}], account='jdoe', copies=2, rse_expression=self.T1, grouping='NONE', activity=activity)
         get = self.rule_client.get_replication_rule(ret[0])
         assert(ret[0] == get['id'])
 
     def test_get_rule_by_account(self, mock_scope, did_factory, jdoe_account, rucio_client):
         """ ACCOUNT (CLIENT): Get Replication Rule by account """
+        activity = get_schema_value('ACTIVITY')['enum'][0]
         files = create_files(3, mock_scope, self.rse1_id)
         dataset = did_factory.random_dataset_did()
         add_did(did_type=DIDType.DATASET, account=jdoe_account, **dataset)
         attach_dids(dids=files, account=jdoe_account, **dataset)
 
-        ret = self.rule_client.add_replication_rule(dids=[{'scope': mock_scope.external, 'name': dataset['name']}], account='jdoe', copies=2, rse_expression=self.T1, grouping='NONE')
+        ret = self.rule_client.add_replication_rule(dids=[{'scope': mock_scope.external, 'name': dataset['name']}], account='jdoe', copies=2, rse_expression=self.T1, grouping='NONE', activity=activity)
         get = rucio_client.list_account_rules('jdoe')
         rules = [rule['id'] for rule in get]
 


### PR DESCRIPTION
Fix unit tests for non atlas policies round 2/3 : Closes #5839
This PR fix most of the units test to be able to handle non-ATLAS policies in particular Belle II. The remaining tests are either testing feature not used by Belle II or the method they test are not working for non-ATLAS policies.
The tests that are not fixed yet:
- rucio_tests/test_redirect.py : Redirection doesn't work for DID with name with `/` 
- rucio_tests/test_bad_replica.py : PFN to LFN method only work for hash convention
- rucio_tests/test_multi_vo.py : Not used by Belle II
- rucio_tests/test_naming_convention.py : Test non-Belle II convention
- rucio_tests/test_bin_rucio.py : CLI not used by Belle II
- rucio_tests/test_auditor_hdfs.py : Auditor not used by Belle II