### PR TITLE
traces: change default trace dir #5940

### DIFF
--- a/lib/rucio/core/trace.py
+++ b/lib/rucio/core/trace.py
@@ -36,7 +36,7 @@ CONFIG_COMMON_LOGLEVEL = getattr(logging, config_get('common', 'loglevel', raise
 
 CONFIG_TRACE_LOGLEVEL = getattr(logging, config_get('trace', 'loglevel', raise_exception=False, default='DEBUG').upper())
 CONFIG_TRACE_LOGFORMAT = config_get('trace', 'logformat', raise_exception=False, default='%(message)s')
-CONFIG_TRACE_TRACEDIR = config_get('trace', 'tracedir', raise_exception=False, default='/var/log/rucio')
+CONFIG_TRACE_TRACEDIR = config_get('trace', 'tracedir', raise_exception=False, default='/var/log/rucio/trace')
 CONFIG_TRACE_MAXBYTES = config_get_int('trace', 'maxbytes', raise_exception=False, default=1000000000)
 CONFIG_TRACE_BACKUPCOUNT = config_get_int('trace', 'backupCount', raise_exception=False, default=10)
 


### PR DESCRIPTION
Fix #5940
Should also fix failing build of `rucio/documentation` repo