### PR TITLE
Feature 5930 unsetting the child rule

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -1397,7 +1397,10 @@ def update_rule(args):
     if args.priority:
         options['priority'] = int(args.priority)
     if args.child_rule_id:
-        options['child_rule_id'] = args.child_rule_id
+        if args.child_rule_id.lower() == 'none':
+            options['child_rule_id'] = None
+        else:
+            options['child_rule_id'] = args.child_rule_id
     if args.boost_rule:
         options['boost_rule'] = args.boost_rule
     client.update_replication_rule(rule_id=args.rule_id, options=options)
@@ -2496,7 +2499,7 @@ You can filter by account::
     update_rule_parser.add_argument('--comment', dest='comment', action='store', help="Update comment for the rule")
     update_rule_parser.add_argument('--cancel-requests', dest='cancel_requests', action='store_true', help='Cancel requests when setting rules to stuck.')
     update_rule_parser.add_argument('--priority', dest='priority', action='store', help='Priority of the requests of the rule.')
-    update_rule_parser.add_argument('--child-rule-id', dest='child_rule_id', action='store', help='Child rule id of the rule.')
+    update_rule_parser.add_argument('--child-rule-id', dest='child_rule_id', action='store', help='Child rule id of the rule. Use "None" to remove an existing parent/child relationship.')
     update_rule_parser.add_argument('--boost-rule', dest='boost_rule', action='store_true', help='Quickens the transition of a rule from STUCK to REPLICATING.')
 
     # The move_rule command

--- a/lib/rucio/api/rule.py
+++ b/lib/rucio/api/rule.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import Any, Dict, TYPE_CHECKING
 
 from rucio.api.permission import has_permission
 from rucio.common.config import config_get_bool
@@ -233,7 +233,7 @@ def delete_replication_rule(rule_id, purge_replicas, issuer, vo='def', *, sessio
 
 
 @transactional_session
-def update_replication_rule(rule_id, options, issuer, vo='def', *, session: "Session"):
+def update_replication_rule(rule_id: str, options: Dict[str, Any], issuer: str, vo: str = 'def', *, session: "Session"):
     """
     Update lock state of a replication rule.
 
@@ -251,11 +251,11 @@ def update_replication_rule(rule_id, options, issuer, vo='def', *, session: "Ses
         if not has_permission(issuer=issuer, vo=vo, action='approve_rule', kwargs=kwargs, session=session):
             raise AccessDenied('Account %s can not approve/deny this replication rule.' % (issuer))
 
-        issuer = InternalAccount(issuer, vo=vo)
+        issuer_ia = InternalAccount(issuer, vo=vo)
         if options['approve']:
-            rule.approve_rule(rule_id=rule_id, approver=issuer, session=session)
+            rule.approve_rule(rule_id=rule_id, approver=issuer_ia, session=session)
         else:
-            rule.deny_rule(rule_id=rule_id, approver=issuer, reason=options.get('comment', None), session=session)
+            rule.deny_rule(rule_id=rule_id, approver=issuer_ia, reason=options.get('comment', None), session=session)
     else:
         if not has_permission(issuer=issuer, vo=vo, action='update_rule', kwargs=kwargs, session=session):
             raise AccessDenied('Account %s can not update this replication rule.' % (issuer))

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -22,6 +22,7 @@ import random
 import shutil
 import signal
 import time
+import subprocess
 
 from queue import Queue, Empty, deque
 from threading import Thread
@@ -831,7 +832,13 @@ class DownloadClient:
             try:
                 to_exec = cmd % (os.getpid(), rpc_secret, port)
                 logger(logging.DEBUG, to_exec)
-                rpcproc = execute(to_exec, False)
+                rpcproc = subprocess.Popen(
+                    cmd,
+                    shell=True,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE
+                )
             except Exception as error:
                 raise RucioException('Failed to execute aria2c!', error)
 

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -17,6 +17,7 @@ from json import dumps, loads
 
 from requests.status_codes import codes
 from urllib.parse import quote_plus
+from typing import Dict, List, Any, Optional, Union
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice
@@ -29,31 +30,50 @@ class RuleClient(BaseClient):
 
     RULE_BASEURL = 'rules'
 
-    def add_replication_rule(self, dids, copies, rse_expression, weight=None, lifetime=None, grouping='DATASET', account=None,
-                             locked=False, source_replica_expression=None, activity=None, notify='N', purge_replicas=False,
-                             ignore_availability=False, comment=None, ask_approval=False, asynchronous=False, delay_injection=None,
-                             priority=3, meta=None):
+    def add_replication_rule(
+        self,
+        dids: List[str],
+        copies: int,
+        rse_expression: str,
+        priority: int = 3,
+        lifetime: Optional[int] = None,
+        grouping: str = 'DATASET',
+        notify: str = 'N',
+        source_replica_expression: Optional[str] = None,
+        activity: Optional[str] = None,
+        account: Optional[str] = None,
+        meta: Optional[str] = None,
+        ignore_availability: bool = False,
+        purge_replicas: bool = False,
+        ask_approval: bool = False,
+        asynchronous: bool = False,
+        locked: bool = False,
+        delay_injection=None,
+        comment=None,
+        weight=None,
+    ):
         """
         :param dids:                       The data identifier set.
         :param copies:                     The number of replicas.
         :param rse_expression:             Boolean string expression to give the list of RSEs.
-        :param weight:                     If the weighting option of the replication rule is used, the choice of RSEs takes their weight into account.
+        :param priority:                   Priority of the transfers.
         :param lifetime:                   The lifetime of the replication rules (in seconds).
         :param grouping:                   ALL -  All files will be replicated to the same RSE.
                                            DATASET - All files in the same dataset will be replicated to the same RSE.
                                            NONE - Files will be completely spread over all allowed RSEs without any grouping considerations at all.
-        :param account:                    The account owning the rule.
-        :param locked:                     If the rule is locked, it cannot be deleted.
+        :param notify:                     Notification setting for the rule (Y, N, C).
         :param source_replica_expression:  RSE Expression for RSEs to be considered for source replicas.
         :param activity:                   Transfer Activity to be passed to FTS.
-        :param notify:                     Notification setting for the rule (Y, N, C).
-        :param purge_replicas:             When the rule gets deleted purge the associated replicas immediately.
+        :param account:                    The account owning the rule.
+        :param meta:                       Metadata, as dictionary.
         :param ignore_availability:        Option to ignore the availability of RSEs.
+        :param purge_replicas:             When the rule gets deleted purge the associated replicas immediately.
         :param ask_approval:               Ask for approval of this replication rule.
         :param asynchronous:               Create rule asynchronously by judge-injector.
-        :param priority:                   Priority of the transfers.
+        :param locked:                     If the rule is locked, it cannot be deleted.
+        :param delay_injection:
         :param comment:                    Comment about the rule.
-        :param meta:                       Metadata, as dictionary.
+        :param weight:                     If the weighting option of the replication rule is used, the choice of RSEs takes their weight into account.
         """
         path = self.RULE_BASEURL + '/'
         url = build_url(choice(self.list_hosts), path=path)
@@ -70,7 +90,9 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def delete_replication_rule(self, rule_id, purge_replicas=None):
+    def delete_replication_rule(
+        self, rule_id: str, purge_replicas: Optional[bool] = None
+    ):
         """
         Deletes a replication rule and all associated locks.
 
@@ -91,7 +113,7 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def get_replication_rule(self, rule_id):
+    def get_replication_rule(self, rule_id: str):
         """
         Get a replication rule.
 
@@ -107,7 +129,7 @@ class RuleClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def update_replication_rule(self, rule_id, options):
+    def update_replication_rule(self, rule_id: str, options: Dict[str, Any]):
         """
         :param rule_id:   The id of the rule to be retrieved.
         :param options:   Options dictionary.
@@ -122,7 +144,9 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def reduce_replication_rule(self, rule_id, copies, exclude_expression=None):
+    def reduce_replication_rule(
+        self, rule_id: str, copies: int, exclude_expression=None
+    ):
         """
         :param rule_id:             Rule to be reduced.
         :param copies:              Number of copies of the new rule.
@@ -139,7 +163,9 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def move_replication_rule(self, rule_id, rse_expression, override):
+    def move_replication_rule(
+        self, rule_id: str, rse_expression: str, override
+    ):
         """
         Move a replication rule to another RSE and, once done, delete the original one.
 
@@ -162,7 +188,7 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def approve_replication_rule(self, rule_id):
+    def approve_replication_rule(self, rule_id: str):
         """
         :param rule_id:             Rule to be approved.
         :raises:                    RuleNotFound
@@ -177,7 +203,7 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def deny_replication_rule(self, rule_id):
+    def deny_replication_rule(self, rule_id: str):
         """
         :param rule_id:             Rule to be denied.
         :raises:                    RuleNotFound
@@ -192,7 +218,9 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def list_replication_rule_full_history(self, scope, name):
+    def list_replication_rule_full_history(
+            self, scope: Union[str, bytes], name: Union[str, bytes]
+    ):
         """
         List the rule history of a DID.
 
@@ -207,7 +235,7 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(r.headers, r.status_code)
         raise exc_cls(exc_msg)
 
-    def examine_replication_rule(self, rule_id):
+    def examine_replication_rule(self, rule_id: str):
         """
         Examine a replication rule for errors during transfer.
 
@@ -222,7 +250,7 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(r.headers, r.status_code)
         raise exc_cls(exc_msg)
 
-    def list_replica_locks(self, rule_id):
+    def list_replica_locks(self, rule_id: str):
         """
         List details of all replica locks for a rule.
 

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -33,6 +33,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from typing import Tuple
 import zlib
 from collections import OrderedDict
 from enum import Enum
@@ -434,7 +435,7 @@ def parse_response(data):
     return json.loads(data, object_hook=datetime_parser)
 
 
-def execute(cmd, blocking=True):
+def execute(cmd) -> Tuple[int, str, str]:
     """
     Executes a command in a subprocess. Returns a tuple
     of (exitcode, out, err), where out is the string output
@@ -450,12 +451,10 @@ def execute(cmd, blocking=True):
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
 
-    if blocking:
-        result = process.communicate()
-        (out, err) = result
-        exitcode = process.returncode
-        return exitcode, out.decode(encoding='utf-8'), err.decode(encoding='utf-8')
-    return process
+    result = process.communicate()
+    (out, err) = result
+    exitcode = process.returncode
+    return exitcode, out.decode(encoding='utf-8'), err.decode(encoding='utf-8')
 
 
 def rse_supported_protocol_operations():

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -1175,7 +1175,7 @@ def get_rule(rule_id, *, session: "Session"):
 
 
 @transactional_session
-def update_rule(rule_id, options, *, session: "Session"):
+def update_rule(rule_id: str, options: Dict[str, Any], *, session: "Session") -> None:
     """
     Update a rules options.
 
@@ -1185,7 +1185,10 @@ def update_rule(rule_id, options, *, session: "Session"):
     :raises:            RuleNotFound if no Rule can be found, InputValidationError if invalid option is used, ScratchDiskLifetimeConflict if wrong ScratchDiskLifetime is used.
     """
 
-    valid_options = ['comment', 'locked', 'lifetime', 'account', 'state', 'activity', 'source_replica_expression', 'cancel_requests', 'priority', 'child_rule_id', 'eol_at', 'meta', 'purge_replicas', 'boost_rule']
+    valid_options = ['comment', 'locked', 'lifetime', 'account', 'state',
+                     'activity', 'source_replica_expression', 'cancel_requests',
+                     'priority', 'child_rule_id', 'eol_at', 'meta',
+                     'purge_replicas', 'boost_rule']
 
     for key in options:
         if key not in valid_options:

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -16,6 +16,7 @@
 from json import dumps
 
 from flask import Flask, request, Response
+from typing import Any, Dict
 
 from rucio.api.lock import get_replica_locks_for_rule_id
 from rucio.api.rule import add_replication_rule, delete_replication_rule, get_replication_rule, \
@@ -151,7 +152,7 @@ class Rule(ErrorHandlingMethodView):
             description: No rule found for the given id
        """
         parameters = json_parameters()
-        options = param_get(parameters, 'options')
+        options: Dict[str, Any] = param_get(parameters, 'options')
         try:
             update_replication_rule(rule_id=rule_id, options=options, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
         except AccessDenied as error:

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -21,7 +21,7 @@ from rucio.api.lock import get_replica_locks_for_rule_id
 from rucio.api.rule import add_replication_rule, delete_replication_rule, get_replication_rule, \
     update_replication_rule, reduce_replication_rule, list_replication_rule_history, \
     list_replication_rule_full_history, list_replication_rules, examine_replication_rule, move_replication_rule
-from rucio.common.exception import InsufficientAccountLimit, RuleNotFound, AccessDenied, InvalidRSEExpression, \
+from rucio.common.exception import InputValidationError, InsufficientAccountLimit, RuleNotFound, AccessDenied, InvalidRSEExpression, \
     InvalidReplicationRule, DataIdentifierNotFound, InsufficientTargetRSEs, ReplicationRuleCreationTemporaryFailed, \
     InvalidRuleWeight, StagingAreaRuleRequiresLifetime, DuplicateRule, InvalidObject, AccountNotFound, \
     RuleReplaceFailed, ScratchDiskLifetimeConflict, ManualRuleApprovalBlocked, UnsupportedOperation
@@ -158,7 +158,8 @@ class Rule(ErrorHandlingMethodView):
             return generate_http_error_flask(401, error)
         except (RuleNotFound, AccountNotFound) as error:
             return generate_http_error_flask(404, error)
-        except (ScratchDiskLifetimeConflict, UnsupportedOperation) as error:
+        except (ScratchDiskLifetimeConflict,
+                UnsupportedOperation, InputValidationError) as error:
             return generate_http_error_flask(409, error)
 
         return '', 200


### PR DESCRIPTION
* putting in `child_rule_id` as `None` in `update_rule` will unset a previously set child rule.
* wrote tests (`test_bin_rucio` and `test_rule`)

* also included: a small edit solving the `execute` function that is mainly used in `test_bin_rucio`. originally, this function had two different return signatures, depending on the value of a keyword-argument `blocking`, which defaulted to `True`. This duality caused the linter/type checker to raise a warning each time the execute-function was called and unpacked into the three elements of the tuple it would normally return (ie when blocking is True). since the function is called frequently during the testing process, a file such as `test_bin_rucio` might have >200 warnings. the solution was to keep the `execute`-function only in the default form (returning a tuple of three elements) and (since the other form was only used once in the entire codebase) replace the function call with `blocking=False` with the code block within the `execute` function that would have been called otherwise.
