### PR TITLE
Core: Prevent Self-Referencing Parent-Child-Relations; Fix #5931

### DIFF
--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -1288,6 +1288,9 @@ def update_rule(rule_id, options, session=None):
                 child_rule = session.query(models.ReplicationRule).filter_by(id=options[key]).one()
                 if rule.scope != child_rule.scope or rule.name != child_rule.name:
                     raise InputValidationError('Parent and child rule must be set on the same dataset.')
+
+                if rule.id == options[key]:
+                    raise InputValidationError('Self-referencing parent/child-relationship.')
                 if child_rule.state != RuleState.OK:
                     rule.child_rule_id = options[key]
 


### PR DESCRIPTION
raises an InputValidationError when child id and parent id match.
much of the test that i have written for this commit can be merged with the test written in `test_bin_rucio.py` of PR #5943 