### PR TITLE
Subscription : Add the possibility to filter on average file size : Closes #5927

### DIFF
--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -325,6 +325,19 @@ def __is_matching_subscription(subscription, did, metadata):
                     break
             if not match_did_type:
                 return False
+        elif key in ["min_avg_file_size", "max_avg_file_size"]:
+            length = metadata["length"]
+            size = metadata["bytes"]
+            if length and size:
+                avg_file_size = size / length
+                if key == "min_avg_file_size" and avg_file_size < values:
+                    return False
+                if key == "max_avg_file_size" and avg_file_size > values:
+                    return False
+            else:
+                # If the DID is evaluated at the creation, length and bytes are not set yet
+                # In that case, just ignore min_avg_file_size and max_avg_file_size filter
+                continue
         else:
             if not isinstance(values, list):
                 values = [


### PR DESCRIPTION
Subscription : Add the possibility to filter on average file size : Closes #5927

2 new filter parameters are added to the subscriptions : 
- `min_avg_file_size`
- `max_avg_file_size`
If set and the number of files and bytes from the dataset or container is known, the filter is applied to the subscription. If number of files and bytes are not set (e.g. when the dataset is open), the parameter is ignored.