### PR TITLE
Introduce new exclude_site algorithm for chained subscriptions : Closes #5935

### DIFF
--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -154,6 +154,8 @@ def __split_rule_select_rses(
         ):
             preferred_rses.add(rse_dict["rse"])
     preferred_rses = list(preferred_rses)
+    preferred_unmatched = list()
+    selected_rses = list()
 
     for attempt in range(0, 2):
         # First attempt excludes blocklisted RSEs


### PR DESCRIPTION
- Refactorize `__split_rule_select_rses`
- Introduce new exclude_site algorithm for chained subscriptions : Closes #5935. 
When this algorithm is used in a chained subscription, the transmogrifier will exclude all the RSEs on the same site (based on RSE attribute site) for the second step of the chain