### PR TITLE
Automatix: Revert `set_metadata` default value to `False`; Fix #5965

### DIFF
--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -154,7 +154,7 @@ def run_once(heartbeat_handler: "HeartbeatHandler", inputfile: str, **_kwargs) -
             return True
 
     set_metadata = config_get_bool(
-        "automatix", "set_metadata", raise_exception=False, default=True
+        "automatix", "set_metadata", raise_exception=False, default=False
     )
     dataset_lifetime = config_get_int(
         "automatix", "dataset_lifetime", raise_exception=False, default=0


### PR DESCRIPTION
Changes the default value of `set_metadata` to match the documentation and also what it was previously. 