### PR TITLE
Testing: remove podman-specific settings in docker-compose. Closes #5983

### DIFF
--- a/etc/docker/dev/docker-compose-storage-alldb.yml
+++ b/etc/docker/dev/docker-compose-storage-alldb.yml
@@ -1,36 +1,9 @@
+version: "3"
 services:
   rucio:
     image: docker.io/rucio/rucio-dev
-    extra_hosts:
-      - "ruciomy8:127.0.0.1"
-      - "oracle:127.0.0.1"
-      - "ruciodb:127.0.0.1"
-      - "graphite:127.0.0.1"
-      - "fts:127.0.0.1"
-      - "ftsdb:127.0.0.1"
-      - "xrd1:127.0.0.1"
-      - "xrd2:127.0.0.1"
-      - "xrd3:127.0.0.1"
-      - "xrd4:127.0.0.1"
-      - "minio:127.0.0.1"
-      - "activemq:127.0.0.1"
-      - "ssh1:127.0.0.1"
     ports:
       - "127.0.0.1:8443:443"
-      - "127.0.0.1:3308:3308"
-      - "127.0.0.1:1521:1521"
-      - "127.0.0.1:5432:5432"
-      - "127.0.0.1:8080:80"
-      - "127.0.0.1:8446:8446"
-      - "127.0.0.1:8449:8449"
-      - "127.0.0.1:3306:3306"
-      - "127.0.0.1:1094:1094"
-      - "127.0.0.1:1095:1095"
-      - "127.0.0.1:1096:1096"
-      - "127.0.0.1:1097:1097"
-      - "127.0.0.1:9000:9000"
-      - "127.0.0.1:61613:61613"
-      - "127.0.0.1:2222:22"
     volumes:
       - ../../../tools:/opt/rucio/tools:Z
       - ../../../bin:/opt/rucio/bin:Z
@@ -41,7 +14,8 @@ services:
       - RDBMS=postgres14
   ruciomy8:
     image: docker.io/mysql:8
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:3308:3308"
     environment:
       - MYSQL_USER=rucio
       - MYSQL_PASSWORD=rucio
@@ -50,7 +24,8 @@ services:
       - MYSQL_TCP_PORT=3308
   oracle:
     image: docker.io/gvenzl/oracle-xe:21-slim
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1521:1521"
     environment:
       - ORACLE_PASSWORD=rucio
       - ORACLE_ALLOW_REMOTE=true
@@ -60,7 +35,8 @@ services:
       - transactions=1215
   ruciodb:
     image: docker.io/postgres:14
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=rucio
@@ -68,13 +44,17 @@ services:
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
   graphite:
     image: docker.io/graphiteapp/graphite-statsd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:8080:80"
   fts:
     image: docker.io/rucio/fts
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:8446:8446"
+      - "127.0.0.1:8449:8449"
   ftsdb:
     image: docker.io/mysql:8
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:3306:3306"
     command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_USER=fts
@@ -83,7 +63,8 @@ services:
       - MYSQL_DATABASE=fts
   xrd1:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1094:1094"
     environment:
       - XRDPORT=1094
     volumes:
@@ -91,7 +72,8 @@ services:
       - ../../certs/hostcert_xrd1.key.pem:/tmp/xrdkey.pem:Z
   xrd2:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1095:1095"
     environment:
       - XRDPORT=1095
     volumes:
@@ -99,7 +81,8 @@ services:
       - ../../certs/hostcert_xrd2.key.pem:/tmp/xrdkey.pem:Z
   xrd3:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1096:1096"
     environment:
       - XRDPORT=1096
     volumes:
@@ -107,7 +90,8 @@ services:
       - ../../certs/hostcert_xrd3.key.pem:/tmp/xrdkey.pem:Z
   xrd4:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1097:1097"
     environment:
       - XRDPORT=1097
     volumes:
@@ -115,7 +99,8 @@ services:
       - ../../certs/hostcert_xrd4.key.pem:/tmp/xrdkey.pem:Z
   minio:
     image: docker.io/minio/minio
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:9000:9000"
     environment:
       - MINIO_ACCESS_KEY=admin
       - MINIO_SECRET_KEY=password
@@ -125,7 +110,9 @@ services:
     command: ["server", "/data"]
   activemq:
     image: docker.io/webcenter/activemq:latest
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:61613:61613"
+      - "127.0.0.1:8161:8161"
     environment:
       - ACTIVEMQ_CONFIG_NAME=activemq
       - ACTIVEMQ_CONFIG_DEFAULTACCOUNT=false
@@ -136,6 +123,7 @@ services:
       - ACTIVEMQ_CONFIG_SCHEDULERENABLED=true
   ssh1:
     image: docker.io/rucio/ssh
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:2222:22"
     volumes:
       - ../../certs/ssh/ruciouser_sshkey.pub:/tmp/sshkey.pub:Z

--- a/etc/docker/dev/docker-compose-storage-externalmetadata.yml
+++ b/etc/docker/dev/docker-compose-storage-externalmetadata.yml
@@ -2,36 +2,8 @@ version: "3.5"
 services:
   rucio:
     image: docker.io/rucio/rucio-dev
-    extra_hosts:
-      - "ruciodb:127.0.0.1"
-      - "graphite:127.0.0.1"
-      - "fts:127.0.0.1"
-      - "ftsdb:127.0.0.1"
-      - "xrd1:127.0.0.1"
-      - "xrd2:127.0.0.1"
-      - "xrd3:127.0.0.1"
-      - "xrd4:127.0.0.1"
-      - "minio:127.0.0.1"
-      - "activemq:127.0.0.1"
-      - "ssh1:127.0.0.1"
-      - "mongo:127.0.0.1"
-      - "postgres:127.0.0.1"
     ports:
       - "127.0.0.1:8443:443"
-      - "127.0.0.1:5432:5432"
-      - "127.0.0.1:8080:80"
-      - "127.0.0.1:8446:8446"
-      - "127.0.0.1:8449:8449"
-      - "127.0.0.1:3306:3306"
-      - "127.0.0.1:1094:1094"
-      - "127.0.0.1:1095:1095"
-      - "127.0.0.1:1096:1096"
-      - "127.0.0.1:1097:1097"
-      - "127.0.0.1:9000:9000"
-      - "127.0.0.1:61613:61613"
-      - "127.0.0.1:2222:22"
-      - "127.0.0.1:27017:27017"
-      - "127.0.0.1:5433:5433"
     volumes:
       - ../../../tools:/opt/rucio/tools:Z
       - ../../../bin:/opt/rucio/bin:Z
@@ -42,7 +14,8 @@ services:
       - RDBMS=postgres11
   ruciodb:
     image: docker.io/postgres:11
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=rucio
@@ -50,13 +23,17 @@ services:
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
   graphite:
     image: docker.io/graphiteapp/graphite-statsd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:8080:80"
   fts:
     image: docker.io/rucio/fts
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:8446:8446"
+      - "127.0.0.1:8449:8449"
   ftsdb:
     image: docker.io/mysql:5
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:3306:3306"
     environment:
       - MYSQL_USER=fts
       - MYSQL_PASSWORD=fts
@@ -64,7 +41,8 @@ services:
       - MYSQL_DATABASE=fts
   xrd1:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1094:1094"
     environment:
       - XRDPORT=1094
     volumes:
@@ -72,7 +50,8 @@ services:
       - ../../certs/hostcert_xrd1.key.pem:/tmp/xrdkey.pem:Z
   xrd2:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1095:1095"
     environment:
       - XRDPORT=1095
     volumes:
@@ -80,7 +59,8 @@ services:
       - ../../certs/hostcert_xrd2.key.pem:/tmp/xrdkey.pem:Z
   xrd3:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1096:1096"
     environment:
       - XRDPORT=1096
     volumes:
@@ -88,7 +68,8 @@ services:
       - ../../certs/hostcert_xrd3.key.pem:/tmp/xrdkey.pem:Z
   xrd4:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1097:1097"
     environment:
       - XRDPORT=1097
     volumes:
@@ -96,7 +77,8 @@ services:
       - ../../certs/hostcert_xrd4.key.pem:/tmp/xrdkey.pem:Z
   minio:
     image: docker.io/minio/minio
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:9000:9000"
     environment:
       - MINIO_ACCESS_KEY=admin
       - MINIO_SECRET_KEY=password
@@ -106,7 +88,9 @@ services:
     command: ["server", "/data"]
   activemq:
     image: docker.io/webcenter/activemq:latest
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:61613:61613"
+      - "127.0.0.1:8161:8161"
     environment:
       - ACTIVEMQ_CONFIG_NAME=activemq
       - ACTIVEMQ_CONFIG_DEFAULTACCOUNT=false
@@ -117,15 +101,18 @@ services:
       - ACTIVEMQ_CONFIG_SCHEDULERENABLED=true
   ssh1:
     image: docker.io/rucio/ssh
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:2222:22"
     volumes:
       - ../../certs/ssh/ruciouser_sshkey.pub:/tmp/sshkey.pub:Z
   mongo:
     image: docker.io/mongo:5.0
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:27017:27017"
   influxdb:
     image: docker.io/influxdb:latest
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:8086:8086"
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup
       - DOCKER_INFLUXDB_INIT_USERNAME=myusername
@@ -135,12 +122,15 @@ services:
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken
   elasticsearch:
     image: docker.io/elasticsearch:7.4.0
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:9200:9200"
+      - "127.0.0.1:9300:9300"
     environment:
       - discovery.type=single-node
   postgres:
     image: docker.io/postgres:14
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:5433:5433"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=metadata

--- a/etc/docker/dev/docker-compose-storage-monit.yml
+++ b/etc/docker/dev/docker-compose-storage-monit.yml
@@ -1,42 +1,9 @@
+version: "3"
 services:
   rucio:
     image: docker.io/rucio/rucio-dev
-    extra_hosts:
-      - "ruciodb:127.0.0.1"
-      - "graphite:127.0.0.1"
-      - "fts:127.0.0.1"
-      - "ftsdb:127.0.0.1"
-      - "xrd1:127.0.0.1"
-      - "xrd2:127.0.0.1"
-      - "xrd3:127.0.0.1"
-      - "xrd4:127.0.0.1"
-      - "minio:127.0.0.1"
-      - "ssh1:127.0.0.1"
-      - "activemq:127.0.0.1"
-      - "elasticsearch:127.0.0.1"
-      - "logstash:127.0.0.1"
-      - "kibana:127.0.0.1"
-      - "grafana:127.0.0.1"
     ports:
       - "127.0.0.1:8443:443"
-      - "127.0.0.1:5432:5432"
-      - "127.0.0.1:8080:80"
-      - "127.0.0.1:8446:8446"
-      - "127.0.0.1:8449:8449"
-      - "127.0.0.1:3306:3306"
-      - "127.0.0.1:1094:1094"
-      - "127.0.0.1:1095:1095"
-      - "127.0.0.1:1096:1096"
-      - "127.0.0.1:1097:1097"
-      - "127.0.0.1:9000:9000"
-      - "127.0.0.1:2222:22"
-      - "127.0.0.1:61613:61613"
-      - "127.0.0.1:8161:8161"
-      - "127.0.0.1:9200:9200"
-      - "127.0.0.1:9300:9300"
-      - "127.0.0.1:5044:5044"
-      - "127.0.0.1:5601:5601"
-      - "127.0.0.1:3000:3000"
     volumes:
       - ../../../tools:/opt/rucio/tools:Z
       - ../../../bin:/opt/rucio/bin:Z
@@ -48,7 +15,8 @@ services:
     command: ["/monit-entrypoint.sh"]
   ruciodb:
     image: docker.io/postgres:14
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=rucio
@@ -56,13 +24,17 @@ services:
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
   graphite:
     image: docker.io/graphiteapp/graphite-statsd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:8080:80"
   fts:
     image: docker.io/rucio/fts
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:8446:8446"
+      - "127.0.0.1:8449:8449"
   ftsdb:
     image: docker.io/mysql:8
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:3306:3306"
     command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_USER=fts
@@ -71,7 +43,8 @@ services:
       - MYSQL_DATABASE=fts
   xrd1:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1094:1094"
     environment:
       - XRDPORT=1094
     volumes:
@@ -79,7 +52,8 @@ services:
       - ../../certs/hostcert_xrd1.key.pem:/tmp/xrdkey.pem:Z
   xrd2:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1095:1095"
     environment:
       - XRDPORT=1095
     volumes:
@@ -87,7 +61,8 @@ services:
       - ../../certs/hostcert_xrd2.key.pem:/tmp/xrdkey.pem:Z
   xrd3:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1096:1096"
     environment:
       - XRDPORT=1096
     volumes:
@@ -95,7 +70,8 @@ services:
       - ../../certs/hostcert_xrd3.key.pem:/tmp/xrdkey.pem:Z
   xrd4:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1097:1097"
     environment:
       - XRDPORT=1097
     volumes:
@@ -103,7 +79,8 @@ services:
       - ../../certs/hostcert_xrd4.key.pem:/tmp/xrdkey.pem:Z
   minio:
     image: docker.io/minio/minio
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:9000:9000"
     environment:
       - MINIO_ACCESS_KEY=admin
       - MINIO_SECRET_KEY=password
@@ -113,12 +90,15 @@ services:
     command: ["server", "/data"]
   ssh1:
     image: docker.io/rucio/ssh
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:2222:22"
     volumes:
       - ../../certs/ssh/ruciouser_sshkey.pub:/tmp/sshkey.pub:Z
   activemq:
     image: docker.io/webcenter/activemq:latest
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:61613:61613"
+      - "127.0.0.1:8161:8161"
     environment:
        - ACTIVEMQ_CONFIG_NAME=activemq
        - ACTIVEMQ_CONFIG_DEFAULTACCOUNT=false
@@ -131,18 +111,23 @@ services:
        - ACTIVEMQ_CONFIG_SCHEDULERENABLED=true
   elasticsearch:
     image: docker.io/elasticsearch:7.4.0
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:9200:9200"
+      - "127.0.0.1:9300:9300"
     environment:
       - discovery.type=single-node
   logstash:
     image: docker.elastic.co/logstash/logstash-oss:7.3.2
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:5044:5044"
     command: bash -c "logstash-plugin install logstash-input-stomp ; /usr/local/bin/docker-entrypoint"
     volumes:
       - ./pipeline.conf:/usr/share/logstash/pipeline/pipeline.conf:Z
   kibana:
     image: docker.io/kibana:7.4.0
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:5601:5601"
   grafana:
     image: docker.io/grafana/grafana:latest
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:3000:3000"

--- a/etc/docker/dev/docker-compose-storage.yml
+++ b/etc/docker/dev/docker-compose-storage.yml
@@ -1,32 +1,9 @@
+version: "3"
 services:
   rucio:
     image: docker.io/rucio/rucio-dev
-    extra_hosts:
-      - "ruciodb:127.0.0.1"
-      - "graphite:127.0.0.1"
-      - "fts:127.0.0.1"
-      - "ftsdb:127.0.0.1"
-      - "xrd1:127.0.0.1"
-      - "xrd2:127.0.0.1"
-      - "xrd3:127.0.0.1"
-      - "xrd4:127.0.0.1"
-      - "minio:127.0.0.1"
-      - "activemq:127.0.0.1"
-      - "ssh1:127.0.0.1"
     ports:
       - "127.0.0.1:8443:443"
-      - "127.0.0.1:5432:5432"
-      - "127.0.0.1:8080:80"
-      - "127.0.0.1:8446:8446"
-      - "127.0.0.1:8449:8449"
-      - "127.0.0.1:3306:3306"
-      - "127.0.0.1:1094:1094"
-      - "127.0.0.1:1095:1095"
-      - "127.0.0.1:1096:1096"
-      - "127.0.0.1:1097:1097"
-      - "127.0.0.1:9000:9000"
-      - "127.0.0.1:61613:61613"
-      - "127.0.0.1:2222:22"
     volumes:
       - ../../../tools:/opt/rucio/tools:Z
       - ../../../bin:/opt/rucio/bin:Z
@@ -37,7 +14,8 @@ services:
       - RDBMS=postgres14
   ruciodb:
     image: docker.io/postgres:14
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=rucio
@@ -45,13 +23,17 @@ services:
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
   graphite:
     image: docker.io/graphiteapp/graphite-statsd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:8080:80"
   fts:
     image: docker.io/rucio/fts
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:8446:8446"
+      - "127.0.0.1:8449:8449"
   ftsdb:
     image: docker.io/mysql:8
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:3306:3306"
     command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_USER=fts
@@ -60,7 +42,8 @@ services:
       - MYSQL_DATABASE=fts
   xrd1:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1094:1094"
     environment:
       - XRDPORT=1094
     volumes:
@@ -68,7 +51,8 @@ services:
       - ../../certs/hostcert_xrd1.key.pem:/tmp/xrdkey.pem:Z
   xrd2:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1095:1095"
     environment:
       - XRDPORT=1095
     volumes:
@@ -76,7 +60,8 @@ services:
       - ../../certs/hostcert_xrd2.key.pem:/tmp/xrdkey.pem:Z
   xrd3:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1096:1096"
     environment:
       - XRDPORT=1096
     volumes:
@@ -84,7 +69,8 @@ services:
       - ../../certs/hostcert_xrd3.key.pem:/tmp/xrdkey.pem:Z
   xrd4:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:1097:1097"
     environment:
       - XRDPORT=1097
     volumes:
@@ -92,7 +78,8 @@ services:
       - ../../certs/hostcert_xrd4.key.pem:/tmp/xrdkey.pem:Z
   minio:
     image: docker.io/minio/minio
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:9000:9000"
     environment:
       - MINIO_ACCESS_KEY=admin
       - MINIO_SECRET_KEY=password
@@ -102,7 +89,8 @@ services:
     command: ["server", "/data"]
   activemq:
     image: docker.io/webcenter/activemq:latest
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:61613:61613"
     environment:
       - ACTIVEMQ_CONFIG_NAME=activemq
       - ACTIVEMQ_CONFIG_DEFAULTACCOUNT=false
@@ -113,6 +101,7 @@ services:
       - ACTIVEMQ_CONFIG_SCHEDULERENABLED=true
   ssh1:
     image: docker.io/rucio/ssh
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:2222:22"
     volumes:
       - ../../certs/ssh/ruciouser_sshkey.pub:/tmp/sshkey.pub:Z

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -2,20 +2,8 @@ version: "3"
 services:
   rucio:
     image: docker.io/rucio/rucio-dev
-    extra_hosts:
-      - "ruciodb:127.0.0.1"
-      - "graphite:127.0.0.1"
-      - "influxdb:127.0.0.1"
-      - "elasticsearch:127.0.0.1"
-      - "activemq:127.0.0.1"
     ports:
       - "127.0.0.1:8443:443"
-      - "127.0.0.1:5432:5432"
-      - "127.0.0.1:8080:80"
-      - "127.0.0.1:8086:8086"
-      - "127.0.0.1:9200:9200"
-      - "127.0.0.1:9300:9300"
-      - "127.0.0.1:61613:61613"
     volumes:
       - ../../../tools:/opt/rucio/tools:Z
       - ../../../bin:/opt/rucio/bin:Z
@@ -26,7 +14,8 @@ services:
       - RDBMS=postgres14
   ruciodb:
     image: docker.io/postgres:14
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=rucio
@@ -34,10 +23,12 @@ services:
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
   graphite:
     image: docker.io/graphiteapp/graphite-statsd
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:8080:80"
   influxdb:
     image: docker.io/influxdb:latest
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:8086:8086"
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup
       - DOCKER_INFLUXDB_INIT_USERNAME=myusername
@@ -47,12 +38,16 @@ services:
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken
   elasticsearch:
     image: docker.io/elasticsearch:7.4.0
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:9200:9200"
+      - "127.0.0.1:9300:9300"
     environment:
       - discovery.type=single-node
   activemq:
     image: docker.io/webcenter/activemq:latest
-    network_mode: "service:rucio"
+    ports:
+      - "127.0.0.1:61613:61613"
+      - "127.0.0.1:8161:8161"
     environment:
       - ACTIVEMQ_CONFIG_NAME=activemq
       - ACTIVEMQ_CONFIG_DEFAULTACCOUNT=false


### PR DESCRIPTION
Switch network mode to the default bridged network. It is supported both by docker-compose and podman-compose.

Move port configuration inside each service configuration. This is required to be able to switch to the bridged network. The ports are not open on the rucio service anymore.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
