### PR TITLE
Remove 'network_mode: "service:rucio"' from docker-compose-*

### DIFF
--- a/etc/docker/dev/docker-compose-storage-alldb.yml
+++ b/etc/docker/dev/docker-compose-storage-alldb.yml
@@ -1,36 +1,8 @@
 services:
   rucio:
     image: docker.io/rucio/rucio-dev
-    extra_hosts:
-      - "ruciomy8:127.0.0.1"
-      - "oracle:127.0.0.1"
-      - "ruciodb:127.0.0.1"
-      - "graphite:127.0.0.1"
-      - "fts:127.0.0.1"
-      - "ftsdb:127.0.0.1"
-      - "xrd1:127.0.0.1"
-      - "xrd2:127.0.0.1"
-      - "xrd3:127.0.0.1"
-      - "xrd4:127.0.0.1"
-      - "minio:127.0.0.1"
-      - "activemq:127.0.0.1"
-      - "ssh1:127.0.0.1"
     ports:
-      - "127.0.0.1:8443:443"
-      - "127.0.0.1:3308:3308"
-      - "127.0.0.1:1521:1521"
-      - "127.0.0.1:5432:5432"
-      - "127.0.0.1:8080:80"
-      - "127.0.0.1:8446:8446"
-      - "127.0.0.1:8449:8449"
-      - "127.0.0.1:3306:3306"
-      - "127.0.0.1:1094:1094"
-      - "127.0.0.1:1095:1095"
-      - "127.0.0.1:1096:1096"
-      - "127.0.0.1:1097:1097"
-      - "127.0.0.1:9000:9000"
-      - "127.0.0.1:61613:61613"
-      - "127.0.0.1:2222:22"
+      - "8443:443"
     volumes:
       - ../../../tools:/opt/rucio/tools:Z
       - ../../../bin:/opt/rucio/bin:Z
@@ -41,7 +13,6 @@ services:
       - RDBMS=postgres14
   ruciomy8:
     image: docker.io/mysql:8
-    network_mode: "service:rucio"
     environment:
       - MYSQL_USER=rucio
       - MYSQL_PASSWORD=rucio
@@ -50,7 +21,6 @@ services:
       - MYSQL_TCP_PORT=3308
   oracle:
     image: docker.io/gvenzl/oracle-xe:21-slim
-    network_mode: "service:rucio"
     environment:
       - ORACLE_PASSWORD=rucio
       - ORACLE_ALLOW_REMOTE=true
@@ -60,21 +30,21 @@ services:
       - transactions=1215
   ruciodb:
     image: docker.io/postgres:14
-    network_mode: "service:rucio"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=rucio
       - POSTGRES_PASSWORD=secret
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
+    ports:
+      - "5432:5432"
   graphite:
     image: docker.io/graphiteapp/graphite-statsd
-    network_mode: "service:rucio"
+    ports:
+      - "8080:80"
   fts:
     image: docker.io/rucio/fts
-    network_mode: "service:rucio"
   ftsdb:
     image: docker.io/mysql:8
-    network_mode: "service:rucio"
     command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_USER=fts
@@ -83,7 +53,6 @@ services:
       - MYSQL_DATABASE=fts
   xrd1:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1094
     volumes:
@@ -91,7 +60,6 @@ services:
       - ../../certs/hostcert_xrd1.key.pem:/tmp/xrdkey.pem:Z
   xrd2:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1095
     volumes:
@@ -99,7 +67,6 @@ services:
       - ../../certs/hostcert_xrd2.key.pem:/tmp/xrdkey.pem:Z
   xrd3:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1096
     volumes:
@@ -107,7 +74,6 @@ services:
       - ../../certs/hostcert_xrd3.key.pem:/tmp/xrdkey.pem:Z
   xrd4:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1097
     volumes:
@@ -115,7 +81,6 @@ services:
       - ../../certs/hostcert_xrd4.key.pem:/tmp/xrdkey.pem:Z
   minio:
     image: docker.io/minio/minio
-    network_mode: "service:rucio"
     environment:
       - MINIO_ACCESS_KEY=admin
       - MINIO_SECRET_KEY=password
@@ -125,7 +90,6 @@ services:
     command: ["server", "/data"]
   activemq:
     image: docker.io/webcenter/activemq:latest
-    network_mode: "service:rucio"
     environment:
       - ACTIVEMQ_CONFIG_NAME=activemq
       - ACTIVEMQ_CONFIG_DEFAULTACCOUNT=false
@@ -134,8 +98,9 @@ services:
       - ACTIVEMQ_USERS_receiver=supersecret
       - ACTIVEMQ_GROUPS_reads=receiver
       - ACTIVEMQ_CONFIG_SCHEDULERENABLED=true
+    ports:
+      - "8161:8161"
   ssh1:
     image: docker.io/rucio/ssh
-    network_mode: "service:rucio"
     volumes:
       - ../../certs/ssh/ruciouser_sshkey.pub:/tmp/sshkey.pub:Z

--- a/etc/docker/dev/docker-compose-storage-externalmetadata.yml
+++ b/etc/docker/dev/docker-compose-storage-externalmetadata.yml
@@ -2,36 +2,8 @@ version: "3.5"
 services:
   rucio:
     image: docker.io/rucio/rucio-dev
-    extra_hosts:
-      - "ruciodb:127.0.0.1"
-      - "graphite:127.0.0.1"
-      - "fts:127.0.0.1"
-      - "ftsdb:127.0.0.1"
-      - "xrd1:127.0.0.1"
-      - "xrd2:127.0.0.1"
-      - "xrd3:127.0.0.1"
-      - "xrd4:127.0.0.1"
-      - "minio:127.0.0.1"
-      - "activemq:127.0.0.1"
-      - "ssh1:127.0.0.1"
-      - "mongo:127.0.0.1"
-      - "postgres:127.0.0.1"
     ports:
-      - "127.0.0.1:8443:443"
-      - "127.0.0.1:5432:5432"
-      - "127.0.0.1:8080:80"
-      - "127.0.0.1:8446:8446"
-      - "127.0.0.1:8449:8449"
-      - "127.0.0.1:3306:3306"
-      - "127.0.0.1:1094:1094"
-      - "127.0.0.1:1095:1095"
-      - "127.0.0.1:1096:1096"
-      - "127.0.0.1:1097:1097"
-      - "127.0.0.1:9000:9000"
-      - "127.0.0.1:61613:61613"
-      - "127.0.0.1:2222:22"
-      - "127.0.0.1:27017:27017"
-      - "127.0.0.1:5433:5433"
+      - "8443:443"
     volumes:
       - ../../../tools:/opt/rucio/tools:Z
       - ../../../bin:/opt/rucio/bin:Z
@@ -42,7 +14,6 @@ services:
       - RDBMS=postgres11
   ruciodb:
     image: docker.io/postgres:11
-    network_mode: "service:rucio"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=rucio
@@ -50,13 +21,12 @@ services:
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
   graphite:
     image: docker.io/graphiteapp/graphite-statsd
-    network_mode: "service:rucio"
+    ports:
+      - "8080:80"
   fts:
     image: docker.io/rucio/fts
-    network_mode: "service:rucio"
   ftsdb:
     image: docker.io/mysql:5
-    network_mode: "service:rucio"
     environment:
       - MYSQL_USER=fts
       - MYSQL_PASSWORD=fts
@@ -64,7 +34,6 @@ services:
       - MYSQL_DATABASE=fts
   xrd1:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1094
     volumes:
@@ -72,7 +41,6 @@ services:
       - ../../certs/hostcert_xrd1.key.pem:/tmp/xrdkey.pem:Z
   xrd2:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1095
     volumes:
@@ -80,7 +48,6 @@ services:
       - ../../certs/hostcert_xrd2.key.pem:/tmp/xrdkey.pem:Z
   xrd3:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1096
     volumes:
@@ -88,7 +55,6 @@ services:
       - ../../certs/hostcert_xrd3.key.pem:/tmp/xrdkey.pem:Z
   xrd4:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1097
     volumes:
@@ -96,7 +62,6 @@ services:
       - ../../certs/hostcert_xrd4.key.pem:/tmp/xrdkey.pem:Z
   minio:
     image: docker.io/minio/minio
-    network_mode: "service:rucio"
     environment:
       - MINIO_ACCESS_KEY=admin
       - MINIO_SECRET_KEY=password
@@ -106,7 +71,6 @@ services:
     command: ["server", "/data"]
   activemq:
     image: docker.io/webcenter/activemq:latest
-    network_mode: "service:rucio"
     environment:
       - ACTIVEMQ_CONFIG_NAME=activemq
       - ACTIVEMQ_CONFIG_DEFAULTACCOUNT=false
@@ -115,17 +79,16 @@ services:
       - ACTIVEMQ_USERS_receiver=supersecret
       - ACTIVEMQ_GROUPS_reads=receiver
       - ACTIVEMQ_CONFIG_SCHEDULERENABLED=true
+    ports:
+      - "8161:8161"
   ssh1:
     image: docker.io/rucio/ssh
-    network_mode: "service:rucio"
     volumes:
       - ../../certs/ssh/ruciouser_sshkey.pub:/tmp/sshkey.pub:Z
   mongo:
     image: docker.io/mongo:5.0
-    network_mode: "service:rucio"
   influxdb:
     image: docker.io/influxdb:latest
-    network_mode: "service:rucio"
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup
       - DOCKER_INFLUXDB_INIT_USERNAME=myusername
@@ -135,12 +98,10 @@ services:
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken
   elasticsearch:
     image: docker.io/elasticsearch:7.4.0
-    network_mode: "service:rucio"
     environment:
       - discovery.type=single-node
   postgres:
     image: docker.io/postgres:14
-    network_mode: "service:rucio"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=metadata

--- a/etc/docker/dev/docker-compose-storage-monit.yml
+++ b/etc/docker/dev/docker-compose-storage-monit.yml
@@ -1,42 +1,9 @@
 services:
   rucio:
     image: docker.io/rucio/rucio-dev
-    extra_hosts:
-      - "ruciodb:127.0.0.1"
-      - "graphite:127.0.0.1"
-      - "fts:127.0.0.1"
-      - "ftsdb:127.0.0.1"
-      - "xrd1:127.0.0.1"
-      - "xrd2:127.0.0.1"
-      - "xrd3:127.0.0.1"
-      - "xrd4:127.0.0.1"
-      - "minio:127.0.0.1"
-      - "ssh1:127.0.0.1"
-      - "activemq:127.0.0.1"
-      - "elasticsearch:127.0.0.1"
-      - "logstash:127.0.0.1"
-      - "kibana:127.0.0.1"
-      - "grafana:127.0.0.1"
     ports:
-      - "127.0.0.1:8443:443"
-      - "127.0.0.1:5432:5432"
-      - "127.0.0.1:8080:80"
-      - "127.0.0.1:8446:8446"
-      - "127.0.0.1:8449:8449"
-      - "127.0.0.1:3306:3306"
-      - "127.0.0.1:1094:1094"
-      - "127.0.0.1:1095:1095"
-      - "127.0.0.1:1096:1096"
-      - "127.0.0.1:1097:1097"
-      - "127.0.0.1:9000:9000"
-      - "127.0.0.1:2222:22"
-      - "127.0.0.1:61613:61613"
-      - "127.0.0.1:8161:8161"
-      - "127.0.0.1:9200:9200"
-      - "127.0.0.1:9300:9300"
-      - "127.0.0.1:5044:5044"
-      - "127.0.0.1:5601:5601"
-      - "127.0.0.1:3000:3000"
+      - "8443:443"
+      - "8080:80"
     volumes:
       - ../../../tools:/opt/rucio/tools:Z
       - ../../../bin:/opt/rucio/bin:Z
@@ -48,21 +15,21 @@ services:
     command: ["/monit-entrypoint.sh"]
   ruciodb:
     image: docker.io/postgres:14
-    network_mode: "service:rucio"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=rucio
       - POSTGRES_PASSWORD=secret
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
+    ports:
+      - "5432:5432"
   graphite:
     image: docker.io/graphiteapp/graphite-statsd
-    network_mode: "service:rucio"
+    ports:
+      - "8080:80"
   fts:
     image: docker.io/rucio/fts
-    network_mode: "service:rucio"
   ftsdb:
     image: docker.io/mysql:8
-    network_mode: "service:rucio"
     command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_USER=fts
@@ -71,7 +38,6 @@ services:
       - MYSQL_DATABASE=fts
   xrd1:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1094
     volumes:
@@ -79,7 +45,6 @@ services:
       - ../../certs/hostcert_xrd1.key.pem:/tmp/xrdkey.pem:Z
   xrd2:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1095
     volumes:
@@ -87,7 +52,6 @@ services:
       - ../../certs/hostcert_xrd2.key.pem:/tmp/xrdkey.pem:Z
   xrd3:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1096
     volumes:
@@ -95,7 +59,6 @@ services:
       - ../../certs/hostcert_xrd3.key.pem:/tmp/xrdkey.pem:Z
   xrd4:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1097
     volumes:
@@ -103,7 +66,6 @@ services:
       - ../../certs/hostcert_xrd4.key.pem:/tmp/xrdkey.pem:Z
   minio:
     image: docker.io/minio/minio
-    network_mode: "service:rucio"
     environment:
       - MINIO_ACCESS_KEY=admin
       - MINIO_SECRET_KEY=password
@@ -113,12 +75,10 @@ services:
     command: ["server", "/data"]
   ssh1:
     image: docker.io/rucio/ssh
-    network_mode: "service:rucio"
     volumes:
       - ../../certs/ssh/ruciouser_sshkey.pub:/tmp/sshkey.pub:Z
   activemq:
     image: docker.io/webcenter/activemq:latest
-    network_mode: "service:rucio"
     environment:
        - ACTIVEMQ_CONFIG_NAME=activemq
        - ACTIVEMQ_CONFIG_DEFAULTACCOUNT=false
@@ -129,20 +89,22 @@ services:
        - ACTIVEMQ_GROUPS_writes=hermes,fts
        - ACTIVEMQ_GROUPS_reads=logstash,receiver
        - ACTIVEMQ_CONFIG_SCHEDULERENABLED=true
+    ports:
+      - "8161:8161"
   elasticsearch:
     image: docker.io/elasticsearch:7.4.0
-    network_mode: "service:rucio"
     environment:
       - discovery.type=single-node
   logstash:
     image: docker.elastic.co/logstash/logstash-oss:7.3.2
-    network_mode: "service:rucio"
     command: bash -c "logstash-plugin install logstash-input-stomp ; /usr/local/bin/docker-entrypoint"
     volumes:
       - ./pipeline.conf:/usr/share/logstash/pipeline/pipeline.conf:Z
   kibana:
     image: docker.io/kibana:7.4.0
-    network_mode: "service:rucio"
+    ports:
+      - "5601:5601"
   grafana:
     image: docker.io/grafana/grafana:latest
-    network_mode: "service:rucio"
+    ports:
+      - "3000:3000"

--- a/etc/docker/dev/docker-compose-storage.yml
+++ b/etc/docker/dev/docker-compose-storage.yml
@@ -1,32 +1,8 @@
 services:
   rucio:
     image: docker.io/rucio/rucio-dev
-    extra_hosts:
-      - "ruciodb:127.0.0.1"
-      - "graphite:127.0.0.1"
-      - "fts:127.0.0.1"
-      - "ftsdb:127.0.0.1"
-      - "xrd1:127.0.0.1"
-      - "xrd2:127.0.0.1"
-      - "xrd3:127.0.0.1"
-      - "xrd4:127.0.0.1"
-      - "minio:127.0.0.1"
-      - "activemq:127.0.0.1"
-      - "ssh1:127.0.0.1"
     ports:
-      - "127.0.0.1:8443:443"
-      - "127.0.0.1:5432:5432"
-      - "127.0.0.1:8080:80"
-      - "127.0.0.1:8446:8446"
-      - "127.0.0.1:8449:8449"
-      - "127.0.0.1:3306:3306"
-      - "127.0.0.1:1094:1094"
-      - "127.0.0.1:1095:1095"
-      - "127.0.0.1:1096:1096"
-      - "127.0.0.1:1097:1097"
-      - "127.0.0.1:9000:9000"
-      - "127.0.0.1:61613:61613"
-      - "127.0.0.1:2222:22"
+      - "8443:443"
     volumes:
       - ../../../tools:/opt/rucio/tools:Z
       - ../../../bin:/opt/rucio/bin:Z
@@ -37,21 +13,21 @@ services:
       - RDBMS=postgres14
   ruciodb:
     image: docker.io/postgres:14
-    network_mode: "service:rucio"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=rucio
       - POSTGRES_PASSWORD=secret
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
+    ports:
+      - "5432:5432"
   graphite:
     image: docker.io/graphiteapp/graphite-statsd
-    network_mode: "service:rucio"
+    ports:
+      - "8080:80"
   fts:
     image: docker.io/rucio/fts
-    network_mode: "service:rucio"
   ftsdb:
     image: docker.io/mysql:8
-    network_mode: "service:rucio"
     command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_USER=fts
@@ -60,7 +36,6 @@ services:
       - MYSQL_DATABASE=fts
   xrd1:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1094
     volumes:
@@ -68,7 +43,6 @@ services:
       - ../../certs/hostcert_xrd1.key.pem:/tmp/xrdkey.pem:Z
   xrd2:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1095
     volumes:
@@ -76,7 +50,6 @@ services:
       - ../../certs/hostcert_xrd2.key.pem:/tmp/xrdkey.pem:Z
   xrd3:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1096
     volumes:
@@ -84,7 +57,6 @@ services:
       - ../../certs/hostcert_xrd3.key.pem:/tmp/xrdkey.pem:Z
   xrd4:
     image: docker.io/rucio/xrootd
-    network_mode: "service:rucio"
     environment:
       - XRDPORT=1097
     volumes:
@@ -92,7 +64,6 @@ services:
       - ../../certs/hostcert_xrd4.key.pem:/tmp/xrdkey.pem:Z
   minio:
     image: docker.io/minio/minio
-    network_mode: "service:rucio"
     environment:
       - MINIO_ACCESS_KEY=admin
       - MINIO_SECRET_KEY=password
@@ -102,7 +73,6 @@ services:
     command: ["server", "/data"]
   activemq:
     image: docker.io/webcenter/activemq:latest
-    network_mode: "service:rucio"
     environment:
       - ACTIVEMQ_CONFIG_NAME=activemq
       - ACTIVEMQ_CONFIG_DEFAULTACCOUNT=false
@@ -111,8 +81,9 @@ services:
       - ACTIVEMQ_USERS_receiver=supersecret
       - ACTIVEMQ_GROUPS_reads=receiver
       - ACTIVEMQ_CONFIG_SCHEDULERENABLED=true
+    ports:
+      - "8161:8161"
   ssh1:
     image: docker.io/rucio/ssh
-    network_mode: "service:rucio"
     volumes:
       - ../../certs/ssh/ruciouser_sshkey.pub:/tmp/sshkey.pub:Z

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -2,20 +2,8 @@ version: "3"
 services:
   rucio:
     image: docker.io/rucio/rucio-dev
-    extra_hosts:
-      - "ruciodb:127.0.0.1"
-      - "graphite:127.0.0.1"
-      - "influxdb:127.0.0.1"
-      - "elasticsearch:127.0.0.1"
-      - "activemq:127.0.0.1"
     ports:
-      - "127.0.0.1:8443:443"
-      - "127.0.0.1:5432:5432"
-      - "127.0.0.1:8080:80"
-      - "127.0.0.1:8086:8086"
-      - "127.0.0.1:9200:9200"
-      - "127.0.0.1:9300:9300"
-      - "127.0.0.1:61613:61613"
+      - "8443:443"
     volumes:
       - ../../../tools:/opt/rucio/tools:Z
       - ../../../bin:/opt/rucio/bin:Z
@@ -26,18 +14,19 @@ services:
       - RDBMS=postgres14
   ruciodb:
     image: docker.io/postgres:14
-    network_mode: "service:rucio"
     environment:
       - POSTGRES_USER=rucio
       - POSTGRES_DB=rucio
       - POSTGRES_PASSWORD=secret
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
+    ports:
+      - "5432:5432"
   graphite:
     image: docker.io/graphiteapp/graphite-statsd
-    network_mode: "service:rucio"
+    ports:
+      - "8080:80"
   influxdb:
     image: docker.io/influxdb:latest
-    network_mode: "service:rucio"
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup
       - DOCKER_INFLUXDB_INIT_USERNAME=myusername
@@ -47,12 +36,10 @@ services:
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken
   elasticsearch:
     image: docker.io/elasticsearch:7.4.0
-    network_mode: "service:rucio"
     environment:
       - discovery.type=single-node
   activemq:
     image: docker.io/webcenter/activemq:latest
-    network_mode: "service:rucio"
     environment:
       - ACTIVEMQ_CONFIG_NAME=activemq
       - ACTIVEMQ_CONFIG_DEFAULTACCOUNT=false
@@ -63,3 +50,5 @@ services:
       - ACTIVEMQ_CONFIG_SCHEDULERENABLED=true
       - ACTIVEMQ_USERS_hermes=supersecret
       - ACTIVEMQ_CONFIG_QUEUES_events=/queue/events'
+    ports:
+      - "8161:8161"


### PR DESCRIPTION
p.s. Ports are forwarded from hosts only to the containers mentioned in the [Setting up Rucio Demo Environment](http://rucio.cern.ch/documentation/setting_up_demo) page in rucio documentation. The rest of the containers should resolve each-other internally via the docker/podman bridge network.

Fix #5996 
Fix #5983 

