### PR TITLE
Protocols: Fix bad-str-strip-call (Pylint); Fix #6002

### DIFF
--- a/lib/rucio/rse/protocols/rclone.py
+++ b/lib/rucio/rse/protocols/rclone.py
@@ -195,7 +195,7 @@ class Default(protocol.RSEProtocol):
 
             if status_query == 0:
                 chsum = 'md5'
-                val = out.strip('  ').split()
+                val = out.strip(' ').split()
                 ret[chsum] = val[0]
 
         except Exception as e:

--- a/lib/rucio/rse/protocols/ssh.py
+++ b/lib/rucio/rse/protocols/ssh.py
@@ -110,7 +110,7 @@ class Default(protocol.RSEProtocol):
 
             if status_query == 0:
                 chsum = 'md5'
-                val = out.strip('  ').split()
+                val = out.strip(' ').split()
                 ret[chsum] = val[0]
 
         except Exception as e:
@@ -324,7 +324,7 @@ class Rsync(Default):
 
             if status_query == 0:
                 chsum = 'md5'
-                val = out.strip('  ').split()
+                val = out.strip(' ').split()
                 ret[chsum] = val[0]
 
         except Exception as e:


### PR DESCRIPTION
Pylint raises error E1310 within the protocols for SSH and rclone. Changed the arguments in str.strip-function calls. Read the  [definition of str.strip](https://docs.python.org/3/library/stdtypes.html?highlight=strip#str.strip)
The replacement is semantically equivalent. Only spaces (but any amount of these) will be stripped.
