### PR TITLE
Tests: Changed syntax of outputting to modern form in test yamls; Fix…

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          sudo apt-get install -y npm libkrb5-dev libxmlsec1-dev 
+          sudo apt-get install -y npm libkrb5-dev libxmlsec1-dev
           npm install --global pyright
           python -m pip --no-cache-dir install --upgrade -r requirements.txt
       - name: Make pyright report of current commit
@@ -127,15 +127,15 @@ jobs:
         run: python3 -m pip install -U PyYAML
       - name: Identify branch
         id: branch
-        run: python3 -c 'from os import environ as env; print("::set-output name=branch::" + (env.get("GITHUB_BASE_REF", None) if env.get("GITHUB_BASE_REF", None) else env.get("GITHUB_REF", "master")))'
+        run: python3 -c 'from os import environ as env; print("branch=" + (env.get("GITHUB_BASE_REF", None) if env.get("GITHUB_BASE_REF", None) else env.get("GITHUB_REF", "master")))' >> $GITHUB_OUTPUT
       - name: Identify Matrix
         id: matrix
         run: |
           EVENT="${{ github.event_name }}"
           if [ $EVENT != 'schedule' ]; then
-            echo "::set-output name=matrix::$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix.yml)"
+            echo "matrix=$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix.yml)" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=matrix::$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix_nightly.yml)"
+            echo "matrix=$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix_nightly.yml)" >> $GITHUB_OUTPUT
           fi
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
@@ -166,7 +166,7 @@ jobs:
           done
           docker logout https://ghcr.io
           if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
-          echo "::set-output name=images::$IMAGES"
+          echo "images=$IMAGES" >> $GITHUB_OUTPUT
       - name: Run test with cfg
         run: 'echo ''{"matrix": ${{ toJson(matrix.cfg) }}, "images": ${{ steps.images.outputs.images }} }'' | ./tools/test/run_tests.py'
   release-patch-setup:
@@ -182,10 +182,10 @@ jobs:
         run: python3 -m pip install -U sh PyYAML
       - name: Grab latest release branch
         id: grabrelease
-        run: echo "::set-output name=release_branch::$(echo "${{ github.event.repository.branches_url }}" | ./tools/github/workflow/grabrelease.py)"
+        run: echo "release_branch=$(echo "${{ github.event.repository.branches_url }}" | ./tools/github/workflow/grabrelease.py)" >> $GITHUB_OUTPUT
       - name: Fetch pull request commit range
         id: prcommits
-        run: echo "::set-output name=source_commits::$(echo "${{ github.event.pull_request.commits_url }}" | ./tools/github/workflow/prcommits.py)"
+        run: echo "source_commits=$(echo "${{ github.event.pull_request.commits_url }}" | ./tools/github/workflow/prcommits.py)" >> $GITHUB_OUTPUT
       - name: Test cherry-picking pull request changes
         run: |
           echo '{
@@ -197,7 +197,7 @@ jobs:
           }' | ./tools/github/workflow/mergetest.py
       - name: Identify Matrix
         id: matrix
-        run: echo "::set-output name=matrix::$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix.yml)"
+        run: echo "matrix=$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix.yml)" >> $GITHUB_OUTPUT
     outputs:
       release_branch: ${{ steps.grabrelease.outputs.release_branch }}
       source_commits: ${{ steps.prcommits.outputs.source_commits }}
@@ -241,6 +241,6 @@ jobs:
           done
           docker logout https://ghcr.io
           if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
-          echo "::set-output name=images::$IMAGES"
+          echo "images=$IMAGES" >> $GITHUB_OUTPUT
       - name: Run test with cfg
         run: 'echo ''{"matrix": ${{ toJson(matrix.cfg) }}, "images": ${{ steps.images.outputs.images }} }'' | ./tools/test/run_tests.py'

--- a/.github/workflows/imagecache.yml
+++ b/.github/workflows/imagecache.yml
@@ -16,7 +16,7 @@ jobs:
           BRANCHES="$(echo "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/branches{/branch}" | \
               ./tools/github/workflow/grabrelease.py --all --json --add master)"
           echo "Will build image cache for branches: ${BRANCHES}"
-          echo "::set-output name=branches::${BRANCHES}"
+          echo "branches=${BRANCHES}" >> $GITHUB_OUTPUT
     outputs:
       branches: ${{ steps.branches.outputs.branches }}
   build_autotests:
@@ -38,10 +38,10 @@ jobs:
           MATRIX_PARSER_PY="${{ github.workspace }}/tools/test/matrix_parser.py"
           MATRIX_CONF="${{ github.workspace }}/etc/docker/test/matrix.yml"
           BUILD_IMAGES_PY="${{ github.workspace }}/tools/test/build_images.py"
-          echo "::set-output name=requirements_met::$(if [[ -r "$MATRIX_CONF" && -x "$MATRIX_PARSER_PY" && -x "$BUILD_IMAGES_PY" ]]; then echo "true"; else echo "false"; fi)"
-          echo "::set-output name=matrix_parser::$MATRIX_PARSER_PY"
-          echo "::set-output name=matrix_configuration::$MATRIX_CONF"
-          echo "::set-output name=build_images::$BUILD_IMAGES_PY"
+          echo "requirements_met=$(if [[ -r "$MATRIX_CONF" && -x "$MATRIX_PARSER_PY" && -x "$BUILD_IMAGES_PY" ]]; then echo "true"; else echo "false"; fi)" >> $GITHUB_OUTPUT
+          echo "matrix_parser=$MATRIX_PARSER_PY" >> $GITHUB_OUTPUT
+          echo "matrix_configuration=$MATRIX_CONF" >> $GITHUB_OUTPUT
+          echo "build_images=$BUILD_IMAGES_PY" >> $GITHUB_OUTPUT
       - name: Update pip, install python requirements for matrix parser
         if: ${{ steps.files.outputs.requirements_met == 'true' }}
         run: |
@@ -50,7 +50,7 @@ jobs:
       - name: Identify Matrix
         if: ${{ steps.files.outputs.requirements_met == 'true' }}
         id: matrix
-        run: echo "::set-output name=matrix::$(${{ steps.files.outputs.matrix_parser }} < ${{ steps.files.outputs.matrix_configuration }})"
+        run: echo "matrix=$(${{ steps.files.outputs.matrix_parser }} < ${{ steps.files.outputs.matrix_configuration }})" >> $GITHUB_OUTPUT
       - name: Build and upload images
         if: ${{ steps.files.outputs.requirements_met == 'true' }}
         id: images
@@ -108,10 +108,10 @@ jobs:
           MATRIX_PARSER_PY="${{ github.workspace }}/dev/rucio/tools/test/matrix_parser.py"
           MATRIX_CONF="${{ github.workspace }}/dev/rucio/etc/docker/test/matrix_integration_tests.yml"
           BUILD_IMAGES_PY="${{ github.workspace }}/dev/rucio/tools/test/build_images.py"
-          echo "::set-output name=requirements_met::$(if [[ -r "$MATRIX_CONF" && -x "$MATRIX_PARSER_PY" && -x "$BUILD_IMAGES_PY" ]]; then echo "true"; else echo "false"; fi)"
-          echo "::set-output name=matrix_parser::$MATRIX_PARSER_PY"
-          echo "::set-output name=matrix_configuration::$MATRIX_CONF"
-          echo "::set-output name=build_images::$BUILD_IMAGES_PY"
+          echo "requirements_met=$(if [[ -r "$MATRIX_CONF" && -x "$MATRIX_PARSER_PY" && -x "$BUILD_IMAGES_PY" ]]; then echo "true"; else echo "false"; fi)" >> $GITHUB_OUTPUT
+          echo "matrix_parser=$MATRIX_PARSER_PY" >> $GITHUB_OUTPUT
+          echo "matrix_configuration=$MATRIX_CONF" >> $GITHUB_OUTPUT
+          echo "build_images=$BUILD_IMAGES_PY" >> $GITHUB_OUTPUT
       - name: Update pip, install python requirements for matrix parser
         if: ${{ steps.files.outputs.requirements_met == 'true' }}
         run: |
@@ -120,7 +120,7 @@ jobs:
       - name: Identify Matrix
         if: ${{ steps.files.outputs.requirements_met == 'true' }}
         id: matrix
-        run: echo "::set-output name=matrix::$(${{ steps.files.outputs.matrix_parser }} < ${{ steps.files.outputs.matrix_configuration }})"
+        run: echo "matrix=$(${{ steps.files.outputs.matrix_parser }} < ${{ steps.files.outputs.matrix_configuration }})" >> $GITHUB_OUTPUT
       - name: Build and upload images
         if: ${{ steps.files.outputs.requirements_met == 'true' }}
         id: images

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -15,10 +15,10 @@ jobs:
         run: python3 -m pip install -U PyYAML
       - name: Identify branch
         id: branch
-        run: python3 -c 'from os import environ as env; print("::set-output name=branch::" + (env.get("GITHUB_BASE_REF", None) if env.get("GITHUB_BASE_REF", None) else env.get("GITHUB_REF", "master")))'
+        run: python3 -c 'from os import environ as env; print("branch=" + (env.get("GITHUB_BASE_REF", None) if env.get("GITHUB_BASE_REF", None) else env.get("GITHUB_REF", "master")))' >> $GITHUB_OUTPUT
       - name: Identify Matrix
         id: matrix
-        run: echo "::set-output name=matrix::$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix_integration_tests.yml)"
+        run: echo "matrix=$(./tools/test/matrix_parser.py < ./etc/docker/test/matrix_integration_tests.yml)" >> $GITHUB_OUTPUT
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -111,7 +111,7 @@ jobs:
           done
           docker logout https://ghcr.io
           if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
-          echo "::set-output name=images::$IMAGES"
+          echo "images=$IMAGES" >> $GITHUB_OUTPUT
       - name: Prepare Docker Compose
         shell: bash
         run: |
@@ -147,7 +147,7 @@ jobs:
         run: |
           docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short --export-artifacts-from="test_tpc" test_tpc.py
           FTS_LOG_FILE=$(docker exec -t dev_rucio_1 cat /tmp/test_tpc.artifact)
-          echo "::set-output name=fts3log::$FTS_LOG_FILE"
+          echo "fts3log=$FTS_LOG_FILE" >> $GITHUB_OUTPUT
       - name: Verify TPC transfers from FTS logs
         shell: bash
         run: |

--- a/.github/workflows/vo_tests.yml
+++ b/.github/workflows/vo_tests.yml
@@ -16,10 +16,10 @@ jobs:
         run: python3 -m pip install -U PyYAML
       - name: Identify branch
         id: branch
-        run: python3 -c 'from os import environ as env; print("::set-output name=branch::" + (env.get("GITHUB_BASE_REF", None) if env.get("GITHUB_BASE_REF", None) else env.get("GITHUB_REF", "master")))'
+        run: python3 -c 'from os import environ as env; print("branch=" + (env.get("GITHUB_BASE_REF", None) if env.get("GITHUB_BASE_REF", None) else env.get("GITHUB_REF", "master")))' >> $GITHUB_OUTPUT
       - name: Identify Matrix
         id: matrix
-        run: echo "::set-output name=matrix::$(./tools/test/votest_helper.py)"
+        run: echo "matrix=$(./tools/test/votest_helper.py)" >> $GITHUB_OUTPUT
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
       matrix: ${{ steps.matrix.outputs.matrix }}


### PR DESCRIPTION
… #5984

Formerly used 
`echo "::set-output name={name}::{value}"`
now uses
`echo "{name}={value}" >> $GITHUB_OUTPUT`.
This is done since Github is deprecating the old syntax. Accessing the values outputted remains the same.
