### PR TITLE
Web: Moved Location of AuthenticatedBlueprint to REST; Fix #5822

### DIFF
--- a/lib/rucio/web/rest/flaskapi/authenticated_bp.py
+++ b/lib/rucio/web/rest/flaskapi/authenticated_bp.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from flask import Blueprint
+from rucio.web.rest.flaskapi.v1.common import request_auth_env
+
+
+class AuthenticatedBlueprint(Blueprint):
+    """
+    Enforce authorisation of blueprints by default
+    returns a normal blueprint otherwise
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.before_request(request_auth_env)

--- a/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
@@ -20,7 +20,7 @@ from rucio.api.account_limit import set_local_account_limit, delete_local_accoun
 from rucio.common.exception import RSENotFound, AccessDenied, AccountNotFound
 from rucio.web.rest.flaskapi.v1.common import response_headers, ErrorHandlingMethodView, \
     generate_http_error_flask, json_parameters, param_get
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class LocalAccountLimit(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -30,7 +30,7 @@ from rucio.common.exception import AccountNotFound, Duplicate, AccessDenied, Rul
 from rucio.common.utils import APIEncoder, render_json
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     try_stream, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Attributes(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/archives.py
+++ b/lib/rucio/web/rest/flaskapi/v1/archives.py
@@ -20,7 +20,7 @@ from flask import Flask, request
 from rucio.api.did import list_archive_content
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     parse_scope_name, try_stream, generate_http_error_flask, ErrorHandlingMethodView
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Archive(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/config.py
+++ b/lib/rucio/web/rest/flaskapi/v1/config.py
@@ -19,7 +19,7 @@ from rucio.api import config
 from rucio.common.exception import ConfigurationError, AccessDenied, ConfigNotFound
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     generate_http_error_flask, ErrorHandlingMethodView, json_parameters
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Config(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/credentials.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credentials.py
@@ -23,7 +23,7 @@ from rucio.common.exception import CannotAuthenticate
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, extract_vo, \
     generate_http_error_flask, ErrorHandlingMethodView, response_headers
 
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 if TYPE_CHECKING:
     from typing import Optional
     from rucio.web.rest.flaskapi.v1.common import HeadersType

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -32,7 +32,7 @@ from rucio.common.utils import render_json, APIEncoder
 from rucio.db.sqla.constants import DIDType
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     parse_scope_name, try_stream, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, json_list, param_get, json_parse
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Scope(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/dirac.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dirac.py
@@ -21,7 +21,7 @@ from rucio.common.exception import AccessDenied, DataIdentifierAlreadyExists, Da
 from rucio.common.utils import parse_response
 from rucio.web.rest.flaskapi.v1.common import response_headers, generate_http_error_flask, \
     ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class AddFiles(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/export.py
+++ b/lib/rucio/web/rest/flaskapi/v1/export.py
@@ -19,7 +19,7 @@ from rucio.api.exporter import export_data
 from rucio.common.utils import render_json
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     ErrorHandlingMethodView
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Export(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
+++ b/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
@@ -18,7 +18,7 @@ import json
 from flask import Flask, Response, request
 
 from rucio.api.heartbeat import list_heartbeats, create_heartbeat
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.common.utils import APIEncoder
 from rucio.common.exception import UnsupportedValueType, UnsupportedKeyType, KeyNotFound, AccessDenied
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \

--- a/lib/rucio/web/rest/flaskapi/v1/identities.py
+++ b/lib/rucio/web/rest/flaskapi/v1/identities.py
@@ -18,7 +18,7 @@ from flask import Flask, request, jsonify
 from rucio.api.identity import add_identity, add_account_identity, list_accounts_for_identity
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     ErrorHandlingMethodView
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class UserPass(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/import.py
+++ b/lib/rucio/web/rest/flaskapi/v1/import.py
@@ -18,7 +18,7 @@ from flask import Flask, request
 from rucio.api.importer import import_data
 from rucio.common.utils import parse_response
 from rucio.web.rest.flaskapi.v1.common import response_headers, ErrorHandlingMethodView, json_parameters
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Import(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
@@ -23,7 +23,7 @@ from rucio.common.exception import LifetimeExceptionNotFound, UnsupportedOperati
 from rucio.common.utils import APIEncoder
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     try_stream, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class LifetimeException(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/locks.py
+++ b/lib/rucio/web/rest/flaskapi/v1/locks.py
@@ -20,7 +20,7 @@ from rucio.common.exception import RSENotFound
 from rucio.common.utils import render_json
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, parse_scope_name, try_stream, \
     response_headers, generate_http_error_flask, ErrorHandlingMethodView, json_parse
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class LockByRSE(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/meta.py
+++ b/lib/rucio/web/rest/flaskapi/v1/meta.py
@@ -19,7 +19,7 @@ from rucio.api.meta import add_key, add_value, list_keys, list_values
 from rucio.common.exception import Duplicate, InvalidValueForKey, KeyNotFound, UnsupportedValueType, UnsupportedKeyType
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, response_headers, \
     generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Meta(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -35,7 +35,7 @@ from rucio.core.replica_sorter import sort_replicas
 from rucio.db.sqla.constants import BadFilesStatus
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, try_stream, parse_scope_name, \
     response_headers, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 def _sorted_with_priorities(replicas, sorted_pfns, limit=None):

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -25,7 +25,7 @@ from rucio.core.rse import get_rses_with_attribute_value, get_rse_name
 from rucio.db.sqla.constants import RequestState
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, parse_scope_name, try_stream, \
     response_headers, generate_http_error_flask, ErrorHandlingMethodView
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class RequestGet(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -29,7 +29,7 @@ from rucio.common.utils import Availability, render_json, APIEncoder
 from rucio.rse import rsemanager
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     try_stream, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class RSEs(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -28,7 +28,7 @@ from rucio.common.exception import InsufficientAccountLimit, RuleNotFound, Acces
 from rucio.common.utils import render_json, APIEncoder
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, parse_scope_name, try_stream, \
     response_headers, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Rule(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/scopes.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scopes.py
@@ -19,7 +19,7 @@ from rucio.api.scope import add_scope, list_scopes, get_scopes
 from rucio.common.exception import AccountNotFound, Duplicate, ScopeNotFound
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, response_headers, \
     generate_http_error_flask, ErrorHandlingMethodView
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Scope(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -25,7 +25,7 @@ from rucio.common.exception import InvalidObject, SubscriptionDuplicate, Subscri
 from rucio.common.utils import render_json, APIEncoder
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, try_stream, \
     response_headers, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Subscription(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/tmp_dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/tmp_dids.py
@@ -17,7 +17,7 @@ from flask import Flask, request
 
 from rucio.api.temporary_did import add_temporary_dids
 from rucio.web.rest.flaskapi.v1.common import response_headers, ErrorHandlingMethodView, json_list
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class BulkDIDS(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/vos.py
+++ b/lib/rucio/web/rest/flaskapi/v1/vos.py
@@ -20,7 +20,7 @@ from rucio.common.exception import AccessDenied, AccountNotFound, Duplicate, VON
 from rucio.common.utils import render_json
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     try_stream, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.ui.flask.bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class VOs(ErrorHandlingMethodView):

--- a/lib/rucio/web/ui/flask/bp.py
+++ b/lib/rucio/web/ui/flask/bp.py
@@ -18,7 +18,7 @@ from flask import Blueprint, request, render_template, make_response
 
 from rucio.api.authentication import get_auth_token_x509
 from rucio.common.config import config_get, config_get_bool
-from rucio.web.rest.flaskapi.v1.common import generate_http_error_flask, request_auth_env
+from rucio.web.rest.flaskapi.v1.common import generate_http_error_flask
 from rucio.web.ui.flask.common.utils import get_token, authenticate, userpass_auth, x509token_auth, saml_auth, oidc_auth, finalize_auth, AUTH_ISSUERS, SAML_SUPPORT
 
 MULTI_VO = config_get_bool('common', 'multi_vo', raise_exception=False, default=False)
@@ -140,17 +140,6 @@ else:
 
 def view_maker(template, title):
     return lambda: authenticate(template=template, title=title)
-
-
-class AuthenticatedBlueprint(Blueprint):
-    """
-    Enforce authorisation of blueprints by default
-    returns a normal blueprint otherwise
-    """
-
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self.before_request(request_auth_env)
 
 
 def blueprint():


### PR DESCRIPTION
Fix issue where the release package is not shipped with the webui contents, triggering ModuleNotFound. The AuthenticatedBlueprint class was moved to `rucio/web/rest/flaskapi/authenticated_bp.py`.