### PR TITLE
Rebalancing: Add the new 'Data Rebalancing' ACTIVITY …

### DIFF
--- a/lib/rucio/common/schema/atlas.py
+++ b/lib/rucio/common/schema/atlas.py
@@ -36,7 +36,7 @@ ACCOUNT_TYPE = {"description": "Account type",
 
 ACTIVITY = {"description": "Activity name",
             "type": "string",
-            "enum": ["Data Brokering", "Data Consolidation", "Data rebalancing",
+            "enum": ["Data Brokering", "Data Consolidation", "Data rebalancing", "Data Rebalancing",
                      "Debug", "Express", "Functional Test", "Functional Test XrootD",
                      "Functional Test WebDAV", "Group Subscriptions",
                      "Production Input", "Production Output",

--- a/lib/rucio/common/schema/generic.py
+++ b/lib/rucio/common/schema/generic.py
@@ -36,7 +36,7 @@ ACCOUNT_TYPE = {"description": "Account type",
 
 ACTIVITY = {"description": "Activity name",
             "type": "string",
-            "enum": ["Data Brokering", "Data Consolidation", "Data rebalancing",
+            "enum": ["Data Brokering", "Data Consolidation", "Data rebalancing", "Data Rebalancing",
                      "Debug", "Express", "Functional Test", "Group Subscriptions",
                      "Production Input", "Production Output",
                      "Analysis Input", "Analysis Output", "Staging",

--- a/lib/rucio/common/schema/generic_multi_vo.py
+++ b/lib/rucio/common/schema/generic_multi_vo.py
@@ -37,7 +37,7 @@ ACCOUNT_TYPE = {"description": "Account type",
 
 ACTIVITY = {"description": "Activity name",
             "type": "string",
-            "enum": ["Data Brokering", "Data Consolidation", "Data rebalancing",
+            "enum": ["Data Brokering", "Data Consolidation", "Data rebalancing", "Data Rebalancing",
                      "Debug", "Express", "Functional Test", "Group Subscriptions",
                      "Production Input", "Production Output",
                      "Analysis Input", "Analysis Output", "Staging",

--- a/lib/rucio/daemons/bb8/common.py
+++ b/lib/rucio/daemons/bb8/common.py
@@ -668,7 +668,7 @@ def rebalance_rse(
                 if not dry_run:
                     child_rule_id = rebalance_rule(
                         parent_rule=rule,
-                        activity="Data rebalancing",
+                        activity="Data Rebalancing",
                         rse_expression=target_rse_exp,
                         priority=priority,
                         source_replica_expression=source_replica_expression,


### PR DESCRIPTION
… in the atlas, generic and generic_multi_vo schemas; make bb8 daemon use it (instead of 'Data rebalancing'). #5967

This implements just first step to fix/close #5967, as the clean-up of the old 'Data rebalancing' will follow with another PR.
