### PR TITLE
Monitoring & Logging: don't use statsd prefix for prometheus

### DIFF
--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -84,7 +84,7 @@ PORT = config_get('monitor', 'carbon_port', raise_exception=False, default=8125)
 SCOPE = config_get('monitor', 'user_scope', raise_exception=False, default='rucio')
 STATSD_CLIENT = None
 if SERVER is not None:
-    STATSD_CLIENT = StatsClient(host=SERVER, port=PORT)
+    STATSD_CLIENT = StatsClient(host=SERVER, port=PORT, prefix=SCOPE)
 
 ENABLE_METRICS = config_get_bool('monitor', 'enable_metrics', raise_exception=False, default=False)
 if ENABLE_METRICS:
@@ -319,14 +319,16 @@ class MetricManager:
     """
     def __init__(self, prefix: "Optional[str]" = None, module: "Optional[str]" = None):
         if prefix:
-            self.prefix = f'{SCOPE}.{prefix}'
+            self.prefix = prefix
         elif module:
-            if module.startswith('rucio.'):
-                module = module[len('rucio.'):]
-            self.prefix = f'{SCOPE}.{module}'
+            self.prefix = module
+        else:
+            self.prefix = None
 
     def full_name(self, name: str):
-        return f'{self.prefix}.{name}'
+        if self.prefix:
+            return f'{self.prefix}.{name}'
+        return name
 
     def counter(
             self,

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -23,7 +23,6 @@ from sqlalchemy import delete
 
 from rucio.common.exception import RequestNotFound
 from rucio.core import distance as distance_core
-from rucio.core import monitor as monitor_core
 from rucio.core import request as request_core
 from rucio.core import rse as rse_core
 from rucio.core import replica as replica_core
@@ -198,7 +197,7 @@ def test_multihop_sources_created(rse_factory, did_factory, root_account, core_c
     assert replica['tombstone'] is None
 
     # Ensure that prometheus metrics were correctly registered. Only one submission, mock transfertool groups everything into one job.
-    assert metrics_mock.get_sample_value(f'{monitor_core.SCOPE}_daemons_conveyor_common_submit_transfer_total') == 1
+    assert metrics_mock.get_sample_value('rucio_daemons_conveyor_common_submit_transfer_total') == 1
 
 
 @pytest.mark.noparallel(reason="multiple submitters cannot be run in parallel due to partial job assignment by hash")

--- a/lib/rucio/tests/test_monitor.py
+++ b/lib/rucio/tests/test_monitor.py
@@ -21,17 +21,17 @@ class TestMonitor:
     def test_record_counter_message(self, metrics_mock):
         """MONITOR (CORE): Send a counter message to graphite """
         monitor.MetricManager(prefix='test').counter('counter').inc(10)
-        assert metrics_mock.get_sample_value(f'{monitor.SCOPE}_test_counter_total') == 10
+        assert metrics_mock.get_sample_value('test_counter_total') == 10
 
     def test_record_gauge_message(self, metrics_mock):
         """MONITOR (CORE): Send a gauge message to graphite """
         monitor.MetricManager(prefix='test').gauge('gauge').set(10)
-        assert metrics_mock.get_sample_value(f'{monitor.SCOPE}_test_gauge') == 10
+        assert metrics_mock.get_sample_value('test_gauge') == 10
 
     def test_record_timer_message(self, metrics_mock):
         """MONITOR (CORE): Send a timer message to graphite """
         monitor.MetricManager(prefix='test').timer('runtime').observe(500)
-        assert metrics_mock.get_sample_value(f'{monitor.SCOPE}_test_runtime_count') == 1
+        assert metrics_mock.get_sample_value('test_runtime_count') == 1
 
     def test_context_record_timer(self, metrics_mock):
         """MONITOR (CORE): Send a timer message to graphite using context """
@@ -40,9 +40,9 @@ class TestMonitor:
         with metric_manager.timer('context_timer'):
             var_a = 2 * 100
             var_a = var_a * 1
-        assert metrics_mock.get_sample_value(f'{monitor.SCOPE}_test_context_timer_count') == 1
+        assert metrics_mock.get_sample_value('test_context_timer_count') == 1
 
         with metric_manager.timer('context_timer'):
             var_a = 2 * 100
             var_a = var_a * 1
-        assert metrics_mock.get_sample_value(f'{monitor.SCOPE}_test_context_timer_count') == 2
+        assert metrics_mock.get_sample_value('test_context_timer_count') == 2


### PR DESCRIPTION
I incorrectly interpreted the meaning of the scope configuration during the recent metrics refactoring. Revert to the old behavior: using it only to prefix statsd metrics.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
