### PR TITLE
Clients: allow reason parameter for denying; Fix #6020

### DIFF
--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -203,15 +203,19 @@ class RuleClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def deny_replication_rule(self, rule_id: str):
+    def deny_replication_rule(self, rule_id: str, reason: Optional[str] = None):
         """
         :param rule_id:             Rule to be denied.
+        :param reason:              Reason for denying the rule.
         :raises:                    RuleNotFound
         """
 
         path = self.RULE_BASEURL + '/' + rule_id
         url = build_url(choice(self.list_hosts), path=path)
-        data = dumps({'options': {'approve': False}})
+        options: Dict[str, Union[bool, str]] = {'approve': False}
+        if reason:
+            options['comment'] = reason
+        data = dumps({'options': options})
         r = self._send_request(url, type_='PUT', data=data)
         if r.status_code == codes.ok:
             return True


### PR DESCRIPTION
When "bulk-denying" rules, one can specify a reason (e.g. `Reason: No lifetime set`. The relevant functionality was already implemented in #487, but the client function lacked a parameter so far.

I tested this "in production" simply by creating a subclass of the client.

Fixes #6020