### PR TITLE
RSE: Make use of GFAL create_parent; Fix #2973

### DIFF
--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -445,13 +445,8 @@ class Default(protocol.RSEProtocol):
             params.timeout = int(transfer_timeout)
             watchdog = Timer(params.timeout + 60, self.__gfal2_cancel)
 
-        if not (self.renaming and dest[:5] == 'https'):
-            dir_name = os.path.dirname(dest)
-            # This function will be removed soon. gfal2 will create parent dir automatically.
-            try:
-                ctx.mkdir_rec(str(dir_name), 0o775)
-            except:
-                pass
+        if not (self.renaming and dest.startswith('https')):
+            params.create_parent = True
 
         if not self.renaming:
             params.strict_copy = True


### PR DESCRIPTION
Replace code which creates the parent directories manually (recursively) by setting the params.create_parent = True flag within __gfal2_copy