### PR TITLE
Feature 6006 support storage not supporting multirange byte requests

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -804,6 +804,8 @@ def _build_list_replicas_pfn(
         sign_urls: bool,
         signature_lifetime: int,
         client_location: "Dict[str, Any]",
+        logger = logging.log,
+        *,
         session: "Session",
 ) -> str:
     """
@@ -856,6 +858,21 @@ def _build_list_replicas_pfn(
                         else:
                             # don't forget to mangle gfal-style davs URL into generic https URL
                             pfn = 'root://' + root_proxy_internal + '//' + pfn.replace('davs://', 'https://')
+
+    simulate_multirange = get_rse_attribute(rse_id, 'simulate_multirange')
+        
+    if simulate_multirange is not None:
+        try:
+            # cover values that cannot be cast to int
+            simulate_multirange = int(simulate_multirange)
+        except ValueError:
+            simulate_multirange = 1
+            logger(logging.WARNING, 'Value encountered when retrieving RSE attribute "simulate_multirange" not compatible with "int", used default value "1".')
+        if simulate_multirange <= 0:
+            logger(logging.WARNING, f'Value {simulate_multirange} encountered when retrieving RSE attribute "simulate_multirange" is <= 0, used default value "1".')
+            simulate_multirange = 1
+        pfn += f'&#multirange=false&nconnections={simulate_multirange}'
+
     return pfn
 
 

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -804,7 +804,7 @@ def _build_list_replicas_pfn(
         sign_urls: bool,
         signature_lifetime: int,
         client_location: "Dict[str, Any]",
-        logger = logging.log,
+        logger=logging.log,
         *,
         session: "Session",
 ) -> str:
@@ -813,9 +813,9 @@ def _build_list_replicas_pfn(
     If needed, sign the PFN url
     If relevant, add the server-side root proxy to te pfn url
     """
-    pfn = list(protocol.lfns2pfns(lfns={'scope': scope.external,
-                                        'name': name,
-                                        'path': path}).values())[0]
+    pfn: str = list(protocol.lfns2pfns(lfns={'scope': scope.external,
+                                             'name': name,
+                                             'path': path}).values())[0]
 
     # do we need to sign the URLs?
     if sign_urls and protocol.attributes['scheme'] == 'https':
@@ -841,7 +841,7 @@ def _build_list_replicas_pfn(
                     # print('filename', name)
                     selected_prefix = get_multi_cache_prefix(cache_site, name)
                     if selected_prefix:
-                        pfn = 'root://' + selected_prefix + '//' + pfn.replace('davs://', 'root://')
+                        pfn = f"root://{selected_prefix}//{pfn.replace('davs://', 'root://')}"
                 else:
                     # print('site:', client_location['site'], 'has no cache')
                     # print('lets check if it has defined an internal root proxy ')
@@ -857,10 +857,10 @@ def _build_list_replicas_pfn(
                             pass  # ATLAS HACK
                         else:
                             # don't forget to mangle gfal-style davs URL into generic https URL
-                            pfn = 'root://' + root_proxy_internal + '//' + pfn.replace('davs://', 'https://')
+                            pfn = f"root://{root_proxy_internal}//{pfn.replace('davs://', 'https://')}"
 
     simulate_multirange = get_rse_attribute(rse_id, 'simulate_multirange')
-        
+
     if simulate_multirange is not None:
         try:
             # cover values that cannot be cast to int

--- a/lib/rucio/tests/temp_factories.py
+++ b/lib/rucio/tests/temp_factories.py
@@ -31,6 +31,10 @@ from rucio.tests.common import did_name_generator
 from rucio.tests.common_server import cleanup_db_deps
 from sqlalchemy import and_, or_, delete
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from typing import Tuple
+
 
 class TemporaryRSEFactory:
     """
@@ -68,7 +72,7 @@ class TemporaryRSEFactory:
             # So running test in parallel results in some tests failing on foreign key errors.
             rse_core.del_rse(rse_id)
 
-    def _make_rse(self, scheme, protocol_impl, parameters=None, add_rse_kwargs=None):
+    def _make_rse(self, scheme, protocol_impl, parameters=None, add_rse_kwargs=None) -> "Tuple[str, str]":
         rse_name = self.name_prefix + ''.join(choice(ascii_uppercase) for _ in range(6))
         if add_rse_kwargs and 'vo' in add_rse_kwargs:
             rse_id = rse_core.add_rse(rse_name, **add_rse_kwargs)

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -46,6 +46,10 @@ from rucio.db.sqla.session import transactional_session
 from rucio.rse import rsemanager as rsemgr
 from rucio.tests.common import execute, headers, auth, Mime, accept, did_name_generator
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from rucio.tests.temp_factories import TemporaryRSEFactory
+
 
 def mocked_VP_requests_get(*args, **kwargs):
     """This method will be used by the mock to replace requests.get to VP server."""
@@ -199,7 +203,7 @@ class TestReplicaCore:
     @pytest.mark.parametrize(
         "params",
         [
-            (False, None, None), 
+            (False, None, None),
             (True, 10, 10),
             (True, -2, 1),
             (True, 0, 1),
@@ -207,7 +211,9 @@ class TestReplicaCore:
             (True, "oops", 1)
         ]
     )
-    def test_list_replicas_sim_multirange(self, params, rse_factory, mock_scope, root_account):
+    def test_list_replicas_sim_multirange(
+        self, params, rse_factory: "TemporaryRSEFactory", mock_scope, root_account
+    ):
         """ REPLICA (CORE): List file replicas for storage that does not support multirange-byte requests should add suffix to PFN"""
 
         # bear in mind that if a bad value is entered as rse_attribute, the default value is 1
@@ -233,7 +239,6 @@ class TestReplicaCore:
             assert f'&#multirange=false&nconnections={expectedconns}' in pfn
         else:
             assert '&#multirange=false&nconnections' not in pfn
-
 
     @pytest.mark.parametrize("file_config_mock", [
         # Run test twice: with, and without, temp tables

--- a/lib/rucio/tests/test_replica.py
+++ b/lib/rucio/tests/test_replica.py
@@ -196,6 +196,45 @@ class TestReplicaCore:
 
         assert nbfiles == replica_cpt
 
+    @pytest.mark.parametrize(
+        "params",
+        [
+            (False, None, None), 
+            (True, 10, 10),
+            (True, -2, 1),
+            (True, 0, 1),
+            (True, 56.7, 1),
+            (True, "oops", 1)
+        ]
+    )
+    def test_list_replicas_sim_multirange(self, params, rse_factory, mock_scope, root_account):
+        """ REPLICA (CORE): List file replicas for storage that does not support multirange-byte requests should add suffix to PFN"""
+
+        # bear in mind that if a bad value is entered as rse_attribute, the default value is 1
+        simulate_multirange, nconns, expectedconns = params
+
+        _, rse_id = rse_factory.make_mock_rse()
+
+        if simulate_multirange:
+            add_rse_attribute(
+                rse_id=rse_id, key='simulate_multirange', value=str(nconns)
+            )
+
+        # add files
+        file_name = did_name_generator('testfiles')
+        add_replica(rse_id, mock_scope, file_name, 2, root_account)
+
+        dids = [{'scope': mock_scope, 'name': file_name, 'type': DIDType.FILE}]
+        file = next(list_replicas(dids=dids))
+        pfn = list(file['pfns'].keys())[0]
+        assert pfn[:7] == 'mock://'
+        assert file_name in pfn
+        if simulate_multirange:
+            assert f'&#multirange=false&nconnections={expectedconns}' in pfn
+        else:
+            assert '&#multirange=false&nconnections' not in pfn
+
+
     @pytest.mark.parametrize("file_config_mock", [
         # Run test twice: with, and without, temp tables
         {"overrides": [('core', 'use_temp_tables', 'True')]},


### PR DESCRIPTION
If an RSE has the RSE attribute `simulate_multirange: <int>`, then `&#multirange=false&nconnections=10` is appended to the PFN as described in the issue.
Added unit tests.
Also worked on decorative changes (type hints and reformatting, mainly converting different forms of building strings into f-strings)