### PR TITLE
Feature 5979 handle exception replication rule on file

### DIFF
--- a/etc/mail_templates/rule_approval_request.tmpl
+++ b/etc/mail_templates/rule_approval_request.tmpl
@@ -16,7 +16,7 @@ DID description:
   Type:                 $did_type
   Number of files:      $length
   Total size:           $bytes
-  Closed:               $closed
+  Open:                 $open
   Complete replicas:    $complete_rses
   Rucio UI:             https://rucio-ui.cern.ch/did?scope=$scope&name=$name
 

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -67,6 +67,7 @@ from rucio.db.sqla.session import read_session, transactional_session, stream_se
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+    from typing import List, Tuple
 
 
 REGION = make_region_memcached(expiration_time=900)
@@ -3224,7 +3225,7 @@ def __create_rule_approval_email(rule, *, session: "Session"):
                                          'did_type': rule.did_type,
                                          'length': '0' if did['length'] is None else str(did['length']),
                                          'bytes': '0' if did['bytes'] is None else sizefmt(did['bytes']),
-                                         'closed': not did['open'],
+                                         'open': did.get('open', 'Not Applicable'),
                                          'complete_rses': ', '.join(rses),
                                          'approvers': ','.join([r[0] for r in recipents]),
                                          'approver': recipent[1],
@@ -3248,7 +3249,7 @@ def __create_recipents_list(rse_expression, filter_=None, *, session: "Session")
     :param session:         The database session in use.
     """
 
-    recipents = []  # (eMail, account)
+    recipents: "List[Tuple]" = []  # (eMail, account)
 
     # APPROVERS-LIST
     # If there are accounts in the approvers-list of any of the RSEs only these should be used

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -2247,7 +2247,7 @@ def approve_rule(rule_id, approver=None, notify_approvers=True, *, session: "Ses
                 text = template.safe_substitute({'rule_id': str(rule.id),
                                                  'approver': approver})
                 vo = rule.account.vo
-                recipients = __create_recipients_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
+                recipients = _create_recipients_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
                 for recipient in recipients:
                     add_message(event_type='email',
                                 payload={'body': text,
@@ -2306,7 +2306,7 @@ def deny_rule(rule_id, approver=None, reason=None, *, session: "Session"):
                                                    'approver': approver,
                                                    'reason': reason})
             vo = rule.account.vo
-            recipients = __create_recipients_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
+            recipients = _create_recipients_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
             for recipient in recipients:
                 add_message(event_type='email',
                             payload={'body': email_body,
@@ -3223,7 +3223,7 @@ def __create_rule_approval_email(rule: "models.ReplicationRule", *, session: "Se
             pass
 
     # Resolve recipients:
-    recipients = __create_recipients_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
+    recipients = _create_recipients_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
 
     for recipient in recipients:
         text = template.safe_substitute(
@@ -3258,7 +3258,7 @@ def __create_rule_approval_email(rule: "models.ReplicationRule", *, session: "Se
 
 
 @transactional_session
-def __create_recipients_list(rse_expression: str, filter_=None, *, session: "Session"):
+def _create_recipients_list(rse_expression: str, filter_=None, *, session: "Session"):
     """
     Create a list of recipients for a notification email based on rse_expression.
 

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -24,6 +24,7 @@ from datetime import datetime, timedelta
 from re import match
 from string import Template
 from typing import Dict, Any, Optional
+from os import path
 
 from dogpile.cache.api import NO_VALUE
 
@@ -2246,11 +2247,11 @@ def approve_rule(rule_id, approver=None, notify_approvers=True, *, session: "Ses
                 text = template.safe_substitute({'rule_id': str(rule.id),
                                                  'approver': approver})
                 vo = rule.account.vo
-                recipents = __create_recipents_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
-                for recipent in recipents:
+                recipients = __create_recipients_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
+                for recipient in recipients:
                     add_message(event_type='email',
                                 payload={'body': text,
-                                         'to': [recipent[0]],
+                                         'to': [recipient[0]],
                                          'subject': 'Re: [RUCIO] Request to approve replication rule %s' % (str(rule.id))},
                                 session=session)
     except NoResultFound:
@@ -2305,11 +2306,11 @@ def deny_rule(rule_id, approver=None, reason=None, *, session: "Session"):
                                                    'approver': approver,
                                                    'reason': reason})
             vo = rule.account.vo
-            recipents = __create_recipents_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
-            for recipent in recipents:
+            recipients = __create_recipients_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
+            for recipient in recipients:
                 add_message(event_type='email',
                             payload={'body': email_body,
-                                     'to': [recipent[0]],
+                                     'to': [recipient[0]],
                                      'subject': 'Re: [RUCIO] Request to approve replication rule %s' % (str(rule.id))},
                             session=session)
     except NoResultFound:
@@ -3171,7 +3172,7 @@ def __delete_lock_and_update_replica(lock, purge_replicas=False, nowait=False, *
 
 
 @transactional_session
-def __create_rule_approval_email(rule, *, session: "Session"):
+def __create_rule_approval_email(rule: "models.ReplicationRule", *, session: "Session"):
     """
     Create the rule notification email.
 
@@ -3179,11 +3180,23 @@ def __create_rule_approval_email(rule, *, session: "Session"):
     :param session:   The database session in use.
     """
 
-    with open('%s/rule_approval_request.tmpl' % config_get('common', 'mailtemplatedir'), 'r') as templatefile:
+    filepath = path.join(
+        config_get('common', 'mailtemplatedir'), 'rule_approval_request.tmpl'  # type: ignore
+    )
+    with open(filepath, 'r') as templatefile:
         template = Template(templatefile.read())
 
-    did = rucio.core.did.get_did(scope=rule.scope, name=rule.name, dynamic_depth=DIDType.FILE, session=session)
-    rses = [rep['rse_id'] for rep in rucio.core.replica.list_dataset_replicas(scope=rule.scope, name=rule.name, session=session) if rep['state'] == ReplicaState.AVAILABLE]
+    did = rucio.core.did.get_did(
+        scope=rule.scope,
+        name=rule.name,
+        dynamic_depth=DIDType.FILE,
+        session=session
+    )
+
+    reps = rucio.core.replica.list_dataset_replicas(
+        scope=rule.scope, name=rule.name, session=session
+    )
+    rses = [rep['rse_id'] for rep in reps if rep['state'] == ReplicaState.AVAILABLE]
 
     # RSE occupancy
     vo = rule.account.vo
@@ -3209,47 +3222,51 @@ def __create_rule_approval_email(rule, *, session: "Session"):
         except Exception:
             pass
 
-    # Resolve recipents:
-    recipents = __create_recipents_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
+    # Resolve recipients:
+    recipients = __create_recipients_list(rse_expression=rule.rse_expression, filter_={'vo': vo}, session=session)
 
-    for recipent in recipents:
-        text = template.safe_substitute({'rule_id': str(rule.id),
-                                         'created_at': str(rule.created_at),
-                                         'expires_at': str(rule.expires_at),
-                                         'account': rule.account.external,
-                                         'email': get_account(account=rule.account, session=session).email,
-                                         'rse_expression': rule.rse_expression,
-                                         'comment': rule.comments,
-                                         'scope': rule.scope.external,
-                                         'name': rule.name,
-                                         'did_type': rule.did_type,
-                                         'length': '0' if did['length'] is None else str(did['length']),
-                                         'bytes': '0' if did['bytes'] is None else sizefmt(did['bytes']),
-                                         'open': did.get('open', 'Not Applicable'),
-                                         'complete_rses': ', '.join(rses),
-                                         'approvers': ','.join([r[0] for r in recipents]),
-                                         'approver': recipent[1],
-                                         'target_rse': target_rse,
-                                         'free_space': free_space,
-                                         'free_space_after': free_space_after})
+    for recipient in recipients:
+        text = template.safe_substitute(
+            {
+                'rule_id': str(rule.id),
+                'created_at': str(rule.created_at),
+                'expires_at': str(rule.expires_at),
+                'account': rule.account.external,
+                'email': get_account(account=rule.account, session=session).email,
+                'rse_expression': rule.rse_expression,
+                'comment': rule.comments,
+                'scope': rule.scope.external,
+                'name': rule.name,
+                'did_type': rule.did_type,
+                'length': '0' if did['length'] is None else str(did['length']),
+                'bytes': '0' if did['bytes'] is None else sizefmt(did['bytes']),
+                'open': did.get('open', 'Not Applicable'),
+                'complete_rses': ', '.join(rses),
+                'approvers': ','.join([r[0] for r in recipients]),
+                'approver': recipient[1],
+                'target_rse': target_rse,
+                'free_space': free_space,
+                'free_space_after': free_space_after
+            }
+        )
 
         add_message(event_type='email',
                     payload={'body': text,
-                             'to': [recipent[0]],
+                             'to': [recipient[0]],
                              'subject': '[RUCIO] Request to approve replication rule %s' % (str(rule.id))},
                     session=session)
 
 
 @transactional_session
-def __create_recipents_list(rse_expression, filter_=None, *, session: "Session"):
+def __create_recipients_list(rse_expression: str, filter_=None, *, session: "Session"):
     """
-    Create a list of recipents for a notification email based on rse_expression.
+    Create a list of recipients for a notification email based on rse_expression.
 
     :param rse_exoression:  The rse_expression.
     :param session:         The database session in use.
     """
 
-    recipents: "List[Tuple]" = []  # (eMail, account)
+    recipients: "List[Tuple]" = []  # (eMail, account)
 
     # APPROVERS-LIST
     # If there are accounts in the approvers-list of any of the RSEs only these should be used
@@ -3261,47 +3278,57 @@ def __create_recipents_list(rse_expression, filter_=None, *, session: "Session")
                 try:
                     email = get_account(account=account, session=session).email
                     if email:
-                        recipents.append((email, account))
+                        recipients.append((email, account))
                 except Exception:
                     pass
 
     # LOCALGROUPDISK/LOCALGROUPTAPE
-    if not recipents:
+    if not recipients:
         for rse in parse_expression(rse_expression, filter_=filter_, session=session):
             rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
             if rse_attr.get('type', '') in ('LOCALGROUPDISK', 'LOCALGROUPTAPE'):
-                accounts = session.query(models.AccountAttrAssociation.account).filter_by(key='country-%s' % rse_attr.get('country', ''),
-                                                                                          value='admin').all()
+                accounts = session.query(
+                    models.AccountAttrAssociation.account
+                ).filter_by(
+                    key=f'country-{rse_attr.get("country", "")}',
+                    value='admin'
+                ).all()
                 for account in accounts:
                     try:
                         email = get_account(account=account[0], session=session).email
                         if email:
-                            recipents.append((email, account[0]))
+                            recipients.append((email, account[0]))
                     except Exception:
                         pass
 
     # GROUPDISK
-    if not recipents:
+    if not recipients:
         for rse in parse_expression(rse_expression, filter_=filter_, session=session):
             rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
             if rse_attr.get('type', '') == 'GROUPDISK':
-                accounts = session.query(models.AccountAttrAssociation.account).filter_by(key='group-%s' % rse_attr.get('physgroup', ''),
-                                                                                          value='admin').all()
+                accounts = session.query(
+                    models.AccountAttrAssociation.account
+                ).filter_by(
+                    key=f'group-{rse_attr.get("physgroup", "")}',
+                    value='admin'
+                ).all()
                 for account in accounts:
                     try:
                         email = get_account(account=account[0], session=session).email
                         if email:
-                            recipents.append((email, account[0]))
+                            recipients.append((email, account[0]))
                     except Exception:
                         pass
 
     # DDMADMIN as default
-    if not recipents:
-        default_mail_from = config_get('core', 'default_mail_from', raise_exception=False, default=None)
+    if not recipients:
+        default_mail_from = config_get(
+            'core', 'default_mail_from', raise_exception=False, default=None
+        )
         if default_mail_from:
-            recipents = [(default_mail_from, 'ddmadmin')]
+            recipients = [(default_mail_from, 'ddmadmin')]
 
-    return list(set(recipents))
+    return list(set(recipients))
 
 
 def __progress_class(replicating_locks, total_locks):

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -3287,17 +3287,19 @@ def __create_recipients_list(rse_expression: str, filter_=None, *, session: "Ses
         for rse in parse_expression(rse_expression, filter_=filter_, session=session):
             rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
             if rse_attr.get('type', '') in ('LOCALGROUPDISK', 'LOCALGROUPTAPE'):
-                accounts = session.query(
+
+                query = select(
                     models.AccountAttrAssociation.account
-                ).filter_by(
-                    key=f'country-{rse_attr.get("country", "")}',
-                    value='admin'
-                ).all()
-                for account in accounts:
+                ).where(
+                    models.AccountAttrAssociation.key == f'country-{rse_attr.get("country", "")}',
+                    models.AccountAttrAssociation.value == 'admin'
+                )
+
+                for account in session.execute(query).scalars().all():
                     try:
-                        email = get_account(account=account[0], session=session).email
+                        email = get_account(account=account, session=session).email
                         if email:
-                            recipients.append((email, account[0]))
+                            recipients.append((email, account))
                     except Exception:
                         pass
 
@@ -3306,17 +3308,19 @@ def __create_recipients_list(rse_expression: str, filter_=None, *, session: "Ses
         for rse in parse_expression(rse_expression, filter_=filter_, session=session):
             rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
             if rse_attr.get('type', '') == 'GROUPDISK':
-                accounts = session.query(
+
+                query = select(
                     models.AccountAttrAssociation.account
-                ).filter_by(
-                    key=f'group-{rse_attr.get("physgroup", "")}',
-                    value='admin'
-                ).all()
-                for account in accounts:
+                ).where(
+                    models.AccountAttrAssociation.key == f'group-{rse_attr.get("physgroup", "")}',
+                    models.AccountAttrAssociation.value == 'admin'
+                )
+
+                for account in session.execute(query).scalars().all():
                     try:
-                        email = get_account(account=account[0], session=session).email
+                        email = get_account(account=account, session=session).email
                         if email:
-                            recipients.append((email, account[0]))
+                            recipients.append((email, account))
                     except Exception:
                         pass
 

--- a/lib/rucio/tests/test_rule.py
+++ b/lib/rucio/tests/test_rule.py
@@ -149,6 +149,29 @@ def setup_class(request, vo, root_account, jdoe_account, rse_factory):
 @pytest.mark.usefixtures('setup_class')
 class TestCore:
 
+    def test_add_rule_to_file_ask_approval(self, vo, mock_scope, jdoe_account):
+        """ REPLICATION RULE (CORE): Add a replication rule, asking approval"""
+        rse = rse_name_generator()
+        rse_id = add_rse(rse, vo=vo)
+
+        add_rse_attribute(rse_id, "rule_approvers", jdoe_account)
+
+        files = create_files(1, mock_scope, rse_id)
+        output = add_rule(
+            dids=files,
+            account=jdoe_account,
+            copies=1,
+            rse_expression=str(rse),
+            grouping='NONE',
+            weight=None,
+            lifetime=None,
+            locked=False,
+            subscription_id=None,
+            ask_approval=True
+        )
+        assert len(output) == 1
+        assert isinstance(output[0], str)
+
     def test_add_rule_file_none(self, mock_scope, jdoe_account):
         """ REPLICATION RULE (CORE): Add a replication rule on a group of files, NONE Grouping"""
         files = create_files(3, mock_scope, self.rse1_id)


### PR DESCRIPTION
Fixed issue and added unit tests: 

The issue was that core/rule.py::add_rule is designed to be applied on
DIDs with the boolean flag 'open'. When applyied to files, the call to
the did dict with key 'open' is still performed, leading to a keyerror.

By performing a check whether the key exists first (and setting the
value to None otherwise), the keyerror is avoided.

This issue did not show up in any tests so far because the code that
causes the error is only run when the --ask-approval flag is passed and
the file has rule_approvers assigned.

This was followed by typing and decorative changes in the functions edited in the process of working on this branch.
