### PR TITLE
Transfers: handle failed files in any final job_state. Closes #6043

### DIFF
--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -593,7 +593,7 @@ class FTS3ApiTransferStatusReport(Fts3TransferStatusReport):
         if file_state_is_final:
             if file_state == FTS_STATE.FINISHED:
                 new_state = RequestState.DONE
-            elif file_state == FTS_STATE.FAILED and job_state == FTS_STATE.FAILED or \
+            elif file_state == FTS_STATE.FAILED and job_state_is_final or \
                     file_state == FTS_STATE.FAILED and not self._multi_sources:  # for multi-source transfers we must wait for the job to be in a final state
                 if self._is_recoverable_fts_overwrite_error(self.request(session), reason, self._file_metadata):
                     new_state = RequestState.DONE


### PR DESCRIPTION
Otherwise transfers with job_state = canceled and file_state = failed are never handled by the poller.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
