### PR TITLE
Patch 5608 slash name issue for create did sample

### DIFF
--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -663,9 +663,16 @@ class DIDClient(BaseClient):
         :param account: The account.
         :param nbfiles: The number of files to register in the output dataset.
         """
-        path = '/'.join([self.DIDS_BASEURL, quote_plus(input_scope), quote_plus(input_name), quote_plus(output_scope), quote_plus(output_name), str(nbfiles), 'sample'])
+        path = '/'.join([self.DIDS_BASEURL, 'sample'])
+        data = dumps({
+            'input_scope': input_scope,
+            'input_name': input_name,
+            'output_scope': output_scope,
+            'output_name': output_name,
+            'nbfiles': str(nbfiles)
+        })
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='POST', data=dumps({}))
+        r = self._send_request(url, type_='POST', data=data)
         if r.status_code == codes.created:
             return True
         else:

--- a/lib/rucio/tests/test_did.py
+++ b/lib/rucio/tests/test_did.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from datetime import datetime, timedelta
-import os
 
 import pytest
 
@@ -529,7 +528,6 @@ class TestDIDClients:
         did_client.close(scope=tmp_scope, name=tmp_dsn)
 
     @pytest.mark.dirty
-    @pytest.mark.skipif(os.environ.get('POLICY') != 'atlas', reason='REST API only works with ATLAS DID convention')
     @pytest.mark.noparallel(reason='uses pre-defined scope')
     def test_create_sample(self, vo, root_account, did_client, rse_factory):
         """ DATA IDENTIFIERS (CLIENT): Create a sample"""

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -1962,7 +1962,6 @@ class Sample(ErrorHandlingMethodView):
                   nbfiles:
                     description: The number of files to register in the output dataset.
                     type: string
-        parameters:
         responses:
           201:
             description: OK

--- a/lib/rucio/web/ui/static/rucio.js
+++ b/lib/rucio/web/ui/static/rucio.js
@@ -1386,13 +1386,20 @@ RucioClient.prototype.get_scopes = function(options) {
 /* Create a new did with a random sample from the original did */
 RucioClient.prototype.create_did_sample = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.input_scope + '/' + options.input_name + '/' + options.output_scope + '/' + options.output_name + '/' + options.nbfiles + '/sample';
+    var url = this.url + '/dids/sample';
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
                  type: 'POST',
                  async: options.async,
+                 data: JSON.stringify({
+                    'input_scope': options.input_scope,
+                    'input_name': options.input_name,
+                    'output_scope': options.output_scope,
+                    'output_name': options.output_name,
+                    'nbfiles': options.nbfiles
+                 }),
                  success: function(data)
                  {
                      options.success(data);

--- a/tools/test/prepare_db_for_ui.sh
+++ b/tools/test/prepare_db_for_ui.sh
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ACCOUNT=anton
+IDENTITY=antonid
+EMAIL='antonmail@mail.ch'
+PASSWORD=anton
+SCOPE=user.anton
+DATASET=antondset
+RSE=XRD1
+
+rucio-admin account add $ACCOUNT
+rucio-admin account add-attribute --key 'admin' --value true $ACCOUNT
+
+# add userpass identity
+rucio-admin identity add --account $ACCOUNT --type USERPASS --id $IDENTITY --email $EMAIL --pass $PASSWORD
+
+# ( logging into rucio UI requires you to use the IDENTITY not the ACCOUNT)
+
+# create scope antonscope
+rucio-admin scope add --account $ACCOUNT --scope $SCOPE
+rucio-admin scope add --account $ACCOUNT --scope user.$ACCOUNT
+# test using rucio list-scopes
+
+# add dataset antondset
+rucio add-dataset $SCOPE:$DATASET
+
+# create test files numbered tfile1.txt through tfile3.txt
+echo 'Creating test files'
+echo {1..3} | sed -e 's/\s/\n/g' | xargs -I{} sh -c "echo hello test no {} >> tfile{}.txt"
+
+rucio upload --scope $SCOPE --rse $RSE tfile*
+
+rucio-admin account set-limits $ACCOUNT $RSE infinity
+
+rucio attach $SCOPE:$DATASET $SCOPE:tfile{1..3}.txt
+
+rucio add-rule $SCOPE:$DATASET 1 $RSE


### PR DESCRIPTION
`dids.py::Sample` of the Flask-API does not work when scope or name of the dataset/collection to be sampled from contains slashes `/`. These parameters are passed from client to server via the URL, and slashes are not URL-safe. In order to change this, the server backend has been changed to accept data in the form of JSON. The old server endpoint remains, albeit under a different name.

The WebUI, which is used to generate such samples, has been adapted so as to make the correct API call using Ajax. The changes to the WebUI have been manually tested.

In order to manually test the WebUI, a script was written to populate the database with entries that are necessary to perform the test.