### PR TITLE
auth: update x509 endpoint for browser clients #6048

### DIFF
--- a/lib/rucio/core/identity.py
+++ b/lib/rucio/core/identity.py
@@ -83,8 +83,10 @@ def verify_identity(identity: str, type_: IdentityType, password: Union[str, Non
 
     id_ = session.query(models.Identity).filter_by(identity=identity, identity_type=type_).first()
     if id_ is None:
-        raise exception.IdentityError('Identity pair \'%s\',\'%s\' does not exist!' % (identity, type_))
-    if type_ == IdentityType.USERPASS:
+        raise exception.IdentityError('Identity \'%s\' of type \'%s\' does not exist!' % (identity, type_))
+    if type_ == IdentityType.X509:
+        return True
+    elif type_ == IdentityType.USERPASS:
         salted_password = id_.salt + password.encode()
         password = hashlib.sha256(salted_password).hexdigest()
         if password != id_.password:

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -18,11 +18,11 @@ import contextlib
 import itertools
 import json
 import os
+from random import choice, choices
+import requests
+from string import ascii_uppercase, ascii_letters, digits
 import tempfile
 from typing import Optional
-from random import choice, choices
-from string import ascii_uppercase, ascii_letters, digits
-import requests
 
 import pytest
 
@@ -44,10 +44,7 @@ def is_influxdb_available() -> bool:
     """Return True if influxdb is available, else return False."""
     try:
         response = requests.get('http://localhost:8086/ping')
-        if response.status_code == 204:
-            return True
-        else:
-            return False
+        return response.status_code == 204
     except requests.exceptions.ConnectionError:
         print('InfluxDB is not running at localhost:8086')
         return False
@@ -57,10 +54,7 @@ def is_elasticsearch_available() -> bool:
     """Return True if elasticsearch is available, else return False."""
     try:
         response = requests.get('http://localhost:9200/')
-        if response.status_code == 200:
-            return True
-        else:
-            return False
+        return response.status_code == 200
     except requests.exceptions.ConnectionError:
         print('Elasticsearch is not running at localhost:9200')
         return False

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -19,8 +19,9 @@ import itertools
 import json
 import os
 import tempfile
-from random import choice
-from string import ascii_uppercase
+from typing import Optional
+from random import choice, choices
+from string import ascii_uppercase, ascii_letters, digits
 import requests
 
 import pytest
@@ -39,23 +40,27 @@ skip_non_belleii = pytest.mark.skipif(not ('POLICY' in os.environ and os.environ
                                       reason="specific belleii tests")
 
 
-def is_influxdb_available():
+def is_influxdb_available() -> bool:
     """Return True if influxdb is available, else return False."""
     try:
         response = requests.get('http://localhost:8086/ping')
         if response.status_code == 204:
             return True
+        else:
+            return False
     except requests.exceptions.ConnectionError:
         print('InfluxDB is not running at localhost:8086')
         return False
 
 
-def is_elasticsearch_available():
+def is_elasticsearch_available() -> bool:
     """Return True if elasticsearch is available, else return False."""
     try:
         response = requests.get('http://localhost:9200/')
         if response.status_code == 200:
             return True
+        else:
+            return False
     except requests.exceptions.ConnectionError:
         print('Elasticsearch is not running at localhost:9200')
         return False
@@ -64,18 +69,20 @@ def is_elasticsearch_available():
 skip_missing_elasticsearch_influxdb_in_env = pytest.mark.skipif(not (is_influxdb_available() and is_elasticsearch_available()), reason='influxdb is not available')
 
 
-def get_long_vo():
+def get_long_vo() -> str:
     """ Get the VO name from the config file for testing.
     Don't map the name to a short version.
     :returns: VO name string.
     """
     vo_name = 'def'
     if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
-        vo_name = config_get('client', 'vo', raise_exception=False, default=None)
+        vo = config_get('client', 'vo', raise_exception=False, default=None)
+        if vo is not None:
+            vo_name = vo
     return vo_name
 
 
-def account_name_generator():
+def account_name_generator() -> str:
     """ Generate random account name.
 
     :returns: A random account name
@@ -83,7 +90,7 @@ def account_name_generator():
     return 'jdoe-' + str(uuid()).lower()[:16]
 
 
-def scope_name_generator():
+def scope_name_generator() -> str:
     """ Generate random scope name.
 
     :returns: A random scope name
@@ -91,7 +98,7 @@ def scope_name_generator():
     return 'mock_' + str(uuid()).lower()[:16]
 
 
-def did_name_generator(did_type='file', name_prefix='', name_suffix='', path=None):
+def did_name_generator(did_type: str = 'file', name_prefix: str = '', name_suffix: str = '', path: Optional[str] = None) -> str:
     """ Generate random did name.
     :param did_type: A string to create a meaningful did_name depending on the did_type (file, dataset, container)
     :param name_prefix: String to prefix to the did name
@@ -121,7 +128,7 @@ def did_name_generator(did_type='file', name_prefix='', name_suffix='', path=Non
     return '%s%s_%s%s' % (name_prefix, did_type, str(uuid()), name_suffix)
 
 
-def rse_name_generator(size=10):
+def rse_name_generator(size: int = 10) -> str:
     """ Generate random RSE name.
 
     :returns: A random RSE name
@@ -129,7 +136,19 @@ def rse_name_generator(size=10):
     return 'MOCK-' + ''.join(choice(ascii_uppercase) for x in range(size))
 
 
-def file_generator(size=2, namelen=10):
+def rfc2253_dn_generator():
+    """ Generate a random DN in RFC 2253 format.
+
+    :returns: A random DN
+    """
+    random_cn = ''.join(choices(ascii_letters + digits, k=8))
+    random_o = ''.join(choices(ascii_letters + digits, k=8))
+    random_c = ''.join(choices(ascii_letters, k=2))
+    random_dn = "CN={}, O={}, C={}".format(random_cn, random_o, random_c)
+    return random_dn
+
+
+def file_generator(size: int = 2, namelen: int = 10):
     """ Create a bogus file and returns it's name.
     :param size: size in bytes
     :returns: The name of the generated file.
@@ -139,7 +158,7 @@ def file_generator(size=2, namelen=10):
     return fn
 
 
-def make_temp_file(dir_, data):
+def make_temp_file(dir_: str, data: str) -> str:
     """
     Creates a temporal file and write `data` on it.
     :param data: String to be writen on the created file.

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -57,7 +57,7 @@ class UserPass(ErrorHandlingMethodView):
         headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
         headers['Access-Control-Allow-Methods'] = '*'
         headers['Access-Control-Allow-Credentials'] = 'true'
-        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token, X-Rucio-Auth-Account, X-Rucio-Auth-Accounts'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token, X-Rucio-Auth-Token-Expires, X-Rucio-Auth-Account, X-Rucio-Auth-Accounts'
         return headers
 
     def options(self):
@@ -942,7 +942,7 @@ class x509(ErrorHandlingMethodView):
         headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
         headers['Access-Control-Allow-Methods'] = '*'
         headers['Access-Control-Allow-Credentials'] = 'true'
-        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token, X-Rucio-Auth-Account, X-Rucio-Auth-Accounts'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token, X-Rucio-Auth-Token-Expires, X-Rucio-Auth-Account, X-Rucio-Auth-Accounts'
         return headers
 
     def options(self):
@@ -1018,6 +1018,10 @@ class x509(ErrorHandlingMethodView):
                 description: The time when the token expires
                 schema:
                   type: string
+              X-Rucio-Auth-Account:
+                description: The rucio account corresponding to the provided identity
+                schema:
+                  type: string
           206:
             description: Partial content containing X-Rucio-Auth-Accounts header
             headers:
@@ -1085,9 +1089,9 @@ class x509(ErrorHandlingMethodView):
                 exc_msg=f'Cannot authenticate to account {account} with given credentials',
                 headers=headers
             )
-
         headers['X-Rucio-Auth-Token'] = result['token']
         headers['X-Rucio-Auth-Token-Expires'] = date_to_str(result['expires_at'])
+        headers['X-Rucio-Auth-Account'] = account
         return '', 200, headers
 
 

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -189,16 +189,15 @@ class UserPass(ErrorHandlingMethodView):
         if not username or not password:
             return generate_http_error_flask(401, CannotAuthenticate.__name__, 'Cannot authenticate without passing all required arguments', headers=headers)
 
-        try:
-            verify_identity(identity_key=username, id_type='USERPASS', password=password)
-        except IdentityNotFound:
-            return generate_http_error_flask(401, IdentityNotFound.__name__, 'Cannot authenticate. Username/Password pair does not exist.', headers=headers)
-        except IdentityError:
-            return generate_http_error_flask(401, IdentityError.__name__, 'Cannot authenticate. The identity does not exist.', headers=headers)
-
         if not account:
             accounts = list_accounts_for_identity(identity_key=username, id_type='USERPASS')
-            if len(accounts) == 0 or accounts is None:
+            if accounts is None or len(accounts) == 0:
+                try:
+                    verify_identity(identity_key=username, id_type='USERPASS', password=password)
+                except IdentityNotFound:
+                    return generate_http_error_flask(401, IdentityNotFound.__name__, 'Cannot authenticate. Username/Password pair does not exist.', headers=headers)
+                except IdentityError:
+                    return generate_http_error_flask(401, IdentityError.__name__, 'Cannot authenticate. The identity does not exist.', headers=headers)
                 return generate_http_error_flask(401, CannotAuthenticate.__name__, 'Cannot authenticate with provided username or password. Identity is not mapped to any accounts.', headers=headers)
             if len(accounts) > 1:
                 try:
@@ -208,7 +207,7 @@ class UserPass(ErrorHandlingMethodView):
                     return json.dumps(accounts), 206, headers
             else:
                 account = accounts[0]
-        account_name = account.external if type(account) is not str else account
+        account_name = account if isinstance(account, str) else account.external
         try:
             result = get_auth_token_user_pass(account_name, username, password, appid, ip, vo=vo)
         except AccessDenied:
@@ -943,7 +942,7 @@ class x509(ErrorHandlingMethodView):
         headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
         headers['Access-Control-Allow-Methods'] = '*'
         headers['Access-Control-Allow-Credentials'] = 'true'
-        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token'
+        headers['Access-Control-Expose-Headers'] = 'X-Rucio-Auth-Token, X-Rucio-Auth-Account, X-Rucio-Auth-Accounts'
         return headers
 
     def options(self):
@@ -1002,6 +1001,11 @@ class x509(ErrorHandlingMethodView):
           in: header
           schema:
             type: string
+        - name: X-Rucio-Allow-Return-Multiple-Accounts
+          in: header
+          schema:
+            type: boolean
+          description: If set to true, a HTTP 206 response will be returned if the identity is associated with multiple accounts.
         responses:
           200:
             description: OK
@@ -1014,11 +1018,17 @@ class x509(ErrorHandlingMethodView):
                 description: The time when the token expires
                 schema:
                   type: string
+          206:
+            description: Partial content containing X-Rucio-Auth-Accounts header
+            headers:
+              X-Rucio-Auth-Accounts:
+                schema:
+                  type: string
+                description: The rucio accounts corresponding to the provided identity as a csv string
           401:
             description: Cannot authenticate
         """
         headers = self.get_headers()
-
         headers['Content-Type'] = 'application/octet-stream'
         headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
         headers.add('Cache-Control', 'post-check=0, pre-check=0')
@@ -1032,7 +1042,9 @@ class x509(ErrorHandlingMethodView):
         dn = strip_x509_proxy_attributes(dn)
         appid = request.headers.get('X-Rucio-AppID', default='unknown')
         ip = request.headers.get('X-Forwarded-For', default=request.remote_addr)
+        return_multiple_accounts = request.headers.get('X-Rucio-Allow-Return-Multiple-Accounts', default=None)
 
+        result = None
         try:
             result = get_auth_token_x509(account, dn, appid, ip, vo=vo)
         except AccessDenied:
@@ -1043,12 +1055,28 @@ class x509(ErrorHandlingMethodView):
                 headers=headers
             )
         except IdentityError:
-            return generate_http_error_flask(
-                status_code=401,
-                exc=CannotAuthenticate.__name__,
-                exc_msg=f'No default account set for {dn}',
-                headers=headers
-            )
+            if not return_multiple_accounts:
+                return generate_http_error_flask(
+                    status_code=401,
+                    exc=CannotAuthenticate.__name__,
+                    exc_msg=f'No default account set for {dn}',
+                    headers=headers
+                )
+            accounts = list_accounts_for_identity(identity_key=dn, id_type='X509')
+            if len(accounts) == 1:
+                account = accounts[0]
+                account_name = account if isinstance(account, str) else account.external
+                result = get_auth_token_x509(account_name, dn, appid, ip, vo=vo)
+            elif len(accounts) > 1:
+                headers['X-Rucio-Auth-Accounts'] = ','.join(accounts)
+                return json.dumps(accounts), 206, headers
+            else:
+                return generate_http_error_flask(
+                    status_code=401,
+                    exc=CannotAuthenticate.__name__,
+                    exc_msg=f'No account set for {dn}',
+                    headers=headers
+                )
 
         if not result:
             return generate_http_error_flask(

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -49,7 +49,7 @@ class CORSMiddleware(object):
     This middleware intercepts the preflight OPTIONS requests and returns a 200 OK response.
     """
 
-    def __init__(self, app: flask.Flask) -> typing.NoReturn:
+    def __init__(self, app: flask.Flask) -> None:
         self.app = app
 
     def __call__(self, environ: typing.Dict, start_response: typing.Callable) -> typing.Union[Response, typing.Iterable[bytes]]:

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -2148,7 +2148,7 @@ def blueprint():
     search_view = Search.as_view('search')
     bp.add_url_rule('/<scope>/dids/search', view_func=search_view, methods=['get', ])
     dids_view = DIDs.as_view('dids')
-    bp.add_url_rule('/<path:scope_name>/status', view_func=dids_view, methods=['put', ])
+    bp.add_url_rule('/<path:scope_name>/status', view_func=dids_view, methods=['put', 'get'])
     files_view = Files.as_view('files')
     bp.add_url_rule('/<path:scope_name>/files', view_func=files_view, methods=['get', ])
     attachment_history_view = AttachmentHistory.as_view('attachment_history')


### PR DESCRIPTION
Fix #6048 ( solves the auth server aspect of the issue )

The new webui requires the x509 endpoint to be updated to support browser clients. This commit updates the endpoint to support both browser clients and CLI clients.

The /auth/x509 endpoint can return HTTP 206 Partial Content to indicate that multiple accounts were found for the given x509 identity and can work with the new WebUI to pick an account.

The /auth/x509 endpoint can return more detailed error messages to the webui (identity does not exist, identity not mapped to an account, ..).

