### PR TITLE
Transfers: fix list_transfer_limits

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1629,7 +1629,6 @@ def list_transfer_limits(
     )
     for limit in session.execute(stmt).scalars():
         dict_resp = limit.to_dict()
-        dict_resp.pop('_sa_instance_state')
         yield dict_resp
 
 

--- a/lib/rucio/tests/test_preparer.py
+++ b/lib/rucio/tests/test_preparer.py
@@ -18,7 +18,7 @@ import pytest
 
 from rucio.core.distance import get_distances, add_distance
 from rucio.core.replica import add_replicas
-from rucio.core.request import list_transfer_requests_and_source_replicas, set_transfer_limit
+from rucio.core.request import list_transfer_requests_and_source_replicas, set_transfer_limit, list_transfer_limits
 from rucio.core.transfer import get_supported_transfertools
 from rucio.core.rse import add_rse_attribute, RseData
 from rucio.daemons.conveyor import preparer
@@ -103,6 +103,7 @@ def test_preparer_setting_request_state_waiting(db_session, dest_rse, mock_reque
         max_transfers=1,
         strategy='fifo',
     )
+    list(list_transfer_limits())
 
     preparer.run_once(logger=print)
 


### PR DESCRIPTION
The dict value is already popped by to_dict() at the line before. This was a behavioral change in to_dict introduced in 1.30. Tests didn't catch the issue because list_transfer_limits is currently not used.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
