### PR TITLE
Transfers: set transfertool in submitter. Closes #5814

### DIFF
--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -493,8 +493,15 @@ def _submit_transfers(transfertool_obj, transfers, job_params, submitter='submit
 
     if state_to_set:
         try:
-            transfer_core.set_transfers_state(transfers, state=state_to_set, external_host=transfertool_obj.external_host,
-                                              external_id=eid, submitted_at=datetime.datetime.utcnow(), logger=logger)
+            transfer_core.set_transfers_state(
+                transfers,
+                state=state_to_set,
+                external_host=transfertool_obj.external_host,
+                external_id=eid,
+                submitted_at=datetime.datetime.utcnow(),
+                transfertool=transfertool_obj.external_name,
+                logger=logger
+            )
         except Exception:
             logger(logging.ERROR, 'Failed to register transfer state with error', exc_info=True)
             if eid is not None:

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -299,6 +299,7 @@ def test_ignore_availability(rse_factory, did_factory, root_account, core_config
     submitter(once=True, rses=[{'id': rse_id} for rse_id in (src_rse_id, dst_rse_id)], partition_wait_time=None, transfertools=['mock'], transfertype='single', ignore_availability=True)
     request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
     assert request['state'] == RequestState.SUBMITTED
+    assert request['transfertool'] == 'mock'
 
 
 @pytest.mark.noparallel(reason="multiple submitters cannot be run in parallel due to partial job assignment by hash")
@@ -374,8 +375,10 @@ def test_globus(rse_factory, did_factory, root_account):
         assert job_did2['metadata']['name'] == did2['name']
     request = request_core.get_request_by_did(rse_id=rse2_id, **did1)
     assert request['state'] == RequestState.SUBMITTED
+    assert request['transfertool'] == 'globus'
     request = request_core.get_request_by_did(rse_id=rse4_id, **did2)
     assert request['state'] == RequestState.SUBMITTED
+    assert request['transfertool'] == 'globus'
 
 
 @pytest.mark.noparallel(reason="multiple submitters cannot be run in parallel due to partial job assignment by hash")


### PR DESCRIPTION
The submitter has some flexibility to submit with another transfertool than the one initially requested. For example, when it fallbacks to using another source than the one selected by preparer. In such cases, it's important to correctly record the actual transfertool used for submission, to be able to poll the transfer status from the correct transfertool.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
