### PR TITLE
Introduce the RSE Decommissioner daemon #6321

### DIFF
--- a/bin/rucio-rse-decommissioner
+++ b/bin/rucio-rse-decommissioner
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+RSE-Decommissioner is a daemon that clears RSEs scheduled for decommissioning.
+The actual operations (e.g. just delete all replicas, move the replicas to
+specific RSEs, etc.) that are performed on the RSEs depend on the
+"decommissioning profile", which must be specified for each RSE through RSE
+attributes.
+"""
+
+import argparse
+import signal
+
+from rucio.daemons.rsedecommissioner.rse_decommissioner import run, stop
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Construct and return the argparse parser."""
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog="""\
+To mark an RSE for decommissioning
+----------------------------------
+
+Clearing with the generic "delete all" profile:
+
+$ rucio-admin rse set-attribute --rse MOCK_RSE --key decommission \
+              --value profile=generic_delete
+
+Clearing with the generic "move all" profile:
+
+$ rucio-admin rse set-attribute --rse MOCK_RSE --key decommission \
+              --value profile=generic_move,destination=ANOTHER_RSE""",
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument('--run-once', dest='run_once', action='store_true',
+                        help='One iteration only.')
+    parser.add_argument('--sleep-time', dest='sleep_time', action='store',
+                        default=86400, type=int,
+                        help='Concurrency control: thread sleep time after each'
+                        ' chunk of work')
+    return parser
+
+
+if __name__ == '__main__':
+    signal.signal(signal.SIGTERM, stop)
+    args = get_parser().parse_args()
+    try:
+        run(once=args.run_once, sleep_time=args.sleep_time)
+    except KeyboardInterrupt:
+        stop()

--- a/lib/rucio/daemons/rsedecommissioner/__init__.py
+++ b/lib/rucio/daemons/rsedecommissioner/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/lib/rucio/daemons/rsedecommissioner/config.py
+++ b/lib/rucio/daemons/rsedecommissioner/config.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Functions to manage decommissioning configurations."""
+
+from enum import Enum
+from typing import Any
+
+from rucio.core.rse import add_rse_attribute, get_rse_attribute
+
+
+class DecommissioningStatus(Enum):
+    """Decommissioning status flags."""
+
+    PROCESSING = 'processing'
+    DONE = 'done'
+    SUSPENDED = 'suspended'
+
+
+class InvalidStatusName(Exception):
+    """Exception for invalid decommissioning status name set from command line."""
+
+
+def config_to_attr(config: dict[str, Any]) -> str:
+    """Form the attribute string from a config dictionary.
+
+    :param config: Decommissioning configuration dictionary.
+    :returns: Comma-separated key-value string encoding the configuration.
+    """
+    attr = f'profile={config["profile"].value}'
+    if config.get('move_dest'):
+        attr += f',move_dest={config["move_dest"]}'
+    attr += f',status={config["status"].value}'
+
+    return attr
+
+
+def attr_to_config(attr: str) -> dict[str, Any]:
+    """Form the config dictionary from an attribute string.
+
+    :param attr: Comma-separated key-value string encoding the configuration.
+    :returns: Decommissioning configuration dictionary.
+    """
+    # The decommission attribute is a comma-separated list of key=value settings
+    config: dict[str, Any] = dict(map(lambda s: s.split('='), attr.split(',')))
+    if 'status' in config:
+        try:
+            config['status'] = DecommissioningStatus[config['status'].upper()]
+        except KeyError as exc:
+            raise InvalidStatusName() from exc
+    else:
+        config['status'] = DecommissioningStatus.PROCESSING
+
+    return config
+
+
+def set_status(
+    rse_id: str,
+    status: DecommissioningStatus
+) -> None:
+    """Update the decommission attribute of the RSE.
+
+    :param rse_id: RSE ID.
+    :param status: RSE decommissioning status.
+    """
+    config = attr_to_config(get_rse_attribute(rse_id, 'decommission'))
+    config['status'] = status
+    # add_rse_attribute can handle updating existing entries too
+    add_rse_attribute(rse_id, 'decommission', config_to_attr(config))

--- a/lib/rucio/daemons/rsedecommissioner/profiles/__init__.py
+++ b/lib/rucio/daemons/rsedecommissioner/profiles/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Decommissioning profile definitions."""
+
+from .atlas import atlas_move
+from .generic import generic_delete, generic_move
+
+PROFILE_MAP = {
+    'generic_delete': generic_delete,
+    'generic_move': generic_move,
+    'atlas_move': atlas_move
+}

--- a/lib/rucio/daemons/rsedecommissioner/profiles/atlas.py
+++ b/lib/rucio/daemons/rsedecommissioner/profiles/atlas.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ATLAS-specific decommissioning profiles."""
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from rucio.core.did import get_metadata
+
+from .generic import _call_for_attention, generic_move
+
+if TYPE_CHECKING:
+    from .types import DecommissioningProfile
+
+
+def atlas_move(rse: dict[str, Any], config: dict[str, Any]) -> 'DecommissioningProfile':
+    """Return a profile for moving rules that satisfy conditions to a specific destination.
+
+    The "ATLAS move" profile lists out all rules that are locking replicas
+    at the given RSE, and moves them to the specified destination if either
+    one of the following is true:
+
+    - The RSE expression of the rule is trivial (the RSE name itself).
+    - There are no replicas locked by the rule that reside on another RSE.
+    - The datatype of the DID is not "log".
+
+    :param rse: RSE to decommission.
+    :param config: Decommissioning configuration dictionary.
+    :returns: A decommissioning profile dictionary.
+    """
+    profile = generic_move(rse, config)
+    # Insert before the trivial RSE expression handler
+    idx = next(pos for pos, handler in enumerate(profile.handlers)
+               if handler[0].__name__ == '_has_trivial_rse_expression')
+    profile.handlers.insert(idx, (_is_log_file, _call_for_attention))
+    return profile
+
+
+def _is_log_file(
+    rule: dict[str, Any],
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log
+) -> bool:
+    """Check if the datatype metadata is 'log'."""
+    return get_metadata(rule['scope'], rule['name'])['datatype'] == 'log'

--- a/lib/rucio/daemons/rsedecommissioner/profiles/generic.py
+++ b/lib/rucio/daemons/rsedecommissioner/profiles/generic.py
@@ -1,0 +1,449 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic decommissioning profiles."""
+import logging
+from collections.abc import Callable, Iterable
+from datetime import datetime, timedelta
+from typing import Any
+
+from sqlalchemy.exc import NoResultFound
+
+from rucio.common.exception import (Duplicate, RequestNotFound, ReplicaNotFound, RucioException,
+                                    RuleNotFound, RuleReplaceFailed, UnsupportedOperation)
+from rucio.core.lock import get_replica_locks, get_replica_locks_for_rule_id
+from rucio.core.replica import list_replicas_per_rse, set_tombstone, update_replica_state
+from rucio.core.request import get_request_by_did
+from rucio.core.rse import add_rse_attribute, update_rse
+from rucio.core.rule import list_rules_for_rse_decommissioning, move_rule, update_rule
+from rucio.db.sqla.constants import ReplicaState
+
+from .types import DecommissioningProfile, HandlerOutcome
+
+
+def generic_delete(rse: dict[str, Any], config: dict[str, Any]) -> DecommissioningProfile:
+    """Return a profile for simply deleting rules.
+
+    The "generic delete" profile lists out all rules that are locking replicas at the given RSE,
+    and deletes them if either one of the following is true:
+
+    - The RSE expression of the rule is trivial (the RSE name itself).
+    - There are no replicas locked by the rule that reside on another RSE.
+
+    :param rse: RSE to decommission.
+    :param config: Decommissioning configuration dictionary.
+    :returns: A decommissioning profile.
+    """
+    return DecommissioningProfile(
+        rse=rse,
+        initializer=_generic_initialize,
+        discoverer=_generic_discover,
+        handlers=[
+            (_is_locked, _call_for_attention),
+            (_is_being_deleted, _count_as_processed),
+            (_has_trivial_rse_expression, _delete_rule),
+            (_has_all_replicas_on_rse, _delete_rule),
+        ],
+        finalizer=_generic_finalize
+    )
+
+
+def generic_move(rse: dict[str, Any], config: dict[str, Any]) -> DecommissioningProfile:
+    """Return a profile for moving rules that satisfy conditions to a specific destination.
+
+    The "generic move" profile lists out all rules that are locking replicas at the given RSE,
+    and moves them to the specified destination if either one of the following is true:
+
+    - The RSE expression of the rule is trivial (the RSE name itself).
+    - There are no replicas locked by the rule that reside on another RSE.
+
+    :param rse: RSE to decommission.
+    :param config: Decommissioning configuration dictionary.
+    :returns: A decommissioning profile dictionary.
+    """
+    try:
+        destination = config['destination']
+    except KeyError as exc:
+        raise RucioException('Configuration parameter "destination" not set') from exc
+
+    move_to_destination = RuleMover(destination)
+    return DecommissioningProfile(
+        rse=rse,
+        initializer=_generic_initialize,
+        discoverer=_generic_discover,
+        handlers=[
+            (_is_locked, _call_for_attention),
+            (_is_being_deleted, _count_as_processed),
+            (_has_child_rule_id, _count_as_processed),
+            (_has_trivial_rse_expression, move_to_destination),
+            (_has_all_replicas_on_rse, move_to_destination),
+        ],
+        finalizer=_generic_finalize
+    )
+
+
+def _generic_initialize(
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log,
+) -> None:
+    """Initializer function that sets the RSE availability flags and the decommissioning status.
+
+    When an RSE is initialized for decommissioning, the availability flags are set as follows:
+
+    - `availability_read=True`
+    - `availability_write=False`
+    - `availability_delete=True`
+
+    and the following attribute is set:
+
+    - `greedyDeletion=True`
+
+    :param rse: RSE table entry as a dictionary.
+    :param logger: Logging function.
+    """
+    logger(logging.INFO,
+           '(%s) Setting RSE availability flags of to read !write delete, greedyDeletion=true.',
+           rse['rse'])
+
+    parameters = {
+        'availability_read': True,
+        'availability_write': False,
+        'availability_delete': True
+    }
+    update_rse(rse['id'], parameters)
+
+    try:
+        add_rse_attribute(rse['id'], 'greedyDeletion', True)
+    except Duplicate:
+        pass
+
+
+def _generic_discover(
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log
+) -> Iterable[dict[str, Any]]:
+    """Discoverer function that calls the listing function from core.rule.
+
+    :param rse: RSE table entry as a dictionary.
+    :param logger: Logging function.
+    :returns: An iterable of rule dictionaries.
+    """
+    return list_rules_for_rse_decommissioning(rse['id'])
+
+
+def _generic_finalize(
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log
+) -> bool:
+    """Check for remaining replicas at the RSE and resolve where possible.
+
+    If for some reason there are still a large number of replicas remaining at the RSE, this
+    function cuts off automatic processing attempts at a hard-coded 100.
+
+    :param rse: RSE table entry as a dictionary.
+    :param logger: Logging function.
+    :returns: A boolean flag indicating the completion status.
+    """
+    num_remaining_replicas = _process_replicas_with_no_locks(rse,
+                                                             list_replicas_per_rse(rse['id']),
+                                                             limit=100,
+                                                             logger=logger)
+
+    if num_remaining_replicas == 0:
+        # The RSE is now really completely cleared.
+        logger(logging.INFO,
+               '(%s) Completed deleting the RSE contents. Updating the decommissioning status'
+               ' to "done".',
+               rse['rse'])
+        return True
+
+    logger(logging.WARNING,
+           '(%s) %d replicas remain on the RSE even though there are no more rules creating'
+           ' locks on them.',
+           rse['rse'], num_remaining_replicas)
+
+    # We now wait for reaper to pick the updated replicas (if there are any). Hopefully all
+    # replicas will be deleted at the next cycle.
+    return False
+
+
+def _process_replicas_with_no_locks(
+    rse: dict[str, Any],
+    replicas: Iterable[dict[str, Any]],
+    limit: int = 0,
+    *,
+    logger: Callable[..., None] = logging.log,
+) -> int:
+    """Process replicas that remain at the RSE after the decommissioning.
+
+    Replicas that remain at the RSE at this point should be unlocked. While this is a situation
+    that should not happen, it can due to various errors. This function checks each such replica
+    and attempt to resolve the invalid state for known cases.
+
+    :param rse: RSE table entry as a dictionary.
+    :param replicas: Sequence or generator of replica objects.
+    :param logger: Logging function.
+    :returns: Number of processed replicas.
+    """
+    num_processed = 0
+    num_updated = 0
+    num_waiting_reap = 0
+
+    # Check if each replica satisfies the condition in list_and_mark_unlocked_replicas() (in
+    # core.replica).
+    # For each of the conditions, in case of failure, handle cases that can be handled.
+    for replica in replicas:
+        num_processed += 1
+        if limit > 0 and num_processed == limit:
+            break
+
+        updated = False
+
+        # If the replica fails any of the following three conditions, reaper won't pick it up.
+        reap_pending = True
+
+        # 1. Condition on the replica state & update time
+        in_stable_state = replica['state'] in [ReplicaState.AVAILABLE,
+                                               ReplicaState.UNAVAILABLE,
+                                               ReplicaState.BAD]
+
+        ten_minutes_ago = datetime.utcnow() - timedelta(seconds=600)
+        deleting_stuck = (replica['state'] == ReplicaState.BEING_DELETED
+                          and replica['updated_at'] < ten_minutes_ago)
+
+        if not (in_stable_state or deleting_stuck):
+            # 1.1 If COPYING without a valid request
+            # -> Update the state to UNAVAILABLE
+            if replica['state'] == ReplicaState.COPYING:
+                # Should we allow requests in certain states? Depends on the details of the
+                # request state machine.
+                try:
+                    get_request_by_did(replica['scope'], replica['name'], rse['id'])
+                except RequestNotFound:
+                    logger(logging.INFO,
+                           '(%s) Replica %s:%s is in COPYING state without a valid request.'
+                           ' Changing state to UNAVAILABLE.',
+                           rse['rse'], replica['scope'], replica['name'])
+
+                    try:
+                        update_replica_state(rse['id'], replica['scope'], replica['name'],
+                                             ReplicaState.UNAVAILABLE)
+                    except ReplicaNotFound:
+                        logger(logging.WARNING,
+                               '(%s) Replica %s:%s disappeared during cleanup',
+                               rse['rse'], replica['scope'], replica['name'])
+                    except UnsupportedOperation as error:
+                        logger(logging.ERROR, '(%s) %s', rse['rse'], str(error))
+                    else:
+                        updated = True
+
+            reap_pending = False
+
+        # 2. Condition on the lock count
+        if replica['lock_cnt'] != 0:
+            # 2.1 No actual lock -> Reset the lock count
+            try:
+                locks = get_replica_locks(replica['scope'], replica['name'],
+                                          restrict_rses=[rse['id']])
+            except NoResultFound:
+                logger(logging.WARNING,
+                       '(%s) Replica %s:%s disappeared during cleanup',
+                       rse['rse'], replica['scope'], replica['name'])
+            else:
+                if len(locks) == 0:
+                    logger(logging.WARNING,
+                           '(%s) Replica %s:%s has lock count %s but zero actual locks. Please'
+                           ' fix the counts.',
+                           rse['rse'], replica['scope'], replica['name'], replica['lock_cnt'])
+
+            reap_pending = False
+
+        # 3. Tombstone missing or in the future -> RIP now
+        if replica['tombstone'] is None or replica['tombstone'] >= datetime.utcnow():
+            logger(logging.INFO, '(%s) Marking tombstone of replica %s:%s as UTCNOW.',
+                   rse['rse'], replica['scope'], replica['name'])
+
+            try:
+                set_tombstone(rse['id'], replica['scope'], replica['name'],
+                              tombstone=datetime.utcnow())
+            except ReplicaNotFound as error:
+                logger(logging.WARNING, '(%s) %s', rse['rse'], str(error))
+            else:
+                updated = True
+
+            reap_pending = False
+
+        if updated:
+            num_updated += 1
+
+        if reap_pending:
+            num_waiting_reap += 1
+
+    logger(logging.INFO, '(%s) %s replicas have been updated. %s replicas are pending deletion.'
+           ' >=%s replicas remain unhandled.',
+           rse['rse'], num_updated, num_waiting_reap,
+           num_processed - num_updated - num_waiting_reap)
+
+    return num_processed
+
+
+# Condition functions
+
+def _is_locked(
+    rule: dict[str, Any],
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log
+) -> bool:
+    logger(logging.INFO,
+           '(%s) Rule %s for %s:%s is locked',
+           rse['rse'], rule['id'], rule['scope'], rule['name'])
+    return rule['locked']
+
+
+def _is_being_deleted(
+    rule: dict[str, Any],
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log
+) -> bool:
+    """Check if the rule is already set to be deleted."""
+    if rule['expires_at'] is not None and rule['expires_at'] < datetime.utcnow():
+        logger(logging.DEBUG,
+               '(%s) Rule %s for %s:%s is bound for deletion',
+               rse['rse'], rule['id'], rule['scope'], rule['name'])
+        return True
+    return False
+
+
+def _has_trivial_rse_expression(
+    rule: dict[str, Any],
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log
+) -> bool:
+    """Check for a trivial rse_expression."""
+    return rule['rse_expression'] == rse['rse']
+
+
+def _has_all_replicas_on_rse(
+    rule: dict[str, Any],
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log
+) -> bool:
+    """Check if the all the replicas are on the RSE."""
+    # Check the list of RSEs that the replicas locked by this rule reside on.
+    try:
+        locks = get_replica_locks_for_rule_id(rule['id'])
+    except NoResultFound:
+        # No replica is locked to begin with -> treat as having the last replica on this RSE
+        return True
+
+    replica_rse_ids = set(lock['rse_id'] for lock in locks)
+
+    return len(replica_rse_ids) == 1 and list(replica_rse_ids)[0] == rse['id']
+
+
+def _has_child_rule_id(
+    rule: dict[str, Any],
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log
+) -> bool:
+    """Check for non-empty child_rule_id."""
+    if rule['child_rule_id']:
+        logger(logging.DEBUG, '(%s) Rule %s for %s:%s is being moved',
+               rse['rse'], rule['id'], rule['scope'], rule['name'])
+        return True
+    return False
+
+
+# Action functions
+
+def _call_for_attention(
+    rule: dict[str, Any],
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log
+) -> HandlerOutcome:
+    return HandlerOutcome.NEED_ATTENTION
+
+
+def _count_as_processed(
+    rule: dict[str, Any],
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log
+) -> HandlerOutcome:
+    """Do nothing but increment the limit checker."""
+    return HandlerOutcome.UNTOUCHED
+
+
+def _delete_rule(
+    rule: dict[str, Any],
+    rse: dict[str, Any],
+    *,
+    logger: Callable[..., None] = logging.log
+) -> HandlerOutcome:
+    """Delete the rule."""
+    logger(logging.DEBUG, '(%s) Deleting rule %s for %s:%s',
+           rse['rse'], rule['id'], rule['scope'], rule['name'])
+
+    try:
+        update_rule(rule['id'], {'lifetime': 0})
+    except RuleNotFound:
+        logger(logging.WARNING, '(%s) Rule %s for %s:%s disappeared before deleting',
+               rse['rse'], rule['id'], rule['scope'], rule['name'])
+        return HandlerOutcome.UNTOUCHED
+
+    return HandlerOutcome.REMOVED
+
+
+class RuleMover:
+    """Callable object with a destination attribute."""
+    def __init__(self, destination: str) -> None:
+        self.destination = destination
+
+    def __call__(
+        self,
+        rule: dict[str, Any],
+        rse: dict[str, Any],
+        *,
+        logger: Callable[..., None] = logging.log
+    ) -> HandlerOutcome:
+        """Move the rule."""
+        # Move the rule.
+        logger(logging.DEBUG, '(%s) Moving rule %s for %s:%s to %s',
+               rse['rse'], rule['id'], rule['scope'], rule['name'],
+               self.destination)
+
+        try:
+            move_rule(rule['id'], self.destination,
+                      override={'weight': None, 'source_replica_expression': None})
+        except RuleNotFound:
+            logger(logging.WARNING, '(%s) Rule %s for %s:%s disappeared before moving',
+                   rse['rse'], rule['id'], rule['scope'], rule['name'])
+            return HandlerOutcome.UNTOUCHED
+        except RuleReplaceFailed:
+            logger(logging.ERROR,
+                   '(%s) Failed to move rule %s for %s:%s to %s',
+                   rse['rse'], rule['id'], rule['scope'], rule['name'],
+                   self.destination)
+            return HandlerOutcome.NEED_ATTENTION
+        return HandlerOutcome.REMOVED

--- a/lib/rucio/daemons/rsedecommissioner/profiles/types.py
+++ b/lib/rucio/daemons/rsedecommissioner/profiles/types.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Types used for profile definitions."""
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class HandlerOutcome(Enum):
+    """Possible outcomes of the handler functions."""
+    UNTOUCHED = "Untouched"
+    REMOVED = "Removed"
+    NEED_ATTENTION = "NeedAttention"
+
+
+@dataclass
+class DecommissioningProfile:
+    """Collection of functions that define the action of the decommissioning daemon on an RSE.
+
+    :param rse: RSE to decommission.
+    :param initializer: Profile initialization function.
+    :param discoverer: Function to find and list the rules to process.
+    :param handlers: A list of (condition, action) functions.
+    :param finalizer: Finalization function.
+    """
+
+    rse: dict[str, Any]
+    initializer: Callable[..., None]
+    discoverer: Callable[..., Iterable[dict[str, Any]]]
+    handlers: list[tuple[Callable[..., bool], Callable[..., HandlerOutcome]]]
+    finalizer: Callable[..., bool]
+
+    def initialize(
+        self,
+        *,
+        logger: Callable[..., None] = logging.log
+    ) -> None:
+        """Call the initializer."""
+        self.initializer(self.rse, logger=logger)
+
+    def discover(
+        self,
+        *,
+        logger: Callable[..., None] = logging.log
+    ) -> Iterable[dict[str, Any]]:
+        """Call the discoverer."""
+        return self.discoverer(self.rse, logger=logger)
+
+    def process(
+        self,
+        rule: dict[str, Any],
+        *,
+        logger: Callable[..., None] = logging.log
+    ) -> HandlerOutcome:
+        """Process a rule.
+
+        :param rule: Rule dict.
+        :returns: Boolean indicating whether the rule was removed. None if no condition matches.
+        """
+        for condition, action in self.handlers:
+            if condition(rule, self.rse, logger=logger):
+                return action(rule, self.rse, logger=logger)
+
+        logger(logging.INFO,
+               '(%s) No handler matched rule %s for %s:%s',
+               rule['rse'], rule['id'], rule['scope'], rule['name'])
+        return HandlerOutcome.NEED_ATTENTION
+
+    def finalize(
+        self,
+        *,
+        logger: Callable[..., None] = logging.log
+    ) -> bool:
+        """Call the finalizer."""
+        return self.finalizer(self.rse, logger=logger)

--- a/lib/rucio/daemons/rsedecommissioner/rse_decommissioner.py
+++ b/lib/rucio/daemons/rsedecommissioner/rse_decommissioner.py
@@ -1,0 +1,279 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+RSE-Decommissioner is a daemon that clears RSEs to be decommissioning. The
+actual operations (e.g. just delete all replicas, move the replicas to specific
+RSEs, etc.) that are performed on the RSEs depend on the "decommissioning
+profile", which must be specified for each RSE upon triggering decommissioning.
+"""
+
+from collections.abc import Callable
+import logging
+import random
+import socket
+import threading
+from types import FrameType
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+from rucio.common.config import config_get_int
+from rucio.common.logging import setup_logging
+from rucio.common.exception import RucioException
+from rucio.core.heartbeat import sanity_check
+from rucio.core.rse import get_rses_with_attribute, get_rse_attribute
+from rucio.daemons.common import run_daemon
+from rucio.db.sqla.constants import RuleState
+
+from .config import DecommissioningStatus, InvalidStatusName, attr_to_config, set_status
+from .profiles import PROFILE_MAP
+from .profiles.types import DecommissioningProfile, HandlerOutcome
+
+if TYPE_CHECKING:
+    from rucio.daemons.common import HeartbeatHandler
+
+GRACEFUL_STOP = threading.Event()
+DAEMON_NAME = 'rsedecommissioner'
+
+
+def rse_decommissioner(
+    once: bool,
+    sleep_time: int
+) -> None:
+    """Daemon runner.
+
+    :param once: Whether to execute once and exit.
+    :param sleep_time: Number of seconds to sleep before restarting.
+    """
+    run_daemon(
+        once=once,
+        graceful_stop=GRACEFUL_STOP,
+        executable=DAEMON_NAME,
+        partition_wait_time=1,
+        sleep_time=sleep_time,
+        run_once_fnc=run_once
+    )
+
+
+def run_once(
+    *,
+    heartbeat_handler: 'HeartbeatHandler',
+    activity: Union[str, None]
+) -> bool:
+    """Decommission an RSE.
+
+    Identifies an RSE to decommission and sets its decommissioning status to
+    PROCESSING. Once all replication rules are processed, tries to finalize
+    the RSE by cleaning up the remaining replicas. Should be run in only one
+    worker thread (worker_number == 0).
+
+    :param heartbeat_handler: A HeartbeatHandler instance.
+    :param activity: Activity to work on.
+    :returns: A boolean flag indicating whether the daemon should go to sleep.
+    """
+    worker_number, _, logger = heartbeat_handler.live()
+
+    if worker_number != 0:
+        logger(logging.INFO, 'RSE decommissioner thread id is not 0, will sleep.'
+               ' Only thread 0 will work')
+        return True
+
+    # Collect all RSEs with the 'decommission' attribute
+    rses = get_rses_with_attribute('decommission')
+    random.shuffle(rses)
+
+    for rse in rses:
+        # Get the decommission attribute (encodes the decommissioning config)
+        attr = get_rse_attribute(rse['id'], 'decommission')
+        try:
+            config = attr_to_config(attr)
+        except InvalidStatusName:
+            logger(logging.ERROR, 'RSE %s has an invalid decommissioning status',
+                   rse['rse'])
+            continue
+
+        if config['status'] != DecommissioningStatus.PROCESSING:
+            logger(logging.INFO, 'Skipping RSE %s which has decommissioning status "%s"',
+                   config['status'])
+            continue
+
+        try:
+            profile_maker = PROFILE_MAP[config['profile']]
+        except KeyError:
+            logger(logging.ERROR, 'Invalid decommissioning profile name %s used for %s',
+                   config['profile'], rse['rse'])
+            continue
+
+        try:
+            profile = profile_maker(rse, config)
+        except RucioException:
+            logger(logging.ERROR, 'Invalid configuration for profile %s', config['profile'])
+            raise
+
+        logger(logging.INFO, 'Decommissioning %s: %s', rse['rse'], attr)
+        try:
+            decommission_rse(rse, profile, logger=logger)
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logger(logging.ERROR, 'Unexpected error while decommissioning %s: %s',
+                   rse['rse'], str(error), exc_info=True)
+
+    return True
+
+
+def run(
+    once: bool = False,
+    sleep_time: int = 86400
+) -> None:
+    """
+    Starts up the decommissioner threads.
+
+    :param once: Whether to execute once and exit.
+    :param sleep_time: Number of seconds to sleep before restarting.
+    """
+    setup_logging(process_name=DAEMON_NAME)
+    hostname = socket.gethostname()
+    sanity_check(executable='rucio-rsedecommissioner', hostname=hostname)
+
+    logging.info('RSE-Decommissioner starting 1 thread')
+
+    # Creating only one thread but putting it in a list to conform to how
+    # other daemons are run.
+    threads = [
+        threading.Thread(
+            target=rse_decommissioner,
+            kwargs={
+                'sleep_time': sleep_time,
+                'once': once
+            },
+        )
+    ]
+    [thread.start() for thread in threads]
+    # Interruptible joins require a timeout.
+    while any(thread.is_alive() for thread in threads):
+        [thread.join(timeout=3.14) for thread in threads]
+
+
+def stop(
+    signum: Optional[int] = None,
+    frame: Optional[FrameType] = None
+) -> None:
+    """
+    Graceful exit.
+    """
+    GRACEFUL_STOP.set()
+
+
+def decommission_rse(
+    rse: dict[str, Any],
+    profile: DecommissioningProfile,
+    *,
+    logger: Callable[..., None] = logging.log
+) -> None:
+    """RSE decommissioning template function.
+
+    RSE decommissioning proceeds in common steps of
+    - Profile initialization
+    - Discovery of rules to act (move / delete / etc.) on
+    - Actual handling of the rules
+    - Finalization
+    This function takes the functions corresponding to the four steps as its arguments and
+    executes them in order.
+
+    The handlers are given as a list of pairs of functions. The two functions both have a
+    signature
+    (rule, rse, *, logger=logging.log) -> bool
+    with the following actions:
+    - The first function is the "condition" against which each rule is tested. The returned
+      boolean indicates whether the rule satisfies it.
+    - The second function is the "(in)action" taken against the rule if the first function
+      returns True. The returned boolean indicates whether the limit checker should be
+      incremented after executing the action.
+
+    For each rule listed by the discoverer function, the conditions are applied in the order
+    given in the handlers list until one evaluates to True, at which point the corresponding
+    action function is executed. All remaining condition-action pairs are skipped for the rule.
+
+    :param rse: RSE table entry as a dictionary.
+    :param profile: Decommissioning profile.
+    :param logger: Logging function.
+    """
+    remove_max = {
+        'rules': config_get_int('rse-decommissioner', 'max_rules', default=-1),
+        'locks': config_get_int('rse-decommissioner', 'max_locks', default=-1)
+    }
+    if any(lim < 0 for lim in remove_max.values()):
+        raise RucioException('This daemon requires configuration parameters'
+                             ' rse-decommissioner/max_rules and rse-decommissioner/max_locks'
+                             ' set to non-negative integers.')
+
+    # Initialize the RSE for decommissioning.
+    profile.initialize(logger=logger)
+    # Counters for throttling.
+    num_untouched = 0
+    num_need_attention = 0
+    num_removed = {'rules': 0, 'locks': 0}
+
+    # Iterate over rules locking datasets / replicas at the RSE.
+    stop_reason = None
+    for rule in profile.discover(logger=logger):
+        outcome = profile.process(rule, logger=logger)
+
+        if outcome == HandlerOutcome.UNTOUCHED:
+            num_untouched += 1
+        elif outcome == HandlerOutcome.REMOVED:
+            # Rule removed; increment the counters and check the throttling conditions.
+            num_removed['rules'] += 1
+
+            if rule['state'] in [RuleState.SUSPENDED, RuleState.WAITING_APPROVAL,
+                                 RuleState.INJECT]:
+                logger(logging.WARNING,
+                       'Rule %s is in state "%s"; cannot extract number of locks',
+                       rule['id'], rule['state'])
+
+            num_removed['locks'] += (rule['locks_ok_cnt'] + rule['locks_replicating_cnt']
+                                     + rule['locks_stuck_cnt'])
+
+            for counter in ['rules', 'locks']:
+                if num_removed[counter] >= remove_max[counter]:
+                    stop_reason = counter
+                    break
+            if stop_reason:
+                break
+        elif outcome == HandlerOutcome.NEED_ATTENTION:
+            num_need_attention += 1
+
+    if stop_reason:
+        logger(logging.INFO,
+               '(%s) Stopping decommissioning cycle because number of deleted %s reached the'
+               ' limit=%d',
+               rse['rse'], stop_reason, remove_max[stop_reason])
+
+    if num_removed['rules'] != 0:
+        logger(logging.INFO,
+               '(%s) %s rules are being deleted. Decommissioning is not complete.',
+               rse['rse'], num_removed['rules'])
+    elif num_untouched != 0:
+        logger(logging.INFO,
+               '(%s) %s rules are acknowledged by the daemon and are expected to be removed'
+               ' soon. Decommissioning is not complete.',
+               rse['rse'], num_untouched)
+    elif num_need_attention != 0:
+        logger(logging.WARNING,
+               '(%s) %s rules were not handled under the current profile. We need to move the'
+               ' replicas manually and/or update the rules for decommissioning to proceed.',
+               rse['rse'], num_need_attention)
+        set_status(rse['id'], DecommissioningStatus.SUSPENDED)
+    elif profile.finalize(logger=logger):
+        # Finalizer returns True -> RSE is decommissioned
+        set_status(rse['id'], DecommissioningStatus.DONE)


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
RSE-Decommissioner is a daemon that clears RSEs scheduled for decommissioning. To clear an RSE, the administrator would set an RSE attribute that is monitored by the daemon. The attribute is used not just to trigger the RSE cleanup but also to set the "policy" under which the cleaning happens. As examples (and for standard use cases) this PR contains three policies: "generic_delete" to delete all replicas on the RSE matching certain conditions; "generic_move" to move the replicas to a specific RSE; and "atlas_move", which is a derivative of generic_move with some ATLAS-specific operations. Replica deletion and relocation happens through updating the rules for the given DIDs. The decommissioner daemon is therefore reliant on other daemons to perform the actual cleanup tasks, and will require running multiple cycles to complete the cleanup of each RSE.

Here are the example commands for the admin to use to start the decommissioning process:

Clearing with the generic "delete all" profile:
```
$ rucio-admin rse set-attribute --rse MOCK_RSE --key decommission --value profile=generic_delete
```
Clearing with the generic "move all" profile:
```
$ rucio-admin rse set-attribute --rse MOCK_RSE --key decommission --value profile=generic_move,destination=ANOTHER_RSE
```