### PR TITLE
Authentication: Rework to raise CannotAuthenticate; Fix #5986

### DIFF
--- a/lib/rucio/api/authentication.py
+++ b/lib/rucio/api/authentication.py
@@ -288,12 +288,10 @@ def validate_auth_token(token, session=None):
                            audience: <audience>,
                            authz_scope: <authz_scope>,
                            vo: <vo> }
-              if successful, None otherwise.
     """
 
     auth = authentication.validate_auth_token(token, session=session)
-    if auth is not None:
-        vo = auth['account'].vo
-        auth = api_update_return_dict(auth, session=session)
-        auth['vo'] = vo
+    vo = auth['account'].vo
+    auth = api_update_return_dict(auth, session=session)
+    auth['vo'] = vo
     return auth

--- a/lib/rucio/tests/test_authentication.py
+++ b/lib/rucio/tests/test_authentication.py
@@ -24,7 +24,7 @@ import time
 from rucio.api.authentication import get_auth_token_user_pass, get_auth_token_ssh, get_ssh_challenge_token, \
     get_auth_token_saml
 from rucio.common.config import config_get_bool
-from rucio.common.exception import Duplicate, AccessDenied
+from rucio.common.exception import Duplicate, AccessDenied, CannotAuthenticate
 from rucio.common.types import InternalAccount
 from rucio.common.utils import ssh_sign
 from rucio.core.identity import add_account_identity, del_account_identity
@@ -282,3 +282,10 @@ def test_many_tokens(vo, root_account, db_session):
     # Ensures that the tokens are expired
     time.sleep(1)
     print(get_auth_token_user_pass(account='root', username='ddmlab', password='secret', appid='test', ip='127.0.0.1', vo=vo))
+
+
+def test_non_JWT_validation():
+    """ AUTHENTICATION: passing a fake X-Rucio-Auth-Token that looks like a JWT """
+    from rucio.api.authentication import validate_auth_token
+    with pytest.raises(CannotAuthenticate):
+        validate_auth_token('a.b.c')

--- a/lib/rucio/tests/test_oidc.py
+++ b/lib/rucio/tests/test_oidc.py
@@ -758,9 +758,8 @@ class TestAuthCoreAPIoidc(unittest.TestCase):
         # mocking the token response
         access_token = rndstr() + '.' + rndstr() + '.' + rndstr()
         # trying to validate a token that does not exist in the Rucio DB
-        value = validate_auth_token(access_token, session=self.db_session)
-        # checking if validation went OK (we bypassed it with the dictionary above)
-        assert value is None
+        with pytest.raises(CannotAuthenticate):
+            validate_auth_token(access_token, session=self.db_session)
         # most importantly, check that the token was saved in Rucio DB
         db_token = get_token_row(access_token, account=self.account, session=self.db_session)
         assert not db_token

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -141,14 +141,13 @@ def request_auth_env():
 
     try:
         auth = validate_auth_token(auth_token)
+    except CannotAuthenticate:
+        return generate_http_error_flask(401, CannotAuthenticate.__name__, 'Cannot authenticate with given credentials')
     except RucioException as error:
         return generate_http_error_flask(500, error.__class__.__name__, error.args[0])
     except Exception:
         logging.exception('Internal error in validate_auth_token')
         return 'Internal Error', 500
-
-    if auth is None:
-        return generate_http_error_flask(401, CannotAuthenticate.__name__, 'Cannot authenticate with given credentials')
 
     flask.request.environ['vo'] = auth.get('vo', 'def')
     flask.request.environ['issuer'] = auth.get('account')


### PR DESCRIPTION
NOTE: the commit was modified in order to be cherry-picked into 1.29-LTS

flaskapi/v1/common.py::request_auth_env makes a call to validate the auth-token which it receives via the request header (as "X-Rucio-Auth-Token"). In the call stack that is created to validate this token, errors are propagated back to the flask environment by means of "raise CannotAuthenticate" and "return None".

This confusing mixture means that in some cases, the more generic "RucioException" is caught instead of the specific "raise CannotAuthenticate", causing flask to return a HTTP500 (instead of HTTP401, which would cause the client to attempt to reconnect).

This commit reworks the call stack to return a Dictionary for a successfully validated token and raise CannotAuthenticate otherwise. This streamlines the current process, which returns Optional[Dict] or raises CannotAuthenticate.

The issue which triggered this patch was #5986, regarding the automatix daemon.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
