### PR TITLE
Tests/Rule `move_rule` with invalid Source Replica Expression; Fix #4845

### DIFF
--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1069,3 +1069,14 @@ class PolicyPackageVersionError(RucioException):
         super(PolicyPackageVersionError, self).__init__(*args, **kwargs)
         self._message = 'Policy package %s is not compatible with this Rucio version' % package
         self.error_code = 103
+
+
+class InvalidSourceReplicaExpression(RucioException):
+    """
+    Source Replica Expression Considered Invalid
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(InvalidSourceReplicaExpression, self).__init__(*args, **kwargs)
+        self._message = 'Provided Source Replica expression is considered invalid.'
+        self.error_code = 104

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -47,7 +47,8 @@ from rucio.common.exception import (InvalidRSEExpression, InvalidReplicationRule
                                     ReplicationRuleCreationTemporaryFailed, InsufficientTargetRSEs, RucioException,
                                     InvalidRuleWeight, StagingAreaRuleRequiresLifetime, DuplicateRule,
                                     InvalidObject, RSEWriteBlocked, RuleReplaceFailed, RequestNotFound,
-                                    ManualRuleApprovalBlocked, UnsupportedOperation, UndefinedPolicy, InvalidValueForKey)
+                                    ManualRuleApprovalBlocked, UnsupportedOperation, UndefinedPolicy, InvalidValueForKey,
+                                    InvalidSourceReplicaExpression)
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalScope, InternalAccount
 from rucio.common.utils import str_to_date, sizefmt, chunks
@@ -151,7 +152,10 @@ def add_rule(dids, account, copies, rse_expression, grouping, weight, lifetime, 
                         raise ManualRuleApprovalBlocked()
 
             if source_replica_expression:
-                source_rses = parse_expression(source_replica_expression, filter_={'vo': vo}, session=session)
+                try:
+                    source_rses = parse_expression(source_replica_expression, filter_={'vo': vo}, session=session)
+                except InvalidRSEExpression:
+                    raise InvalidSourceReplicaExpression
             else:
                 source_rses = []
 


### PR DESCRIPTION
Currently, a misleading error message is raised to the user upon attempting to move a rule which has an invalid Source Replica Expression. An invalid Source Replica Expression is an RSE expression which evaluates to an empty set, which can occur due to a variety of reasons.

The misleading error message informs the user that the provided `RSE expression is considered invalid`, this is misleading, since the error does not stem from the RSE expression provided to the `move_rule` command but from the Source Replica Expression attribute of the rule prior to moving/updating it.

The solution is to introduce a new exception
`InvalidSourceReplicaExpression` and raise it within `core/rule.py::add_rule`, should the attempt to parse the Source Replica Expression with `parse_expression` fail.

This commit also includes a test added to `test_rule.py::TestCore` which simulates two ways in which the Source Replica Expression might become invalid:
1) By deleting the only RSE the Source Replica Expression points to.
2) By matching the RSE to the Source Replica Expression via an RSE attribute but then deleting
   this RSE attribute from the RSE.
In both cases the Source Replica Expression will evaluate to an empty set.

As per the conversation with @dchristidis, no further action (i.e. further than raising a more specific error message) is taken. The two options would be:
1. Server-Side correction (replacing the Source Replica Expression by `None`) as is currently the common workaround.
2. Client-Side correction (upon receiving the specific error message, first run `update-rule --source-replica-expression None ...` and then continue).

In the end, both options would lead to rucio client/server taking action that does not fully correspond to user input.