### PR TITLE
Patch 5447 missing locks on container files: added tests

### DIFF
--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import namedtuple
 import contextlib
 import itertools
 import json
@@ -226,3 +227,6 @@ def load_test_conf_file(file_name):
     config_dir = next(filter(lambda d: os.path.exists(os.path.join(d, file_name)), get_config_dirs()))
     with open(os.path.join(config_dir, file_name)) as f:
         return json.load(f)
+
+
+RSE_namedtuple = namedtuple('RSE_namedtuple', ['name', 'id'])


### PR DESCRIPTION
Added two tests in an attempt to isolate the bug described in issue #5447 . This was unsuccessful in the sense that the tests passed without changes made to the underlying codebase. Specific descriptions of the tests written can be found in both the commit messages and the docstrings of each test.

The tests have in common that they make extensive and deliberate use of pytest fixtures. They are placed outside of the `TestJudgeEvaluator`-class which stems from unittest.

A new data container `RSE_namedtuple` inheriting from `collections.namedtuple` was introduced to `tests/common.py` for easier management of RSE `name` and `id` in the same data structure.
