### PR TITLE
Testing: add a rucioclient container to docker files. documentation#177

### DIFF
--- a/etc/docker/dev/docker-compose-storage-alldb.yml
+++ b/etc/docker/dev/docker-compose-storage-alldb.yml
@@ -1,5 +1,16 @@
 version: "3"
 services:
+  rucioclient:
+    image: docker.io/rucio/rucio-dev
+    command: ["sleep", "infinity"]
+    volumes:
+      - ../../../tools:/opt/rucio/tools:Z
+      - ../../../bin:/opt/rucio/bin:Z
+      - ../../../lib:/opt/rucio/lib:Z
+    environment:
+      - X509_USER_CERT=/opt/rucio/etc/usercert.pem
+      - X509_USER_KEY=/opt/rucio/etc/userkey.pem
+      - RDBMS=postgres14
   rucio:
     image: docker.io/rucio/rucio-dev
     ports:

--- a/etc/docker/dev/docker-compose-storage-externalmetadata.yml
+++ b/etc/docker/dev/docker-compose-storage-externalmetadata.yml
@@ -1,5 +1,16 @@
 version: "3.5"
 services:
+  rucioclient:
+    image: docker.io/rucio/rucio-dev
+    command: ["sleep", "infinity"]
+    volumes:
+      - ../../../tools:/opt/rucio/tools:Z
+      - ../../../bin:/opt/rucio/bin:Z
+      - ../../../lib:/opt/rucio/lib:Z
+    environment:
+      - X509_USER_CERT=/opt/rucio/etc/usercert.pem
+      - X509_USER_KEY=/opt/rucio/etc/userkey.pem
+      - RDBMS=postgres14
   rucio:
     image: docker.io/rucio/rucio-dev
     ports:

--- a/etc/docker/dev/docker-compose-storage-monit.yml
+++ b/etc/docker/dev/docker-compose-storage-monit.yml
@@ -1,5 +1,16 @@
 version: "3"
 services:
+  rucioclient:
+    image: docker.io/rucio/rucio-dev
+    command: ["sleep", "infinity"]
+    volumes:
+      - ../../../tools:/opt/rucio/tools:Z
+      - ../../../bin:/opt/rucio/bin:Z
+      - ../../../lib:/opt/rucio/lib:Z
+    environment:
+      - X509_USER_CERT=/opt/rucio/etc/usercert.pem
+      - X509_USER_KEY=/opt/rucio/etc/userkey.pem
+      - RDBMS=postgres14
   rucio:
     image: docker.io/rucio/rucio-dev
     ports:

--- a/etc/docker/dev/docker-compose-storage.yml
+++ b/etc/docker/dev/docker-compose-storage.yml
@@ -1,5 +1,16 @@
 version: "3"
 services:
+  rucioclient:
+    image: docker.io/rucio/rucio-dev
+    command: ["sleep", "infinity"]
+    volumes:
+      - ../../../tools:/opt/rucio/tools:Z
+      - ../../../bin:/opt/rucio/bin:Z
+      - ../../../lib:/opt/rucio/lib:Z
+    environment:
+      - X509_USER_CERT=/opt/rucio/etc/usercert.pem
+      - X509_USER_KEY=/opt/rucio/etc/userkey.pem
+      - RDBMS=postgres14
   rucio:
     image: docker.io/rucio/rucio-dev
     ports:

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -1,5 +1,16 @@
 version: "3"
 services:
+  rucioclient:
+    image: docker.io/rucio/rucio-dev
+    command: ["sleep", "infinity"]
+    volumes:
+      - ../../../tools:/opt/rucio/tools:Z
+      - ../../../bin:/opt/rucio/bin:Z
+      - ../../../lib:/opt/rucio/lib:Z
+    environment:
+      - X509_USER_CERT=/opt/rucio/etc/usercert.pem
+      - X509_USER_KEY=/opt/rucio/etc/userkey.pem
+      - RDBMS=postgres14
   rucio:
     image: docker.io/rucio/rucio-dev
     ports:


### PR DESCRIPTION
Add a container which is identical to the rucio container, but does nothing at all. It's just a placeholder.

This commit is a pre-requirement for usage of the intellij docker-compose remote execution. When configuring intellij remote interpreter, the user has to define the container in which the commands will be executed. However, when you actually execute the commands via the intellij UI, that container is destroyed and re-created while overriding the entry-point with intellij wrappers. As a result, we cannot use the "rucio" container for that, because the httpd server will be killed.

While I don't like adding such IDE-specific hacks upstream, I don't see a better solution if we want to create an official document about how to use intellij remote execution. I maintained a local override patch since forever for that, but we cannot require other developers to do the same thing.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
