### PR TITLE
Add params and type hints to stop() #6075

### DIFF
--- a/lib/rucio/daemons/abacus/account.py
+++ b/lib/rucio/daemons/abacus/account.py
@@ -20,6 +20,7 @@ Abacus-Account is a daemon to update Account counters.
 import logging
 import threading
 import time
+from typing import TYPE_CHECKING
 
 import rucio.db.sqla.util
 from rucio.common import exception
@@ -27,6 +28,10 @@ from rucio.common.logging import setup_logging
 from rucio.common.utils import get_thread_with_periodic_running_function
 from rucio.core.account_counter import get_updated_account_counters, update_account_counter, fill_account_counter_history_table
 from rucio.daemons.common import run_daemon
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 graceful_stop = threading.Event()
 
@@ -68,7 +73,7 @@ def run_once(heartbeat_handler, **_kwargs):
         logger(logging.DEBUG, 'update of account-rse counter "%s-%s" took %f' % (account_rse_id[0], account_rse_id[1], time.time() - start_time))
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/abacus/collection_replica.py
+++ b/lib/rucio/daemons/abacus/collection_replica.py
@@ -20,12 +20,17 @@ import functools
 import logging
 import threading
 import time
+from typing import TYPE_CHECKING
 
 import rucio.db.sqla.util
 from rucio.common import exception
 from rucio.common.logging import setup_logging
 from rucio.core.replica import get_cleaned_updated_collection_replicas, update_collection_replica
 from rucio.daemons.common import run_daemon
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 graceful_stop = threading.Event()
 
@@ -77,7 +82,7 @@ def run_once(heartbeat_handler, limit, **_kwargs):
     return must_sleep
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/abacus/rse.py
+++ b/lib/rucio/daemons/abacus/rse.py
@@ -20,6 +20,7 @@ Abacus-RSE is a daemon to update RSE counters.
 import logging
 import threading
 import time
+from typing import TYPE_CHECKING
 
 import rucio.db.sqla.util
 from rucio.common import exception
@@ -27,6 +28,10 @@ from rucio.common.logging import setup_logging
 from rucio.common.utils import get_thread_with_periodic_running_function
 from rucio.core.rse_counter import get_updated_rse_counters, update_rse_counter, fill_rse_counter_history_table
 from rucio.daemons.common import run_daemon
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 graceful_stop = threading.Event()
 
@@ -69,7 +74,7 @@ def run_once(heartbeat_handler, **_kwargs):
         logger(logging.DEBUG, 'update of rse "%s" took %f' % (rse_id, time.time() - start_time))
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/atropos/atropos.py
+++ b/lib/rucio/daemons/atropos/atropos.py
@@ -36,6 +36,9 @@ from rucio.daemons.common import run_daemon
 from rucio.db.sqla.constants import LifetimeExceptionsState
 
 if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
+
     from rucio.daemons.common import HeartbeatHandler
 
 GRACEFUL_STOP = threading.Event()
@@ -233,7 +236,7 @@ def run(
         thread_list = [t.join(timeout=3.14) for t in thread_list if t and t.is_alive()]
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -40,6 +40,9 @@ from rucio.daemons.common import run_daemon
 
 
 if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
+
     from rucio.daemons.common import HeartbeatHandler
 
 METRICS = MetricManager(module=__name__)
@@ -272,7 +275,7 @@ def run(
         [thread.join(timeout=3.14) for thread in threads]
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/badreplicas/minos.py
+++ b/lib/rucio/daemons/badreplicas/minos.py
@@ -40,6 +40,9 @@ from rucio.db.sqla.session import get_session
 
 
 if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
+
     from rucio.daemons.common import HeartbeatHandler
     from rucio.common.types import InternalAccount
 
@@ -302,7 +305,7 @@ def run(threads: int = 1, bulk: int = 100, once: bool = False, sleep_time: int =
             thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.is_alive()]
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
+++ b/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
@@ -37,6 +37,9 @@ from rucio.db.sqla.session import get_session
 
 
 if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
+
     from rucio.daemons.common import HeartbeatHandler
 
 graceful_stop = threading.Event()
@@ -164,7 +167,7 @@ def run(threads: int = 1, bulk: int = 100, once: bool = False, sleep_time: int =
             thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.is_alive()]
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/badreplicas/necromancer.py
+++ b/lib/rucio/daemons/badreplicas/necromancer.py
@@ -38,6 +38,9 @@ from rucio.core.rule import (update_rules_for_lost_replica, update_rules_for_bad
 from rucio.daemons.common import run_daemon
 
 if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
+
     from rucio.daemons.common import HeartbeatHandler
 
 graceful_stop = threading.Event()
@@ -191,7 +194,7 @@ def run(threads: int = 1, bulk: int = 100, once: bool = False, sleep_time: int =
             thread_list = [thread.join(timeout=3.14) for thread in thread_list if thread and thread.is_alive()]
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/bb8/bb8.py
+++ b/lib/rucio/daemons/bb8/bb8.py
@@ -34,6 +34,9 @@ from rucio.daemons.common import run_daemon
 
 
 if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
+
     from rucio.daemons.common import HeartbeatHandler
 
 graceful_stop = threading.Event()
@@ -311,7 +314,7 @@ def run_once(
     return must_sleep
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/c3po/c3po.py
+++ b/lib/rucio/daemons/c3po/c3po.py
@@ -21,8 +21,10 @@ import logging
 from datetime import datetime
 from hashlib import md5
 from json import dumps
+from queue import Queue
 from threading import Event, Thread
 from time import sleep
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from requests import post
@@ -39,7 +41,9 @@ from rucio.daemons.c3po.collectors.free_space import FreeSpaceCollector
 from rucio.daemons.c3po.collectors.jedi_did import JediDIDCollector
 from rucio.daemons.c3po.collectors.workload import WorkloadCollector
 
-from queue import Queue
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 GRACEFUL_STOP = Event()
 
@@ -249,7 +253,7 @@ def place_replica(once=False,
         logging.critical(e)
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/cache/consumer.py
+++ b/lib/rucio/daemons/cache/consumer.py
@@ -22,6 +22,7 @@ import logging
 import threading
 import time
 from traceback import format_exc
+from typing import TYPE_CHECKING
 
 import rucio.db.sqla.util
 from rucio.common import exception
@@ -32,6 +33,10 @@ from rucio.common.types import InternalScope
 from rucio.core.monitor import MetricManager
 from rucio.core.rse import get_rse_id
 from rucio.core.volatile_replica import add_volatile_replicas, delete_volatile_replicas
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 logging.getLogger("stomp").setLevel(logging.CRITICAL)
 
@@ -156,7 +161,7 @@ def consumer(id_, num_thread=1):
     logger(logging.INFO, 'graceful stop done')
 
 
-def stop():
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import threading
+from typing import TYPE_CHECKING
 
 from dogpile.cache.api import NoValue
 from sqlalchemy.exc import DatabaseError
@@ -44,6 +45,10 @@ from rucio.db.sqla.session import transactional_session
 from rucio.rse import rsemanager
 
 from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 graceful_stop = threading.Event()
 
@@ -139,7 +144,7 @@ def finisher(once=False, sleep_time=60, activities=None, bulk=100, db_bulk=1000,
     )
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -26,6 +26,7 @@ import re
 import threading
 import time
 from itertools import groupby
+from typing import TYPE_CHECKING
 
 from requests.exceptions import RequestException
 from configparser import NoOptionError
@@ -44,6 +45,10 @@ from rucio.db.sqla.constants import RequestState, RequestType
 from rucio.daemons.common import run_daemon
 from rucio.transfertool.fts3 import FTS3Transfertool
 from rucio.transfertool.globus import GlobusTransferTool
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 graceful_stop = threading.Event()
 METRICS = MetricManager(module=__name__)
@@ -162,7 +167,7 @@ def poller(once=False, activities=None, sleep_time=60,
     )
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/conveyor/preparer.py
+++ b/lib/rucio/daemons/conveyor/preparer.py
@@ -32,6 +32,7 @@ from rucio.db.sqla.constants import RequestState, RequestType
 from rucio.daemons.common import run_daemon
 
 if TYPE_CHECKING:
+    from types import FrameType
     from typing import Optional, List
     from sqlalchemy.orm import Session
     from rucio.daemons.common import HeartbeatHandler
@@ -39,7 +40,7 @@ if TYPE_CHECKING:
 graceful_stop = threading.Event()
 
 
-def stop():
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -23,6 +23,7 @@ import socket
 import threading
 import time
 import traceback
+from typing import TYPE_CHECKING
 
 import stomp
 
@@ -36,6 +37,10 @@ from rucio.core.monitor import MetricManager
 from rucio.daemons.common import HeartbeatHandler
 from rucio.db.sqla.session import transactional_session
 from rucio.transfertool.fts3 import FTS3CompletionMessageTransferStatusReport
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 logging.getLogger("stomp").setLevel(logging.CRITICAL)
 
@@ -175,7 +180,7 @@ def receiver(id_, total_threads=1, all_vos=False):
                 pass
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -20,6 +20,7 @@ Conveyor stager is a daemon to manage stagein file transfers.
 import functools
 import logging
 import threading
+from typing import TYPE_CHECKING
 
 from configparser import NoOptionError
 
@@ -33,6 +34,10 @@ from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, ne
 from rucio.daemons.common import run_daemon
 from rucio.db.sqla.constants import RequestType
 from rucio.transfertool.fts3 import FTS3Transfertool
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 METRICS = MetricManager(module=__name__)
 graceful_stop = threading.Event()
@@ -156,7 +161,7 @@ def stager(once=False, rses=None, bulk=100, group_bulk=1, group_policy='rule',
     )
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -20,6 +20,7 @@ Conveyor transfer submitter is a daemon to manage non-tape file transfers.
 import functools
 import logging
 import threading
+from typing import TYPE_CHECKING
 
 from configparser import NoOptionError
 
@@ -36,6 +37,10 @@ from rucio.daemons.common import run_daemon
 from rucio.db.sqla.constants import RequestType
 from rucio.transfertool.fts3 import FTS3Transfertool
 from rucio.transfertool.globus import GlobusTransferTool
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 METRICS = MetricManager(module=__name__)
 graceful_stop = threading.Event()
@@ -206,7 +211,7 @@ def submitter(once=False, rses=None, partition_wait_time=10,
     )
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -21,6 +21,7 @@ import math
 import threading
 import traceback
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from sqlalchemy import null
 
@@ -34,6 +35,10 @@ from rucio.core.transfer import applicable_rse_transfer_limits
 from rucio.core.rse import RseCollection
 from rucio.daemons.common import run_daemon
 from rucio.db.sqla.constants import RequestState, TransferLimitDirection
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 graceful_stop = threading.Event()
 METRICS = MetricManager(module=__name__)
@@ -60,7 +65,7 @@ def throttler(once=False, sleep_time=600, partition_wait_time=10):
     )
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/follower/follower.py
+++ b/lib/rucio/daemons/follower/follower.py
@@ -18,6 +18,7 @@ import os
 import socket
 import threading
 import time
+from typing import TYPE_CHECKING
 
 import rucio.db.sqla.util
 from rucio.common import exception
@@ -25,6 +26,10 @@ from rucio.common.logging import setup_logging
 from rucio.common.utils import get_thread_with_periodic_running_function
 from rucio.core.did import create_reports
 from rucio.core.heartbeat import live, die, sanity_check
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 graceful_stop = threading.Event()
 
@@ -57,7 +62,7 @@ def aggregate_events(once=False):
     logging.info('follower: graceful stop done')
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/hermes/hermes.py
+++ b/lib/rucio/daemons/hermes/hermes.py
@@ -18,8 +18,8 @@
 """
 
 import calendar
-import functools
 import datetime
+import functools
 import json
 import logging
 import random
@@ -29,9 +29,9 @@ import socket
 import sys
 import threading
 import time
-from typing import TYPE_CHECKING
 from configparser import NoOptionError, NoSectionError
 from email.mime.text import MIMEText
+from typing import TYPE_CHECKING
 
 import requests
 import stomp
@@ -39,18 +39,20 @@ import stomp
 import rucio.db.sqla.util
 from rucio.common.config import (
     config_get,
-    config_get_int,
     config_get_bool,
+    config_get_int,
     config_get_list,
 )
 from rucio.common.exception import DatabaseException
 from rucio.common.logging import setup_logging
-from rucio.core.message import retrieve_messages, delete_messages
+from rucio.core.message import delete_messages, retrieve_messages
 from rucio.core.monitor import MetricManager
 from rucio.daemons.common import run_daemon
 
 if TYPE_CHECKING:
-    from typing import Callable, List, Dict
+    from types import FrameType
+    from typing import Callable, Dict, List, Optional
+
     from rucio.daemons.common import HeartbeatHandler
 
 logging.getLogger("requests").setLevel(logging.CRITICAL)
@@ -686,7 +688,7 @@ def run_once(heartbeat_handler: "HeartbeatHandler", bulk: int, **_kwargs) -> boo
     return must_sleep
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/judge/cleaner.py
+++ b/lib/rucio/daemons/judge/cleaner.py
@@ -24,6 +24,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from random import randint
 from re import match
+from typing import TYPE_CHECKING
 
 from sqlalchemy.exc import DatabaseError
 
@@ -35,6 +36,10 @@ from rucio.core.monitor import MetricManager
 from rucio.core.rule import delete_rule, get_expired_rules
 from rucio.daemons.common import run_daemon
 from rucio.db.sqla.util import get_db_time
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 METRICS = MetricManager(module=__name__)
 graceful_stop = threading.Event()
@@ -110,7 +115,7 @@ def run_once(paused_rules, heartbeat_handler, **_kwargs):
             pass
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/judge/evaluator.py
+++ b/lib/rucio/daemons/judge/evaluator.py
@@ -25,6 +25,7 @@ import traceback
 from datetime import datetime, timedelta
 from random import randint
 from re import match
+from typing import TYPE_CHECKING
 
 from sqlalchemy.exc import DatabaseError
 from sqlalchemy.orm.exc import FlushError
@@ -36,6 +37,10 @@ from rucio.common.types import InternalScope
 from rucio.core.monitor import MetricManager
 from rucio.core.rule import re_evaluate_did, get_updated_dids, delete_updated_did
 from rucio.daemons.common import run_daemon
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 METRICS = MetricManager(module=__name__)
 graceful_stop = threading.Event()
@@ -137,7 +142,7 @@ def run_once(paused_dids, did_limit, heartbeat_handler, **_kwargs):
             logger(logging.WARNING, 'Flush error for %s:%s', did.scope, did.name)
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/judge/injector.py
+++ b/lib/rucio/daemons/judge/injector.py
@@ -24,6 +24,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from random import randint
 from re import match
+from typing import TYPE_CHECKING
 
 from sqlalchemy.exc import DatabaseError
 
@@ -34,6 +35,10 @@ from rucio.common.exception import (DatabaseException, RuleNotFound, RSEWriteBlo
 from rucio.core.monitor import MetricManager
 from rucio.core.rule import inject_rule, get_injected_rules, update_rule
 from rucio.daemons.common import run_daemon
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 METRICS = MetricManager(module=__name__)
 graceful_stop = threading.Event()
@@ -121,7 +126,7 @@ def run_once(paused_rules, heartbeat_handler, **_kwargs):
             update_rule(rule_id=rule_id, options={'state': 'SUSPENDED'})
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/judge/repairer.py
+++ b/lib/rucio/daemons/judge/repairer.py
@@ -25,6 +25,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from random import randint
 from re import match
+from typing import TYPE_CHECKING
 
 from sqlalchemy.exc import DatabaseError
 
@@ -35,6 +36,10 @@ from rucio.common.logging import setup_logging
 from rucio.core.monitor import MetricManager
 from rucio.core.rule import repair_rule, get_stuck_rules
 from rucio.daemons.common import run_daemon
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 METRICS = MetricManager(module=__name__)
 graceful_stop = threading.Event()
@@ -111,7 +116,7 @@ def run_once(paused_rules, delta, heartbeat_handler, **_kwargs):
                 METRICS.counter('exceptions.{exception}').labels(exception=e.__class__.__name__).inc()
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/oauthmanager/oauthmanager.py
+++ b/lib/rucio/daemons/oauthmanager/oauthmanager.py
@@ -31,6 +31,7 @@ import logging
 import threading
 import traceback
 from re import match
+from typing import TYPE_CHECKING
 
 from sqlalchemy.exc import DatabaseError
 
@@ -43,6 +44,10 @@ from rucio.core.monitor import MetricManager
 from rucio.core.oidc import delete_expired_oauthrequests, refresh_jwt_tokens
 from rucio.daemons.common import run_daemon
 from rucio.daemons.common import HeartbeatHandler
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 METRICS = MetricManager(module=__name__)
 graceful_stop = threading.Event()
@@ -187,7 +192,7 @@ def run(once: bool = False, threads: int = 1, max_rows: int = 100, sleep_time: i
             _ = [t.join(timeout=3.14) for t in threads]
 
 
-def stop() -> None:
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/reaper/dark_reaper.py
+++ b/lib/rucio/daemons/reaper/dark_reaper.py
@@ -45,7 +45,9 @@ from rucio.daemons.common import run_daemon
 from rucio.rse import rsemanager as rsemgr
 
 if TYPE_CHECKING:
+    from types import FrameType
     from typing import Sequence, Optional
+
     from rucio.daemons.common import HeartbeatHandler
 
 logging.getLogger("requests").setLevel(logging.CRITICAL)
@@ -184,7 +186,7 @@ def run_once(
     return must_sleep
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/reaper/light_reaper.py
+++ b/lib/rucio/daemons/reaper/light_reaper.py
@@ -26,6 +26,7 @@ import sys
 import threading
 import time
 import traceback
+from typing import TYPE_CHECKING
 
 import rucio.db.sqla.util
 from rucio.common.config import config_get_bool
@@ -40,6 +41,10 @@ from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.temporary_did import (list_expired_temporary_dids, delete_temporary_dids)
 from rucio.core.vo import list_vos
 from rucio.rse import rsemanager as rsemgr
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 logging.getLogger("requests").setLevel(logging.CRITICAL)
 
@@ -164,7 +169,7 @@ def reaper(rses=[], worker_number=0, total_workers=1, chunk_size=100, once=False
     return
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -56,7 +56,9 @@ from rucio.daemons.common import run_daemon
 from rucio.rse import rsemanager as rsemgr
 
 if TYPE_CHECKING:
+    from types import FrameType
     from typing import Any, Callable, Optional, Tuple
+
     from rucio.daemons.common import HeartbeatHandler
 
 GRACEFUL_STOP = threading.Event()
@@ -642,7 +644,7 @@ def _run_once(rses_to_process, chunk_size, greedy, scheme,
     return rses_with_more_work
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/storage/consistency/actions.py
+++ b/lib/rucio/daemons/storage/consistency/actions.py
@@ -27,6 +27,7 @@ import socket
 import time
 import threading
 import traceback
+from typing import TYPE_CHECKING
 
 from datetime import datetime
 
@@ -48,6 +49,10 @@ from rucio.db.sqla.session import transactional_session
 from rucio.db.sqla.constants import (ReplicaState, BadFilesStatus)
 from sqlalchemy.exc import DatabaseError, IntegrityError
 from sqlalchemy.orm.exc import FlushError
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 METRICS = MetricManager(module=__name__)
 graceful_stop = threading.Event()
@@ -683,7 +688,7 @@ def actions_loop(once, scope, rses, sleep_time, dark_min_age, dark_threshold_per
     die(executable=executable, hostname=hostname, pid=pid, thread=current_thread)
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/tracer/kronos.py
+++ b/lib/rucio/daemons/tracer/kronos.py
@@ -25,6 +25,7 @@ import functools
 from json import loads as jloads, dumps as jdumps
 from threading import Event, Thread
 from time import time
+from typing import TYPE_CHECKING
 
 import rucio.db.sqla.util
 from rucio.daemons.common import HeartbeatHandler, run_daemon
@@ -42,6 +43,10 @@ from rucio.core.rse import get_rse_id
 from rucio.db.sqla.constants import DIDType, BadFilesStatus
 
 from queue import Queue
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 
 logging.getLogger("stomp").setLevel(logging.CRITICAL)
@@ -475,7 +480,7 @@ def run_once_kronos_dataset(dataset_queue: Queue, return_values: dict, heartbeat
     logger(logging.INFO, 'update done for %d collection replicas, %d failed (%ds)' % (total, failed, time() - start))
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -52,6 +52,9 @@ from rucio.core.subscription import list_subscriptions, update_subscription
 from rucio.daemons.common import run_daemon
 
 if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
+
     from rucio.daemons.common import HeartbeatHandler
     from rucio.common.types import InternalScope
 
@@ -742,7 +745,7 @@ def run(
             ]
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """

--- a/lib/rucio/daemons/undertaker/undertaker.py
+++ b/lib/rucio/daemons/undertaker/undertaker.py
@@ -25,7 +25,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from random import randint
 from re import match
-from typing import Tuple, Dict
+from typing import TYPE_CHECKING, Tuple, Dict
 
 from sqlalchemy.exc import DatabaseError
 
@@ -37,6 +37,10 @@ from rucio.common.utils import chunks
 from rucio.core.did import list_expired_dids, delete_dids
 from rucio.core.monitor import MetricManager
 from rucio.daemons.common import run_daemon, HeartbeatHandler
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
 
 logging.getLogger("requests").setLevel(logging.CRITICAL)
 
@@ -104,7 +108,7 @@ def run_once(paused_dids: Dict[Tuple, datetime], chunk_size: int, heartbeat_hand
         logging.critical(traceback.format_exc())
 
 
-def stop(signum=None, frame=None):
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
     """
     Graceful exit.
     """


### PR DESCRIPTION
Fixes issue #6075 

### Overview
https://github.com/rucio/rucio/blob/f9d52b7c7afbc1cfa41076f1d24f85299aa06cb8/lib/rucio/daemons/conveyor/preparer.py#L42-L47 should accept parameters `signalnum` and `handler` before being used as as signal handler in https://github.com/rucio/rucio/blob/f9d52b7c7afbc1cfa41076f1d24f85299aa06cb8/bin/rucio-conveyor-preparer#L23-L28 according to the [python docs](https://docs.python.org/3/library/signal.html#signal.signal). However the same function is being called without parameters in Line 28 https://github.com/rucio/rucio/blob/f9d52b7c7afbc1cfa41076f1d24f85299aa06cb8/bin/rucio-conveyor-preparer#L28 So I added `*args` to the function parameters to resolve the issue. 

### Alternative Solution
The other possible solution is to add the parameters:
```python
def stop(signalnum, handler):
```
However, then for the function call in Line 28,
https://github.com/rucio/rucio/blob/f9d52b7c7afbc1cfa41076f1d24f85299aa06cb8/bin/rucio-conveyor-preparer#L28 I will have to pass those arguments to `stop()`.