### PR TITLE
trace: added option to submit trace to elastic. Fix #5756

### DIFF
--- a/etc/docker/test/extra/rucio_multi_vo_ts2_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_ts2_postgres14.cfg
@@ -95,7 +95,7 @@ username = username
 password = password
 topic = /topic/rucio.tracer
 to_elastic = True
-elastic_url = http://elasticsearch:9200
+elastic_url = http://elastic:9200
 elastic_index = trace
 
 [tracer-kronos]

--- a/etc/docker/test/extra/rucio_multi_vo_ts2_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_ts2_postgres14.cfg
@@ -94,6 +94,9 @@ port=61013
 username = username
 password = password
 topic = /topic/rucio.tracer
+to_elastic = True
+elastic_url = http://elasticsearch:9200
+elastic_index = trace
 
 [tracer-kronos]
 brokers=activemq

--- a/etc/docker/test/extra/rucio_multi_vo_tst_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_tst_postgres14.cfg
@@ -95,7 +95,7 @@ username = username
 password = password
 topic = /topic/rucio.tracer
 to_elastic = True
-elastic_url = http://elasticsearch:9200
+elastic_url = http://elastic:9200
 elastic_index = trace
 
 [tracer-kronos]

--- a/etc/docker/test/extra/rucio_multi_vo_tst_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_tst_postgres14.cfg
@@ -94,6 +94,9 @@ port=61013
 username = username
 password = password
 topic = /topic/rucio.tracer
+to_elastic = True
+elastic_url = http://elasticsearch:9200
+elastic_index = trace
 
 [tracer-kronos]
 brokers=activemq

--- a/etc/docker/test/extra/rucio_mysql8.cfg
+++ b/etc/docker/test/extra/rucio_mysql8.cfg
@@ -92,7 +92,7 @@ username = username
 password = password
 topic = /topic/rucio.tracer
 to_elastic = True
-elastic_url = http://elasticsearch:9200
+elastic_url = http://elastic:9200
 elastic_index = trace
 
 [tracer-kronos]

--- a/etc/docker/test/extra/rucio_mysql8.cfg
+++ b/etc/docker/test/extra/rucio_mysql8.cfg
@@ -91,6 +91,9 @@ port=61013
 username = username
 password = password
 topic = /topic/rucio.tracer
+to_elastic = True
+elastic_url = http://elasticsearch:9200
+elastic_index = trace
 
 [tracer-kronos]
 brokers=activemq

--- a/etc/docker/test/extra/rucio_oracle.cfg
+++ b/etc/docker/test/extra/rucio_oracle.cfg
@@ -92,7 +92,7 @@ username = username
 password = password
 topic = /topic/rucio.tracer
 to_elastic = True
-elastic_url = http://elasticsearch:9200
+elastic_url = http://elastic:9200
 elastic_index = trace
 
 [tracer-kronos]

--- a/etc/docker/test/extra/rucio_oracle.cfg
+++ b/etc/docker/test/extra/rucio_oracle.cfg
@@ -91,6 +91,9 @@ port=61013
 username = username
 password = password
 topic = /topic/rucio.tracer
+to_elastic = True
+elastic_url = http://elasticsearch:9200
+elastic_index = trace
 
 [tracer-kronos]
 brokers=activemq

--- a/etc/docker/test/extra/rucio_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_postgres14.cfg
@@ -92,7 +92,7 @@ username = username
 password = password
 topic = /topic/rucio.tracer
 to_elastic = True
-elastic_url = http://elasticsearch:9200
+elastic_url = http://elastic:9200
 elastic_index = trace
 
 [tracer-kronos]

--- a/etc/docker/test/extra/rucio_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_postgres14.cfg
@@ -91,6 +91,9 @@ port=61013
 username = username
 password = password
 topic = /topic/rucio.tracer
+to_elastic = True
+elastic_url = http://elasticsearch:9200
+elastic_index = trace
 
 [tracer-kronos]
 brokers=activemq

--- a/etc/docker/test/extra/rucio_postgres9.cfg
+++ b/etc/docker/test/extra/rucio_postgres9.cfg
@@ -92,7 +92,7 @@ username = username
 password = password
 topic = /topic/rucio.tracer
 to_elastic = True
-elastic_url = http://elasticsearch:9200
+elastic_url = http://elastic:9200
 elastic_index = trace
 
 [tracer-kronos]

--- a/etc/docker/test/extra/rucio_postgres9.cfg
+++ b/etc/docker/test/extra/rucio_postgres9.cfg
@@ -91,6 +91,9 @@ port=61013
 username = username
 password = password
 topic = /topic/rucio.tracer
+to_elastic = True
+elastic_url = http://elasticsearch:9200
+elastic_index = trace
 
 [tracer-kronos]
 brokers=activemq

--- a/etc/docker/test/extra/rucio_sqlite.cfg
+++ b/etc/docker/test/extra/rucio_sqlite.cfg
@@ -88,6 +88,9 @@ port=61013
 username = username
 password = password
 topic = /topic/rucio.tracer
+to_elastic = True
+elastic_url = http://elasticsearch:9200
+elastic_index = trace
 
 [tracer-kronos]
 brokers=activemq

--- a/etc/docker/test/extra/rucio_sqlite.cfg
+++ b/etc/docker/test/extra/rucio_sqlite.cfg
@@ -89,7 +89,7 @@ username = username
 password = password
 topic = /topic/rucio.tracer
 to_elastic = True
-elastic_url = http://elasticsearch:9200
+elastic_url = http://elastic:9200
 elastic_index = trace
 
 [tracer-kronos]

--- a/etc/docker/test/extra/rucio_syntax.cfg
+++ b/etc/docker/test/extra/rucio_syntax.cfg
@@ -88,6 +88,9 @@ port=61013
 username = username
 password = password
 topic = /topic/rucio.tracer
+to_elastic = True
+elastic_url = http://elasticsearch:9200
+elastic_index = trace
 
 [tracer-kronos]
 brokers=activemq

--- a/etc/docker/test/extra/rucio_syntax.cfg
+++ b/etc/docker/test/extra/rucio_syntax.cfg
@@ -89,7 +89,7 @@ username = username
 password = password
 topic = /topic/rucio.tracer
 to_elastic = True
-elastic_url = http://elasticsearch:9200
+elastic_url = http://elastic:9200
 elastic_index = trace
 
 [tracer-kronos]

--- a/lib/rucio/tests/test_trace.py
+++ b/lib/rucio/tests/test_trace.py
@@ -20,7 +20,7 @@ import logging
 import pytest
 import json
 from rucio.common.schema.generic import IPv4orIPv6
-from rucio.core.trace import SCHEMAS, validate_schema
+from rucio.core.trace import SCHEMAS, validate_schema, submit_to_elastic
 from rucio.common.exception import InvalidObject
 
 
@@ -95,3 +95,17 @@ def test_non_existant_event_type_validation_rejection(caplog):
     obj = json.dumps({"eventType": f"{event_type}"})
     validate_schema(obj)
     assert f"schema for eventType {event_type} is not currently supported" in caplog.text
+
+
+def test_submit_to_elastic():
+    payload = {'uuid': str(uuid.uuid4()),  # str, because not JSON serializable
+               'string': 'deadbeef',
+               'hex': 0xDEADBEEF,
+               'int': 3,
+               'float': 3.45,
+               'long': 314314314314314314,
+               'timestamp': time.time(),
+               'datetime_str': str(datetime.datetime.utcnow()),  # str, because not JSON serializable
+               'boolean': True}
+    ret = submit_to_elastic(messages=[payload])
+    assert ret in [201, 200]


### PR DESCRIPTION
Currently, trace is sent to activeMQ and cosumed by Kronos daemon to updata metadata of dids. Since we can sent extra information in trace , we want to see aggregated information of trace and infer something out of it.
To do this, we want to store trace into ElasticSearch, which this PR does.
Sending trace to elastic is optional via rucio config as:

```
[trace]
...
...
elastic_url = http://elasticsearch:9200
elastic_index = trace
to_elastic = True   
```
If to_elastic is False no trace is sent to elastic.

Closes: #5756 

