### PR TITLE
REST & API: cast account string to Internal Account Fix #6100

### DIFF
--- a/lib/rucio/api/rule.py
+++ b/lib/rucio/api/rule.py
@@ -329,4 +329,4 @@ def move_replication_rule(rule_id, rse_expression, override, issuer, vo='def', *
     if not has_permission(issuer=issuer, vo=vo, action='move_rule', kwargs=kwargs, session=session):
         raise AccessDenied('Account %s can not move this replication rule.' % (issuer))
 
-    return rule.move_rule(**kwargs, session=session)
+    return rule.move_rule(**kwargs, vo=vo, session=session)

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -1550,7 +1550,7 @@ def reduce_rule(rule_id, copies, exclude_expression=None, *, session: "Session")
 
 
 @transactional_session
-def move_rule(rule_id: str, rse_expression: str, override: Optional[Dict[str, Any]] = None, *, session: "Session"):
+def move_rule(rule_id: str, rse_expression: str, override: Optional[Dict[str, Any]] = None, vo: str = 'def', *, session: "Session"):
     """
     Move a replication rule to another RSE and, once done, delete the original one.
 
@@ -1601,6 +1601,8 @@ def move_rule(rule_id: str, rse_expression: str, override: Optional[Dict[str, An
                 raise UnsupportedOperation('Not allowed to override option %s' % key)
             elif key not in options:
                 raise UnsupportedOperation('Non-valid override option %s' % key)
+            elif key == "account":
+                options["account"] = InternalAccount(override["account"], vo=vo)
             else:
                 options[key] = override[key]
 


### PR DESCRIPTION
in move_replication_rule function which calls add_rule 

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->

Hi @dchristidis 
Are there more checks that I might be missing? 
I will add some tests soon, once you confirm this would be the right way.

Thanks