### PR TITLE
REST & API: Convert account to InternalAccount #6100

### DIFF
--- a/lib/rucio/api/rule.py
+++ b/lib/rucio/api/rule.py
@@ -318,6 +318,9 @@ def move_replication_rule(rule_id, rse_expression, override, issuer, vo='def', *
     :param vo:                         The VO to act on.
     :raises:                           RuleNotFound, RuleReplaceFailed, InvalidRSEExpression, AccessDenied
     """
+    override = override.copy()
+    if 'account' in override:
+        override['account'] = InternalAccount(override['account'], vo=vo)
     kwargs = {
         'rule_id': rule_id,
         'rse_expression': rse_expression,


### PR DESCRIPTION
Commit d440f9353a made it possible to override any option when moving a rule. However, it omitted to convert the account from a string to an InternalAccount, potentially leading to an unhandled exception.

Fix #6100.
