### PR TITLE
testing: fix pyright issues

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -91,8 +91,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          sudo apt-get install -y npm libkrb5-dev libxmlsec1-dev 
-          npm install --global pyright@"<1.1.292 || >1.1.292"  # TODO: remove version range: https://github.com/microsoft/pyright/issues/4564
+          sudo apt-get update && sudo apt-get install -y npm libkrb5-dev libxmlsec1-dev 
+          npm install --global pyright
           python -m pip --no-cache-dir install --upgrade -r requirements.txt
       - name: Make pyright report of current commit
         run: |


### PR DESCRIPTION
Fix #6116 
- remove the pinned version of pyright. We use the latest release now.
- update runner dependencies 

