### PR TITLE
Core & Internals: activate temp tables by default. Closes #6084

### DIFF
--- a/etc/docker/test/matrix.yml
+++ b/etc/docker/test/matrix.yml
@@ -59,7 +59,7 @@ suites:
   - id: client_syntax
     RUN_HTTPD: false
   - id: client
-    RDBMS: sqlite
+    RDBMS: postgres14
   - id: remote_dbs
     RDBMS:
       - oracle

--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -287,7 +287,7 @@ def attach_dids_to_dids(
     :param ignore_duplicate: If True, ignore duplicate entries.
     :param session: The database session in use.
     """
-    use_temp_tables = config_get_bool('core', 'use_temp_tables', default=False, session=session)
+    use_temp_tables = config_get_bool('core', 'use_temp_tables', default=True, session=session)
     if use_temp_tables:
         return _attach_dids_to_dids(attachments=attachments, account=account, ignore_duplicate=ignore_duplicate, session=session)
     else:
@@ -1212,7 +1212,7 @@ def delete_dids(
     :param session:       The database session in use.
     :param logger:        Optional decorated logger that can be passed from the calling daemons or servers.
     """
-    use_temp_tables = config_get_bool('core', 'use_temp_tables', default=False, session=session)
+    use_temp_tables = config_get_bool('core', 'use_temp_tables', default=True, session=session)
     if use_temp_tables:
         return _delete_dids(dids, account, expire_rules, session=session, logger=logger)
     else:

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1078,7 +1078,7 @@ def list_replicas(
     # For historical reasons:
     # - list_replicas([some_file_did]), must return the file even if it doesn't have replicas
     # - list_replicas([some_collection_did]) must only return files with replicas
-    use_temp_tables = config_get_bool('core', 'use_temp_tables', default=False, session=session)
+    use_temp_tables = config_get_bool('core', 'use_temp_tables', default=True, session=session)
     if use_temp_tables:
         yield from _list_replicas_with_temp_tables(
             dids, schemes, unavailable, request_id, ignore_availability, all_states, pfns, rse_expression, client_location,
@@ -1690,7 +1690,7 @@ def delete_replicas(rse_id, files, ignore_availability=True, *, session: "Sessio
     :param ignore_availability: Ignore the RSE blocklisting.
     :param session: The database session in use.
     """
-    use_temp_tables = config_get_bool('core', 'use_temp_tables', default=False, session=session)
+    use_temp_tables = config_get_bool('core', 'use_temp_tables', default=True, session=session)
     if use_temp_tables:
         __delete_replicas(rse_id, files, ignore_availability=ignore_availability, session=session)
     else:

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -441,7 +441,7 @@ def list_transfer_requests_and_source_replicas(
     else:
         sub_requests = sub_requests.with_hint(models.Request, "INDEX(REQUESTS REQUESTS_TYP_STA_UPD_IDX)", 'oracle')
 
-    use_temp_tables = config_get_bool('core', 'use_temp_tables', default=False, session=session)
+    use_temp_tables = config_get_bool('core', 'use_temp_tables', default=True, session=session)
     if rses and use_temp_tables:
         temp_table_cls = temp_table_mngr(session).create_id_table()
 

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -573,7 +573,7 @@ def _run_once(rses_to_process, chunk_size, greedy, scheme,
         # List and mark BEING_DELETED the files to delete
         del_start_time = time.time()
         try:
-            use_temp_tables = config_get_bool('core', 'use_temp_tables', default=False)
+            use_temp_tables = config_get_bool('core', 'use_temp_tables', default=True)
             with METRICS.timer('list_unlocked_replicas'):
                 if only_delete_obsolete:
                     logger(logging.DEBUG, 'Will run list_and_mark_unlocked_replicas on %s. No space needed, will only delete EPOCH tombstoned replicas', rse.name)

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -209,7 +209,12 @@ def test_multihop_sources_created(rse_factory, did_factory, root_account, core_c
     'rucio.daemons.reaper.reaper.REGION',
     'rucio.core.rse_expression_parser.REGION',  # The list of multihop RSEs is retrieved by an expression
 ]}], indirect=True)
-def test_source_avoid_deletion(caches_mock, core_config_mock, rse_factory, did_factory, root_account):
+@pytest.mark.parametrize("file_config_mock", [
+    # Run test twice: with, and without, temp tables
+    {"overrides": [('core', 'use_temp_tables', 'True')]},
+    {"overrides": [('core', 'use_temp_tables', 'False')]},
+], indirect=True)
+def test_source_avoid_deletion(caches_mock, core_config_mock, rse_factory, did_factory, root_account, file_config_mock):
     """ Test that sources on a file block it from deletion """
 
     _, reaper_region, _ = caches_mock


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
