### PR TITLE
Tests: fix nightly client tests workflow

### DIFF
--- a/etc/docker/test/matrix_nightly.yml
+++ b/etc/docker/test/matrix_nightly.yml
@@ -35,7 +35,7 @@ suites:
   - id: client_syntax
     RUN_HTTPD: false
   - id: client
-    RDBMS: sqlite
+    RDBMS: postgres14
   - id: remote_dbs
     RDBMS:
       - oracle


### PR DESCRIPTION
Since we activated the temporary table by default, nightly tests fail on centos7 because sqlite is too old and doesn't support the needed functions.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
