### PR TITLE
Clients: also bundle merger_rucio_configs.py

### DIFF
--- a/setup_rucio_client.py
+++ b/setup_rucio_client.py
@@ -39,6 +39,7 @@ description = "Rucio Client Lite Package"
 data_files = [
     ('', ['requirements.txt']),
     ('etc/', ['etc/rse-accounts.cfg.template', 'etc/rucio.cfg.template', 'etc/rucio.cfg.atlas.client.template']),
+    ('rucio_client/', ['tools/merge_rucio_configs.py']),
 ]
 scripts = ['bin/rucio', 'bin/rucio-admin']
 


### PR DESCRIPTION
This will be useful in the clients container to get rid of the old jinja script for doing the same job:
https://github.com/rucio/containers/blob/b067d3e6fe4fd1380878e5741ed08d534cfcf0fb/clients/rucio.cfg.j2#L1

Put it into a different directory to avoid conflict with the server one if we install both the client and rucio itself.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
