### PR TITLE
Transfers: allow configuring intermediate hop RSE expression. Fix #6163

### DIFF
--- a/lib/rucio/tests/test_conveyor.py
+++ b/lib/rucio/tests/test_conveyor.py
@@ -1389,6 +1389,7 @@ def test_multi_vo_certificates(file_config_mock, rse_factory, did_factory, scope
     {"table_content": [
         ('transfers', 'use_multihop', True),
         ('transfers', 'multihop_tombstone_delay', -1),  # Set OBSOLETE tombstone for intermediate replicas
+        ('transfers', 'multihop_rse_expression', '*'),
     ]},
 ], indirect=True)
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
@@ -1422,7 +1423,6 @@ def test_two_multihops_same_intermediate_rse(rse_factory, did_factory, root_acco
     all_rses = [rse1_id, rse2_id, rse3_id, rse4_id, rse5_id, rse6_id, rse7_id]
     for rse_id in all_rses:
         rse_core.add_rse_attribute(rse_id, 'fts', TEST_FTS_HOST)
-        rse_core.add_rse_attribute(rse_id, 'available_for_multihop', True)
         rse_core.set_rse_limits(rse_id=rse_id, name='MinFreeSpace', value=1)
         rse_core.set_rse_usage(rse_id=rse_id, source='storage', used=1, free=0)
     distance_core.add_distance(rse1_id, rse2_id, distance=10)

--- a/lib/rucio/tests/test_conveyor_submitter.py
+++ b/lib/rucio/tests/test_conveyor_submitter.py
@@ -112,12 +112,14 @@ def test_request_submitted_in_order(rse_factory, did_factory, root_account, file
     {
         "table_content": [
             ('transfers', 'use_multihop', True),
+            ('transfers', 'multihop_rse_expression', '*'),
             ('core', 'use_temp_tables', False),
         ]
     },
     {
         "table_content": [
             ('transfers', 'use_multihop', True),
+            ('transfers', 'multihop_rse_expression', '*'),
             ('core', 'use_temp_tables', True),
         ]
     }
@@ -138,9 +140,6 @@ def test_multihop_sources_created(rse_factory, did_factory, root_account, core_c
 
     jump_rses = [jump_rse1_id, jump_rse2_id, jump_rse3_id]
     all_rses = jump_rses + [src_rse_id, dst_rse_id]
-
-    for rse_id in jump_rses:
-        rse_core.add_rse_attribute(rse_id, 'available_for_multihop', True)
 
     rse_tombstone_delay = 3600
     rse_multihop_tombstone_delay = 12 * 3600


### PR DESCRIPTION
This will allow to have a dynamic list of RSEs, which depends on their utilisation. For example: `available_for_multihop=true&freespace>500`.

It will also allow people to activate multihop globally with one configuration value: `*`.

The commit also fixes one configuration retrieval related to #6107.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
