### PR TITLE
Patch 6159 checks for available replicas

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -3133,15 +3133,15 @@ def get_and_lock_file_replicas_for_dataset(scope, name, nowait=False, restrict_r
                                           models.DataIdentifierAssociation.md5,
                                           models.DataIdentifierAssociation.adler32,
                                           models.RSEFileAssociation)\
-                                   .with_hint(models.DataIdentifierAssociation,
-                                              "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
-                                              'oracle')\
-                                   .filter(and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
-                                                models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
-                                                models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
-                                                or_(*rse_clause)))\
-                                   .filter(models.DataIdentifierAssociation.scope == scope,
-                                           models.DataIdentifierAssociation.name == name)
+                        .with_hint(models.DataIdentifierAssociation,
+                                   "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
+                                   'oracle')\
+                        .filter(and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
+                                     models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
+                                     models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
+                                     or_(*rse_clause)))\
+                        .filter(models.DataIdentifierAssociation.scope == scope,
+                                models.DataIdentifierAssociation.name == name)
 
     else:
         query = session.query(models.DataIdentifierAssociation.child_scope,
@@ -3173,16 +3173,16 @@ def get_and_lock_file_replicas_for_dataset(scope, name, nowait=False, restrict_r
                                           models.DataIdentifierAssociation.md5,
                                           models.DataIdentifierAssociation.adler32,
                                           models.RSEFileAssociation)\
-                                   .with_hint(models.DataIdentifierAssociation,
-                                              "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
-                                              'oracle')\
-                                   .outerjoin(models.RSEFileAssociation,
-                                              and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
-                                                   models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
-                                                   models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
-                                                   or_(*rse_clause)))\
-                                   .filter(models.DataIdentifierAssociation.scope == scope,
-                                           models.DataIdentifierAssociation.name == name)
+                        .with_hint(models.DataIdentifierAssociation,
+                                   "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
+                                   'oracle')\
+                        .outerjoin(models.RSEFileAssociation,
+                                   and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
+                                        models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
+                                        models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
+                                        or_(*rse_clause)))\
+                        .filter(models.DataIdentifierAssociation.scope == scope,
+                                models.DataIdentifierAssociation.name == name)
 
     if total_threads and total_threads > 1:
         query = filter_thread_work(session=session, query=query, total_threads=total_threads,
@@ -3243,14 +3243,14 @@ def get_source_replicas_for_dataset(scope, name, source_rses=None,
                 query = session.query(models.DataIdentifierAssociation.child_scope,
                                       models.DataIdentifierAssociation.child_name,
                                       models.RSEFileAssociation.rse_id)\
-                               .with_hint(models.DataIdentifierAssociation, "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)", 'oracle')\
-                               .outerjoin(models.RSEFileAssociation,
-                                          and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
-                                               models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
-                                               models.RSEFileAssociation.state == ReplicaState.AVAILABLE,
-                                               or_(*rse_clause)))\
-                               .filter(models.DataIdentifierAssociation.scope == scope,
-                                       models.DataIdentifierAssociation.name == name)
+                    .with_hint(models.DataIdentifierAssociation, "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)", 'oracle')\
+                    .outerjoin(models.RSEFileAssociation,
+                               and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
+                                    models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
+                                    models.RSEFileAssociation.state == ReplicaState.AVAILABLE,
+                                    or_(*rse_clause)))\
+                    .filter(models.DataIdentifierAssociation.scope == scope,
+                            models.DataIdentifierAssociation.name == name)
 
     if total_threads and total_threads > 1:
         query = filter_thread_work(session=session, query=query, total_threads=total_threads,
@@ -3536,7 +3536,7 @@ def list_dataset_replicas_vp(scope, name, deep=False, *, session: "Session", log
 
     if vp_replies != ['other']:
         # check that there is at least one regular replica
-        # that is not on tape and has a protocol  with scheme "root"
+        # that is not on tape and has a protocol with scheme "root"
         # and can be accessed from WAN
         accessible_replica_exists = False
         for reply in list_dataset_replicas(scope=scope, name=name, deep=deep, session=session):
@@ -3726,12 +3726,12 @@ def update_collection_replica(update_request, *, session: "Session"):
             session.query(models.CollectionReplica).filter_by(scope=update_request['scope'],
                                                               name=update_request['name'],
                                                               rse_id=update_request['rse_id'])\
-                                                   .delete()
+                .delete()
         else:
             updated_replica = session.query(models.CollectionReplica).filter_by(scope=update_request['scope'],
                                                                                 name=update_request['name'],
                                                                                 rse_id=update_request['rse_id'])\
-                                                                     .one()
+                .one()
             updated_replica.state = ds_replica_state
             updated_replica.available_replicas_cnt = available_replicas
             updated_replica.length = ds_length

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -3540,7 +3540,8 @@ def list_dataset_replicas_vp(scope, name, deep=False, *, session: "Session", log
         # and can be accessed from WAN
         accessible_replica_exists = False
         for reply in list_dataset_replicas(scope=scope, name=name, deep=deep, session=session):
-            print(">>>>>", reply['state'], "<<<<<<<")
+            if reply['state'] == 'UNAVAILABLE':
+                continue
             rse_info = rsemgr.get_rse_info(rse=reply['rse'], vo=scope.vo, session=session)
             if rse_info['rse_type'] == 'TAPE':
                 continue

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -3133,15 +3133,15 @@ def get_and_lock_file_replicas_for_dataset(scope, name, nowait=False, restrict_r
                                           models.DataIdentifierAssociation.md5,
                                           models.DataIdentifierAssociation.adler32,
                                           models.RSEFileAssociation)\
-                        .with_hint(models.DataIdentifierAssociation,
-                                   "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
-                                   'oracle')\
-                        .filter(and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
-                                     models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
-                                     models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
-                                     or_(*rse_clause)))\
-                        .filter(models.DataIdentifierAssociation.scope == scope,
-                                models.DataIdentifierAssociation.name == name)
+                                   .with_hint(models.DataIdentifierAssociation,
+                                              "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
+                                              'oracle')\
+                                   .filter(and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
+                                                models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
+                                                models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
+                                                or_(*rse_clause)))\
+                                   .filter(models.DataIdentifierAssociation.scope == scope,
+                                           models.DataIdentifierAssociation.name == name)
 
     else:
         query = session.query(models.DataIdentifierAssociation.child_scope,
@@ -3173,16 +3173,16 @@ def get_and_lock_file_replicas_for_dataset(scope, name, nowait=False, restrict_r
                                           models.DataIdentifierAssociation.md5,
                                           models.DataIdentifierAssociation.adler32,
                                           models.RSEFileAssociation)\
-                        .with_hint(models.DataIdentifierAssociation,
-                                   "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
-                                   'oracle')\
-                        .outerjoin(models.RSEFileAssociation,
-                                   and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
-                                        models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
-                                        models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
-                                        or_(*rse_clause)))\
-                        .filter(models.DataIdentifierAssociation.scope == scope,
-                                models.DataIdentifierAssociation.name == name)
+                                   .with_hint(models.DataIdentifierAssociation,
+                                              "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
+                                              'oracle')\
+                                   .outerjoin(models.RSEFileAssociation,
+                                              and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
+                                                   models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
+                                                   models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
+                                                   or_(*rse_clause)))\
+                                   .filter(models.DataIdentifierAssociation.scope == scope,
+                                           models.DataIdentifierAssociation.name == name)
 
     if total_threads and total_threads > 1:
         query = filter_thread_work(session=session, query=query, total_threads=total_threads,
@@ -3243,14 +3243,14 @@ def get_source_replicas_for_dataset(scope, name, source_rses=None,
                 query = session.query(models.DataIdentifierAssociation.child_scope,
                                       models.DataIdentifierAssociation.child_name,
                                       models.RSEFileAssociation.rse_id)\
-                    .with_hint(models.DataIdentifierAssociation, "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)", 'oracle')\
-                    .outerjoin(models.RSEFileAssociation,
-                               and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
-                                    models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
-                                    models.RSEFileAssociation.state == ReplicaState.AVAILABLE,
-                                    or_(*rse_clause)))\
-                    .filter(models.DataIdentifierAssociation.scope == scope,
-                            models.DataIdentifierAssociation.name == name)
+                               .with_hint(models.DataIdentifierAssociation, "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)", 'oracle')\
+                               .outerjoin(models.RSEFileAssociation,
+                                          and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
+                                               models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
+                                               models.RSEFileAssociation.state == ReplicaState.AVAILABLE,
+                                               or_(*rse_clause)))\
+                               .filter(models.DataIdentifierAssociation.scope == scope,
+                                       models.DataIdentifierAssociation.name == name)
 
     if total_threads and total_threads > 1:
         query = filter_thread_work(session=session, query=query, total_threads=total_threads,
@@ -3726,12 +3726,12 @@ def update_collection_replica(update_request, *, session: "Session"):
             session.query(models.CollectionReplica).filter_by(scope=update_request['scope'],
                                                               name=update_request['name'],
                                                               rse_id=update_request['rse_id'])\
-                .delete()
+                                                   .delete()
         else:
             updated_replica = session.query(models.CollectionReplica).filter_by(scope=update_request['scope'],
                                                                                 name=update_request['name'],
                                                                                 rse_id=update_request['rse_id'])\
-                .one()
+                                                                     .one()
             updated_replica.state = ds_replica_state
             updated_replica.available_replicas_cnt = available_replicas
             updated_replica.length = ds_length

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -3540,6 +3540,8 @@ def list_dataset_replicas_vp(scope, name, deep=False, *, session: "Session", log
         # and can be accessed from WAN
         accessible_replica_exists = False
         for reply in list_dataset_replicas(scope=scope, name=name, deep=deep, session=session):
+            if reply['state'] != ReplicaState.AVAILABLE:
+                continue
             rse_info = rsemgr.get_rse_info(rse=reply['rse'], vo=scope.vo, session=session)
             if rse_info['rse_type'] == 'TAPE':
                 continue

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -3133,15 +3133,15 @@ def get_and_lock_file_replicas_for_dataset(scope, name, nowait=False, restrict_r
                                           models.DataIdentifierAssociation.md5,
                                           models.DataIdentifierAssociation.adler32,
                                           models.RSEFileAssociation)\
-                                   .with_hint(models.DataIdentifierAssociation,
-                                              "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
-                                              'oracle')\
-                                   .filter(and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
-                                                models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
-                                                models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
-                                                or_(*rse_clause)))\
-                                   .filter(models.DataIdentifierAssociation.scope == scope,
-                                           models.DataIdentifierAssociation.name == name)
+                        .with_hint(models.DataIdentifierAssociation,
+                                   "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
+                                   'oracle')\
+                        .filter(and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
+                                     models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
+                                     models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
+                                     or_(*rse_clause)))\
+                        .filter(models.DataIdentifierAssociation.scope == scope,
+                                models.DataIdentifierAssociation.name == name)
 
     else:
         query = session.query(models.DataIdentifierAssociation.child_scope,
@@ -3173,16 +3173,16 @@ def get_and_lock_file_replicas_for_dataset(scope, name, nowait=False, restrict_r
                                           models.DataIdentifierAssociation.md5,
                                           models.DataIdentifierAssociation.adler32,
                                           models.RSEFileAssociation)\
-                                   .with_hint(models.DataIdentifierAssociation,
-                                              "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
-                                              'oracle')\
-                                   .outerjoin(models.RSEFileAssociation,
-                                              and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
-                                                   models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
-                                                   models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
-                                                   or_(*rse_clause)))\
-                                   .filter(models.DataIdentifierAssociation.scope == scope,
-                                           models.DataIdentifierAssociation.name == name)
+                        .with_hint(models.DataIdentifierAssociation,
+                                   "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)",
+                                   'oracle')\
+                        .outerjoin(models.RSEFileAssociation,
+                                   and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
+                                        models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
+                                        models.RSEFileAssociation.state != ReplicaState.BEING_DELETED,
+                                        or_(*rse_clause)))\
+                        .filter(models.DataIdentifierAssociation.scope == scope,
+                                models.DataIdentifierAssociation.name == name)
 
     if total_threads and total_threads > 1:
         query = filter_thread_work(session=session, query=query, total_threads=total_threads,
@@ -3243,14 +3243,14 @@ def get_source_replicas_for_dataset(scope, name, source_rses=None,
                 query = session.query(models.DataIdentifierAssociation.child_scope,
                                       models.DataIdentifierAssociation.child_name,
                                       models.RSEFileAssociation.rse_id)\
-                               .with_hint(models.DataIdentifierAssociation, "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)", 'oracle')\
-                               .outerjoin(models.RSEFileAssociation,
-                                          and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
-                                               models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
-                                               models.RSEFileAssociation.state == ReplicaState.AVAILABLE,
-                                               or_(*rse_clause)))\
-                               .filter(models.DataIdentifierAssociation.scope == scope,
-                                       models.DataIdentifierAssociation.name == name)
+                    .with_hint(models.DataIdentifierAssociation, "INDEX_RS_ASC(CONTENTS CONTENTS_PK) NO_INDEX_FFS(CONTENTS CONTENTS_PK)", 'oracle')\
+                    .outerjoin(models.RSEFileAssociation,
+                               and_(models.DataIdentifierAssociation.child_scope == models.RSEFileAssociation.scope,
+                                    models.DataIdentifierAssociation.child_name == models.RSEFileAssociation.name,
+                                    models.RSEFileAssociation.state == ReplicaState.AVAILABLE,
+                                    or_(*rse_clause)))\
+                    .filter(models.DataIdentifierAssociation.scope == scope,
+                            models.DataIdentifierAssociation.name == name)
 
     if total_threads and total_threads > 1:
         query = filter_thread_work(session=session, query=query, total_threads=total_threads,
@@ -3540,6 +3540,7 @@ def list_dataset_replicas_vp(scope, name, deep=False, *, session: "Session", log
         # and can be accessed from WAN
         accessible_replica_exists = False
         for reply in list_dataset_replicas(scope=scope, name=name, deep=deep, session=session):
+            print(">>>>>", reply['state'], "<<<<<<<")
             rse_info = rsemgr.get_rse_info(rse=reply['rse'], vo=scope.vo, session=session)
             if rse_info['rse_type'] == 'TAPE':
                 continue
@@ -3724,12 +3725,12 @@ def update_collection_replica(update_request, *, session: "Session"):
             session.query(models.CollectionReplica).filter_by(scope=update_request['scope'],
                                                               name=update_request['name'],
                                                               rse_id=update_request['rse_id'])\
-                                                   .delete()
+                .delete()
         else:
             updated_replica = session.query(models.CollectionReplica).filter_by(scope=update_request['scope'],
                                                                                 name=update_request['name'],
                                                                                 rse_id=update_request['rse_id'])\
-                                                                     .one()
+                .one()
             updated_replica.state = ds_replica_state
             updated_replica.available_replicas_cnt = available_replicas
             updated_replica.length = ds_length

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -3540,7 +3540,7 @@ def list_dataset_replicas_vp(scope, name, deep=False, *, session: "Session", log
         # and can be accessed from WAN
         accessible_replica_exists = False
         for reply in list_dataset_replicas(scope=scope, name=name, deep=deep, session=session):
-            if reply['state'] == 'UNAVAILABLE':
+            if reply['state'] != ReplicaState.AVAILABLE:
                 continue
             rse_info = rsemgr.get_rse_info(rse=reply['rse'], vo=scope.vo, session=session)
             if rse_info['rse_type'] == 'TAPE':


### PR DESCRIPTION
VP replicas should be delivered only when there is an available replica that is not on the TAPE.
This change just adds a condition that the replica is AVAILABLE.