### PR TITLE
Transfers: apply hop penalty from the node, not towards. Fix #6170

### DIFF
--- a/lib/rucio/core/topology.py
+++ b/lib/rucio/core/topology.py
@@ -161,10 +161,12 @@ class Topology:
                 if adjacent_node not in remaining_sources and adjacent_node not in self.multihop_rses:
                     continue
 
-                try:
-                    hop_penalty = int(self.rse_collection[adjacent_node].attributes.get('hop_penalty', HOP_PENALTY))
-                except ValueError:
-                    hop_penalty = HOP_PENALTY
+                hop_penalty = 0
+                if current_node != dest_rse_id:
+                    try:
+                        hop_penalty = int(self.rse_collection[current_node].attributes.get('hop_penalty', HOP_PENALTY))
+                    except ValueError:
+                        hop_penalty = HOP_PENALTY
                 new_adjacent_distance = current_distance + link_distance + hop_penalty
                 if next_hop.get(adjacent_node, {}).get('cumulated_distance', 9999) <= new_adjacent_distance:
                     continue


### PR DESCRIPTION
This way it will not be applied on the first hop, while still correctly
using the RSE attribute for multi-hop transfers. 

This is a slight behavioral change. Under some combinations of short
distances, more single hops will be preferred over multihops. But it's 
unlikely that anybody will complain about this behavioral change. 
Moreover, it's more in line with the definition of "hop_penalty".