### PR TITLE
Transfers: delete 1.27 compatibility code. Closes #6172

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -960,11 +960,6 @@ def is_intermediate_hop(request):
     """
     Check if the request is an intermediate hop in a multi-hop transfer.
     """
-    if (request['attributes'] or {}).get('next_hop_request_id'):
-        # This is only needed during the migration. When pre- 1.28 requests still exist
-        # in the database and we have to handle them correctly.
-        # TODO: remove this if
-        return True
     if (request['attributes'] or {}).get('is_intermediate_hop'):
         return True
     return False


### PR DESCRIPTION
When we released 1.28, the multihop behavior was changed. The removed code allowed correct handling of transfers created by rucio 1.27.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
