### PR TITLE
Core : Add missing permission for set_metadata_bulk : Closes #5880 

### DIFF
--- a/lib/rucio/core/permission/atlas.py
+++ b/lib/rucio/core/permission/atlas.py
@@ -27,6 +27,7 @@ from rucio.db.sqla.constants import IdentityType, BadPFNStatus
 if TYPE_CHECKING:
     from typing import Dict, Optional
     from sqlalchemy.orm import Session
+    from rucio.common.types import InternalAccount
 
 
 def has_permission(issuer, action, kwargs, *, session: "Optional[Session]" = None):
@@ -80,6 +81,7 @@ def has_permission(issuer, action, kwargs, *, session: "Optional[Session]" = Non
             'attach_dids_to_dids': perm_attach_dids_to_dids,
             'create_did_sample': perm_create_did_sample,
             'set_metadata': perm_set_metadata,
+            'set_metadata_bulk': perm_set_metadata_bulk,
             'set_status': perm_set_status,
             'queue_requests': perm_queue_requests,
             'set_rse_usage': perm_set_rse_usage,
@@ -698,6 +700,18 @@ def perm_detach_dids(issuer, kwargs, *, session: "Optional[Session]" = None):
     :returns: True if account is allowed, otherwise False
     """
     return perm_attach_dids(issuer, kwargs, session=session)
+
+
+def perm_set_metadata_bulk(issuer: "InternalAccount", kwargs: dict, *, session: "Optional[Session]" = None) -> bool:
+    """
+    Checks if an account can set a metadata on a data identifier.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
+    :returns: True if account is allowed, otherwise False
+    """
+    return perm_set_metadata(issuer, kwargs, session=session)
 
 
 def perm_set_metadata(issuer, kwargs, *, session: "Optional[Session]" = None):

--- a/lib/rucio/core/permission/belleii.py
+++ b/lib/rucio/core/permission/belleii.py
@@ -80,6 +80,7 @@ def has_permission(issuer: "InternalAccount", action: str, kwargs: dict, *, sess
             'attach_dids_to_dids': perm_attach_dids_to_dids,
             'create_did_sample': perm_create_did_sample,
             'set_metadata': perm_set_metadata,
+            'set_metadata_bulk': perm_set_metadata_bulk,
             'set_status': perm_set_status,
             'queue_requests': perm_queue_requests,
             'set_rse_usage': perm_set_rse_usage,
@@ -566,6 +567,22 @@ def perm_detach_dids(issuer: "InternalAccount", kwargs: dict, *, session: "Optio
     """
     return perm_default(issuer, kwargs, session=session)\
         or has_account_attribute(account=issuer, key='did_admin', session=session)\
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
+
+
+def perm_set_metadata_bulk(issuer: "InternalAccount", kwargs: dict, *, session: "Optional[Session]" = None) -> bool:
+    """
+    Checks if an account can set a metadata on a data identifier.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
+    :returns: True if account is allowed, otherwise False
+    """
+    meta = get_metadata(kwargs['scope'], kwargs['name'], session=session)
+    return perm_default(issuer, kwargs, session=session)\
+        or has_account_attribute(account=issuer, key='did_admin', session=session)\
+        or meta.get('account', '') == issuer\
         or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -26,6 +26,7 @@ from rucio.db.sqla.constants import IdentityType
 if TYPE_CHECKING:
     from typing import Optional
     from sqlalchemy.orm import Session
+    from rucio.common.types import InternalAccount
 
 
 def has_permission(issuer, action, kwargs, *, session: "Optional[Session]" = None):
@@ -79,6 +80,7 @@ def has_permission(issuer, action, kwargs, *, session: "Optional[Session]" = Non
             'attach_dids_to_dids': perm_attach_dids_to_dids,
             'create_did_sample': perm_create_did_sample,
             'set_metadata': perm_set_metadata,
+            'set_metadata_bulk': perm_set_metadata_bulk,
             'set_status': perm_set_status,
             'queue_requests': perm_queue_requests,
             'set_rse_usage': perm_set_rse_usage,
@@ -561,6 +563,18 @@ def perm_detach_dids(issuer, kwargs, *, session: "Optional[Session]" = None):
     :returns: True if account is allowed, otherwise False
     """
     return perm_attach_dids(issuer, kwargs, session=session)
+
+
+def perm_set_metadata_bulk(issuer: "InternalAccount", kwargs: dict, *, session: "Optional[Session]" = None) -> bool:
+    """
+    Checks if an account can set a metadata on a data identifier.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
+    :returns: True if account is allowed, otherwise False
+    """
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_set_metadata(issuer, kwargs, *, session: "Optional[Session]" = None):


### PR DESCRIPTION
This PR address the missing permission for `set_metadata_bulk` and also fix some Belle II permissions