### PR TITLE
Allow for pushing metrics to servers

### DIFF
--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -327,7 +327,7 @@ class MetricManager:
     """
 
     def __init__(self, prefix: "Optional[str]" = None, module: "Optional[str]" = None,
-                 registry: "Optional[CollectorRegistry]" = None, push_gateways: "Optional[List[str]]" = None):
+                 registry: "Optional[CollectorRegistry]" = None, push_gateways: "Optional[Sequence[str]]" = None):
         if prefix:
             self.prefix = prefix
         elif module:
@@ -422,7 +422,7 @@ class MetricManager:
             return _decorator(original_function)
         return _decorator
 
-    def push_metrics_to_gw(self, job=None, grouping_key=None):
+    def push_metrics_to_gw(self, job: "Optional[str]" = None, grouping_key: "Optional[Sequence[str]]" = None):
         """
         Push the metrics out to the prometheus push gateways. This is useful for short-running programs which don't
         live long enough to be reliably scraped in the prometheus pull model.

--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -334,7 +334,7 @@ class MetricManager:
             self.prefix = module
         else:
             self.prefix = None
-        self.registry = registry
+        self.registry = registry or REGISTRY
         self.push_gateways = push_gateways or []
 
     def full_name(self, name: str):
@@ -422,7 +422,7 @@ class MetricManager:
             return _decorator(original_function)
         return _decorator
 
-    def push_metrics_to_gw(self, job: "Optional[str]" = None, grouping_key: "Optional[Sequence[str]]" = None) -> None:
+    def push_metrics_to_gw(self, job: "Optional[str]" = None, grouping_key: "Optional[Dict[str, Any]]" = None) -> None:
         """
         Push the metrics out to the prometheus push gateways. This is useful for short-running programs which don't
         live long enough to be reliably scraped in the prometheus pull model.

--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -38,7 +38,7 @@ from rucio.common.stopwatch import Stopwatch
 from rucio.common.utils import retrying
 
 if TYPE_CHECKING:
-    from typing import Callable, Dict, Iterable, Optional, Sequence, TypeVar
+    from typing import Any, Callable, Dict, Iterable, Optional, Sequence, TypeVar
 
     T = TypeVar('T')
 

--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -342,6 +342,9 @@ class MetricManager:
             return f'{self.prefix}.{name}'
         return name
 
+    def get_registry(self) -> CollectorRegistry:
+        return self.registry
+
     def counter(
             self,
             name: str,

--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -422,7 +422,7 @@ class MetricManager:
             return _decorator(original_function)
         return _decorator
 
-    def push_metrics_to_gw(self, job: "Optional[str]" = None, grouping_key: "Optional[Sequence[str]]" = None):
+    def push_metrics_to_gw(self, job: "Optional[str]" = None, grouping_key: "Optional[Sequence[str]]" = None) -> None:
         """
         Push the metrics out to the prometheus push gateways. This is useful for short-running programs which don't
         live long enough to be reliably scraped in the prometheus pull model.

--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -430,7 +430,7 @@ class MetricManager:
 
         if not job:
             job = Path(main.__file__).stem
-        grouping_key = grouping_key or []
+        grouping_key = grouping_key or {}
 
         for server in self.push_gateways:
             try:

--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -17,6 +17,7 @@
 Graphite and prometheus metrics
 """
 
+import __main__ as main
 import atexit
 import logging
 import os
@@ -25,11 +26,12 @@ from abc import abstractmethod
 from datetime import datetime, timedelta
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING
 from threading import Lock
 
-from prometheus_client import start_http_server, Counter, Gauge, Histogram, REGISTRY, CollectorRegistry, generate_latest, values, multiprocess
+from prometheus_client import (Counter, Gauge, Histogram, REGISTRY, CollectorRegistry, generate_latest, multiprocess,
+                               push_to_gateway, start_http_server, values)
 from statsd import StatsClient
+from typing import TYPE_CHECKING
 
 from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.stopwatch import Stopwatch
@@ -275,12 +277,14 @@ def _fetch_or_create_counter(
         name: str,
         labelnames: "Optional[Sequence[str]]" = None,
         documentation: "Optional[str]" = None,
+        registry: "Optional[CollectorRegistry]" = None,
 ) -> _MultiCounter:
     return _fetch_or_create_metric(
         name=name,
         labelnames=labelnames,
         container=COUNTERS,
-        factory=lambda _name, _labelnames: _MultiCounter(statsd=_name, labelnames=_labelnames, documentation=documentation)
+        factory=lambda _name, _labelnames: _MultiCounter(statsd=_name, labelnames=_labelnames,
+                                                         documentation=documentation, registry=registry)
     )
 
 
@@ -288,12 +292,14 @@ def _fetch_or_create_gauge(
         name: str,
         labelnames: "Optional[Sequence[str]]" = None,
         documentation: "Optional[str]" = None,
+        registry: "Optional[CollectorRegistry]" = None,
 ) -> _MultiGauge:
     return _fetch_or_create_metric(
         name=name,
         labelnames=labelnames,
         container=GAUGES,
-        factory=lambda _name, _labelnames: _MultiGauge(statsd=_name, labelnames=_labelnames, documentation=documentation)
+        factory=lambda _name, _labelnames: _MultiGauge(statsd=_name, labelnames=_labelnames,
+                                                       documentation=documentation, registry=registry)
     )
 
 
@@ -301,13 +307,15 @@ def _fetch_or_create_timer(
         name: str,
         labelnames: "Optional[Sequence[str]]" = None,
         documentation: "Optional[str]" = None,
-        buckets: "Iterable[float]" = _HISTOGRAM_DEFAULT_BUCKETS
+        registry: "Optional[CollectorRegistry]" = None,
+        buckets: "Iterable[float]" = _HISTOGRAM_DEFAULT_BUCKETS,
 ) -> _MultiTiming:
     return _fetch_or_create_metric(
         name=name,
         labelnames=labelnames,
         container=TIMINGS,
-        factory=lambda _name, _labels: _MultiTiming(statsd=_name, labelnames=_labels, documentation=documentation, buckets=buckets)
+        factory=lambda _name, _labels: _MultiTiming(statsd=_name, labelnames=_labels, documentation=documentation,
+                                                    registry=registry, buckets=buckets)
     )
 
 
@@ -317,13 +325,17 @@ class MetricManager:
     Wrapper for metrics which prefixes them automatically with the given prefix or,
     alternatively, with the path of the module.
     """
-    def __init__(self, prefix: "Optional[str]" = None, module: "Optional[str]" = None):
+
+    def __init__(self, prefix: "Optional[str]" = None, module: "Optional[str]" = None,
+                 registry: "Optional[CollectorRegistry]" = None, push_gateways: "Optional[List[str]]" = None):
         if prefix:
             self.prefix = prefix
         elif module:
             self.prefix = module
         else:
             self.prefix = None
+        self.registry = registry
+        self.push_gateways = push_gateways or []
 
     def full_name(self, name: str):
         if self.prefix:
@@ -409,3 +421,19 @@ class MetricManager:
         if original_function:
             return _decorator(original_function)
         return _decorator
+
+    def push_metrics_to_gw(self, job=None, grouping_key=None):
+        """
+        Push the metrics out to the prometheus push gateways. This is useful for short-running programs which don't
+        live long enough to be reliably scraped in the prometheus pull model.
+        """
+
+        if not job:
+            job = Path(main.__file__).stem
+        grouping_key = grouping_key or []
+
+        for server in self.push_gateways:
+            try:
+                push_to_gateway(server.strip(), job=job, registry=self.registry, grouping_key=grouping_key)
+            except:
+                continue


### PR DESCRIPTION
@rcarpa @bari12 

Here's the push method and the specification/retrieval of the registry.

I also have a new version of the context manager originally defined here: https://github.com/rucio/probes/blob/7b8ba2d345dd9d1795d44f3fc4222183c62a89f8/common/utils/common.py#L39

Which lets you do something like 

```
        with PrometheusPusher() as manager:
            (manager.gauge(name='statsd_name.{rse}.{country}.{rse_type}.{source}',
                           documentation='Space used at an RSE from various sources')
                    .labels(rse=rse['rse'], country=country, rse_type=rse_type, source=source)
                    .set(usage['used']))
```
And all the metrics you created in there get pushed at the end. Would you prefer I keep that in probes or put this in monitor.py too?