### PR TITLE
Tests: don't install as package in client tests

### DIFF
--- a/tools/test/install_script.sh
+++ b/tools/test/install_script.sh
@@ -20,7 +20,6 @@ echo "* Using $(which python) $(python --version 2>&1) and $(which pip) $(pip --
 
 if [ "$SUITE" == "client" -o "$SUITE" == "client_syntax" ]; then
     cd /usr/local/src/rucio
-    python setup_rucio_client.py install
     cp etc/docker/test/extra/rucio_client.cfg etc/rucio.cfg
 
 elif [ "$SUITE" == "syntax" -o "$SUITE" == "docs" ]; then


### PR DESCRIPTION
This results in easy_install being used, which is deprecated and uses deprecated features of setuptools, resulting in test failures.

As PATH is already correctly set to allow access to the `rucio` and `rucio-admin` binaries, this installation step is not required.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
