### PR TITLE
Core & Internals: handle root proxy for geoip sorting. Closes #6242

### DIFF
--- a/lib/rucio/core/replica_sorter.py
+++ b/lib/rucio/core/replica_sorter.py
@@ -313,7 +313,13 @@ def sort_geoip(dictreplica: "Dict", client_location: "Dict", ignore_error: bool 
     """
 
     def distance(pfn):
-        return __get_distance(urlparse(pfn).hostname, client_location, ignore_error)
+        url = urlparse(pfn)
+        if url.scheme == 'root':
+            # handle root proxy urls: root://10.0.0.1//root://192.168.1.1:1094//dpm/....
+            sub_url = urlparse(url.path.lstrip('/'))
+            if sub_url.scheme and sub_url.hostname:
+                url = sub_url
+        return __get_distance(url.hostname, client_location, ignore_error)
 
     return list(sorted(dictreplica, key=distance))
 


### PR DESCRIPTION
When proxy servers are used the distance must be computed towards the inner hostname, because the outer one is the proxy address and will be the same for all replicas.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
