### PR TITLE
Authentication: Restrict some permissions #6267

### DIFF
--- a/lib/rucio/core/permission/atlas.py
+++ b/lib/rucio/core/permission/atlas.py
@@ -303,7 +303,7 @@ def perm_add_scope(issuer, kwargs, *, session: "Optional[Session]" = None):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -372,7 +372,7 @@ def perm_add_account_identity(issuer, kwargs, *, session: "Optional[Session]" = 
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_account_identity(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -385,7 +385,7 @@ def perm_del_account_identity(issuer, kwargs, *, session: "Optional[Session]" = 
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_identity(issuer, kwargs, *, session: "Optional[Session]" = None):

--- a/lib/rucio/core/permission/cms.py
+++ b/lib/rucio/core/permission/cms.py
@@ -301,7 +301,7 @@ def perm_add_scope(issuer, kwargs, *, session: "Optional[Session]" = None):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -370,7 +370,7 @@ def perm_add_account_identity(issuer, kwargs, *, session: "Optional[Session]" = 
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_account_identity(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -383,7 +383,7 @@ def perm_del_account_identity(issuer, kwargs, *, session: "Optional[Session]" = 
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_identity(issuer, kwargs, *, session: "Optional[Session]" = None):

--- a/lib/rucio/core/permission/escape.py
+++ b/lib/rucio/core/permission/escape.py
@@ -275,7 +275,7 @@ def perm_add_scope(issuer, kwargs, *, session: "Optional[Session]" = None):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -344,7 +344,7 @@ def perm_add_account_identity(issuer, kwargs, *, session: "Optional[Session]" = 
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_account_identity(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -357,7 +357,7 @@ def perm_del_account_identity(issuer, kwargs, *, session: "Optional[Session]" = 
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_identity(issuer, kwargs, *, session: "Optional[Session]" = None):

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -279,7 +279,7 @@ def perm_add_scope(issuer, kwargs, *, session: "Optional[Session]" = None):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -348,7 +348,7 @@ def perm_add_account_identity(issuer, kwargs, *, session: "Optional[Session]" = 
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_account_identity(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -361,7 +361,7 @@ def perm_del_account_identity(issuer, kwargs, *, session: "Optional[Session]" = 
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_identity(issuer, kwargs, *, session: "Optional[Session]" = None):

--- a/lib/rucio/core/permission/generic_multi_vo.py
+++ b/lib/rucio/core/permission/generic_multi_vo.py
@@ -281,7 +281,7 @@ def perm_add_scope(issuer, kwargs, *, session: "Optional[Session]" = None):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -350,7 +350,7 @@ def perm_add_account_identity(issuer, kwargs, *, session: "Optional[Session]" = 
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_account_identity(issuer, kwargs, *, session: "Optional[Session]" = None):
@@ -363,7 +363,7 @@ def perm_del_account_identity(issuer, kwargs, *, session: "Optional[Session]" = 
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_identity(issuer, kwargs, *, session: "Optional[Session]" = None):

--- a/tests/test_multi_vo.py
+++ b/tests/test_multi_vo.py
@@ -150,9 +150,7 @@ class TestVOCoreAPI:
         with pytest.raises(AccessDenied):
             add_rse(rse_name, 'super_root', vo='def')
         with pytest.raises(AccessDenied):
-            add_scope(scope, 'root', 'super_root', vo='def')
-        add_scope(scope, 'super_root', 'super_root', vo='def')
-        assert scope in [s for s in list_scopes(filter_={}, vo='def')]
+            add_scope(scope, 'super_root', 'super_root', vo='def')
 
     @pytest.mark.noparallel(reason='changes global configuration value')
     def test_super_root_naming(self, vo, second_vo):


### PR DESCRIPTION
This affects the following:

* Adding new scopes (perm_add_scope)
* Adding new identities (perm_add_account_identity)
* Deleting existing identities (perm_del_account_identity)

Previously, they were unrestricted (for the latter two, they could only affect one's own account). Instead, they will now require administrative privileges.
