### PR TITLE
Authentication: Restrict some permissions #6267

### DIFF
--- a/lib/rucio/core/permission/atlas.py
+++ b/lib/rucio/core/permission/atlas.py
@@ -302,7 +302,7 @@ def perm_add_scope(issuer, kwargs, session=None):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, session=None):
@@ -371,7 +371,7 @@ def perm_add_account_identity(issuer, kwargs, session=None):
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_account_identity(issuer, kwargs, session=None):
@@ -384,7 +384,7 @@ def perm_del_account_identity(issuer, kwargs, session=None):
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_identity(issuer, kwargs, session=None):

--- a/lib/rucio/core/permission/cms.py
+++ b/lib/rucio/core/permission/cms.py
@@ -301,7 +301,7 @@ def perm_add_scope(issuer, kwargs, session=None):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, session=None):
@@ -370,7 +370,7 @@ def perm_add_account_identity(issuer, kwargs, session=None):
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_account_identity(issuer, kwargs, session=None):
@@ -383,7 +383,7 @@ def perm_del_account_identity(issuer, kwargs, session=None):
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_identity(issuer, kwargs, session=None):

--- a/lib/rucio/core/permission/escape.py
+++ b/lib/rucio/core/permission/escape.py
@@ -275,7 +275,7 @@ def perm_add_scope(issuer, kwargs, session=None):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, session=None):
@@ -344,7 +344,7 @@ def perm_add_account_identity(issuer, kwargs, session=None):
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_account_identity(issuer, kwargs, session=None):
@@ -357,7 +357,7 @@ def perm_del_account_identity(issuer, kwargs, session=None):
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_identity(issuer, kwargs, session=None):

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -278,7 +278,7 @@ def perm_add_scope(issuer, kwargs, session=None):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, session=None):
@@ -347,7 +347,7 @@ def perm_add_account_identity(issuer, kwargs, session=None):
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_account_identity(issuer, kwargs, session=None):
@@ -360,7 +360,7 @@ def perm_del_account_identity(issuer, kwargs, session=None):
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_identity(issuer, kwargs, session=None):

--- a/lib/rucio/core/permission/generic_multi_vo.py
+++ b/lib/rucio/core/permission/generic_multi_vo.py
@@ -281,7 +281,7 @@ def perm_add_scope(issuer, kwargs, session=None):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, session=None):
@@ -350,7 +350,7 @@ def perm_add_account_identity(issuer, kwargs, session=None):
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_account_identity(issuer, kwargs, session=None):
@@ -363,7 +363,7 @@ def perm_del_account_identity(issuer, kwargs, session=None):
     :returns: True if account is allowed, otherwise False
     """
 
-    return _is_root(issuer) or issuer == kwargs.get('account')
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
 
 def perm_del_identity(issuer, kwargs, session=None):

--- a/lib/rucio/tests/test_multi_vo.py
+++ b/lib/rucio/tests/test_multi_vo.py
@@ -177,9 +177,7 @@ class TestVOCoreAPI(unittest.TestCase):
         with pytest.raises(AccessDenied):
             add_rse(rse_name, 'super_root', vo='def')
         with pytest.raises(AccessDenied):
-            add_scope(scope, 'root', 'super_root', vo='def')
-        add_scope(scope, 'super_root', 'super_root', vo='def')
-        assert scope in [s for s in list_scopes(filter_={}, vo='def')]
+            add_scope(scope, 'super_root', 'super_root', vo='def')
 
     @pytest.mark.noparallel(reason='changes global configuration value')
     def test_super_root_naming(self):

--- a/lib/rucio/tests/test_permission.py
+++ b/lib/rucio/tests/test_permission.py
@@ -21,7 +21,7 @@ from rucio.common.config import config_get, config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.scope import add_scope
 from rucio.core.account import add_account_attribute, del_account_attribute
-from rucio.tests.common import scope_name_generator
+from rucio.tests.common import scope_name_generator, skip_non_belleii
 from rucio.tests.common_server import get_vo
 
 
@@ -58,8 +58,17 @@ class TestPermissionCoreApi(unittest.TestCase):
     @pytest.mark.noparallel(reason='Add/delete account attribute of an existing account')
     def test_permission_add_scope(self):
         """ PERMISSION(CORE): Check permission to add scope """
-        assert has_permission(issuer='root', action='add_scope', kwargs={'account': 'account1'}, **self.vo)
-        assert not has_permission(issuer=self.usr, action='add_scope', kwargs={'account': 'root'}, **self.vo)
+        assert has_permission(issuer='root', action='add_scope', kwargs={'account': 'root'}, **self.vo)
+        assert not has_permission(issuer=self.usr, action='add_scope', kwargs={'account': self.usr}, **self.vo)
+        add_account_attribute(InternalAccount(self.usr, **self.vo), 'admin', True)
+        assert has_permission(issuer=self.usr, action='add_scope', kwargs={'account': self.usr}, **self.vo)
+        del_account_attribute(InternalAccount(self.usr, **self.vo), 'admin')
+
+    @pytest.mark.noparallel(reason='Add/delete account attribute of an existing account')
+    @skip_non_belleii
+    def test_permission_add_scope_admin(self):
+        """ PERMISSION(CORE): Check permission to add scope with scope_admin attribute (Belle II)"""
+        assert not has_permission(issuer=self.usr, action='add_scope', kwargs={'account': self.usr}, **self.vo)
         add_account_attribute(InternalAccount(self.usr, **self.vo), 'scope_admin', True)
         assert has_permission(issuer=self.usr, action='add_scope', kwargs={'account': self.usr}, **self.vo)
         del_account_attribute(InternalAccount(self.usr, **self.vo), 'scope_admin')


### PR DESCRIPTION
This affects the following:

* Adding new scopes (perm_add_scope)
* Adding new identities (perm_add_account_identity)
* Deleting existing identities (perm_del_account_identity)

Previously, they were unrestricted (for the latter two, they could only affect one's own account). Instead, they will now require administrative privileges.

Same as #6274, but adapted for `release-1.29-LTS`.
