### PR TITLE
Core & Internals: run automatic import optimization

### DIFF
--- a/lib/rucio/api/account.py
+++ b/lib/rucio/api/account.py
@@ -18,12 +18,11 @@ from typing import TYPE_CHECKING
 import rucio.api.permission
 import rucio.common.exception
 import rucio.core.identity
-
+from rucio.common.schema import validate_schema
+from rucio.common.types import InternalAccount
+from rucio.common.utils import api_update_return_dict
 from rucio.core import account as account_core
 from rucio.core.rse import get_rse_id
-from rucio.common.schema import validate_schema
-from rucio.common.utils import api_update_return_dict
-from rucio.common.types import InternalAccount
 from rucio.db.sqla.constants import AccountType
 from rucio.db.sqla.session import read_session, stream_session, transactional_session
 

--- a/lib/rucio/api/account_limit.py
+++ b/lib/rucio/api/account_limit.py
@@ -17,10 +17,8 @@ from typing import TYPE_CHECKING
 
 import rucio.api.permission
 import rucio.common.exception
-
-from rucio.common.utils import api_update_return_dict
 from rucio.common.types import InternalAccount
-
+from rucio.common.utils import api_update_return_dict
 from rucio.core import account_limit as account_limit_core
 from rucio.core.account import account_exists
 from rucio.core.rse import get_rse_id, get_rse_name

--- a/lib/rucio/api/dirac.py
+++ b/lib/rucio/api/dirac.py
@@ -17,11 +17,10 @@ from typing import TYPE_CHECKING
 
 from rucio.api.permission import has_permission
 from rucio.api.scope import list_scopes
-
-from rucio.core.rse import get_rse_id
-from rucio.core import dirac
 from rucio.common.exception import AccessDenied
 from rucio.common.utils import extract_scope
+from rucio.core import dirac
+from rucio.core.rse import get_rse_id
 from rucio.db.sqla.session import transactional_session
 
 if TYPE_CHECKING:

--- a/lib/rucio/api/lifetime_exception.py
+++ b/lib/rucio/api/lifetime_exception.py
@@ -16,10 +16,10 @@
 from typing import TYPE_CHECKING
 
 from rucio.api import permission
-from rucio.core import lifetime_exception
 from rucio.common import exception
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import api_update_return_dict
+from rucio.core import lifetime_exception
 from rucio.db.sqla.session import stream_session, transactional_session
 
 if TYPE_CHECKING:

--- a/lib/rucio/api/permission.py
+++ b/lib/rucio/api/permission.py
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
-from copy import deepcopy
+from rucio.common.exception import RSENotFound
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core import permission
 from rucio.core.rse import get_rse_id
-from rucio.common.exception import RSENotFound
 from rucio.db.sqla.session import read_session
 
 if TYPE_CHECKING:

--- a/lib/rucio/api/quarantined_replica.py
+++ b/lib/rucio/api/quarantined_replica.py
@@ -16,11 +16,11 @@
 from typing import TYPE_CHECKING
 
 from rucio.api import permission
-from rucio.db.sqla.session import transactional_session
-from rucio.core.rse import get_rse_id
-from rucio.core.quarantined_replica import add_quarantined_replicas
-from rucio.common.types import InternalScope
 from rucio.common import exception
+from rucio.common.types import InternalScope
+from rucio.core.quarantined_replica import add_quarantined_replicas
+from rucio.core.rse import get_rse_id
+from rucio.db.sqla.session import transactional_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import uuid
 import datetime
+import uuid
 from typing import TYPE_CHECKING
 
 from rucio.api import permission
-from rucio.db.sqla.constants import BadFilesStatus
-from rucio.db.sqla.session import read_session, stream_session, transactional_session
-from rucio.core import replica
-from rucio.core.rse import get_rse_id, get_rse_name
 from rucio.common import exception
+from rucio.common.constants import SuspiciousAvailability
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import api_update_return_dict, invert_dict
-from rucio.common.constants import SuspiciousAvailability
+from rucio.core import replica
+from rucio.core.rse import get_rse_id, get_rse_name
+from rucio.db.sqla.constants import BadFilesStatus
+from rucio.db.sqla.session import read_session, stream_session, transactional_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/lib/rucio/api/scope.py
+++ b/lib/rucio/api/scope.py
@@ -17,10 +17,9 @@ from typing import TYPE_CHECKING
 
 import rucio.api.permission
 import rucio.common.exception
-
-from rucio.core import scope as core_scope
-from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.schema import validate_schema
+from rucio.common.types import InternalAccount, InternalScope
+from rucio.core import scope as core_scope
 from rucio.db.sqla.session import read_session, transactional_session
 
 if TYPE_CHECKING:

--- a/lib/rucio/api/subscription.py
+++ b/lib/rucio/api/subscription.py
@@ -13,10 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
-
 from collections import namedtuple
 from json import dumps, loads
+from typing import TYPE_CHECKING
 
 from rucio.api.permission import has_permission
 from rucio.common.exception import InvalidObject, AccessDenied

--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 from json import dumps
+from urllib.parse import quote_plus
 
 from requests.status_codes import codes
-from urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/accountlimitclient.py
+++ b/lib/rucio/client/accountlimitclient.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 from json import dumps
+from urllib.parse import quote_plus
 
 from requests.status_codes import codes
-from urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -23,16 +23,16 @@ import os
 import random
 import sys
 import time
+from configparser import NoOptionError, NoSectionError
 from os import environ, fdopen, path, makedirs, geteuid
 from shutil import move
 from tempfile import mkstemp
+from urllib.parse import urlparse
 
 from dogpile.cache import make_region
 from requests import Session, Response
 from requests.exceptions import ConnectionError
 from requests.status_codes import codes
-from configparser import NoOptionError, NoSectionError
-from urllib.parse import urlparse
 
 from rucio import version
 from rucio.common import exception

--- a/lib/rucio/client/client.py
+++ b/lib/rucio/client/client.py
@@ -19,9 +19,13 @@ Client class for callers of the Rucio system
 
 from rucio.client.accountclient import AccountClient
 from rucio.client.accountlimitclient import AccountLimitClient
+from rucio.client.configclient import ConfigClient
+from rucio.client.credentialclient import CredentialClient
 from rucio.client.didclient import DIDClient
+from rucio.client.diracclient import DiracClient
 from rucio.client.exportclient import ExportClient
 from rucio.client.importclient import ImportClient
+from rucio.client.lifetimeclient import LifetimeClient
 from rucio.client.lockclient import LockClient
 from rucio.client.metaclient import MetaClient
 from rucio.client.pingclient import PingClient
@@ -31,11 +35,7 @@ from rucio.client.rseclient import RSEClient
 from rucio.client.ruleclient import RuleClient
 from rucio.client.scopeclient import ScopeClient
 from rucio.client.subscriptionclient import SubscriptionClient
-from rucio.client.configclient import ConfigClient
 from rucio.client.touchclient import TouchClient
-from rucio.client.credentialclient import CredentialClient
-from rucio.client.diracclient import DiracClient
-from rucio.client.lifetimeclient import LifetimeClient
 
 
 class Client(AccountClient,

--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -15,9 +15,9 @@
 
 from datetime import datetime
 from json import dumps
+from urllib.parse import quote_plus
 
 from requests.status_codes import codes
-from urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/diracclient.py
+++ b/lib/rucio/client/diracclient.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from json import dumps
+
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -21,22 +21,21 @@ import os
 import random
 import shutil
 import signal
-import time
 import subprocess
-
+import time
 from queue import Queue, Empty, deque
 from threading import Thread
 
+from rucio import version
 from rucio.client.client import Client
 from rucio.common.config import config_get
-from rucio.common.exception import (InputValidationError, NoFilesDownloaded, NotAllFilesDownloaded, RucioException)
 from rucio.common.didtype import DID
+from rucio.common.exception import (InputValidationError, NoFilesDownloaded, NotAllFilesDownloaded, RucioException)
 from rucio.common.pcache import Pcache
+from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS, CHECKSUM_ALGO_DICT, PREFERRED_CHECKSUM
 from rucio.common.utils import adler32, detect_client_location, generate_uuid, parse_replicas_from_string, \
     send_trace, sizefmt, execute, parse_replicas_from_file, extract_scope
-from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS, CHECKSUM_ALGO_DICT, PREFERRED_CHECKSUM
 from rucio.rse import rsemanager as rsemgr
-from rucio import version
 
 
 @enum.unique

--- a/lib/rucio/client/fileclient.py
+++ b/lib/rucio/client/fileclient.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 from json import loads
+from urllib.parse import quote_plus
 
 from requests.status_codes import codes
-from urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/lifetimeclient.py
+++ b/lib/rucio/client/lifetimeclient.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from json import loads
+
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient

--- a/lib/rucio/client/lockclient.py
+++ b/lib/rucio/client/lockclient.py
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from requests.status_codes import codes
 from urllib.parse import quote_plus
+
+from requests.status_codes import codes
+
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice
 from rucio.common.utils import build_url, render_json

--- a/lib/rucio/client/metaclient.py
+++ b/lib/rucio/client/metaclient.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 from json import dumps, loads
+from urllib.parse import quote_plus
 
 from requests.status_codes import codes
-from urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/pingclient.py
+++ b/lib/rucio/client/pingclient.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from json import loads
+
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -15,9 +15,9 @@
 
 from datetime import datetime
 from json import dumps, loads
+from urllib.parse import quote_plus
 
 from requests.status_codes import codes
-from urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from requests.status_codes import codes
 from urllib.parse import quote_plus
+
+from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 from json import dumps, loads
+from urllib.parse import quote
 
 from requests.status_codes import codes
-from urllib.parse import quote
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 from json import dumps, loads
+from typing import Any, Optional, Union
+from urllib.parse import quote_plus
 
 from requests.status_codes import codes
-from urllib.parse import quote_plus
-from typing import Any, Optional, Union
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/scopeclient.py
+++ b/lib/rucio/client/scopeclient.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 from json import loads
+from urllib.parse import quote_plus
 
 from requests.status_codes import codes
-from urllib.parse import quote_plus
 
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice

--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from json import dumps
+
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient

--- a/lib/rucio/client/touchclient.py
+++ b/lib/rucio/client/touchclient.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from json import dumps
+
 from requests import post
 
 from rucio.client.baseclient import BaseClient

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -15,14 +15,14 @@
 
 import copy
 import json
+import logging
 import os
 import os.path
-import socket
-
-import logging
-import time
 import random
+import socket
+import time
 
+from rucio import version
 from rucio.client.client import Client
 from rucio.common.config import config_get_int, config_get
 from rucio.common.exception import (RucioException, RSEWriteBlocked, DataIdentifierAlreadyExists, RSEOperationNotSupported,
@@ -32,7 +32,6 @@ from rucio.common.exception import (RucioException, RSEWriteBlocked, DataIdentif
 from rucio.common.utils import (adler32, detect_client_location, execute, generate_uuid, make_valid_did, md5, send_trace,
                                 retry, GLOBALLY_SUPPORTED_CHECKSUMS)
 from rucio.rse import rsemanager as rsemgr
-from rucio import version
 
 
 class UploadClient:

--- a/lib/rucio/common/cache.py
+++ b/lib/rucio/common/cache.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 from typing import TYPE_CHECKING
+
 from dogpile.cache import make_region
 
 from rucio.common.config import config_get

--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import namedtuple
 import enum
+from collections import namedtuple
 
 from rucio.common.config import config_get_bool
 

--- a/lib/rucio/common/dumper/__init__.py
+++ b/lib/rucio/common/dumper/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import bz2
 import contextlib
 import datetime
 import gzip
@@ -25,7 +26,6 @@ import tempfile
 import gfal2
 import magic
 import requests
-import bz2
 
 from rucio.common import config
 from rucio.core.rse import get_rse_id, get_rse_protocols

--- a/lib/rucio/common/dumper/consistency.py
+++ b/lib/rucio/common/dumper/consistency.py
@@ -23,7 +23,6 @@ import tempfile
 from rucio.common import dumper
 from rucio.common.dumper import error, DUMPS_CACHE_DIR, data_models, path_parsing
 
-
 subcommands = ['consistency', 'consistency-manual']
 
 

--- a/lib/rucio/common/dumper/data_models.py
+++ b/lib/rucio/common/dumper/data_models.py
@@ -24,6 +24,7 @@ import logging
 import operator
 import os
 import re
+
 from tabulate import tabulate
 
 from rucio.common.dumper import DUMPS_CACHE_DIR

--- a/lib/rucio/common/pcache.py
+++ b/lib/rucio/common/pcache.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import errno
-import fcntl
 import getopt
 import os
 import re
@@ -24,9 +23,10 @@ import subprocess
 import sys
 import time
 from socket import gethostname
-
 from urllib.parse import urlencode
 from urllib.request import urlopen
+
+import fcntl
 
 # The pCache Version
 pcacheversion = "4.2.3"

--- a/lib/rucio/common/policy.py
+++ b/lib/rucio/common/policy.py
@@ -15,10 +15,9 @@
 
 import json
 import os
-
+from configparser import NoOptionError, NoSectionError
 from functools import wraps
 
-from configparser import NoOptionError, NoSectionError
 from dogpile.cache import make_region
 from dogpile.cache.api import NoValue
 

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os import environ
-
+import importlib
 from configparser import NoOptionError, NoSectionError
+from os import environ
 
 from rucio.common import config, exception
 from rucio.common.utils import check_policy_package_version
-
-import importlib
 
 # dictionary of schema modules for each VO
 schema_modules = {}

--- a/lib/rucio/common/stomp_utils.py
+++ b/lib/rucio/common/stomp_utils.py
@@ -17,13 +17,12 @@
 Common utility functions for stomp connections
 """
 
+import logging
 import socket
 from time import monotonic
 from typing import TYPE_CHECKING
 
 from stomp import Connection
-
-import logging
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence

--- a/lib/rucio/common/test_rucio_server.py
+++ b/lib/rucio/common/test_rucio_server.py
@@ -17,7 +17,6 @@ import unittest
 from os import remove
 from os.path import basename
 
-
 from rucio.common.utils import generate_uuid as uuid, execute
 
 

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -23,7 +23,6 @@ import io
 import itertools
 import json
 import logging
-import mmap
 import os
 import os.path
 import re
@@ -33,24 +32,24 @@ import subprocess
 import tempfile
 import threading
 import time
-import zlib
 from collections import OrderedDict
+from configparser import NoOptionError, NoSectionError
 from enum import Enum
 from functools import partial, wraps
-from uuid import uuid4 as uuid
-from typing import TYPE_CHECKING
-from xml.etree import ElementTree
-
-import requests
 from io import StringIO
 from itertools import zip_longest
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlencode, quote, parse_qsl, urlunparse
-from configparser import NoOptionError, NoSectionError
+from uuid import uuid4 as uuid
+from xml.etree import ElementTree
+
+import mmap
+import requests
+import zlib
 
 from rucio.common.config import config_get, config_has_section
 from rucio.common.exception import MissingModuleException, InvalidType, InputValidationError, MetalinkJsonParsingError, RucioException, \
     DuplicateCriteriaInDIDFilter, DIDFilterSyntaxError, InvalidAlgorithmName, PolicyPackageVersionError
-
 from rucio.common.extra import import_extras
 from rucio.common.types import InternalAccount, InternalScope
 

--- a/lib/rucio/core/account.py
+++ b/lib/rucio/core/account.py
@@ -25,7 +25,6 @@ from sqlalchemy.orm import exc
 
 import rucio.core.account_counter
 import rucio.core.rse
-
 from rucio.common import exception
 from rucio.common.config import config_get_bool
 from rucio.core.vo import vo_exists

--- a/lib/rucio/core/account_counter.py
+++ b/lib/rucio/core/account_counter.py
@@ -15,8 +15,8 @@
 import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy import literal, insert, select
+from sqlalchemy.orm.exc import NoResultFound
 
 from rucio.db.sqla import models, filter_thread_work
 from rucio.db.sqla.session import read_session, transactional_session

--- a/lib/rucio/core/authentication.py
+++ b/lib/rucio/core/authentication.py
@@ -23,8 +23,8 @@ from base64 import b64decode
 from typing import TYPE_CHECKING
 
 import paramiko
-from dogpile.cache.api import NO_VALUE
 from dogpile.cache import make_region
+from dogpile.cache.api import NO_VALUE
 from sqlalchemy import and_, or_, select, delete
 
 from rucio.common.cache import make_region_memcached

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -18,12 +18,12 @@ import datetime
 import hmac
 import time
 from hashlib import sha1
+from urllib.parse import urlparse, urlencode
 
 import boto3
 from botocore.client import Config
 from dogpile.cache.api import NO_VALUE
 from google.oauth2.service_account import Credentials
-from urllib.parse import urlparse, urlencode
 
 from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get, get_rse_credentials

--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -14,12 +14,11 @@
 # limitations under the License.
 
 import importlib
+from configparser import NoOptionError, NoSectionError
 from typing import TYPE_CHECKING
 
 from rucio.common import config, exception
 from rucio.db.sqla.session import read_session, transactional_session
-
-from configparser import NoOptionError, NoSectionError
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import operator
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
-import operator
 
 from sqlalchemy import update, inspect
 from sqlalchemy.exc import CompileError, InvalidRequestError

--- a/lib/rucio/core/dirac.py
+++ b/lib/rucio/core/dirac.py
@@ -14,15 +14,12 @@
 # limitations under the License.
 
 import re
-from typing import TYPE_CHECKING
-
 from json import loads
 from json.decoder import JSONDecodeError
+from typing import TYPE_CHECKING
 
 from sqlalchemy.orm.exc import NoResultFound
-from rucio.db.sqla import models
-from rucio.db.sqla.session import transactional_session, read_session
-from rucio.db.sqla.constants import DIDType
+
 from rucio.common.config import config_get
 from rucio.common.exception import InvalidType, UnsupportedOperation, ConfigNotFound, RucioException
 from rucio.common.types import InternalScope, InternalAccount
@@ -31,6 +28,9 @@ from rucio.core.did import add_did, attach_dids_to_dids
 from rucio.core.replica import add_replicas
 from rucio.core.rule import add_rule, list_rules, update_rule
 from rucio.core.scope import list_scopes
+from rucio.db.sqla import models
+from rucio.db.sqla.constants import DIDType
+from rucio.db.sqla.session import transactional_session, read_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/lib/rucio/core/heartbeat.py
+++ b/lib/rucio/core/heartbeat.py
@@ -20,10 +20,10 @@ from typing import TYPE_CHECKING
 from sqlalchemy import func
 from sqlalchemy.sql import distinct
 
-from rucio.db.sqla.models import Heartbeats
-from rucio.db.sqla.session import read_session, transactional_session
 from rucio.common.exception import DatabaseException
 from rucio.common.utils import pid_exists
+from rucio.db.sqla.models import Heartbeats
+from rucio.db.sqla.session import read_session, transactional_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/lib/rucio/core/identity.py
+++ b/lib/rucio/core/identity.py
@@ -16,18 +16,18 @@
 import hashlib
 import os
 from re import match
+from typing import Optional
 from typing import TYPE_CHECKING
 
 from sqlalchemy import asc
 from sqlalchemy.exc import IntegrityError
 
 from rucio.common import exception
+from rucio.common.types import InternalAccount
 from rucio.core.account import account_exists
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import IdentityType
 from rucio.db.sqla.session import read_session, transactional_session
-from rucio.common.types import InternalAccount
-from typing import Optional
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/lib/rucio/core/importer.py
+++ b/lib/rucio/core/importer.py
@@ -15,13 +15,13 @@
 
 from typing import TYPE_CHECKING
 
+from rucio.common.config import config_get
 from rucio.common.exception import RSEOperationNotSupported
 from rucio.common.types import InternalAccount
 from rucio.core import rse as rse_module, distance as distance_module, account as account_module, identity as identity_module
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import RSEType, AccountType, IdentityType
 from rucio.db.sqla.session import transactional_session
-from rucio.common.config import config_get
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/lib/rucio/core/lifetime_exception.py
+++ b/lib/rucio/core/lifetime_exception.py
@@ -13,23 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from re import match
-from datetime import datetime, timedelta
 from configparser import NoSectionError
+from datetime import datetime, timedelta
+from re import match
 from typing import TYPE_CHECKING
 
 from sqlalchemy import or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
+import rucio.common.policy
 from rucio.common.config import config_get, config_get_int, config_get_list
 from rucio.common.exception import RucioException, LifetimeExceptionDuplicate, LifetimeExceptionNotFound, UnsupportedOperation, ConfigNotFound
 from rucio.common.utils import generate_uuid, str_to_date
-import rucio.common.policy
 from rucio.core.message import add_message
-
 from rucio.core.rse import list_rse_attributes
-
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import DIDType, LifetimeExceptionsState
 from rucio.db.sqla.session import transactional_session, stream_session, read_session

--- a/lib/rucio/core/lock.py
+++ b/lib/rucio/core/lock.py
@@ -20,17 +20,15 @@ from typing import TYPE_CHECKING
 from sqlalchemy.exc import DatabaseError
 from sqlalchemy.sql.expression import and_, or_
 
-import rucio.core.rule
 import rucio.core.did
+import rucio.core.rule
 from rucio.common.exception import DataIdentifierNotFound
+from rucio.common.types import InternalScope
 from rucio.core.lifetime_exception import define_eol
 from rucio.core.rse import get_rse_attribute, get_rse_name
-
 from rucio.db.sqla import models, filter_thread_work
 from rucio.db.sqla.constants import LockState, RuleState, RuleGrouping, DIDType, RuleNotification
 from rucio.db.sqla.session import read_session, transactional_session, stream_session
-
-from rucio.common.types import InternalScope
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/lib/rucio/core/message.py
+++ b/lib/rucio/core/message.py
@@ -14,14 +14,13 @@
 # limitations under the License.
 
 import json
-
 from typing import TYPE_CHECKING
 
 from sqlalchemy import or_, delete, update, insert
 from sqlalchemy.exc import IntegrityError
 
-from rucio.common.constants import HermesService, MAX_MESSAGE_LENGTH
 from rucio.common.config import config_get_list
+from rucio.common.constants import HermesService, MAX_MESSAGE_LENGTH
 from rucio.common.exception import InvalidObject, RucioException
 from rucio.common.utils import APIEncoder, chunks
 from rucio.db.sqla import filter_thread_work

--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -27,8 +27,8 @@ from collections.abc import Callable, Iterable, Sequence
 from datetime import datetime, timedelta
 from functools import wraps
 from pathlib import Path
-from typing import Any, Optional, TypeVar, Union
 from threading import Lock
+from typing import Any, Optional, TypeVar, Union
 
 from prometheus_client import (Counter, Gauge, Histogram, REGISTRY, CollectorRegistry, generate_latest, multiprocess,
                                push_to_gateway, start_http_server, values)

--- a/lib/rucio/core/naming_convention.py
+++ b/lib/rucio/core/naming_convention.py
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 from re import match, compile, error
-from sqlalchemy.exc import IntegrityError
 from traceback import format_exc
 from typing import TYPE_CHECKING
 
 from dogpile.cache.api import NO_VALUE
+from sqlalchemy.exc import IntegrityError
 
-from rucio.common.exception import Duplicate, RucioException, InvalidObject
 from rucio.common.cache import make_region_memcached
+from rucio.common.exception import Duplicate, RucioException, InvalidObject
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import KeyType
 from rucio.db.sqla.session import read_session, transactional_session

--- a/lib/rucio/core/nongrid_trace.py
+++ b/lib/rucio/core/nongrid_trace.py
@@ -24,7 +24,6 @@ from rucio.common.config import config_get, config_get_int
 from rucio.common.logging import rucio_log_formatter
 from rucio.core.monitor import MetricManager
 
-
 METRICS = MetricManager(module=__name__)
 
 CONFIG_COMMON_LOGLEVEL = getattr(logging, config_get('common', 'loglevel', raise_exception=False, default='DEBUG').upper())

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -14,17 +14,17 @@
 # limitations under the License.
 
 import json
+import logging
 import random
 import subprocess
-import logging
 import traceback
 from datetime import datetime, timedelta
-from math import floor
-from urllib.parse import urlparse, parse_qs
 from typing import Any, TYPE_CHECKING, Optional
+from urllib.parse import urlparse, parse_qs
 
 from jwkest.jws import JWS
 from jwkest.jwt import JWT
+from math import floor
 from oic import rndstr
 from oic.oauth2.message import CCAccessTokenRequest
 from oic.oic import Client, Grant, Token, REQUEST2ENDPOINT
@@ -35,12 +35,12 @@ from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from sqlalchemy import and_
 from sqlalchemy.sql.expression import true
 
+from rucio.common import types
 from rucio.common.config import config_get, config_get_int
 from rucio.common.exception import (CannotAuthenticate, CannotAuthorize,
                                     RucioException)
 from rucio.common.stopwatch import Stopwatch
 from rucio.common.utils import all_oidc_req_claims_present, build_url, val_to_space_sep_str
-from rucio.common import types
 from rucio.core.account import account_exists
 from rucio.core.identity import exist_identity_account, get_default_account
 from rucio.core.monitor import MetricManager

--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+from configparser import NoOptionError, NoSectionError
 from os import environ
 from typing import TYPE_CHECKING
 
-from configparser import NoOptionError, NoSectionError
 from rucio.common import config, exception
 from rucio.common.utils import check_policy_package_version
-
-import importlib
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/lib/rucio/core/permission/belleii.py
+++ b/lib/rucio/core/permission/belleii.py
@@ -15,18 +15,17 @@
 
 from typing import TYPE_CHECKING
 
+import rucio.core.scope
 from rucio.common.config import config_get
+from rucio.common.types import InternalScope, InternalAccount
+from rucio.core.account import has_account_attribute, list_account_attributes
 from rucio.core.did import get_metadata
+from rucio.core.identity import exist_identity_account
+from rucio.core.lifetime_exception import list_exceptions
 from rucio.core.rse import list_rse_attributes
 from rucio.core.rse_expression_parser import parse_expression
-from rucio.core.lifetime_exception import list_exceptions
-import rucio.core.scope
-from rucio.core.account import has_account_attribute, list_account_attributes
-from rucio.core.identity import exist_identity_account
 from rucio.core.rule import get_rule
 from rucio.db.sqla.constants import IdentityType
-from rucio.common.types import InternalScope, InternalAccount
-
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/lib/rucio/core/quarantined_replica.py
+++ b/lib/rucio/core/quarantined_replica.py
@@ -19,9 +19,9 @@ from typing import TYPE_CHECKING
 from sqlalchemy import and_, or_
 from sqlalchemy.sql.expression import false, insert
 
+from rucio.common.utils import chunks
 from rucio.db.sqla import models, filter_thread_work
 from rucio.db.sqla.session import read_session, transactional_session
-from rucio.common.utils import chunks
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -15,7 +15,6 @@
 import copy
 import heapq
 import logging
-import math
 import random
 from collections import defaultdict, namedtuple
 from curses.ascii import isprint
@@ -25,9 +24,10 @@ from itertools import groupby
 from json import dumps
 from re import match
 from struct import unpack
-from typing import TYPE_CHECKING
 from traceback import format_exc
+from typing import TYPE_CHECKING
 
+import math
 import requests
 from dogpile.cache.api import NO_VALUE
 from sqlalchemy import func, and_, or_, exists, not_, update, delete, insert, union
@@ -42,9 +42,9 @@ import rucio.core.lock
 from rucio.common import exception
 from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get, config_get_bool
+from rucio.common.constants import SuspiciousAvailability
 from rucio.common.types import InternalScope
 from rucio.common.utils import chunks, clean_surls, str_to_date, add_url_query
-from rucio.common.constants import SuspiciousAvailability
 from rucio.core.credential import get_signed_url
 from rucio.core.message import add_messages
 from rucio.core.monitor import MetricManager

--- a/lib/rucio/core/replica_sorter.py
+++ b/lib/rucio/core/replica_sorter.py
@@ -19,7 +19,6 @@ import socket
 import tarfile
 from collections import OrderedDict
 from datetime import datetime, timedelta
-from math import asin, cos, radians, sin, sqrt
 from pathlib import Path
 from tempfile import TemporaryDirectory, TemporaryFile
 from typing import TYPE_CHECKING, Union
@@ -28,6 +27,7 @@ from urllib.parse import urlparse
 import geoip2.database
 import requests
 from dogpile.cache.api import NO_VALUE
+from math import asin, cos, radians, sin, sqrt
 
 from rucio.common import utils
 from rucio.common.cache import make_region_memcached

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from collections.abc import Iterator, Iterable
 from datetime import datetime
-import json
 from io import StringIO
 from re import match
 from typing import Any, Generic, Optional, TypeVar, Union, TYPE_CHECKING

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -15,10 +15,10 @@
 
 import abc
 import re
+from hashlib import sha256
 from typing import TYPE_CHECKING
 
 from dogpile.cache.api import NoValue
-from hashlib import sha256
 
 from rucio.common.cache import make_region_memcached
 from rucio.common.exception import InvalidRSEExpression, RSEWriteBlocked

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -15,31 +15,25 @@
 
 import json
 import logging
-from typing import TYPE_CHECKING
-
 from configparser import NoOptionError
-
 from copy import deepcopy
 from datetime import datetime, timedelta
+from os import path
 from re import match
 from string import Template
 from typing import Any, Optional
-from os import path
+from typing import TYPE_CHECKING
 
 from dogpile.cache.api import NO_VALUE
-
 from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError, StatementError
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import and_, or_, true, null, tuple_, false
 
-from rucio.core.account import has_account_attribute
 import rucio.core.did
 import rucio.core.lock  # import get_replica_locks, get_files_and_replica_locks_of_dataset
 import rucio.core.replica  # import get_and_lock_file_replicas, get_and_lock_file_replicas_for_dataset
-from rucio.common.policy import policy_filter, get_scratchdisk_lifetime
-
 from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get
 from rucio.common.exception import (InvalidRSEExpression, InvalidReplicationRule, InsufficientAccountLimit,
@@ -49,11 +43,13 @@ from rucio.common.exception import (InvalidRSEExpression, InvalidReplicationRule
                                     InvalidObject, RSEWriteBlocked, RuleReplaceFailed, RequestNotFound,
                                     ManualRuleApprovalBlocked, UnsupportedOperation, UndefinedPolicy, InvalidValueForKey,
                                     InvalidSourceReplicaExpression)
+from rucio.common.policy import policy_filter, get_scratchdisk_lifetime
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalScope, InternalAccount
 from rucio.common.utils import str_to_date, sizefmt, chunks
 from rucio.core import account_counter, rse_counter, request as request_core, transfer as transfer_core
 from rucio.core.account import get_account
+from rucio.core.account import has_account_attribute
 from rucio.core.lifetime_exception import define_eol
 from rucio.core.message import add_message
 from rucio.core.monitor import MetricManager

--- a/lib/rucio/core/rule_grouping.py
+++ b/lib/rucio/core/rule_grouping.py
@@ -14,19 +14,18 @@
 # limitations under the License.
 
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING
 
-from datetime import datetime
-
-from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy import func
+from sqlalchemy.orm.exc import NoResultFound
 
-from rucio.common.config import config_get_int
-from rucio.common.exception import InsufficientTargetRSEs
-from rucio.core import account_counter, rse_counter, request as request_core
 import rucio.core.did
 import rucio.core.lock
 import rucio.core.replica
+from rucio.common.config import config_get_int
+from rucio.common.exception import InsufficientTargetRSEs
+from rucio.core import account_counter, rse_counter, request as request_core
 from rucio.core.rse import get_rse, get_rse_attribute, get_rse_name
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import LockState, RuleGrouping, ReplicaState, RequestType, DIDType, OBSOLETE

--- a/lib/rucio/core/scope.py
+++ b/lib/rucio/core/scope.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 
 from re import match
-from sqlalchemy.exc import IntegrityError
 from traceback import format_exc
 from typing import TYPE_CHECKING
+
+from sqlalchemy.exc import IntegrityError
 
 from rucio.common.exception import AccountNotFound, Duplicate, RucioException, VONotFound
 from rucio.core.vo import vo_exists

--- a/lib/rucio/core/subscription.py
+++ b/lib/rucio/core/subscription.py
@@ -16,10 +16,9 @@
 import datetime
 import logging
 import re
-from typing import TYPE_CHECKING
 from configparser import NoOptionError, NoSectionError
-
 from json import dumps
+from typing import TYPE_CHECKING
 
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError, StatementError

--- a/lib/rucio/core/temporary_did.py
+++ b/lib/rucio/core/temporary_did.py
@@ -23,6 +23,7 @@ from rucio.core.did import attach_dids
 from rucio.core.replica import add_replica
 from rucio.db.sqla import models, filter_thread_work
 from rucio.db.sqla.session import read_session, transactional_session
+
 # from rucio.rse import rsemanager as rsemgr
 
 if TYPE_CHECKING:

--- a/lib/rucio/core/topology.py
+++ b/lib/rucio/core/topology.py
@@ -22,9 +22,9 @@ from typing import TYPE_CHECKING, cast, Any, Generic, Optional, TypeVar, Union
 
 from sqlalchemy import and_, select
 
-from rucio.common.utils import PriorityQueue
 from rucio.common.config import config_get_int, config_get
 from rucio.common.exception import NoDistance, RSEProtocolNotSupported, InvalidRSEExpression
+from rucio.common.utils import PriorityQueue
 from rucio.core.rse import RseCollection, RseData
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla import models

--- a/lib/rucio/core/trace.py
+++ b/lib/rucio/core/trace.py
@@ -17,13 +17,13 @@
 Core tracer module
 """
 
+import ipaddress
 import json
 import logging.handlers
 import random
 import socket
 
 import stomp
-import ipaddress
 from jsonschema import validate, ValidationError, Draft7Validator
 
 from rucio.common.config import config_get, config_get_int
@@ -31,7 +31,6 @@ from rucio.common.exception import InvalidObject
 from rucio.common.logging import rucio_log_formatter
 from rucio.common.schema.generic import UUID, TIME_ENTRY, IPv4orIPv6
 from rucio.core.monitor import MetricManager
-
 
 METRICS = MetricManager(module=__name__)
 

--- a/lib/rucio/core/vo.py
+++ b/lib/rucio/core/vo.py
@@ -15,6 +15,7 @@
 
 import re
 from typing import TYPE_CHECKING
+
 from sqlalchemy.exc import DatabaseError, IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 

--- a/lib/rucio/daemons/auditor/__init__.py
+++ b/lib/rucio/daemons/auditor/__init__.py
@@ -13,15 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import queue as Queue
 import bz2
 import glob
 import logging
 import os
-import select
-
+import queue as Queue
 from datetime import datetime
 from datetime import timedelta
+
+import select
+
 from rucio.common import config
 from rucio.common.dumper import LogPipeHandler
 from rucio.common.dumper import mkdir
@@ -32,8 +33,8 @@ from rucio.common.utils import chunks
 from rucio.core.quarantined_replica import add_quarantined_replicas
 from rucio.core.replica import declare_bad_file_replicas, list_replicas
 from rucio.core.rse import get_rse_usage, get_rse_id
-from rucio.daemons.auditor.hdfs import ReplicaFromHDFS
 from rucio.daemons.auditor import srmdumps
+from rucio.daemons.auditor.hdfs import ReplicaFromHDFS
 from rucio.db.sqla.constants import BadFilesStatus
 
 

--- a/lib/rucio/daemons/auditor/hdfs.py
+++ b/lib/rucio/daemons/auditor/hdfs.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rucio.common.dumper import DUMPS_CACHE_DIR
-from rucio.common.dumper import temp_file
-from rucio.common.dumper.data_models import Replica
 import hashlib
 import logging
 import os
@@ -23,6 +20,10 @@ import re
 import shutil
 import subprocess
 import tempfile
+
+from rucio.common.dumper import DUMPS_CACHE_DIR
+from rucio.common.dumper import temp_file
+from rucio.common.dumper.data_models import Replica
 
 
 def _hdfs_get(src_url, dst_path):

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -13,22 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rucio.common.config import get_config_dirs
-from rucio.common.dumper import DUMPS_CACHE_DIR
-from rucio.common.dumper import http_download_to_file, gfal_download_to_file, ddmendpoint_url, temp_file
-
 import configparser as ConfigParser
-import html.parser as HTMLParser
 import datetime
 import glob
 import hashlib
+import html.parser as HTMLParser
 import logging
 import operator
 import os
 import re
-import requests
 
 import gfal2
+import requests
+
+from rucio.common.config import get_config_dirs
+from rucio.common.dumper import DUMPS_CACHE_DIR
+from rucio.common.dumper import http_download_to_file, gfal_download_to_file, ddmendpoint_url, temp_file
 
 CHUNK_SIZE = 10485760
 

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -38,7 +38,6 @@ from rucio.core.scope import list_scopes
 from rucio.core.vo import map_vo
 from rucio.daemons.common import run_daemon
 
-
 if TYPE_CHECKING:
     from types import FrameType
     from typing import Optional

--- a/lib/rucio/daemons/badreplicas/minos.py
+++ b/lib/rucio/daemons/badreplicas/minos.py
@@ -15,13 +15,13 @@
 
 import functools
 import logging
-import math
 import re
 import threading
 from collections.abc import Callable
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+import math
 from sqlalchemy.exc import DatabaseError
 
 import rucio.db.sqla.util
@@ -37,7 +37,6 @@ from rucio.core.rse import get_rse_name
 from rucio.daemons.common import run_daemon
 from rucio.db.sqla.constants import BadFilesStatus, BadPFNStatus, ReplicaState
 from rucio.db.sqla.session import get_session
-
 
 if TYPE_CHECKING:
     from types import FrameType

--- a/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
+++ b/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
@@ -15,12 +15,12 @@
 
 import functools
 import logging
-import math
 import re
 import threading
 import traceback
 from typing import TYPE_CHECKING
 
+import math
 from sqlalchemy.exc import DatabaseError
 
 import rucio.db.sqla.util
@@ -34,7 +34,6 @@ from rucio.core.replica import (update_replicas_states, get_replicas_state,
 from rucio.daemons.common import run_daemon
 from rucio.db.sqla.constants import BadFilesStatus, ReplicaState
 from rucio.db.sqla.session import get_session
-
 
 if TYPE_CHECKING:
     from types import FrameType

--- a/lib/rucio/daemons/badreplicas/necromancer.py
+++ b/lib/rucio/daemons/badreplicas/necromancer.py
@@ -18,14 +18,13 @@ import logging
 import re
 import threading
 import time
-from typing import TYPE_CHECKING
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
-from sqlalchemy.exc import DatabaseError
 from dogpile.cache.api import NO_VALUE
+from sqlalchemy.exc import DatabaseError
 
 import rucio.db.sqla.util
-from rucio.db.sqla.constants import ReplicaState
 from rucio.common import exception
 from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get_int
@@ -36,6 +35,7 @@ from rucio.core.replica import list_bad_replicas, get_replicas_state, get_bad_re
 from rucio.core.rule import (update_rules_for_lost_replica, update_rules_for_bad_replica,
                              get_evaluation_backlog)
 from rucio.daemons.common import run_daemon
+from rucio.db.sqla.constants import ReplicaState
 
 if TYPE_CHECKING:
     from types import FrameType

--- a/lib/rucio/daemons/bb8/bb8.py
+++ b/lib/rucio/daemons/bb8/bb8.py
@@ -26,12 +26,11 @@ from typing import TYPE_CHECKING
 from rucio.common.config import config_get_float
 from rucio.common.exception import InvalidRSEExpression
 from rucio.common.logging import setup_logging
-from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.heartbeat import sanity_check, list_payload_counts
 from rucio.core.rse import get_rse_usage
+from rucio.core.rse_expression_parser import parse_expression
 from rucio.daemons.bb8.common import rebalance_rse, get_active_locks
 from rucio.daemons.common import run_daemon
-
 
 if TYPE_CHECKING:
     from types import FrameType

--- a/lib/rucio/daemons/bb8/common.py
+++ b/lib/rucio/daemons/bb8/common.py
@@ -14,18 +14,14 @@
 # limitations under the License.
 
 import logging
-
 from datetime import datetime, date, timedelta
 from string import Template
-from sqlalchemy.orm import aliased
+
+from requests import get
 from sqlalchemy import func, and_, or_, cast, BigInteger
+from sqlalchemy.orm import aliased
 from sqlalchemy.sql.expression import case, select
 
-from rucio.core.lock import get_dataset_locks
-from rucio.core.rule import get_rule, add_rule, update_rule
-from rucio.core.rse_expression_parser import parse_expression
-from rucio.core.rse import list_rse_attributes, get_rse_name, get_rse_vo
-from rucio.core.rse_selector import RSESelector
 from rucio.common.config import config_get, config_get_int, config_get_bool
 from rucio.common.exception import (
     InsufficientTargetRSEs,
@@ -34,11 +30,14 @@ from rucio.common.exception import (
     InsufficientAccountLimit,
 )
 from rucio.common.types import InternalAccount, InternalScope
-
-from rucio.db.sqla.session import transactional_session, read_session
+from rucio.core.lock import get_dataset_locks
+from rucio.core.rse import list_rse_attributes, get_rse_name, get_rse_vo
+from rucio.core.rse_expression_parser import parse_expression
+from rucio.core.rse_selector import RSESelector
+from rucio.core.rule import get_rule, add_rule, update_rule
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import DIDType, RuleState, RuleGrouping, LockState
-from requests import get
+from rucio.db.sqla.session import transactional_session, read_session
 
 
 @transactional_session

--- a/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
@@ -19,13 +19,12 @@ This script is to be used to background rebalance ATLAS t2 datadisks
 
 from sqlalchemy import or_
 
-from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.rse import get_rse_usage, get_rse_attribute
+from rucio.core.rse_expression_parser import parse_expression
 from rucio.daemons.bb8.common import rebalance_rse
 from rucio.db.sqla import models
-from rucio.db.sqla.session import get_session
 from rucio.db.sqla.constants import RuleState
-
+from rucio.db.sqla.session import get_session
 
 tolerance = 0.15
 max_total_rebalance_volume = 200 * 1E12

--- a/lib/rucio/daemons/bb8/t2_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/t2_background_rebalance.py
@@ -19,13 +19,12 @@ This script is to be used to background rebalance ATLAS t2 datadisks
 
 from sqlalchemy import or_
 
-from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.rse import get_rse_usage, get_rse_attribute
+from rucio.core.rse_expression_parser import parse_expression
 from rucio.daemons.bb8.common import rebalance_rse
 from rucio.db.sqla import models
-from rucio.db.sqla.session import get_session
 from rucio.db.sqla.constants import RuleState
-
+from rucio.db.sqla.session import get_session
 
 tolerance = 0.1
 max_total_rebalance_volume = 200 * 1E12

--- a/lib/rucio/daemons/c3po/algorithms/simple.py
+++ b/lib/rucio/daemons/c3po/algorithms/simple.py
@@ -17,11 +17,11 @@ import logging
 from operator import itemgetter
 from random import shuffle
 
+from rucio.common.exception import DataIdentifierNotFound
+from rucio.core.did import get_did
+from rucio.core.replica import list_dataset_replicas
 from rucio.daemons.c3po.collectors.agis import MappingCollector
 from rucio.daemons.c3po.collectors.workload import WorkloadCollector
-from rucio.common.exception import DataIdentifierNotFound
-from rucio.core.replica import list_dataset_replicas
-from rucio.core.did import get_did
 from rucio.db.sqla.constants import ReplicaState
 
 

--- a/lib/rucio/daemons/c3po/collectors/agis.py
+++ b/lib/rucio/daemons/c3po/collectors/agis.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from json import loads
+
 from requests import get
 
 from rucio.common.config import config_get

--- a/lib/rucio/daemons/c3po/collectors/network_metrics.py
+++ b/lib/rucio/daemons/c3po/collectors/network_metrics.py
@@ -16,6 +16,7 @@
 from json import loads
 
 from redis import StrictRedis
+
 from rucio.common.config import config_get, config_get_int
 
 

--- a/lib/rucio/daemons/c3po/utils/popularity.py
+++ b/lib/rucio/daemons/c3po/utils/popularity.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import logging
-
 from json import dumps, loads
+
 from requests import post
 from requests.auth import HTTPBasicAuth
 

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -24,6 +24,7 @@ import re
 import threading
 from types import FrameType
 from typing import TYPE_CHECKING, Optional
+from urllib.parse import urlparse
 
 from dogpile.cache.api import NoValue
 from sqlalchemy.exc import DatabaseError
@@ -43,8 +44,6 @@ from rucio.daemons.common import db_workqueue, ProducerConsumerDaemon
 from rucio.db.sqla.constants import RequestState, RequestType, ReplicaState, BadFilesStatus
 from rucio.db.sqla.session import transactional_session
 from rucio.rse import rsemanager
-
-from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from rucio.daemons.common import HeartbeatHandler

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -34,14 +34,14 @@ from sqlalchemy.exc import DatabaseError
 import rucio.db.sqla.util
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import DatabaseException, TransferToolTimeout, TransferToolWrongAnswer
-from rucio.common.types import InternalAccount
 from rucio.common.logging import setup_logging
 from rucio.common.stopwatch import Stopwatch
+from rucio.common.types import InternalAccount
 from rucio.common.utils import dict_chunks
 from rucio.core import transfer as transfer_core, request as request_core
 from rucio.core.monitor import MetricManager
-from rucio.db.sqla.constants import RequestState, RequestType
 from rucio.daemons.common import db_workqueue, ProducerConsumerDaemon
+from rucio.db.sqla.constants import RequestState, RequestType
 from rucio.transfertool.fts3 import FTS3Transfertool
 from rucio.transfertool.globus import GlobusTransferTool
 

--- a/lib/rucio/daemons/conveyor/preparer.py
+++ b/lib/rucio/daemons/conveyor/preparer.py
@@ -26,10 +26,10 @@ from rucio.common.exception import RucioException
 from rucio.common.logging import setup_logging
 from rucio.core import transfer as transfer_core
 from rucio.core.request import set_requests_state_if_possible, list_and_mark_transfer_requests_and_source_replicas
-from rucio.core.transfer import prepare_transfers, list_transfer_admin_accounts, build_transfer_paths, ProtocolFactory
 from rucio.core.topology import Topology, ExpiringObjectCache
-from rucio.db.sqla.constants import RequestState, RequestType
+from rucio.core.transfer import prepare_transfers, list_transfer_admin_accounts, build_transfer_paths, ProtocolFactory
 from rucio.daemons.common import db_workqueue, ProducerConsumerDaemon
+from rucio.db.sqla.constants import RequestState, RequestType
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -31,10 +31,10 @@ from rucio.common.stopwatch import Stopwatch
 from rucio.core.monitor import MetricManager
 from rucio.core.request import list_and_mark_transfer_requests_and_source_replicas
 from rucio.core.topology import Topology, ExpiringObjectCache
-from rucio.core.transfer import DEFAULT_MULTIHOP_TOMBSTONE_DELAY, list_transfer_admin_accounts, transfer_path_str,\
+from rucio.core.transfer import DEFAULT_MULTIHOP_TOMBSTONE_DELAY, list_transfer_admin_accounts, transfer_path_str, \
     TRANSFERTOOL_CLASSES_BY_NAME, ProtocolFactory
-from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, pick_and_prepare_submission_path
 from rucio.daemons.common import db_workqueue, ProducerConsumerDaemon
+from rucio.daemons.conveyor.common import submit_transfer, get_conveyor_rses, pick_and_prepare_submission_path
 from rucio.db.sqla.constants import RequestType, RequestState
 from rucio.transfertool.fts3 import FTS3Transfertool
 from rucio.transfertool.globus import GlobusTransferTool

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -17,13 +17,13 @@
 Conveyor throttler is a daemon to manage rucio internal queue.
 """
 import logging
-import math
 import threading
 import traceback
 from collections import defaultdict
 from types import FrameType
 from typing import TYPE_CHECKING, Optional
 
+import math
 from sqlalchemy import null
 
 import rucio.db.sqla.util
@@ -32,8 +32,8 @@ from rucio.common.logging import setup_logging
 from rucio.core.monitor import MetricManager
 from rucio.core.request import (get_request_stats, release_all_waiting_requests, release_waiting_requests_fifo,
                                 release_waiting_requests_grouped_fifo, set_transfer_limit_stats, re_sync_all_transfer_limits)
-from rucio.core.transfer import applicable_rse_transfer_limits
 from rucio.core.rse import RseCollection
+from rucio.core.transfer import applicable_rse_transfer_limits
 from rucio.daemons.common import db_workqueue, ProducerConsumerDaemon
 from rucio.db.sqla.constants import RequestState, TransferLimitDirection
 

--- a/lib/rucio/daemons/judge/cleaner.py
+++ b/lib/rucio/daemons/judge/cleaner.py
@@ -30,8 +30,8 @@ from sqlalchemy.exc import DatabaseError
 
 import rucio.db.sqla.util
 from rucio.common import exception
-from rucio.common.logging import setup_logging
 from rucio.common.exception import DatabaseException, UnsupportedOperation, RuleNotFound
+from rucio.common.logging import setup_logging
 from rucio.core.monitor import MetricManager
 from rucio.core.rule import delete_rule, get_expired_rules
 from rucio.daemons.common import run_daemon

--- a/lib/rucio/daemons/judge/injector.py
+++ b/lib/rucio/daemons/judge/injector.py
@@ -29,9 +29,9 @@ from typing import TYPE_CHECKING
 from sqlalchemy.exc import DatabaseError
 
 import rucio.db.sqla.util
-from rucio.common.logging import setup_logging
 from rucio.common.exception import (DatabaseException, RuleNotFound, RSEWriteBlocked,
                                     ReplicationRuleCreationTemporaryFailed, InsufficientAccountLimit)
+from rucio.common.logging import setup_logging
 from rucio.core.monitor import MetricManager
 from rucio.core.rule import inject_rule, get_injected_rules, update_rule
 from rucio.daemons.common import run_daemon

--- a/lib/rucio/daemons/oauthmanager/oauthmanager.py
+++ b/lib/rucio/daemons/oauthmanager/oauthmanager.py
@@ -42,8 +42,8 @@ from rucio.common.stopwatch import Stopwatch
 from rucio.core.authentication import delete_expired_tokens
 from rucio.core.monitor import MetricManager
 from rucio.core.oidc import delete_expired_oauthrequests, refresh_jwt_tokens
-from rucio.daemons.common import run_daemon
 from rucio.daemons.common import HeartbeatHandler
+from rucio.daemons.common import run_daemon
 
 if TYPE_CHECKING:
     from types import FrameType

--- a/lib/rucio/daemons/reaper/dark_reaper.py
+++ b/lib/rucio/daemons/reaper/dark_reaper.py
@@ -26,6 +26,7 @@ import time
 import traceback
 from typing import TYPE_CHECKING
 
+import rucio.core.rse as rse_core
 import rucio.db.sqla.util
 from rucio.common import exception
 from rucio.common.config import config_get_bool
@@ -38,7 +39,6 @@ from rucio.core.monitor import MetricManager
 from rucio.core.quarantined_replica import (list_quarantined_replicas,
                                             delete_quarantined_replicas,
                                             list_rses_with_quarantined_replicas)
-import rucio.core.rse as rse_core
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.vo import list_vos
 from rucio.daemons.common import run_daemon

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -25,27 +25,27 @@ import time
 import traceback
 from configparser import NoOptionError, NoSectionError
 from datetime import datetime, timedelta
-from math import log2
 from typing import TYPE_CHECKING
 
 from dogpile.cache.api import NoValue
+from math import log2
 from sqlalchemy.exc import DatabaseError, IntegrityError
 
 import rucio.db.sqla.util
-from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.cache import make_region_memcached
+from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.exception import (DatabaseException, RSENotFound,
                                     ReplicaUnAvailable, ReplicaNotFound, ServiceUnavailable,
                                     RSEAccessDenied, ResourceTemporaryUnavailable, SourceNotFound,
                                     VONotFound, RSEProtocolNotSupported)
 from rucio.common.logging import setup_logging
-from rucio.common.types import InternalAccount
 from rucio.common.stopwatch import Stopwatch
+from rucio.common.types import InternalAccount
 from rucio.common.utils import chunks
-from rucio.core.monitor import MetricManager
 from rucio.core.credential import get_signed_url
 from rucio.core.heartbeat import list_payload_counts
 from rucio.core.message import add_message
+from rucio.core.monitor import MetricManager
 from rucio.core.oidc import get_token_for_account_operation
 from rucio.core.replica import list_and_mark_unlocked_replicas, delete_replicas
 from rucio.core.rse import list_rses, RseData

--- a/lib/rucio/daemons/storage/consistency/actions.py
+++ b/lib/rucio/daemons/storage/consistency/actions.py
@@ -24,12 +24,14 @@ import logging
 import os
 import re
 import socket
-import time
 import threading
+import time
 import traceback
+from datetime import datetime
 from typing import TYPE_CHECKING
 
-from datetime import datetime
+from sqlalchemy.exc import DatabaseError, IntegrityError
+from sqlalchemy.orm.exc import FlushError
 
 from rucio.common import exception
 from rucio.common.logging import formatted_logger, setup_logging
@@ -40,15 +42,12 @@ from rucio.core.monitor import MetricManager
 from rucio.core.quarantined_replica import add_quarantined_replicas
 from rucio.core.replica import __exist_replicas, update_replicas_states
 from rucio.core.rse import list_rses, get_rse_id
-from rucio.rse.rsemanager import lfns2pfns, get_rse_info, parse_pfns
-
 # FIXME: these are needed by local version of declare_bad_file_replicas()
 # TODO: remove after move of this code to core/replica.py - see https://github.com/rucio/rucio/pull/5068
 from rucio.db.sqla import models
-from rucio.db.sqla.session import transactional_session
 from rucio.db.sqla.constants import (ReplicaState, BadFilesStatus)
-from sqlalchemy.exc import DatabaseError, IntegrityError
-from sqlalchemy.orm.exc import FlushError
+from rucio.db.sqla.session import transactional_session
+from rucio.rse.rsemanager import lfns2pfns, get_rse_info, parse_pfns
 
 if TYPE_CHECKING:
     from types import FrameType

--- a/lib/rucio/daemons/tracer/kronos.py
+++ b/lib/rucio/daemons/tracer/kronos.py
@@ -17,18 +17,18 @@
 This daemon consumes tracer messages from ActiveMQ and updates the atime for replicas.
 """
 
+import functools
 import logging
 import re
 from configparser import NoOptionError, NoSectionError
 from datetime import datetime
-import functools
 from json import loads as jloads, dumps as jdumps
+from queue import Queue
 from threading import Event, Thread
 from time import time
 from typing import TYPE_CHECKING
 
 import rucio.db.sqla.util
-from rucio.daemons.common import HeartbeatHandler, run_daemon
 from rucio.common.config import config_get, config_get_bool, config_get_int, config_get_list
 from rucio.common.exception import RSENotFound, DatabaseException
 from rucio.common.logging import setup_logging
@@ -40,9 +40,8 @@ from rucio.core.lock import touch_dataset_locks
 from rucio.core.monitor import MetricManager
 from rucio.core.replica import touch_replica, touch_collection_replicas, declare_bad_file_replicas
 from rucio.core.rse import get_rse_id
+from rucio.daemons.common import HeartbeatHandler, run_daemon
 from rucio.db.sqla.constants import DIDType, BadFilesStatus
-
-from queue import Queue
 
 if TYPE_CHECKING:
     from types import FrameType

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -24,7 +24,6 @@ from json import loads, dumps
 from typing import TYPE_CHECKING
 
 import rucio.db.sqla.util
-from rucio.db.sqla.constants import DIDType, SubscriptionState
 from rucio.common.config import config_get
 from rucio.common.exception import (
     DatabaseException,
@@ -43,14 +42,15 @@ from rucio.common.logging import setup_logging
 from rucio.common.stopwatch import Stopwatch
 from rucio.common.types import InternalAccount
 from rucio.common.utils import chunks
-from rucio.core.monitor import MetricManager
 from rucio.core.did import list_new_dids, set_new_dids, get_metadata
+from rucio.core.monitor import MetricManager
 from rucio.core.rse import list_rses, rse_exists, get_rse_id, list_rse_attributes
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.rse_selector import resolve_rse_expression
 from rucio.core.rule import add_rule, list_rules, get_rule
 from rucio.core.subscription import list_subscriptions, update_subscription
 from rucio.daemons.common import run_daemon
+from rucio.db.sqla.constants import DIDType, SubscriptionState
 
 if TYPE_CHECKING:
     from types import FrameType

--- a/lib/rucio/db/sqla/migrate_repo/versions/0f1adb7a599a_create_transfer_hops_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/0f1adb7a599a_create_transfer_hops_table.py
@@ -18,13 +18,11 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key,
                         create_check_constraint, create_index, drop_table)
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '0f1adb7a599a'

--- a/lib/rucio/db/sqla/migrate_repo/versions/13d4f70c66a9_introduce_transfer_limits.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/13d4f70c66a9_introduce_transfer_limits.py
@@ -17,7 +17,6 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key,
                         create_index, create_check_constraint, drop_table)

--- a/lib/rucio/db/sqla/migrate_repo/versions/1803333ac20f_adding_provenance_and_phys_group.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1803333ac20f_adding_provenance_and_phys_group.py
@@ -16,10 +16,8 @@
 ''' adding provenance and phys_group '''
 
 import sqlalchemy as sa
-
-from alembic.op import add_column, drop_column
 from alembic import context
-
+from alembic.op import add_column, drop_column
 
 # Alembic revision identifiers
 revision = '1803333ac20f'

--- a/lib/rucio/db/sqla/migrate_repo/versions/1a29d6a9504c_add_didtype_chck_to_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1a29d6a9504c_add_didtype_chck_to_requests.py
@@ -16,7 +16,6 @@
 ''' add didtype_chck to requests '''
 
 import sqlalchemy as sa
-
 from alembic import context, op
 from alembic.op import add_column, drop_column
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/1d1215494e95_add_quarantined_replicas_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1d1215494e95_add_quarantined_replicas_table.py
@@ -18,7 +18,6 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key,
                         create_check_constraint, drop_table)

--- a/lib/rucio/db/sqla/migrate_repo/versions/1fc15ab60d43_add_message_history_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1fc15ab60d43_add_message_history_table.py
@@ -18,7 +18,6 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import create_table, drop_table
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/2190e703eb6e_move_rse_settings_to_rse_attributes.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2190e703eb6e_move_rse_settings_to_rse_attributes.py
@@ -16,7 +16,6 @@
 """ move rse settings to rse attributes """
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import get_bind
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/22d887e4ec0a_create_sources_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/22d887e4ec0a_create_sources_table.py
@@ -18,13 +18,11 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key,
                         create_check_constraint, create_index, drop_table)
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '22d887e4ec0a'

--- a/lib/rucio/db/sqla/migrate_repo/versions/277b5fbb41d3_switch_heartbeats_executable.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/277b5fbb41d3_switch_heartbeats_executable.py
@@ -16,12 +16,10 @@
 ''' switch heartbeats executable '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import create_primary_key, add_column, drop_constraint, drop_column
 
 from rucio.db.sqla.models import String
-
 
 # Alembic revision identifiers
 revision = '277b5fbb41d3'

--- a/lib/rucio/db/sqla/migrate_repo/versions/2854cd9e168_added_rule_id_column.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2854cd9e168_added_rule_id_column.py
@@ -16,12 +16,10 @@
 ''' added_rule_id_column '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import add_column, drop_column
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '2854cd9e168'

--- a/lib/rucio/db/sqla/migrate_repo/versions/2af3291ec4c_added_replicas_history_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2af3291ec4c_added_replicas_history_table.py
@@ -16,13 +16,11 @@
 ''' added replicas history table '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key,
                         create_check_constraint, drop_constraint, drop_table)
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '2af3291ec4c'

--- a/lib/rucio/db/sqla/migrate_repo/versions/2b8e7bcb4783_add_config_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2b8e7bcb4783_add_config_table.py
@@ -18,12 +18,10 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key,
                         create_check_constraint,
                         drop_constraint, drop_table)
-
 
 # Alembic revision identifiers
 revision = '2b8e7bcb4783'

--- a/lib/rucio/db/sqla/migrate_repo/versions/2edee4a83846_add_source_to_requests_and_requests_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2edee4a83846_add_source_to_requests_and_requests_.py
@@ -16,12 +16,10 @@
 ''' add source to requests and requests_history '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import add_column, drop_column
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '2edee4a83846'

--- a/lib/rucio/db/sqla/migrate_repo/versions/3082b8cef557_add_naming_convention_table_and_closed_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3082b8cef557_add_naming_convention_table_and_closed_.py
@@ -18,14 +18,12 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key, add_column,
                         create_check_constraint, drop_column, drop_table)
 
 from rucio.common.schema import get_schema_value
 from rucio.db.sqla.constants import KeyType
-
 
 # Alembic revision identifiers
 revision = '3082b8cef557'

--- a/lib/rucio/db/sqla/migrate_repo/versions/32c7d2783f7e_create_bad_replicas_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/32c7d2783f7e_create_bad_replicas_table.py
@@ -18,13 +18,11 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key,
                         create_check_constraint, create_index, drop_table)
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '32c7d2783f7e'

--- a/lib/rucio/db/sqla/migrate_repo/versions/379a19b5332d_create_rse_limits_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/379a19b5332d_create_rse_limits_table.py
@@ -18,13 +18,11 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key,
                         create_check_constraint, drop_table)
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '379a19b5332d'

--- a/lib/rucio/db/sqla/migrate_repo/versions/384b96aa0f60_created_rule_history_tables.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/384b96aa0f60_created_rule_history_tables.py
@@ -18,13 +18,11 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import create_table, create_index, drop_table, drop_index, create_primary_key
 
 from rucio.db.sqla.constants import (DIDType, RuleGrouping, RuleState, RuleNotification)
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '384b96aa0f60'

--- a/lib/rucio/db/sqla/migrate_repo/versions/3ad36e2268b0_create_collection_replicas_updates_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3ad36e2268b0_create_collection_replicas_updates_table.py
@@ -18,7 +18,6 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, add_column,
                         create_check_constraint, create_index,
@@ -26,7 +25,6 @@ from alembic.op import (create_table, create_primary_key, add_column,
 
 from rucio.db.sqla.constants import DIDType
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '3ad36e2268b0'

--- a/lib/rucio/db/sqla/migrate_repo/versions/4783c1f49cb4_create_distance_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4783c1f49cb4_create_distance_table.py
@@ -18,13 +18,11 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key,
                         create_check_constraint, create_index, drop_table)
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '4783c1f49cb4'

--- a/lib/rucio/db/sqla/migrate_repo/versions/4c3a4acfe006_new_attr_account_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4c3a4acfe006_new_attr_account_table.py
@@ -18,11 +18,9 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key,
                         create_check_constraint, create_index, drop_table)
-
 
 # Alembic revision identifiers
 revision = '4c3a4acfe006'

--- a/lib/rucio/db/sqla/migrate_repo/versions/575767d9f89_added_source_history_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/575767d9f89_added_source_history_table.py
@@ -16,12 +16,10 @@
 ''' added source history table '''
 
 import sqlalchemy as sa
-
-from alembic.op import create_table, add_column, drop_column, drop_table
 from alembic import context
+from alembic.op import create_table, add_column, drop_column, drop_table
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '575767d9f89'

--- a/lib/rucio/db/sqla/migrate_repo/versions/5f139f77382a_added_child_rule_id_column.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/5f139f77382a_added_child_rule_id_column.py
@@ -16,13 +16,11 @@
 ''' added child_rule_id column '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_foreign_key, add_column, create_index,
                         drop_constraint, drop_column, drop_index)
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '5f139f77382a'

--- a/lib/rucio/db/sqla/migrate_repo/versions/688ef1840840_adding_did_meta_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/688ef1840840_adding_did_meta_table.py
@@ -16,12 +16,10 @@
 ''' adding did_meta table '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import create_primary_key, create_table, create_foreign_key, drop_table
 
 from rucio.db.sqla.types import JSON
-
 
 # Alembic revision identifiers
 revision = '688ef1840840'

--- a/lib/rucio/db/sqla/migrate_repo/versions/7541902bf173_add_didsfollowed_and_followevents_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/7541902bf173_add_didsfollowed_and_followevents_table.py
@@ -15,9 +15,9 @@
 
 ''' add DidsFollowed and FollowEvents table '''
 
-import sqlalchemy as sa
 import datetime
 
+import sqlalchemy as sa
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_check_constraint,
                         create_foreign_key, create_index, drop_table)

--- a/lib/rucio/db/sqla/migrate_repo/versions/914b8f02df38_new_table_for_lifetime_model_exceptions.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/914b8f02df38_new_table_for_lifetime_model_exceptions.py
@@ -18,14 +18,12 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key,
                         create_check_constraint, drop_table)
 
 from rucio.db.sqla.constants import DIDType, LifetimeExceptionsState
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = '914b8f02df38'

--- a/lib/rucio/db/sqla/migrate_repo/versions/9a45bc4ea66d_add_vp_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/9a45bc4ea66d_add_vp_table.py
@@ -16,7 +16,6 @@
 ''' add VP table '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import create_primary_key, create_table, create_foreign_key, drop_table
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/a118956323f8_added_vo_table_and_vo_col_to_rse.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a118956323f8_added_vo_table_and_vo_col_to_rse.py
@@ -18,11 +18,10 @@
 import datetime
 
 import sqlalchemy as sa
-from sqlalchemy import String
 from alembic import context
 from alembic.op import (add_column, create_primary_key, create_table, create_unique_constraint,
                         drop_column, drop_constraint, drop_table, bulk_insert)
-
+from sqlalchemy import String
 
 # Alembic revision identifiers
 revision = 'a118956323f8'

--- a/lib/rucio/db/sqla/migrate_repo/versions/a616581ee47_added_columns_to_table_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a616581ee47_added_columns_to_table_requests.py
@@ -16,12 +16,10 @@
 ''' added columns to table requests '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import add_column, drop_column
 
 from rucio.db.sqla.models import String
-
 
 # Alembic revision identifiers
 revision = 'a616581ee47'

--- a/lib/rucio/db/sqla/migrate_repo/versions/a74275a1ad30_added_global_quota_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a74275a1ad30_added_global_quota_table.py
@@ -16,12 +16,11 @@
 ''' added global acount limits table '''
 
 import datetime
-import sqlalchemy as sa
 
+import sqlalchemy as sa
 from alembic import context
 from alembic.op import (create_primary_key, create_check_constraint,
                         create_table, drop_table, create_foreign_key)
-
 
 # Alembic revision identifiers
 revision = 'a74275a1ad30'

--- a/lib/rucio/db/sqla/migrate_repo/versions/a93e4e47bda_heartbeats.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a93e4e47bda_heartbeats.py
@@ -18,12 +18,10 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key,
                         create_check_constraint, create_index,
                         drop_constraint, drop_table)
-
 
 # Alembic revision identifiers
 revision = 'a93e4e47bda'

--- a/lib/rucio/db/sqla/migrate_repo/versions/ae2a56fcc89_added_comment_column_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/ae2a56fcc89_added_comment_column_to_rules.py
@@ -16,12 +16,10 @@
 ''' added comment column to rules '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import add_column, drop_column
 
 from rucio.db.sqla.models import String
-
 
 # Alembic revision identifiers
 revision = 'ae2a56fcc89'

--- a/lib/rucio/db/sqla/migrate_repo/versions/bf3baa1c1474_correct_pk_and_idx_for_history_tables.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/bf3baa1c1474_correct_pk_and_idx_for_history_tables.py
@@ -16,13 +16,11 @@
 ''' correct PK and IDX for history tables '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_primary_key, drop_constraint,
                         drop_index, drop_column, add_column)
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = 'bf3baa1c1474'

--- a/lib/rucio/db/sqla/migrate_repo/versions/c0937668555f_add_qos_policy_map_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/c0937668555f_add_qos_policy_map_table.py
@@ -18,7 +18,6 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import create_table, create_primary_key, create_foreign_key, drop_table, create_check_constraint
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/ccdbcd48206e_add_did_type_column_index_on_did_meta_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/ccdbcd48206e_add_did_type_column_index_on_did_meta_.py
@@ -16,11 +16,10 @@
 ''' Add did_type column + index on did_meta table '''
 
 import sqlalchemy as sa
-
+from alembic.context import get_context
 from alembic.op import (add_column, drop_column,
                         create_index, drop_index,
                         execute)
-from alembic.context import get_context
 
 from rucio.db.sqla.constants import DIDType
 from rucio.db.sqla.util import try_drop_constraint

--- a/lib/rucio/db/sqla/migrate_repo/versions/cebad904c4dd_new_payload_column_for_heartbeats.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/cebad904c4dd_new_payload_column_for_heartbeats.py
@@ -16,7 +16,6 @@
 ''' New payload column for heartbeats '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import add_column, drop_column, create_index, drop_index
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/d91002c5841_new_account_limits_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/d91002c5841_new_account_limits_table.py
@@ -18,13 +18,11 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_check_constraint, create_table, create_primary_key,
                         create_foreign_key, drop_table)
 
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = 'd91002c5841'

--- a/lib/rucio/db/sqla/migrate_repo/versions/e59300c8b179_support_for_archive.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/e59300c8b179_support_for_archive.py
@@ -18,14 +18,12 @@
 import datetime
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import (create_table, create_primary_key, create_foreign_key, add_column,
                         create_index, drop_column, drop_table)
 
 from rucio.db.sqla.models import String
 from rucio.db.sqla.types import GUID
-
 
 # Alembic revision identifiers
 revision = 'e59300c8b179'

--- a/lib/rucio/db/sqla/migrate_repo/versions/f41ffe206f37_oracle_global_temporary_tables.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/f41ffe206f37_oracle_global_temporary_tables.py
@@ -16,9 +16,9 @@
 ''' oracle_global_temporary_tables '''
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import create_table, drop_table
+
 from rucio.common.schema import get_schema_value
 from rucio.db.sqla.types import InternalScopeString, String, GUID
 

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -16,12 +16,11 @@
 import copy
 import os
 import sys
-
 from functools import update_wrapper
 from inspect import isgeneratorfunction, getfullargspec
+from os.path import basename
 from threading import Lock
 from typing import TYPE_CHECKING
-from os.path import basename
 
 from sqlalchemy import create_engine, event, MetaData
 from sqlalchemy.exc import DatabaseError, DisconnectionError, OperationalError, TimeoutError
@@ -30,8 +29,8 @@ from sqlalchemy.pool import QueuePool, SingletonThreadPool, NullPool
 
 from rucio.common.config import config_get
 from rucio.common.exception import RucioException, DatabaseException, InputValidationError
-from rucio.common.utils import retrying
 from rucio.common.extra import import_extras
+from rucio.common.utils import retrying
 
 EXTRA_MODULES = import_extras(['MySQLdb', 'pymysql'])
 

--- a/lib/rucio/db/sqla/types.py
+++ b/lib/rucio/db/sqla/types.py
@@ -15,12 +15,13 @@
 
 import uuid
 
-from sqlalchemy.dialects.postgresql import UUID, JSONB
-from sqlalchemy.dialects.oracle import RAW, CLOB
-from sqlalchemy.dialects.mysql import BINARY
-from sqlalchemy.types import TypeDecorator, CHAR, String
-from sqlalchemy.sql import operators
 import sqlalchemy.types as types
+from sqlalchemy.dialects.mysql import BINARY
+from sqlalchemy.dialects.oracle import RAW, CLOB
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.sql import operators
+from sqlalchemy.types import TypeDecorator, CHAR, String
+
 from rucio.common.exception import InvalidType
 from rucio.common.types import InternalAccount, InternalScope
 

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -20,7 +20,6 @@ import os
 import re
 import subprocess
 import urllib.parse as urlparse
-
 from threading import Timer
 
 from rucio.common import exception, config

--- a/lib/rucio/rse/protocols/globus.py
+++ b/lib/rucio/rse/protocols/globus.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import logging
-
 from urllib.parse import urlparse
 
 from rucio.common import exception

--- a/lib/rucio/rse/protocols/gsiftp.py
+++ b/lib/rucio/rse/protocols/gsiftp.py
@@ -15,6 +15,7 @@
 
 import json
 import os
+
 import requests
 
 from rucio.common import exception

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -20,7 +20,6 @@ along with some of the default methods for LFN2PFN translations.
 
 import hashlib
 import logging
-
 from configparser import NoOptionError, NoSectionError
 from urllib.parse import urlparse
 

--- a/lib/rucio/rse/protocols/rclone.py
+++ b/lib/rucio/rse/protocols/rclone.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import json
-import os
 import logging
+import os
 
 from rucio.common import exception
 from rucio.common.config import get_config_dirs

--- a/lib/rucio/rse/protocols/rfio.py
+++ b/lib/rucio/rse/protocols/rfio.py
@@ -18,11 +18,11 @@ RFIO protocol
 """
 
 import os
-
 from os.path import dirname
 from urllib.parse import urlparse
-from rucio.common.utils import execute
+
 from rucio.common import exception
+from rucio.common.utils import execute
 from rucio.rse.protocols import protocol
 
 

--- a/lib/rucio/rse/protocols/srm.py
+++ b/lib/rucio/rse/protocols/srm.py
@@ -16,7 +16,6 @@
 import os
 import re
 import urllib.parse as urlparse
-
 from subprocess import getstatusoutput
 
 from rucio.common import exception

--- a/lib/rucio/rse/protocols/storm.py
+++ b/lib/rucio/rse/protocols/storm.py
@@ -15,9 +15,9 @@
 
 import logging
 import os
-import requests
-
 from xml.dom import minidom
+
+import requests
 
 from rucio.common import exception
 from rucio.common.utils import run_cmd_process

--- a/lib/rucio/rse/protocols/webdav.py
+++ b/lib/rucio/rse/protocols/webdav.py
@@ -15,15 +15,14 @@
 
 import os
 import sys
-from typing import Optional
-from dataclasses import dataclass
-
 import xml.etree.ElementTree as ET
+from typing import Optional
+from urllib.parse import urlparse
 
 import requests
+from dataclasses import dataclass
 from requests.adapters import HTTPAdapter
 from urllib3.poolmanager import PoolManager
-from urllib.parse import urlparse
 
 from rucio.common import exception
 from rucio.rse.protocols import protocol

--- a/lib/rucio/rse/protocols/xrootd.py
+++ b/lib/rucio/rse/protocols/xrootd.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import logging
+import os
 
 from rucio.common import exception
-from rucio.rse.protocols import protocol
 from rucio.common.utils import execute, PREFERRED_CHECKSUM
+from rucio.rse.protocols import protocol
 
 
 class Default(protocol.RSEProtocol):

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -17,7 +17,6 @@ import copy
 import logging
 import random
 from time import sleep
-
 from urllib.parse import urlparse
 
 from rucio.common import exception, utils, constants

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -13,22 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import namedtuple
 import contextlib
 import itertools
 import json
 import os
-from random import choice, choices
-import requests
-from string import ascii_uppercase, ascii_letters, digits
 import tempfile
+from collections import namedtuple
+from random import choice, choices
+from string import ascii_uppercase, ascii_letters, digits
 from typing import Optional
 
 import pytest
+import requests
 
 from rucio.common.config import config_get, config_get_bool, get_config_dirs
 from rucio.common.utils import generate_uuid as uuid, execute
-
 
 skip_rse_tests_with_accounts = pytest.mark.skipif(not any(os.path.exists(os.path.join(d, 'rse-accounts.cfg')) for d in get_config_dirs()),
                                                   reason='fails if no rse-accounts.cfg found')

--- a/lib/rucio/tests/common_server.py
+++ b/lib/rucio/tests/common_server.py
@@ -23,7 +23,6 @@ from rucio.db.sqla import models
 from rucio.db.sqla.session import transactional_session, get_session
 from .common import get_long_vo
 
-
 # Functions containing server-only includes that can't be included in client tests
 # For each table, get the foreign key constraints from all other tables towards this table.
 INBOUND_FOREIGN_KEYS = {}

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -20,16 +20,15 @@ import pathlib
 import traceback
 import uuid
 from collections.abc import Callable
+from configparser import NoOptionError, NoSectionError
+from json import loads
 from typing import Any, Optional, TYPE_CHECKING
 from urllib.parse import urlparse
 
 import requests
-from configparser import NoOptionError, NoSectionError
-from json import loads
+from dogpile.cache.api import NoValue
 from requests.adapters import ReadTimeout
 from requests.packages.urllib3 import disable_warnings  # pylint: disable=import-error
-
-from dogpile.cache.api import NoValue
 
 from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get, config_get_bool
@@ -37,12 +36,12 @@ from rucio.common.constants import FTS_JOB_TYPE, FTS_STATE, FTS_COMPLETE_STATE
 from rucio.common.exception import TransferToolTimeout, TransferToolWrongAnswer, DuplicateFileTransferSubmission
 from rucio.common.stopwatch import Stopwatch
 from rucio.common.utils import APIEncoder, chunks, PREFERRED_CHECKSUM
+from rucio.core.monitor import MetricManager
+from rucio.core.oidc import get_token_for_account_operation
 from rucio.core.request import get_source_rse, get_transfer_error
 from rucio.core.rse import get_rse_supported_checksums_from_attributes
-from rucio.core.oidc import get_token_for_account_operation
-from rucio.core.monitor import MetricManager
-from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder, TransferStatusReport
 from rucio.db.sqla.constants import RequestState
+from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder, TransferStatusReport
 
 if TYPE_CHECKING:
     from rucio.core.transfer import DirectTransferDefinition

--- a/lib/rucio/transfertool/globus.py
+++ b/lib/rucio/transfertool/globus.py
@@ -16,8 +16,8 @@
 import logging
 
 from rucio.common.utils import chunks
-from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder, TransferStatusReport
 from rucio.db.sqla.constants import RequestState
+from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder, TransferStatusReport
 from .globus_library import bulk_submit_xfer, submit_xfer, bulk_check_xfers
 
 

--- a/lib/rucio/transfertool/mock.py
+++ b/lib/rucio/transfertool/mock.py
@@ -15,9 +15,9 @@
 
 import itertools
 import logging
+import uuid
 
 from rucio.transfertool.transfertool import Transfertool, TransferToolBuilder
-import uuid
 
 
 class MockTransfertool(Transfertool):

--- a/lib/rucio/transfertool/transfertool.py
+++ b/lib/rucio/transfertool/transfertool.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING
-
 from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING
 
 from rucio.core.request import get_request
 

--- a/lib/rucio/web/rest/flaskapi/authenticated_bp.py
+++ b/lib/rucio/web/rest/flaskapi/authenticated_bp.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from flask import Blueprint
+
 from rucio.web.rest.flaskapi.v1.common import request_auth_env
 
 

--- a/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
@@ -18,9 +18,9 @@ from flask import Flask, request
 from rucio.api.account_limit import set_local_account_limit, delete_local_account_limit, set_global_account_limit, \
     delete_global_account_limit
 from rucio.common.exception import RSENotFound, AccessDenied, AccountNotFound
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, ErrorHandlingMethodView, \
     generate_http_error_flask, json_parameters, param_get
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class LocalAccountLimit(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -28,9 +28,9 @@ from rucio.api.scope import add_scope, get_scopes
 from rucio.common.exception import AccountNotFound, Duplicate, AccessDenied, RuleNotFound, RSENotFound, \
     IdentityError, CounterNotFound, ScopeNotFound, InvalidObject
 from rucio.common.utils import APIEncoder, render_json
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     try_stream, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Attributes(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/archives.py
+++ b/lib/rucio/web/rest/flaskapi/v1/archives.py
@@ -18,9 +18,9 @@ from json import dumps
 from flask import Flask, request
 
 from rucio.api.did import list_archive_content
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     parse_scope_name, try_stream, generate_http_error_flask, ErrorHandlingMethodView
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Archive(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -14,24 +14,24 @@
 # limitations under the License.
 
 import base64
+import json
 import logging
 import time
-import json
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from flask import Flask, Blueprint, request, Response, redirect, render_template
-from urllib.parse import urlparse
 from werkzeug.datastructures import Headers
 
 from rucio.api.authentication import get_auth_token_user_pass, get_auth_token_gss, get_auth_token_x509, \
     get_auth_token_ssh, get_ssh_challenge_token, validate_auth_token, get_auth_oidc, redirect_auth_oidc, \
     get_token_oidc, refresh_cli_auth_token, get_auth_token_saml
+from rucio.api.identity import list_accounts_for_identity, get_default_account, verify_identity
 from rucio.common.config import config_get
 from rucio.common.exception import AccessDenied, IdentityError, IdentityNotFound, CannotAuthenticate, CannotAuthorize
 from rucio.common.extra import import_extras
 from rucio.common.utils import date_to_str
 from rucio.core.authentication import strip_x509_proxy_attributes
-from rucio.api.identity import list_accounts_for_identity, get_default_account, verify_identity
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, error_headers, \
     extract_vo, generate_http_error_flask, ErrorHandlingMethodView
 

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -17,6 +17,7 @@ import itertools
 import json
 import logging
 import re
+from configparser import NoOptionError, NoSectionError
 from functools import wraps
 from time import time
 from typing import TYPE_CHECKING
@@ -28,13 +29,11 @@ from werkzeug.exceptions import HTTPException
 from werkzeug.wrappers import Request, Response
 
 from rucio.api.authentication import validate_auth_token
+from rucio.common import config
 from rucio.common.exception import DatabaseException, RucioException, CannotAuthenticate, UnsupportedRequestedContentType
 from rucio.common.schema import get_schema_value
 from rucio.common.utils import generate_uuid, render_json
 from rucio.core.vo import map_vo
-from rucio.common import config
-from configparser import NoOptionError, NoSectionError
-
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence

--- a/lib/rucio/web/rest/flaskapi/v1/config.py
+++ b/lib/rucio/web/rest/flaskapi/v1/config.py
@@ -17,9 +17,9 @@ from flask import Flask, request as request, jsonify
 
 from rucio.api import config
 from rucio.common.exception import ConfigurationError, AccessDenied, ConfigNotFound
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     generate_http_error_flask, ErrorHandlingMethodView, json_parameters
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Config(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/credentials.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credentials.py
@@ -20,10 +20,10 @@ from werkzeug.datastructures import Headers
 
 from rucio.api.credential import get_signed_url
 from rucio.common.exception import CannotAuthenticate
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, extract_vo, \
     generate_http_error_flask, ErrorHandlingMethodView, response_headers
 
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 if TYPE_CHECKING:
     from typing import Optional
     from rucio.web.rest.flaskapi.v1.common import HeadersType

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import ast
-
 from json import dumps
 
 from flask import Flask, Response, request
@@ -30,9 +29,9 @@ from rucio.common.exception import ScopeNotFound, DataIdentifierNotFound, DataId
     UnsupportedOperation, RSENotFound, RuleNotFound, InvalidMetadata, InvalidPath, FileAlreadyExists, InvalidObject, FileConsistencyMismatch
 from rucio.common.utils import render_json, APIEncoder
 from rucio.db.sqla.constants import DIDType
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     parse_scope_name, try_stream, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, json_list, param_get, json_parse
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Scope(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/dirac.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dirac.py
@@ -19,9 +19,9 @@ from rucio.api.dirac import add_files
 from rucio.common.exception import AccessDenied, DataIdentifierAlreadyExists, DatabaseException, \
     Duplicate, InvalidPath, ResourceTemporaryUnavailable, RSENotFound, UnsupportedOperation
 from rucio.common.utils import parse_response
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, generate_http_error_flask, \
     ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class AddFiles(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/export.py
+++ b/lib/rucio/web/rest/flaskapi/v1/export.py
@@ -17,9 +17,9 @@ from flask import Flask, request, Response
 
 from rucio.api.exporter import export_data
 from rucio.common.utils import render_json
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     ErrorHandlingMethodView
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Export(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
+++ b/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
@@ -18,9 +18,9 @@ import json
 from flask import Flask, Response, request
 
 from rucio.api.heartbeat import list_heartbeats, create_heartbeat
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
-from rucio.common.utils import APIEncoder
 from rucio.common.exception import UnsupportedValueType, UnsupportedKeyType, KeyNotFound, AccessDenied
+from rucio.common.utils import APIEncoder
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     ErrorHandlingMethodView, json_parameters, param_get, generate_http_error_flask
 

--- a/lib/rucio/web/rest/flaskapi/v1/identities.py
+++ b/lib/rucio/web/rest/flaskapi/v1/identities.py
@@ -16,9 +16,9 @@
 from flask import Flask, request, jsonify
 
 from rucio.api.identity import add_identity, add_account_identity, list_accounts_for_identity
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     ErrorHandlingMethodView
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class UserPass(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/import.py
+++ b/lib/rucio/web/rest/flaskapi/v1/import.py
@@ -17,8 +17,8 @@ from flask import Flask, request
 
 from rucio.api.importer import import_data
 from rucio.common.utils import parse_response
-from rucio.web.rest.flaskapi.v1.common import response_headers, ErrorHandlingMethodView, json_parameters
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.v1.common import response_headers, ErrorHandlingMethodView, json_parameters
 
 
 class Import(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
@@ -21,9 +21,9 @@ from rucio.api.lifetime_exception import list_exceptions, add_exception, update_
 from rucio.common.exception import LifetimeExceptionNotFound, UnsupportedOperation, InvalidObject, AccessDenied, \
     LifetimeExceptionDuplicate
 from rucio.common.utils import APIEncoder
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     try_stream, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class LifetimeException(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/locks.py
+++ b/lib/rucio/web/rest/flaskapi/v1/locks.py
@@ -18,9 +18,9 @@ from flask import Flask, request
 from rucio.api.lock import get_dataset_locks_by_rse, get_dataset_locks, get_dataset_locks_bulk
 from rucio.common.exception import RSENotFound
 from rucio.common.utils import render_json
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, parse_scope_name, try_stream, \
     response_headers, generate_http_error_flask, ErrorHandlingMethodView, json_parse
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class LockByRSE(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/main.py
+++ b/lib/rucio/web/rest/flaskapi/v1/main.py
@@ -17,10 +17,11 @@
 import importlib
 
 from flask import Flask
-from rucio.web.rest.flaskapi.v1.common import CORSMiddleware
+
 from rucio.common.config import config_get
 from rucio.common.exception import ConfigurationError
 from rucio.common.logging import setup_logging
+from rucio.web.rest.flaskapi.v1.common import CORSMiddleware
 
 DEFAULT_ENDPOINTS = [
     'accountlimits',

--- a/lib/rucio/web/rest/flaskapi/v1/meta.py
+++ b/lib/rucio/web/rest/flaskapi/v1/meta.py
@@ -17,9 +17,9 @@ from flask import Flask, request, jsonify
 
 from rucio.api.meta import add_key, add_value, list_keys, list_values
 from rucio.common.exception import Duplicate, InvalidValueForKey, KeyNotFound, UnsupportedValueType, UnsupportedKeyType
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, response_headers, \
     generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Meta(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/metrics.py
+++ b/lib/rucio/web/rest/flaskapi/v1/metrics.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 from flask import Flask, Blueprint
-from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView
+
 from rucio.core.monitor import generate_prometheus_metrics
+from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView
 
 
 class Metrics(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -21,11 +21,11 @@ from xml.sax.saxutils import escape
 
 from flask import Flask, Response, request
 
+from rucio.api.quarantined_replica import quarantine_file_replicas
 from rucio.api.replica import add_replicas, list_replicas, list_dataset_replicas, list_dataset_replicas_bulk, \
     delete_replicas, get_did_from_pfns, update_replicas_states, declare_bad_file_replicas, add_bad_dids, add_bad_pfns, \
     get_suspicious_files, declare_suspicious_file_replicas, list_bad_replicas_status, get_bad_replicas_summary, \
     list_datasets_per_rse, set_tombstone, list_dataset_replicas_vp
-from rucio.api.quarantined_replica import quarantine_file_replicas
 from rucio.common.config import config_get, config_get_int
 from rucio.common.constants import SUPPORTED_PROTOCOLS
 from rucio.common.exception import AccessDenied, DataIdentifierAlreadyExists, InvalidType, DataIdentifierNotFound, \
@@ -33,9 +33,9 @@ from rucio.common.exception import AccessDenied, DataIdentifierAlreadyExists, In
 from rucio.common.utils import parse_response, APIEncoder, render_json_list
 from rucio.core.replica_sorter import sort_replicas
 from rucio.db.sqla.constants import BadFilesStatus
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, try_stream, parse_scope_name, \
     response_headers, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 def _sorted_with_priorities(replicas, sorted_pfns, limit=None):

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -23,9 +23,9 @@ from rucio.common.exception import RequestNotFound
 from rucio.common.utils import APIEncoder, render_json
 from rucio.core.rse import get_rses_with_attribute_value
 from rucio.db.sqla.constants import RequestState
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, parse_scope_name, try_stream, \
     response_headers, generate_http_error_flask, ErrorHandlingMethodView
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class RequestGet(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -27,9 +27,9 @@ from rucio.common.exception import Duplicate, AccessDenied, RSENotFound, RSEOper
     InvalidRSEExpression, RSEAttributeNotFound, CounterNotFound, InvalidPath, ReplicaNotFound, InputValidationError
 from rucio.common.utils import Availability, render_json, APIEncoder
 from rucio.rse import rsemanager
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     try_stream, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class RSEs(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 from json import dumps
+from typing import Any
 
 from flask import Flask, request, Response
-from typing import Any
 
 from rucio.api.lock import get_replica_locks_for_rule_id
 from rucio.api.rule import add_replication_rule, delete_replication_rule, get_replication_rule, \
@@ -27,9 +27,9 @@ from rucio.common.exception import InputValidationError, InsufficientAccountLimi
     InvalidRuleWeight, StagingAreaRuleRequiresLifetime, DuplicateRule, InvalidObject, AccountNotFound, \
     RuleReplaceFailed, ScratchDiskLifetimeConflict, ManualRuleApprovalBlocked, UnsupportedOperation
 from rucio.common.utils import render_json, APIEncoder
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, parse_scope_name, try_stream, \
     response_headers, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Rule(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/scopes.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scopes.py
@@ -17,9 +17,9 @@ from flask import Flask, request, jsonify
 
 from rucio.api.scope import add_scope, list_scopes, get_scopes
 from rucio.common.exception import AccountNotFound, Duplicate, ScopeNotFound
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, response_headers, \
     generate_http_error_flask, ErrorHandlingMethodView
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Scope(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -23,9 +23,9 @@ from rucio.api.subscription import list_subscriptions, add_subscription, update_
 from rucio.common.exception import InvalidObject, SubscriptionDuplicate, SubscriptionNotFound, RuleNotFound, \
     AccessDenied
 from rucio.common.utils import render_json, APIEncoder
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, try_stream, \
     response_headers, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class Subscription(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/tmp_dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/tmp_dids.py
@@ -16,8 +16,8 @@
 from flask import Flask, request
 
 from rucio.api.temporary_did import add_temporary_dids
-from rucio.web.rest.flaskapi.v1.common import response_headers, ErrorHandlingMethodView, json_list
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
+from rucio.web.rest.flaskapi.v1.common import response_headers, ErrorHandlingMethodView, json_list
 
 
 class BulkDIDS(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/vos.py
+++ b/lib/rucio/web/rest/flaskapi/v1/vos.py
@@ -18,9 +18,9 @@ from flask import Flask, request
 from rucio.api.vo import add_vo, list_vos, recover_vo_root_identity, update_vo
 from rucio.common.exception import AccessDenied, AccountNotFound, Duplicate, VONotFound, UnsupportedOperation
 from rucio.common.utils import render_json
+from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import response_headers, check_accept_header_wrapper_flask, \
     try_stream, generate_http_error_flask, ErrorHandlingMethodView, json_parameters, param_get
-from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 
 
 class VOs(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/metrics.py
+++ b/lib/rucio/web/rest/metrics.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rucio.common.logging import setup_logging
 from flask import Flask
+
+from rucio.common.logging import setup_logging
 from rucio.web.rest.flaskapi.v1.metrics import blueprint as metrics_blueprint
 
 # Allow to run the /metrics endpoint as a separate application on a separate PORT


### PR DESCRIPTION
Automatically re-arrange imports in 3 blocks: builtin, dependencies, rucio. And re-order them alphabetically.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
