### PR TITLE
Transfers: Do not skip requests failed during submission #6300

### DIFF
--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -290,9 +290,6 @@ def _finish_requests(reqs, suspicious_patterns, retry_protocol_mismatches, logge
 
             # All other failures
             elif req['state'] in failed_during_submission or req['state'] in failed_no_submission_attempts:
-                if req['state'] in failed_during_submission and req['updated_at'] > (datetime.datetime.utcnow() - FAILED_DURING_SUBMISSION_DELAY):
-                    # To prevent race conditions
-                    continue
                 try:
                     if request_core.should_retry_request(req, retry_protocol_mismatches):
                         new_req = request_core.requeue_and_archive(req, source_ranking_update=False, retry_protocol_mismatches=retry_protocol_mismatches, logger=logger)


### PR DESCRIPTION
Following 21513abef, requests are now implicitly updated by `list_and_mark_transfer_requests_and_source_replicas()` at the time they are fetched for processing. However, there is a check in the Finisher to silently skip recently-updated requests. As such, requests failed during submission end up in an endless cycle which prevents their resubmission.

There does not seem to be a valid motivation for this. Requests in states `SUBMISSION_FAILED` and `LOST` are not processed by any other daemon. Requests in state `SUBMITTING` that are recently updated are already skipped in `_fetch_requests()`.

This commit removes that check.
