### PR TITLE
Testing: Replace `which` with `command -v` #6303

### DIFF
--- a/tools/test/install_script.sh
+++ b/tools/test/install_script.sh
@@ -16,7 +16,7 @@
 
 set -eo pipefail
 
-echo "* Using $(which python) $(python --version 2>&1) and $(which pip) $(pip --version 2>&1)"
+echo "* Using $(command -v python) $(python --version 2>&1) and $(command -v pip) $(pip --version 2>&1)"
 
 if [ "$SUITE" == "client" -o "$SUITE" == "client_syntax" ]; then
     cd /usr/local/src/rucio


### PR DESCRIPTION
The `which` utility is an external utility that has to be installed as an RPM package. We could include it during the container creation or we could use the equivalent `command -v` builtin from the Bash (the default shell).
