### PR TITLE
Testing: Rename deprecated minio env vars #6324

### DIFF
--- a/etc/docker/dev/docker-compose-storage-alldb.yml
+++ b/etc/docker/dev/docker-compose-storage-alldb.yml
@@ -159,8 +159,8 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
     environment:
-      - MINIO_ACCESS_KEY=admin
-      - MINIO_SECRET_KEY=password
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
     volumes:
       - ../../certs/hostcert_minio.pem:/root/.minio/certs/public.crt:Z
       - ../../certs/hostcert_minio.key.pem:/root/.minio/certs/private.key:Z

--- a/etc/docker/dev/docker-compose-storage-externalmetadata.yml
+++ b/etc/docker/dev/docker-compose-storage-externalmetadata.yml
@@ -137,8 +137,8 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
     environment:
-      - MINIO_ACCESS_KEY=admin
-      - MINIO_SECRET_KEY=password
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
     volumes:
       - ../../certs/hostcert_minio.pem:/root/.minio/certs/public.crt:Z
       - ../../certs/hostcert_minio.key.pem:/root/.minio/certs/private.key:Z

--- a/etc/docker/dev/docker-compose-storage-monit.yml
+++ b/etc/docker/dev/docker-compose-storage-monit.yml
@@ -139,8 +139,8 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
     environment:
-      - MINIO_ACCESS_KEY=admin
-      - MINIO_SECRET_KEY=password
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
     volumes:
       - ../../certs/hostcert_minio.pem:/root/.minio/certs/public.crt:Z
       - ../../certs/hostcert_minio.key.pem:/root/.minio/certs/private.key:Z

--- a/etc/docker/dev/docker-compose-storage.yml
+++ b/etc/docker/dev/docker-compose-storage.yml
@@ -138,8 +138,8 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
     environment:
-      - MINIO_ACCESS_KEY=admin
-      - MINIO_SECRET_KEY=password
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
     volumes:
       - ../../certs/hostcert_minio.pem:/root/.minio/certs/public.crt:Z
       - ../../certs/hostcert_minio.key.pem:/root/.minio/certs/private.key:Z


### PR DESCRIPTION
Minor change: renamed MINIO_ACCESS_KEY and MINIO_SECRET_KEY in docker-compose files under `/etc/dev/docker` to avoid deprecation warning
