### PR TITLE
FlaskAPI: Fixed docs of `RSEs` to use query params

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -43,15 +43,12 @@ class RSEs(ErrorHandlingMethodView):
         description: Lists all RSEs.
         tags:
           - Rucio Storage Elements
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  expression:
-                    description: An RSE expression.
-                    type: string
+        parameters:
+        - name: expression
+          in: query
+          description: RSE expression to select RSEs.
+          schema:
+            type: string
         responses:
           200:
             description: OK


### PR DESCRIPTION
The RSE Expression is passed via the query params and not the body. The docs were wrong, this will fix it