### PR TITLE
Core & Internals: Resolving improper use of NoResultFound #6309

### DIFF
--- a/lib/rucio/core/account.py
+++ b/lib/rucio/core/account.py
@@ -337,10 +337,9 @@ def get_usage_history(rse_id, account, *, session: "Session"):
 
     result = []
     AccountUsageHistory = models.AccountUsageHistory
-    try:
-        query = session.query(AccountUsageHistory).filter_by(rse_id=rse_id, account=account).order_by(AccountUsageHistory.updated_at)
-        for row in query.all():
-            result.append({'bytes': row.bytes, 'files': row.files, 'updated_at': row.updated_at})
-    except exc.NoResultFound:
+    query = session.query(AccountUsageHistory).filter_by(rse_id=rse_id, account=account).order_by(AccountUsageHistory.updated_at)
+    for row in query.all():
+        result.append({'bytes': row.bytes, 'files': row.files, 'updated_at': row.updated_at})
+    if not result:
         raise exception.CounterNotFound('No usage can be found for account %s on RSE %s' % (account, rucio.core.rse.get_rse_name(rse_id=rse_id, session=session)))
     return result

--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -1655,20 +1655,17 @@ def list_content(scope, name, *, session: "Session"):
     :param name: The data identifier name.
     :param session: The database session in use.
     """
-    try:
-        stmt = select(
-            models.DataIdentifierAssociation
-        ).with_hint(
-            models.DataIdentifierAssociation, "INDEX(CONTENTS CONTENTS_PK)", 'oracle'
-        ).filter_by(
-            scope=scope,
-            name=name
-        )
-        for tmp_did in session.execute(stmt).yield_per(5).scalars():
-            yield {'scope': tmp_did.child_scope, 'name': tmp_did.child_name, 'type': tmp_did.child_type,
-                   'bytes': tmp_did.bytes, 'adler32': tmp_did.adler32, 'md5': tmp_did.md5}
-    except NoResultFound:
-        raise exception.DataIdentifierNotFound(f"Data identifier '{scope}:{name}' not found")
+    stmt = select(
+        models.DataIdentifierAssociation
+    ).with_hint(
+        models.DataIdentifierAssociation, "INDEX(CONTENTS CONTENTS_PK)", 'oracle'
+    ).filter_by(
+        scope=scope,
+        name=name
+    )
+    for tmp_did in session.execute(stmt).yield_per(5).scalars():
+        yield {'scope': tmp_did.child_scope, 'name': tmp_did.child_name, 'type': tmp_did.child_type,
+               'bytes': tmp_did.bytes, 'adler32': tmp_did.adler32, 'md5': tmp_did.md5}
 
 
 @stream_session
@@ -1680,21 +1677,18 @@ def list_content_history(scope, name, *, session: "Session"):
     :param name: The data identifier name.
     :param session: The database session in use.
     """
-    try:
-        stmt = select(
-            models.DataIdentifierAssociationHistory
-        ).filter_by(
-            scope=scope,
-            name=name
-        )
-        for tmp_did in session.execute(stmt).yield_per(5).scalars():
-            yield {'scope': tmp_did.child_scope, 'name': tmp_did.child_name,
-                   'type': tmp_did.child_type,
-                   'bytes': tmp_did.bytes, 'adler32': tmp_did.adler32, 'md5': tmp_did.md5,
-                   'deleted_at': tmp_did.deleted_at, 'created_at': tmp_did.created_at,
-                   'updated_at': tmp_did.updated_at}
-    except NoResultFound:
-        raise exception.DataIdentifierNotFound(f"Data identifier '{scope}:{name}' not found")
+    stmt = select(
+        models.DataIdentifierAssociationHistory
+    ).filter_by(
+        scope=scope,
+        name=name
+    )
+    for tmp_did in session.execute(stmt).yield_per(5).scalars():
+        yield {'scope': tmp_did.child_scope, 'name': tmp_did.child_name,
+               'type': tmp_did.child_type,
+               'bytes': tmp_did.bytes, 'adler32': tmp_did.adler32, 'md5': tmp_did.md5,
+               'deleted_at': tmp_did.deleted_at, 'created_at': tmp_did.created_at,
+               'updated_at': tmp_did.updated_at}
 
 
 @stream_session
@@ -2249,21 +2243,19 @@ def list_parent_dids_bulk(dids, *, session: "Session"):
         condition.append(and_(models.DataIdentifierAssociation.child_scope == did['scope'],
                               models.DataIdentifierAssociation.child_name == did['name']))
 
-    try:
-        for chunk in chunks(condition, 50):
-            stmt = select(
-                models.DataIdentifierAssociation.child_scope,
-                models.DataIdentifierAssociation.child_name,
-                models.DataIdentifierAssociation.scope,
-                models.DataIdentifierAssociation.name,
-                models.DataIdentifierAssociation.did_type
-            ).where(
-                or_(*chunk)
-            )
-            for did_chunk in session.execute(stmt).yield_per(5):
-                yield {'scope': did_chunk.scope, 'name': did_chunk.name, 'child_scope': did_chunk.child_scope, 'child_name': did_chunk.child_name, 'type': did_chunk.did_type}
-    except NoResultFound:
-        raise exception.DataIdentifierNotFound('No Data Identifiers found')
+    for chunk in chunks(condition, 50):
+        stmt = select(
+            models.DataIdentifierAssociation.child_scope,
+            models.DataIdentifierAssociation.child_name,
+            models.DataIdentifierAssociation.scope,
+            models.DataIdentifierAssociation.name,
+            models.DataIdentifierAssociation.did_type
+        ).where(
+            or_(*chunk)
+        )
+        for did_chunk in session.execute(stmt).yield_per(5):
+            yield {'scope': did_chunk.scope, 'name': did_chunk.name, 'child_scope': did_chunk.child_scope,
+                   'child_name': did_chunk.child_name, 'type': did_chunk.did_type}
 
 
 @stream_session
@@ -2319,19 +2311,16 @@ def get_metadata_bulk(dids, inherit=False, *, session: "Session"):
         for did in dids:
             condition.append(and_(models.DataIdentifier.scope == did['scope'],
                                   models.DataIdentifier.name == did['name']))
-        try:
-            for chunk in chunks(condition, 50):
-                stmt = select(
-                    models.DataIdentifier
-                ).with_hint(
-                    models.DataIdentifier, "INDEX(DIDS DIDS_PK)", 'oracle'
-                ).where(
-                    or_(*chunk)
-                )
-                for row in session.execute(stmt).scalars():
-                    yield row.to_dict()
-        except NoResultFound:
-            raise exception.DataIdentifierNotFound('No Data Identifiers found')
+        for chunk in chunks(condition, 50):
+            stmt = select(
+                models.DataIdentifier
+            ).with_hint(
+                models.DataIdentifier, "INDEX(DIDS DIDS_PK)", 'oracle'
+            ).where(
+                or_(*chunk)
+            )
+            for row in session.execute(stmt).scalars():
+                yield row.to_dict()
 
 
 @transactional_session
@@ -2737,21 +2726,18 @@ def list_archive_content(scope, name, *, session: "Session"):
     :param name: The archive data identifier name.
     :param session: The database session in use.
     """
-    try:
-        stmt = select(
-            models.ConstituentAssociation
-        ).with_hint(
-            models.ConstituentAssociation, "INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_PK)", 'oracle'
-        ).filter_by(
-            scope=scope,
-            name=name
-        )
+    stmt = select(
+        models.ConstituentAssociation
+    ).with_hint(
+        models.ConstituentAssociation, "INDEX(ARCHIVE_CONTENTS ARCH_CONTENTS_PK)", 'oracle'
+    ).filter_by(
+        scope=scope,
+        name=name
+    )
 
-        for tmp_did in session.execute(stmt).yield_per(5).scalars():
-            yield {'scope': tmp_did.child_scope, 'name': tmp_did.child_name,
-                   'bytes': tmp_did.bytes, 'adler32': tmp_did.adler32, 'md5': tmp_did.md5}
-    except NoResultFound:
-        raise exception.DataIdentifierNotFound(f"Data identifier '{scope}:{name}' not found")
+    for tmp_did in session.execute(stmt).yield_per(5).scalars():
+        yield {'scope': tmp_did.child_scope, 'name': tmp_did.child_name,
+               'bytes': tmp_did.bytes, 'adler32': tmp_did.adler32, 'md5': tmp_did.md5}
 
 
 @transactional_session
@@ -2807,19 +2793,15 @@ def get_users_following_did(scope, name, *, session: "Session"):
     :param name: The data identifier name.
     :param session: The database session in use.
     """
-    try:
-        stmt = select(
-            models.DidsFollowed
-        ).filter_by(
-            scope=scope,
-            name=name
-        )
-        for user in session.execute(stmt).scalars().all():
-            # Return a dictionary of users to be rendered as json.
-            yield {'user': user.account}
-
-    except NoResultFound:
-        raise exception.DataIdentifierNotFound("Data identifier '%s:%s' not found" % (scope, name))
+    stmt = select(
+        models.DidsFollowed
+    ).filter_by(
+        scope=scope,
+        name=name
+    )
+    for user in session.execute(stmt).scalars().all():
+        # Return a dictionary of users to be rendered as json.
+        yield {'user': user.account}
 
 
 @transactional_session

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -2902,28 +2902,29 @@ def list_dataset_replicas_bulk(names_by_intscope, *, session: "Session"):
         condition.append(and_(models.CollectionReplica.scope == scope,
                               models.CollectionReplica.name.in_(names_by_intscope[scope])))
 
-    try:
-        # chunk size refers to the number of different scopes, see above
-        for chunk in chunks(condition, 10):
-            query = session.query(models.CollectionReplica.scope,
-                                  models.CollectionReplica.name,
-                                  models.RSE.rse,
-                                  models.CollectionReplica.rse_id,
-                                  models.CollectionReplica.bytes,
-                                  models.CollectionReplica.length,
-                                  models.CollectionReplica.available_bytes,
-                                  models.CollectionReplica.available_replicas_cnt.label("available_length"),
-                                  models.CollectionReplica.state,
-                                  models.CollectionReplica.created_at,
-                                  models.CollectionReplica.updated_at,
-                                  models.CollectionReplica.accessed_at) \
-                .filter(models.CollectionReplica.did_type == DIDType.DATASET) \
-                .filter(models.CollectionReplica.rse_id == models.RSE.id) \
-                .filter(or_(*chunk)) \
-                .filter(models.RSE.deleted == false())
-            for row in query:
-                yield row._asdict()
-    except NoResultFound:
+    # chunk size refers to the number of different scopes, see above
+    yielded = False
+    for chunk in chunks(condition, 10):
+        query = session.query(models.CollectionReplica.scope,
+                              models.CollectionReplica.name,
+                              models.RSE.rse,
+                              models.CollectionReplica.rse_id,
+                              models.CollectionReplica.bytes,
+                              models.CollectionReplica.length,
+                              models.CollectionReplica.available_bytes,
+                              models.CollectionReplica.available_replicas_cnt.label("available_length"),
+                              models.CollectionReplica.state,
+                              models.CollectionReplica.created_at,
+                              models.CollectionReplica.updated_at,
+                              models.CollectionReplica.accessed_at) \
+            .filter(models.CollectionReplica.did_type == DIDType.DATASET) \
+            .filter(models.CollectionReplica.rse_id == models.RSE.id) \
+            .filter(or_(*chunk)) \
+            .filter(models.RSE.deleted == false())
+        for row in query:
+            yield row._asdict()
+            yielded = True
+    if not yielded:
         raise exception.DataIdentifierNotFound('No Data Identifiers found')
 
 


### PR DESCRIPTION
Initial idea of this PR was introducing `yielded` flag (like in`lib/rucio/core/replica.py`) which will indicate if any result was yielded at all and raise exception if not. Such implementation wasn't fully successful for all uses in `lib/rucio/core/did.py` due to failed tests so I considered removing unused constraints here for now.