### PR TITLE
Transfers: implement preliminary support for packet marking. #5856

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -372,7 +372,7 @@ def db_session():
 
 def __get_fixture_param(request):
     fixture_param = getattr(request, "param", None)
-    if not fixture_param:
+    if not fixture_param and request.instance:
         # Parametrize support is incomplete for legacy unittest test cases
         # Manually retrieve the parameters from the list of marks:
         mark = next(iter(filter(lambda m: m.name == 'parametrize', request.instance.pytestmark)), None)

--- a/tests/inputs/__init__.py
+++ b/tests/inputs/__init__.py
@@ -16,7 +16,12 @@
 import os
 from pathlib import Path
 
+DIRECTORY = Path(os.path.abspath(__file__)).parent
+
 # GeoLite2-City-Test.mmdb downloaded on 26/Jan/2022 from ./test-data/ in
 # https://github.com/maxmind/MaxMind-DB/tree/2f0ef0249245c7f19feffa366793a6fffd529701/
 # Check ./source-data/GeoLite2-City-Test.json in this repository for IPs to use in tests
-GEOIP_LITE2_CITY_TEST_DB = Path(os.path.abspath(__file__)).parent / 'GeoLite2-City-Test.tar.gz'
+GEOIP_LITE2_CITY_TEST_DB = DIRECTORY / 'GeoLite2-City-Test.tar.gz'
+
+# Downloaded on 05/oct/2023 from https://www.scitags.org/api.json
+SCITAGS_JSON = DIRECTORY / 'scitags.json'

--- a/tests/inputs/scitags.json
+++ b/tests/inputs/scitags.json
@@ -1,0 +1,432 @@
+{
+  "experiments": [
+    {
+      "expName": "default",
+      "expId": 1,
+      "activities": [
+        {
+          "activityName": "default",
+          "activityId": 1
+        },
+        {
+          "activityName": "perfsonar",
+          "activityId": 2
+        },
+        {
+          "activityName": "cache",
+          "activityId": 3
+        },
+        {
+          "activityName": "datachallenge",
+          "activityId": 4
+        }
+      ]
+    },
+    {
+      "expName": "atlas",
+      "expId": 2,
+      "activities": [
+        {
+          "activityName": "perfsonar",
+          "activityId": 2
+        },
+        {
+          "activityName": "cache",
+          "activityId": 3
+        },
+        {
+          "activityName": "datachallenge",
+          "activityId": 4
+        },
+        {
+          "activityName": "default",
+          "activityId": 8
+        },
+        {
+          "activityName": "analysis download",
+          "activityId": 9
+        },
+        {
+          "activityName": "analysis download direct io",
+          "activityId": 10
+        },
+        {
+          "activityName": "analysis input",
+          "activityId": 11
+        },
+        {
+          "activityName": "analysis upload",
+          "activityId": 12
+        },
+        {
+          "activityName": "cli download",
+          "activityId": 13
+        },
+        {
+          "activityName": "cli upload",
+          "activityId": 14
+        },
+        {
+          "activityName": "data consolidation",
+          "activityId": 15
+        },
+        {
+          "activityName": "data rebalancing",
+          "activityId": 16
+        },
+        {
+          "activityName": "express",
+          "activityId": 17
+        },
+        {
+          "activityName": "test",
+          "activityId": 18
+        },
+        {
+          "activityName": "production download",
+          "activityId": 19
+        },
+        {
+          "activityName": "production input",
+          "activityId": 20
+        },
+        {
+          "activityName": "production output",
+          "activityId": 21
+        },
+        {
+          "activityName": "production upload",
+          "activityId": 22
+        },
+        {
+          "activityName": "recovery",
+          "activityId": 23
+        },
+        {
+          "activityName": "staging",
+          "activityId": 24
+        },
+        {
+          "activityName": "t0 export",
+          "activityId": 25
+        },
+        {
+          "activityName": "user subscriptions",
+          "activityId": 26
+        }
+      ]
+    },
+    {
+      "expName": "cms",
+      "expId": 3,
+      "activities": [
+        {
+          "activityName": "default",
+          "activityId": 1
+        },
+        {
+          "activityName": "perfsonar",
+          "activityId": 2
+        },
+        {
+          "activityName": "cache",
+          "activityId": 3
+        },
+        {
+          "activityName": "datachallenge",
+          "activityId": 4
+        }
+      ]
+    },
+    {
+      "expName": "lhcb",
+      "expId": 4,
+      "activities": [
+        {
+          "activityName": "default",
+          "activityId": 1
+        },
+        {
+          "activityName": "perfsonar",
+          "activityId": 2
+        },
+        {
+          "activityName": "cache",
+          "activityId": 3
+        },
+        {
+          "activityName": "datachallenge",
+          "activityId": 4
+        }
+      ]
+    },
+    {
+      "expName": "alice",
+      "expId": 5,
+      "activities": [
+        {
+          "activityName": "default",
+          "activityId": 1
+        },
+        {
+          "activityName": "perfsonar",
+          "activityId": 2
+        },
+        {
+          "activityName": "cache",
+          "activityId": 3
+        },
+        {
+          "activityName": "datachallenge",
+          "activityId": 4
+        },
+        {
+          "activityName": "data consolidation",
+          "activityId": 8
+        },
+        {
+          "activityName": "job preparation",
+          "activityId": 9
+        },
+        {
+          "activityName": "data access",
+          "activityId": 10
+        },
+        {
+          "activityName": "calibration data access",
+          "activityId": 11
+        },
+        {
+          "activityName": "job output",
+          "activityId": 12
+        },
+        {
+          "activityName": "data replication",
+          "activityId": 13
+        },
+        {
+          "activityName": "cli download",
+          "activityId": 14
+        },
+        {
+          "activityName": "cli upload",
+          "activityId": 15
+        },
+        {
+          "activityName": "functional tests",
+          "activityId": 16
+        }
+      ]
+    },
+    {
+      "expName": "belleii",
+      "expId": 6,
+      "activities": [
+        {
+          "activityName": "default",
+          "activityId": 1
+        },
+        {
+          "activityName": "perfsonar",
+          "activityId": 2
+        },
+        {
+          "activityName": "cache",
+          "activityId": 3
+        },
+        {
+          "activityName": "datachallenge",
+          "activityId": 4
+        },
+        {
+          "activityName": "data consolidation",
+          "activityId": 8
+        },
+        {
+          "activityName": "data rebalancing",
+          "activityId": 9
+        },
+        {
+          "activityName": "functional test",
+          "activityId": 10
+        },
+        {
+          "activityName": "functional test webdav",
+          "activityId": 11
+        },
+        {
+          "activityName": "recovery",
+          "activityId": 12
+        },
+        {
+          "activityName": "production input",
+          "activityId": 13
+        },
+        {
+          "activityName": "production output",
+          "activityId": 14
+        },
+        {
+          "activityName": "production merge",
+          "activityId": 15
+        },
+        {
+          "activityName": "analysis input",
+          "activityId": 16
+        },
+        {
+          "activityName": "analysis output",
+          "activityId": 17
+        },
+        {
+          "activityName": "staging",
+          "activityId": 18
+        },
+        {
+          "activityName": "raw export",
+          "activityId": 19
+        },
+        {
+          "activityName": "upload/download (job)",
+          "activityId": 20
+        },
+        {
+          "activityName": "upload/download (user)",
+          "activityId": 21
+        },
+        {
+          "activityName": "user merge",
+          "activityId": 22
+        },
+        {
+          "activityName": "user transfers",
+          "activityId": 23
+        },
+        {
+          "activityName": "user subscription",
+          "activityId": 24
+        },
+        {
+          "activityName": "t0 tape",
+          "activityId": 25
+        },
+        {
+          "activityName": "t0 export",
+          "activityId": 26
+        }
+      ]
+    },
+    {
+      "expName": "ska",
+      "expId": 7,
+      "activities": [
+        {
+          "activityName": "default",
+          "activityId": 1
+        },
+        {
+          "activityName": "perfsonar",
+          "activityId": 2
+        },
+        {
+          "activityName": "cache",
+          "activityId": 3
+        },
+        {
+          "activityName": "datachallenge",
+          "activityId": 4
+        }
+      ]
+    },
+    {
+      "expName": "dune",
+      "expId": 8,
+      "activities": [
+        {
+          "activityName": "default",
+          "activityId": 1
+        },
+        {
+          "activityName": "perfsonar",
+          "activityId": 2
+        },
+        {
+          "activityName": "cache",
+          "activityId": 3
+        },
+        {
+          "activityName": "datachallenge",
+          "activityId": 4
+        }
+      ]
+    },
+    {
+      "expName": "lsst",
+      "expId": 9,
+      "activities": [
+        {
+          "activityName": "default",
+          "activityId": 1
+        },
+        {
+          "activityName": "perfsonar",
+          "activityId": 2
+        },
+        {
+          "activityName": "cache",
+          "activityId": 3
+        },
+        {
+          "activityName": "datachallenge",
+          "activityId": 4
+        }
+      ]
+    },
+    {
+      "expName": "ilc",
+      "expId": 10,
+      "activities": [
+        {
+          "activityName": "default",
+          "activityId": 1
+        },
+        {
+          "activityName": "perfsonar",
+          "activityId": 2
+        },
+        {
+          "activityName": "cache",
+          "activityId": 3
+        },
+        {
+          "activityName": "datachallenge",
+          "activityId": 4
+        }
+      ]
+    },
+    {
+      "expName": "auger",
+      "expId": 11,
+      "activities": [
+        {
+          "activityName": "default",
+          "activityId": 1
+        },
+        {
+          "activityName": "perfsonar",
+          "activityId": 2
+        },
+        {
+          "activityName": "cache",
+          "activityId": 3
+        },
+        {
+          "activityName": "datachallenge",
+          "activityId": 4
+        }
+      ]
+    }
+  ],
+  "version": 1,
+  "modified": "2023-04-14T08:45:55.373545+00:00"
+}

--- a/tests/mocks/mock_http_server.py
+++ b/tests/mocks/mock_http_server.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from http.server import SimpleHTTPRequestHandler
+from http.server import HTTPServer
+from threading import Thread
+
+
+class MockServer:
+    """
+    Start A simple http server in a separate thread to serve as MOCK for testing the client
+    """
+
+    class Handler(SimpleHTTPRequestHandler):
+        def send_code_and_message(self, code, headers, message):
+            """
+            Helper which wraps the quite-low-level BaseHTTPRequestHandler primitives and is used to send reponses.
+            """
+            self.send_response(code)
+            self.send_header("Content-type", "text/plain")
+            for name, content in headers.items():
+                self.send_header(name, content)
+            self.end_headers()
+            self.wfile.write(message.encode())
+
+    def __init__(self, request_handler_cls):
+        self.server = HTTPServer(('localhost', 0), request_handler_cls)
+        self.thread = Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.server.shutdown()
+        self.thread.join()
+        self.server.server_close()
+
+    @property
+    def base_url(self):
+        name, port = self.server.server_address
+        return 'http://{}:{}'.format(name, port)


### PR DESCRIPTION
Fetch the marking configuration once, on startup, then every 2 days. If fetching fails, re-fetch again more rapidly to recover from transient failures.

For now, the marking is added as a file_metadata field. Waiting for the final decision from FTS developers about the correct way of passing this parameter

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
