### PR TITLE
Recovery: Adjust suspicious replica recoverer creation of rules. #6337

### DIFF
--- a/bin/rucio-replica-recoverer
+++ b/bin/rucio-replica-recoverer
@@ -228,8 +228,8 @@ Note that attempting the use the ``--vos`` argument when in single-VO mode will 
   $ rucio-replica-recoverer --run-once --vos abc xyz
   2020-07-28 15:21:33,349 5488    WARNING Ignoring argument vos, this is only applicable in a multi-VO setup.
 ''', formatter_class=argparse.RawDescriptionHelpFormatter)  # NOQA: E501
-    parser.add_argument("--nattempts", action="store", default=10, help='Minimum count of suspicious file replica appearance in bad_replicas table. Default value is 10.')
-    parser.add_argument("--younger-than", action="store", default=3, help='Consider all file replicas logged in bad_replicas table since speicified number of younger-than days. Default value is 3.')
+    parser.add_argument("--nattempts", action="store", default=5, help='Minimum count of suspicious file replica appearance in bad_replicas table. Default value is 5.')
+    parser.add_argument("--younger-than", action="store", default=5, help='Consider all file replicas logged in bad_replicas table since speicified number of younger-than days. Default value is 5.')
     parser.add_argument('--vos', nargs='+', type=str, help='Optional list of VOs to consider. Only used in multi-VO mode.')
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only.')
     parser.add_argument("--limit-suspicious-files-on-rse", action="store", default=5, help='Maximum number of suspicious replicas on an RSE before that RSE is considered problematic and the suspicious replicas on that RSE are declared "TEMPORARY_UNAVAILABLE". Default value is 5.')

--- a/etc/suspicious_replica_recoverer.json
+++ b/etc/suspicious_replica_recoverer.json
@@ -9,4 +9,9 @@
         "datatype": ["RAW"],
         "scope": []
     }
+    {
+        "action": "dry run",
+        "datatype": [],
+        "scope": ["mc.*"]
+    }
 ]

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -3406,7 +3406,7 @@ def get_replicas_state(scope=None, name=None, *, session: "Session"):
 
 
 @read_session
-def get_suspicious_files(rse_expression, available_elsewhere, filter_=None, logger=logging.log, younger_than=10, nattempts=0, nattempts_exact=False, *, session: "Session", exclude_states=['B', 'R', 'D'], is_suspicious=False):
+def get_suspicious_files(rse_expression, available_elsewhere, filter_=None, logger=logging.log, younger_than=5, nattempts=0, nattempts_exact=False, *, session: "Session", exclude_states=['B', 'R', 'D'], is_suspicious=False):
     """
     Gets a list of replicas from bad_replicas table which are: declared more than <nattempts> times since <younger_than> date,
     present on the RSE specified by the <rse_expression> and do not have a state in <exclude_states> list.
@@ -3539,7 +3539,12 @@ def get_suspicious_reason(rse_id, scope, name, nattempts=0, logger=logging.log, 
     query = session.query(bad_replicas_alias.scope, bad_replicas_alias.name, bad_replicas_alias.reason, bad_replicas_alias.rse_id)\
                    .filter(bad_replicas_alias.rse_id == rse_id,
                            bad_replicas_alias.scope == scope,
-                           bad_replicas_alias.name == name)
+                           bad_replicas_alias.name == name,
+                           bad_replicas_alias.state == 'S',
+                           ~exists(select(1).where(and_(bad_replicas_alias.rse_id == rse_id,
+                                                        bad_replicas_alias.scope == scope,
+                                                        bad_replicas_alias.name == name,
+                                                        bad_replicas_alias.state != 'S',))))
     count = query.count()
 
     query_result = query.group_by(bad_replicas_alias.rse_id, bad_replicas_alias.scope, bad_replicas_alias.name, bad_replicas_alias.reason).having(func.count() > nattempts).all()

--- a/lib/rucio/daemons/auditor/__init__.py
+++ b/lib/rucio/daemons/auditor/__init__.py
@@ -155,7 +155,7 @@ def process_output(output, sanity_check=True, compress=True):
     rse = os.path.basename(output[:output.rfind('_')])
     rse_id = get_rse_id(rse=rse)
     usage = get_rse_usage(rse_id=rse_id, source='rucio')[0]
-    threshold = config.config_get_float('auditor', 'threshold', False, 0.2)
+    threshold = config.config_get_float('auditor', 'threshold', False, 0.1)
 
     # Perform a basic sanity check by comparing the number of entries
     # with the total number of files on the RSE.  If the percentage is

--- a/tests/test_replica_recoverer.py
+++ b/tests/test_replica_recoverer.py
@@ -55,12 +55,14 @@ class TestReplicaRecoverer:
         self.tmp_file8 = file_factory.file_generator()
         self.tmp_file9 = file_factory.file_generator()
         self.tmp_file10 = file_factory.file_generator()
-        self.tmp_file11 = file_factory.file_generator()
+        self.tmp_file11 = file_factory.file_generator()  # tmp_file11 shouldn't be declare as bad, as it doesn't have a data type.
+        self.tmp_file12 = file_factory.file_generator()  # tmp_file12 is used to test the creation of rules by the daemon.
+        self.tmp_file13 = file_factory.file_generator()
 
         self.listdids_mock = [{'scope': mock_scope, 'name': f.name, 'type': DIDType.FILE}
-                              for f in [self.tmp_file1, self.tmp_file2, self.tmp_file3, self.tmp_file4, self.tmp_file5, self.tmp_file6]]
+                              for f in [self.tmp_file1, self.tmp_file2, self.tmp_file3, self.tmp_file4, self.tmp_file5, self.tmp_file6, self.tmp_file12]]
         self.listdids_declarebad = [{'scope': self.scope_declarebad, 'name': f.name, 'type': DIDType.FILE}
-                                    for f in [self.tmp_file7, self.tmp_file9, self.tmp_file11]]
+                                    for f in [self.tmp_file7, self.tmp_file9, self.tmp_file11, self.tmp_file13]]
         self.listdids_nopolicy = [{'scope': self.scope_nopolicy, 'name': f.name, 'type': DIDType.FILE}
                                   for f in [self.tmp_file8]]
         self.listdids_ignore = [{'scope': self.scope_ignore, 'name': f.name, 'type': DIDType.FILE}
@@ -68,14 +70,14 @@ class TestReplicaRecoverer:
 
         for rse in [self.rse4suspicious, self.rse4recovery]:
             # Upload files with scope "mock_scope"
-            cmd = 'rucio -v upload --rse {0} --scope {1} {2} {3} {4} {5} {6} {7}'.format(rse, mock_scope.external, self.tmp_file1, self.tmp_file2, self.tmp_file3, self.tmp_file4, self.tmp_file5, self.tmp_file6)
+            cmd = 'rucio -v upload --rse {0} --scope {1} {2} {3} {4} {5} {6} {7} {8}'.format(rse, mock_scope.external, self.tmp_file1, self.tmp_file2, self.tmp_file3, self.tmp_file4, self.tmp_file5, self.tmp_file6, self.tmp_file12)
             exitcode, out, err = execute(cmd)
             print("mock_scope:", exitcode, out, err)
             # checking if Rucio upload went OK
             assert exitcode == 0
 
             # Upload files with scope "scope_declarebad"
-            cmd = 'rucio -v upload --rse {0} --scope {1} {2} {3} {4}'.format(rse, self.scope_declarebad.external, self.tmp_file7, self.tmp_file9, self.tmp_file11)
+            cmd = 'rucio -v upload --rse {0} --scope {1} {2} {3} {4} {5}'.format(rse, self.scope_declarebad.external, self.tmp_file7, self.tmp_file9, self.tmp_file11, self.tmp_file13)
             exitcode, out, err = execute(cmd)
             print("scope_declarebad:", exitcode, out, err)
             # checking if Rucio upload went OK
@@ -109,7 +111,8 @@ class TestReplicaRecoverer:
         set_metadata(self.scope_nopolicy, self.tmp_file8.name, 'datatype', 'testtypenopolicy')
         set_metadata(self.scope_declarebad, self.tmp_file9.name, 'datatype', 'testtypeignore')
         set_metadata(self.scope_ignore, self.tmp_file10.name, 'datatype', 'testtypedeclarebad')
-        # tmp_file11 doesn't have a datatype.
+        set_metadata(self.scope_declarebad, self.tmp_file13.name, 'datatype', 'testtypedryrun')
+        # tmp_file1, 2, 11 and 12 don't have a datatypes.
 
         # Allow for the RSEs to be affected by the suspicious file recovery daemon
         add_rse_attribute(self.rse4suspicious_id, "enable_suspicious_file_recovery", True)
@@ -127,15 +130,17 @@ class TestReplicaRecoverer:
         remove(self.tmp_file9)
         remove(self.tmp_file10)
         remove(self.tmp_file11)
+        remove(self.tmp_file12)
+        remove(self.tmp_file13)
 
         # Reset the cache to include the new RSEs
         rse_expression_parser.REGION.invalidate()
 
         # Gather replica info
-        replicalist_mock = list(list_replicas(dids=self.listdids_mock))
-        replicalist_declarebad = list(list_replicas(dids=self.listdids_declarebad))
-        replicalist_nopolicy = list(list_replicas(dids=self.listdids_nopolicy))
-        replicalist_ignore = list(list_replicas(dids=self.listdids_ignore))
+        replicalist_scope_mock = list(list_replicas(dids=self.listdids_mock))
+        replicalist_scope_declarebad = list(list_replicas(dids=self.listdids_declarebad))
+        replicalist_scope_nopolicy = list(list_replicas(dids=self.listdids_nopolicy))
+        replicalist_scope_ignore = list(list_replicas(dids=self.listdids_ignore))
 
         # Changing the replica statuses as follows:
         # ----------------------------------------------------------------------------------------------------------------------------------------------------
@@ -152,16 +157,26 @@ class TestReplicaRecoverer:
         # tmp_file9    unavailable                              suspicious (available)                    scope_declarebad            testtypeignore
         # tmp_file10   unavailable                              suspicious (available)                    scope_ignore                testtypedeclarebad
         # tmp_file11   unavailable                              suspicious (available)                    scope_declarebad            <none>
+        # tmp_file12   unavailable                              suspicious (available)                    mock_scope                  <none>
+        # tmp_file13   unavailable                              suspicious (available)                    scope_declarebad            testtypedryrun
         # ----------------------------------------------------------------------------------------------------------------------------------------------------
 
-        for replica in replicalist_mock:
+        for replica in replicalist_scope_mock:
             suspicious_pfns = replica['rses'][self.rse4suspicious_id]
-            #  Declare each file as suspicious multiple times
-            for i in range(3):
+            # Declare each file as suspicious multiple times, apart from tmp_file12, which
+            # should only be declared suspicious once. tmp_file12 is used to test the
+            # creation of rules by the daemon.
+            if replica['name'] == self.tmp_file12.name:
                 print("Declaring suspicious file replica: " + suspicious_pfns[0])
                 # The reason must contain the word "checksum", so that the replica can be declared bad.
                 replica_client.declare_suspicious_file_replicas([suspicious_pfns[0], ], 'checksum')
                 sleep(1)
+            else:
+                for i in range(3):
+                    print("Declaring suspicious file replica: " + suspicious_pfns[0])
+                    # The reason must contain the word "checksum", so that the replica can be declared bad.
+                    replica_client.declare_suspicious_file_replicas([suspicious_pfns[0], ], 'checksum')
+                    sleep(1)
             if replica['name'] == self.tmp_file2.name:
                 print("Declaring bad file replica: " + suspicious_pfns[0])
                 replica_client.declare_bad_file_replicas([suspicious_pfns[0], ], 'checksum')
@@ -177,8 +192,11 @@ class TestReplicaRecoverer:
             if replica['name'] == self.tmp_file6.name:
                 print("Updating replica state as unavailable: " + replica['rses'][self.rse4recovery_id][0])
                 update_replica_state(self.rse4recovery_id, mock_scope, self.tmp_file6.name, ReplicaState.UNAVAILABLE)
+            if replica['name'] == self.tmp_file12.name:
+                print("Updating replica state as unavailable: " + replica['rses'][self.rse4recovery_id][0])
+                update_replica_state(self.rse4recovery_id, mock_scope, self.tmp_file12.name, ReplicaState.UNAVAILABLE)
 
-        for replica in replicalist_declarebad:
+        for replica in replicalist_scope_declarebad:
             suspicious_pfns = replica['rses'][self.rse4suspicious_id]
             #  Declare each file as suspicious multiple times
             for i in range(3):
@@ -195,8 +213,11 @@ class TestReplicaRecoverer:
             if replica['name'] == self.tmp_file11.name:
                 print("Updating replica state as unavailable: " + replica['rses'][self.rse4recovery_id][0])
                 update_replica_state(self.rse4recovery_id, self.scope_declarebad, self.tmp_file11.name, ReplicaState.UNAVAILABLE)
+            if replica['name'] == self.tmp_file13.name:
+                print("Updating replica state as unavailable: " + replica['rses'][self.rse4recovery_id][0])
+                update_replica_state(self.rse4recovery_id, self.scope_declarebad, self.tmp_file13.name, ReplicaState.UNAVAILABLE)
 
-        for replica in replicalist_nopolicy:
+        for replica in replicalist_scope_nopolicy:
             suspicious_pfns = replica['rses'][self.rse4suspicious_id]
             #  Declare each file as suspicious multiple times
             for i in range(3):
@@ -208,7 +229,7 @@ class TestReplicaRecoverer:
                 print("Updating replica state as unavailable: " + replica['rses'][self.rse4recovery_id][0])
                 update_replica_state(self.rse4recovery_id, self.scope_nopolicy, self.tmp_file8.name, ReplicaState.UNAVAILABLE)
 
-        for replica in replicalist_ignore:
+        for replica in replicalist_scope_ignore:
             suspicious_pfns = replica['rses'][self.rse4suspicious_id]
             #  Declare each file as suspicious multiple times
             for i in range(3):
@@ -221,13 +242,13 @@ class TestReplicaRecoverer:
                 update_replica_state(self.rse4recovery_id, self.scope_ignore, self.tmp_file10.name, ReplicaState.UNAVAILABLE)
 
         # Gather replica info after setting initial replica statuses
-        replicalist_mock = list(list_replicas(dids=self.listdids_mock))
-        replicalist_declarebad = list(list_replicas(dids=self.listdids_declarebad))
-        replicalist_nopolicy = list(list_replicas(dids=self.listdids_nopolicy))
-        replicalist_ignore = list(list_replicas(dids=self.listdids_ignore))
+        replicalist_scope_mock = list(list_replicas(dids=self.listdids_mock))
+        replicalist_scope_declarebad = list(list_replicas(dids=self.listdids_declarebad))
+        replicalist_scope_nopolicy = list(list_replicas(dids=self.listdids_nopolicy))
+        replicalist_scope_ignore = list(list_replicas(dids=self.listdids_ignore))
 
         # Checking if the status changes were effective
-        for replica in replicalist_mock:
+        for replica in replicalist_scope_mock:
             if replica['name'] == self.tmp_file1.name:
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert replica['states'][self.rse4recovery_id] == 'AVAILABLE'
@@ -246,8 +267,11 @@ class TestReplicaRecoverer:
             if replica['name'] == self.tmp_file6.name:
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
+            if replica['name'] == self.tmp_file12.name:
+                assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
+                assert (self.rse4recovery_id in replica['states']) is False
 
-        for replica in replicalist_declarebad:
+        for replica in replicalist_scope_declarebad:
             if replica['name'] == self.tmp_file7.name:
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
@@ -255,16 +279,19 @@ class TestReplicaRecoverer:
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
             if replica['name'] == self.tmp_file11.name:
-            # tmp_file11 should be ignored, as it doesn't have a datatype
+                # tmp_file11 should be ignored, as it doesn't have a datatype
+                assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
+                assert (self.rse4recovery_id in replica['states']) is False
+            if replica['name'] == self.tmp_file13.name:
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
 
-        for replica in replicalist_nopolicy:
+        for replica in replicalist_scope_nopolicy:
             if replica['name'] == self.tmp_file8.name:
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
 
-        for replica in replicalist_ignore:
+        for replica in replicalist_scope_ignore:
             if replica['name'] == self.tmp_file10.name:
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
@@ -285,6 +312,8 @@ class TestReplicaRecoverer:
         assert (self.tmp_file9.name, self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
         assert (self.tmp_file10.name, self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
         assert (self.tmp_file11.name, self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (self.tmp_file12.name, self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (self.tmp_file13.name, self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
 
         bad_replicas_list = list_bad_replicas_status(rse_id=self.rse4recovery_id, younger_than=self.from_date, vo=vo)
         bad_checklist = [(badf['name'], badf['rse_id'], badf['state']) for badf in bad_replicas_list]
@@ -300,6 +329,8 @@ class TestReplicaRecoverer:
         assert (self.tmp_file9.name, self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
         assert (self.tmp_file10.name, self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
         assert (self.tmp_file11.name, self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (self.tmp_file12.name, self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (self.tmp_file13.name, self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
 
         # Purposefully not checking for the 'SUSPICIOUS' status on rse4suspicious.
         # The only existing function (to date) gathering info about 'SUSPICIOUS' replicas
@@ -318,10 +349,11 @@ class TestReplicaRecoverer:
             # "datatype": [] and "scope": [] are wildcards; they stand for every datatype or scope.
             json_testentry1 = {"action": "ignore", "datatype": ["testtypedeclarebad"], "scope": [str(self.scope_ignore)]}
             json_testentry2 = {"action": "declare bad", "datatype": ["testtypeignore"], "scope": [str(self.scope_declarebad)]}
-            json_testentry3 = {"action": "declare bad", "datatype": ["testtypedeclarebad"], "scope": []}
-            json_testentry4 = {"action": "ignore", "datatype": ["testtypeignore"], "scope": []}
-            json_testentry5 = {"action": "declare bad", "datatype": [], "scope": [str(self.scope_declarebad)]}
-            json_testentry6 = {"action": "ignore", "datatype": [], "scope": [str(self.scope_ignore)]}
+            json_testentry3 = {"action": "dry run", "datatype": ["testtypedryrun"], "scope": [str(self.scope_declarebad)]}
+            json_testentry4 = {"action": "declare bad", "datatype": ["testtypedeclarebad"], "scope": []}
+            json_testentry5 = {"action": "ignore", "datatype": ["testtypeignore"], "scope": []}
+            json_testentry6 = {"action": "declare bad", "datatype": [], "scope": [str(self.scope_declarebad)]}
+            json_testentry7 = {"action": "ignore", "datatype": [], "scope": [str(self.scope_ignore)]}
             json_data.append(json_HITS)
             json_data.append(json_RAW)
             json_data.append(json_testentry1)
@@ -330,6 +362,7 @@ class TestReplicaRecoverer:
             json_data.append(json_testentry4)
             json_data.append(json_testentry5)
             json_data.append(json_testentry6)
+            json_data.append(json_testentry7)
             json.dump(json_data, json_file)
 
     def test_replica_recoverer(self, vo):
@@ -354,6 +387,9 @@ class TestReplicaRecoverer:
         # tmp_file8    unavailable                              suspicious (available)                    scope_nopolicy              testtypenopolicy
         # tmp_file9    unavailable                              suspicious (available)                    scope_declarebad            testtypeignore
         # tmp_file10   unavailable                              suspicious (available)                    scope_ignore                testtypedeclarebad
+        # tmp_file11   unavailable                              suspicious (available)                    scope_declarebad            <none>
+        # tmp_file12   unavailable                              suspicious (available)                    mock_scope                  <none>
+        # tmp_file13   unavailable                              suspicious (available)                    scope_declarebad            testtypedryrun
         # ----------------------------------------------------------------------------------------------------------------------------------------------------
 
             - Explaination: Suspicious replicas that are the last remaining copy (unavailable on rse4recovery) are handeled differently depending
@@ -374,7 +410,7 @@ class TestReplicaRecoverer:
 
             Concluding:
 
-            - checks that tmp_file1, tmp_file4, tmp_file7, tmp_file9 and tmp_file10 were declared as 'BAD' on rse4suspicious
+            - checks that tmp_file1, tmp_file4, tmp_file7, tmp_file9, tmp_file10 were declared as 'BAD' on rse4suspicious
 
         """
 
@@ -384,12 +420,12 @@ class TestReplicaRecoverer:
             stop()
 
         # Checking the outcome:
-        # We expect to see four changes: tmp_file1, tmp_file4, tmp_file7 and tmp_file9 should be declared as bad on rse4suspicious
+        # We expect to see four changes: tmp_file1, tmp_file4, tmp_file7, tmp_file9, tmp_file10 should be declared as bad on rse4suspicious
         # ----------------------------------------------------------------------------------------------------------------------------------------------------
         # Name         State(s) declared on rse4recovery       State(s) declared on rse4suspicious        Scope                     Metadata "datatype"
         # ----------------------------------------------------------------------------------------------------------------------------------------------------
-        # tmp_file1    available                                suspicious + bad (unavailable)            mock_scope
-        # tmp_file2    available                                suspicious + bad (unavailable)            mock_scope
+        # tmp_file1    available                                suspicious + bad (unavailable)            mock_scope                  <none>
+        # tmp_file2    available                                suspicious + bad (unavailable)            mock_scope                  <none>
         # tmp_file3    unavailable                              suspicious (available)                    mock_scope                  RAW
         # tmp_file4    unavailable                              suspicious + bad (unavailable)            mock_scope                  testtypedeclarebad
         # tmp_file5    unavailable                              suspicious (available)                    mock_scope                  testtypenopolicy
@@ -398,15 +434,18 @@ class TestReplicaRecoverer:
         # tmp_file8    unavailable                              suspicious (available)                    scope_nopolicy              testtypenopolicy
         # tmp_file9    unavailable                              suspicious + bad (unavailable)            scope_declarebad            testtypeignore
         # tmp_file10   unavailable                              suspicious (available)                    scope_ignore                testtypedeclarebad
+        # tmp_file11   unavailable                              suspicious (available)                    scope_declarebad            <none>
+        # tmp_file12   unavailable                              suspicious (available)                    mock_scope                  <none>
+        # tmp_file13   unavailable                              suspicious (available)                    scope_declarebad            testtypedryrun
         # ----------------------------------------------------------------------------------------------------------------------------------------------------
 
         # Gather replica info after replica_recoverer has run.
-        replicalist_mock = list(list_replicas(dids=self.listdids_mock))
-        replicalist_declarebad = list(list_replicas(dids=self.listdids_declarebad))
-        replicalist_nopolicy = list(list_replicas(dids=self.listdids_nopolicy))
-        replicalist_ignore = list(list_replicas(dids=self.listdids_ignore))
+        replicalist_scope_mock = list(list_replicas(dids=self.listdids_mock))
+        replicalist_scope_declarebad = list(list_replicas(dids=self.listdids_declarebad))
+        replicalist_scope_nopolicy = list(list_replicas(dids=self.listdids_nopolicy))
+        replicalist_scope_ignore = list(list_replicas(dids=self.listdids_ignore))
 
-        for replica in replicalist_mock:
+        for replica in replicalist_scope_mock:
             if replica['name'] == self.tmp_file1.name or replica['name'] == self.tmp_file2.name:
                 assert (self.rse4suspicious_id in replica['states']) is False
                 assert replica['states'][self.rse4recovery_id] == 'AVAILABLE'
@@ -419,24 +458,31 @@ class TestReplicaRecoverer:
             if replica['name'] == self.tmp_file5.name:
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
+            if replica['name'] == self.tmp_file12.name:
+                assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
+                assert (self.rse4recovery_id in replica['states']) is False
 
-        for replica in replicalist_declarebad:
+        for replica in replicalist_scope_declarebad:
             if replica['name'] == self.tmp_file7.name:
                 # The 'states' key doesn't exist if the replica isn't available on at least one RSE
                 assert not replica.get('states')
             if replica['name'] == self.tmp_file9.name:
                 assert not replica.get('states')
             if replica['name'] == self.tmp_file11.name:
-            # tmp_file11 should have been ignored, as it doesn't have a datatype
+                # tmp_file11 should have been ignored, as it doesn't have a datatype
+                assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
+                assert (self.rse4recovery_id in replica['states']) is False
+            if replica['name'] == self.tmp_file13.name:
+                # tmp_file13 should have been ignored, as it is running as a dry run
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
 
-        for replica in replicalist_nopolicy:
+        for replica in replicalist_scope_nopolicy:
             if replica['name'] == self.tmp_file8.name:
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
 
-        for replica in replicalist_ignore:
+        for replica in replicalist_scope_ignore:
             if replica['name'] == self.tmp_file10.name:
                 assert replica['states'][self.rse4suspicious_id] == 'AVAILABLE'
                 assert (self.rse4recovery_id in replica['states']) is False
@@ -456,6 +502,8 @@ class TestReplicaRecoverer:
         assert (self.tmp_file9.name, self.rse4suspicious_id, BadFilesStatus.BAD) in bad_checklist
         assert (self.tmp_file10.name, self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
         assert (self.tmp_file11.name, self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (self.tmp_file12.name, self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (self.tmp_file13.name, self.rse4suspicious_id, BadFilesStatus.BAD) not in bad_checklist
 
         bad_replicas_list = list_bad_replicas_status(rse_id=self.rse4recovery_id, younger_than=self.from_date, vo=vo)
         bad_checklist = [(badf['name'], badf['rse_id'], badf['state']) for badf in bad_replicas_list]
@@ -471,3 +519,5 @@ class TestReplicaRecoverer:
         assert (self.tmp_file9.name, self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
         assert (self.tmp_file10.name, self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
         assert (self.tmp_file11.name, self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (self.tmp_file12.name, self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist
+        assert (self.tmp_file13.name, self.rse4recovery_id, BadFilesStatus.BAD) not in bad_checklist


### PR DESCRIPTION
Currently, ten rules are created for one day for replicas that are declared suspicious only once. This allows for those files to be handled by the recoverer during its next run. This lead to an edge case where a few thousand rules were created at once, so some changes will be applied to prevent this from happening again.