### PR TITLE
Automatix: Correct automatix.json default path. Fix 6352

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -44,6 +44,7 @@ Individual contributors to the source code
 - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 - Aristeidis Fkiaras <aristeidis.fkiaras@cern.ch>, 2019
 - Matt Snyder <msnyder@bnl.gov>, 2019
+- Brandon White <bjwhite@fnal.gov> 2019-2023
 - Benedikt Ziemons <benedikt.ziemons@cern.ch>, 2020
 - Muhammad Aditya Hilmy <mhilmy@hey.com>, 2020
 - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020

--- a/bin/rucio-automatix
+++ b/bin/rucio-automatix
@@ -30,7 +30,7 @@ def get_parser():
     """
     parser = argparse.ArgumentParser(description="Automatix is a daemon used to inject random generated files to an RSE. It is used to continuosly check that an RSE is reachable and operating as spected.")
     parser.add_argument("--run-once", action="store_true", default=False, help='Runs one loop iteration')
-    parser.add_argument("--input-file", action="store", default=" /opt/rucio/etc/automatix.json", type=str, help='Automatix configuration')
+    parser.add_argument("--input-file", action="store", default="/opt/rucio/etc/automatix.json", type=str, help='Automatix configuration')
     parser.add_argument("--threads-per-process", action="store", default=1, type=int, help='Total number of workers per process')
     parser.add_argument('--sleep-time', action="store", default=-1, type=int, help='Concurrency control: thread sleep time after each chunk of work')
     return parser


### PR DESCRIPTION
Fixed a typo in the automatix.json default location.