### PR TITLE
Subscription history updates throw unknown database errors : Closes #6351

### DIFF
--- a/lib/rucio/core/subscription.py
+++ b/lib/rucio/core/subscription.py
@@ -99,20 +99,21 @@ def add_subscription(name: str,
                                            lifetime=date_lifetime,
                                            retroactive=retroactive,
                                            policyid=priority, comments=comments)
-    if keep_history:
-        subscription_history = SubscriptionHistory(id=new_subscription.id,
-                                                   name=new_subscription.name,
-                                                   filter=new_subscription.filter,
-                                                   account=new_subscription.account,
-                                                   replication_rules=new_subscription.replication_rules,
-                                                   state=new_subscription.state,
-                                                   lifetime=new_subscription.lifetime,
-                                                   retroactive=new_subscription.retroactive,
-                                                   policyid=new_subscription.policyid,
-                                                   comments=new_subscription.comments)
     try:
         new_subscription.save(session=session)
         if keep_history:
+            subscription_history = SubscriptionHistory(id=new_subscription.id,
+                                                       name=new_subscription.name,
+                                                       filter=new_subscription.filter,
+                                                       account=new_subscription.account,
+                                                       replication_rules=new_subscription.replication_rules,
+                                                       state=new_subscription.state,
+                                                       lifetime=new_subscription.lifetime,
+                                                       retroactive=new_subscription.retroactive,
+                                                       policyid=new_subscription.policyid,
+                                                       created_at=new_subscription.created_at,
+                                                       updated_at=new_subscription.created_at,
+                                                       comments=new_subscription.comments)
             subscription_history.save(session=session)
     except IntegrityError as error:
         if re.match('.*IntegrityError.*ORA-00001: unique constraint.*SUBSCRIPTIONS_PK.*violated.*', error.args[0])\

--- a/lib/rucio/core/subscription.py
+++ b/lib/rucio/core/subscription.py
@@ -25,7 +25,7 @@ from sqlalchemy.exc import IntegrityError, StatementError
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.exc import NoResultFound
 
-from rucio.common.config import config_get
+from rucio.common.config import config_get_bool
 from rucio.common.exception import SubscriptionNotFound, SubscriptionDuplicate, RucioException
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import SubscriptionState
@@ -78,7 +78,7 @@ def add_subscription(name: str,
     :returns:                  The subscriptionid
     """
     try:
-        keep_history = config_get('subscriptions', 'keep_history')
+        keep_history = config_get_bool('subscriptions', 'keep_history')
     except (NoOptionError, NoSectionError, RuntimeError):
         keep_history = False
 
@@ -146,7 +146,7 @@ def update_subscription(name: str,
     :raises: SubscriptionNotFound if subscription is not found
     """
     try:
-        keep_history = config_get('subscriptions', 'keep_history')
+        keep_history = config_get_bool('subscriptions', 'keep_history')
     except (NoOptionError, NoSectionError, RuntimeError):
         keep_history = False
     values = {'state': SubscriptionState.UPDATED}

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -21,7 +21,7 @@ from rucio.api.rule import list_replication_rules
 from rucio.api.subscription import list_subscriptions, add_subscription, update_subscription, \
     list_subscription_rule_states, get_subscription_by_id
 from rucio.common.exception import InvalidObject, SubscriptionDuplicate, SubscriptionNotFound, RuleNotFound, \
-    AccessDenied
+    AccessDenied, UnsupportedOperation
 from rucio.common.utils import render_json, APIEncoder
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import check_accept_header_wrapper_flask, try_stream, \
@@ -182,6 +182,8 @@ class Subscription(ErrorHandlingMethodView):
             description: Invalid Auth Token
           404:
             description: Not found
+          409:
+            description: Unsupported Operation
         """
         parameters = json_parameters()
         options = param_get(parameters, 'options')
@@ -202,6 +204,8 @@ class Subscription(ErrorHandlingMethodView):
             return generate_http_error_flask(400, InvalidObject.__name__, error.args[0])
         except AccessDenied as error:
             return generate_http_error_flask(401, error)
+        except UnsupportedOperation as error:
+            return generate_http_error_flask(409, error)
         except SubscriptionNotFound as error:
             return generate_http_error_flask(404, error)
 


### PR DESCRIPTION
This patch tries to address the problem reported in #6351 (eventhough I was not able to reproduce the bug) : 
-  `config_get_bool` is now used to read `keep_history` option
-  Fix a bug when a new subscription is added (subscription_id set to null)
- Introduce a new exception in case there's a problem updating the history

