### PR TITLE
Metadata: external postgres database calls now made under context manager

### DIFF
--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1090,3 +1090,13 @@ class DeprecationError(RucioException):
         super(DeprecationError, self).__init__(*args, **kwargs)
         self._message = 'Command or function has been deprecated.'
         self.error_code = 105
+
+
+class MetadataPluginGenericError(RucioException):
+    """
+    Generic metadata plugin error.
+    """
+    def __init__(self, *args, **kwargs):
+        super(MetadataPluginGenericError, self).__init__(*args, **kwargs)
+        self._message = 'Generic metadata plugin error.'
+        self.error_code = 106


### PR DESCRIPTION
added try/except for general psycopg2 errors.
added new exception for generic metadata error & added 500s to flask returns

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
