### PR TITLE
Transfers: fix fts argument for scitag

### DIFF
--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -942,7 +942,7 @@ class FTS3Transfertool(Transfertool):
         if isinstance(self.scitags_exp_id, int):
             activity_id = self.scitags_activity_ids.get(rws.activity)
             if isinstance(activity_id, int):
-                t_file['metadata']['scitags_id'] = self.scitags_exp_id << 6 | activity_id
+                t_file['scitag'] = self.scitags_exp_id << 6 | activity_id
         return t_file
 
     def submit(self, transfers, job_params, timeout=None):


### PR DESCRIPTION
Now that we have an FTS version which supports it in our test env, make the final adjustments.

For some reason, FTS only sends the scitag in completion messages. So had to migrate the check to the test case which has access to those messages.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
