### PR TITLE
Transfers: re-introduce last_processed_by logic in poller. Closes #6376

### DIFF
--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -66,6 +66,7 @@ def _fetch_requests(
         filter_transfertool,
         cached_topology,
         activity,
+        set_last_processed_by: bool,
         heartbeat_handler
 ):
     worker_number, total_workers, logger = heartbeat_handler.live()
@@ -77,6 +78,7 @@ def _fetch_requests(
         rse_collection=topology,
         request_type=[RequestType.TRANSFER, RequestType.STAGEIN, RequestType.STAGEOUT],
         state=[RequestState.SUBMITTED],
+        processed_by=heartbeat_handler.short_executable if set_last_processed_by else None,
         limit=db_bulk,
         older_than=datetime.datetime.utcnow() - datetime.timedelta(seconds=older_than) if older_than else None,
         total_workers=total_workers,
@@ -197,6 +199,7 @@ def poller(
             filter_transfertool=filter_transfertool,
             cached_topology=cached_topology,
             activity=activity,
+            set_last_processed_by=not once,
             heartbeat_handler=heartbeat_handler,
         )
 

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -956,12 +956,6 @@ class FTS3Transfertool(Transfertool):
         """
         files = []
         for transfer in transfers:
-            if isinstance(transfer, dict):
-                # Compatibility with scripts form /tools which directly use transfertools and pass a dict to it instead of transfer definitions
-                # TODO: ensure that those scripts are still used and get rid of this compatibility otherwise
-                files.append(transfer)
-                continue
-
             files.append(self._file_from_transfer(transfer, job_params))
 
         # FTS3 expects 'davs' as the scheme identifier instead of https

--- a/lib/rucio/transfertool/globus.py
+++ b/lib/rucio/transfertool/globus.py
@@ -196,16 +196,5 @@ class GlobusTransferTool(Transfertool):
     def cancel(self):
         pass
 
-    def query(self, transfer_ids, details=False, timeout=None):
-        """
-        Query the status of a transfer in Globus Online.
-
-        :param transfer_ids: transfer identifiers as list of strings.
-        :param details:      Switch if detailed information should be listed.
-        :param timeout:      Timeout in seconds.
-        :returns:            Transfer status information as a list of dictionaries.
-        """
-        pass
-
     def update_priority(self):
         pass

--- a/lib/rucio/transfertool/mock.py
+++ b/lib/rucio/transfertool/mock.py
@@ -74,9 +74,6 @@ class MockTransfertool(Transfertool):
                 response.setdefault(transfer_id, {})[request_id] = MockTransferStatusReport(request_id, transfer_id)
         return response
 
-    def query(self, transfer_ids: Sequence[str], details: bool = False, timeout: Optional[float] = None):
-        return [{'status': 'ok'}]
-
     def cancel(self, transfer_ids: Sequence[str], timeout: Optional[float] = None):
         return True
 

--- a/lib/rucio/transfertool/transfertool.py
+++ b/lib/rucio/transfertool/transfertool.py
@@ -179,14 +179,12 @@ class Transfertool(object, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def query(self, transfer_ids, details=False, timeout=None):
+    def bulk_query(self, requests_by_eid, timeout=None) -> dict[str, dict[str, TransferStatusReport]]:
         """
-        Query the status of transfers in the transfertool.
+        Query the status of a bulk of transfers in FTS3 via JSON.
 
-        :param transfer_ids: List of transfertool internal identifiers as a string.
-        :param details:      Switch if detailed information should be listed.
-        :param timeout:      Timeout in seconds.
-        :returns:            Transfer status information as list of dictionaries.
+        :param requests_by_eid: dictionary {external_id1: {request_id1: request1, ...}, ...} of request to be queried
+        :returns: Transfer status information as a dictionary.
         """
         pass
 

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -660,10 +660,7 @@ def test_receiver_archiving(vo, did_factory, root_account, caches_mock, scitags_
 @pytest.mark.parametrize("file_config_mock", [{
     "overrides": [('conveyor', 'use_preparer', 'true')]
 }], indirect=True)
-@pytest.mark.parametrize("core_config_mock", [{
-    "table_content": [('throttler', 'mode', 'DEST_PER_ALL_ACT')]
-}], indirect=True)
-def test_preparer_throttler_submitter(rse_factory, did_factory, root_account, file_config_mock, core_config_mock, metrics_mock):
+def test_preparer_throttler_submitter(rse_factory, did_factory, root_account, file_config_mock, metrics_mock):
     """
     Integration test of the preparer/throttler workflow.
     """


### PR DESCRIPTION
The protection provided by older_than, mentioned in 33f957827b6035ae330d5f7f4bc3adc729617f4f,
was over-estimated.

Use a WITH FOR UPDATE SKIP LOCKED query to avoid lock contention between the poller and receiver. 

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
