### PR TITLE
Rules: Return 404 when DID rules not found #6334

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -1526,6 +1526,7 @@ class Rules(ErrorHandlingMethodView):
             scope, name = parse_scope_name(scope_name, request.environ.get('vo'))
 
             def generate(vo):
+                get_did(scope=scope, name=name, vo=vo)
                 for rule in list_replication_rules({'scope': scope, 'name': name}, vo=vo):
                     yield dumps(rule, cls=APIEncoder) + '\n'
 
@@ -1533,6 +1534,8 @@ class Rules(ErrorHandlingMethodView):
         except ValueError as error:
             return generate_http_error_flask(400, error)
         except RuleNotFound as error:
+            return generate_http_error_flask(404, error)
+        except DataIdentifierNotFound as error:
             return generate_http_error_flask(404, error)
 
 


### PR DESCRIPTION
This PR fixes #6334.

The empty generator on the line

https://github.com/alexanderrichards/rucio/blob/01aa2184041e34584a82669ba846dfedfd8f0f51/lib/rucio/api/rule.py#L163

means that this generator never yields anything but neither does it raise an exception to get caught which would trigger a return value other than 200.

Instead of duplicating the generator and peeking I simply add a counter to see if it ever yields. If not then there were no rules and we can raise RuleNotFound.