### PR TITLE
Dependencies: update for the 33.0.0 release

### DIFF
--- a/lib/rucio/core/did_meta_plugins/filter_engine.py
+++ b/lib/rucio/core/did_meta_plugins/filter_engine.py
@@ -368,7 +368,7 @@ class FilterEngine:
                     # Infer what type key should be cast to from typecasting the value in the expression.
                     try:
                         if isinstance(value, int):                                          # this could be bool or int (as bool subclass of int)
-                            if type(value) == bool:
+                            if isinstance(value, bool):
                                 if is_in_json_column:
                                     expression = "({}->>'{}')::boolean {} {}".format(jsonb_column, key, POSTGRES_OP_MAP[oper], str(value).lower())
                                 else:
@@ -473,7 +473,7 @@ class FilterEngine:
                             # Infer what type key should be cast to from typecasting the value in the expression.
                             try:
                                 if isinstance(value, int):                                          # this could be bool or int (as bool subclass of int)
-                                    if type(value) == bool:
+                                    if isinstance(value, bool):
                                         expression = oper(json_column[key].as_boolean(), value)
                                     else:
                                         expression = oper(json_column[key].as_float(), value)       # cast as float, not integer, to avoid potentially losing precision in key

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -2568,7 +2568,7 @@ def __find_stuck_locks_and_repair_them(datasetfiles, locks, replicas, source_rep
 
     logger(logging.DEBUG, "Finding and repairing stuck locks for rule %s [%d/%d/%d]", str(rule.id), rule.locks_ok_cnt, rule.locks_replicating_cnt, rule.locks_stuck_cnt)
 
-    replicas_to_create, locks_to_create, transfers_to_create,\
+    replicas_to_create, locks_to_create, transfers_to_create, \
         locks_to_delete = repair_stuck_locks_and_apply_rule_grouping(datasetfiles=datasetfiles,
                                                                      locks=locks,
                                                                      replicas=replicas,

--- a/lib/rucio/core/rule_grouping.py
+++ b/lib/rucio/core/rule_grouping.py
@@ -59,7 +59,7 @@ def apply_rule_grouping(datasetfiles, locks, replicas, source_replicas, rseselec
     # transfers_to_create = [{'dest_rse_id':, 'scope':, 'name':, 'request_type':, 'metadata':}]
 
     if rule.grouping == RuleGrouping.NONE:
-        replicas_to_create, locks_to_create,\
+        replicas_to_create, locks_to_create, \
             transfers_to_create = __apply_rule_to_files_none_grouping(datasetfiles=datasetfiles,
                                                                       locks=locks,
                                                                       replicas=replicas,
@@ -70,7 +70,7 @@ def apply_rule_grouping(datasetfiles, locks, replicas, source_replicas, rseselec
                                                                       source_rses=source_rses,
                                                                       session=session)
     elif rule.grouping == RuleGrouping.ALL:
-        replicas_to_create, locks_to_create,\
+        replicas_to_create, locks_to_create, \
             transfers_to_create = __apply_rule_to_files_all_grouping(datasetfiles=datasetfiles,
                                                                      locks=locks,
                                                                      replicas=replicas,
@@ -81,7 +81,7 @@ def apply_rule_grouping(datasetfiles, locks, replicas, source_replicas, rseselec
                                                                      source_rses=source_rses,
                                                                      session=session)
     else:  # rule.grouping == RuleGrouping.DATASET:
-        replicas_to_create, locks_to_create,\
+        replicas_to_create, locks_to_create, \
             transfers_to_create = __apply_rule_to_files_dataset_grouping(datasetfiles=datasetfiles,
                                                                          locks=locks,
                                                                          replicas=replicas,
@@ -119,7 +119,7 @@ def repair_stuck_locks_and_apply_rule_grouping(datasetfiles, locks, replicas, so
     # locks_to_delete =     {'rse_id': [locks]}
 
     if rule.grouping == RuleGrouping.NONE:
-        replicas_to_create, locks_to_create, transfers_to_create,\
+        replicas_to_create, locks_to_create, transfers_to_create, \
             locks_to_delete = __repair_stuck_locks_with_none_grouping(datasetfiles=datasetfiles,
                                                                       locks=locks,
                                                                       replicas=replicas,
@@ -129,7 +129,7 @@ def repair_stuck_locks_and_apply_rule_grouping(datasetfiles, locks, replicas, so
                                                                       source_rses=source_rses,
                                                                       session=session)
     elif rule.grouping == RuleGrouping.ALL:
-        replicas_to_create, locks_to_create, transfers_to_create,\
+        replicas_to_create, locks_to_create, transfers_to_create, \
             locks_to_delete = __repair_stuck_locks_with_all_grouping(datasetfiles=datasetfiles,
                                                                      locks=locks,
                                                                      replicas=replicas,
@@ -139,7 +139,7 @@ def repair_stuck_locks_and_apply_rule_grouping(datasetfiles, locks, replicas, so
                                                                      source_rses=source_rses,
                                                                      session=session)
     else:
-        replicas_to_create, locks_to_create, transfers_to_create,\
+        replicas_to_create, locks_to_create, transfers_to_create, \
             locks_to_delete = __repair_stuck_locks_with_dataset_grouping(datasetfiles=datasetfiles,
                                                                          locks=locks,
                                                                          replicas=replicas,

--- a/lib/rucio/daemons/storage/consistency/actions.py
+++ b/lib/rucio/daemons/storage/consistency/actions.py
@@ -174,7 +174,7 @@ def cmp2dark(new_list, old_list, comm_list, stats_file):
     stats_key = "cmp2dark"
     my_stats = stats = None
 
-    with open(new_list, "r") as a_list, open(old_list, "r") as b_list,\
+    with open(new_list, "r") as a_list, open(old_list, "r") as b_list, \
          open(comm_list, "w") as out_list:
 
         if stats_file is not None:

--- a/lib/rucio/db/sqla/sautils.py
+++ b/lib/rucio/db/sqla/sautils.py
@@ -30,7 +30,7 @@ class InsertFromSelect(Executable, ClauseElement):
 
 @compiles(InsertFromSelect)
 def visit_insert_from_select(element, compiler, **kw):
-    if type(element.insert_spec) == list:
+    if isinstance(element.insert_spec, list):
         columns = []
         for column in element.insert_spec:
             if element.insert_spec[0].table != column.table:

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -51,7 +51,7 @@ class Default(protocol.RSEProtocol):
 
         :returns: Fully qualified PFN.
         """
-        lfns = [lfns] if type(lfns) == dict else lfns
+        lfns = [lfns] if isinstance(lfns, dict) else lfns
 
         pfns = {}
         prefix = self.attributes['prefix']

--- a/lib/rucio/rse/protocols/rclone.py
+++ b/lib/rucio/rse/protocols/rclone.py
@@ -242,7 +242,7 @@ class Default(protocol.RSEProtocol):
         if not prefix.endswith('/'):
             prefix = ''.join([prefix, '/'])
 
-        lfns = [lfns] if type(lfns) == dict else lfns
+        lfns = [lfns] if isinstance(lfns, dict) else lfns
         for lfn in lfns:
             scope, name = lfn['scope'], lfn['name']
             if 'path' in lfn and lfn['path'] is not None:

--- a/lib/rucio/rse/protocols/srm.py
+++ b/lib/rucio/rse/protocols/srm.py
@@ -51,7 +51,7 @@ class Default(protocol.RSEProtocol):
         if '://' in hostname:
             hostname = hostname.split("://")[1]
 
-        lfns = [lfns] if type(lfns) == dict else lfns
+        lfns = [lfns] if isinstance(lfns, dict) else lfns
         if not self.attributes['port']:
             for lfn in lfns:
                 scope, name, path = lfn['scope'], lfn['name'], lfn.get('path')

--- a/lib/rucio/rse/protocols/ssh.py
+++ b/lib/rucio/rse/protocols/ssh.py
@@ -157,7 +157,7 @@ class Default(protocol.RSEProtocol):
         if not prefix.endswith('/'):
             prefix = ''.join([prefix, '/'])
 
-        lfns = [lfns] if type(lfns) == dict else lfns
+        lfns = [lfns] if isinstance(lfns, dict) else lfns
         for lfn in lfns:
             scope, name = lfn['scope'], lfn['name']
             if 'path' in lfn and lfn['path'] is not None:

--- a/lib/rucio/rse/protocols/xrootd.py
+++ b/lib/rucio/rse/protocols/xrootd.py
@@ -160,7 +160,7 @@ class Default(protocol.RSEProtocol):
         if not prefix.endswith('/'):
             prefix = ''.join([prefix, '/'])
 
-        lfns = [lfns] if type(lfns) == dict else lfns
+        lfns = [lfns] if isinstance(lfns, dict) else lfns
         for lfn in lfns:
             scope, name = lfn['scope'], lfn['name']
             if 'path' in lfn and lfn['path'] is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,55 +1,55 @@
 # All dependencies needed to run rucio client (and server/daemons) should be defined here
 requests>=2.25.1,<=2.31.0                                   # Python HTTP for Humans.
-urllib3~=1.26.16                                            # HTTP library with thread-safe connection pooling, file post, etc.
+urllib3~=1.26.18                                            # HTTP library with thread-safe connection pooling, file post, etc.
 dogpile.cache~=1.2.2                                        # Caching API plugins (1.1.2 is the first version to support pymemcache)
 tabulate~=0.9.0                                             # Pretty-print tabular data
-jsonschema~=4.18.4                                          # For JSON schema validation (Policy modules)
+jsonschema~=4.20.0                                          # For JSON schema validation (Policy modules)
 
 # All dependencies needed in extras for rucio client (and server/daemons) should be defined here
-paramiko~=3.2.0                                             # ssh_extras; SSH2 protocol library (also needed in the server)
+paramiko~=3.3.1                                             # ssh_extras; SSH2 protocol library (also needed in the server)
 kerberos~=1.3.1                                             # kerberos_extras for client and server
 pykerberos~=1.2.4                                           # kerberos_extras for client and server
 requests-kerberos>=0.14.0                                   # kerberos_extras for client and server
-python-swiftclient~=4.3.0                                   # swift_extras
-argcomplete~=3.1.1                                          # argcomplete_extras; Bash tab completion for argparse
+python-swiftclient~=4.4.0                                   # swift_extras
+argcomplete~=3.1.6                                          # argcomplete_extras; Bash tab completion for argparse
 python-magic~=0.4.27                                        # dumper_extras; File type identification using libmagic
 
 # All dependencies needed to run rucio server/daemons should be defined here
-SQLAlchemy==2.0.19                                          # DB backend
-alembic~=1.11.1                                             # Lightweight database migration tool for SQLAlchemy
+SQLAlchemy==2.0.23                                          # DB backend
+alembic~=1.12.1                                             # Lightweight database migration tool for SQLAlchemy
 pymemcache==4.0.0                                           # A comprehensive, fast, pure-Python memcached client (Used by Dogpile)
 python-dateutil==2.8.2                                      # Extensions to the standard datetime module
 stomp.py==8.1.0                                             # ActiveMQ Messaging Protocol
 statsd==4.0.1                                               # Needed to log into graphite with more than 1 Hz
 geoip2==4.7.0                                               # GeoIP2 API (for IPv6 support)
-google-auth==2.22.0                                         # Google authentication library for Python
-redis==4.6.0                                                # Python client for Redis key-value store
-Flask==2.3.2                                                # Python web framework
+google-auth==2.23.4                                         # Google authentication library for Python
+redis==5.0.1                                                # Python client for Redis key-value store
+Flask==3.0.0                                                # Python web framework
 oic==1.6.1                                                  # for authentication via OpenID Connect protocol
-prometheus_client==0.17.1                                   # Python client for the Prometheus monitoring system
-boto3==1.28.5                                               # S3 boto protocol (new version)
+prometheus_client==0.19.0                                   # Python client for the Prometheus monitoring system
+boto3==1.29.5                                               # S3 boto protocol (new version)
 
 # All dependencies needed in extras for rucio server/daemons should be defined here
 cx_oracle==8.3.0                                            # oracle_extras
-psycopg2-binary==2.9.6                                      # postgresql_extras
+psycopg2-binary==2.9.9                                      # postgresql_extras
 PyMySQL==1.1.0                                              # mysql_extras
 PyYAML==6.0.1                                               # globus_extras and used for reading test configuration files
-globus-sdk==3.24.0                                          # globus_extras
-python3-saml==1.15.0                                        # saml_extras
-pymongo==4.4.1                                              # pymongo (metadata plugin)
+globus-sdk==3.32.0                                          # globus_extras
+python3-saml==1.16.0                                        # saml_extras
+pymongo==4.6.0                                              # pymongo (metadata plugin)
 
 # All dependencies needed to develop/test rucio should be defined here
-pytest==7.4.0
-pytest-xdist~=3.3.1                                         # Used for parallel testing
-pyflakes==3.0.1                                             # Passive checker of Python programs
-flake8==6.0.0                                               # Wrapper around PyFlakes&pep8; python_version < '3.9'
-pycodestyle==2.10.0                                         # New package replacing pep8; python_version < '3.9'
-pylint==3.0.0a7
-astroid==3.0.0a9
-virtualenv==20.24.0                                         # Virtual Python Environment builder
+pytest==7.4.3
+pytest-xdist~=3.5.0                                         # Used for parallel testing
+pyflakes==3.1.0                                             # Passive checker of Python programs
+flake8==6.1.0                                               # Wrapper around PyFlakes&pep8; python_version < '3.9'
+pycodestyle==2.11.0                                         # New package replacing pep8; python_version < '3.9'
+pylint==3.0.2
+astroid==3.0.1
+virtualenv==20.24.7                                         # Virtual Python Environment builder
 xmltodict==0.13.0                                           # Makes working with XML feel like you are working with JSON
-pytz==2023.3                                                # World timezone definitions, modern and historical
+pytz==2023.3.post1                                          # World timezone definitions, modern and historical
 pydoc-markdown~=4.8.2                                       # Used for generating Markdown documentation for docusaurus
-sh~=2.0.4                                                   # Convenience library for running subprocesses in Python
+sh~=2.0.6                                                   # Convenience library for running subprocesses in Python
 apispec==6.3.0                                              # Generate OpenApi definition out of pydoc comments
 apispec-webframeworks                                       # Integration of apispec in Flask


### PR DESCRIPTION
There are 2 notable major version bumps: `Flask` and `redis`

urllib3 also has a new major version, but it's not possible
to upgrade due to conflicts between the requirements of
`requests` and `boto3`.