### PR TITLE
Auth: Introduce a new token request procedure #6187 

### DIFF
--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -188,10 +188,6 @@ def __initialize_oidc_clients() -> None:
         pass
 
 
-# try loading OIDC clients uppon module import
-__initialize_oidc_clients()
-
-
 def __get_init_oidc_client(token_object: models.Token = None, token_type: str = None, **kwargs) -> dict[Any, Any]:
     """
     Get an OIDC client object, (re-)initialised with parameters corresponding


### PR DESCRIPTION
I made all attempts to ensure that the existing token implementation is not affect. To that end, I decided to reuse the configuration and also mimicked the code style (e.g. global variables).

This PR is downsized compare to the original goals described in the issue. Instead of having a high-level interface which can handle multiple plugins, it introduces a mid-level layer which can handle the OAuth flow, but does not decide itself the content of the claims. This should be considered and intermediate step that offers the necessary support for the Data Challenge 2024 and allows us to gain some experience.