### PR TITLE
REST & API: uniform case for urls in flask subscription endpoint Fix: #6316

### DIFF
--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -86,7 +86,7 @@ class SubscriptionClient(BaseClient):
             if name:
                 path += '/%s' % (name)
         elif name:
-            path += '/Name/%s' % (name)
+            path += '/name/%s' % (name)
         else:
             path += '/'
         url = build_url(choice(self.list_hosts), path=path)
@@ -150,7 +150,7 @@ class SubscriptionClient(BaseClient):
         :param name:    Name of the subscription.
         """
 
-        path = '/'.join([self.SUB_BASEURL, account, name, 'Rules'])
+        path = '/'.join([self.SUB_BASEURL, account, name, 'rules'])
         url = build_url(choice(self.list_hosts), path=path)
         result = self._send_request(url, type_='GET')
         if result.status_code == codes.ok:   # pylint: disable=no-member

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -618,17 +618,25 @@ def blueprint():
     bp = AuthenticatedBlueprint('subscriptions', __name__, url_prefix='/subscriptions')
 
     subscription_id_view = SubscriptionId.as_view('subscription_id')
-    bp.add_url_rule('/Id/<subscription_id>', view_func=subscription_id_view, methods=['get', ])
+    bp.add_url_rule('/id/<subscription_id>', view_func=subscription_id_view, methods=['get', ])
     states_view = States.as_view('states')
-    bp.add_url_rule('/<account>/<name>/Rules/States', view_func=states_view, methods=['get', ])
-    bp.add_url_rule('/<account>/Rules/States', view_func=states_view, methods=['get', ])
+    bp.add_url_rule('/<account>/<name>/rules/states', view_func=states_view, methods=['get', ])
+    bp.add_url_rule('/<account>/rules/states', view_func=states_view, methods=['get', ])
     rules_view = Rules.as_view('rules')
-    bp.add_url_rule('/<account>/<name>/Rules', view_func=rules_view, methods=['get', ])
+    bp.add_url_rule('/<account>/<name>/rules', view_func=rules_view, methods=['get', ])
     subscription_view = Subscription.as_view('subscription')
     bp.add_url_rule('/<account>/<name>', view_func=subscription_view, methods=['get', 'post', 'put'])
     bp.add_url_rule('/<account>', view_func=subscription_view, methods=['get', ])
     bp.add_url_rule('/', view_func=subscription_view, methods=['get', ])
     subscription_name_view = SubscriptionName.as_view('subscription_name')
+    bp.add_url_rule('/name/<name>', view_func=subscription_name_view, methods=['get', ])
+
+    # Legacy url support
+    # TODO: Take out with Rucio 38
+    bp.add_url_rule('/Id/<subscription_id>', view_func=subscription_id_view, methods=['get', ])
+    bp.add_url_rule('/<account>/<name>/Rules/States', view_func=states_view, methods=['get', ])
+    bp.add_url_rule('/<account>/Rules/States', view_func=states_view, methods=['get', ])
+    bp.add_url_rule('/<account>/<name>/Rules', view_func=rules_view, methods=['get', ])
     bp.add_url_rule('/Name/<name>', view_func=subscription_name_view, methods=['get', ])
 
     bp.after_request(response_headers)

--- a/tests/test_permission.py
+++ b/tests/test_permission.py
@@ -14,6 +14,7 @@
 
 from rucio.common.config import config_get
 from rucio.common.types import InternalScope
+from rucio.core.scope import add_scope
 from rucio.core.account import add_account_attribute
 from rucio.core.scope import add_scope
 from rucio.gateway.permission import has_permission

--- a/tests/test_rse.py
+++ b/tests/test_rse.py
@@ -19,8 +19,8 @@ from rucio.common import exception
 from rucio.common.constants import RseAttr
 from rucio.common.exception import Duplicate, InputValidationError, InvalidObject, ResourceTemporaryUnavailable, RSEAttributeNotFound, RSENotFound, RSEOperationNotSupported, RSEProtocolNotSupported
 from rucio.common.schema import get_schema_value
-from rucio.common.utils import CHECKSUM_KEY, GLOBALLY_SUPPORTED_CHECKSUMS
-from rucio.core.account_limit import get_rse_account_usage, set_local_account_limit
+from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS, CHECKSUM_KEY
+from rucio.core.account_limit import set_local_account_limit, get_rse_account_usage
 from rucio.core.did import add_did, attach_dids
 from rucio.core.request import delete_transfer_limit, set_transfer_limit
 from rucio.core.rse import (

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -218,7 +218,7 @@ def test_create_and_list_subscription_by_id(rse_factory, rest_client, auth_token
     assert response.status_code == 201
 
     subscription_id = response.get_data(as_text=True)
-    response = rest_client.get('/subscriptions/Id/' + subscription_id, headers=headers(auth(auth_token)))
+    response = rest_client.get('/subscriptions/id/' + subscription_id, headers=headers(auth(auth_token)))
     assert response.status_code == 200
     assert loads(loads(response.get_data(as_text=True))['filter'])['project'][0] == 'data12_900GeV'
 
@@ -287,7 +287,7 @@ def test_list_rules_states(vo, rse_factory, rest_client, auth_token, root_accoun
     add_rule(dids=[{'scope': tmp_scope, 'name': dsn}], account=root_account, copies=1, rse_expression=rse3, grouping='NONE', weight=None, lifetime=None, locked=False, subscription_id=subid)
     add_rule(dids=[{'scope': tmp_scope, 'name': dsn}], account=root_account, copies=1, rse_expression=rse4, grouping='NONE', weight=None, lifetime=None, locked=False, subscription_id=subid)
 
-    response = rest_client.get('/subscriptions/%s/%s/Rules/States' % ('root', subscription_name), headers=headers(auth(auth_token)))
+    response = rest_client.get('/subscriptions/%s/%s/rules/states' % ('root', subscription_name), headers=headers(auth(auth_token)))
     assert response.status_code == 200
 
     rulestates = None


### PR DESCRIPTION
Addressing #6316 

As stated in the comment there - this is almost certainly a minor mistake. Alt solution would be setting up a automatic redirect for variants of urls with mixed case - which would be a larger undertaking and a separate issue. 
