### PR TITLE
API: allow exposing /ping on a separate rest endpoint. Closes #6394

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/ping.py
+++ b/lib/rucio/web/rest/flaskapi/v1/ping.py
@@ -69,8 +69,8 @@ class Ping(ErrorHandlingMethodView):
         return response
 
 
-def blueprint(with_doc=False):
-    bp = Blueprint('ping', __name__, url_prefix='/ping')
+def blueprint(standalone=False, with_doc=False):
+    bp = Blueprint('ping', __name__, url_prefix='/' if standalone else '/ping')
 
     ping_view = Ping.as_view('ping')
     if not with_doc:

--- a/lib/rucio/web/rest/ping.py
+++ b/lib/rucio/web/rest/ping.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from flask import Flask
+
+from rucio.common.logging import setup_logging
+from rucio.web.rest.flaskapi.v1.ping import blueprint as metrics_blueprint
+
+# Allow to run the /ping endpoint as a separate application on a separate PORT
+
+setup_logging()
+application = Flask(__name__)
+application.register_blueprint(metrics_blueprint(standalone=True))
+
+if __name__ == '__main__':
+    application.run()


### PR DESCRIPTION
This is to allow health checks in kubernetes to be done on a different port. Otherwise things don't play nicely with the proxy protocol

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
