### PR TITLE
enhancement: reset stale waiting requests Fix #6404

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -2817,3 +2817,39 @@ def list_requests_history(src_rse_ids, dst_rse_ids, states=None, offset=None, li
         stmt = stmt.limit(limit)
     for request in session.execute(stmt).yield_per(500).scalars():
         yield request
+
+
+@transactional_session
+def reset_stale_waiting_requests(time_limit: Optional[datetime.timedelta] = datetime.timedelta(days=1), *, session: "Session") -> None:
+    """
+    Clear source_rse_id for requests that have been in the waiting state for > time_limit amount of time and
+    transition back to preparing state (default time limit = 1 day).
+    This allows for stale requests that have been in the waiting state for a long time to be able to
+    react to source changes that have occurred in the meantime.
+    :param time_limit: The amount of time a request must be in the waiting state to be reset.
+    :param session: The database session in use.
+    """
+    try:
+        # Cutoff timestamp based on time limit
+        time_limit_timestamp = datetime.datetime.utcnow() - time_limit
+
+        # Select all waiting requests that precede the time limit, then clear source_rse_id and reset state to preparing
+        stmt = update(
+            models.Request
+        ).where(
+            and_(
+                models.Request.state == RequestState.WAITING,
+                models.Request.last_processed_at < time_limit_timestamp
+            )
+        ).execution_options(
+            synchronize_session=False
+        ).values(
+            {
+                models.Request.source_rse_id: None,
+                models.Request.state: RequestState.PREPARING
+            }
+        )
+        session.execute(stmt)
+
+    except IntegrityError as error:
+        raise RucioException(error.args)

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -31,7 +31,8 @@ from rucio.common import exception
 from rucio.common.logging import setup_logging
 from rucio.core.monitor import MetricManager
 from rucio.core.request import (get_request_stats, release_all_waiting_requests, release_waiting_requests_fifo,
-                                release_waiting_requests_grouped_fifo, set_transfer_limit_stats, re_sync_all_transfer_limits)
+                                release_waiting_requests_grouped_fifo, set_transfer_limit_stats, re_sync_all_transfer_limits,
+                                reset_stale_waiting_requests)
 from rucio.core.rse import RseCollection
 from rucio.core.transfer import applicable_rse_transfer_limits
 from rucio.daemons.common import db_workqueue, ProducerConsumerDaemon
@@ -82,6 +83,7 @@ def throttler(
             _handle_requests(release_groups, logger=logger)
         except Exception:
             logger(logging.CRITICAL, "Failed to schedule requests, error: %s" % (traceback.format_exc()))
+        reset_stale_waiting_requests()
 
     ProducerConsumerDaemon(
         producers=[_db_producer],


### PR DESCRIPTION
Added functionality at the end of the conveyor-throttler main loop that will reset all requests that have been in the waiting state for >1 day back to the preparing state and clear their source_rse_id. Also added additional checks to the integration test of the preparer/throttler workflow to validate this scenario and ensure that requests properly get reset based on the last_processed_at timestamp. This allows for requests that have been throttled for a long time to account for new sources and changes that have occurred while they have been throttled.