### PR TITLE
Transfers: add average transfer wait time metric #5012

### DIFF
--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -553,6 +553,9 @@ def update_transfer_state(
                     activity=request['activity'],
                     state=tt_status_report.state,
                     file_size=request['bytes'],
+                    submitted_at=request.get('submitted_at', None),
+                    started_at=request.get('started_at', None),
+                    transferred_at=request.get('transferred_at', None),
                     session=session,
                 )
             request_core.add_monitor_message(


### PR DESCRIPTION
We keep track of the running average wait time for all completed transfers sent to update_transfer_state. This metric aims to measure the effectiveness of load distribution from different source node selection strategies. Lower average wait time generally signifies a more effective strategy. The average is based on a tumbling window of 6 hours.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
