### PR TITLE
Transfers: skip updating transfers if state didn't change. Closes #6424

### DIFF
--- a/lib/rucio/daemons/conveyor/preparer.py
+++ b/lib/rucio/daemons/conveyor/preparer.py
@@ -25,7 +25,7 @@ from rucio.common.config import config_get_list
 from rucio.common.exception import RucioException
 from rucio.common.logging import setup_logging
 from rucio.core import transfer as transfer_core
-from rucio.core.request import set_requests_state_if_possible, list_and_mark_transfer_requests_and_source_replicas
+from rucio.core.request import transition_requests_state_if_possible, list_and_mark_transfer_requests_and_source_replicas
 from rucio.core.topology import Topology, ExpiringObjectCache
 from rucio.core.transfer import prepare_transfers, list_transfer_admin_accounts, build_transfer_paths, ProtocolFactory
 from rucio.daemons.common import db_workqueue, ProducerConsumerDaemon
@@ -185,13 +185,13 @@ def _handle_requests(
             reqs_no_source.update(reqs_no_transfertool)
             if reqs_no_source:
                 logger(logging.INFO, "Marking requests as no-sources: %s", reqs_no_source)
-                set_requests_state_if_possible(reqs_no_source, RequestState.NO_SOURCES, logger=logger)
+                transition_requests_state_if_possible(reqs_no_source, RequestState.NO_SOURCES, logger=logger)
             if reqs_only_tape_source:
                 logger(logging.INFO, "Marking requests as only-tape-sources: %s", reqs_only_tape_source)
-                set_requests_state_if_possible(reqs_only_tape_source, RequestState.ONLY_TAPE_SOURCES, logger=logger)
+                transition_requests_state_if_possible(reqs_only_tape_source, RequestState.ONLY_TAPE_SOURCES, logger=logger)
             if reqs_scheme_mismatch:
                 logger(logging.INFO, "Marking requests as scheme-mismatch: %s", reqs_scheme_mismatch)
-                set_requests_state_if_possible(reqs_scheme_mismatch, RequestState.MISMATCH_SCHEME, logger=logger)
+                transition_requests_state_if_possible(reqs_scheme_mismatch, RequestState.MISMATCH_SCHEME, logger=logger)
     except RucioException:
         logger(logging.ERROR, 'errored with a RucioException, retrying later', exc_info=True)
         updated_msg = 'errored'

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -872,7 +872,7 @@ def test_transfer_to_mas_existing_replica(rse_factory, did_factory, root_account
 
     # mock a successful stagein
     request = request_core.get_request(request_id=request['id'])
-    request_core.set_request_state(request_id=request['id'], state=RequestState.DONE, external_id=request['external_id'])
+    request_core.transition_request_state(request_id=request['id'], state=RequestState.DONE, external_id=request['external_id'])
     finisher(once=True, partition_wait_time=0)
 
     assert lock_core.get_replica_locks_for_rule_id(rule_id=rule1_id)[0]['state'] == LockState.OK
@@ -911,7 +911,7 @@ def test_failed_transfers_to_mas_existing_replica(rse_factory, did_factory, root
 
     # mock a failed transfer
     request = request_core.get_request(request_id=request['id'])
-    request_core.set_request_state(request_id=request['id'], state=RequestState.FAILED, external_id=request['external_id'])
+    request_core.transition_request_state(request_id=request['id'], state=RequestState.FAILED, external_id=request['external_id'])
     finisher(once=True, partition_wait_time=0)
     lock_core.failed_transfer(scope=did['scope'], name=did['name'], rse_id=dst_rse_id)
 
@@ -934,7 +934,7 @@ def test_failed_transfers_to_mas_existing_replica(rse_factory, did_factory, root
 
     # mock a failed transfer for the second rule
     request = request_core.get_request(request_id=request['id'])
-    request_core.set_request_state(request_id=request['id'], state=RequestState.FAILED, external_id=request['external_id'])
+    request_core.transition_request_state(request_id=request['id'], state=RequestState.FAILED, external_id=request['external_id'])
     finisher(once=True, partition_wait_time=0)
     lock_core.failed_transfer(scope=did['scope'], name=did['name'], rse_id=dst_rse_id)
 


### PR DESCRIPTION
It shouldn't be problematic to skip those updates. This should only happen during releases/partitioning issues and when receiver+poller work on the same request in parallel. In both cases, having the request with the desired state already in the database would mean that the request was already correctly handled.

To make it clear that the function shouldn't be used for routine updates of requests, rename it to transition_request_state.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
