### PR TITLE
Policies: refactor policy package code to use new plugin code #6382

### DIFF
--- a/lib/rucio/common/plugins.py
+++ b/lib/rucio/common/plugins.py
@@ -20,8 +20,6 @@ from typing import Any, Callable, Dict, TypeVar, Type
 
 from rucio.common import config
 from rucio.common.exception import InvalidAlgorithmName
-from rucio.common.utils import check_policy_package_version
-from rucio.core.vo import list_vos
 
 
 PolicyPackageAlgorithmsT = TypeVar('PolicyPackageAlgorithmsT', bound='PolicyPackageAlgorithms')
@@ -114,6 +112,7 @@ class PolicyPackageAlgorithms():
                 cls._try_importing_policy(vo)
             # on server, list all VOs and register their algorithms
             else:
+                from rucio.core.vo import list_vos
                 # policy package per VO
                 vos = list_vos()
                 for vo in vos:
@@ -122,6 +121,9 @@ class PolicyPackageAlgorithms():
     @classmethod
     def _try_importing_policy(cls: Type[PolicyPackageAlgorithmsT], vo: str = "") -> None:
         try:
+            # import from utils here to avoid circular import
+            from rucio.common.utils import check_policy_package_version
+
             env_name = 'RUCIO_POLICY_PACKAGE' + ('' if not vo else '_' + vo.upper())
             package = getattr(os.environ, env_name, "")
             if not package:

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -43,6 +43,7 @@ from rucio.common.exception import (InvalidRSEExpression, InvalidReplicationRule
                                     InvalidObject, RSEWriteBlocked, RuleReplaceFailed, RequestNotFound,
                                     ManualRuleApprovalBlocked, UnsupportedOperation, UndefinedPolicy, InvalidValueForKey,
                                     InvalidSourceReplicaExpression)
+from rucio.common.plugins import PolicyPackageAlgorithms
 from rucio.common.policy import policy_filter, get_scratchdisk_lifetime
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalScope, InternalAccount, LoggerFunction, RuleDict
@@ -53,7 +54,6 @@ from rucio.core.account import has_account_attribute
 from rucio.core.lifetime_exception import define_eol
 from rucio.core.message import add_message
 from rucio.core.monitor import MetricManager
-from rucio.core.plugins import PolicyPackageAlgorithms
 from rucio.core.rse import get_rse_name, list_rse_attributes, get_rse, get_rse_usage
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.rse_selector import RSESelector

--- a/lib/rucio/transfertool/fts3_plugins.py
+++ b/lib/rucio/transfertool/fts3_plugins.py
@@ -19,9 +19,9 @@ import sys
 from configparser import NoSectionError
 from typing import Any, Callable, Optional
 
-from rucio.core.plugins import PolicyPackageAlgorithms
 from rucio.common.config import config_get_int, config_get_items
 from rucio.common.exception import InvalidRequest
+from rucio.common.plugins import PolicyPackageAlgorithms
 
 
 class FTS3TapeMetadataPlugin(PolicyPackageAlgorithms):


### PR DESCRIPTION
This PR refactors the policy package algorithm code to use the new class introduced as part of the rule auto-approval work. All of the algorithm types (SURL, LFN2PFN and scope extraction) now use this base class, resulting in less duplication and hopefully cleaner code.

I have moved `plugins.py` from `core` to `common` to preserve the layering of the code, because the scope extraction algorithms are used client side.
