### PR TITLE
Protocols: Overcome GFAL credential location when using tokens #6428

### DIFF
--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -189,6 +189,11 @@ class Default(protocol.RSEProtocol):
         self.__ctx.set_opt_boolean("XROOTD PLUGIN", "NORMALIZE_PATH", False)
         auth_configured = False
         if self.auth_token:
+            for key in ["CERT", "KEY"]:
+                try:
+                    self.__ctx.remove_opt("X509", key)
+                except gfal2.GError:  # pylint: disable=no-member
+                    pass
             self.__ctx.set_opt_string("BEARER", "TOKEN", self.auth_token)
             auth_configured = True
         # Configure gfal authentication to use the rucio client proxy if and only if gfal didn't initialize its credentials already


### PR DESCRIPTION
When a GFAL context is initialised, it will attempt to locate and use and X.509 certificate through some environmental variables or standard locations. This commits undoes this configuration when using a token.
