### PR TITLE
Replicas: For declaring bad replicas, use plugin for deteriming scope

### DIFF
--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -15,6 +15,7 @@
 import copy
 import logging
 import random
+from collections.abc import Callable
 from time import sleep
 from urllib.parse import urlparse
 
@@ -23,6 +24,18 @@ from rucio.common.config import config_get_int
 from rucio.common.constraints import STRING_TYPES
 from rucio.common.logging import formatted_logger
 from rucio.common.utils import GLOBALLY_SUPPORTED_CHECKSUMS, make_valid_did
+
+
+def get_scope_protocol(vo: str = 'def') -> Callable:
+    """
+        Returns the callable protocol to translate the pfn to a name/scope pair
+
+    :returns:
+        Callable: Scope Parser function
+    """
+    from rucio.rse.protocols.protocol import RSEDeterministicScopeTranslation
+    translation = RSEDeterministicScopeTranslation(vo=vo)
+    return translation.parser
 
 
 def get_rse_info(rse=None, vo='def', rse_id=None, session=None) -> types.RSESettingsDict:


### PR DESCRIPTION
Replacing the hard coded `Warning: Atlas Only` sections of replicas.__declare_bad_replicas and replicas.get_did_from_pfns to use a policy subclassed from policypackagealgorithms
