### PR TITLE
Transfers: metadata for collocation on tape #6398

### DIFF
--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -2180,3 +2180,16 @@ def retrying(
                 time.sleep(wait_fixed / 1000.0)
         return _wrapper
     return _decorator
+
+
+def deep_merge_dict(source: dict, destination: dict) -> dict:
+    """Merge two dictionaries together recurively"""
+    for key, value in source.items():
+        if isinstance(value, dict):
+            # get node or create one
+            node = destination.setdefault(key, {})
+            deep_merge_dict(value, node)
+        else:
+            destination[key] = value
+
+    return destination

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -40,7 +40,7 @@ from enum import Enum
 from functools import partial, wraps
 from io import StringIO
 from itertools import zip_longest
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Optional
 from urllib.parse import urlparse, urlencode, quote, parse_qsl, urlunparse
 from uuid import uuid4 as uuid
 from xml.etree import ElementTree
@@ -65,9 +65,7 @@ if EXTRA_MODULES['paramiko']:
         EXTRA_MODULES['paramiko'] = False
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import TypeVar, Optional
-
+    from typing import TypeVar
     T = TypeVar('T')
 
 
@@ -2183,7 +2181,7 @@ def retrying(
 
 
 def deep_merge_dict(source: dict, destination: dict) -> dict:
-    """Merge two dictionaries together recurively"""
+    """Merge two dictionaries together recursively"""
     for key, value in source.items():
         if isinstance(value, dict):
             # get node or create one

--- a/lib/rucio/transfertool/fts3_plugins.py
+++ b/lib/rucio/transfertool/fts3_plugins.py
@@ -12,37 +12,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import logging
-from typing import Callable, Optional
 import json
 import sys
+from configparser import NoSectionError
+from typing import Any, Callable, Optional
 
 from rucio.core.plugins import PolicyPackageAlgorithms
 from rucio.common.config import config_get_int, config_get_items
-from configparser import NoSectionError
-
 from rucio.common.exception import InvalidRequest
 
 
-class FTS3MetadataPlugin(PolicyPackageAlgorithms):
+class FTS3TapeMetadataPlugin(PolicyPackageAlgorithms):
     """
     Add a "archive_metadata" field to a file's transfer parameters.
     Plugins are registered during initialization and called during a transfer with FTS3
     """
 
-    ALGORITHM_NAME = "fts3_plugins"
-    HINTS_NAME = "fts3_plugins_init"
+    ALGORITHM_NAME = "fts3_tape_metadata_plugins"
+    _HINTS_NAME = "fts3_plugins_init"
     DEFAULT = "def"
 
-    def __init__(self, policy_algorithm: str):
+    def __init__(self, policy_algorithm: str) -> None:
         """
-        :param policy_algorithm: policy algorithm indentifier - choose from any of the policy package algorithms registered under the `fts3_plugins` group.
-        :type policy_algorithm: str
+        :param policy_algorithm: policy algorithm indentifier - choose from any of the policy package algorithms registered under the `fts3_tape_metadata_plugins` group.
         """
         super().__init__()
-        self.register("activity", func=self._activity_hints, init_func=self._init_activity_hints)
+        self.register("activity", func=self._activity_hints, init_func=self._init_instance_activity_hints)
         self.register(self.DEFAULT, func=lambda x: self._collocation(self._default, x))
-        self.register("cms_collocation", func=lambda x: self._collocation(self._cms_collocation, x))
         self.register("test", func=lambda x: self._collocation(self._test_collocation, x))
 
         self.transfer_limit = config_get_int(
@@ -58,8 +56,8 @@ class FTS3MetadataPlugin(PolicyPackageAlgorithms):
             policy_algorithm = self.DEFAULT
 
         # If the policy has a supplied and registered init function
-        if self._supports(self.HINTS_NAME, policy_algorithm):
-            self._get_one_algorithm(self.HINTS_NAME, name=policy_algorithm)()
+        if self._supports(self._HINTS_NAME, policy_algorithm):
+            self._get_one_algorithm(self._HINTS_NAME, name=policy_algorithm)()
 
         self.set_in_hints = self._get_one_algorithm(self.ALGORITHM_NAME, name=policy_algorithm)
 
@@ -69,24 +67,24 @@ class FTS3MetadataPlugin(PolicyPackageAlgorithms):
         Register a fts3 transfer plugin
 
         :param name: name to register under
-        :type name: str
         :param func: function called by the plugin
-        :type func: Callable
         :param init_func: Initialization requirements for the plugin, defaults to None
-        :type init_func: Optional[Callable], optional
         """
         super()._register(cls.ALGORITHM_NAME, algorithm_dict={name: func})
         if init_func is not None:
-            super()._register(cls.HINTS_NAME, algorithm_dict={name: init_func})
+            super()._register(cls._HINTS_NAME, algorithm_dict={name: init_func})
 
-    def _init_activity_hints(self):
+    def _init_instance_activity_hints(self) -> None:
+        """
+            Load prorities for activities from the config
+        """
         try:
             self.prority_table = dict(config_get_items("tape_priority"))
         except NoSectionError:
             self.prority_table = {}
 
     def _activity_hints(self, activity_kwargs: dict[str, str], default_prority: str = '20') -> dict[str, dict]:
-        """ Activity Hints - assign a prorioty based on activity"""
+        """ Activity Hints - assign a priority based on activity"""
         if "activity" in activity_kwargs:
             activity = activity_kwargs["activity"].lower()
 
@@ -98,30 +96,23 @@ class FTS3MetadataPlugin(PolicyPackageAlgorithms):
 
         return {"scheduling_hints": {"priority": priority}}
 
-    def _collocation(self, collocation_func: Callable, hints: dict) -> dict[str, dict]:
+    def _collocation(self, collocation_func: Callable, hints: dict[str, Any]) -> dict[str, dict]:
         """
         Wraps a 'collacation' style plugin for formatting
 
         :param collocation_func: Function that defines the collocation rules
-        :type collocation_func: Callable
         :param hints: kwargs utilized by the collocation rules
-        :type hints: dict
         :return: Collocation hints produced by the collocation_func, wrapped
-        :rtype: dict
         """
         return {"collocation_hints": collocation_func(*hints)}
 
-    def _test_collocation(self, *hint: dict) -> dict:
+    def _test_collocation(self, *hint: dict) -> dict[str, Any]:
         return {"0": "", "1": "", "2": "", "3": ""}
 
     def _default(self, *hints: dict) -> dict:
         return {}
 
-    def _cms_collocation(self, *hints: dict) -> None:
-        # Placeholder - should not be used
-        raise NotImplementedError
-
-    def _verify_in_format(self, hint_dict: dict) -> None:
+    def _verify_in_format(self, hint_dict: dict[str, Any]) -> None:
         """Check the to-be-submitted file transfer params are both json encodable and under the size limit for transfer"""
         try:
             hints_json = json.dumps(hint_dict)
@@ -134,14 +125,12 @@ class FTS3MetadataPlugin(PolicyPackageAlgorithms):
                 f"Request too large, decrease to less than {self.transfer_limit}", e
             )
 
-    def hints(self, hint_kwargs: dict) -> dict:
+    def hints(self, hint_kwargs: dict) -> dict[str, Any]:
         """
         Produce "archive_metadata" hints for how a transfer should be executed by fts3.
 
         :param hint_kwargs: Args passed forward to the plugin algorithm
-        :type hint_kwargs: dict
         :return: Archiving metadata in the format {archive_metadata: {<plugin produced hints>}}
-        :rtype: dict
         """
         hints = self.set_in_hints(hint_kwargs)
         self._verify_in_format(hints)
@@ -149,4 +138,4 @@ class FTS3MetadataPlugin(PolicyPackageAlgorithms):
 
 
 # Register the policies
-FTS3MetadataPlugin("")
+FTS3TapeMetadataPlugin("")

--- a/lib/rucio/transfertool/fts3_plugins.py
+++ b/lib/rucio/transfertool/fts3_plugins.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import Callable, Optional
+import json
+import sys
+
+from rucio.core.plugins import PolicyPackageAlgorithms
+from rucio.common.config import config_get_int, config_get_items
+from configparser import NoSectionError
+
+from rucio.common.exception import InvalidRequest
+
+
+class FTS3MetadataPlugin(PolicyPackageAlgorithms):
+    """
+    Add a "archive_metadata" field to a file's transfer parameters.
+    Plugins are registered during initialization and called during a transfer with FTS3
+    """
+
+    ALGORITHM_NAME = "fts3_plugins"
+    HINTS_NAME = "fts3_plugins_init"
+    DEFAULT = "def"
+
+    def __init__(self, policy_algorithm: str):
+        """
+        :param policy_algorithm: policy algorithm indentifier - choose from any of the policy package algorithms registered under the `fts3_plugins` group.
+        :type policy_algorithm: str
+        """
+        super().__init__()
+        self.register("activity", func=self._activity_hints, init_func=self._init_activity_hints)
+        self.register(self.DEFAULT, func=lambda x: self._collocation(self._default, x))
+        self.register("cms_collocation", func=lambda x: self._collocation(self._cms_collocation, x))
+        self.register("test", func=lambda x: self._collocation(self._test_collocation, x))
+
+        self.transfer_limit = config_get_int(
+            "transfers",
+            option="metadata_byte_limit",
+            raise_exception=False,
+            default=4096,
+        )
+
+        # Use a default if the algorithm isn't supported
+        if not self._supports(self.ALGORITHM_NAME, policy_algorithm):
+            logging.debug(f"Policy Algorithm {policy_algorithm} not found, ignoring.")
+            policy_algorithm = self.DEFAULT
+
+        # If the policy has a supplied and registered init function
+        if self._supports(self.HINTS_NAME, policy_algorithm):
+            self._get_one_algorithm(self.HINTS_NAME, name=policy_algorithm)()
+
+        self.set_in_hints = self._get_one_algorithm(self.ALGORITHM_NAME, name=policy_algorithm)
+
+    @classmethod
+    def register(cls, name: str, func: Callable, init_func: Optional[Callable] = None) -> None:
+        """
+        Register a fts3 transfer plugin
+
+        :param name: name to register under
+        :type name: str
+        :param func: function called by the plugin
+        :type func: Callable
+        :param init_func: Initialization requirements for the plugin, defaults to None
+        :type init_func: Optional[Callable], optional
+        """
+        super()._register(cls.ALGORITHM_NAME, algorithm_dict={name: func})
+        if init_func is not None:
+            super()._register(cls.HINTS_NAME, algorithm_dict={name: init_func})
+
+    def _init_activity_hints(self):
+        try:
+            self.prority_table = dict(config_get_items("tape_priority"))
+        except NoSectionError:
+            self.prority_table = {}
+
+    def _activity_hints(self, activity_kwargs: dict[str, str], default_prority: str = '20') -> dict[str, dict]:
+        """ Activity Hints - assign a prorioty based on activity"""
+        if "activity" in activity_kwargs:
+            activity = activity_kwargs["activity"].lower()
+
+        else:
+            raise InvalidRequest("`activity` field not found in passed metadata")
+
+        default_prority = self.prority_table.get("default", default_prority)
+        priority = self.prority_table.get(activity, default_prority)
+
+        return {"scheduling_hints": {"priority": priority}}
+
+    def _collocation(self, collocation_func: Callable, hints: dict) -> dict[str, dict]:
+        """
+        Wraps a 'collacation' style plugin for formatting
+
+        :param collocation_func: Function that defines the collocation rules
+        :type collocation_func: Callable
+        :param hints: kwargs utilized by the collocation rules
+        :type hints: dict
+        :return: Collocation hints produced by the collocation_func, wrapped
+        :rtype: dict
+        """
+        return {"collocation_hints": collocation_func(*hints)}
+
+    def _test_collocation(self, *hint: dict) -> dict:
+        return {"0": "", "1": "", "2": "", "3": ""}
+
+    def _default(self, *hints: dict) -> dict:
+        return {}
+
+    def _cms_collocation(self, *hints: dict) -> None:
+        # Placeholder - should not be used
+        raise NotImplementedError
+
+    def _verify_in_format(self, hint_dict: dict) -> None:
+        """Check the to-be-submitted file transfer params are both json encodable and under the size limit for transfer"""
+        try:
+            hints_json = json.dumps(hint_dict)
+            assert sys.getsizeof(hints_json) < self.transfer_limit
+
+        except TypeError as e:
+            raise InvalidRequest("Request malformed, cannot encode to JSON", e)
+        except AssertionError as e:
+            raise InvalidRequest(
+                f"Request too large, decrease to less than {self.transfer_limit}", e
+            )
+
+    def hints(self, hint_kwargs: dict) -> dict:
+        """
+        Produce "archive_metadata" hints for how a transfer should be executed by fts3.
+
+        :param hint_kwargs: Args passed forward to the plugin algorithm
+        :type hint_kwargs: dict
+        :return: Archiving metadata in the format {archive_metadata: {<plugin produced hints>}}
+        :rtype: dict
+        """
+        hints = self.set_in_hints(hint_kwargs)
+        self._verify_in_format(hints)
+        return {"archive_metadata": hints}
+
+
+# Register the policies
+FTS3MetadataPlugin("")

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -138,9 +138,9 @@ def scitags_mock(core_config_mock):
             self.send_code_and_message(200, {'Content-Type': 'application/json'}, file_content)
 
     with MockServer(_SendScitagsJson) as mock_server:
-        core_config.set('packet-marking', 'enabled',  True)
-        core_config.set('packet-marking', 'fetch_url',  mock_server.base_url)
-        core_config.set('packet-marking', 'exp_name',  'atlas')
+        core_config.set('packet-marking', 'enabled', True)
+        core_config.set('packet-marking', 'fetch_url', mock_server.base_url)
+        core_config.set('packet-marking', 'exp_name', 'atlas')
         yield mock_server
 
 

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -1663,6 +1663,67 @@ def test_preparer_ignore_availability(rse_factory, did_factory, root_account, fi
 
 
 @skip_rse_tests_with_accounts
+@pytest.mark.noparallel(groups=[NoParallelGroups.PREPARER, NoParallelGroups.SUBMITTER])
+@pytest.mark.parametrize("file_config_mock", [
+    {
+        "overrides": [
+            ("transfers", "fts3tape_metadata_plugins", "activity"),
+            ('tape_priority', 'fast', '100'),
+            ('tape_priority', 'slow', '1')
+        ]
+    }
+], indirect=True)
+def test_transfer_plugins(rse_factory, did_factory, root_account, file_config_mock):
+    """
+        Add existing plugin to fts3 transfertool, verify submission goes through.
+    """
+    def __setup_test():
+        src_rse, src_rse_id = rse_factory.make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.posix.Default', rse_type=RSEType.TAPE)
+        dst_rse, dst_rse_id = rse_factory.make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.posix.Default', rse_type=RSEType.TAPE)
+
+        distance_core.add_distance(src_rse_id, dst_rse_id, distance=10)
+        rse_core.add_rse_attribute(dst_rse_id, 'verify_checksum', False)
+
+        for rse_id in [src_rse_id, dst_rse_id]:
+            rse_core.add_rse_attribute(rse_id, 'fts', TEST_FTS_HOST)
+
+        did_fast = did_factory.upload_test_file(src_rse)
+        did_slow = did_factory.upload_test_file(src_rse)
+
+        activity_dict = {did_fast['name']: "fast", did_slow['name']: "slow"}
+
+        rule_core.add_rule(dids=[did_fast, did_slow], account=root_account, copies=1, rse_expression=dst_rse, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
+        return src_rse_id, dst_rse_id, did_fast, did_slow, activity_dict
+
+    src_rse_id, dst_rse_id, did_fast, did_slow, activity_dict = __setup_test()
+
+    class _Fts3PluginTestWrapper(FTS3Transfertool):
+        def _file_from_transfer(self, transfer, job_params):
+            transfer.rws.activity = activity_dict[transfer.rws.name]
+            super()._file_from_transfer(transfer, job_params)
+
+    preparer(once=True, sleep_time=1, bulk=2, partition_wait_time=0, ignore_availability=False)
+    request = request_core.get_request_by_did(rse_id=dst_rse_id, **did_fast)
+    assert request['state'] == RequestState.QUEUED
+
+    request = request_core.get_request_by_did(rse_id=dst_rse_id, **did_slow)
+    assert request['state'] == RequestState.QUEUED
+
+    with patch("rucio.transfertool.fts3.FTS3Transfertool", _Fts3PluginTestWrapper):
+        submitter(once=True, rses=[{'id': rse_id} for rse_id in (src_rse_id, dst_rse_id)], group_bulk=1, partition_wait_time=0, transfertools=['fts3'], transfertype='single')
+
+    # Verify that both the submission works
+    request_fast = request_core.get_request_by_did(rse_id=dst_rse_id, **did_fast)
+    request_slow = request_core.get_request_by_did(rse_id=dst_rse_id, **did_slow)
+
+    # Does not impact the actual prority of the transfer - is read by placement algorithm not fts3.
+    assert request_fast['state'] != RequestState.SUBMISSION_FAILED
+    assert request_slow['state'] != RequestState.SUBMISSION_FAILED
+    assert request_fast['state'] != RequestState.FAILED
+    assert request_slow['state'] != RequestState.FAILED
+
+
+@skip_rse_tests_with_accounts
 @pytest.mark.noparallel(groups=[NoParallelGroups.XRD, NoParallelGroups.SUBMITTER, NoParallelGroups.POLLER, NoParallelGroups.FINISHER])
 @pytest.mark.parametrize("file_config_mock", [{
     "overrides": [('client', 'register_bittorrent_meta', 'true')]

--- a/tests/test_transfer_plugins.py
+++ b/tests/test_transfer_plugins.py
@@ -22,7 +22,7 @@ from rucio.core.transfer import ProtocolFactory, build_transfer_paths
 from rucio.core.request import list_and_mark_transfer_requests_and_source_replicas
 
 from rucio.db.sqla.session import get_session
-from rucio.transfertool.fts3_plugins import FTS3MetadataPlugin
+from rucio.transfertool.fts3_plugins import FTS3TapeMetadataPlugin
 
 from rucio.core import distance as distance_core
 from rucio.core import replica as replica_core
@@ -73,7 +73,7 @@ def _make_transfer_path(did, rse_factory, root_account):
     {
         "overrides": [
             ('tape_priority', 'User Subscriptions', '100'),
-            ("transfers", "plugins", "activity")
+            ("transfers", "fts3tape_metadata_plugins", "activity")
         ]
     }
 ], indirect=True)
@@ -88,7 +88,7 @@ def test_scheduling_hints(file_config_mock, did_factory, rse_factory, root_accou
     transfer_path = _make_transfer_path(mock_did, rse_factory, root_account)
 
     # Need to re-init the module once the config is set
-    FTS3MetadataPlugin(" ")
+    FTS3TapeMetadataPlugin(" ")
 
     # Mock Transfer Tool
     fts3_tool = FTS3Transfertool(TEST_FTS_HOST)
@@ -104,7 +104,7 @@ def test_scheduling_hints(file_config_mock, did_factory, rse_factory, root_accou
     # Get the job params used for each transfer
     job_params = fts3_tool._file_from_transfer(transfer_path[0], job_params)
 
-    # Exstract the hints
+    # Extract the hints
     assert "archive_metadata" in job_params
     assert len(job_params["archive_metadata"].keys()) == 1
     generated_scheduling_hints = job_params["archive_metadata"]["scheduling_hints"]
@@ -116,7 +116,7 @@ def test_scheduling_hints(file_config_mock, did_factory, rse_factory, root_accou
 @pytest.mark.parametrize("file_config_mock", [
     {
         "overrides": [
-            ("transfers", "plugins", "activity")
+            ("transfers", "fts3tape_metadata_plugins", "activity")
         ]
     }
 ], indirect=True)
@@ -147,7 +147,7 @@ def test_activity_missing(file_config_mock, did_factory, rse_factory, root_accou
 
     job_params = fts3_tool._file_from_transfer(transfer_params, job_params)
 
-    # Exstract the hints
+    # Extract the hints
     assert "archive_metadata" in job_params
     generated_scheduling_hints = job_params["archive_metadata"]["scheduling_hints"]
 
@@ -158,7 +158,7 @@ def test_activity_missing(file_config_mock, did_factory, rse_factory, root_accou
 @pytest.mark.parametrize("file_config_mock", [
     {
         "overrides": [
-            ("transfers", "plugins", "test")
+            ("transfers", "fts3tape_metadata_plugins", "test")
         ]
     }
 ], indirect=True)
@@ -203,7 +203,7 @@ def test_collocation_hints(file_config_mock, did_factory, rse_factory, root_acco
 @pytest.mark.parametrize("file_config_mock", [
     {
         "overrides": [
-            ("transfers", "plugins", "activity, test")
+            ("transfers", "fts3tape_metadata_plugins", "activity, test")
         ]
     }
 ], indirect=True)
@@ -244,7 +244,7 @@ def test_multiple_plugin_concat(file_config_mock, did_factory, rse_factory, root
     {
         "overrides": [
             ("transfers", "metadata_byte_limit", "4"),
-            ("transfers", "plugins", "def")
+            ("transfers", "fts3tape_metadata_plugins", "def")
 
         ]
     }

--- a/tests/test_transfer_plugins.py
+++ b/tests/test_transfer_plugins.py
@@ -1,0 +1,271 @@
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import logging
+
+from rucio.transfertool.fts3 import FTS3Transfertool, build_job_params
+from rucio.core.topology import Topology
+from rucio.core.transfer import ProtocolFactory, build_transfer_paths
+from rucio.core.request import list_and_mark_transfer_requests_and_source_replicas
+
+from rucio.db.sqla.session import get_session
+from rucio.transfertool.fts3_plugins import FTS3MetadataPlugin
+
+from rucio.core import distance as distance_core
+from rucio.core import replica as replica_core
+from rucio.core import rule as rule_core
+
+
+mock_session = get_session()
+
+MAX_POLL_WAIT_SECONDS = 60
+TEST_FTS_HOST = "https://fts:8446"
+
+
+def _make_transfer_path(did, rse_factory, root_account):
+    _, src_rse_id = rse_factory.make_mock_rse()
+    dst_rse, dst_rse_id = rse_factory.make_mock_rse()
+    all_rses = [src_rse_id, dst_rse_id]
+    distance_core.add_distance(src_rse_id, dst_rse_id, distance=1)
+
+    topology = Topology(rse_ids=all_rses)
+    file = {"scope": did["scope"], "name": did["name"], "bytes": 1}
+    replica_core.add_replicas(rse_id=src_rse_id, files=[file], account=root_account)
+    rule_core.add_rule(
+        dids=[did],
+        account=root_account,
+        copies=1,
+        rse_expression=dst_rse,
+        grouping="ALL",
+        weight=None,
+        lifetime=None,
+        locked=False,
+        subscription_id=None,
+    )
+
+    requests_by_id = list_and_mark_transfer_requests_and_source_replicas(
+        rse_collection=topology, rses=[src_rse_id, dst_rse_id]
+    )
+    requests, *_ = build_transfer_paths(
+        topology=topology,
+        protocol_factory=ProtocolFactory(),
+        requests_with_sources=requests_by_id.values(),
+    )
+    _, [transfer_path] = next(iter(requests.items()))
+
+    return transfer_path
+
+
+@pytest.mark.parametrize("file_config_mock", [
+    {
+        "overrides": [
+            ('tape_priority', 'User Subscriptions', '100'),
+            ("transfers", "plugins", "activity")
+        ]
+    }
+], indirect=True)
+def test_scheduling_hints(file_config_mock, did_factory, rse_factory, root_account):
+
+    """Transfer with an installed plugin for scheduling based on transfer activity"""
+
+    # Produce a new did
+    mock_did = did_factory.random_file_did()
+
+    # Make the transfer path
+    transfer_path = _make_transfer_path(mock_did, rse_factory, root_account)
+
+    # Need to re-init the module once the config is set
+    FTS3MetadataPlugin(" ")
+
+    # Mock Transfer Tool
+    fts3_tool = FTS3Transfertool(TEST_FTS_HOST)
+
+    job_params = build_job_params(
+        transfer_path=transfer_path,
+        bring_online=None,
+        default_lifetime=None,
+        archive_timeout_override=None,
+        max_time_in_queue=None,
+        logger=logging.log,
+    )
+    # Get the job params used for each transfer
+    job_params = fts3_tool._file_from_transfer(transfer_path[0], job_params)
+
+    # Exstract the hints
+    assert "archive_metadata" in job_params
+    assert len(job_params["archive_metadata"].keys()) == 1
+    generated_scheduling_hints = job_params["archive_metadata"]["scheduling_hints"]
+
+    expected_scheduling_hints = {"priority": "100"}
+    assert expected_scheduling_hints == generated_scheduling_hints
+
+
+@pytest.mark.parametrize("file_config_mock", [
+    {
+        "overrides": [
+            ("transfers", "plugins", "activity")
+        ]
+    }
+], indirect=True)
+def test_activity_missing(file_config_mock, did_factory, rse_factory, root_account):
+    """Ensure default is selected when the activity is not listed in the config, but is in the schema"""
+    # Do not add config section for priority, but do add the FTS3
+    # Produce a new did
+    mock_did = did_factory.random_file_did()
+
+    # Make the transfer path
+    transfer_path = _make_transfer_path(mock_did, rse_factory, root_account)
+
+    # Mock Transfer Tool
+    fts3_tool = FTS3Transfertool(TEST_FTS_HOST)
+
+    job_params = build_job_params(
+        transfer_path=transfer_path,
+        bring_online=None,
+        default_lifetime=None,
+        archive_timeout_override=None,
+        max_time_in_queue=None,
+        logger=logging.log,
+    )
+
+    # Get the job params used for each transfer
+    transfer_params = transfer_path[0]
+    transfer_params.rws.activity = "Not A Real Activity"
+
+    job_params = fts3_tool._file_from_transfer(transfer_params, job_params)
+
+    # Exstract the hints
+    assert "archive_metadata" in job_params
+    generated_scheduling_hints = job_params["archive_metadata"]["scheduling_hints"]
+
+    expected_scheduling_hints = {"priority": "20"}
+    assert expected_scheduling_hints == generated_scheduling_hints
+
+
+@pytest.mark.parametrize("file_config_mock", [
+    {
+        "overrides": [
+            ("transfers", "plugins", "test")
+        ]
+    }
+], indirect=True)
+def test_collocation_hints(file_config_mock, did_factory, rse_factory, root_account):
+    """For a mock collocation algorithm, it can produce the 4 levels of hints required for each did"""
+
+    mock_did = did_factory.random_file_did()
+    transfer_path = _make_transfer_path(mock_did, rse_factory, root_account)
+
+    # Mock Transfer Tool
+    fts3_tool = FTS3Transfertool(TEST_FTS_HOST)
+
+    job_params = build_job_params(
+        transfer_path=transfer_path,
+        bring_online=None,
+        default_lifetime=None,
+        archive_timeout_override=None,
+        max_time_in_queue=None,
+        logger=logging.log,
+    )
+
+    # Get the job params used for each transfer
+    job_params = fts3_tool._file_from_transfer(transfer_path[0], job_params)
+
+    expected_collocation_hints = {
+        "collocation_hints": {
+            "0": "",
+            "1": "",
+            "2": "",
+            "3": "",
+        }
+    }
+
+    assert "archive_metadata" in job_params
+    generated_collocation_hints = job_params["archive_metadata"]["collocation_hints"]
+
+    assert (
+        expected_collocation_hints["collocation_hints"] == generated_collocation_hints
+    )
+
+
+@pytest.mark.parametrize("file_config_mock", [
+    {
+        "overrides": [
+            ("transfers", "plugins", "activity, test")
+        ]
+    }
+], indirect=True)
+def test_multiple_plugin_concat(file_config_mock, did_factory, rse_factory, root_account):
+    """When multiple plugins are used (like prority and collocation), both logics are applied"""
+
+    mock_did = did_factory.random_file_did()
+    transfer_path = _make_transfer_path(mock_did, rse_factory, root_account)
+
+    # Mock Transfer Tool
+    fts3_tool = FTS3Transfertool(TEST_FTS_HOST)
+
+    job_params = build_job_params(
+        transfer_path=transfer_path,
+        bring_online=None,
+        default_lifetime=None,
+        archive_timeout_override=None,
+        max_time_in_queue=None,
+        logger=logging.log,
+    )
+
+    # Get the job params used for each transfer
+    job_params = fts3_tool._file_from_transfer(transfer_path[0], job_params)
+    expected_hints = {
+        "scheduling_hints": {"priority": "20"},
+        "collocation_hints": {"0": "", "1": "", "2": "", "3": ""},
+    }
+    assert "archive_metadata" in job_params
+
+    generated_collocation_hints = job_params["archive_metadata"]["collocation_hints"]
+    assert expected_hints["collocation_hints"] == generated_collocation_hints
+
+    expected_schedule_hints = job_params["archive_metadata"]["scheduling_hints"]
+    assert expected_hints["scheduling_hints"] == expected_schedule_hints
+
+
+@pytest.mark.parametrize("file_config_mock", [
+    {
+        "overrides": [
+            ("transfers", "metadata_byte_limit", "4"),
+            ("transfers", "plugins", "def")
+
+        ]
+    }
+], indirect=True)
+def test_transfer_over_limit(file_config_mock, did_factory, rse_factory, root_account):
+    mock_did = did_factory.random_file_did()
+    transfer_path = _make_transfer_path(mock_did, rse_factory, root_account)
+
+    # Mock Transfer Tool
+    fts3_tool = FTS3Transfertool(TEST_FTS_HOST)
+
+    job_params = build_job_params(
+        transfer_path=transfer_path,
+        bring_online=None,
+        default_lifetime=None,
+        archive_timeout_override=None,
+        max_time_in_queue=None,
+        logger=logging.log,
+    )
+
+    from rucio.common.exception import InvalidRequest
+
+    with pytest.raises(InvalidRequest):
+        job_params = fts3_tool._file_from_transfer(transfer_path[0], job_params)

--- a/tools/test/test.sh
+++ b/tools/test/test.sh
@@ -31,7 +31,7 @@ function srchome() {
 
 function wait_for_httpd() {
     echo 'Waiting for httpd'
-    curl --output /dev/null --silent --retry 15 --retry-all-errors --retry-delay 1 -k https://localhost/ping
+    curl --retry 15 --retry-all-errors --retry-delay 1 -k https://localhost/ping
 }
 
 function wait_for_database() {


### PR DESCRIPTION
Constructs a plugin class that adds a field to the transfer metadata, utilized by fts3 for placing like with like when storing on tape

Plugin is a subclass of `PolicyPackageAlgorithm`, so any experiment-specific plugin someone writes needs to be registered as a policy under the name "fts3_plugins" to be picked up during the initialization of the fts3 transfer tool. 

Additionally, to use a specifically plugin, it needs to be included in the rucio.config as the following: 
```
[transfers] 
plugins=<A list of the names of plugins being used, as defined during the plugin registration>
```

Included pre-build is a priority field based on activity, which produces an append to the transfer job submission in the form: 
```
{"archive_metadata": {"scheduling_hints": {"priority": "20"}}
```
Where priority is assigned based on activity, defined by a table set in the config. Default priority is 20. 
```

[transfers]
plugins=activity

[tape priority]
<activity_1>=40 
<activity_2>=100
```