### PR TITLE
Docker & Kubernetes: Specify amd64 platform on images with no arm64 support #6447

### DIFF
--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -72,8 +72,7 @@ services:
       - DOCKER_INFLUXDB_INIT_BUCKET=rucio
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken
   elasticsearch:
-    image: docker.io/elasticsearch:7.4.0
-    platform: linux/amd64
+    image: docker.io/elasticsearch:7.8.0
     environment:
       - discovery.type=single-node
   activemq:

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - RDBMS
   rucio:
     image: docker.io/rucio/rucio-dev:latest-alma9
+    platform: linux/amd64
     entrypoint: ["/rucio_source/etc/docker/dev/rucio/entrypoint.sh"]
     command: ["httpd","-D","FOREGROUND"]
     volumes:
@@ -72,6 +73,7 @@ services:
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken
   elasticsearch:
     image: docker.io/elasticsearch:7.4.0
+    platform: linux/amd64
     environment:
       - discovery.type=single-node
   activemq:


### PR DESCRIPTION
Setting `platform: linux/amd64` for images without `arm64` support in order to support the Docker compose file in ARM-based environments (fixes #6447)