### PR TITLE
Testing: fix test warnings

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -12,7 +12,7 @@ jobs:
     name: Add header lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # We need the history to determine the file creation date.
           fetch-depth: 0
@@ -121,7 +121,7 @@ jobs:
     if: github.repository_owner == 'rucio' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install -U pip setuptools
       - name: Install python requirements for matrix_parser.py
@@ -149,7 +149,7 @@ jobs:
       matrix:
         cfg: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build images
         id: images
         shell: bash
@@ -176,7 +176,7 @@ jobs:
       && (github.repository_owner == 'rucio' || github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install -U pip setuptools
       - name: Install python requirements for matrix_parser.py
@@ -211,7 +211,7 @@ jobs:
       matrix:
         cfg: ${{ fromJson(needs.release-patch-setup.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install -U pip setuptools
       - name: Install python requirements for mergetest.py

--- a/.github/workflows/imagecache.yml
+++ b/.github/workflows/imagecache.yml
@@ -9,7 +9,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Identify branches
         id: branches
         run: |
@@ -28,7 +28,7 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.setup.outputs.branches) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
       - name: Check and get files
@@ -93,11 +93,11 @@ jobs:
         branch: ${{ fromJson(needs.setup.outputs.branches) }}
     steps:
       - name: Checkout rucio containers repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: rucio/containers
       - name: Checkout rucio source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: dev/rucio
           ref: ${{ matrix.branch }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -8,7 +8,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install -U pip setuptools
       - name: Install python requirements for matrix_parser.py
@@ -32,11 +32,11 @@ jobs:
         cfg: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout rucio containers repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: rucio/containers
           fetch-depth: 0
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout rucio source
         with:
           path: dev/rucio

--- a/.github/workflows/vo_tests.yml
+++ b/.github/workflows/vo_tests.yml
@@ -9,7 +9,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip
         run: python3 -m pip install -U pip setuptools
       - name: Install python requirements for matrix_parser.py
@@ -31,7 +31,7 @@ jobs:
       matrix:
         cfg: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build Images and Run Tests
         uses: ./.github/actions/build-images-and-run-tests
         with:

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -81,11 +81,6 @@ def reset_rses():
     db_session.commit()
 
 
-def test_active():
-    db_session = session.get_session()
-    assert db_session.bind.dialect.name != 'sqlite'
-
-
 @pytest.fixture
 def importer_example_data(vo):
     if not config_has_section('importer'):

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -83,9 +83,7 @@ def reset_rses():
 
 def test_active():
     db_session = session.get_session()
-    if db_session.bind.dialect.name == 'sqlite':
-        return False
-    return True
+    assert db_session.bind.dialect.name != 'sqlite'
 
 
 @pytest.fixture


### PR DESCRIPTION
Issue: #5522

Fixing test warning:
```
/opt/venv/lib64/python3.9/site-packages/_pytest/python.py:198: PytestReturnNotNoneWarning: Expected None, but tests/test_import_export.py::test_active returned True, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
```