### PR TITLE
bug: Fix prepare-commit-msg to work on both GNU and BSD sed

### DIFF
--- a/tools/prepare-commit-msg
+++ b/tools/prepare-commit-msg
@@ -23,7 +23,7 @@ else
     if echo $EDITMSG | grep "# Please enter the commit message for your changes.*"
     then
 	echo "No commit message given, preparing template for editing."
-	sed -i "1s/^/\#\<component\>: \<message\>; Fix \#$NUMBER\n/" $1
+	sed -i.bak "1s/^/\#\<component\>: \<message\>; Fix \#$NUMBER\n/" $1 && rm $1.bak
     else
 	echo "Using CLI commit message."
     fi


### PR DESCRIPTION
fixes #6452

From https://unix.stackexchange.com/questions/401905/bsd-sed-vs-gnu-sed-and-i:
>the BSD build of sed mandates the extension for the backup file with -i, rather than it being optional, as in GNU sed.

Fixing the prepare-commit-msg script so that it works for both BSD and GNU based `sed`

See also:
- https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
- https://unix.stackexchange.com/questions/92895/how-can-i-achieve-portability-with-sed-i-in-place-editing