### PR TITLE
Transfer: fix transfer time and wait time metrics. Closes #6482

### DIFF
--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -561,8 +561,8 @@ def update_transfer_state(
                     state=tt_status_report.state,
                     file_size=request['bytes'],
                     submitted_at=request.get('submitted_at', None),
-                    started_at=request.get('started_at', None),
-                    transferred_at=request.get('transferred_at', None),
+                    started_at=fields_to_update.get('started_at', None),
+                    transferred_at=fields_to_update.get('transferred_at', None),
                     session=session,
                 )
             request_core.add_monitor_message(


### PR DESCRIPTION
Getting the started_at and transferred_at from the request is useless, because this is the request _before_ its update in the database. The information must be retrieved from the transfertool message.

Also, record the transfer time without including the wait time.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
