### PR TITLE
 Metadata: Rename core.meta to core.meta_conventions #5224

### DIFF
--- a/lib/rucio/api/did.py
+++ b/lib/rucio/api/did.py
@@ -22,8 +22,9 @@ from rucio.common.exception import RucioException
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import api_update_return_dict
-from rucio.core import did, naming_convention, meta as meta_core
+from rucio.core import did, naming_convention
 from rucio.core.rse import get_rse_id
+from rucio.core import meta_conventions as meta_convention_core
 from rucio.db.sqla.constants import DIDType
 from rucio.db.sqla.session import read_session, stream_session, transactional_session
 
@@ -117,7 +118,7 @@ def add_did(scope, name, did_type, issuer, account=None, statuses={}, meta={}, r
                 raise rucio.common.exception.InvalidObject("Provided metadata %s doesn't match the naming convention: %s != %s" % (k, meta[k], extra_meta[k]))
 
         # Validate metadata
-        meta_core.validate_meta(meta=meta, did_type=DIDType[did_type.upper()], session=session)
+        meta_convention_core.validate_meta(meta=meta, did_type=DIDType[did_type.upper()], session=session)
 
     return did.add_did(scope=scope, name=name, did_type=DIDType[did_type.upper()], account=account or issuer,
                        statuses=statuses, meta=meta, rules=rules, lifetime=lifetime,

--- a/lib/rucio/client/client.py
+++ b/lib/rucio/client/client.py
@@ -27,7 +27,7 @@ from rucio.client.exportclient import ExportClient
 from rucio.client.importclient import ImportClient
 from rucio.client.lifetimeclient import LifetimeClient
 from rucio.client.lockclient import LockClient
-from rucio.client.metaclient import MetaClient
+from rucio.client.metaconventionsclient import MetaConventionClient
 from rucio.client.pingclient import PingClient
 from rucio.client.replicaclient import ReplicaClient
 from rucio.client.requestclient import RequestClient
@@ -40,7 +40,7 @@ from rucio.client.touchclient import TouchClient
 
 class Client(AccountClient,
              AccountLimitClient,
-             MetaClient,
+             MetaConventionClient,
              PingClient,
              ReplicaClient,
              RequestClient,

--- a/lib/rucio/client/metaconventionsclient.py
+++ b/lib/rucio/client/metaconventionsclient.py
@@ -21,17 +21,19 @@ from requests.status_codes import codes
 from rucio.client.baseclient import BaseClient
 from rucio.client.baseclient import choice
 from rucio.common.utils import build_url
+from rucio.db.sqla.constants import KeyType
+from typing import Union, Optional
 
 
-class MetaClient(BaseClient):
+class MetaConventionClient(BaseClient):
 
-    """Meta client class for working with data identifier attributes"""
+    """Metadata client class for working with data identifier attributes"""
 
-    META_BASEURL = 'meta'
+    META_BASEURL = 'meta_conventions'
 
-    def add_key(self, key, key_type, value_type=None, value_regexp=None):
+    def add_key(self, key: str, key_type: Union[KeyType, str], value_type: Optional[str] = None, value_regexp: Optional[str] = None) -> Optional[bool]:
         """
-        Sends the request to add a new key.
+        Sends the request to add an allowed key for DID metadata (update the DID Metadata Conventions table with a new key).
 
         :param key: the name for the new key.
         :param key_type: the type of the key: all(container, dataset, file), collection(dataset or container), file, derived(compute from file for collection).
@@ -56,9 +58,9 @@ class MetaClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def list_keys(self):
+    def list_keys(self) -> Optional[list[str]]:
         """
-        Sends the request to list all keys.
+        Sends the request to list all keys for DID Metadata Conventions.
 
         :return: a list containing the names of all keys.
         """
@@ -72,9 +74,10 @@ class MetaClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def list_values(self, key):
+    def list_values(self, key: str) -> Optional[list[str]]:
         """
-        Sends the request to list all values for a key.
+        Sends the request to lists all allowed values for a DID key (all values for a key in DID Metadata Conventions).
+.
 
         :return: a list containing the names of all values for a key.
         """
@@ -88,9 +91,9 @@ class MetaClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def add_value(self, key, value):
+    def add_value(self, key: str, value: str) -> Optional[bool]:
         """
-        Sends the request to add a value to a key.
+        Sends the request to add a value for a key in DID Metadata Convention.
 
         :param key: the name for key.
         :param value: the value.
@@ -111,7 +114,7 @@ class MetaClient(BaseClient):
 
     def del_value(self, key, value):
         """
-        Delete a value for a key.
+        Delete a key in the DID Metadata Conventions table.
 
         :param key: the name for key.
         :param value: the value.

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -605,8 +605,8 @@ class QuarantinedReplicaHistory(BASE, ModelBase):
     _table_args = ()
 
 
-class DIDKey(BASE, ModelBase):
-    """Represents Data IDentifier property keys"""
+class DIDMetaConventionsKey(BASE, ModelBase):
+    """Represents allowed keys of DID Metadata"""
     __tablename__ = 'did_keys'
     key: Mapped[str] = mapped_column(String(255))
     is_enum: Mapped[bool] = mapped_column(Boolean(name='DID_KEYS_IS_ENUM_CHK', create_constraint=True),
@@ -621,8 +621,8 @@ class DIDKey(BASE, ModelBase):
                    CheckConstraint('is_enum IS NOT NULL', name='DID_KEYS_IS_ENUM_NN'))
 
 
-class DIDKeyValueAssociation(BASE, ModelBase):
-    """Represents Data IDentifier property key/values"""
+class DIDMetaConventionsConstraints(BASE, ModelBase):
+    """Represents a map for constraint values a DID metadata key must follow """
     __tablename__ = 'did_key_map'
     key: Mapped[str] = mapped_column(String(255))
     value: Mapped[str] = mapped_column(String(255))
@@ -1696,8 +1696,8 @@ def register_models(engine):
               ConstituentAssociationHistory,
               DataIdentifierAssociation,
               DataIdentifierAssociationHistory,
-              DIDKey,
-              DIDKeyValueAssociation,
+              DIDMetaConventionsKey,
+              DIDMetaConventionsConstraints,
               DataIdentifier,
               DidMeta,
               VirtualPlacements,
@@ -1766,8 +1766,8 @@ def unregister_models(engine):
               ConstituentAssociationHistory,
               DataIdentifierAssociation,
               DataIdentifierAssociationHistory,
-              DIDKey,
-              DIDKeyValueAssociation,
+              DIDMetaConventionsKey,
+              DIDMetaConventionsConstraints,
               DidMeta,
               DataIdentifier,
               DeletedDataIdentifier,

--- a/tests/test_meta_conventions.py
+++ b/tests/test_meta_conventions.py
@@ -17,13 +17,13 @@ import pytest
 
 from rucio.common.exception import InvalidValueForKey, RucioException, UnsupportedValueType, UnsupportedKeyType
 from rucio.common.utils import generate_uuid as uuid
-from rucio.core.meta import add_key
+from rucio.core.meta_conventions import add_key
 from rucio.db.sqla import session, models
 from rucio.db.sqla.constants import DIDType, KeyType
 
 
 @pytest.mark.dirty
-class TestMetaClient:
+class TestMetaConventionsClient:
 
     def test_add_and_list_keys(self, rucio_client):
         """ META (CLIENTS): Add a key and List all keys."""
@@ -99,7 +99,7 @@ class TestMetaClient:
         for key_type in types:
             key_name = 'datatype%s' % str(uuid())
             rucio_client.add_key(key_name, key_type['type'])
-            stored_key_type = session.get_session().query(models.DIDKey).filter_by(key=key_name).one()['key_type']
+            stored_key_type = session.get_session().query(models.DIDMetaConventionsKey).filter_by(key=key_name).one()['key_type']
             assert stored_key_type, key_type['expected']
 
         with pytest.raises(UnsupportedKeyType):
@@ -131,7 +131,7 @@ def test_add_key():
     for key_type in types:
         key_name = 'datatype%s' % str(uuid())
         add_key(key_name, key_type['type'])
-        stored_key_type = session.get_session().query(models.DIDKey).filter_by(key=key_name).one()['key_type']
+        stored_key_type = session.get_session().query(models.DIDMetaConventionsKey).filter_by(key=key_name).one()['key_type']
         assert stored_key_type, key_type['expected']
 
     with pytest.raises(UnsupportedKeyType):


### PR DESCRIPTION
Renaming `meta` to `meta_conventions` - updates the core and internal api calls to following the naming scheme. For the web api, a legacy endpoint is included with a warning it will be depreciated. 