### PR TITLE
Add type annotations and refactor to use TokenDict type

### DIFF
--- a/lib/rucio/common/types.py
+++ b/lib/rucio/common/types.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
 from typing import Any, Callable, Literal, Optional, TypedDict, Union
+
+from rucio.db.sqla.constants import AccountType, IdentityType
 
 
 class InternalType(object):
@@ -174,3 +177,96 @@ class RuleDict(TypedDict):
     activity: str
     notify: Optional[Literal['Y', 'N', 'C']]
     purge_replicas: bool
+
+
+class RSEAccountCounterDict(TypedDict):
+    account: InternalAccount
+    rse_id: str
+
+
+class RSEAccountUsageDict(TypedDict):
+    rse_id: str
+    rse: str
+    account: InternalAccount
+    used_files: int
+    used_bytes: int
+    quota_bytes: int
+
+
+class RSEGlobalAccountUsageDict(TypedDict):
+    rse_expression: str
+    bytes: int
+    files: int
+    bytes_limit: int
+    bytes_remaining: int
+
+
+class RSELocalAccountUsageDict(TypedDict):
+    rse_id: str
+    rse: str
+    bytes: int
+    files: int
+    bytes_limit: int
+    bytes_remaining: int
+
+
+class RSEResolvedGlobalAccountLimitDict(TypedDict):
+    resolved_rses: str
+    resolved_rse_ids: list[str]
+    limit: float
+
+
+class TokenDict(TypedDict):
+    token: str
+    expires_at: datetime
+
+
+class TokenValidationDict(TypedDict):
+    account: Optional[InternalAccount]
+    identity: Optional[str]
+    lifetime: Optional[datetime]
+    audience: Optional[str]
+    authz_scope: Optional[str]
+
+
+class AccountDict(TypedDict):
+    account: InternalAccount
+    type: AccountType
+    email: str
+
+
+class AccountAttributesDict(TypedDict):
+    key: str
+    value: Union[bool, str]
+
+
+class IdentityDict(TypedDict):
+    type: IdentityType
+    identity: str
+    email: str
+
+
+class UsageDict(TypedDict):
+    bytes: int
+    files: int
+    updated_at: Optional[datetime]
+
+
+class TokenOIDCAutoDict(TypedDict, total=False):
+    webhome: Optional[str]
+    token: Optional[TokenDict]
+
+
+class TokenOIDCNoAutoDict(TypedDict):
+    fetchcode: str
+
+
+class TokenOIDCPollingDict(TypedDict):
+    polling: bool
+
+
+class AccountUsageModelDict(TypedDict):
+    account: InternalAccount
+    rse_id: str
+    files: int
+    bytes: int

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -40,7 +40,7 @@ from enum import Enum
 from functools import partial, wraps
 from io import StringIO
 from itertools import zip_longest
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import Any, Callable, Optional, TYPE_CHECKING
 from urllib.parse import urlparse, urlencode, quote, parse_qsl, urlunparse
 from uuid import uuid4 as uuid
 from xml.etree import ElementTree
@@ -568,7 +568,7 @@ def str_to_date(string):
     return datetime.datetime.strptime(string, DATE_FORMAT) if string else None
 
 
-def val_to_space_sep_str(vallist):
+def val_to_space_sep_str(vallist: Any) -> str:
     """ Converts a list of values into a string of space separated values
 
     :param vallist: the list of values to to convert into string

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1198,7 +1198,7 @@ def detect_client_location():
             'longitude': longitude}
 
 
-def ssh_sign(private_key, message):
+def ssh_sign(private_key: str, message: str) -> str:
     """
     Sign a string message using the private key.
 
@@ -1206,14 +1206,13 @@ def ssh_sign(private_key, message):
     :param message: The message to sign as a string.
     :return: Base64 encoded signature as a string.
     """
-    if isinstance(message, str):
-        message = message.encode()
+    encoded_message = message.encode()
     if not EXTRA_MODULES['paramiko']:
         raise MissingModuleException('The paramiko module is not installed or faulty.')
     sio_private_key = StringIO(private_key)
     priv_k = RSAKey.from_private_key(sio_private_key)
     sio_private_key.close()
-    signature_stream = priv_k.sign_ssh_data(message)
+    signature_stream = priv_k.sign_ssh_data(encoded_message)
     signature_stream.rewind()
     base64_encoded = base64.b64encode(signature_stream.get_remainder())
     base64_encoded = base64_encoded.decode()

--- a/lib/rucio/core/account_counter.py
+++ b/lib/rucio/core/account_counter.py
@@ -12,12 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import datetime
-from typing import TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 
 from sqlalchemy import literal, insert, select
 from sqlalchemy.orm.exc import NoResultFound
 
+from rucio.common.types import InternalAccount, RSEAccountCounterDict
 from rucio.db.sqla import models, filter_thread_work
 from rucio.db.sqla.session import read_session, transactional_session
 
@@ -28,7 +30,7 @@ MAX_COUNTERS = 10
 
 
 @transactional_session
-def add_counter(rse_id, account, *, session: "Session"):
+def add_counter(rse_id: str, account: InternalAccount, *, session: "Session") -> None:
     """
     Creates the specified counter for a rse_id and account.
 
@@ -41,7 +43,7 @@ def add_counter(rse_id, account, *, session: "Session"):
 
 
 @transactional_session
-def increase(rse_id, account, files, bytes_, *, session: "Session"):
+def increase(rse_id: str, account: InternalAccount, files: int, bytes_: int, *, session: "Session") -> None:
     """
     Increments the specified counter by the specified amount.
 
@@ -55,7 +57,7 @@ def increase(rse_id, account, files, bytes_, *, session: "Session"):
 
 
 @transactional_session
-def decrease(rse_id, account, files, bytes_, *, session: "Session"):
+def decrease(rse_id: str, account: InternalAccount, files: int, bytes_: int, *, session: "Session") -> None:
     """
     Decreases the specified counter by the specified amount.
 
@@ -69,7 +71,7 @@ def decrease(rse_id, account, files, bytes_, *, session: "Session"):
 
 
 @transactional_session
-def del_counter(rse_id, account, *, session: "Session"):
+def del_counter(rse_id: str, account: InternalAccount, *, session: "Session") -> None:
     """
     Resets the specified counter and initializes it by the specified amounts.
 
@@ -82,7 +84,7 @@ def del_counter(rse_id, account, *, session: "Session"):
 
 
 @read_session
-def get_updated_account_counters(total_workers, worker_number, *, session: "Session"):
+def get_updated_account_counters(total_workers: int, worker_number: int, *, session: "Session") -> list[RSEAccountCounterDict]:
     """
     Get updated rse_counters.
 
@@ -104,7 +106,7 @@ def get_updated_account_counters(total_workers, worker_number, *, session: "Sess
 
 
 @transactional_session
-def update_account_counter(account, rse_id, *, session: "Session"):
+def update_account_counter(account: InternalAccount, rse_id: str, *, session: "Session") -> None:
     """
     Read the updated_account_counters and update the account_counter.
 
@@ -130,7 +132,7 @@ def update_account_counter(account, rse_id, *, session: "Session"):
 
 
 @transactional_session
-def update_account_counter_history(account, rse_id, *, session: "Session"):
+def update_account_counter_history(account: InternalAccount, rse_id: str, *, session: "Session") -> None:
     """
     Read the AccountUsage and update the AccountUsageHistory.
 
@@ -146,7 +148,7 @@ def update_account_counter_history(account, rse_id, *, session: "Session"):
 
 
 @transactional_session
-def fill_account_counter_history_table(*, session: "Session"):
+def fill_account_counter_history_table(*, session: "Session") -> None:
     """
     Make a snapshot of current counters
 

--- a/lib/rucio/core/account_counter.py
+++ b/lib/rucio/core/account_counter.py
@@ -91,17 +91,16 @@ def get_updated_account_counters(total_workers, worker_number, *, session: "Sess
     :param session:            Database session in use.
     :returns:                  List of rse_ids whose rse_counters need to be updated.
     """
-    query = session.query(models.UpdatedAccountCounter.account, models.UpdatedAccountCounter.rse_id).\
-        distinct(models.UpdatedAccountCounter.account, models.UpdatedAccountCounter.rse_id)
 
-    if session.bind.dialect.name == 'oracle':
-        hash_variable = 'CONCAT(account, rse_id)'''
-    else:
-        hash_variable = 'concat(account, rse_id)'
+    query = select(
+        models.UpdatedAccountCounter.account,
+        models.UpdatedAccountCounter.rse_id,
+    ).distinct(
+    )
 
-    query = filter_thread_work(session=session, query=query, total_threads=total_workers, thread_id=worker_number, hash_variable=hash_variable)
+    query = filter_thread_work(session=session, query=query, total_threads=total_workers, thread_id=worker_number, hash_variable='CONCAT(account, rse_id)')
 
-    return query.all()
+    return [cast(RSEAccountCounterDict, row._asdict()) for row in session.execute(query).all()]
 
 
 @transactional_session

--- a/lib/rucio/core/account_limit.py
+++ b/lib/rucio/core/account_limit.py
@@ -13,12 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
+from uuid import UUID
 
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.sql import func, select, literal
+from sqlalchemy.sql import func, literal, select
 from sqlalchemy.sql.expression import and_, or_
 
+from rucio.common.types import (InternalAccount, RSEAccountUsageDict,
+                                RSEGlobalAccountUsageDict,
+                                RSELocalAccountUsageDict,
+                                RSEResolvedGlobalAccountLimitDict)
 from rucio.core.account import get_all_rse_usages_per_account
 from rucio.core.rse import get_rse_name
 from rucio.core.rse_expression_parser import parse_expression
@@ -30,7 +35,7 @@ if TYPE_CHECKING:
 
 
 @read_session
-def get_rse_account_usage(rse_id, *, session: "Session"):
+def get_rse_account_usage(rse_id: str, *, session: "Session") -> list[RSEAccountUsageDict]:
     """
     Returns the account limit and usage for all accounts on a RSE.
 
@@ -90,7 +95,7 @@ def get_rse_account_usage(rse_id, *, session: "Session"):
 
 
 @read_session
-def get_global_account_limits(account=None, *, session: "Session"):
+def get_global_account_limits(account: Optional[InternalAccount] = None, *, session: "Session") -> dict[str, RSEResolvedGlobalAccountLimitDict]:
     """
     Returns the global account limits for the account.
 
@@ -121,7 +126,7 @@ def get_global_account_limits(account=None, *, session: "Session"):
 
 
 @read_session
-def get_global_account_limit(account, rse_expression, *, session: "Session"):
+def get_global_account_limit(account: InternalAccount, rse_expression: str, *, session: "Session") -> Union[int, float, None]:
     """
     Returns the global account limit for the account on the rse expression.
 
@@ -141,7 +146,7 @@ def get_global_account_limit(account, rse_expression, *, session: "Session"):
 
 
 @read_session
-def get_local_account_limit(account, rse_id, *, session: "Session"):
+def get_local_account_limit(account: InternalAccount, rse_id: str, *, session: "Session") -> Union[int, float, None]:
     """
     Returns the account limit for the account on the rse.
 
@@ -162,7 +167,7 @@ def get_local_account_limit(account, rse_id, *, session: "Session"):
 
 
 @read_session
-def get_local_account_limits(account, rse_ids=None, *, session: "Session"):
+def get_local_account_limits(account: InternalAccount, rse_ids: Optional[list[str]] = None, *, session: "Session") -> dict[str, int]:
     """
     Returns the account limits for the account on the list of rses.
 
@@ -196,7 +201,7 @@ def get_local_account_limits(account, rse_ids=None, *, session: "Session"):
 
 
 @transactional_session
-def set_local_account_limit(account, rse_id, bytes_, *, session: "Session"):
+def set_local_account_limit(account: InternalAccount, rse_id: str, bytes_: int, *, session: "Session") -> None:
     """
     Returns the limits for the account on the rse.
 
@@ -214,7 +219,7 @@ def set_local_account_limit(account, rse_id, bytes_, *, session: "Session"):
 
 
 @transactional_session
-def set_global_account_limit(account, rse_expression, bytes_, *, session: "Session"):
+def set_global_account_limit(account: InternalAccount, rse_expression: str, bytes_: int, *, session: "Session") -> None:
     """
     Sets the global limit for the account on a RSE expression.
 
@@ -232,7 +237,7 @@ def set_global_account_limit(account, rse_expression, bytes_, *, session: "Sessi
 
 
 @transactional_session
-def delete_local_account_limit(account, rse_id, *, session: "Session"):
+def delete_local_account_limit(account: InternalAccount, rse_id: str, *, session: "Session") -> bool:
     """
     Deletes a local account limit.
 
@@ -250,7 +255,7 @@ def delete_local_account_limit(account, rse_id, *, session: "Session"):
 
 
 @transactional_session
-def delete_global_account_limit(account, rse_expression, *, session: "Session"):
+def delete_global_account_limit(account: InternalAccount, rse_expression: str, *, session: "Session") -> bool:
     """
     Deletes a global account limit.
 
@@ -268,7 +273,7 @@ def delete_global_account_limit(account, rse_expression, *, session: "Session"):
 
 
 @transactional_session
-def get_local_account_usage(account, rse_id=None, *, session: "Session"):
+def get_local_account_usage(account: InternalAccount, rse_id: Optional[UUID] = None, *, session: "Session") -> list[RSELocalAccountUsageDict]:
     """
     Read the account usage and connect it with (if available) the account limits of the account.
 
@@ -311,7 +316,7 @@ def get_local_account_usage(account, rse_id=None, *, session: "Session"):
 
 
 @transactional_session
-def get_global_account_usage(account, rse_expression=None, *, session: "Session"):
+def get_global_account_usage(account: InternalAccount, rse_expression: Optional[str] = None, *, session: "Session") -> list[RSEGlobalAccountUsageDict]:
     """
     Read the account usage and connect it with the global account limits of the account.
 

--- a/lib/rucio/daemons/abacus/account.py
+++ b/lib/rucio/daemons/abacus/account.py
@@ -55,22 +55,22 @@ def run_once(heartbeat_handler, **_kwargs):
     worker_number, total_workers, logger = heartbeat_handler.live()
 
     start = time.time()  # NOQA
-    account_rse_ids = get_updated_account_counters(total_workers=total_workers,
-                                                   worker_number=worker_number)
-    logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(account_rse_ids)))
+    updated_account_counters = get_updated_account_counters(total_workers=total_workers,
+                                                            worker_number=worker_number)
+    logger(logging.DEBUG, 'Index query time %f size=%d' % (time.time() - start, len(updated_account_counters)))
 
     # If the list is empty, sent the worker to sleep
-    if not account_rse_ids:
+    if not updated_account_counters:
         logger(logging.INFO, 'did not get any work')
         return
 
-    for account_rse_id in account_rse_ids:
+    for account_counter in updated_account_counters:
         worker_number, total_workers, logger = heartbeat_handler.live()
         if graceful_stop.is_set():
             break
         start_time = time.time()
-        update_account_counter(account=account_rse_id[0], rse_id=account_rse_id[1])
-        logger(logging.DEBUG, 'update of account-rse counter "%s-%s" took %f' % (account_rse_id[0], account_rse_id[1], time.time() - start_time))
+        update_account_counter(account=account_counter['account'], rse_id=account_counter['rse_id'])
+        logger(logging.DEBUG, 'update of account-rse counter "%s-%s" took %f' % (account_counter['account'], account_counter['rse_id'], time.time() - start_time))
 
 
 def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -143,7 +143,7 @@ class TestAuthCoreApi:
         except Duplicate:
             pass  # might already exist, can skip
 
-        signature = ssh_sign(PRIVATE_KEY, 'sign_something_else')
+        signature = base64.b64decode(ssh_sign(PRIVATE_KEY, 'sign_something_else'))
 
         result = get_auth_token_ssh(account='root', signature=signature, appid='test', ip='127.0.0.1', vo=vo)
 


### PR DESCRIPTION
#6454 - Adding various type annotations, and replacing the method:

```
def token_dictionary(token: models.Token):
    return {'token': token.token, 'expires_at': token.expired_at}
```

with a specific datatype `TokenDict` in order to be more specific with the return types.