### PR TITLE
Auth: Remove support for wildcard audiences #6524

### DIFF
--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -33,7 +33,7 @@ from sqlalchemy.exc import DatabaseError, IntegrityError
 
 import rucio.db.sqla.util
 from rucio.common.cache import make_region_memcached
-from rucio.common.config import config_get, config_get_bool, config_get_int
+from rucio.common.config import config_get_bool, config_get_int
 from rucio.common.exception import (DatabaseException, RSENotFound,
                                     ReplicaUnAvailable, ReplicaNotFound, ServiceUnavailable,
                                     RSEAccessDenied, ResourceTemporaryUnavailable, SourceNotFound,
@@ -581,7 +581,7 @@ def _run_once(rses_to_process, chunk_size, greedy, scheme,
             rse.ensure_loaded(load_info=True, load_attributes=True)
             prot = rsemgr.create_protocol(rse.info, 'delete', scheme=scheme, logger=logger)
             if rse.attributes.get('oidc_support') is True and prot.attributes['scheme'] == 'davs':
-                audience = config_get('reaper', 'oidc_audience', False) or determine_audience_for_rse(rse.id)
+                audience = determine_audience_for_rse(rse.id)
                 # FIXME: At the time of writing, StoRM requires `storage.read`
                 # in order to perform a stat operation.
                 scope = determine_scope_for_rse(rse.id, scopes=['storage.modify', 'storage.read'])

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -936,11 +936,11 @@ class FTS3Transfertool(Transfertool):
         if self.token:
             t_file['source_tokens'] = []
             for source in transfer.sources:
-                src_audience = config_get('conveyor', 'request_oidc_audience', False) or determine_audience_for_rse(rse_id=source.rse.id)
+                src_audience = determine_audience_for_rse(rse_id=source.rse.id)
                 src_scope = determine_scope_for_rse(rse_id=source.rse.id, scopes=['storage.read'], extra_scopes=['offline_access'])
                 t_file['source_tokens'].append(request_token(src_audience, src_scope))
 
-            dst_audience = config_get('conveyor', 'request_oidc_audience', False) or determine_audience_for_rse(transfer.dst.rse.id)
+            dst_audience = determine_audience_for_rse(transfer.dst.rse.id)
             # FIXME: At the time of writing, StoRM requires `storage.read` in
             # order to perform a stat operation.
             dst_scope = determine_scope_for_rse(transfer.dst.rse.id, scopes=['storage.modify', 'storage.read'], extra_scopes=['offline_access'])


### PR DESCRIPTION
This affects third-party-copy transfers and deletions.  The following configuration options are removed:

    [conveyor]
    request_oidc_audience = ...

    [reaper]
    oidc_audience = ...

They were part of the original token implementation and were kept as a contingency option for the Data Challenge 2024.  However, they should not be used due to security concerns.

Wildcard audiences can make tokens less secure than X.509 certificates. For one thing, an unintentional token leak is more likely to happen (e.g. debugging logs).  For another, the token is fully transferred to the storages; a compromised site could be used as a vector to affect data at other sites.

Moving forward, Rucio communities which use tokens must coordinate with their sites to ensure that the storages properly identify themselves as the intended recipient of a token (using the domains of the RSE protocols in the audience claim).
