### PR TITLE
Tests: Remove writing curl output to /dev/null

### DIFF
--- a/tools/test/test.sh
+++ b/tools/test/test.sh
@@ -31,7 +31,7 @@ function srchome() {
 
 function wait_for_httpd() {
     echo 'Waiting for httpd'
-    curl --output /dev/null --silent --retry 15 --retry-all-errors --retry-delay 1 -k https://localhost/ping
+    curl --silent --retry 15 --retry-all-errors --retry-delay 1 -k https://localhost/ping
 }
 
 function wait_for_database() {


### PR DESCRIPTION
This test sometimes errors out due to write errors when curl writes output to /dev/null.
Reference: https://github.com/rucio/rucio/pull/6445#issuecomment-1977134159