### PR TITLE
Typing: Add type annotations to vo.py

### DIFF
--- a/lib/rucio/core/vo.py
+++ b/lib/rucio/core/vo.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.exc import DatabaseError, IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 
 @read_session
-def vo_exists(vo, *, session: "Session"):
+def vo_exists(vo: str, *, session: "Session") -> bool:
     """
     Verify that the vo exists.
 
@@ -47,7 +47,7 @@ def vo_exists(vo, *, session: "Session"):
 
 
 @transactional_session
-def add_vo(vo, description, email, *, session: "Session"):
+def add_vo(vo: str, description: str, email: str, *, session: "Session") -> None:
     """
     Add a VO and setup a new root user.
     New root user will have account name 'root' and a userpass identity with username: 'root@<vo>' and password: 'password'
@@ -89,7 +89,7 @@ def add_vo(vo, description, email, *, session: "Session"):
 
 
 @read_session
-def list_vos(*, session: "Session"):
+def list_vos(*, session: "Session") -> list[dict[str, Any]]:
     """
     List all the VOs in the db.
 
@@ -114,7 +114,7 @@ def list_vos(*, session: "Session"):
 
 
 @transactional_session
-def update_vo(vo, parameters, *, session: "Session"):
+def update_vo(vo: str, parameters: dict[str, Any], *, session: "Session") -> None:
     """
     Update VO properties (email, description).
 
@@ -136,7 +136,7 @@ def update_vo(vo, parameters, *, session: "Session"):
     query.update(param)
 
 
-def map_vo(vo):
+def map_vo(vo: str) -> str:
     """
     Converts a long VO name into the internal short (three letter)
     tag mapping.

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -166,7 +166,7 @@ def run_once(heartbeat_handler: "HeartbeatHandler", inputfile: str, **_kwargs) -
     account = config_get("automatix", "account", raise_exception=False, default="root")
     scope = config_get("automatix", "scope", raise_exception=False, default="test")
     client = Client(account=account)
-    vo = map_vo(client.vo)
+    vo = map_vo(client.vo)  # type: ignore
     filters = {"scope": InternalScope("*", vo=vo)}
     scopes = list_scopes(filter_=filters)
     if InternalScope(scope, vo=vo) not in scopes:


### PR DESCRIPTION
#6454 

On the `# type: ignore` change: the error log ignored by this message is [this one](https://github.com/rdimaio/rucio/actions/runs/8252482940/job/22572081906):

```
Found 1 new problems in /home/runner/work/rucio/rucio/lib/rucio/daemons/automatix/automatix.py
  - 1 errors with message """Argument of type "Unknown | str | None" cannot be assigned to parameter "vo" of type "str" in function "map_vo"
                               Type "Unknown | str | None" cannot be assigned to type "str"
                                 "None" is incompatible with "str"""".
    Candidates: line 169
```

I tried a few fixes, but the issue is that that portion of code assumes that `client.vo` is not `None`, even though it might be. A functional change needs to be done to fix that logic. We can do this at a later point, when handling the `# type: ignore` comments.