### PR TITLE
Core & Internals: Regression fix for judge #6569

### DIFF
--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -2113,8 +2113,8 @@ def get_updated_dids(
         stmt = stmt.where(tuple_(models.UpdatedDID.scope, models.UpdatedDID.name).notin_(chunk))
 
     if limit:
-        fetched_dids = stmt.order_by(models.UpdatedDID.created_at).limit(limit).all()
-        filtered_dids = [did for did in fetched_dids if (did.scope, did.name) not in blocked_dids]
+        fetched_dids = session.execute(stmt.order_by(models.UpdatedDID.created_at).limit(limit)).all()
+        filtered_dids = [did._tuple() for did in fetched_dids if (did.scope, did.name) not in blocked_dids]
         if len(fetched_dids) == limit and not filtered_dids:
             return get_updated_dids(total_workers=total_workers,
                                     worker_number=worker_number,


### PR DESCRIPTION
Missing `session.execute` was causing the judge evaluator to crash. Tested in the docker-compose stack with:

```
tools/run_tests.sh -ir
rucio add-dataset test:mynewdataset
rucio attach test:mynewdataset test:file1 test:file2 test:file3 test:file4
rucio add-rule test:mynewdataset 1 XRD3
rucio-judge-evaluator --run-once
```

This procedure fails without these changes, and does not with them.
Additionally, I looked through `rule.py` for similar errors, but did not find any