### PR TITLE
Clients: remove "--estimate_ttc" #6473

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -1334,9 +1334,6 @@ def info_rule(args):
 
     Retrieve information about a rule.
     """
-    if args.estimate_ttc:
-        logger.error('"--estimate-ttc" is deprecated!')
-        return FAILURE
     client = get_client(args)
     if args.examine:
         analysis = client.examine_replication_rule(rule_id=args.rule_id)
@@ -2352,7 +2349,6 @@ You can filter by key/value, e.g.::
     info_rule_parser.set_defaults(function=info_rule)
     info_rule_parser.add_argument(dest='rule_id', action='store', help='The rule ID')
     info_rule_parser.add_argument('--examine', dest='examine', action='store_true', help='Detailed analysis of transfer errors')
-    info_rule_parser.add_argument('--estimate-ttc', dest='estimate_ttc', action='store_true', help='Deprecated, specifying this will cause the program to fail.')
 
     # The list_rules command
     list_rules_parser = subparsers.add_parser('list-rules', help='List replication rules.', formatter_class=argparse.RawDescriptionHelpFormatter, epilog='''Usage example


### PR DESCRIPTION
Remove deprecated agrument "--estimate_ttc".  It is safe to remove since the deprecation was added in version 1.28.0 which is no longer supported.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
