### PR TITLE
Testing: Linting, Add pyupgrade and fix isort

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,27 +26,39 @@ import time
 import traceback
 import unittest
 import uuid
+from configparser import NoOptionError, NoSectionError
 from copy import deepcopy
 from datetime import datetime
 from functools import wraps
-
-from configparser import NoOptionError, NoSectionError
-from tabulate import tabulate
 
 # rucio module has the same name as this executable module, so this rule fails. pylint: disable=no-name-in-module
 from rucio import version
 from rucio.client import Client
 from rucio.common.config import config_get, config_get_float
-from rucio.common.exception import (DataIdentifierAlreadyExists, AccessDenied, DataIdentifierNotFound, InvalidObject,
-                                    RSENotFound, InvalidRSEExpression, InputValidationError, DuplicateContent,
-                                    RuleNotFound, CannotAuthenticate, MissingDependency, UnsupportedOperation,
-                                    RucioException, DuplicateRule, InvalidType, DuplicateCriteriaInDIDFilter,
-                                    DIDFilterSyntaxError)
+from rucio.common.constants import ReplicaState
+from rucio.common.exception import (
+    AccessDenied,
+    CannotAuthenticate,
+    DataIdentifierAlreadyExists,
+    DataIdentifierNotFound,
+    DIDFilterSyntaxError,
+    DuplicateContent,
+    DuplicateCriteriaInDIDFilter,
+    DuplicateRule,
+    InputValidationError,
+    InvalidObject,
+    InvalidRSEExpression,
+    InvalidType,
+    MissingDependency,
+    RSENotFound,
+    RucioException,
+    RuleNotFound,
+    UnsupportedOperation,
+)
 from rucio.common.extra import import_extras
 from rucio.common.test_rucio_server import TestRucioServer
-from rucio.common.utils import sizefmt, Color, detect_client_location, chunks, parse_did_filter_from_string, \
-    parse_did_filter_from_string_fe, extract_scope, setup_logger, StoreAndDeprecateWarningAction
-from rucio.common.constants import ReplicaState
+from rucio.common.utils import Color, StoreAndDeprecateWarningAction, chunks, detect_client_location, extract_scope, parse_did_filter_from_string, parse_did_filter_from_string_fe, setup_logger, sizefmt
+from tabulate import tabulate
 
 EXTRA_MODULES = import_extras(['argcomplete'])
 
@@ -488,7 +499,7 @@ def attach(args):
         try:
             f = open(dids[0], 'r')
             dids = [did.rstrip() for did in f.readlines()]
-        except IOError:
+        except OSError:
             logger.error("Can't open file '" + dids[0] + "'.")
             return FAILURE
 

--- a/bin/rucio
+++ b/bin/rucio
@@ -31,6 +31,8 @@ from copy import deepcopy
 from datetime import datetime
 from functools import wraps
 
+from tabulate import tabulate
+
 # rucio module has the same name as this executable module, so this rule fails. pylint: disable=no-name-in-module
 from rucio import version
 from rucio.client import Client
@@ -58,7 +60,6 @@ from rucio.common.exception import (
 from rucio.common.extra import import_extras
 from rucio.common.test_rucio_server import TestRucioServer
 from rucio.common.utils import Color, StoreAndDeprecateWarningAction, chunks, detect_client_location, extract_scope, parse_did_filter_from_string, parse_did_filter_from_string_fe, setup_logger, sizefmt
-from tabulate import tabulate
 
 EXTRA_MODULES = import_extras(['argcomplete'])
 

--- a/bin/rucio-abacus-account
+++ b/bin/rucio-abacus-account
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-abacus-collection-replica
+++ b/bin/rucio-abacus-collection-replica
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-abacus-rse
+++ b/bin/rucio-abacus-rse
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -28,6 +28,8 @@ from configparser import NoOptionError, NoSectionError
 from functools import wraps
 from textwrap import dedent
 
+from tabulate import tabulate
+
 from rucio import version
 from rucio.client import Client
 from rucio.common.config import config_get
@@ -53,7 +55,6 @@ from rucio.common.exception import (
 from rucio.common.extra import import_extras
 from rucio.common.utils import StoreAndDeprecateWarningAction, chunks, clean_surls, construct_surl, extract_scope, get_bytes_value_from_string, parse_response, render_json, sizefmt
 from rucio.rse import rsemanager as rsemgr
-from tabulate import tabulate
 
 EXTRA_MODULES = import_extras(['argcomplete'])
 

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,26 +24,36 @@ import signal
 import sys
 import time
 import traceback
-from textwrap import dedent
-from functools import wraps
-
 from configparser import NoOptionError, NoSectionError
-from tabulate import tabulate
+from functools import wraps
+from textwrap import dedent
 
 from rucio import version
 from rucio.client import Client
 from rucio.common.config import config_get
-from rucio.common.exception import (AccountNotFound, DataIdentifierAlreadyExists, AccessDenied,
-                                    DataIdentifierNotFound, InvalidObject, ReplicaNotFound,
-                                    RSENotFound, RSEOperationNotSupported, InvalidRSEExpression,
-                                    DuplicateContent, RuleNotFound, CannotAuthenticate,
-                                    Duplicate, ReplicaIsLocked, ConfigNotFound, ScopeNotFound,
-                                    InputValidationError)
+from rucio.common.exception import (
+    AccessDenied,
+    AccountNotFound,
+    CannotAuthenticate,
+    ConfigNotFound,
+    DataIdentifierAlreadyExists,
+    DataIdentifierNotFound,
+    Duplicate,
+    DuplicateContent,
+    InputValidationError,
+    InvalidObject,
+    InvalidRSEExpression,
+    ReplicaIsLocked,
+    ReplicaNotFound,
+    RSENotFound,
+    RSEOperationNotSupported,
+    RuleNotFound,
+    ScopeNotFound,
+)
 from rucio.common.extra import import_extras
-from rucio.common.utils import (chunks, construct_surl, sizefmt, get_bytes_value_from_string,
-                                render_json, parse_response, extract_scope, clean_surls,
-                                StoreAndDeprecateWarningAction)
+from rucio.common.utils import StoreAndDeprecateWarningAction, chunks, clean_surls, construct_surl, extract_scope, get_bytes_value_from_string, parse_response, render_json, sizefmt
 from rucio.rse import rsemanager as rsemgr
+from tabulate import tabulate
 
 EXTRA_MODULES = import_extras(['argcomplete'])
 
@@ -1277,7 +1286,7 @@ def import_data(args):
         print('There was problem with decoding your file.')
         print(error)
         return FAILURE
-    except IOError as error:
+    except OSError as error:
         print('There was a problem with reading your file.')
         print(error)
         return FAILURE
@@ -1309,7 +1318,7 @@ def export_data(args):
             print('File successfully written.')
         print('Data successfully exported to %s' % args.file_path)
         return SUCCESS
-    except IOError as error:
+    except OSError as error:
         print('There was a problem with reading your file.')
         print(error)
         return FAILURE

--- a/bin/rucio-atropos
+++ b/bin/rucio-atropos
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-auditor
+++ b/bin/rucio-auditor
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +23,7 @@ import textwrap
 import time
 from datetime import datetime
 from functools import partial
-from multiprocessing import Queue, Process, Event, Pipe
+from multiprocessing import Event, Pipe, Process, Queue
 
 import rucio.common.config as config
 import rucio.common.dumper as dumper

--- a/bin/rucio-automatix
+++ b/bin/rucio-automatix
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-bb8
+++ b/bin/rucio-bb8
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-c3po
+++ b/bin/rucio-c3po
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-cache-client
+++ b/bin/rucio-cache-client
@@ -26,6 +26,7 @@ import sys
 
 import stomp
 from jsonschema import validate
+
 from rucio.client.didclient import DIDClient
 from rucio.client.rseclient import RSEClient
 from rucio.common.config import config_get, config_get_int

--- a/bin/rucio-cache-client
+++ b/bin/rucio-cache-client
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +26,6 @@ import sys
 
 import stomp
 from jsonschema import validate
-
 from rucio.client.didclient import DIDClient
 from rucio.client.rseclient import RSEClient
 from rucio.common.config import config_get, config_get_int

--- a/bin/rucio-cache-consumer
+++ b/bin/rucio-cache-consumer
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-finisher
+++ b/bin/rucio-conveyor-finisher
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-poller
+++ b/bin/rucio-conveyor-poller
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-preparer
+++ b/bin/rucio-conveyor-preparer
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-receiver
+++ b/bin/rucio-conveyor-receiver
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-stager
+++ b/bin/rucio-conveyor-stager
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-submitter
+++ b/bin/rucio-conveyor-submitter
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-conveyor-throttler
+++ b/bin/rucio-conveyor-throttler
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-dark-reaper
+++ b/bin/rucio-dark-reaper
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-dumper
+++ b/bin/rucio-dumper
@@ -18,9 +18,10 @@ import datetime
 import logging
 import sys
 
+import tabulate
+
 import rucio.common.dumper.consistency as consistency
 import rucio.common.dumper.data_models as data_models
-import tabulate
 from rucio.common.dumper import error
 
 logger = logging.getLogger('rucio-dumper')

--- a/bin/rucio-dumper
+++ b/bin/rucio-dumper
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,11 +17,10 @@ import argparse
 import datetime
 import logging
 import sys
-import tabulate
 
 import rucio.common.dumper.consistency as consistency
 import rucio.common.dumper.data_models as data_models
-
+import tabulate
 from rucio.common.dumper import error
 
 logger = logging.getLogger('rucio-dumper')
@@ -130,7 +128,7 @@ if __name__ == "__main__":
             fields.append(args.sum)
             data = []
             for key, value in data_dict.items():
-                total = sum((getattr(x, args.sum) for x in value))
+                total = sum(getattr(x, args.sum) for x in value)
                 # FIXME: Ugly hack to have some result
                 setattr(value[0], args.sum, total)
                 data.append(value[0])
@@ -139,12 +137,12 @@ if __name__ == "__main__":
 
     if args.fields:
         _show_fields = args.fields.split(',')
-        if not all((f in fields for f in _show_fields)):
+        if not all(f in fields for f in _show_fields):
             error('Invalid field in --fields argument')
         fields = _show_fields
     elif args.hide:
         _hide_fields = args.hide.split(',')
-        if not all((f in fields for f in _hide_fields)):
+        if not all(f in fields for f in _hide_fields):
             error('Invalid field in --hide argument')
         fields = [f for f in fields if f not in _hide_fields]
 

--- a/bin/rucio-follower
+++ b/bin/rucio-follower
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-hermes
+++ b/bin/rucio-hermes
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-judge-cleaner
+++ b/bin/rucio-judge-cleaner
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-judge-evaluator
+++ b/bin/rucio-judge-evaluator
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-judge-injector
+++ b/bin/rucio-judge-injector
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-judge-repairer
+++ b/bin/rucio-judge-repairer
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-kronos
+++ b/bin/rucio-kronos
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-minos
+++ b/bin/rucio-minos
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-minos-temporary-expiration
+++ b/bin/rucio-minos-temporary-expiration
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-necromancer
+++ b/bin/rucio-necromancer
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-oauth-manager
+++ b/bin/rucio-oauth-manager
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-reaper
+++ b/bin/rucio-reaper
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-replica-recoverer
+++ b/bin/rucio-replica-recoverer
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-rse-decommissioner
+++ b/bin/rucio-rse-decommissioner
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-storage-consistency-actions
+++ b/bin/rucio-storage-consistency-actions
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-transmogrifier
+++ b/bin/rucio-transmogrifier
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/rucio-undertaker
+++ b/bin/rucio-undertaker
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/etc/docker/dev/configure_qbittorrent.py
+++ b/etc/docker/dev/configure_qbittorrent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/__init__.py
+++ b/lib/rucio/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/alembicrevision.py
+++ b/lib/rucio/alembicrevision.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/__init__.py
+++ b/lib/rucio/api/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/account.py
+++ b/lib/rucio/api/account.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/account_limit.py
+++ b/lib/rucio/api/account_limit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/authentication.py
+++ b/lib/rucio/api/authentication.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/config.py
+++ b/lib/rucio/api/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/credential.py
+++ b/lib/rucio/api/credential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/did.py
+++ b/lib/rucio/api/did.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/dirac.py
+++ b/lib/rucio/api/dirac.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/exporter.py
+++ b/lib/rucio/api/exporter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/heartbeat.py
+++ b/lib/rucio/api/heartbeat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/identity.py
+++ b/lib/rucio/api/identity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/importer.py
+++ b/lib/rucio/api/importer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/lifetime_exception.py
+++ b/lib/rucio/api/lifetime_exception.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/lock.py
+++ b/lib/rucio/api/lock.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/meta_conventions.py
+++ b/lib/rucio/api/meta_conventions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/permission.py
+++ b/lib/rucio/api/permission.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/quarantined_replica.py
+++ b/lib/rucio/api/quarantined_replica.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/replica.py
+++ b/lib/rucio/api/replica.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/request.py
+++ b/lib/rucio/api/request.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/rse.py
+++ b/lib/rucio/api/rse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/rule.py
+++ b/lib/rucio/api/rule.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/scope.py
+++ b/lib/rucio/api/scope.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/subscription.py
+++ b/lib/rucio/api/subscription.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/api/vo.py
+++ b/lib/rucio/api/vo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/__init__.py
+++ b/lib/rucio/client/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/accountlimitclient.py
+++ b/lib/rucio/client/accountlimitclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -67,7 +67,7 @@ def choice(hosts):
     return random.choice(hosts)
 
 
-class BaseClient(object):
+class BaseClient:
 
     """Main client class for accessing Rucio resources. Handles the authentication."""
 

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -412,7 +412,7 @@ class BaseClient:
                 if retry > self.request_retries:
                     raise
                 continue
-            except IOError as error:
+            except OSError as error:
                 # Handle Broken Pipe
                 # While in python3 we can directly catch 'BrokenPipeError', in python2 it doesn't exist.
                 if getattr(error, 'errno') != errno.EPIPE:
@@ -859,7 +859,7 @@ class BaseClient:
             token_file_handler = open(self.token_file, 'r')
             self.auth_token = token_file_handler.readline()
             self.headers['X-Rucio-Auth-Token'] = self.auth_token
-        except IOError as error:
+        except OSError as error:
             print("I/O error({0}): {1}".format(error.errno, error.strerror))
         except Exception:
             raise
@@ -890,7 +890,7 @@ class BaseClient:
                 with fdopen(file_d, "w") as f_exp_epoch:
                     f_exp_epoch.write(str(self.token_exp_epoch))
                 move(file_n, self.token_exp_epoch_file)
-        except IOError as error:
+        except OSError as error:
             print("I/O error({0}): {1}".format(error.errno, error.strerror))
         except Exception:
             raise

--- a/lib/rucio/client/client.py
+++ b/lib/rucio/client/client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/configclient.py
+++ b/lib/rucio/client/configclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/credentialclient.py
+++ b/lib/rucio/client/credentialclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/diracclient.py
+++ b/lib/rucio/client/diracclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/exportclient.py
+++ b/lib/rucio/client/exportclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/fileclient.py
+++ b/lib/rucio/client/fileclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/importclient.py
+++ b/lib/rucio/client/importclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/lifetimeclient.py
+++ b/lib/rucio/client/lifetimeclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/lockclient.py
+++ b/lib/rucio/client/lockclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/metaconventionsclient.py
+++ b/lib/rucio/client/metaconventionsclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/pingclient.py
+++ b/lib/rucio/client/pingclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/scopeclient.py
+++ b/lib/rucio/client/scopeclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/touchclient.py
+++ b/lib/rucio/client/touchclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/__init__.py
+++ b/lib/rucio/common/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/cache.py
+++ b/lib/rucio/common/cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/cache.py
+++ b/lib/rucio/common/cache.py
@@ -35,7 +35,7 @@ try:
         import pymemcache
         _mc_client = pymemcache.Client(CACHE_URL, connect_timeout=1, timeout=1)
         _mc_client.version()
-except IOError:
+except OSError:
     ENABLE_CACHING = False
 except ImportError:
     ENABLE_CACHING = False

--- a/lib/rucio/common/cache.py
+++ b/lib/rucio/common/cache.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 from typing import TYPE_CHECKING
 

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/constraints.py
+++ b/lib/rucio/common/constraints.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/didtype.py
+++ b/lib/rucio/common/didtype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/didtype.py
+++ b/lib/rucio/common/didtype.py
@@ -19,7 +19,7 @@ DID type to represent a did and to simplify operations on it
 from rucio.common.exception import DIDError
 
 
-class DID(object):
+class DID:
 
     """
     Class used to store a DID

--- a/lib/rucio/common/dumper/__init__.py
+++ b/lib/rucio/common/dumper/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/dumper/__init__.py
+++ b/lib/rucio/common/dumper/__init__.py
@@ -38,7 +38,7 @@ class HTTPDownloadFailed(Exception):
         super(HTTPDownloadFailed, self).__init__(msg)
 
 
-class LogPipeHandler(logging.Handler, object):
+class LogPipeHandler(logging.Handler):
     def __init__(self, pipe):
         super(LogPipeHandler, self).__init__()
         self.pipe = pipe

--- a/lib/rucio/common/dumper/consistency.py
+++ b/lib/rucio/common/dumper/consistency.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/dumper/data_models.py
+++ b/lib/rucio/common/dumper/data_models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/dumper/data_models.py
+++ b/lib/rucio/common/dumper/data_models.py
@@ -29,7 +29,7 @@ from tabulate import tabulate
 from rucio.common.dumper import DUMPS_CACHE_DIR, HTTPDownloadFailed, get_requests_session, http_download_to_file, smart_open, temp_file, to_datetime
 
 
-class DataModel(object):
+class DataModel:
     """
     Data model for the dumps
     """
@@ -267,7 +267,7 @@ class Replica(DataModel):
         assert len(args) <= 9
 
 
-class Filter(object):
+class Filter:
     _Condition = collections.namedtuple('_Condition', ('comparator', 'attribute', 'expected'))
 
     def __init__(self, filter_str, record_class):

--- a/lib/rucio/common/dumper/path_parsing.py
+++ b/lib/rucio/common/dumper/path_parsing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/extra.py
+++ b/lib/rucio/common/extra.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/logging.py
+++ b/lib/rucio/common/logging.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/pcache.py
+++ b/lib/rucio/common/pcache.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/pcache.py
+++ b/lib/rucio/common/pcache.py
@@ -1127,7 +1127,7 @@ class Pcache:
             return
         try:
             f = open(name, 'w')
-        except IOError as e:
+        except OSError as e:
             self.log(ERROR, "open: %s", e)
             return e.errno
 
@@ -1139,7 +1139,7 @@ class Pcache:
             try:
                 status = fcntl.lockf(f, flag)
                 break
-            except IOError as e:
+            except OSError as e:
                 if e.errno in (errno.EAGAIN, errno.EACCES) and not blocking:
                     f.close()
                     del self.locks[name]

--- a/lib/rucio/common/pcache.py
+++ b/lib/rucio/common/pcache.py
@@ -258,7 +258,7 @@ class Pcache:
             elif opt in ("-r", "--retry"):
                 self.max_retries = int(arg)
             elif opt in ("-V", "--version"):
-                print((str(self.version)))
+                print(str(self.version))
                 sys.exit(0)
             elif opt in ("-l", "--log"):
                 self.log_file = arg

--- a/lib/rucio/common/plugins.py
+++ b/lib/rucio/common/plugins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/plugins.py
+++ b/lib/rucio/common/plugins.py
@@ -23,7 +23,7 @@ from rucio.common.exception import InvalidAlgorithmName
 PolicyPackageAlgorithmsT = TypeVar('PolicyPackageAlgorithmsT', bound='PolicyPackageAlgorithms')
 
 
-class PolicyPackageAlgorithms():
+class PolicyPackageAlgorithms:
     """
     Base class for Rucio Policy Package Algorithms
 

--- a/lib/rucio/common/policy.py
+++ b/lib/rucio/common/policy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/schema/atlas.py
+++ b/lib/rucio/common/schema/atlas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/schema/belleii.py
+++ b/lib/rucio/common/schema/belleii.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/schema/cms.py
+++ b/lib/rucio/common/schema/cms.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/schema/domatpc.py
+++ b/lib/rucio/common/schema/domatpc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/schema/escape.py
+++ b/lib/rucio/common/schema/escape.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/schema/generic.py
+++ b/lib/rucio/common/schema/generic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/schema/generic_multi_vo.py
+++ b/lib/rucio/common/schema/generic_multi_vo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/schema/icecube.py
+++ b/lib/rucio/common/schema/icecube.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/schema/lsst.py
+++ b/lib/rucio/common/schema/lsst.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/stomp_utils.py
+++ b/lib/rucio/common/stomp_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/stopwatch.py
+++ b/lib/rucio/common/stopwatch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/test_rucio_server.py
+++ b/lib/rucio/common/test_rucio_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/types.py
+++ b/lib/rucio/common/types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/types.py
+++ b/lib/rucio/common/types.py
@@ -15,7 +15,7 @@
 from typing import Any, Callable, Literal, Optional, TypedDict, Union
 
 
-class InternalType(object):
+class InternalType:
     '''
     Base for Internal representations of string types
     '''

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1658,7 +1658,7 @@ def get_thread_with_periodic_running_function(interval, action, graceful_stop):
         while not graceful_stop.is_set():
             starttime = time.time()
             action()
-            time.sleep(interval - ((time.time() - starttime)))
+            time.sleep(interval - (time.time() - starttime))
     t = threading.Thread(target=start)
     return t
 

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -578,7 +578,7 @@ def val_to_space_sep_str(vallist):
         else:
             return str(vallist)
     except:
-        return str('')
+        return ''
 
 
 def date_to_str(date):

--- a/lib/rucio/core/__init__.py
+++ b/lib/rucio/core/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/account.py
+++ b/lib/rucio/core/account.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/account_counter.py
+++ b/lib/rucio/core/account_counter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/account_limit.py
+++ b/lib/rucio/core/account_limit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/authentication.py
+++ b/lib/rucio/core/authentication.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/config.py
+++ b/lib/rucio/core/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/did_meta_plugins/did_meta_plugin_interface.py
+++ b/lib/rucio/core/did_meta_plugins/did_meta_plugin_interface.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/did_meta_plugins/did_meta_plugin_interface.py
+++ b/lib/rucio/core/did_meta_plugins/did_meta_plugin_interface.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 
-class DidMetaPlugin(object, metaclass=ABCMeta):
+class DidMetaPlugin(metaclass=ABCMeta):
     """
     Interface for plugins managing metadata of DIDs
     """

--- a/lib/rucio/core/did_meta_plugins/filter_engine.py
+++ b/lib/rucio/core/did_meta_plugins/filter_engine.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/did_meta_plugins/json_meta.py
+++ b/lib/rucio/core/did_meta_plugins/json_meta.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/did_meta_plugins/mongo_meta.py
+++ b/lib/rucio/core/did_meta_plugins/mongo_meta.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/did_meta_plugins/postgres_meta.py
+++ b/lib/rucio/core/did_meta_plugins/postgres_meta.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/dirac.py
+++ b/lib/rucio/core/dirac.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/distance.py
+++ b/lib/rucio/core/distance.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/exporter.py
+++ b/lib/rucio/core/exporter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/heartbeat.py
+++ b/lib/rucio/core/heartbeat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/identity.py
+++ b/lib/rucio/core/identity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/importer.py
+++ b/lib/rucio/core/importer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/lifetime_exception.py
+++ b/lib/rucio/core/lifetime_exception.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/lock.py
+++ b/lib/rucio/core/lock.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/message.py
+++ b/lib/rucio/core/message.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/meta_conventions.py
+++ b/lib/rucio/core/meta_conventions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/monitor.py
+++ b/lib/rucio/core/monitor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/naming_convention.py
+++ b/lib/rucio/core/naming_convention.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/nongrid_trace.py
+++ b/lib/rucio/core/nongrid_trace.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/permission/atlas.py
+++ b/lib/rucio/core/permission/atlas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/permission/belleii.py
+++ b/lib/rucio/core/permission/belleii.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/permission/cms.py
+++ b/lib/rucio/core/permission/cms.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/permission/escape.py
+++ b/lib/rucio/core/permission/escape.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/permission/generic_multi_vo.py
+++ b/lib/rucio/core/permission/generic_multi_vo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/quarantined_replica.py
+++ b/lib/rucio/core/quarantined_replica.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -94,7 +94,7 @@ def get_bad_replicas_summary(rse_expression=None, from_date=None, to_date=None, 
             rse_clause.append(models.BadReplicas.rse_id == rse['id'])
 
     if session.bind.dialect.name == 'oracle':
-        to_days = func.trunc(models.BadReplicas.created_at, str('DD'))
+        to_days = func.trunc(models.BadReplicas.created_at, 'DD')
     elif session.bind.dialect.name == 'mysql':
         to_days = func.date(models.BadReplicas.created_at)
     elif session.bind.dialect.name == 'postgresql':

--- a/lib/rucio/core/replica_sorter.py
+++ b/lib/rucio/core/replica_sorter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/rse_counter.py
+++ b/lib/rucio/core/rse_counter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -208,7 +208,7 @@ def __extract_term(expression):
     raise SystemError('This point in the code should not be reachable')
 
 
-class BaseExpressionElement(object, metaclass=abc.ABCMeta):
+class BaseExpressionElement(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def resolve_elements(self, session):
         """

--- a/lib/rucio/core/rse_selector.py
+++ b/lib/rucio/core/rse_selector.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/rse_selector.py
+++ b/lib/rucio/core/rse_selector.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 
-class RSESelector():
+class RSESelector:
     """
     Representation of the RSE selector
     """

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -2791,7 +2791,7 @@ def generate_email_for_rule_ok_notification(
         try:
             with open(template_path, 'r') as templatefile:
                 template = Template(templatefile.read())
-        except IOError as ex:
+        except OSError as ex:
             logger(logging.ERROR, "Couldn't open file '%s'", template_path, exc_info=ex)
             return
 

--- a/lib/rucio/core/rule_grouping.py
+++ b/lib/rucio/core/rule_grouping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/scope.py
+++ b/lib/rucio/core/scope.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/subscription.py
+++ b/lib/rucio/core/subscription.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/topology.py
+++ b/lib/rucio/core/topology.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/trace.py
+++ b/lib/rucio/core/trace.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -927,7 +927,7 @@ class SourceRankingStrategy:
         """
         pass
 
-    class _ClassNameDescriptor(object):
+    class _ClassNameDescriptor:
         """
         Automatically set the external_name of the strategy to the class name.
         """

--- a/lib/rucio/core/vo.py
+++ b/lib/rucio/core/vo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/core/volatile_replica.py
+++ b/lib/rucio/core/volatile_replica.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/__init__.py
+++ b/lib/rucio/daemons/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/abacus/__init__.py
+++ b/lib/rucio/daemons/abacus/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/abacus/account.py
+++ b/lib/rucio/daemons/abacus/account.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/abacus/collection_replica.py
+++ b/lib/rucio/daemons/abacus/collection_replica.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/abacus/rse.py
+++ b/lib/rucio/daemons/abacus/rse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/atropos/__init__.py
+++ b/lib/rucio/daemons/atropos/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/atropos/atropos.py
+++ b/lib/rucio/daemons/atropos/atropos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/auditor/__init__.py
+++ b/lib/rucio/daemons/auditor/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/auditor/hdfs.py
+++ b/lib/rucio/daemons/auditor/hdfs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/auditor/hdfs.py
+++ b/lib/rucio/daemons/auditor/hdfs.py
@@ -32,7 +32,7 @@ def _hdfs_get(src_url, dst_path):
     )
     _, stderr = get.communicate()
     if get.returncode != 0:
-        raise IOError('_hdfs_get(): "{0}": {1}. Return code {2}'.format(
+        raise OSError('_hdfs_get(): "{0}": {1}. Return code {2}'.format(
             ' '.join(cmd),
             stderr,
             get.returncode,

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -34,7 +34,7 @@ __DUMPERCONFIGDIRS = (os.path.join(confdir, 'auditor') for confdir in get_config
 __DUMPERCONFIGDIRS = list(filter(os.path.exists, __DUMPERCONFIGDIRS))
 
 
-class Parser(ConfigParser.RawConfigParser, object):
+class Parser(ConfigParser.RawConfigParser):
     '''
     RawConfigParser subclass that doesn't modify the the name of the options
     and removes any quotes arround the string values.
@@ -110,7 +110,7 @@ def gfal_links(base_url):
     return ['/'.join((base_url, f)) for f in ctxt.listdir(str(base_url))]
 
 
-class _LinkCollector(HTMLParser.HTMLParser, object):
+class _LinkCollector(HTMLParser.HTMLParser):
     def __init__(self):
         super(_LinkCollector, self).__init__()
         self.links = []

--- a/lib/rucio/daemons/automatix/__init__.py
+++ b/lib/rucio/daemons/automatix/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/badreplicas/__init__.py
+++ b/lib/rucio/daemons/badreplicas/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/badreplicas/minos.py
+++ b/lib/rucio/daemons/badreplicas/minos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
+++ b/lib/rucio/daemons/badreplicas/minos_temporary_expiration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/badreplicas/necromancer.py
+++ b/lib/rucio/daemons/badreplicas/necromancer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/bb8/__init__.py
+++ b/lib/rucio/daemons/bb8/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/bb8/bb8.py
+++ b/lib/rucio/daemons/bb8/bb8.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/bb8/common.py
+++ b/lib/rucio/daemons/bb8/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/bb8/t2_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/t2_background_rebalance.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/__init__.py
+++ b/lib/rucio/daemons/c3po/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/algorithms/__init__.py
+++ b/lib/rucio/daemons/c3po/algorithms/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/algorithms/simple.py
+++ b/lib/rucio/daemons/c3po/algorithms/simple.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/c3po.py
+++ b/lib/rucio/daemons/c3po/c3po.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/collectors/__init__.py
+++ b/lib/rucio/daemons/c3po/collectors/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/collectors/agis.py
+++ b/lib/rucio/daemons/c3po/collectors/agis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/collectors/agis.py
+++ b/lib/rucio/daemons/c3po/collectors/agis.py
@@ -19,11 +19,11 @@ from requests import get
 from rucio.common.config import config_get
 
 
-class MappingCollector(object):
+class MappingCollector:
     """
     Provides mappings from PanDA / DDM resources to ATLAS sites and back.
     """
-    class _MappingCollector(object):
+    class _MappingCollector:
         '''
         _MappingCollector
         '''

--- a/lib/rucio/daemons/c3po/collectors/free_space.py
+++ b/lib/rucio/daemons/c3po/collectors/free_space.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/collectors/free_space.py
+++ b/lib/rucio/daemons/c3po/collectors/free_space.py
@@ -20,11 +20,11 @@ from rucio.db.sqla.models import RSEAttrAssociation, RSEUsage
 from rucio.db.sqla.session import read_session
 
 
-class FreeSpaceCollector(object):
+class FreeSpaceCollector:
     """
     Collector to get the SRM free and used information for DATADISK RSEs.
     """
-    class _FreeSpaceCollector(object):
+    class _FreeSpaceCollector:
         """
         Hidden implementation
         """

--- a/lib/rucio/daemons/c3po/collectors/jedi_did.py
+++ b/lib/rucio/daemons/c3po/collectors/jedi_did.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/collectors/jedi_did.py
+++ b/lib/rucio/daemons/c3po/collectors/jedi_did.py
@@ -17,7 +17,7 @@ import logging
 from rucio.db.sqla.session import read_session
 
 
-class JediDIDCollector():
+class JediDIDCollector:
     def __init__(self, queue):
         self.queue = queue
         self.max_tid = 0

--- a/lib/rucio/daemons/c3po/collectors/mock_did.py
+++ b/lib/rucio/daemons/c3po/collectors/mock_did.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/collectors/mock_did.py
+++ b/lib/rucio/daemons/c3po/collectors/mock_did.py
@@ -19,7 +19,7 @@ Mock DID collector
 from random import choice
 
 
-class MockDIDCollector(object):
+class MockDIDCollector:
     """
     Simple collector that reads dids from a file. Used to
     test the interface.

--- a/lib/rucio/daemons/c3po/collectors/network_metrics.py
+++ b/lib/rucio/daemons/c3po/collectors/network_metrics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/collectors/network_metrics.py
+++ b/lib/rucio/daemons/c3po/collectors/network_metrics.py
@@ -19,7 +19,7 @@ from redis import StrictRedis
 from rucio.common.config import config_get, config_get_int
 
 
-class NetworkMetricsCollector(object):
+class NetworkMetricsCollector:
     """
     Collector to get the bandwidth metrics between two sites.
     """

--- a/lib/rucio/daemons/c3po/collectors/workload.py
+++ b/lib/rucio/daemons/c3po/collectors/workload.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/collectors/workload.py
+++ b/lib/rucio/daemons/c3po/collectors/workload.py
@@ -26,13 +26,13 @@ from rucio.common.config import config_get, config_get_int
 from rucio.daemons.c3po.utils.timeseries import RedisTimeSeries
 
 
-class WorkloadCollector(object):
+class WorkloadCollector:
     """
     Collector to retrieve the workload from PanDA. It stores it as a time series in Redis and provides
     the average and maximum number of running jobs for a sliding window.
     """
 
-    class __WorkloadCollector(object):
+    class __WorkloadCollector:
         """
         Private class needed implement singleton.
         """

--- a/lib/rucio/daemons/c3po/utils/__init__.py
+++ b/lib/rucio/daemons/c3po/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/utils/dataset_cache.py
+++ b/lib/rucio/daemons/c3po/utils/dataset_cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/utils/dataset_cache.py
+++ b/lib/rucio/daemons/c3po/utils/dataset_cache.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 from rucio.daemons.c3po.utils.timeseries import RedisTimeSeries
 
 
-class DatasetCache(object):
+class DatasetCache:
     """
     Utility to count the accesses of the datasets during the last day.
     """

--- a/lib/rucio/daemons/c3po/utils/expiring_dataset_cache.py
+++ b/lib/rucio/daemons/c3po/utils/expiring_dataset_cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/utils/expiring_dataset_cache.py
+++ b/lib/rucio/daemons/c3po/utils/expiring_dataset_cache.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 from redis import StrictRedis
 
 
-class ExpiringDatasetCache(object):
+class ExpiringDatasetCache:
     """
     Cache with expiring values to keep track of recently created replicas.
     """

--- a/lib/rucio/daemons/c3po/utils/expiring_list.py
+++ b/lib/rucio/daemons/c3po/utils/expiring_list.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/utils/expiring_list.py
+++ b/lib/rucio/daemons/c3po/utils/expiring_list.py
@@ -20,7 +20,7 @@ from collections import deque
 from threading import Lock, Timer
 
 
-class ExpiringList(object):
+class ExpiringList:
     """
     Simple list with time based element expiration
     """

--- a/lib/rucio/daemons/c3po/utils/popularity.py
+++ b/lib/rucio/daemons/c3po/utils/popularity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/utils/timeseries.py
+++ b/lib/rucio/daemons/c3po/utils/timeseries.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/c3po/utils/timeseries.py
+++ b/lib/rucio/daemons/c3po/utils/timeseries.py
@@ -21,7 +21,7 @@ from time import time
 from redis import StrictRedis
 
 
-class RedisTimeSeries(object):
+class RedisTimeSeries:
     """
     Redis time series abstraction
     """

--- a/lib/rucio/daemons/common.py
+++ b/lib/rucio/daemons/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/conveyor/__init__.py
+++ b/lib/rucio/daemons/conveyor/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/conveyor/preparer.py
+++ b/lib/rucio/daemons/conveyor/preparer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -70,9 +70,9 @@ class Receiver:
         if 'job_metadata' in msg.keys() \
            and isinstance(msg['job_metadata'], dict) \
            and 'issuer' in msg['job_metadata'].keys() \
-           and str(msg['job_metadata']['issuer']) == str('rucio'):
+           and str(msg['job_metadata']['issuer']) == 'rucio':
 
-            if 'job_state' in msg.keys() and (str(msg['job_state']) != str('ACTIVE') or msg.get('job_multihop', False) is True):
+            if 'job_state' in msg.keys() and (str(msg['job_state']) != 'ACTIVE' or msg.get('job_multihop', False) is True):
                 METRICS.counter('message_rucio').inc()
 
                 self._perform_request_update(msg)

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -46,7 +46,7 @@ GRACEFUL_STOP = threading.Event()
 DAEMON_NAME = 'conveyor-receiver'
 
 
-class Receiver(object):
+class Receiver:
 
     def __init__(self, broker, id_, total_threads, transfer_stats_manager: request_core.TransferStatsManager, all_vos=False):
         self.__all_vos = all_vos

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/follower/__init__.py
+++ b/lib/rucio/daemons/follower/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/follower/follower.py
+++ b/lib/rucio/daemons/follower/follower.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/hermes/__init__.py
+++ b/lib/rucio/daemons/hermes/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/hermes/hermes.py
+++ b/lib/rucio/daemons/hermes/hermes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/judge/__init__.py
+++ b/lib/rucio/daemons/judge/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/judge/cleaner.py
+++ b/lib/rucio/daemons/judge/cleaner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/judge/evaluator.py
+++ b/lib/rucio/daemons/judge/evaluator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/judge/injector.py
+++ b/lib/rucio/daemons/judge/injector.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/judge/repairer.py
+++ b/lib/rucio/daemons/judge/repairer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/oauthmanager/__init__.py
+++ b/lib/rucio/daemons/oauthmanager/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/oauthmanager/oauthmanager.py
+++ b/lib/rucio/daemons/oauthmanager/oauthmanager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/reaper/__init__.py
+++ b/lib/rucio/daemons/reaper/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/reaper/dark_reaper.py
+++ b/lib/rucio/daemons/reaper/dark_reaper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/replicarecoverer/__init__.py
+++ b/lib/rucio/daemons/replicarecoverer/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
+++ b/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/rsedecommissioner/__init__.py
+++ b/lib/rucio/daemons/rsedecommissioner/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/rsedecommissioner/config.py
+++ b/lib/rucio/daemons/rsedecommissioner/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/rsedecommissioner/profiles/__init__.py
+++ b/lib/rucio/daemons/rsedecommissioner/profiles/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/rsedecommissioner/profiles/atlas.py
+++ b/lib/rucio/daemons/rsedecommissioner/profiles/atlas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/rsedecommissioner/profiles/generic.py
+++ b/lib/rucio/daemons/rsedecommissioner/profiles/generic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/rsedecommissioner/profiles/types.py
+++ b/lib/rucio/daemons/rsedecommissioner/profiles/types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/rsedecommissioner/rse_decommissioner.py
+++ b/lib/rucio/daemons/rsedecommissioner/rse_decommissioner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/storage/__init__.py
+++ b/lib/rucio/daemons/storage/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/storage/consistency/__init__.py
+++ b/lib/rucio/daemons/storage/consistency/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/storage/consistency/actions.py
+++ b/lib/rucio/daemons/storage/consistency/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/storage/consistency/actions.py
+++ b/lib/rucio/daemons/storage/consistency/actions.py
@@ -122,7 +122,7 @@ def declare_bad_file_replicas(dids, rse_id, reason, issuer,
 # TODO: This is Igor's Stats class.It will be factored out as a separate class in a future version of the code.
 # - Igor Mandrichenko <ivm@fnal.gov>, 2018
 
-class Stats(object):
+class Stats:
 
     def __init__(self, path):
         self.path = path

--- a/lib/rucio/daemons/tracer/__init__.py
+++ b/lib/rucio/daemons/tracer/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/tracer/kronos.py
+++ b/lib/rucio/daemons/tracer/kronos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/transmogrifier/__init__.py
+++ b/lib/rucio/daemons/transmogrifier/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/undertaker/__init__.py
+++ b/lib/rucio/daemons/undertaker/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/daemons/undertaker/undertaker.py
+++ b/lib/rucio/daemons/undertaker/undertaker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/__init__.py
+++ b/lib/rucio/db/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/__init__.py
+++ b/lib/rucio/db/sqla/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/constants.py
+++ b/lib/rucio/db/sqla/constants.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/__init__.py
+++ b/lib/rucio/db/sqla/migrate_repo/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/env.py
+++ b/lib/rucio/db/sqla/migrate_repo/env.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/01eaf73ab656_add_new_rule_notification_state_progress.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/01eaf73ab656_add_new_rule_notification_state_progress.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/01eaf73ab656_add_new_rule_notification_state_progress.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/01eaf73ab656_add_new_rule_notification_state_progress.py
@@ -16,6 +16,7 @@
 
 from alembic import context, op
 from alembic.op import create_check_constraint
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/0437a40dbfd1_add_eol_at_in_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/0437a40dbfd1_add_eol_at_in_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/0f1adb7a599a_create_transfer_hops_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/0f1adb7a599a_create_transfer_hops_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/0f1adb7a599a_create_transfer_hops_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/0f1adb7a599a_create_transfer_hops_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_index, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/102efcf145f4_added_stuck_at_column_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/102efcf145f4_added_stuck_at_column_to_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/13d4f70c66a9_introduce_transfer_limits.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/13d4f70c66a9_introduce_transfer_limits.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/13d4f70c66a9_introduce_transfer_limits.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/13d4f70c66a9_introduce_transfer_limits.py
@@ -18,6 +18,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_index, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.constants import TransferLimitDirection
 from rucio.db.sqla.types import GUID
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/140fef722e91_cleanup_distances_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/140fef722e91_cleanup_distances_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/14ec5aeb64cf_add_request_external_host.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/14ec5aeb64cf_add_request_external_host.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/156fb5b5a14_add_request_type_to_requests_idx.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/156fb5b5a14_add_request_type_to_requests_idx.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/1677d4d803c8_split_rse_availability_into_multiple.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1677d4d803c8_split_rse_availability_into_multiple.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/1677d4d803c8_split_rse_availability_into_multiple.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1677d4d803c8_split_rse_availability_into_multiple.py
@@ -17,8 +17,9 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, drop_column, get_bind
-from rucio.db.sqla.types import GUID
 from sqlalchemy.sql.expression import true
+
+from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers
 revision = "1677d4d803c8"

--- a/lib/rucio/db/sqla/migrate_repo/versions/16a0aca82e12_create_index_on_table_replicas_path.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/16a0aca82e12_create_index_on_table_replicas_path.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/1803333ac20f_adding_provenance_and_phys_group.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1803333ac20f_adding_provenance_and_phys_group.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/1a29d6a9504c_add_didtype_chck_to_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1a29d6a9504c_add_didtype_chck_to_requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/1a29d6a9504c_add_didtype_chck_to_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1a29d6a9504c_add_didtype_chck_to_requests.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context, op
 from alembic.op import add_column, drop_column
+
 from rucio.db.sqla.constants import DIDType
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/1a80adff031a_create_index_on_rules_hist_recent.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1a80adff031a_create_index_on_rules_hist_recent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/1c45d9730ca6_increase_identity_length.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1c45d9730ca6_increase_identity_length.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/1c45d9730ca6_increase_identity_length.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1c45d9730ca6_increase_identity_length.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context, op
 from alembic.op import alter_column, create_check_constraint, create_foreign_key, drop_constraint, execute
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/1d1215494e95_add_quarantined_replicas_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1d1215494e95_add_quarantined_replicas_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/1d1215494e95_add_quarantined_replicas_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1d1215494e95_add_quarantined_replicas_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_primary_key, create_table, drop_table
+
 from rucio.common.schema import get_schema_value
 from rucio.db.sqla.types import GUID
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/1d96f484df21_asynchronous_rules_and_rule_approval.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1d96f484df21_asynchronous_rules_and_rule_approval.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/1d96f484df21_asynchronous_rules_and_rule_approval.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1d96f484df21_asynchronous_rules_and_rule_approval.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context, op
 from alembic.op import add_column, create_check_constraint, drop_column
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/1f46c5f240ac_add_bytes_column_to_bad_replicas.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1f46c5f240ac_add_bytes_column_to_bad_replicas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/1fc15ab60d43_add_message_history_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1fc15ab60d43_add_message_history_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/1fc15ab60d43_add_message_history_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1fc15ab60d43_add_message_history_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_table, drop_table
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/2190e703eb6e_move_rse_settings_to_rse_attributes.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2190e703eb6e_move_rse_settings_to_rse_attributes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2190e703eb6e_move_rse_settings_to_rse_attributes.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2190e703eb6e_move_rse_settings_to_rse_attributes.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import get_bind
+
 from rucio.db.sqla.types import GUID, BooleanString
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/2190e703eb6e_move_rse_settings_to_rse_attributes.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2190e703eb6e_move_rse_settings_to_rse_attributes.py
@@ -83,7 +83,7 @@ def upgrade():
             )
 
             conn.execute(
-                sa.insert((get_rse_attr_association())).from_select(
+                sa.insert(get_rse_attr_association()).from_select(
                     ["rse_id", "key", "value", "created_at", "updated_at"], select_stmt
                 )
             )

--- a/lib/rucio/db/sqla/migrate_repo/versions/21d6b9dc9961_add_mismatch_scheme_state_to_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/21d6b9dc9961_add_mismatch_scheme_state_to_requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/21d6b9dc9961_add_mismatch_scheme_state_to_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/21d6b9dc9961_add_mismatch_scheme_state_to_requests.py
@@ -16,6 +16,7 @@
 
 from alembic import context, op
 from alembic.op import create_check_constraint
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/22cf51430c78_add_availability_column_to_table_rses.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/22cf51430c78_add_availability_column_to_table_rses.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/22d887e4ec0a_create_sources_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/22d887e4ec0a_create_sources_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/22d887e4ec0a_create_sources_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/22d887e4ec0a_create_sources_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_index, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/25821a8a45a3_remove_unique_constraint_on_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/25821a8a45a3_remove_unique_constraint_on_requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/25fc855625cf_added_unique_constraint_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/25fc855625cf_added_unique_constraint_to_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/269fee20dee9_add_repair_cnt_to_locks.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/269fee20dee9_add_repair_cnt_to_locks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/271a46ea6244_add_ignore_availability_column_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/271a46ea6244_add_ignore_availability_column_to_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/277b5fbb41d3_switch_heartbeats_executable.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/277b5fbb41d3_switch_heartbeats_executable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/277b5fbb41d3_switch_heartbeats_executable.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/277b5fbb41d3_switch_heartbeats_executable.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, create_primary_key, drop_column, drop_constraint
+
 from rucio.db.sqla.models import String
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/27e3a68927fb_remove_replicas_tombstone_and_replicas_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/27e3a68927fb_remove_replicas_tombstone_and_replicas_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2854cd9e168_added_rule_id_column.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2854cd9e168_added_rule_id_column.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2854cd9e168_added_rule_id_column.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2854cd9e168_added_rule_id_column.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, drop_column
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/295289b5a800_processed_by_and__at_in_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/295289b5a800_processed_by_and__at_in_requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2962ece31cf4_add_nbaccesses_column_in_the_did_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2962ece31cf4_add_nbaccesses_column_in_the_did_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2af3291ec4c_added_replicas_history_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2af3291ec4c_added_replicas_history_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2af3291ec4c_added_replicas_history_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2af3291ec4c_added_replicas_history_table.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_primary_key, create_table, drop_constraint, drop_table
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/2b69addda658_add_columns_for_third_party_copy_read_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2b69addda658_add_columns_for_third_party_copy_read_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2b8e7bcb4783_add_config_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2b8e7bcb4783_add_config_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2ba5229cb54c_add_submitted_at_to_requests_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2ba5229cb54c_add_submitted_at_to_requests_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2cbee484dcf9_added_column_volume_to_rse_transfer_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2cbee484dcf9_added_column_volume_to_rse_transfer_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2edee4a83846_add_source_to_requests_and_requests_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2edee4a83846_add_source_to_requests_and_requests_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2edee4a83846_add_source_to_requests_and_requests_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2edee4a83846_add_source_to_requests_and_requests_.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, drop_column
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/2eef46be23d4_change_tokens_pk.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2eef46be23d4_change_tokens_pk.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/2f648fc909f3_index_in_rule_history_on_scope_name.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/2f648fc909f3_index_in_rule_history_on_scope_name.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/3082b8cef557_add_naming_convention_table_and_closed_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3082b8cef557_add_naming_convention_table_and_closed_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/3082b8cef557_add_naming_convention_table_and_closed_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3082b8cef557_add_naming_convention_table_and_closed_.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, create_check_constraint, create_foreign_key, create_primary_key, create_table, drop_column, drop_table
+
 from rucio.common.schema import get_schema_value
 from rucio.db.sqla.constants import KeyType
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/30fa38b6434e_add_index_on_service_column_in_the_message_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/30fa38b6434e_add_index_on_service_column_in_the_message_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/3152492b110b_added_staging_area_column.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3152492b110b_added_staging_area_column.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/3152492b110b_added_staging_area_column.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3152492b110b_added_staging_area_column.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context, op
 from alembic.op import add_column, create_check_constraint, drop_column, drop_constraint
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/32c7d2783f7e_create_bad_replicas_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/32c7d2783f7e_create_bad_replicas_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/32c7d2783f7e_create_bad_replicas_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/32c7d2783f7e_create_bad_replicas_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_index, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/3345511706b8_replicas_table_pk_definition_is_in_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3345511706b8_replicas_table_pk_definition_is_in_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/35ef10d1e11b_change_index_on_table_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/35ef10d1e11b_change_index_on_table_requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/379a19b5332d_create_rse_limits_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/379a19b5332d_create_rse_limits_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/379a19b5332d_create_rse_limits_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/379a19b5332d_create_rse_limits_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/384b96aa0f60_created_rule_history_tables.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/384b96aa0f60_created_rule_history_tables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/384b96aa0f60_created_rule_history_tables.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/384b96aa0f60_created_rule_history_tables.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_index, create_primary_key, create_table, drop_index, drop_table
+
 from rucio.db.sqla.constants import DIDType, RuleGrouping, RuleNotification, RuleState
 from rucio.db.sqla.types import GUID
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/3ac1660a1a72_extend_distance_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3ac1660a1a72_extend_distance_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/3ad36e2268b0_create_collection_replicas_updates_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3ad36e2268b0_create_collection_replicas_updates_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/3ad36e2268b0_create_collection_replicas_updates_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3ad36e2268b0_create_collection_replicas_updates_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, create_check_constraint, create_index, create_primary_key, create_table, drop_column, drop_constraint, drop_index, drop_table
+
 from rucio.db.sqla.constants import DIDType
 from rucio.db.sqla.types import GUID
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/3c9df354071b_extend_waiting_request_state.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3c9df354071b_extend_waiting_request_state.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/3c9df354071b_extend_waiting_request_state.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3c9df354071b_extend_waiting_request_state.py
@@ -16,6 +16,7 @@
 
 from alembic import context, op
 from alembic.op import create_check_constraint
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/3d9813fab443_add_a_new_state_lost_in_badfilesstatus.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3d9813fab443_add_a_new_state_lost_in_badfilesstatus.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/3d9813fab443_add_a_new_state_lost_in_badfilesstatus.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3d9813fab443_add_a_new_state_lost_in_badfilesstatus.py
@@ -16,6 +16,7 @@
 
 from alembic import context
 from alembic.op import create_check_constraint
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/40ad39ce3160_add_transferred_at_to_requests_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/40ad39ce3160_add_transferred_at_to_requests_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/4207be2fd914_add_notification_column_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4207be2fd914_add_notification_column_to_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/4207be2fd914_add_notification_column_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4207be2fd914_add_notification_column_to_rules.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context, op
 from alembic.op import add_column, drop_column
+
 from rucio.db.sqla.constants import RuleNotification
 from rucio.db.sqla.util import try_drop_constraint
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/42db2617c364_create_index_on_requests_external_id.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/42db2617c364_create_index_on_requests_external_id.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/436827b13f82_added_column_activity_to_table_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/436827b13f82_added_column_activity_to_table_requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/44278720f774_update_requests_typ_sta_upd_idx_index.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/44278720f774_update_requests_typ_sta_upd_idx_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/45378a1e76a8_create_collection_replica_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/45378a1e76a8_create_collection_replica_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/45378a1e76a8_create_collection_replica_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/45378a1e76a8_create_collection_replica_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_index, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.constants import DIDType, ReplicaState
 from rucio.db.sqla.types import GUID
 from rucio.db.sqla.util import try_drop_constraint

--- a/lib/rucio/db/sqla/migrate_repo/versions/469d262be19_removing_created_at_index.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/469d262be19_removing_created_at_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/4783c1f49cb4_create_distance_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4783c1f49cb4_create_distance_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/4783c1f49cb4_create_distance_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4783c1f49cb4_create_distance_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_index, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/49a21b4d4357_create_index_on_table_tokens.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/49a21b4d4357_create_index_on_table_tokens.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/4a2cbedda8b9_add_source_replica_expression_column_to_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4a2cbedda8b9_add_source_replica_expression_column_to_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/4a7182d9578b_added_bytes_length_accessed_at_columns.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4a7182d9578b_added_bytes_length_accessed_at_columns.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/4bab9edd01fc_create_index_on_requests_rule_id.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4bab9edd01fc_create_index_on_requests_rule_id.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/4c3a4acfe006_new_attr_account_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4c3a4acfe006_new_attr_account_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/4cf0a2e127d4_adding_transient_metadata.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4cf0a2e127d4_adding_transient_metadata.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/4df2c5ddabc0_remove_temporary_dids.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4df2c5ddabc0_remove_temporary_dids.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/4df2c5ddabc0_remove_temporary_dids.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/4df2c5ddabc0_remove_temporary_dids.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_index, create_primary_key, create_table, drop_table
+
 from rucio.common.schema import get_schema_value
 from rucio.db.sqla.types import GUID, InternalScopeString
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/50280c53117c_add_qos_class_to_rse.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/50280c53117c_add_qos_class_to_rse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/52153819589c_add_rse_id_to_replicas_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/52153819589c_add_rse_id_to_replicas_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/52fd9f4916fa_added_activity_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/52fd9f4916fa_added_activity_to_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/53b479c3cb0f_fix_did_meta_table_missing_updated_at_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/53b479c3cb0f_fix_did_meta_table_missing_updated_at_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/5673b4b6e843_add_wfms_metadata_to_rule_tables.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/5673b4b6e843_add_wfms_metadata_to_rule_tables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/575767d9f89_added_source_history_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/575767d9f89_added_source_history_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/575767d9f89_added_source_history_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/575767d9f89_added_source_history_table.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, create_table, drop_column, drop_table
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/58bff7008037_add_started_at_to_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/58bff7008037_add_started_at_to_requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/58c8b78301ab_rename_callback_to_message.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/58c8b78301ab_rename_callback_to_message.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/58c8b78301ab_rename_callback_to_message.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/58c8b78301ab_rename_callback_to_message.py
@@ -16,6 +16,7 @@
 
 from alembic import context, op
 from alembic.op import create_check_constraint, create_primary_key, drop_constraint, rename_table
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/5f139f77382a_added_child_rule_id_column.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/5f139f77382a_added_child_rule_id_column.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/5f139f77382a_added_child_rule_id_column.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/5f139f77382a_added_child_rule_id_column.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, create_foreign_key, create_index, drop_column, drop_constraint, drop_index
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/688ef1840840_adding_did_meta_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/688ef1840840_adding_did_meta_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/688ef1840840_adding_did_meta_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/688ef1840840_adding_did_meta_table.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_foreign_key, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.types import JSON
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/6e572a9bfbf3_add_new_split_container_column_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/6e572a9bfbf3_add_new_split_container_column_to_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/70587619328_add_comment_column_for_subscriptions.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/70587619328_add_comment_column_for_subscriptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/739064d31565_remove_history_table_pks.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/739064d31565_remove_history_table_pks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/7541902bf173_add_didsfollowed_and_followevents_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/7541902bf173_add_didsfollowed_and_followevents_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/7541902bf173_add_didsfollowed_and_followevents_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/7541902bf173_add_didsfollowed_and_followevents_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_index, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.constants import DIDType
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/7ec22226cdbf_new_replica_state_for_temporary_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/7ec22226cdbf_new_replica_state_for_temporary_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/7ec22226cdbf_new_replica_state_for_temporary_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/7ec22226cdbf_new_replica_state_for_temporary_.py
@@ -16,6 +16,7 @@
 
 from alembic import context, op
 from alembic.op import create_check_constraint
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/810a41685bc1_added_columns_rse_transfer_limits.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/810a41685bc1_added_columns_rse_transfer_limits.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/83f991c63a93_correct_rse_expression_length.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/83f991c63a93_correct_rse_expression_length.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/8523998e2e76_increase_size_of_extended_attributes_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/8523998e2e76_increase_size_of_extended_attributes_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/8ea9122275b1_adding_missing_function_based_indices.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/8ea9122275b1_adding_missing_function_based_indices.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/90f47792bb76_add_clob_payload_to_messages.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/90f47792bb76_add_clob_payload_to_messages.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/914b8f02df38_new_table_for_lifetime_model_exceptions.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/914b8f02df38_new_table_for_lifetime_model_exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/914b8f02df38_new_table_for_lifetime_model_exceptions.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/914b8f02df38_new_table_for_lifetime_model_exceptions.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.constants import DIDType, LifetimeExceptionsState
 from rucio.db.sqla.types import GUID
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/94a5961ddbf2_add_estimator_columns.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/94a5961ddbf2_add_estimator_columns.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/9a1b149a2044_add_saml_identity_type.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/9a1b149a2044_add_saml_identity_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/9a1b149a2044_add_saml_identity_type.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/9a1b149a2044_add_saml_identity_type.py
@@ -16,6 +16,7 @@
 
 from alembic import context
 from alembic.op import create_check_constraint, drop_constraint, execute
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/9a45bc4ea66d_add_vp_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/9a45bc4ea66d_add_vp_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/9a45bc4ea66d_add_vp_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/9a45bc4ea66d_add_vp_table.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_foreign_key, create_primary_key, create_table, drop_table
+
 from rucio.common.schema import get_schema_value
 from rucio.db.sqla.types import JSON
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/9eb936a81eb1_true_is_true.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/9eb936a81eb1_true_is_true.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/a08fa8de1545_transfer_stats_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a08fa8de1545_transfer_stats_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/a08fa8de1545_transfer_stats_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a08fa8de1545_transfer_stats_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_index, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/a118956323f8_added_vo_table_and_vo_col_to_rse.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a118956323f8_added_vo_table_and_vo_col_to_rse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/a193a275255c_add_status_column_in_messages.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a193a275255c_add_status_column_in_messages.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/a5f6f6e928a7_1_7_0.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a5f6f6e928a7_1_7_0.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/a616581ee47_added_columns_to_table_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a616581ee47_added_columns_to_table_requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/a616581ee47_added_columns_to_table_requests.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a616581ee47_added_columns_to_table_requests.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, drop_column
+
 from rucio.db.sqla.models import String
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/a6eb23955c28_state_idx_non_functional.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a6eb23955c28_state_idx_non_functional.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/a74275a1ad30_added_global_quota_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a74275a1ad30_added_global_quota_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/a93e4e47bda_heartbeats.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a93e4e47bda_heartbeats.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/ae2a56fcc89_added_comment_column_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/ae2a56fcc89_added_comment_column_to_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/ae2a56fcc89_added_comment_column_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/ae2a56fcc89_added_comment_column_to_rules.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, drop_column
+
 from rucio.db.sqla.models import String
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/b4293a99f344_added_column_identity_to_table_tokens.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/b4293a99f344_added_column_identity_to_table_tokens.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/b7d287de34fd_removal_of_replicastate_source.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/b7d287de34fd_removal_of_replicastate_source.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/b7d287de34fd_removal_of_replicastate_source.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/b7d287de34fd_removal_of_replicastate_source.py
@@ -16,6 +16,7 @@
 
 from alembic import context, op
 from alembic.op import create_check_constraint
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/b818052fa670_add_index_to_quarantined_replicas.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/b818052fa670_add_index_to_quarantined_replicas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/b8caac94d7f0_add_comments_column_for_subscriptions_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/b8caac94d7f0_add_comments_column_for_subscriptions_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/b96a1c7e1cc4_new_bad_pfns_table_and_bad_replicas_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/b96a1c7e1cc4_new_bad_pfns_table_and_bad_replicas_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/b96a1c7e1cc4_new_bad_pfns_table_and_bad_replicas_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/b96a1c7e1cc4_new_bad_pfns_table_and_bad_replicas_.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context, op
 from alembic.op import add_column, create_check_constraint, create_foreign_key, create_index, create_primary_key, create_table, drop_column, drop_constraint, drop_index, drop_table
+
 from rucio.db.sqla.constants import BadPFNStatus
 from rucio.db.sqla.util import try_drop_constraint
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/bb695f45c04_extend_request_state.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/bb695f45c04_extend_request_state.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/bb695f45c04_extend_request_state.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/bb695f45c04_extend_request_state.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context, op
 from alembic.op import add_column, create_check_constraint, drop_column, drop_constraint
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/bc68e9946deb_add_staging_timestamps_to_request.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/bc68e9946deb_add_staging_timestamps_to_request.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/bf3baa1c1474_correct_pk_and_idx_for_history_tables.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/bf3baa1c1474_correct_pk_and_idx_for_history_tables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/bf3baa1c1474_correct_pk_and_idx_for_history_tables.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/bf3baa1c1474_correct_pk_and_idx_for_history_tables.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, create_primary_key, drop_column, drop_constraint, drop_index
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/c0937668555f_add_qos_policy_map_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/c0937668555f_add_qos_policy_map_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/c0937668555f_add_qos_policy_map_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/c0937668555f_add_qos_policy_map_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/c129ccdb2d5_add_lumiblocknr_to_dids.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/c129ccdb2d5_add_lumiblocknr_to_dids.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/ccdbcd48206e_add_did_type_column_index_on_did_meta_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/ccdbcd48206e_add_did_type_column_index_on_did_meta_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/ccdbcd48206e_add_did_type_column_index_on_did_meta_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/ccdbcd48206e_add_did_type_column_index_on_did_meta_.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic.context import get_context
 from alembic.op import add_column, create_index, drop_column, drop_index, execute
+
 from rucio.db.sqla.constants import DIDType
 from rucio.db.sqla.util import try_drop_constraint
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/cebad904c4dd_new_payload_column_for_heartbeats.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/cebad904c4dd_new_payload_column_for_heartbeats.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/cebad904c4dd_new_payload_column_for_heartbeats.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/cebad904c4dd_new_payload_column_for_heartbeats.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, create_index, drop_column, drop_index
+
 from rucio.db.sqla.models import String
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/d1189a09c6e0_oauth2_0_and_jwt_feature_support_adding_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/d1189a09c6e0_oauth2_0_and_jwt_feature_support_adding_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/d1189a09c6e0_oauth2_0_and_jwt_feature_support_adding_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/d1189a09c6e0_oauth2_0_and_jwt_feature_support_adding_.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, alter_column, create_check_constraint, create_index, create_primary_key, create_table, drop_column, drop_table, execute
+
 from rucio.db.sqla.types import InternalAccountString
 from rucio.db.sqla.util import try_drop_constraint
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/d23453595260_extend_request_state_for_preparer.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/d23453595260_extend_request_state_for_preparer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/d23453595260_extend_request_state_for_preparer.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/d23453595260_extend_request_state_for_preparer.py
@@ -17,6 +17,7 @@ Add PREPARING state to Request model.
 """
 
 from alembic import context, op
+
 from rucio.db.sqla.util import try_drop_constraint
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/d6dceb1de2d_added_purge_column_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/d6dceb1de2d_added_purge_column_to_rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/d6e2c3b2cf26_remove_third_party_copy_column_from_rse.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/d6e2c3b2cf26_remove_third_party_copy_column_from_rse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/d91002c5841_new_account_limits_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/d91002c5841_new_account_limits_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/d91002c5841_new_account_limits_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/d91002c5841_new_account_limits_table.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_primary_key, create_table, drop_table
+
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/migrate_repo/versions/e138c364ebd0_extending_columns_for_filter_and_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/e138c364ebd0_extending_columns_for_filter_and_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/e59300c8b179_support_for_archive.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/e59300c8b179_support_for_archive.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/e59300c8b179_support_for_archive.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/e59300c8b179_support_for_archive.py
@@ -19,6 +19,7 @@ import datetime
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import add_column, create_foreign_key, create_index, create_primary_key, create_table, drop_column, drop_table
+
 from rucio.db.sqla.models import String
 from rucio.db.sqla.types import GUID
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/f1b14a8c2ac1_postgres_use_check_constraints.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/f1b14a8c2ac1_postgres_use_check_constraints.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/f41ffe206f37_oracle_global_temporary_tables.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/f41ffe206f37_oracle_global_temporary_tables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/f41ffe206f37_oracle_global_temporary_tables.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/f41ffe206f37_oracle_global_temporary_tables.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_table, drop_table
+
 from rucio.common.schema import get_schema_value
 from rucio.db.sqla.types import GUID, InternalScopeString, String
 

--- a/lib/rucio/db/sqla/migrate_repo/versions/f85a2962b021_adding_transfertool_column_to_requests_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/f85a2962b021_adding_transfertool_column_to_requests_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/fa7a7d78b602_increase_refresh_token_size.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/fa7a7d78b602_increase_refresh_token_size.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/fb28a95fe288_add_replicas_rse_id_tombstone_idx.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/fb28a95fe288_add_replicas_rse_id_tombstone_idx.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/fe1a65b176c9_set_third_party_copy_read_and_write_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/fe1a65b176c9_set_third_party_copy_read_and_write_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/migrate_repo/versions/fe8ea2fa9788_added_third_party_copy_column_to_rse_.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/fe8ea2fa9788_added_third_party_copy_column_to_rse_.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -182,7 +182,7 @@ def _ck_constraint_name(const, table):
         const.name = "REQUESTS_HISTORY_STATE_CHK"
 
 
-class ModelBase(object):
+class ModelBase:
     """Base class for Rucio Models"""
     __table_initialized__ = False
 

--- a/lib/rucio/db/sqla/sautils.py
+++ b/lib/rucio/db/sqla/sautils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/types.py
+++ b/lib/rucio/db/sqla/types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/db/sqla/util.py
+++ b/lib/rucio/db/sqla/util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/__init__.py
+++ b/lib/rucio/rse/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/__init__.py
+++ b/lib/rucio/rse/protocols/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/bittorrent.py
+++ b/lib/rucio/rse/protocols/bittorrent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/cache.py
+++ b/lib/rucio/rse/protocols/cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/dummy.py
+++ b/lib/rucio/rse/protocols/dummy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/globus.py
+++ b/lib/rucio/rse/protocols/globus.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/gsiftp.py
+++ b/lib/rucio/rse/protocols/gsiftp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/http_cache.py
+++ b/lib/rucio/rse/protocols/http_cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/mock.py
+++ b/lib/rucio/rse/protocols/mock.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/ngarc.py
+++ b/lib/rucio/rse/protocols/ngarc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/posix.py
+++ b/lib/rucio/rse/protocols/posix.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/posix.py
+++ b/lib/rucio/rse/protocols/posix.py
@@ -70,12 +70,12 @@ class Default(protocol.RSEProtocol):
          """
         try:
             shutil.copy(self.pfn2path(pfn), dest)
-        except IOError as e:
+        except OSError as e:
             try:  # To check if the error happend local or remote
                 with open(dest, 'wb'):
                     pass
                 call(['rm', '-rf', dest])
-            except IOError as e:
+            except OSError as e:
                 if e.errno == 2:
                     raise exception.DestinationNotAccessible(e)
                 else:
@@ -109,7 +109,7 @@ class Default(protocol.RSEProtocol):
             if not os.path.exists(dirs):
                 os.makedirs(dirs)
             shutil.copy(sf, target)
-        except IOError as e:
+        except OSError as e:
             if e.errno == 2:
                 raise exception.SourceNotFound(e)
             elif not self.exists(self.rse['prefix']):
@@ -151,7 +151,7 @@ class Default(protocol.RSEProtocol):
             if not os.path.exists(os.path.dirname(new_path)):
                 os.makedirs(os.path.dirname(new_path))
             os.rename(path, new_path)
-        except IOError as e:
+        except OSError as e:
             if e.errno == 2:
                 if self.exists(self.pfn2path(path)):
                     raise exception.SourceNotFound(e)

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -261,7 +261,7 @@ class RSEDeterministicTranslation(PolicyPackageAlgorithms):
 RSEDeterministicTranslation._module_init_()  # pylint: disable=protected-access
 
 
-class RSEProtocol(object):
+class RSEProtocol:
     """ This class is virtual and acts as a base to inherit new protocols from. It further provides some common functionality which applies for the amjority of the protocols."""
 
     def __init__(self, protocol_attr, rse_settings, logger=logging.log):

--- a/lib/rucio/rse/protocols/rclone.py
+++ b/lib/rucio/rse/protocols/rclone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/rfio.py
+++ b/lib/rucio/rse/protocols/rfio.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/srm.py
+++ b/lib/rucio/rse/protocols/srm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/ssh.py
+++ b/lib/rucio/rse/protocols/ssh.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/storm.py
+++ b/lib/rucio/rse/protocols/storm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/webdav.py
+++ b/lib/rucio/rse/protocols/webdav.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/protocols/webdav.py
+++ b/lib/rucio/rse/protocols/webdav.py
@@ -331,13 +331,13 @@ class Default(protocol.RSEProtocol):
                         raise exception.RucioException(result.status_code, result.text)
                 except requests.exceptions.ConnectionError as error:
                     raise exception.ServiceUnavailable(error)
-                except IOError as error:
+                except OSError as error:
                     raise exception.SourceNotFound(error)
         except requests.exceptions.ConnectionError as error:
             raise exception.ServiceUnavailable(error)
         except requests.exceptions.ReadTimeout as error:
             raise exception.ServiceUnavailable(error)
-        except IOError as error:
+        except OSError as error:
             raise exception.SourceNotFound(error)
 
     def rename(self, pfn, new_pfn):

--- a/lib/rucio/rse/protocols/webdav.py
+++ b/lib/rucio/rse/protocols/webdav.py
@@ -39,7 +39,7 @@ class TLSHTTPAdapter(HTTPAdapter):
                                        ca_cert_dir="/etc/grid-security/certificates")
 
 
-class UploadInChunks(object):
+class UploadInChunks:
     '''
     Class to upload by chunks.
     '''
@@ -72,7 +72,7 @@ class UploadInChunks(object):
         return self.__totalsize
 
 
-class IterableToFileAdapter(object):
+class IterableToFileAdapter:
     '''
     Class IterableToFileAdapter
     '''

--- a/lib/rucio/rse/protocols/xrootd.py
+++ b/lib/rucio/rse/protocols/xrootd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/tests/__init__.py
+++ b/lib/rucio/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/tests/common_server.py
+++ b/lib/rucio/tests/common_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/transfertool/__init__.py
+++ b/lib/rucio/transfertool/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/transfertool/bittorrent.py
+++ b/lib/rucio/transfertool/bittorrent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/transfertool/bittorrent_driver.py
+++ b/lib/rucio/transfertool/bittorrent_driver.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/transfertool/bittorrent_driver_qbittorrent.py
+++ b/lib/rucio/transfertool/bittorrent_driver_qbittorrent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -653,7 +653,7 @@ class FTS3CompletionMessageTransferStatusReport(Fts3TransferStatusReport):
         self._transfer_id = fts_message.get('tr_id').split("__")[-1]
 
         self._file_metadata = fts_message['file_metadata']
-        self._multi_sources = str(fts_message.get('job_metadata', {}).get('multi_sources', '')).lower() == str('true')
+        self._multi_sources = str(fts_message.get('job_metadata', {}).get('multi_sources', '')).lower() == 'true'
         self._src_url = fts_message.get('src_url', None)
         self._dst_url = fts_message.get('dst_url', None)
 
@@ -724,7 +724,7 @@ class FTS3ApiTransferStatusReport(Fts3TransferStatusReport):
         self._transfer_id = job_response.get('job_id')
 
         self._file_metadata = file_response['file_metadata']
-        self._multi_sources = str(job_response['job_metadata'].get('multi_sources', '')).lower() == str('true')
+        self._multi_sources = str(job_response['job_metadata'].get('multi_sources', '')).lower() == 'true'
         self._src_url = file_response.get('source_surl', None)
         self._dst_url = file_response.get('dest_surl', None)
         self.logger = logging.log

--- a/lib/rucio/transfertool/fts3_plugins.py
+++ b/lib/rucio/transfertool/fts3_plugins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/transfertool/globus.py
+++ b/lib/rucio/transfertool/globus.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/transfertool/globus_library.py
+++ b/lib/rucio/transfertool/globus_library.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/transfertool/mock.py
+++ b/lib/rucio/transfertool/mock.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/transfertool/transfertool.py
+++ b/lib/rucio/transfertool/transfertool.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/transfertool/transfertool.py
+++ b/lib/rucio/transfertool/transfertool.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from rucio.core.rse import RseData
 
 
-class TransferToolBuilder(object):
+class TransferToolBuilder:
     """
     Builder for Transfertool objects.
     Stores the parameters needed to create the Transfertool object of the given type/class.
@@ -53,7 +53,7 @@ class TransferToolBuilder(object):
         return self.transfertool_class(**all_kwargs)
 
 
-class TransferStatusReport(object, metaclass=ABCMeta):
+class TransferStatusReport(metaclass=ABCMeta):
     """
     Allows to compute the changes which have to be applied to the database
     to reflect the current status reported by the external transfertool into
@@ -113,7 +113,7 @@ class TransferStatusReport(object, metaclass=ABCMeta):
         return updates
 
 
-class Transfertool(object, metaclass=ABCMeta):
+class Transfertool(metaclass=ABCMeta):
     """
     Interface definition of the Rucio transfertool
     """

--- a/lib/rucio/version.py
+++ b/lib/rucio/version.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/__init__.py
+++ b/lib/rucio/web/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/__init__.py
+++ b/lib/rucio/web/rest/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/__init__.py
+++ b/lib/rucio/web/rest/flaskapi/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/authenticated_bp.py
+++ b/lib/rucio/web/rest/flaskapi/authenticated_bp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/__init__.py
+++ b/lib/rucio/web/rest/flaskapi/v1/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/archives.py
+++ b/lib/rucio/web/rest/flaskapi/v1/archives.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     HeadersType = Union[Headers, dict[str, str], Sequence[tuple[str, str]]]
 
 
-class CORSMiddleware(object):
+class CORSMiddleware:
     """
     WebUI 2.0 makes preflight requests to the API, which are not handled by the API.
     This middleware intercepts the preflight OPTIONS requests and returns a 200 OK response.

--- a/lib/rucio/web/rest/flaskapi/v1/config.py
+++ b/lib/rucio/web/rest/flaskapi/v1/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/credentials.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credentials.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/dirac.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dirac.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/export.py
+++ b/lib/rucio/web/rest/flaskapi/v1/export.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
+++ b/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/identities.py
+++ b/lib/rucio/web/rest/flaskapi/v1/identities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/import.py
+++ b/lib/rucio/web/rest/flaskapi/v1/import.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/locks.py
+++ b/lib/rucio/web/rest/flaskapi/v1/locks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/main.py
+++ b/lib/rucio/web/rest/flaskapi/v1/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/meta_conventions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/meta_conventions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/metrics.py
+++ b/lib/rucio/web/rest/flaskapi/v1/metrics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/nongrid_traces.py
+++ b/lib/rucio/web/rest/flaskapi/v1/nongrid_traces.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/ping.py
+++ b/lib/rucio/web/rest/flaskapi/v1/ping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/redirect.py
+++ b/lib/rucio/web/rest/flaskapi/v1/redirect.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/scopes.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scopes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/traces.py
+++ b/lib/rucio/web/rest/flaskapi/v1/traces.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/flaskapi/v1/vos.py
+++ b/lib/rucio/web/rest/flaskapi/v1/vos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/main.py
+++ b/lib/rucio/web/rest/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/metrics.py
+++ b/lib/rucio/web/rest/metrics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/rest/ping.py
+++ b/lib/rucio/web/rest/ping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/ui/__init__.py
+++ b/lib/rucio/web/ui/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/ui/flask/__init__.py
+++ b/lib/rucio/web/ui/flask/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/ui/flask/bp.py
+++ b/lib/rucio/web/ui/flask/bp.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/ui/flask/common/__init__.py
+++ b/lib/rucio/web/ui/flask/common/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/ui/flask/common/utils.py
+++ b/lib/rucio/web/ui/flask/common/utils.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/ui/flask/main.py
+++ b/lib/rucio/web/ui/flask/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/rucio/web/ui/main.py
+++ b/lib/rucio/web/ui/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,18 @@ exclude = [
 [tool.ruff.lint]
 select = [
     "I", # isort
+    "UP", # pyupgrade
 ]
 
 ignore = [
     "ALL",
+    "UP008", # Use `super()` instead of `super(__class__, self)`
+    "UP015", # Unnecessary open mode parameters
+    "UP027", # Replace unpacked list comprehension with a generator expression
+    "UP028", # Replace `yield` over `for` loop with `yield from`
+    "UP030", # Use implicit references for positional format fields
     "UP031", # Use format specifiers instead of percent format
+    "UP032", # Use f-string instead of `format` call
     "SIM210", 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 line-length = 256
 
+extend-include = [
+    "bin/*",
+]
+
 # Exclude a variety of commonly ignored directories.
 exclude = [
     ".bzr",
@@ -50,7 +54,5 @@ ignore = [
     "UP030", # Use implicit references for positional format fields
     "UP031", # Use format specifiers instead of percent format
     "UP032", # Use f-string instead of `format` call
-    "SIM210", 
+    "SIM210",
 ]
-
-extend-safe-fixes = ["I001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,6 @@ ignore = [
     "UP032", # Use f-string instead of `format` call
     "SIM210",
 ]
+
+[tool.ruff.lint.isort]
+known-first-party = ["rucio"]

--- a/setup_rucio.py
+++ b/setup_rucio.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setup_rucio_client.py
+++ b/setup_rucio_client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setup_webui.py
+++ b/setup_webui.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setuputil.py
+++ b/setuputil.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,7 @@ def download_client():
 @pytest.fixture
 def rest_client():
     from flask.testing import FlaskClient
+
     from rucio.tests.common import print_response
     from rucio.web.rest.flaskapi.v1.main import application
 
@@ -393,12 +394,13 @@ def __create_in_memory_db_table(name, *columns, **kwargs):
     """
     import datetime
 
-    from rucio.db.sqla.models import ModelBase
-    from rucio.db.sqla.session import create_engine, get_maker
     from sqlalchemy import CheckConstraint, Column, DateTime
     from sqlalchemy.orm import registry
     from sqlalchemy.pool import StaticPool
     from sqlalchemy.schema import Table
+
+    from rucio.db.sqla.models import ModelBase
+    from rucio.db.sqla.session import create_engine, get_maker
 
     engine = create_engine('sqlite://', connect_args={'check_same_thread': False}, poolclass=StaticPool)
 
@@ -438,9 +440,10 @@ def message_mock():
     """
     from unittest import mock
 
+    from sqlalchemy import Column
+
     from rucio.common.utils import generate_uuid
     from rucio.db.sqla.models import GUID, CheckConstraint, Index, PrimaryKeyConstraint, String, Text
-    from sqlalchemy import Column
 
     InMemoryMessage = __create_in_memory_db_table(
         'message_' + generate_uuid(),
@@ -473,10 +476,11 @@ def core_config_mock(request):
     """
     from unittest import mock
 
+    from sqlalchemy import Column
+
     from rucio.common.utils import generate_uuid
     from rucio.db.sqla.models import PrimaryKeyConstraint, String
     from rucio.db.sqla.session import get_session
-    from sqlalchemy import Column
 
     # Get the fixture parameters
     table_content = []

--- a/tests/inputs/__init__.py
+++ b/tests/inputs/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/lfn2pfn_module_test.py
+++ b/tests/lfn2pfn_module_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/mocks/gfal2.py
+++ b/tests/mocks/gfal2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/mocks/gfal2.py
+++ b/tests/mocks/gfal2.py
@@ -15,13 +15,13 @@
 import contextlib
 
 
-class MockGfal2(object):
+class MockGfal2:
     """
     This is a mock gfal2 to test the Storage dumper
     """
     files = {}
 
-    class MockContext(object):
+    class MockContext:
         '''
         MockContext
         '''

--- a/tests/mocks/mock_http_server.py
+++ b/tests/mocks/mock_http_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/rsemgr_api_test.py
+++ b/tests/rsemgr_api_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/rsemgr_api_test.py
+++ b/tests/rsemgr_api_test.py
@@ -20,6 +20,7 @@ import tempfile
 from uuid import uuid4 as uuid
 
 import pytest
+
 from rucio.common import exception
 from rucio.common.utils import adler32, md5
 from rucio.rse import rsemanager as mgr

--- a/tests/ruciopytest/__init__.py
+++ b/tests/ruciopytest/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/ruciopytest/artifacts_plugin.py
+++ b/tests/ruciopytest/artifacts_plugin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/ruciopytest/xdist_noparallel_remote.py
+++ b/tests/ruciopytest/xdist_noparallel_remote.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/ruciopytest/xdist_noparallel_scheduler.py
+++ b/tests/ruciopytest/xdist_noparallel_scheduler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/temp_factories.py
+++ b/tests/temp_factories.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/temp_factories.py
+++ b/tests/temp_factories.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from random import choice
 from string import ascii_uppercase
 
+from sqlalchemy import and_, delete, or_
+
 from rucio.client.client import Client
 from rucio.client.uploadclient import UploadClient
 from rucio.common.schema import get_schema_value
@@ -30,7 +32,6 @@ from rucio.db.sqla.constants import DIDType
 from rucio.db.sqla.session import transactional_session
 from rucio.tests.common import did_name_generator
 from rucio.tests.common_server import cleanup_db_deps
-from sqlalchemy import and_, delete, or_
 
 
 def _to_external(did):

--- a/tests/test_abacus_account.py
+++ b/tests/test_abacus_account.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_abacus_account.py
+++ b/tests/test_abacus_account.py
@@ -26,7 +26,7 @@ from rucio.db.sqla.session import get_session
 
 
 @pytest.mark.noparallel(reason='uses daemon, failing in parallel to other tests, updates account')
-class TestAbacusAccount2():
+class TestAbacusAccount2:
 
     def test_abacus_account(self, vo, root_account, mock_scope, rse_factory, did_factory, rucio_client):
         """ ABACUS (ACCOUNT): Test update of account usage """

--- a/tests/test_abacus_account.py
+++ b/tests/test_abacus_account.py
@@ -14,6 +14,7 @@
 
 
 import pytest
+
 from rucio.common.schema import get_schema_value
 from rucio.core.account import get_usage_history
 from rucio.core.account_counter import update_account_counter_history

--- a/tests/test_abacus_collection_replica.py
+++ b/tests/test_abacus_collection_replica.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_abacus_collection_replica.py
+++ b/tests/test_abacus_collection_replica.py
@@ -28,7 +28,7 @@ from rucio.tests.common import did_name_generator
 
 
 @pytest.mark.noparallel(reason='uses daemons, fails when run in parallel')
-class TestAbacusCollectionReplica():
+class TestAbacusCollectionReplica:
 
     def test_abacus_collection_replica_cleanup(self, vo, mock_scope, rse_factory, did_client, jdoe_account):
         """ ABACUS (COLLECTION REPLICA): Test if the cleanup procedure works correctly. """

--- a/tests/test_abacus_collection_replica.py
+++ b/tests/test_abacus_collection_replica.py
@@ -14,6 +14,7 @@
 
 
 import pytest
+
 from rucio.common.exception import DataIdentifierNotFound
 from rucio.common.schema import get_schema_value
 from rucio.core.did import add_did, get_did

--- a/tests/test_abacus_rse.py
+++ b/tests/test_abacus_rse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_abacus_rse.py
+++ b/tests/test_abacus_rse.py
@@ -23,7 +23,7 @@ from rucio.db.sqla.session import get_session
 
 
 @pytest.mark.noparallel(reason='uses daemon, failing in parallel to other tests')
-class TestAbacusRSE():
+class TestAbacusRSE:
 
     def test_abacus_rse(self, vo, mock_scope, rse_factory, did_factory, rucio_client):
         """ ABACUS (RSE): Test update of RSE usage. """

--- a/tests/test_abacus_rse.py
+++ b/tests/test_abacus_rse.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from rucio.common.schema import get_schema_value
 from rucio.core.rse import get_rse_usage
 from rucio.daemons.abacus.rse import rse_update

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -15,6 +15,7 @@
 from json import loads
 
 import pytest
+
 from rucio.api.account import account_exists, add_account, del_account, get_account_info, update_account
 from rucio.common.config import config_get
 from rucio.common.exception import AccountNotFound, Duplicate, InvalidObject

--- a/tests/test_account_limits.py
+++ b/tests/test_account_limits.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_account_limits.py
+++ b/tests/test_account_limits.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from rucio.core import account_limit
 
 

--- a/tests/test_api_external_representation.py
+++ b/tests/test_api_external_representation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_api_external_representation.py
+++ b/tests/test_api_external_representation.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from json import loads
 
 import pytest
+
 import rucio.api.account_limit as api_acc_lim
 import rucio.api.rse as api_rse
 import rucio.core.account_counter as account_counter

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta
 from unittest import mock
 
 import pytest
+
 from rucio.daemons import auditor
 
 

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -106,7 +106,7 @@ def test_auditor_check_survives_failures_and_queues_failed_rses(mock_auditor):
         lambda: None,
     )
 
-    class MockMultiProcessing():
+    class MockMultiProcessing:
         def is_set(self):
             return queue.empty()
     terminate = MockMultiProcessing()

--- a/tests/test_auditor_hdfs.py
+++ b/tests/test_auditor_hdfs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_auditor_hdfs.py
+++ b/tests/test_auditor_hdfs.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
+
 from rucio.daemons.auditor import hdfs
 
 

--- a/tests/test_auditor_hdfs.py
+++ b/tests/test_auditor_hdfs.py
@@ -21,7 +21,7 @@ import pytest
 from rucio.daemons.auditor import hdfs
 
 
-class FakeHDFSGet(object):
+class FakeHDFSGet:
     def __init__(self, files=[]):
         self.files = files
 

--- a/tests/test_auditor_srmdumps.py
+++ b/tests/test_auditor_srmdumps.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_auditor_srmdumps.py
+++ b/tests/test_auditor_srmdumps.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
+
 from rucio.daemons.auditor import srmdumps
 
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -18,6 +18,7 @@ import time
 
 import pytest
 from requests import session
+
 from rucio.api.authentication import get_auth_token_saml, get_auth_token_ssh, get_auth_token_user_pass, get_ssh_challenge_token
 from rucio.common.exception import AccessDenied, CannotAuthenticate, Duplicate
 from rucio.common.utils import ssh_sign

--- a/tests/test_automatix.py
+++ b/tests/test_automatix.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_automatix.py
+++ b/tests/test_automatix.py
@@ -19,6 +19,7 @@ from random import choice
 from string import ascii_uppercase
 
 import pytest
+
 from rucio.common.config import config_add_section, config_has_section, config_remove_option, config_set
 from rucio.common.types import InternalScope
 from rucio.core.did import get_metadata, list_dids, list_files

--- a/tests/test_bad_replica.py
+++ b/tests/test_bad_replica.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_bad_replica.py
+++ b/tests/test_bad_replica.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 from json import dumps, loads
 
 import pytest
+
 from rucio.client.rseclient import RSEClient
 from rucio.common.exception import InvalidType, RucioException, UnsupportedOperation
 from rucio.common.utils import clean_surls, generate_uuid

--- a/tests/test_bb8.py
+++ b/tests/test_bb8.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_bb8.py
+++ b/tests/test_bb8.py
@@ -15,6 +15,7 @@
 from datetime import datetime, timedelta
 
 import pytest
+
 from rucio.common.exception import RuleNotFound, UnsupportedOperation
 from rucio.core.account_limit import set_local_account_limit
 from rucio.core.did import attach_dids, set_metadata, set_status

--- a/tests/test_belleii.py
+++ b/tests/test_belleii.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_belleii.py
+++ b/tests/test_belleii.py
@@ -15,6 +15,7 @@
 from datetime import datetime
 
 import pytest
+
 from rucio.common.exception import InvalidObject
 from rucio.common.schema.belleii import validate_schema
 from rucio.common.utils import extract_scope, generate_uuid

--- a/tests/test_bin_rucio.py
+++ b/tests/test_bin_rucio.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_bin_rucio.py
+++ b/tests/test_bin_rucio.py
@@ -20,6 +20,7 @@ from datetime import datetime, timedelta
 from os import environ, listdir, path, remove, rmdir, stat, unlink
 
 import pytest
+
 from rucio.client.accountlimitclient import AccountLimitClient
 from rucio.client.configclient import ConfigClient
 from rucio.client.didclient import DIDClient

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -16,12 +16,12 @@ from datetime import datetime, timedelta
 from os import rename
 
 import pytest
+
 from rucio.client.baseclient import BaseClient
 from rucio.client.client import Client
 from rucio.common.config import Config, config_get, config_set
 from rucio.common.exception import CannotAuthenticate, ClientProtocolNotSupported, RucioException
 from rucio.common.utils import execute
-
 from tests.mocks.mock_http_server import MockServer
 
 

--- a/tests/test_common_types.py
+++ b/tests/test_common_types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 import rucio.core.config as core_config
 from rucio.client.configclient import ConfigClient
 from rucio.common import exception

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -20,6 +20,8 @@ from unittest.mock import patch
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import pytest
+from sqlalchemy import update
+
 import rucio.daemons.reaper.reaper
 from rucio.common.exception import ReplicaNotFound, RequestNotFound
 from rucio.common.types import InternalAccount
@@ -48,8 +50,6 @@ from rucio.db.sqla.constants import LockState, ReplicaState, RequestState, Reque
 from rucio.db.sqla.session import read_session, transactional_session
 from rucio.tests.common import skip_rse_tests_with_accounts
 from rucio.transfertool.fts3 import FTS3Transfertool
-from sqlalchemy import update
-
 from tests.mocks.mock_http_server import MockServer
 from tests.ruciopytest import NoParallelGroups
 

--- a/tests/test_conveyor_submitter.py
+++ b/tests/test_conveyor_submitter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_conveyor_submitter.py
+++ b/tests/test_conveyor_submitter.py
@@ -18,6 +18,8 @@ from random import randint
 from unittest.mock import patch
 
 import pytest
+from sqlalchemy import delete
+
 from rucio.common.exception import RequestNotFound
 from rucio.core import config as core_config
 from rucio.core import distance as distance_core
@@ -30,8 +32,6 @@ from rucio.daemons.reaper.reaper import reaper
 from rucio.db.sqla.constants import RequestState
 from rucio.db.sqla.models import Request, Source
 from rucio.db.sqla.session import read_session, transactional_session
-from sqlalchemy import delete
-
 from tests.ruciopytest import NoParallelGroups
 
 

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -15,6 +15,7 @@ import random
 from time import sleep
 
 import pytest
+
 from rucio.core import account_counter, rse_counter
 from rucio.core.account import get_usage
 from rucio.daemons.abacus.account import account_update

--- a/tests/test_credential.py
+++ b/tests/test_credential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_credential.py
+++ b/tests/test_credential.py
@@ -15,6 +15,7 @@
 import os
 
 import pytest
+
 from rucio.common.exception import UnsupportedOperation
 from rucio.core.credential import get_signed_url
 from rucio.core.replica import add_replicas

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -16,6 +16,7 @@ import json
 import os
 
 import pytest
+
 from rucio.common.config import config_get, config_get_bool
 from rucio.tests.common import account_name_generator, execute, get_long_vo, rse_name_generator
 

--- a/tests/test_daemons.py
+++ b/tests/test_daemons.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_daemons.py
+++ b/tests/test_daemons.py
@@ -15,6 +15,7 @@
 from unittest import mock
 
 import pytest
+
 import rucio.db.sqla.util
 from rucio.common import exception
 from rucio.daemons.abacus import account, collection_replica, rse

--- a/tests/test_dataset_replicas.py
+++ b/tests/test_dataset_replicas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_dataset_replicas.py
+++ b/tests/test_dataset_replicas.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import pytest
+from sqlalchemy.orm.exc import NoResultFound
+
 from rucio.client.didclient import DIDClient
 from rucio.client.replicaclient import ReplicaClient
 from rucio.client.ruleclient import RuleClient
@@ -24,7 +26,6 @@ from rucio.core.rse import add_protocol, add_rse, del_rse, get_rse_id
 from rucio.db.sqla import constants, models
 from rucio.db.sqla.constants import ReplicaState
 from rucio.tests.common import did_name_generator, rse_name_generator
-from sqlalchemy.orm.exc import NoResultFound
 
 
 class TestDatasetReplicaClient:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -15,9 +15,10 @@
 from unittest.mock import patch
 
 import pytest
+from sqlalchemy import text
+
 from rucio.common.exception import InputValidationError
 from rucio.db.sqla.session import NullPool, QueuePool, SingletonThreadPool, _get_engine_poolclass, get_session
-from sqlalchemy import text
 
 
 def test_db_connection():

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -15,6 +15,7 @@
 from datetime import datetime, timedelta
 
 import pytest
+
 from rucio.api import did, scope
 from rucio.common import exception
 from rucio.common.exception import DataIdentifierAlreadyExists, DataIdentifierNotFound, FileAlreadyExists, FileConsistencyMismatch, InvalidPath, ScopeNotFound, UnsupportedOperation, UnsupportedStatus

--- a/tests/test_did_meta_plugins.py
+++ b/tests/test_did_meta_plugins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_did_meta_plugins.py
+++ b/tests/test_did_meta_plugins.py
@@ -15,6 +15,7 @@
 from copy import deepcopy
 
 import pytest
+
 from rucio.client.didclient import DIDClient
 from rucio.common.exception import KeyNotFound
 from rucio.common.utils import generate_uuid

--- a/tests/test_didtype.py
+++ b/tests/test_didtype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -21,6 +21,7 @@ from unittest.mock import ANY, MagicMock, patch
 from zipfile import ZipFile
 
 import pytest
+
 from rucio.client.downloadclient import DownloadClient, FileDownloadState
 from rucio.common.config import config_add_section, config_set
 from rucio.common.exception import InputValidationError, NoFilesDownloaded, RucioException

--- a/tests/test_dumper.py
+++ b/tests/test_dumper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_dumper.py
+++ b/tests/test_dumper.py
@@ -22,6 +22,7 @@ from unittest import mock
 
 import pytest
 import requests
+
 from rucio.common import config, dumper
 from rucio.tests.common import make_temp_file, mock_open
 

--- a/tests/test_dumper.py
+++ b/tests/test_dumper.py
@@ -83,7 +83,7 @@ def test_smart_open_for_bz2_file():
     fd, path = tempfile.mkstemp()
     comp = bz2.BZ2Compressor()
     with os.fdopen(fd, 'wb') as f:
-        f.write(comp.compress('abcdef'.encode()))
+        f.write(comp.compress(b'abcdef'))
         f.write(comp.flush())
     assert not isinstance(dumper.smart_open(path), bz2.BZ2File)
     os.unlink(path)

--- a/tests/test_dumper_consistency.py
+++ b/tests/test_dumper_consistency.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_dumper_data_model.py
+++ b/tests/test_dumper_data_model.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_dumper_data_model.py
+++ b/tests/test_dumper_data_model.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 import pytest
 import requests
+
 from rucio.common import dumper
 from rucio.common.dumper import data_models
 

--- a/tests/test_dumper_data_model.py
+++ b/tests/test_dumper_data_model.py
@@ -214,7 +214,7 @@ CERN-PROD_DATADISK	data12_8TeV	ESD.04972924._000218.pool.root.1	a6152bbc	2498690
             )
 
 
-class TestCompleteDataset(object):
+class TestCompleteDataset:
 
     @staticmethod
     def test_creation_with_7_parameters():
@@ -261,7 +261,7 @@ class TestCompleteDataset(object):
         assert complete_dataset.size is None  # pylint: disable=no-member
 
 
-class TestReplica(object):
+class TestReplica:
 
     @staticmethod
     def test_replica_with_8_parameters():

--- a/tests/test_dumper_path_parsing.py
+++ b/tests/test_dumper_path_parsing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_dumper_path_parsing.py
+++ b/tests/test_dumper_path_parsing.py
@@ -15,7 +15,7 @@
 from rucio.common.dumper.path_parsing import components, remove_prefix
 
 
-class TestPathParsing(object):
+class TestPathParsing:
     def test_remove_prefix(self):
         prefix = ['a', 'b', 'c', 'd']
 

--- a/tests/test_filter_engine.py
+++ b/tests/test_filter_engine.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_filter_engine.py
+++ b/tests/test_filter_engine.py
@@ -17,6 +17,7 @@ import unittest
 from datetime import datetime, timedelta
 
 import pytest
+
 from rucio.common.exception import DuplicateCriteriaInDIDFilter
 from rucio.common.utils import generate_uuid
 from rucio.core.did import add_did

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -17,6 +17,7 @@ import threading
 from datetime import datetime, timedelta
 
 import pytest
+
 from rucio.core.heartbeat import cardiac_arrest, die, list_heartbeats, list_payload_counts, live, sanity_check
 from rucio.db.sqla.models import Heartbeats
 from rucio.db.sqla.session import transactional_session

--- a/tests/test_hermes.py
+++ b/tests/test_hermes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_hermes.py
+++ b/tests/test_hermes.py
@@ -23,6 +23,7 @@ from json import loads
 import pytest
 import requests
 import stomp
+
 from rucio.common.config import config_get, config_get_int
 from rucio.core.message import add_message, retrieve_messages, truncate_messages
 from rucio.daemons.hermes import hermes

--- a/tests/test_hermes.py
+++ b/tests/test_hermes.py
@@ -29,7 +29,7 @@ from rucio.daemons.hermes import hermes
 from rucio.tests.common import rse_name_generator, skip_missing_elasticsearch_influxdb_in_env
 
 
-class MyListener(object):
+class MyListener:
     def __init__(self, conn):
         self.conn = conn
         self.count = 0

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -16,6 +16,7 @@ import random
 import string
 
 import pytest
+
 from rucio.common.config import config_get_bool
 from rucio.common.exception import IdentityError, IdentityNotFound
 from rucio.common.types import InternalAccount

--- a/tests/test_impl_upload_download.py
+++ b/tests/test_impl_upload_download.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_impl_upload_download.py
+++ b/tests/test_impl_upload_download.py
@@ -16,6 +16,7 @@ import re
 from os import path
 
 import pytest
+
 from rucio.common.utils import execute
 from rucio.common.utils import generate_uuid as uuid
 from rucio.tests.common import skip_rse_tests_with_accounts

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -15,6 +15,7 @@
 from copy import deepcopy
 
 import pytest
+
 from rucio.client.exportclient import ExportClient
 from rucio.client.importclient import ImportClient
 from rucio.common.config import config_add_section, config_has_section, config_set

--- a/tests/test_judge_cleaner.py
+++ b/tests/test_judge_cleaner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_judge_cleaner.py
+++ b/tests/test_judge_cleaner.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid

--- a/tests/test_judge_evaluator.py
+++ b/tests/test_judge_evaluator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_judge_evaluator.py
+++ b/tests/test_judge_evaluator.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING
 
 import pytest
+
 from rucio.common.config import config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid as uuid

--- a/tests/test_judge_injector.py
+++ b/tests/test_judge_injector.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_judge_injector.py
+++ b/tests/test_judge_injector.py
@@ -15,6 +15,7 @@
 from datetime import datetime, timedelta
 
 import pytest
+
 from rucio.common.config import config_get_bool
 from rucio.common.exception import RuleNotFound
 from rucio.common.types import InternalAccount, InternalScope

--- a/tests/test_judge_repairer.py
+++ b/tests/test_judge_repairer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_judge_repairer.py
+++ b/tests/test_judge_repairer.py
@@ -17,6 +17,7 @@ from hashlib import sha256
 
 import pytest
 from dogpile.cache import make_region
+
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.account_limit import set_local_account_limit

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -18,6 +18,7 @@ from configparser import NoSectionError
 from datetime import datetime, timedelta
 
 import pytest
+
 from rucio.common.exception import ConfigNotFound, UnsupportedOperation
 from rucio.common.policy import REGION
 from rucio.common.utils import generate_uuid as uuid

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -17,6 +17,7 @@ import random
 import string
 
 import pytest
+
 from rucio.common.constants import MAX_MESSAGE_LENGTH
 from rucio.common.exception import InvalidObject, RucioException
 from rucio.common.utils import generate_uuid

--- a/tests/test_meta_conventions.py
+++ b/tests/test_meta_conventions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_meta_conventions.py
+++ b/tests/test_meta_conventions.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from rucio.common.exception import InvalidValueForKey, RucioException, UnsupportedKeyType, UnsupportedValueType
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.meta_conventions import add_key

--- a/tests/test_meta_did.py
+++ b/tests/test_meta_did.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_meta_did.py
+++ b/tests/test_meta_did.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from rucio.common.utils import generate_uuid as uuid
 
 

--- a/tests/test_module_import.py
+++ b/tests/test_module_import.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_module_import.py
+++ b/tests/test_module_import.py
@@ -15,7 +15,7 @@
 from rucio.common.utils import execute
 
 
-class TestModuleImport():
+class TestModuleImport:
     def test_import(self):
         """ """
         cmd = 'rucio --version'

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_multi_vo.py
+++ b/tests/test_multi_vo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_multi_vo.py
+++ b/tests/test_multi_vo.py
@@ -23,6 +23,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 from oic import rndstr
+
 from rucio.api import vo as vo_api
 from rucio.api.account import add_account, list_accounts
 from rucio.api.account_limit import set_local_account_limit

--- a/tests/test_naming_convention.py
+++ b/tests/test_naming_convention.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_naming_convention.py
+++ b/tests/test_naming_convention.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from rucio.common.exception import InvalidObject
 from rucio.common.types import InternalScope
 from rucio.common.utils import generate_uuid

--- a/tests/test_oauthmanager.py
+++ b/tests/test_oauthmanager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_oauthmanager.py
+++ b/tests/test_oauthmanager.py
@@ -18,11 +18,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from oic import rndstr
+from sqlalchemy import and_, or_
+from sqlalchemy.sql.expression import true
+
 from rucio.daemons.oauthmanager.oauthmanager import run, stop
 from rucio.db.sqla import models
 from rucio.db.sqla.session import get_session
-from sqlalchemy import and_, or_
-from sqlalchemy.sql.expression import true
 
 new_token_dict = {'access_token': '',
                   'expires_in': 3599,

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -22,6 +22,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from jwkest.jwt import JWT
 from oic import rndstr
+
 from rucio.common.config import config_get_bool
 from rucio.common.exception import CannotAuthenticate, DatabaseException, Duplicate
 from rucio.common.types import InternalAccount

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -185,7 +185,7 @@ class MockADMINClientISSOIDC(MagicMock):
         return None
 
 
-class MockResponse(object):
+class MockResponse:
     def __init__(self, json_data):
         self.json_data = json_data
 

--- a/tests/test_permission.py
+++ b/tests/test_permission.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_pfns.py
+++ b/tests/test_pfns.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_preparer.py
+++ b/tests/test_preparer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_preparer.py
+++ b/tests/test_preparer.py
@@ -14,6 +14,7 @@
 
 
 import pytest
+
 from rucio.core.distance import add_distance, get_distances
 from rucio.core.replica import add_replicas
 from rucio.core.request import get_request, list_and_mark_transfer_requests_and_source_replicas, list_transfer_limits, set_transfer_limit

--- a/tests/test_qos.py
+++ b/tests/test_qos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_quarantined_replica.py
+++ b/tests/test_quarantined_replica.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_quarantined_replica.py
+++ b/tests/test_quarantined_replica.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from rucio.common.config import config_get_bool
 from rucio.common.utils import generate_uuid
 from rucio.core.quarantined_replica import add_quarantined_replicas, delete_quarantined_replicas, list_quarantined_replicas

--- a/tests/test_reaper.py
+++ b/tests/test_reaper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_reaper.py
+++ b/tests/test_reaper.py
@@ -15,6 +15,8 @@
 from datetime import datetime, timedelta
 
 import pytest
+from sqlalchemy import and_, or_
+
 from rucio.api import replica as replica_api
 from rucio.api import rse as rse_api
 from rucio.common.exception import DataIdentifierNotFound, ReplicaNotFound
@@ -33,8 +35,6 @@ from rucio.db.sqla.constants import OBSOLETE
 from rucio.db.sqla.models import ConstituentAssociationHistory
 from rucio.db.sqla.session import get_session, read_session
 from rucio.tests.common import rse_name_generator, skip_rse_tests_with_accounts
-from sqlalchemy import and_, or_
-
 from tests.ruciopytest import NoParallelGroups
 
 __mock_protocol = {'scheme': 'MOCK',

--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -23,6 +23,8 @@ from xml.etree import ElementTree
 
 import pytest
 import xmltodict
+from werkzeug.datastructures import Headers, MultiDict
+
 from rucio.client.ruleclient import RuleClient
 from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifierNotFound, InputValidationError, ReplicaIsLocked, ReplicaNotFound, RucioException, ScopeNotFound
 from rucio.common.schema import get_schema_value
@@ -38,7 +40,6 @@ from rucio.db.sqla.constants import OBSOLETE, BadPFNStatus, DIDType, ReplicaStat
 from rucio.db.sqla.session import transactional_session
 from rucio.rse import rsemanager as rsemgr
 from rucio.tests.common import Mime, accept, auth, did_name_generator, execute, headers
-from werkzeug.datastructures import Headers, MultiDict
 
 if TYPE_CHECKING:
     from .temp_factories import TemporaryRSEFactory

--- a/tests/test_replica_recoverer.py
+++ b/tests/test_replica_recoverer.py
@@ -19,6 +19,7 @@ from os import remove
 from time import sleep
 
 import pytest
+
 from rucio.core import rse_expression_parser
 from rucio.core.did import set_metadata
 from rucio.core.replica import list_bad_replicas_status, list_replicas, update_replica_state

--- a/tests/test_replica_recoverer.py
+++ b/tests/test_replica_recoverer.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_replica_sorting.py
+++ b/tests/test_replica_sorting.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_replica_sorting.py
+++ b/tests/test_replica_sorting.py
@@ -21,6 +21,7 @@ from urllib.parse import urlparse
 
 import geoip2.database
 import pytest
+
 from rucio.common.config import config_get
 from rucio.common.utils import parse_replicas_from_string
 from rucio.core import replica_sorter, rse_expression_parser

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from typing import Union
 
 import pytest
+
 from rucio.common.config import config_get_bool
 from rucio.common.utils import generate_uuid, parse_response
 from rucio.core.distance import add_distance

--- a/tests/test_root_proxy.py
+++ b/tests/test_root_proxy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_root_proxy.py
+++ b/tests/test_root_proxy.py
@@ -15,6 +15,7 @@
 from urllib.parse import urlencode
 
 import pytest
+
 from rucio.core.config import set as config_set
 from rucio.core.replica import add_replicas, delete_replicas
 from rucio.core.rse import add_protocol, add_rse, add_rse_attribute, del_rse

--- a/tests/test_rse.py
+++ b/tests/test_rse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse.py
+++ b/tests/test_rse.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from rucio.client.replicaclient import ReplicaClient
 from rucio.common import exception
 from rucio.common.exception import Duplicate, InputValidationError, InvalidObject, ResourceTemporaryUnavailable, RSEAttributeNotFound, RSENotFound, RSEOperationNotSupported, RSEProtocolNotSupported

--- a/tests/test_rse_expression_parser.py
+++ b/tests/test_rse_expression_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_expression_parser.py
+++ b/tests/test_rse_expression_parser.py
@@ -16,6 +16,7 @@ from random import choice
 from string import ascii_lowercase, ascii_uppercase
 
 import pytest
+
 from rucio.common.exception import InvalidRSEExpression, RSEWriteBlocked
 from rucio.core import rse, rse_expression_parser
 

--- a/tests/test_rse_lfn2path.py
+++ b/tests/test_rse_lfn2path.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_lfn2path.py
+++ b/tests/test_rse_lfn2path.py
@@ -17,6 +17,7 @@ import os
 from configparser import NoOptionError, NoSectionError
 
 import pytest
+
 from rucio.common import config
 from rucio.rse.protocols.protocol import RSEDeterministicTranslation
 

--- a/tests/test_rse_protocol_gfal2.py
+++ b/tests/test_rse_protocol_gfal2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_protocol_gfal2.py
+++ b/tests/test_rse_protocol_gfal2.py
@@ -15,6 +15,7 @@
 import os
 
 import pytest
+
 from rucio.common.utils import execute
 from rucio.rse import rsemanager as mgr
 from rucio.tests.common import load_test_conf_file, skip_rse_tests_with_accounts

--- a/tests/test_rse_protocol_gfal2_impl.py
+++ b/tests/test_rse_protocol_gfal2_impl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_protocol_gfal2_impl.py
+++ b/tests/test_rse_protocol_gfal2_impl.py
@@ -15,6 +15,7 @@
 import os
 
 import pytest
+
 from rucio.common.utils import execute
 from rucio.rse import rsemanager
 from rucio.tests.common import load_test_conf_file, skip_rse_tests_with_accounts

--- a/tests/test_rse_protocol_posix.py
+++ b/tests/test_rse_protocol_posix.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_protocol_posix.py
+++ b/tests/test_rse_protocol_posix.py
@@ -16,6 +16,7 @@ import os
 import shutil
 
 import pytest
+
 from rucio.rse import rsemanager as mgr
 from rucio.tests.common import load_test_conf_file, skip_rse_tests_with_accounts
 

--- a/tests/test_rse_protocol_rclone.py
+++ b/tests/test_rse_protocol_rclone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_protocol_rclone.py
+++ b/tests/test_rse_protocol_rclone.py
@@ -15,6 +15,7 @@
 import os
 
 import pytest
+
 from rucio.common.utils import PREFERRED_CHECKSUM, execute, set_preferred_checksum
 from rucio.rse import rsemanager
 from rucio.tests.common import load_test_conf_file, skip_rse_tests_with_accounts

--- a/tests/test_rse_protocol_rsync.py
+++ b/tests/test_rse_protocol_rsync.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_protocol_rsync.py
+++ b/tests/test_rse_protocol_rsync.py
@@ -15,6 +15,7 @@
 import os
 
 import pytest
+
 from rucio.common.utils import PREFERRED_CHECKSUM, execute, set_preferred_checksum
 from rucio.rse import rsemanager
 from rucio.tests.common import load_test_conf_file, skip_rse_tests_with_accounts

--- a/tests/test_rse_protocol_srm.py
+++ b/tests/test_rse_protocol_srm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_protocol_srm.py
+++ b/tests/test_rse_protocol_srm.py
@@ -15,6 +15,7 @@
 import os
 
 import pytest
+
 from rucio.common.utils import execute
 from rucio.rse import rsemanager as mgr
 from rucio.tests.common import load_test_conf_file, skip_rse_tests_with_accounts

--- a/tests/test_rse_protocol_ssh.py
+++ b/tests/test_rse_protocol_ssh.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_protocol_ssh.py
+++ b/tests/test_rse_protocol_ssh.py
@@ -15,6 +15,7 @@
 import os
 
 import pytest
+
 from rucio.common.utils import PREFERRED_CHECKSUM, execute, set_preferred_checksum
 from rucio.rse import rsemanager
 from rucio.tests.common import load_test_conf_file, skip_rse_tests_with_accounts

--- a/tests/test_rse_protocol_webdav.py
+++ b/tests/test_rse_protocol_webdav.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_protocol_webdav.py
+++ b/tests/test_rse_protocol_webdav.py
@@ -16,6 +16,7 @@ import os
 
 import pytest
 import requests
+
 from rucio.common.exception import FileReplicaAlreadyExists
 from rucio.rse import rsemanager
 from rucio.tests.common import load_test_conf_file, skip_rse_tests_with_accounts

--- a/tests/test_rse_protocol_xrootd.py
+++ b/tests/test_rse_protocol_xrootd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_protocol_xrootd.py
+++ b/tests/test_rse_protocol_xrootd.py
@@ -15,6 +15,7 @@
 import os
 
 import pytest
+
 from rucio.common.utils import execute
 from rucio.rse import rsemanager
 from rucio.tests.common import load_test_conf_file, skip_rse_tests_with_accounts

--- a/tests/test_rse_selector.py
+++ b/tests/test_rse_selector.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rse_selector.py
+++ b/tests/test_rse_selector.py
@@ -14,6 +14,7 @@
 
 
 import pytest
+
 from rucio.common.exception import InsufficientAccountLimit, InsufficientTargetRSEs
 from rucio.core.account_counter import increase, update_account_counter
 from rucio.core.account_limit import set_global_account_limit, set_local_account_limit

--- a/tests/test_rucio_server.py
+++ b/tests/test_rucio_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rucio_server.py
+++ b/tests/test_rucio_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 import rucio.common.test_rucio_server as server_test
 
 

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -20,6 +20,7 @@ from logging import getLogger
 from typing import TYPE_CHECKING
 
 import pytest
+
 import rucio.api.rule
 from rucio.api.account import add_account
 from rucio.client.ruleclient import RuleClient

--- a/tests/test_schema_cms.py
+++ b/tests/test_schema_cms.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_schema_cms.py
+++ b/tests/test_schema_cms.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from rucio.common.exception import InvalidObject
 from rucio.common.schema.cms import validate_schema
 

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -15,6 +15,7 @@
 from json import loads
 
 import pytest
+
 from rucio.common.exception import AccountNotFound, Duplicate, InvalidObject, ScopeNotFound
 from rucio.common.types import InternalScope
 from rucio.common.utils import generate_uuid as uuid

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -17,6 +17,7 @@ from json import loads
 from json.decoder import JSONDecodeError
 
 import pytest
+
 from rucio.api.subscription import add_subscription, get_subscription_by_id, list_subscription_rule_states, list_subscriptions, update_subscription
 from rucio.common.exception import InvalidObject, SubscriptionDuplicate, SubscriptionNotFound
 from rucio.common.schema import get_schema_value

--- a/tests/test_throttler.py
+++ b/tests/test_throttler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_throttler.py
+++ b/tests/test_throttler.py
@@ -15,6 +15,8 @@
 from datetime import datetime, timedelta
 
 import pytest
+from sqlalchemy import delete
+
 from rucio.common.utils import generate_uuid
 from rucio.core.did import add_did, attach_dids
 from rucio.core.distance import add_distance
@@ -35,7 +37,6 @@ from rucio.db.sqla import models
 from rucio.db.sqla.constants import DIDType, RequestState, RequestType, TransferLimitDirection
 from rucio.db.sqla.session import get_session, transactional_session
 from rucio.tests.common import skiplimitedsql
-from sqlalchemy import delete
 
 
 @pytest.fixture

--- a/tests/test_tpc.py
+++ b/tests/test_tpc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_tpc.py
+++ b/tests/test_tpc.py
@@ -18,6 +18,7 @@ import re
 import time
 
 import pytest
+
 from rucio.client.rseclient import RSEClient
 from rucio.client.ruleclient import RuleClient
 from rucio.common.utils import generate_uuid, run_cmd_process

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -19,6 +19,7 @@ import time
 import uuid
 
 import pytest
+
 from rucio.common.exception import InvalidObject
 from rucio.common.schema.generic import IPv4orIPv6
 from rucio.core.trace import SCHEMAS, validate_schema

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -16,6 +16,7 @@ import datetime
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+
 from rucio.common.exception import NoDistance
 from rucio.common.utils import generate_uuid
 from rucio.core import request as request_core

--- a/tests/test_transfer_plugins.py
+++ b/tests/test_transfer_plugins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_transfer_plugins.py
+++ b/tests/test_transfer_plugins.py
@@ -15,6 +15,7 @@
 import logging
 
 import pytest
+
 from rucio.core import distance as distance_core
 from rucio.core import replica as replica_core
 from rucio.core import rule as rule_core

--- a/tests/test_undertaker.py
+++ b/tests/test_undertaker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_undertaker.py
+++ b/tests/test_undertaker.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 from logging import getLogger
 
 import pytest
+
 from rucio.common.policy import get_policy
 from rucio.common.types import InternalScope
 from rucio.core.account_limit import set_local_account_limit

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -20,6 +20,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import pytest
+
 from rucio.client.uploadclient import UploadClient
 from rucio.common.config import config_add_section, config_set
 from rucio.common.exception import InputValidationError, NoFilesUploaded, NotAllFilesUploaded

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ import os
 from re import match
 
 import pytest
+
 from rucio.common.exception import InvalidType
 from rucio.common.logging import formatted_logger
 from rucio.common.utils import Availability, adler32, bittorrent_v2_merkle_sha256, md5, parse_did_filter_from_string, retrying

--- a/tools/add_header
+++ b/tools/add_header
@@ -307,8 +307,7 @@ class PythonHeaderTemplate(HeaderTemplate):
         shebag_string = PythonHeaderTemplate._get_file_shebag(self.file_path) or ""
 
         return shebag_string \
-            + """# -*- coding: utf-8 -*-
-# Copyright European Organization for Nuclear Research (CERN) since 2012
+            + """# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/add_header
+++ b/tools/add_header
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/bootstrap_tests.py
+++ b/tools/bootstrap_tests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/convert_database_vo.py
+++ b/tools/convert_database_vo.py
@@ -24,6 +24,13 @@ import argparse  # noqa: E402
 from datetime import datetime  # noqa: E402
 from traceback import format_exc  # noqa: E402
 
+from sqlalchemy import func  # noqa: E402
+from sqlalchemy.engine import reflection  # noqa: E402
+from sqlalchemy.schema import AddConstraint, DropConstraint, ForeignKeyConstraint, MetaData, Table  # noqa: E402
+from sqlalchemy.sql import bindparam  # noqa: E402
+from sqlalchemy.sql.expression import cast  # noqa: E402
+from sqlalchemy.types import CHAR  # noqa: E402
+
 from rucio.common.config import config_get_bool  # noqa: E402
 from rucio.common.types import InternalAccount  # noqa: E402
 from rucio.common.utils import StoreTrueAndDeprecateWarningAction  # noqa: E402
@@ -31,12 +38,6 @@ from rucio.core.account import del_account  # noqa: E402
 from rucio.core.vo import list_vos  # noqa: E402
 from rucio.db.sqla import session  # noqa: E402
 from rucio.db.sqla.util import create_root_account  # noqa: E402
-from sqlalchemy import func  # noqa: E402
-from sqlalchemy.engine import reflection  # noqa: E402
-from sqlalchemy.schema import AddConstraint, DropConstraint, ForeignKeyConstraint, MetaData, Table  # noqa: E402
-from sqlalchemy.sql import bindparam  # noqa: E402
-from sqlalchemy.sql.expression import cast  # noqa: E402
-from sqlalchemy.types import CHAR  # noqa: E402
 
 
 def split_vo(dialect, column, return_vo=False):

--- a/tools/convert_database_vo.py
+++ b/tools/convert_database_vo.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/destroy_database.py
+++ b/tools/destroy_database.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/generate-release-notes
+++ b/tools/generate-release-notes
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import subprocess
 import sys
+
 import requests
-import json
 
 if __name__ == "__main__":
     requests.packages.urllib3.disable_warnings()

--- a/tools/generate-release-notes.py
+++ b/tools/generate-release-notes.py
@@ -38,6 +38,7 @@ for arg in sys.argv:
     else:
         milestone_title = arg
 
+
 def format_issue(issue, doc=False):
     if not doc:
         if issue['component']:
@@ -57,6 +58,7 @@ def load_milestones(github_token, page=1):
                      params={'state': 'all', 'page': page, 'per_page': '100'})
     return json.loads(r.text)
 
+
 def get_issue_component_type(issue):
     component = None
     type_ = 'enhancement'
@@ -71,6 +73,7 @@ def get_issue_component_type(issue):
         elif label['name'].lower() == 'feature':
             type_ = 'feature'
     return component, type_
+
 
 def print_issues(issues, section_title):
     if not issues:
@@ -118,6 +121,7 @@ def print_issues(issues, section_title):
             for issue in bugs:
                 print(format_issue(issue, doc=True))
 
+
 root_git_dir = subprocess.check_output('git rev-parse --show-toplevel', shell=True).decode("utf-8").rstrip()
 # Load OAUTH token
 try:
@@ -152,21 +156,21 @@ for issue in json.loads(r.text):
 # If --backport is specified, we additionally need to scan older issues
 if option_backport:
     r = requests.get(url='https://api.github.com/repos/rucio/rucio/issues',
-                 headers={'Authorization': 'token %s' % github_token},
-                 params={'labels': 'backport', 'state': 'closed', 'per_page': 100})
+                     headers={'Authorization': 'token %s' % github_token},
+                     params={'labels': 'backport', 'state': 'closed', 'per_page': 100})
     for issue in json.loads(r.text):
         # Load the comments
         r = requests.get(url=issue['comments_url'],
-                 headers={'Authorization': 'token %s' % github_token},
-                 params={'per_page': 100})
+                         headers={'Authorization': 'token %s' % github_token},
+                         params={'per_page': 100})
         # Iterate comments
         for comment in json.loads(r.text):
             if 'backport %s' % milestone_title in comment['body'].lower():
                 component, type_ = get_issue_component_type(issue)
                 issues.append({'component': component,
-                   'type': type_,
-                   'number': issue['number'],
-                   'title': issue['title']})
+                               'type': type_,
+                               'number': issue['number'],
+                               'title': issue['title']})
 
 print_issues([issue for issue in issues if issue['component'] not in ['Clients', 'WebUI']], 'General')
 print_issues([issue for issue in issues if issue['component'] in ['Clients']], 'Clients')

--- a/tools/generate_doc.py
+++ b/tools/generate_doc.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/generate_rest_api_doc.py
+++ b/tools/generate_rest_api_doc.py
@@ -15,6 +15,7 @@
 
 from apispec import APISpec
 from apispec_webframeworks.flask import FlaskPlugin
+
 from rucio.vcsversion import VERSION_INFO
 from rucio.web.rest.flaskapi.v1.main import application
 

--- a/tools/generate_rest_api_doc.py
+++ b/tools/generate_rest_api_doc.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/generate_version.py
+++ b/tools/generate_version.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/github/workflow/grabrelease.py
+++ b/tools/github/workflow/grabrelease.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/github/workflow/set_branch_output_env.py
+++ b/tools/github/workflow/set_branch_output_env.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/github/workflow/set_branch_output_env.py
+++ b/tools/github/workflow/set_branch_output_env.py
@@ -21,7 +21,7 @@ def set_output(name: str, value: str) -> None:
 
 
 def main():
-    set_output("branch", str((env.get("GITHUB_BASE_REF", None) if env.get("GITHUB_BASE_REF", None) else env.get("GITHUB_REF", "master"))))
+    set_output("branch", str(env.get("GITHUB_BASE_REF", None) if env.get("GITHUB_BASE_REF", None) else env.get("GITHUB_REF", "master")))
 
 
 if __name__ == "__main__":

--- a/tools/github/workflow/util.py
+++ b/tools/github/workflow/util.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/merge_rucio_configs.py
+++ b/tools/merge_rucio_configs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/monitoring/extract.py
+++ b/tools/monitoring/extract.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/monitoring/extract.py
+++ b/tools/monitoring/extract.py
@@ -28,7 +28,7 @@ import elasticsearch as es
 import stomp
 
 
-class ElasticConn():
+class ElasticConn:
   def __init__(self, host_port, auth):
     self.__es = es.Elasticsearch([host_port[0]],http_auth=auth,consumer_port=host_port[1])
 

--- a/tools/reset_database.py
+++ b/tools/reset_database.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run_pyright/__init__.py
+++ b/tools/run_pyright/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run_pyright/__main__.py
+++ b/tools/run_pyright/__main__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run_pyright/compare.py
+++ b/tools/run_pyright/compare.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run_pyright/generate.py
+++ b/tools/run_pyright/generate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run_pyright/models.py
+++ b/tools/run_pyright/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run_pyright/utils.py
+++ b/tools/run_pyright/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/sync_meta.py
+++ b/tools/sync_meta.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/sync_rses.py
+++ b/tools/sync_rses.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/test/build_images.py
+++ b/tools/test/build_images.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/test/donkeyrider.py
+++ b/tools/test/donkeyrider.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/test/ignoretool.py
+++ b/tools/test/ignoretool.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/test/matrix_parser.py
+++ b/tools/test/matrix_parser.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/test/run_tests.py
+++ b/tools/test/run_tests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/test/votest_helper.py
+++ b/tools/test/votest_helper.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/update_ui_version.py
+++ b/tools/update_ui_version.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Part of #6538

`pyupgrade` is a linter that automatically checks for deprecated syntax from older Python versions.

In this PR, `pyupgrade` is added to the `ruff` linter. Each separate pyupgrade-related change is broken down in its own commit, for ease of review. Most of the commits here have a longer description message you can check, which explains the reasoning behind that particular change, as well as some useful links.

The final three commits that are not related to `pyupgrade`, but to fixing `isort` and general linting:
- 42ab87f733161f84883956e76ef1c8d520c75cc6: extending the linter to detect Python files that it didn't previously detect, e.g. the Python files in `bin/`
- 954c78ac3f8f245347e5628ee2f06067a585fd15: adding the `.py` extension to a Python script that was not being detected by the linter. This script is not used anywhere else in the repository - I think @bari12 is the main user of this script, and I checked with him before doing this change.
- dd0e68eba74e022d0f425d632642553ae4a7f3e4: configuring `isort` to see `rucio` as a first-party package: previously, it erroneously considered it to be a third-party package, likely due to either the project structure or to `__init__` file-related issues.

Feel free to discuss with me in case you need more info to review this - I realize it seems like a pretty bulky PR, but it becomes much easier to review when reviewed commit-by-commit.
