### PR TITLE
Testing: Fix logic in run_tests when exception occurs

### DIFF
--- a/tools/test/run_tests.py
+++ b/tools/test/run_tests.py
@@ -304,11 +304,10 @@ def run_with_httpd(
             '--profile', rdbms,
         )
 
+        rucio_container = 'dev_rucio_1'
         try:
             # Start docker compose
             run('docker', 'compose', '-p', project, *up_down_args, 'up', '-d')
-
-            rucio_container = 'dev_rucio_1'
 
             # Running test.sh
             if tests:
@@ -330,23 +329,22 @@ def run_with_httpd(
                 flush=True,
             )
         finally:
-            if rucio_container:
-                run('docker', *namespace_args, 'logs', rucio_container, check=False)
-                if copy_rucio_logs:
-                    try:
-                        if logs_dir.exists():
-                            shutil.rmtree(logs_dir)
-                        run('docker', *namespace_args, 'cp', f'{rucio_container}:/var/log', str(logs_dir))
-                    except Exception:
-                        print(
-                            "** Error on retrieving logs for",
-                            {**caseenv, "IMAGE": image},
-                            '\n',
-                            traceback.format_exc(),
-                            '\n**',
-                            file=sys.stderr,
-                            flush=True,
-                        )
+            run('docker', *namespace_args, 'logs', rucio_container, check=False)
+            if copy_rucio_logs:
+                try:
+                    if logs_dir.exists():
+                        shutil.rmtree(logs_dir)
+                    run('docker', *namespace_args, 'cp', f'{rucio_container}:/var/log', str(logs_dir))
+                except Exception:
+                    print(
+                        "** Error on retrieving logs for",
+                        {**caseenv, "IMAGE": image},
+                        '\n',
+                        traceback.format_exc(),
+                        '\n**',
+                        file=sys.stderr,
+                        flush=True,
+                    )
             run('docker', 'compose', '-p', project, *up_down_args, 'down', '-t', '30', check=False)
         return False
 


### PR DESCRIPTION
- Defining `rucio_container` before the `try/except/finally` block to avoid this error when an exception occurs:
```
Error response from daemon: Head "https://registry-1.docker.io/v2/library/elasticsearch/manifests/7.8.0": error parsing HTTP 429 response body: invalid character 'S' looking for beginning of value: "Server capacity exceeded.\n"
** Process '['docker', 'compose', '-p', 'ae2d4ad6a22bc3ee', '--file', 'etc/docker/dev/docker-compose.yml', '--file', '/tmp/tmpd2rlhkia', '--profile', 'sqlite', 'up', '-d']' exited with code 18 {'DIST': 'alma9', 'PYTHON': '3.9', 'IMAGE_IDENTIFIER': 'autotest', 'SUITE': 'sqlite', 'RDBMS': 'sqlite', 'IMAGE': 'ghcr.io/rdimaio/rucio/rucio-autotest:alma9-python3.9'}
*** Finalizing {'DIST': 'alma9', 'PYTHON': '3.9', 'IMAGE_IDENTIFIER': 'autotest', 'SUITE': 'sqlite', 'RDBMS': 'sqlite', 'IMAGE': 'ghcr.io/rdimaio/rucio/rucio-autotest:alma9-python3.9'}
Traceback (most recent call last):
  File "/home/runner/work/rucio/rucio/./tools/test/run_tests.py", line 361, in <module>
    main()
  File "/home/runner/work/rucio/rucio/./tools/test/run_tests.py", line 357, in main
    run_tests(cases, obj["images"])
  File "/home/runner/work/rucio/rucio/./tools/test/run_tests.py", line 139, in run_tests
    run_case(**gen_case_kwargs(_case))
  File "/home/runner/work/rucio/rucio/./tools/test/run_tests.py", line 199, in run_case
    success = run_with_httpd(
  File "/home/runner/work/rucio/rucio/./tools/test/run_tests.py", line 333, in run_with_httpd
    if rucio_container:
UnboundLocalError: local variable 'rucio_container' referenced before assignment
```

- removing `if rucio_container:` in the `finally` block (there's a try/except clause that catches errors in any case)