### PR TITLE
Bug: Patch #6598 remove redundant util function #6598

### DIFF
--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -21,7 +21,7 @@ from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
 from rucio.common.exception import DeprecationError
-from rucio.common.utils import build_url, date_to_str, render_json, render_json_list
+from rucio.common.utils import build_url, date_to_str, render_json
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping, Sequence
@@ -142,7 +142,7 @@ class DIDClient(BaseClient):
         """
         path = '/'.join([self.DIDS_BASEURL])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='POST', data=render_json_list(dids))
+        r = self._send_request(url, type_='POST', data=render_json(dids))
         if r.status_code == codes.created:
             return True
         else:

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -625,16 +625,15 @@ class APIEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def render_json(**data: Any) -> str:
-    """ JSON render function
-    """
+def render_json(*args, **kwargs) -> str:
+    """ Render a list or a dict as a JSON-formatted string. """
+    if args and isinstance(args[0], list):
+        data = args[0]
+    elif kwargs:
+        data = kwargs
+    else:
+        raise ValueError("Error while serializing object to JSON-formatted string: supported input types are list or dict.")
     return json.dumps(data, cls=APIEncoder)
-
-
-def render_json_list(list_) -> str:
-    """ JSON render function for list
-    """
-    return json.dumps(list_, cls=APIEncoder)
 
 
 def datetime_parser(dct: dict[Any, Any]) -> dict[Any, Any]:

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -23,7 +23,7 @@ from flask import Flask, Response, request
 from rucio.common.config import config_get, config_get_int
 from rucio.common.constants import SUPPORTED_PROTOCOLS
 from rucio.common.exception import AccessDenied, DataIdentifierAlreadyExists, DataIdentifierNotFound, Duplicate, InvalidObject, InvalidPath, InvalidType, ReplicaIsLocked, ReplicaNotFound, ResourceTemporaryUnavailable, RSENotFound, ScopeNotFound
-from rucio.common.utils import APIEncoder, parse_response, render_json_list
+from rucio.common.utils import APIEncoder, parse_response, render_json
 from rucio.core.replica_sorter import sort_replicas
 from rucio.db.sqla.constants import BadFilesStatus
 from rucio.gateway.quarantined_replica import quarantine_file_replicas
@@ -1066,7 +1066,7 @@ class SuspiciousReplicas(ErrorHandlingMethodView):
                 nattempts = int(params['nattempts'][0])
 
         result = get_suspicious_files(rse_expression=rse_expression, younger_than=younger_than, nattempts=nattempts, vo=request.environ.get('vo'))
-        return Response(render_json_list(result), 200, content_type='application/json')
+        return Response(render_json(result), 200, content_type='application/json')
 
 
 class BadReplicasStates(ErrorHandlingMethodView):


### PR DESCRIPTION
I have found that it was not possible to remove directly `render_json_list` from 'utils.py' as it was called in 'lib/rucio/client/didclient.py' and in 'lib/rucio/web/rest/flaskapi/v1/replicas.py'. 

Since the two functions perform the same operation with different parameter types, I just tried to find a solution that would run with parameters: a generic python list or a generic python dict. 

**N.B.** I tested it with custom lists and dicts as I do not know the content of a realistic parameter for these functions. If you want me to test them with realistic parameters, please provide me them.

