### PR TITLE
Auth: get_auth_token, move signature decoding logic to core

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 import json
 import logging
 import time
@@ -1214,18 +1213,6 @@ class SSH(ErrorHandlingMethodView):
         signature = request.headers.get('X-Rucio-SSH-Signature', default=None)
         appid = request.headers.get('X-Rucio-AppID', default='unknown')
         ip = request.headers.get('X-Forwarded-For', default=request.remote_addr)
-
-        # decode the signature which must come in base64 encoded
-        try:
-            signature += '=' * ((4 - len(signature) % 4) % 4)  # adding required padding
-            signature = base64.b64decode(signature)
-        except TypeError:
-            return generate_http_error_flask(
-                status_code=401,
-                exc=CannotAuthenticate.__name__,
-                exc_msg=f'Cannot authenticate to account {account} with malformed signature',
-                headers=headers
-            )
 
         try:
             result = get_auth_token_ssh(account, signature, appid, ip, vo=vo)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 import datetime
 import time
 
@@ -125,7 +124,7 @@ class TestAuthCoreApi:
 
         challenge_token = get_ssh_challenge_token(account='root', appid='test', ip='127.0.0.1', vo=vo).get('token')
 
-        signature = base64.b64decode(ssh_sign(PRIVATE_KEY, challenge_token))
+        signature = ssh_sign(PRIVATE_KEY, challenge_token)
 
         result = get_auth_token_ssh(account='root', signature=signature, appid='test', ip='127.0.0.1', vo=vo)
 
@@ -159,8 +158,7 @@ class TestAuthCoreApi:
 
         challenge_token = get_ssh_challenge_token(account='root', appid='test', ip='127.0.0.1', vo=vo).get('token')
 
-        ssh_sign_string = ssh_sign(PRIVATE_KEY, challenge_token)
-        signature = base64.b64decode(ssh_sign_string)
+        signature = ssh_sign(PRIVATE_KEY, challenge_token)
         result = get_auth_token_ssh(account='root', signature=signature, appid='test', ip='127.0.0.1', vo=vo)
         assert result is not None
 


### PR DESCRIPTION
Follow-up from this PR: https://github.com/rucio/rucio/pull/6497, specifically this comment: https://github.com/rucio/rucio/pull/6497#discussion_r1516152819