### PR TITLE
bug: Correct wrong specification for 'Create a new replication rule' …

### DIFF
--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Sequence
 from json import dumps, loads
 from typing import Any, Optional, Union
 from urllib.parse import quote_plus
@@ -30,7 +31,7 @@ class RuleClient(BaseClient):
 
     def add_replication_rule(
         self,
-        dids: list[str],
+        dids: Sequence[dict[str, str]],
         copies: int,
         rse_expression: str,
         priority: int = 3,

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -276,7 +276,14 @@ class AllRule(ErrorHandlingMethodView):
                     description: The list of data identifiers.
                     type: array
                     items:
-                      type: string
+                      type: object
+                      properties:
+                        scope:
+                          description: The scope of the data identifier
+                          type: string
+                        name:
+                          description: The name of the data identifier
+                          type: string
                   account:
                     description: The account of the issuer.
                     type: string


### PR DESCRIPTION
…#6515

This commit replaces the wrong specification for dids for 'Create a new replication rule', it was previously specified as a list of strings. It is now specified as a list of dictionaries containing two properties scope and name.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
