### PR TITLE
Collect all functional RSE attributes #6624

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -33,6 +33,7 @@ from tabulate import tabulate
 from rucio import version
 from rucio.client import Client
 from rucio.common.config import config_get
+from rucio.common.constants import RseAttr
 from rucio.common.exception import (
     AccessDenied,
     AccountNotFound,
@@ -1244,7 +1245,7 @@ def list_pfns(args):
                 if not rse_info['deterministic']:
                     logger.warning('This is a non-deterministic site, so the real PFN might be different from the on suggested')
                     rse_attr = client.list_rse_attributes(rse)
-                    naming_convention = rse_attr.get('naming_convention', None)
+                    naming_convention = rse_attr.get(RseAttr.NAMING_CONVENTION, None)
                     parents = [did for did in client.list_parent_dids(scope, name)]
                     if len(parents) > 1:
                         logger.warning('The file has multiple parents')

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -25,6 +25,7 @@ import time
 from rucio import version
 from rucio.client.client import Client
 from rucio.common.config import config_get, config_get_bool, config_get_int
+from rucio.common.constants import RseAttr
 from rucio.common.exception import (
     DataIdentifierAlreadyExists,
     DataIdentifierNotFound,
@@ -195,8 +196,8 @@ class UploadClient:
                 rse_attributes = self.client.list_rse_attributes(rse)
             except:
                 logger(logging.WARNING, 'Attributes of the RSE: %s not available.' % rse)
-            if (self.client_location and 'lan' in rse_settings['domain'] and 'site' in rse_attributes):
-                if self.client_location['site'] == rse_attributes['site']:
+            if (self.client_location and 'lan' in rse_settings['domain'] and RseAttr.SITE in rse_attributes):
+                if self.client_location['site'] == rse_attributes[RseAttr.SITE]:
                     domain = 'lan'
             logger(logging.DEBUG, '{} domain is used for the upload'.format(domain))
 
@@ -674,7 +675,7 @@ class UploadClient:
             raise RSEOperationNotSupported(str(error))
 
         # Is stat after that upload allowed?
-        skip_upload_stat = rse_attributes.get('skip_upload_stat', False)
+        skip_upload_stat = rse_attributes.get(RseAttr.SKIP_UPLOAD_STAT, False)
         self.logger(logging.DEBUG, 'skip_upload_stat=%s', skip_upload_stat)
 
         # Checksum verification, obsolete, see Gabriele changes.

--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -91,3 +91,61 @@ class HermesService(str, enum.Enum):
     ELASTIC = "ELASTIC"
     EMAIL = "EMAIL"
     ACTIVEMQ = "ACTIVEMQ"
+
+
+class RseAttr:
+
+    """
+    List of functional RSE attributes.
+
+    This class acts as a namespace containing all RSE attributes referenced in
+    the Rucio source code. Setting them affects Rucio's behaviour in some way.
+    """
+
+    ARCHIVE_TIMEOUT = 'archive_timeout'
+    ASSOCIATED_SITES = 'associated_sites'
+    AUTO_APPROVE_BYTES = 'auto_approve_bytes'
+    AUTO_APPROVE_FILES = 'auto_approve_files'
+    BITTORRENT_TRACKER_ADDR = 'bittorrent_tracker_addr'
+    BLOCK_MANUAL_APPROVAL = 'block_manual_approval'
+    COUNTRY = 'country'
+    DECOMMISSION = 'decommission'
+    DEFAULT_ACCOUNT_LIMIT_BYTES = 'default_account_limit_bytes'
+    FTS = 'fts'
+    GLOBUS_ENDPOINT_ID = 'globus_endpoint_id'
+    GREEDYDELETION = 'greedyDeletion'
+    IS_OBJECT_STORE = 'is_object_store'
+    LFN2PFN_ALGORITHM = 'lfn2pfn_algorithm'
+    MAXIMUM_PIN_LIFETIME = 'maximum_pin_lifetime'
+    MULTIHOP_TOMBSTONE_DELAY = 'multihop_tombstone_delay'
+    NAMING_CONVENTION = 'naming_convention'
+    OIDC_BASE_PATH = 'oidc_base_path'
+    OIDC_SUPPORT = 'oidc_support'
+    PHYSGROUP = 'physgroup'
+    QBITTORRENT_MANAGEMENT_ADDRESS = 'qbittorrent_management_address'
+    RESTRICTED_READ = 'restricted_read'
+    RESTRICTED_WRITE = 'restricted_write'
+    RULE_APPROVERS = 'rule_approvers'
+    S3_URL_STYLE = 's3_url_style'
+    SIGN_URL = 'sign_url'
+    SIMULATE_MULTIRANGE = 'simulate_multirange'
+    SITE = 'site'
+    SKIP_UPLOAD_STAT = 'skip_upload_stat'
+    SOURCE_FOR_TOTAL_SPACE = 'source_for_total_space'
+    SOURCE_FOR_USED_SPACE = 'source_for_used_space'
+    STAGING_BUFFER = 'staging_buffer'
+    STAGING_REQUIRED = 'staging_required'
+    STRICT_COPY = 'strict_copy'
+    TOMBSTONE_DELAY = 'tombstone_delay'
+    TYPE = 'type'
+    USE_IPV4 = 'use_ipv4'
+    VERIFY_CHECKSUM = 'verify_checksum'
+
+    # The following RSE attributes are exclusively used in the permission layer
+    # and are likely VO-specific.
+
+    BLOCK_MANUAL_APPROVE = 'block_manual_approve'
+    CMS_TYPE = 'cms_type'
+    DEFAULT_LIMIT_FILES = 'default_limit_files'
+    QUOTA_APPROVERS = 'quota_approvers'
+    RULE_DELETERS = 'rule_deleters'

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -26,6 +26,7 @@ from google.oauth2.service_account import Credentials
 
 from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get, get_rse_credentials
+from rucio.common.constants import RseAttr
 from rucio.common.exception import UnsupportedOperation
 from rucio.core.monitor import MetricManager
 from rucio.core.rse import get_rse_attribute
@@ -111,7 +112,7 @@ def get_signed_url(rse_id: str, service: str, operation: str, url: str, lifetime
         # get RSE S3 URL style (path or host)
         # path-style: https://s3.region-code.amazonaws.com/bucket-name/key-name
         # host-style: https://bucket-name.s3.region-code.amazonaws.com/key-name
-        s3_url_style = get_rse_attribute(rse_id, 's3_url_style')
+        s3_url_style = get_rse_attribute(rse_id, RseAttr.S3_URL_STYLE)
 
         # no S3 URL style specified, assume path-style
         if s3_url_style is None:

--- a/lib/rucio/core/importer.py
+++ b/lib/rucio/core/importer.py
@@ -16,6 +16,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 from rucio.common.config import config_get
+from rucio.common.constants import RseAttr
 from rucio.common.exception import RSEOperationNotSupported
 from rucio.common.types import InternalAccount
 from rucio.core import account as account_module
@@ -107,8 +108,8 @@ def import_rses(rses: dict[str, dict[str, Any]], rse_sync_method: str = 'edit', 
 
         # Attributes
         attributes = rse.get('attributes', {})
-        attributes['lfn2pfn_algorithm'] = rse.get('lfn2pfn_algorithm')
-        attributes['verify_checksum'] = rse.get('verify_checksum')
+        attributes[RseAttr.LFN2PFN_ALGORITHM] = rse.get('lfn2pfn_algorithm')
+        attributes[RseAttr.VERIFY_CHECKSUM] = rse.get('verify_checksum')
 
         old_attributes = rse_module.list_rse_attributes(rse_id=rse_id, session=session)
         missing_attributes = [attribute for attribute in old_attributes if attribute not in attributes]

--- a/lib/rucio/core/lifetime_exception.py
+++ b/lib/rucio/core/lifetime_exception.py
@@ -22,6 +22,7 @@ from sqlalchemy.exc import IntegrityError, NoResultFound
 
 import rucio.common.policy
 from rucio.common.config import config_get, config_get_int, config_get_list
+from rucio.common.constants import RseAttr
 from rucio.common.exception import ConfigNotFound, LifetimeExceptionDuplicate, LifetimeExceptionNotFound, RucioException, UnsupportedOperation
 from rucio.common.utils import generate_uuid, str_to_date
 from rucio.core.message import add_message
@@ -283,7 +284,7 @@ def define_eol(
         return None
 
     # Check if on ATLAS managed space
-    if [rse for rse in rses if list_rse_attributes(rse_id=rse['id'], session=session).get('type') in ['LOCALGROUPDISK', 'LOCALGROUPTAPE', 'GROUPDISK', 'GROUPTAPE']]:
+    if [rse for rse in rses if list_rse_attributes(rse_id=rse['id'], session=session).get(RseAttr.TYPE) in ['LOCALGROUPDISK', 'LOCALGROUPTAPE', 'GROUPDISK', 'GROUPTAPE']]:
         return None
     # Now check the lifetime policy
     try:

--- a/lib/rucio/core/lock.py
+++ b/lib/rucio/core/lock.py
@@ -21,6 +21,7 @@ from sqlalchemy.sql.expression import and_, or_
 
 import rucio.core.did
 import rucio.core.rule
+from rucio.common.constants import RseAttr
 from rucio.common.exception import DataIdentifierNotFound
 from rucio.common.types import InternalScope
 from rucio.core.lifetime_exception import define_eol
@@ -399,7 +400,7 @@ def failed_transfer(scope, name, rse_id, error_message=None, broken_rule_id=None
     :param session:         The database session in use.
     """
 
-    staging_required = get_rse_attribute(rse_id, 'staging_required', session=session)
+    staging_required = get_rse_attribute(rse_id, RseAttr.STAGING_REQUIRED, session=session)
     if staging_required:
         rse_name = get_rse_name(rse_id=rse_id, session=session)
         logger(logging.DEBUG, f'Destination RSE {rse_name} is type staging_required so do not update other OK replica locks.')

--- a/lib/rucio/core/permission/belleii.py
+++ b/lib/rucio/core/permission/belleii.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 import rucio.core.scope
 from rucio.common.config import config_get
+from rucio.common.constants import RseAttr
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core.account import has_account_attribute, list_account_attributes
 from rucio.core.did import get_metadata
@@ -132,7 +133,7 @@ def _perm_country(issuer: "InternalAccount", rses: list, roles: list, *, session
             admin_in_country.append(kv['key'].partition('-')[2])
     if admin_in_country:
         for rse in rses:
-            if list_rse_attributes(rse_id=rse['id'], session=session).get('country') in admin_in_country:
+            if list_rse_attributes(rse_id=rse['id'], session=session).get(RseAttr.COUNTRY) in admin_in_country:
                 return True
     return False
 
@@ -510,8 +511,8 @@ def perm_del_rule(issuer: "InternalAccount", kwargs: dict, *, session: "Optional
     # DELETERS can delete the rule
     for rse in rses:
         rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
-        if rse_attr.get('rule_deleters'):
-            if issuer.external in rse_attr.get('rule_deleters').split(','):
+        if rse_attr.get(RseAttr.RULE_DELETERS):
+            if issuer.external in rse_attr.get(RseAttr.RULE_DELETERS).split(','):
                 return True
     return perm_default(issuer, kwargs, session=session)\
         or has_account_attribute(account=issuer, key='rule_admin', session=session)\

--- a/lib/rucio/core/permission/cms.py
+++ b/lib/rucio/core/permission/cms.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING
 
 import rucio.core.scope
+from rucio.common.constants import RseAttr
 from rucio.core.account import has_account_attribute
 from rucio.core.identity import exist_identity_account
 from rucio.core.permission.generic import perm_get_global_account_usage
@@ -189,7 +190,7 @@ def perm_add_rule(issuer, kwargs, *, session: "Optional[Session]" = None):
     all_temp = True
     for rse in rses:
         rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
-        rse_type = rse_attr.get('cms_type', None)
+        rse_type = rse_attr.get(RseAttr.CMS_TYPE, None)
         if rse_type not in ['temp']:
             all_temp = False
 
@@ -548,7 +549,7 @@ def perm_approve_rule(issuer, kwargs, *, session: "Optional[Session]" = None):
     # Those in rule_approvers can approve the rule
     for rse in rses:
         rse_attr = list_rse_attributes(rse_id=rse['id'], session=session)
-        rule_approvers = rse_attr.get('rule_approvers', None)
+        rule_approvers = rse_attr.get(RseAttr.RULE_APPROVERS, None)
         if rule_approvers and issuer.external in rule_approvers.split(','):
             return True
 
@@ -869,12 +870,12 @@ def perm_set_local_account_limit(issuer, kwargs, *, session: "Optional[Session]"
     # for kv in list_account_attributes(account=issuer, session=session):
     #     if kv['key'].startswith('country-') and kv['value'] == 'admin':
     #         admin_in_country.append(kv['key'].partition('-')[2])
-    # if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
+    # if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get(RseAttr.COUNTRY) in admin_in_country:
     #     return True
 
     # Those listed as quota approvers can add to quotas
     rse_attr = list_rse_attributes(rse_id=kwargs['rse_id'], session=session)
-    quota_approvers = rse_attr.get('quota_approvers', None)
+    quota_approvers = rse_attr.get(RseAttr.QUOTA_APPROVERS, None)
     if quota_approvers and issuer.external in quota_approvers.split(','):
         return True
 
@@ -897,7 +898,7 @@ def perm_set_global_account_limit(issuer, kwargs, *, session: "Optional[Session]
     # for kv in list_account_attributes(account=issuer, session=session):
     #     if kv['key'].startswith('country-') and kv['value'] == 'admin':
     #         admin_in_country.add(kv['key'].partition('-')[2])
-    # resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+    # resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get(RseAttr.COUNTRY)
     #                           for rse in parse_expression(kwargs['rse_expression'], filter={'vo': issuer.vo}, session=session)}
     # if resolved_rse_countries.issubset(admin_in_country):
     #     return True
@@ -921,7 +922,7 @@ def perm_delete_global_account_limit(issuer, kwargs, *, session: "Optional[Sessi
     #     if kv['key'].startswith('country-') and kv['value'] == 'admin':
     #         admin_in_country.add(kv['key'].partition('-')[2])
     # if admin_in_country:
-    #     resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+    #     resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get(RseAttr.COUNTRY)
     #                               for rse in parse_expression(kwargs['rse_expression'], filter={'vo': issuer.vo}, session=session)}
     #     if resolved_rse_countries.issubset(admin_in_country):
     #         return True
@@ -944,11 +945,11 @@ def perm_delete_local_account_limit(issuer, kwargs, *, session: "Optional[Sessio
     # for kv in list_account_attributes(account=issuer, session=session):
     #     if kv['key'].startswith('country-') and kv['value'] == 'admin':
     #         admin_in_country.append(kv['key'].partition('-')[2])
-    # if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
+    # if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get(RseAttr.COUNTRY) in admin_in_country:
     #     return True
 
     rse_attr = list_rse_attributes(rse_id=kwargs['rse_id'], session=session)
-    quota_approvers = rse_attr.get('quota_approvers', None)
+    quota_approvers = rse_attr.get(RseAttr.QUOTA_APPROVERS, None)
     if quota_approvers and issuer.external in quota_approvers.split(','):
         return True
 

--- a/lib/rucio/core/permission/escape.py
+++ b/lib/rucio/core/permission/escape.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING
 
 import rucio.core.scope
+from rucio.common.constants import RseAttr
 from rucio.core.account import has_account_attribute, list_account_attributes
 from rucio.core.identity import exist_identity_account
 from rucio.core.lifetime_exception import list_exceptions
@@ -815,7 +816,7 @@ def perm_set_local_account_limit(issuer, kwargs, *, session: "Optional[Session]"
     for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get(RseAttr.COUNTRY) in admin_in_country:
         return True
     return False
 
@@ -836,7 +837,7 @@ def perm_set_global_account_limit(issuer, kwargs, *, session: "Optional[Session]
     for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get(RseAttr.COUNTRY)
                               for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
     if resolved_rse_countries.issubset(admin_in_country):
         return True
@@ -859,7 +860,7 @@ def perm_delete_local_account_limit(issuer, kwargs, *, session: "Optional[Sessio
     for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get(RseAttr.COUNTRY) in admin_in_country:
         return True
     return False
 
@@ -881,7 +882,7 @@ def perm_delete_global_account_limit(issuer, kwargs, *, session: "Optional[Sessi
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
     if admin_in_country:
-        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get(RseAttr.COUNTRY)
                                   for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
         if resolved_rse_countries.issubset(admin_in_country):
             return True

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING
 
 import rucio.core.scope
+from rucio.common.constants import RseAttr
 from rucio.core.account import has_account_attribute, list_account_attributes
 from rucio.core.identity import exist_identity_account
 from rucio.core.lifetime_exception import list_exceptions
@@ -867,7 +868,7 @@ def perm_set_local_account_limit(issuer, kwargs, *, session: "Optional[Session]"
     for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get(RseAttr.COUNTRY) in admin_in_country:
         return True
     return False
 
@@ -888,7 +889,7 @@ def perm_set_global_account_limit(issuer, kwargs, *, session: "Optional[Session]
     for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get(RseAttr.COUNTRY)
                               for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
     if resolved_rse_countries.issubset(admin_in_country):
         return True
@@ -911,7 +912,7 @@ def perm_delete_local_account_limit(issuer, kwargs, *, session: "Optional[Sessio
     for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get(RseAttr.COUNTRY) in admin_in_country:
         return True
     return False
 
@@ -933,7 +934,7 @@ def perm_delete_global_account_limit(issuer, kwargs, *, session: "Optional[Sessi
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
     if admin_in_country:
-        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get(RseAttr.COUNTRY)
                                   for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
         if resolved_rse_countries.issubset(admin_in_country):
             return True

--- a/lib/rucio/core/permission/generic_multi_vo.py
+++ b/lib/rucio/core/permission/generic_multi_vo.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING
 
 import rucio.core.scope
+from rucio.common.constants import RseAttr
 from rucio.core.account import has_account_attribute, list_account_attributes
 from rucio.core.identity import exist_identity_account
 from rucio.core.lifetime_exception import list_exceptions
@@ -833,7 +834,7 @@ def perm_set_local_account_limit(issuer, kwargs, *, session: "Optional[Session]"
     for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get(RseAttr.COUNTRY) in admin_in_country:
         return True
     return False
 
@@ -854,7 +855,7 @@ def perm_set_global_account_limit(issuer, kwargs, *, session: "Optional[Session]
     for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get(RseAttr.COUNTRY)
                               for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
     if resolved_rse_countries.issubset(admin_in_country):
         return True
@@ -877,7 +878,7 @@ def perm_delete_local_account_limit(issuer, kwargs, *, session: "Optional[Sessio
     for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.append(kv['key'].partition('-')[2])
-    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get('country') in admin_in_country:
+    if admin_in_country and list_rse_attributes(rse_id=kwargs['rse_id'], session=session).get(RseAttr.COUNTRY) in admin_in_country:
         return True
     return False
 
@@ -899,7 +900,7 @@ def perm_delete_global_account_limit(issuer, kwargs, *, session: "Optional[Sessi
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
     if admin_in_country:
-        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+        resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get(RseAttr.COUNTRY)
                                   for rse in parse_expression(kwargs['rse_expression'], filter_={'vo': issuer.vo}, session=session)}
         if resolved_rse_countries.issubset(admin_in_country):
             return True
@@ -953,7 +954,7 @@ def perm_get_global_account_usage(issuer, kwargs, *, session: "Optional[Session]
     for kv in list_account_attributes(account=issuer, session=session):
         if kv['key'].startswith('country-') and kv['value'] == 'admin':
             admin_in_country.add(kv['key'].partition('-')[2])
-    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get('country')
+    resolved_rse_countries = {list_rse_attributes(rse_id=rse['rse_id'], session=session).get(RseAttr.COUNTRY)
                               for rse in parse_expression(kwargs['rse_exp'], filter_={'vo': issuer.vo}, session=session)}
 
     if resolved_rse_countries.issubset(admin_in_country):

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -34,6 +34,7 @@ from sqlalchemy.sql.expression import asc, false, func, null, true
 from sqlalchemy.sql.functions import coalesce
 
 from rucio.common.config import config_get_bool, config_get_int
+from rucio.common.constants import RseAttr
 from rucio.common.exception import InvalidRSEExpression, RequestNotFound, RucioException, UnsupportedOperation
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import chunks, generate_uuid
@@ -621,7 +622,7 @@ def list_and_mark_transfer_requests_and_source_replicas(
                                          requested_at=requested_at)
             requests_by_id[request_id] = request
             # if STAGEIN and destination RSE is QoS make sure the source is included
-            if request.request_type == RequestType.STAGEIN and get_rse_attribute(rse_id=dest_rse_id, key='staging_required', session=session):
+            if request.request_type == RequestType.STAGEIN and get_rse_attribute(rse_id=dest_rse_id, key=RseAttr.STAGING_REQUIRED, session=session):
                 source = RequestSource(rse=rse_collection[dest_rse_id])
                 request.sources.append(source)
 

--- a/lib/rucio/core/rule_grouping.py
+++ b/lib/rucio/core/rule_grouping.py
@@ -24,6 +24,7 @@ import rucio.core.did
 import rucio.core.lock
 import rucio.core.replica
 from rucio.common.config import config_get_int
+from rucio.common.constants import RseAttr
 from rucio.common.exception import InsufficientTargetRSEs
 from rucio.common.types import InternalScope
 from rucio.core import account_counter, rse_counter
@@ -878,8 +879,8 @@ def __create_lock_and_replica(file, dataset, rule, rse_id, staging_area, availab
                                                         session=session))
 
     # If staging_required type RSE then set pin to RSE attribute maximum_pin_lifetime
-    staging_required = get_rse_attribute(rse_id, 'staging_required', session=session)
-    maximum_pin_lifetime = get_rse_attribute(rse_id, 'maximum_pin_lifetime', session=session)
+    staging_required = get_rse_attribute(rse_id, RseAttr.STAGING_REQUIRED, session=session)
+    maximum_pin_lifetime = get_rse_attribute(rse_id, RseAttr.MAXIMUM_PIN_LIFETIME, session=session)
 
     if staging_required:
         if (not copy_pin_lifetime and maximum_pin_lifetime) or (copy_pin_lifetime and maximum_pin_lifetime and copy_pin_lifetime < int(maximum_pin_lifetime)):

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -26,6 +26,7 @@ import gfal2
 import requests
 
 from rucio.common.config import get_config_dirs
+from rucio.common.constants import RseAttr
 from rucio.common.dumper import DUMPS_CACHE_DIR, HTTPDownloadFailed, ddmendpoint_url, gfal_download_to_file, http_download_to_file, temp_file
 from rucio.core.credential import get_signed_url
 from rucio.core.rse import get_rse_id, list_rse_attributes
@@ -243,7 +244,7 @@ def download_rse_dump(rse, configuration, date=None, destdir=DUMPS_CACHE_DIR):
     # check for objectstores, which need to be handled differently
     rse_id = get_rse_id(rse)
     rse_attr = list_rse_attributes(rse_id)
-    if 'is_object_store' in rse_attr and rse_attr['is_object_store'] is not False:
+    if RseAttr.IS_OBJECT_STORE in rse_attr and rse_attr[RseAttr.IS_OBJECT_STORE] is not False:
         tries = 1
         if date is None:
             # on objectstores, can't list dump files, so try the last N dates
@@ -263,8 +264,8 @@ def download_rse_dump(rse, configuration, date=None, destdir=DUMPS_CACHE_DIR):
             path = os.path.join(destdir, filename)
             if not os.path.exists(path):
                 logger.debug('Trying to download: "%s"', url)
-                if 'sign_url' in rse_attr:
-                    url = get_signed_url(rse_id, rse_attr['sign_url'], 'read', url)
+                if RseAttr.SIGN_URL in rse_attr:
+                    url = get_signed_url(rse_id, rse_attr[RseAttr.SIGN_URL], 'read', url)
                 try:
                     with temp_file(destdir, final_name=filename) as (f, _):
                         download(url, f)

--- a/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
@@ -18,6 +18,7 @@ This script is to be used to background rebalance ATLAS t2 datadisks
 
 from sqlalchemy import or_
 
+from rucio.common.constants import RseAttr
 from rucio.core.rse import get_rse_attribute, get_rse_usage
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.daemons.bb8.common import rebalance_rse
@@ -59,7 +60,7 @@ total_secondary = 0
 total_total = 0
 global_ratio = float(0)
 for rse in rses:
-    site_name = get_rse_attribute(rse['id'], 'site')
+    site_name = get_rse_attribute(rse['id'], RseAttr.SITE)
     rse['groupdisk'] = group_space(site_name)
     rse['primary'] = get_rse_usage(rse_id=rse['id'], source='rucio')[0]['used'] - get_rse_usage(rse_id=rse['id'], source='expired')[0]['used']
     rse['primary'] += rse['groupdisk']

--- a/lib/rucio/daemons/bb8/t2_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/t2_background_rebalance.py
@@ -18,6 +18,7 @@ This script is to be used to background rebalance ATLAS t2 datadisks
 
 from sqlalchemy import or_
 
+from rucio.common.constants import RseAttr
 from rucio.core.rse import get_rse_attribute, get_rse_usage
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.daemons.bb8.common import rebalance_rse
@@ -59,7 +60,7 @@ total_secondary = 0
 total_total = 0
 global_ratio = float(0)
 for rse in rses:
-    site_name = get_rse_attribute(rse['id'], 'site')
+    site_name = get_rse_attribute(rse['id'], RseAttr.SITE)
     rse['groupdisk'] = group_space(site_name)
     rse['primary'] = get_rse_usage(rse_id=rse['id'], source='rucio')[0]['used'] - get_rse_usage(rse_id=rse['id'], source='expired')[0]['used']
     rse['primary'] += rse['groupdisk']

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
@@ -16,6 +16,7 @@ import logging
 from operator import itemgetter
 
 from rucio.common.config import config_get, config_get_int
+from rucio.common.constants import RseAttr
 from rucio.common.exception import DataIdentifierNotFound
 from rucio.core.did import get_did
 from rucio.core.replica import list_dataset_replicas
@@ -60,7 +61,7 @@ class PlacementAlgorithm:
             rse_attrs = list_rse_attributes(rse_id=rse['id'])
             rse_attrs['rse_id'] = rse['id']
             self._rses[rse['id']] = rse_attrs
-            self._sites[rse_attrs['site']] = rse_attrs
+            self._sites[rse_attrs[RseAttr.SITE]] = rse_attrs
 
         self._dst_penalties = {}
         self._src_penalties = {}
@@ -165,10 +166,10 @@ class PlacementAlgorithm:
         for rep in reps:
             rse_attr = list_rse_attributes(rep['rse_id'])
             src_rse_id = rep['rse_id']
-            if 'site' not in rse_attr:
+            if RseAttr.SITE not in rse_attr:
                 continue
 
-            src_site = rse_attr['site']
+            src_site = rse_attr[RseAttr.SITE]
             src_rse_info = get_rse(rse_id=src_rse_id)
 
             if 'type' not in rse_attr:

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -24,6 +24,7 @@ import re
 from typing import TYPE_CHECKING
 
 from rucio.common.config import config_get_bool
+from rucio.common.constants import RseAttr
 from rucio.common.exception import DatabaseException, DuplicateFileTransferSubmission, InvalidRSEExpression, RequestNotFound, TransferToolTimeout, TransferToolWrongAnswer, VONotFound
 from rucio.common.stopwatch import Stopwatch
 from rucio.core import request as request_core
@@ -324,7 +325,7 @@ def __create_missing_replicas_and_requests(
         if rws.request_id:
             continue
 
-        tombstone_delay = rws.dest_rse.attributes.get('multihop_tombstone_delay', default_tombstone_delay)
+        tombstone_delay = rws.dest_rse.attributes.get(RseAttr.MULTIHOP_TOMBSTONE_DELAY, default_tombstone_delay)
         try:
             tombstone = tombstone_from_delay(tombstone_delay)
         except ValueError:

--- a/lib/rucio/daemons/rsedecommissioner/config.py
+++ b/lib/rucio/daemons/rsedecommissioner/config.py
@@ -17,6 +17,7 @@
 from enum import Enum
 from typing import Any
 
+from rucio.common.constants import RseAttr
 from rucio.core.rse import add_rse_attribute, get_rse_attribute
 
 
@@ -74,7 +75,7 @@ def set_status(
     :param rse_id: RSE ID.
     :param status: RSE decommissioning status.
     """
-    config = attr_to_config(get_rse_attribute(rse_id, 'decommission'))
+    config = attr_to_config(get_rse_attribute(rse_id, RseAttr.DECOMMISSION))
     config['status'] = status
     # add_rse_attribute can handle updating existing entries too
-    add_rse_attribute(rse_id, 'decommission', config_to_attr(config))
+    add_rse_attribute(rse_id, RseAttr.DECOMMISSION, config_to_attr(config))

--- a/lib/rucio/daemons/rsedecommissioner/profiles/generic.py
+++ b/lib/rucio/daemons/rsedecommissioner/profiles/generic.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from sqlalchemy.exc import NoResultFound
 
+from rucio.common.constants import RseAttr
 from rucio.common.exception import Duplicate, ReplicaNotFound, RequestNotFound, RucioException, RuleNotFound, RuleReplaceFailed, UnsupportedOperation
 from rucio.core.lock import get_replica_locks, get_replica_locks_for_rule_id
 from rucio.core.replica import list_replicas_per_rse, set_tombstone, update_replica_state
@@ -124,7 +125,7 @@ def _generic_initialize(
     update_rse(rse['id'], parameters)
 
     try:
-        add_rse_attribute(rse['id'], 'greedyDeletion', True)
+        add_rse_attribute(rse['id'], RseAttr.GREEDYDELETION, True)
     except Duplicate:
         pass
 

--- a/lib/rucio/daemons/rsedecommissioner/rse_decommissioner.py
+++ b/lib/rucio/daemons/rsedecommissioner/rse_decommissioner.py
@@ -28,6 +28,7 @@ from types import FrameType
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from rucio.common.config import config_get_int
+from rucio.common.constants import RseAttr
 from rucio.common.exception import RucioException
 from rucio.common.logging import setup_logging
 from rucio.core.heartbeat import sanity_check
@@ -89,12 +90,12 @@ def run_once(
         return True
 
     # Collect all RSEs with the 'decommission' attribute
-    rses = get_rses_with_attribute('decommission')
+    rses = get_rses_with_attribute(RseAttr.DECOMMISSION)
     random.shuffle(rses)
 
     for rse in rses:
         # Get the decommission attribute (encodes the decommissioning config)
-        attr = get_rse_attribute(rse['id'], 'decommission')
+        attr = get_rse_attribute(rse['id'], RseAttr.DECOMMISSION)
         try:
             config = attr_to_config(attr)
         except InvalidStatusName:

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 
 import rucio.db.sqla.util
 from rucio.common.config import config_get
+from rucio.common.constants import RseAttr
 from rucio.common.exception import (
     DatabaseException,
     DuplicateRule,
@@ -399,7 +400,7 @@ def select_algorithm(algorithm: str, rule_ids: list, params: dict, logger: "Call
             rse_id = get_rse_id(rse, vo=vo)
             rse_attributes = list_rse_attributes(rse_id)
             if algorithm == "associated_site":
-                associated_sites = rse_attributes.get("associated_sites", None)
+                associated_sites = rse_attributes.get(RseAttr.ASSOCIATED_SITES, None)
                 associated_site_idx = params.get("associated_site_idx", None)
                 if not associated_site_idx:
                     raise SubscriptionWrongParameter(
@@ -417,7 +418,7 @@ def select_algorithm(algorithm: str, rule_ids: list, params: dict, logger: "Call
                         "weight": None,
                     }
             if algorithm == "exclude_site":
-                site = rse_attributes.get("site", None)
+                site = rse_attributes.get(RseAttr.SITE, None)
                 rse_expression = params['rse_expression'] + '\\site=%s' % site
                 (
                     selected_rses,

--- a/lib/rucio/rse/protocols/globus.py
+++ b/lib/rucio/rse/protocols/globus.py
@@ -16,6 +16,7 @@ import logging
 from urllib.parse import urlparse
 
 from rucio.common import exception
+from rucio.common.constants import RseAttr
 from rucio.common.extra import import_extras
 from rucio.core.rse import get_rse_attribute
 from rucio.rse.protocols.protocol import RSEProtocol
@@ -36,7 +37,7 @@ class GlobusRSEProtocol(RSEProtocol):
             :param props: Properties of the requested protocol
         """
         super(GlobusRSEProtocol, self).__init__(protocol_attr, rse_settings, logger=logger)
-        self.globus_endpoint_id = get_rse_attribute(self.rse.get('id'), 'globus_endpoint_id')
+        self.globus_endpoint_id = get_rse_attribute(self.rse.get('id'), RseAttr.GLOBUS_ENDPOINT_ID)
         self.logger = logger
 
     def lfns2pfns(self, lfns):

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -24,6 +24,7 @@ from typing import TypeVar
 from urllib.parse import urlparse
 
 from rucio.common import config, exception
+from rucio.common.constants import RseAttr
 from rucio.common.plugins import PolicyPackageAlgorithms
 from rucio.rse import rsemanager
 
@@ -251,7 +252,7 @@ class RSEDeterministicTranslation(PolicyPackageAlgorithms):
 
             :returns: RSE specific URI of the physical file
         """
-        algorithm = self.rse_attributes.get('lfn2pfn_algorithm', 'default')
+        algorithm = self.rse_attributes.get(RseAttr.LFN2PFN_ALGORITHM, 'default')
         if algorithm == 'default':
             algorithm = RSEDeterministicTranslation._DEFAULT_LFN2PFN
         algorithm_callable = super()._get_one_algorithm(RSEDeterministicTranslation._algorithm_type, algorithm)

--- a/lib/rucio/transfertool/bittorrent.py
+++ b/lib/rucio/transfertool/bittorrent.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, Type
 
 from rucio.common import types
 from rucio.common.config import config_get
+from rucio.common.constants import RseAttr
 from rucio.common.extra import import_extras
 from rucio.common.utils import construct_torrent
 from rucio.core.did_meta_plugins import get_metadata
@@ -132,7 +133,7 @@ class BittorrentTransfertool(Transfertool):
         [transfer] = transfers
         rws = transfer.rws
 
-        tracker = transfer.dst.rse.attributes.get('bittorrent_tracker_addr', self.tracker)
+        tracker = transfer.dst.rse.attributes.get(RseAttr.BITTORRENT_TRACKER_ADDR, self.tracker)
 
         src_drivers = {}
         for source in transfer.sources:

--- a/lib/rucio/transfertool/bittorrent_driver_qbittorrent.py
+++ b/lib/rucio/transfertool/bittorrent_driver_qbittorrent.py
@@ -21,6 +21,7 @@ import qbittorrentapi
 
 from rucio.common import types
 from rucio.common.config import get_rse_credentials
+from rucio.common.constants import RseAttr
 from rucio.common.utils import resolve_ip
 from rucio.core.oidc import request_token
 from rucio.db.sqla.constants import RequestState
@@ -66,12 +67,12 @@ class QBittorrentTransferStatusReport(TransferStatusReport):
 class QBittorrentDriver(BittorrentDriver):
 
     external_name = 'qbittorrent'
-    required_rse_attrs = ('qbittorrent_management_address', )
+    required_rse_attrs = (RseAttr.QBITTORRENT_MANAGEMENT_ADDRESS, )
 
     @classmethod
     def make_driver(cls: "Type[QBittorrentDriver]", rse: "RseData", logger: types.LoggerFunction = logging.log) -> "Optional[BittorrentDriver]":
 
-        address = rse.attributes.get('qbittorrent_management_address')
+        address = rse.attributes.get(RseAttr.QBITTORRENT_MANAGEMENT_ADDRESS)
         if not address:
             return None
 

--- a/lib/rucio/transfertool/globus.py
+++ b/lib/rucio/transfertool/globus.py
@@ -14,6 +14,7 @@
 
 import logging
 
+from rucio.common.constants import RseAttr
 from rucio.common.utils import chunks
 from rucio.db.sqla.constants import RequestState
 from rucio.transfertool.transfertool import TransferStatusReport, Transfertool, TransferToolBuilder
@@ -82,7 +83,7 @@ class GlobusTransferTool(Transfertool):
     """
 
     external_name = 'globus'
-    required_rse_attrs = ('globus_endpoint_id', )
+    required_rse_attrs = (RseAttr.GLOBUS_ENDPOINT_ID, )
 
     def __init__(self, external_host, logger=logging.log, group_bulk=200, group_policy='single'):
         """
@@ -161,8 +162,8 @@ class GlobusTransferTool(Transfertool):
                     'dst_rse': transfer.dst.rse.name,
                     'scope': str(transfer.rws.scope),
                     'name': transfer.rws.name,
-                    'source_globus_endpoint_id': transfer.src.rse.attributes['globus_endpoint_id'],
-                    'dest_globus_endpoint_id': transfer.dst.rse.attributes['globus_endpoint_id'],
+                    'source_globus_endpoint_id': transfer.src.rse.attributes[RseAttr.GLOBUS_ENDPOINT_ID],
+                    'dest_globus_endpoint_id': transfer.dst.rse.attributes[RseAttr.GLOBUS_ENDPOINT_ID],
                     'filesize': transfer.rws.byte_count,
                 },
             }

--- a/tests/test_conveyor_submitter.py
+++ b/tests/test_conveyor_submitter.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy import delete
 
+from rucio.common.constants import RseAttr
 from rucio.common.exception import RequestNotFound
 from rucio.core import config as core_config
 from rucio.core import distance as distance_core
@@ -145,15 +146,15 @@ def test_multihop_sources_created(rse_factory, did_factory, root_account, core_c
     default_multihop_tombstone_delay = 24 * 3600
 
     # if both attributes are set, the multihop one will take precedence
-    rse_core.add_rse_attribute(jump_rse1_id, 'tombstone_delay', rse_tombstone_delay)
-    rse_core.add_rse_attribute(jump_rse1_id, 'multihop_tombstone_delay', rse_multihop_tombstone_delay)
+    rse_core.add_rse_attribute(jump_rse1_id, RseAttr.TOMBSTONE_DELAY, rse_tombstone_delay)
+    rse_core.add_rse_attribute(jump_rse1_id, RseAttr.MULTIHOP_TOMBSTONE_DELAY, rse_multihop_tombstone_delay)
 
     # if multihop delay not set, it's the default multihop takes precedence. Not normal tombstone delay.
-    rse_core.add_rse_attribute(jump_rse2_id, 'tombstone_delay', rse_tombstone_delay)
+    rse_core.add_rse_attribute(jump_rse2_id, RseAttr.TOMBSTONE_DELAY, rse_tombstone_delay)
     core_config.set(section='transfers', option='multihop_tombstone_delay', value=default_multihop_tombstone_delay)
 
     # if multihop delay is set to 0, the replica will have no tombstone
-    rse_core.add_rse_attribute(jump_rse3_id, 'multihop_tombstone_delay', 0)
+    rse_core.add_rse_attribute(jump_rse3_id, RseAttr.MULTIHOP_TOMBSTONE_DELAY, 0)
 
     distance_core.add_distance(src_rse_id, jump_rse1_id, distance=10)
     distance_core.add_distance(jump_rse1_id, jump_rse2_id, distance=10)
@@ -354,7 +355,7 @@ def test_globus(rse_factory, did_factory, root_account):
     distance_core.add_distance(rse1_id, rse2_id, distance=10)
     distance_core.add_distance(rse3_id, rse4_id, distance=10)
     for rse_id in all_rses:
-        rse_core.add_rse_attribute(rse_id, 'globus_endpoint_id', rse_id)
+        rse_core.add_rse_attribute(rse_id, RseAttr.GLOBUS_ENDPOINT_ID, rse_id)
 
     # Single submission
     did1 = did_factory.upload_test_file(rse1)

--- a/tests/test_credential.py
+++ b/tests/test_credential.py
@@ -16,6 +16,7 @@ import os
 
 import pytest
 
+from rucio.common.constants import RseAttr
 from rucio.common.exception import UnsupportedOperation
 from rucio.core.credential import get_signed_url
 from rucio.core.replica import add_replicas
@@ -107,7 +108,7 @@ class TestCredential:
                      account=root_account,
                      ignore_availability=True)
 
-        add_rse_attribute(rse_id=self.rse1_id, key='sign_url', value='gcs')
+        add_rse_attribute(rse_id=self.rse1_id, key=RseAttr.SIGN_URL, value='gcs')
         replicas = [r for r in replica_client.list_replicas(dids=[{'scope': 'mock',
                                                                    'name': f['name'],
                                                                    'type': 'FILE'} for f in files],

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -19,6 +19,7 @@ import pytest
 from rucio.client.exportclient import ExportClient
 from rucio.client.importclient import ImportClient
 from rucio.common.config import config_add_section, config_has_section, config_set
+from rucio.common.constants import RseAttr
 from rucio.common.exception import RSENotFound
 from rucio.common.types import InternalAccount
 from rucio.common.utils import parse_response, render_json
@@ -56,8 +57,8 @@ def check_rse(rse_name, test_data, vo='def'):
 def check_protocols(rse, test_data, vo='def'):
     rse_id = get_rse_id(rse=rse, vo=vo)
     protocols = get_rse_protocols(rse_id)
-    assert test_data[rse]['lfn2pfn_algorithm'] == get_rse_attribute(rse_id, 'lfn2pfn_algorithm', use_cache=False)
-    assert test_data[rse]['verify_checksum'] == get_rse_attribute(rse_id, 'verify_checksum', use_cache=False)
+    assert test_data[rse]['lfn2pfn_algorithm'] == get_rse_attribute(rse_id, RseAttr.LFN2PFN_ALGORITHM, use_cache=False)
+    assert test_data[rse]['verify_checksum'] == get_rse_attribute(rse_id, RseAttr.VERIFY_CHECKSUM, use_cache=False)
     assert test_data[rse]['availability_write'] == protocols['availability_write']
     assert test_data[rse]['availability_read'] == protocols['availability_read']
     assert test_data[rse]['availability_delete'] == protocols['availability_delete']
@@ -149,8 +150,8 @@ def importer_example_data(vo, jdoe_account):
 
     set_rse_limits(rse_id=example_data.old_rse_id_1, name='MinFreeSpace', value='10')
     add_rse_attribute(rse_id=example_data.old_rse_id_1, key='attr1', value='test10')
-    add_rse_attribute(rse_id=example_data.old_rse_id_1, key='lfn2pfn_algorithm', value='test10')
-    add_rse_attribute(rse_id=example_data.old_rse_id_1, key='verify_checksum', value=True)
+    add_rse_attribute(rse_id=example_data.old_rse_id_1, key=RseAttr.LFN2PFN_ALGORITHM, value='test10')
+    add_rse_attribute(rse_id=example_data.old_rse_id_1, key=RseAttr.VERIFY_CHECKSUM, value=True)
 
     # RSE 2 that already exists
     example_data.old_rse_2 = rse_name_generator()

--- a/tests/test_multi_vo.py
+++ b/tests/test_multi_vo.py
@@ -30,6 +30,7 @@ from rucio.client.replicaclient import ReplicaClient
 from rucio.client.subscriptionclient import SubscriptionClient
 from rucio.client.uploadclient import UploadClient
 from rucio.common.config import config_add_section, config_has_section, config_remove_option, config_set
+from rucio.common.constants import RseAttr
 from rucio.common.exception import AccessDenied, Duplicate, InvalidRSEExpression, RucioException, UnsupportedAccountName, UnsupportedOperation
 from rucio.common.types import InternalAccount
 from rucio.common.utils import generate_uuid, get_tmp_dir, parse_response, ssh_sign
@@ -1007,12 +1008,12 @@ class TestMultiVODaemons:
                                      'write': 1,
                                      'delete': 1}}}
         rse_client.add_rse(shr_rse)
-        rse_client.add_rse_attribute(rse=shr_rse, key='verify_checksum', value=False)
-        rse_client.add_rse_attribute(rse=shr_rse, key='skip_upload_stat', value=True)
+        rse_client.add_rse_attribute(rse=shr_rse, key=RseAttr.VERIFY_CHECKSUM, value=False)
+        rse_client.add_rse_attribute(rse=shr_rse, key=RseAttr.SKIP_UPLOAD_STAT, value=True)
         rse_client.add_protocol(shr_rse, mock_protocol)
         add_rse(shr_rse, 'root', vo=second_vo)
-        add_rse_attribute(rse=shr_rse, key='verify_checksum', value=False, issuer='root', vo=second_vo)
-        add_rse_attribute(rse=shr_rse, key='skip_upload_stat', value=True, issuer='root', vo=second_vo)
+        add_rse_attribute(rse=shr_rse, key=RseAttr.VERIFY_CHECKSUM, value=False, issuer='root', vo=second_vo)
+        add_rse_attribute(rse=shr_rse, key=RseAttr.SKIP_UPLOAD_STAT, value=True, issuer='root', vo=second_vo)
         add_protocol(rse=shr_rse, data=mock_protocol, issuer='root', vo=second_vo)
 
         if not config_has_section("automatix"):

--- a/tests/test_preparer.py
+++ b/tests/test_preparer.py
@@ -15,6 +15,7 @@
 
 import pytest
 
+from rucio.common.constants import RseAttr
 from rucio.core.distance import add_distance, get_distances
 from rucio.core.replica import add_replicas
 from rucio.core.request import get_request, list_and_mark_transfer_requests_and_source_replicas, list_transfer_limits, set_transfer_limit
@@ -150,8 +151,8 @@ def test_preparer_for_request_without_source(mock_request_no_source):
     'rucio.core.rse.REGION'
 ]}], indirect=True)
 def test_preparer_without_and_with_mat(source_rse, dest_rse, mock_request, caches_mock):
-    add_rse_attribute(source_rse['id'], 'fts', 'a')
-    add_rse_attribute(dest_rse['id'], 'globus_endpoint_id', 'b')
+    add_rse_attribute(source_rse['id'], RseAttr.FTS, 'a')
+    add_rse_attribute(dest_rse['id'], RseAttr.GLOBUS_ENDPOINT_ID, 'b')
 
     [cache_region] = caches_mock
     cache_region.invalidate()
@@ -200,10 +201,10 @@ def test_get_supported_transfertools_fts_globus(vo, rse_factory):
     source_rse, source_rse_id = rse_factory.make_mock_rse()
     dest_rse, dest_rse_id = rse_factory.make_mock_rse()
 
-    add_rse_attribute(source_rse_id, 'fts', 'a')
-    add_rse_attribute(dest_rse_id, 'fts', 'b')
-    add_rse_attribute(source_rse_id, 'globus_endpoint_id', 'a')
-    add_rse_attribute(dest_rse_id, 'globus_endpoint_id', 'b')
+    add_rse_attribute(source_rse_id, RseAttr.FTS, 'a')
+    add_rse_attribute(dest_rse_id, RseAttr.FTS, 'b')
+    add_rse_attribute(source_rse_id, RseAttr.GLOBUS_ENDPOINT_ID, 'a')
+    add_rse_attribute(dest_rse_id, RseAttr.GLOBUS_ENDPOINT_ID, 'b')
 
     transfertools = get_supported_transfertools(source_rse=RseData(source_rse_id), dest_rse=RseData(dest_rse_id), transfertools=['fts3', 'globus'])
 

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -26,6 +26,7 @@ import xmltodict
 from werkzeug.datastructures import Headers, MultiDict
 
 from rucio.client.ruleclient import RuleClient
+from rucio.common.constants import RseAttr
 from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifierNotFound, InputValidationError, ReplicaIsLocked, ReplicaNotFound, RucioException, ScopeNotFound
 from rucio.common.schema import get_schema_value
 from rucio.common.utils import clean_surls, generate_uuid, parse_response
@@ -217,7 +218,7 @@ class TestReplicaCore:
 
         if simulate_multirange:
             add_rse_attribute(
-                rse_id=rse_id, key='simulate_multirange', value=str(nconns)
+                rse_id=rse_id, key=RseAttr.SIMULATE_MULTIRANGE, value=str(nconns)
             )
 
         # add files
@@ -456,7 +457,7 @@ class TestReplicaCore:
                                   'lan': {'read': 1, 'write': 1, 'delete': 1},
                                   'wan': {'read': 1, 'write': 1, 'delete': 1}}})
 
-        add_rse_attribute(rse_id=rse_id, key='site', value='APERTURE')
+        add_rse_attribute(rse_id=rse_id, key=RseAttr.SITE, value='APERTURE')
 
         files = [{'scope': mock_scope, 'name': 'element_%s' % generate_uuid(),
                   'bytes': 1234, 'adler32': 'deadbeef'}]
@@ -467,7 +468,7 @@ class TestReplicaCore:
         replicas = [r for r in replica_client.list_replicas(dids=[{'scope': 'mock', 'name': f['name']} for f in files],
                                                             client_location={'site': 'SOMEWHERE'})]
         assert 'root://' in list(replicas[0]['pfns'].keys())[0]
-        del_rse_attribute(rse_id=rse_id, key='site')
+        del_rse_attribute(rse_id=rse_id, key=RseAttr.SITE)
 
         replicas = [r for r in replica_client.list_replicas(dids=[{'scope': 'mock', 'name': f['name']} for f in files])]
         assert 'root://' in list(replicas[0]['pfns'].keys())[0]
@@ -543,7 +544,7 @@ class TestReplicaCore:
         rse2, rse2_id = rse_factory.make_mock_rse()
         activity = get_schema_value('ACTIVITY')['enum'][0]
         tombstone_delay = 3600
-        add_rse_attribute(rse_id=rse2_id, key='tombstone_delay', value=tombstone_delay)
+        add_rse_attribute(rse_id=rse2_id, key=RseAttr.TOMBSTONE_DELAY, value=tombstone_delay)
 
         # Will use the default tombstone delay
         did1 = did_factory.random_file_did()

--- a/tests/test_replica_sorting.py
+++ b/tests/test_replica_sorting.py
@@ -23,6 +23,7 @@ import geoip2.database
 import pytest
 
 from rucio.common.config import config_get
+from rucio.common.constants import RseAttr
 from rucio.common.utils import parse_replicas_from_string
 from rucio.core import replica_sorter, rse_expression_parser
 from rucio.core.replica import add_replicas, delete_replicas
@@ -108,7 +109,7 @@ def protocols_setup(vo, root_account, mock_scope):
     for idx in range(len(rse_info)):
         rse_info[idx]['name'] = '%s_%s' % (rse_info[idx]['site'], rse_name_generator())
         rse_info[idx]['id'] = add_rse(rse_info[idx]['name'], vo=vo)
-        add_rse_attribute(rse_id=rse_info[idx]['id'], key='site', value=base_rse_info[idx]['site'])
+        add_rse_attribute(rse_id=rse_info[idx]['id'], key=RseAttr.SITE, value=base_rse_info[idx]['site'])
         add_replicas(rse_id=rse_info[idx]['id'], files=files, account=root_account)
 
     # invalidate cache for parse_expression('site=…')
@@ -174,7 +175,7 @@ def protocols_setup(vo, root_account, mock_scope):
 
     for info in rse_info:
         delete_replicas(rse_id=info['id'], files=files)
-        del_rse_attribute(rse_id=info['id'], key='site')
+        del_rse_attribute(rse_id=info['id'], key=RseAttr.SITE)
         del_rse(info['id'])
 
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -19,6 +19,7 @@ from typing import Union
 import pytest
 
 from rucio.common.config import config_get_bool
+from rucio.common.constants import RseAttr
 from rucio.common.utils import generate_uuid, parse_response
 from rucio.core.distance import add_distance
 from rucio.core.replica import add_replica
@@ -178,11 +179,11 @@ def test_api_list(
     source_site2 = tag_factory.new_tag()
     dst_site = tag_factory.new_tag()
     dst_site2 = tag_factory.new_tag()
-    add_rse_attribute(source_rse_id, 'site', source_site, session=db_session)
-    add_rse_attribute(source_rse_id2, 'site', source_site2, session=db_session)
-    add_rse_attribute(source_rse_id3, 'site', source_site, session=db_session)
-    add_rse_attribute(dest_rse_id, 'site', dst_site, session=db_session)
-    add_rse_attribute(dest_rse_id2, 'site', dst_site2, session=db_session)
+    add_rse_attribute(source_rse_id, RseAttr.SITE, source_site, session=db_session)
+    add_rse_attribute(source_rse_id2, RseAttr.SITE, source_site2, session=db_session)
+    add_rse_attribute(source_rse_id3, RseAttr.SITE, source_site, session=db_session)
+    add_rse_attribute(dest_rse_id, RseAttr.SITE, dst_site, session=db_session)
+    add_rse_attribute(dest_rse_id2, RseAttr.SITE, dst_site2, session=db_session)
 
     name1 = generate_uuid()
     name2 = generate_uuid()

--- a/tests/test_root_proxy.py
+++ b/tests/test_root_proxy.py
@@ -16,6 +16,7 @@ from urllib.parse import urlencode
 
 import pytest
 
+from rucio.common.constants import RseAttr
 from rucio.core.config import set as config_set
 from rucio.core.replica import add_replicas, delete_replicas
 from rucio.core.rse import add_protocol, add_rse, add_rse_attribute, del_rse
@@ -35,13 +36,13 @@ def root_proxy_example_data(vo, root_account, mock_scope):
     rse_without_proxy = rse_name_generator()
     rse_without_proxy_id = add_rse(rse_without_proxy, vo=vo)
     add_rse_attribute(rse_id=rse_without_proxy_id,
-                      key='site',
+                      key=RseAttr.SITE,
                       value='BLACKMESA1')
 
     rse_with_proxy = rse_name_generator()
     rse_with_proxy_id = add_rse(rse_with_proxy, vo=vo)
     add_rse_attribute(rse_id=rse_with_proxy_id,
-                      key='site',
+                      key=RseAttr.SITE,
                       value='APERTURE1')
 
     # APERTURE1 site has an internal proxy

--- a/tests/test_rse.py
+++ b/tests/test_rse.py
@@ -16,6 +16,7 @@ import pytest
 
 from rucio.client.replicaclient import ReplicaClient
 from rucio.common import exception
+from rucio.common.constants import RseAttr
 from rucio.common.exception import Duplicate, InputValidationError, InvalidObject, ResourceTemporaryUnavailable, RSEAttributeNotFound, RSENotFound, RSEOperationNotSupported, RSEProtocolNotSupported
 from rucio.common.schema import get_schema_value
 from rucio.common.utils import CHECKSUM_KEY, GLOBALLY_SUPPORTED_CHECKSUMS
@@ -111,7 +112,7 @@ class TestRSECoreApi:
         add_rse_attribute(rse_id=rse_id, key='tier', value='1')
         rses = list_rses(filters={'tier': '1'})
         assert (rse_id, rse) in [(r['id'], r['rse']) for r in rses]
-        add_rse_attribute(rse_id=rse_id, key='country', value='us')
+        add_rse_attribute(rse_id=rse_id, key=RseAttr.COUNTRY, value='us')
 
         rses = list_rses(filters={'tier': '1', 'country': 'us'})
         assert (rse_id, rse) in [(r['id'], r['rse']) for r in rses]
@@ -1481,7 +1482,7 @@ class TestRSEClient:
         """ RSE (CORE): Test validate_checksum in RSEs info"""
         rse = rse_name_generator()
         rse_id = add_rse(rse, vo=vo)
-        add_rse_attribute(rse_id=rse_id, key='verify_checksum', value=False)
+        add_rse_attribute(rse_id=rse_id, key=RseAttr.VERIFY_CHECKSUM, value=False)
         info = get_rse_protocols(rse_id)
 
         assert 'verify_checksum' in info
@@ -1491,7 +1492,7 @@ class TestRSEClient:
 
         rse = rse_name_generator()
         rse_id = add_rse(rse, vo=vo)
-        add_rse_attribute(rse_id=rse_id, key='verify_checksum', value=True)
+        add_rse_attribute(rse_id=rse_id, key=RseAttr.VERIFY_CHECKSUM, value=True)
         info = get_rse_protocols(rse_id)
 
         assert 'verify_checksum' in info

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -24,6 +24,7 @@ import pytest
 import rucio.gateway.rule
 from rucio.client.ruleclient import RuleClient
 from rucio.common.config import config_get_bool
+from rucio.common.constants import RseAttr
 from rucio.common.exception import (
     AccessDenied,
     DuplicateRule,
@@ -240,7 +241,7 @@ class TestCore:
         rse = rse_name_generator()
         rse_id = add_rse(rse, vo=vo)
 
-        add_rse_attribute(rse_id, "rule_approvers", jdoe_account)
+        add_rse_attribute(rse_id, RseAttr.RULE_APPROVERS, jdoe_account)
 
         files = create_files(1, mock_scope, rse_id)
         output = add_rule(
@@ -928,7 +929,7 @@ class TestCore:
 
         rse = rse_name_generator()
         rse_id = add_rse(rse, vo=vo)
-        add_rse_attribute(rse_id, 'country', 'test')
+        add_rse_attribute(rse_id, RseAttr.COUNTRY, 'test')
         set_local_account_limit(jdoe_account, rse_id, -1)
 
         files = create_files(3, mock_scope, self.rse1_id)
@@ -1024,7 +1025,7 @@ class TestCore:
 
         rse = rse_name_generator()
         rse_id = add_rse(rse, vo=vo)
-        add_rse_attribute(rse_id, 'type', 'SCRATCHDISK')
+        add_rse_attribute(rse_id, RseAttr.TYPE, 'SCRATCHDISK')
         set_local_account_limit(jdoe_account, rse_id, -1)
 
         files = create_files(3, mock_scope, self.rse1_id)
@@ -1056,13 +1057,13 @@ class TestCore:
         assert (get_rule(rule_id)['state'] == RuleState.WAITING_APPROVAL)
         delete_rule(rule_id=rule_id)
 
-        add_rse_attribute(rse_id, 'auto_approve_bytes', 500)
+        add_rse_attribute(rse_id, RseAttr.AUTO_APPROVE_BYTES, 500)
         rule_id = add_rule(dids=[dataset], account=jdoe_account, copies=1, rse_expression='%s' % rse, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None, ask_approval=True)[0]
         assert (get_rule(rule_id)['state'] == RuleState.WAITING_APPROVAL)
         delete_rule(rule_id=rule_id)
 
-        del_rse_attribute(rse_id, 'auto_approve_bytes')
-        add_rse_attribute(rse_id, 'auto_approve_bytes', 1000)
+        del_rse_attribute(rse_id, RseAttr.AUTO_APPROVE_BYTES)
+        add_rse_attribute(rse_id, RseAttr.AUTO_APPROVE_BYTES, 1000)
         rule_id = add_rule(dids=[dataset], account=jdoe_account, copies=1, rse_expression='%s' % rse, grouping='DATASET', weight=None, lifetime=None, locked=False, subscription_id=None, ask_approval=True)[0]
         assert (get_rule(rule_id)['state'] == RuleState.INJECT)
 
@@ -1070,7 +1071,7 @@ class TestCore:
         """ REPLICATION RULE (CORE): Add a replication rule for a RSE with manual approval block"""
         rse = rse_name_generator()
         rse_id = add_rse(rse, vo=vo)
-        add_rse_attribute(rse_id, 'block_manual_approval', '1')
+        add_rse_attribute(rse_id, RseAttr.BLOCK_MANUAL_APPROVAL, '1')
         set_local_account_limit(jdoe_account, rse_id, -1)
 
         files = create_files(3, mock_scope, self.rse1_id)

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -18,6 +18,7 @@ from json.decoder import JSONDecodeError
 
 import pytest
 
+from rucio.common.constants import RseAttr
 from rucio.common.exception import InvalidObject, SubscriptionDuplicate, SubscriptionNotFound
 from rucio.common.schema import get_schema_value
 from rucio.common.types import InternalAccount, InternalScope
@@ -441,8 +442,8 @@ class TestDaemon:
         rse4, _ = rse_factory.make_mock_rse()
         rse5, _ = rse_factory.make_mock_rse()
         rse6, _ = rse_factory.make_mock_rse()
-        add_rse_attribute(rse_id=rse1_id, key='associated_sites', value='%s,%s' % (rse3, rse4))
-        add_rse_attribute(rse_id=rse2_id, key='associated_sites', value='%s,%s' % (rse5, rse6))
+        add_rse_attribute(rse_id=rse1_id, key=RseAttr.ASSOCIATED_SITES, value='%s,%s' % (rse3, rse4))
+        add_rse_attribute(rse_id=rse2_id, key=RseAttr.ASSOCIATED_SITES, value='%s,%s' % (rse5, rse6))
         rses = []
         for cnt in range(5):
             rse, _ = rse_factory.make_mock_rse()
@@ -744,7 +745,7 @@ class TestDaemon:
                 rse_type = 'tape'
             add_rse_attribute(rse_id=rse_id, key='tag', value=tag_test)
             add_rse_attribute(rse_id=rse_id, key=rse_type, value='True')
-            add_rse_attribute(rse_id=rse_id, key='site', value=site)
+            add_rse_attribute(rse_id=rse_id, key=RseAttr.SITE, value=site)
             dict_rse[rse] = {'rse_id': rse_id, 'rse_type': rse_type, 'site': site}
 
         tmp_scope = InternalScope('mock_' + uuid()[:8], vo=vo)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -23,6 +23,7 @@ import pytest
 
 from rucio.client.uploadclient import UploadClient
 from rucio.common.config import config_add_section, config_set
+from rucio.common.constants import RseAttr
 from rucio.common.exception import InputValidationError, NoFilesUploaded, NotAllFilesUploaded
 from rucio.common.utils import adler32, generate_uuid
 from rucio.core.rse import add_protocol, add_rse_attribute
@@ -181,7 +182,7 @@ def test_multiple_protocols_same_scheme(rse_factory, upload_client, mock_scope, 
     rse, rse_id = rse_factory.make_rse()
 
     # Ensure client site and rse site are identical. So that "lan" is preferred.
-    add_rse_attribute(rse_id, 'site', 'ROAMING')
+    add_rse_attribute(rse_id, RseAttr.SITE, 'ROAMING')
 
     add_protocol(rse_id, {'scheme': 'file',
                           'hostname': 'file-wan.aperture.com',


### PR DESCRIPTION
Create a namespace with all the RSE attribute names that are referenced in the Rucio source code and replace the hard-coded strings.  This aids in two ways: (1) that we have a full listing of those attributes, (2) It is easier to locate where they are used.

This does not affect non-Python files. The following RSE attributes are referenced in the web UI:
'auto_approve_bytes'
'block_manual_approval'
‘default_account_limit_bytes’
‘rule_approvers’
‘site’

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
