### PR TITLE
Database: Fix import statements for NoResultFound; fix #6682

### DIFF
--- a/lib/rucio/core/account_counter.py
+++ b/lib/rucio/core/account_counter.py
@@ -15,7 +15,7 @@ import datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import insert, literal, select
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from rucio.db.sqla import filter_thread_work, models
 from rucio.db.sqla.session import read_session, transactional_session

--- a/lib/rucio/core/account_limit.py
+++ b/lib/rucio/core/account_limit.py
@@ -14,7 +14,7 @@
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from sqlalchemy.sql import func, literal, select
 from sqlalchemy.sql.expression import and_, or_
 

--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -21,8 +21,7 @@ from re import match
 from typing import TYPE_CHECKING
 
 from sqlalchemy import and_, delete, exists, insert, or_, update
-from sqlalchemy.exc import DatabaseError, IntegrityError
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import DatabaseError, IntegrityError, NoResultFound
 from sqlalchemy.sql import func, not_
 from sqlalchemy.sql.expression import bindparam, case, false, null, select, true
 

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -17,8 +17,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from sqlalchemy import inspect, update
-from sqlalchemy.exc import CompileError, InvalidRequestError
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import CompileError, InvalidRequestError, NoResultFound
 from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import true
 

--- a/lib/rucio/core/did_meta_plugins/json_meta.py
+++ b/lib/rucio/core/did_meta_plugins/json_meta.py
@@ -16,8 +16,7 @@ import json as json_lib
 import operator
 from typing import TYPE_CHECKING, Any, cast
 
-from sqlalchemy.exc import DataError
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import DataError, NoResultFound
 
 from rucio.common import exception
 from rucio.core.did_meta_plugins.did_meta_plugin_interface import DidMetaPlugin

--- a/lib/rucio/core/dirac.py
+++ b/lib/rucio/core/dirac.py
@@ -17,7 +17,7 @@ from json import loads
 from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from rucio.common.config import config_get
 from rucio.common.exception import ConfigNotFound, InvalidType, RucioException, UnsupportedOperation

--- a/lib/rucio/core/lifetime_exception.py
+++ b/lib/rucio/core/lifetime_exception.py
@@ -18,8 +18,7 @@ from re import match
 from typing import TYPE_CHECKING
 
 from sqlalchemy import or_, select, update
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import IntegrityError, NoResultFound
 
 import rucio.common.policy
 from rucio.common.config import config_get, config_get_int, config_get_list

--- a/lib/rucio/core/rse_counter.py
+++ b/lib/rucio/core/rse_counter.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from typing import TYPE_CHECKING
 
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from rucio.common.exception import CounterNotFound
 from rucio.db.sqla import filter_thread_work, models

--- a/lib/rucio/core/rule_grouping.py
+++ b/lib/rucio/core/rule_grouping.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import func
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 import rucio.core.did
 import rucio.core.lock

--- a/lib/rucio/core/subscription.py
+++ b/lib/rucio/core/subscription.py
@@ -20,9 +20,8 @@ from json import dumps
 from typing import TYPE_CHECKING
 
 from sqlalchemy import func
-from sqlalchemy.exc import IntegrityError, StatementError
+from sqlalchemy.exc import IntegrityError, NoResultFound, StatementError
 from sqlalchemy.orm import aliased
-from sqlalchemy.orm.exc import NoResultFound
 
 from rucio.common.config import config_get
 from rucio.common.exception import RucioException, SubscriptionDuplicate, SubscriptionNotFound

--- a/lib/rucio/core/vo.py
+++ b/lib/rucio/core/vo.py
@@ -15,8 +15,7 @@
 import re
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy.exc import DatabaseError, IntegrityError
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import DatabaseError, IntegrityError, NoResultFound
 
 from rucio.common import exception
 from rucio.common.config import config_get, config_get_bool

--- a/lib/rucio/core/volatile_replica.py
+++ b/lib/rucio/core/volatile_replica.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import and_, exists, insert, or_, update
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 from sqlalchemy.sql.expression import select
 
 from rucio.common import exception

--- a/tests/test_dataset_replicas.py
+++ b/tests/test_dataset_replicas.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 from rucio.client.didclient import DIDClient
 from rucio.client.replicaclient import ReplicaClient


### PR DESCRIPTION
NoResultFound should be imported from sqlalchemy.exc, not sqlalchemy.orm.exc: https://docs.sqlalchemy.org/en/20/core/exceptions.html#sqlalchemy.exc.NoResultFound