### PR TITLE
Testing: Specify xmlsec version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ pycodestyle==2.11.0                                         # New package replac
 pylint==3.0.2
 astroid==3.0.1
 virtualenv==20.24.7                                         # Virtual Python Environment builder
+xmlsec==1.3.13                                              # Required to install pyproject.toml-based projects
 xmltodict==0.13.0                                           # Makes working with XML feel like you are working with JSON
 pytz==2023.3.post1                                          # World timezone definitions, modern and historical
 pydoc-markdown~=4.8.2                                       # Used for generating Markdown documentation for docusaurus


### PR DESCRIPTION
fixes #6694
Rolling `xmlsec` back to 1.3.13 (1.3.14 is a broken build)