### PR TITLE
Enhancement: Removing mutable params, adding type hints; #5169

### DIFF
--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -14,6 +14,7 @@
 
 from datetime import datetime
 from json import dumps, loads
+from typing import Any, Optional
 from urllib.parse import quote_plus
 
 from requests.status_codes import codes
@@ -233,7 +234,17 @@ class ReplicaClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
-    def add_replica(self, rse, scope, name, bytes_, adler32, pfn=None, md5=None, meta={}):
+    def add_replica(
+        self,
+        rse: str,
+        scope: str,
+        name: str,
+        bytes_: int,
+        adler32: str,
+        pfn: Optional[str] = None,
+        md5: Optional[str] = None,
+        meta: Optional[dict[str, Any]] = None
+    ) -> bool:
         """
         Add file replicas to a RSE.
 
@@ -249,6 +260,7 @@ class ReplicaClient(BaseClient):
         :return: True if files were created successfully.
 
         """
+        meta = meta or {}
         dict_ = {'scope': scope, 'name': name, 'bytes': bytes_, 'meta': meta, 'adler32': adler32}
         if md5:
             dict_['md5'] = md5

--- a/lib/rucio/core/distance.py
+++ b/lib/rucio/core/distance.py
@@ -121,13 +121,14 @@ def update_distances(src_rse_id: Optional[str] = None, dest_rse_id: Optional[str
 
 
 @read_session
-def list_distances(filter_: dict[str, Any] = {}, *, session: "Session") -> list[dict[str, Any]]:
+def list_distances(filter_: Optional[dict[str, Any]] = None, *, session: "Session") -> list[dict[str, Any]]:
     """
     Get distances between all the RSEs.
 
     :param filter_: dictionary to filter distances.
     :param session: The database session in use.
     """
+    filter_ = filter_ or {}
     return [distance.to_dict() for distance in session.query(Distance).all()]
 
 

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1427,7 +1427,7 @@ def __bulk_add_file_dids(files, account, dataset_meta=None, *, session: "Session
     :param dids: the list of files.
     :param account: The account owner.
     :param session: The database session in use.
-    :returns: True is successful.
+    :returns: list of replicas.
     """
     condition = []
     for f in files:
@@ -1539,7 +1539,7 @@ def add_replicas(rse_id, files, account, ignore_availability=True,
     :param ignore_availability: Ignore the RSE blocklisting.
     :param session: The database session in use.
 
-    :returns: True is successful.
+    :returns: list of replicas.
     """
 
     def _expected_pfns(lfns, rse_settings, scheme, operation='write', domain='wan', protocol_attr=None):
@@ -1634,7 +1634,7 @@ def add_replica(
     :param tombstone: If True, create replica with a tombstone.
     :param session: The database session in use.
 
-    :returns: True is successful.
+    :returns: list of replicas.
     """
     meta = meta or {}
     rules = rules or []

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -700,7 +700,7 @@ def get_rse_vo(rse_id: str, include_deleted: bool = True, *, session: "Session")
 
 
 @read_session
-def list_rses(filters={}, *, session: "Session"):
+def list_rses(filters: Optional[dict[str, Any]] = None, *, session: "Session") -> list[dict[str, Any]]:
     """
     Returns a list of all RSEs.
 
@@ -710,6 +710,7 @@ def list_rses(filters={}, *, session: "Session"):
     :returns: a list of dictionaries.
     """
 
+    filters = filters or {}
     rse_list = []
     filters = filters.copy()  # Make a copy, so we can pop() without affecting the object `filters` outside this function
 

--- a/lib/rucio/core/scope.py
+++ b/lib/rucio/core/scope.py
@@ -14,7 +14,7 @@
 
 from re import match
 from traceback import format_exc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy.exc import IntegrityError
 
@@ -79,7 +79,7 @@ def bulk_add_scopes(scopes, account, skipExisting=False, *, session: "Session"):
 
 
 @read_session
-def list_scopes(filter_={}, *, session: "Session"):
+def list_scopes(filter_: Optional[dict[str, Any]] = None, *, session: "Session") -> list[str]:
     """
     Lists all scopes.
     :param filter_: Dictionary of attributes by which the input data should be filtered
@@ -87,6 +87,7 @@ def list_scopes(filter_={}, *, session: "Session"):
 
     :returns: A list containing all scopes.
     """
+    filter_ = filter_ or {}
     scope_list = []
     query = session.query(models.Scope).filter(models.Scope.status != ScopeStatus.DELETED)
     for filter_type in filter_:

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -21,6 +21,7 @@ import logging
 import operator
 import os
 import re
+from typing import Optional
 
 import gfal2
 import requests
@@ -197,11 +198,12 @@ def download(url, filename):
     return protocol_funcs[protocol(url)]['download'](url, filename)
 
 
-def parse_configuration(conf_dirs=__DUMPERCONFIGDIRS):
+def parse_configuration(conf_dirs: Optional[list[str]] = None) -> Parser:
     '''
     Parses the configuration for the endpoints contained in `conf_dir`.
     Returns a ConfParser.RawConfParser subclass instance.
     '''
+    conf_dirs = conf_dirs or __DUMPERCONFIGDIRS
     logger = logging.getLogger('auditor.srmdumps')
     if len(conf_dirs) == 0:
         logger.error('No configuration directory given to load SRM dumps paths')

--- a/lib/rucio/daemons/bb8/common.py
+++ b/lib/rucio/daemons/bb8/common.py
@@ -15,6 +15,7 @@
 import logging
 from datetime import date, datetime, timedelta
 from string import Template
+from typing import Any, Optional
 
 from requests import get
 from sqlalchemy import BigInteger, and_, cast, func, or_
@@ -478,17 +479,17 @@ def list_rebalance_rule_candidates(rse_id, mode=None, *, session=None):
 
 @read_session
 def select_target_rse(
-    parent_rule,
-    current_rse_id,
-    rse_expression,
-    subscription_id,
-    rse_attributes,
-    other_rses=[],
-    exclude_expression=None,
-    force_expression=None,
+    parent_rule: dict[str, Any],
+    current_rse_id: str,
+    rse_expression: str,
+    subscription_id: str,
+    rse_attributes: dict[str, Any],
+    other_rses: Optional[list[str]] = None,
+    exclude_expression: Optional[str] = None,
+    force_expression: Optional[str] = None,
     *,
     session=None,
-):
+) -> str:
     """
     Select a new target RSE for a rebalanced rule.
     :param parent_rule           rule that is rebalanced.
@@ -503,6 +504,7 @@ def select_target_rse(
     :returns:                    New RSE expression.
     """
 
+    other_rses = other_rses or []
     current_rse = get_rse_name(rse_id=current_rse_id)
     current_rse_expr = current_rse
     # if parent rule has a vo, enforce it

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -79,22 +79,23 @@ def stop(signum: Optional[int] = None, frame: Optional[FrameType] = None) -> Non
 
 
 def run(
-        once=False,
-        total_threads=1,
-        group_bulk=1,
-        group_policy='rule',
-        rses=None,
-        include_rses=None,
-        exclude_rses=None,
-        vos=None,
-        bulk=100,
-        source_strategy=None,
-        activities=[],
-        sleep_time=600
-):
+    once: bool = False,
+    total_threads: int = 1,
+    group_bulk: int = 1,
+    group_policy: str = 'rule',
+    rses: Optional[list[str]] = None,
+    include_rses: Optional[str] = None,
+    exclude_rses: Optional[str] = None,
+    vos: Optional[list[str]] = None,
+    bulk: int = 100,
+    source_strategy: Optional[str] = None,
+    activities: Optional[list[str]] = None,
+    sleep_time: int = 600
+) -> None:
     """
     Starts up the conveyer threads.
     """
+    activities = activities or []
     setup_logging(process_name=DAEMON_NAME)
 
     if rucio.db.sqla.util.is_old_db():

--- a/lib/rucio/daemons/reaper/dark_reaper.py
+++ b/lib/rucio/daemons/reaper/dark_reaper.py
@@ -188,8 +188,18 @@ def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) ->
     GRACEFUL_STOP.set()
 
 
-def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None,
-        exclude_rses=None, include_rses=None, vos=None, delay_seconds=0, sleep_time=300):
+def run(
+    total_workers: int = 1,
+    chunk_size: int = 100,
+    once: bool = False,
+    rses: "Optional[list[str]]" = None,
+    scheme: "Optional[str]" = None,
+    exclude_rses: "Optional[str]" = None,
+    include_rses: "Optional[str]" = None,
+    vos: "Optional[list[str]]" = None,
+    delay_seconds: int = 0,
+    sleep_time: int = 300
+) -> None:
     """
     Starts up the reaper threads.
 
@@ -203,6 +213,7 @@ def run(total_workers=1, chunk_size=100, once=False, rses=[], scheme=None,
     :param vos: VOs on which to look for RSEs. Only used in multi-VO mode.
                 If None, we either use all VOs if run from "def", or the current VO otherwise.
     """
+    rses = rses or []
     setup_logging(process_name=DAEMON_NAME)
 
     if rucio.db.sqla.util.is_old_db():

--- a/lib/rucio/gateway/account.py
+++ b/lib/rucio/gateway/account.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Optional
 
 import rucio.common.exception
 import rucio.core.identity
@@ -115,7 +116,7 @@ def update_account(account, key, value, issuer='root', vo='def', *, session: "Se
 
 
 @stream_session
-def list_accounts(filter_={}, vo='def', *, session: "Session"):
+def list_accounts(filter_: Optional[dict[str, Any]] = None, vo: str = 'def', *, session: "Session") -> Iterator[dict[str, Any]]:
     """
     Lists all the Rucio account names.
 
@@ -128,8 +129,7 @@ def list_accounts(filter_={}, vo='def', *, session: "Session"):
     :returns: List of all accounts.
     """
     # If filter is empty, create a new dict to avoid overwriting the function's default
-    if not filter_:
-        filter_ = {}
+    filter_ = filter_ or {}
 
     if 'account' in filter_:
         filter_['account'] = InternalAccount(filter_['account'], vo=vo)

--- a/lib/rucio/gateway/replica.py
+++ b/lib/rucio/gateway/replica.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import datetime
-from typing import TYPE_CHECKING
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Optional
 
 from rucio.common import exception
 from rucio.common.constants import SuspiciousAvailability
@@ -418,7 +419,7 @@ def list_dataset_replicas_vp(scope, name, deep=False, vo='def', *, session: "Ses
 
 
 @stream_session
-def list_datasets_per_rse(rse, filters={}, limit=None, vo='def', *, session: "Session"):
+def list_datasets_per_rse(rse: str, filters: Optional[dict[str, Any]] = None, limit: Optional[int] = None, vo: str = 'def', *, session: "Session") -> Iterator[dict[str, Any]]:
     """
     :param scope: The scope of the dataset.
     :param name: The name of the dataset.
@@ -430,6 +431,7 @@ def list_datasets_per_rse(rse, filters={}, limit=None, vo='def', *, session: "Se
     :returns: A list of dict dataset replicas
     """
 
+    filters = filters or {}
     rse_id = get_rse_id(rse=rse, vo=vo, session=session)
     if 'scope' in filters:
         filters['scope'] = InternalScope(filters['scope'], vo=vo)

--- a/lib/rucio/gateway/rse.py
+++ b/lib/rucio/gateway/rse.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from rucio.common import exception
 from rucio.common.schema import validate_schema
@@ -109,7 +109,7 @@ def del_rse(rse, issuer, vo='def', *, session: "Session"):
 
 
 @read_session
-def list_rses(filters={}, vo='def', *, session: "Session"):
+def list_rses(filters: "Optional[dict[str, Any]]" = None, vo: str = 'def', *, session: "Session") -> list[dict[str, Any]]:
     """
     Lists all RSEs.
 
@@ -119,8 +119,7 @@ def list_rses(filters={}, vo='def', *, session: "Session"):
 
     :returns: List of all RSEs.
     """
-    if not filters:
-        filters = {}
+    filters = filters or {}
 
     filters['vo'] = vo
 

--- a/lib/rucio/gateway/rule.py
+++ b/lib/rucio/gateway/rule.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Optional
 
 from rucio.common.config import config_get_bool
 from rucio.common.exception import AccessDenied
@@ -134,7 +135,7 @@ def get_replication_rule(rule_id, issuer, vo='def', *, session: "Session"):
 
 
 @stream_session
-def list_replication_rules(filters={}, vo='def', *, session: "Session"):
+def list_replication_rules(filters: Optional[dict[str, Any]] = None, vo: str = 'def', *, session: "Session") -> Iterator[dict[str, Any]]:
     """
     Lists replication rules based on a filter.
 
@@ -143,8 +144,7 @@ def list_replication_rules(filters={}, vo='def', *, session: "Session"):
     :param session: The database session in use.
     """
     # If filters is empty, create a new dict to avoid overwriting the function's default
-    if not filters:
-        filters = {}
+    filters = filters or {}
 
     if 'scope' in filters:
         scope = filters['scope']

--- a/lib/rucio/gateway/scope.py
+++ b/lib/rucio/gateway/scope.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 import rucio.common.exception
 import rucio.gateway.permission
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 
 @read_session
-def list_scopes(filter_={}, vo='def', *, session: "Session"):
+def list_scopes(filter_: Optional[dict[str, Any]] = None, vo: str = 'def', *, session: "Session") -> list[str]:
     """
     Lists all scopes.
 
@@ -37,8 +37,7 @@ def list_scopes(filter_={}, vo='def', *, session: "Session"):
     :returns: A list containing all scopes.
     """
     # If filter is empty, create a new dict to avoid overwriting the function's default
-    if not filter_:
-        filter_ = {}
+    filter_ = filter_ or {}
 
     if 'scope' in filter_:
         filter_['scope'] = InternalScope(scope=filter_['scope'], vo=vo)

--- a/lib/rucio/rse/protocols/webdav.py
+++ b/lib/rucio/rse/protocols/webdav.py
@@ -16,7 +16,7 @@ import os
 import sys
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import urlparse
 
 import requests
@@ -151,7 +151,7 @@ class Default(protocol.RSEProtocol):
 
     """ Implementing access to RSEs using the webDAV protocol."""
 
-    def connect(self, credentials={}):
+    def connect(self, credentials: Optional[dict[str, Any]] = None) -> None:
         """ Establishes the actual connection to the referred RSE.
 
             :param credentials: Provides information to establish a connection
@@ -160,6 +160,7 @@ class Default(protocol.RSEProtocol):
 
             :raises RSEAccessDenied
         """
+        credentials = credentials or {}
         try:
             parse_url = urlparse(self.path2pfn(''))
             self.server = f'{parse_url.scheme}://{parse_url.netloc}'

--- a/lib/rucio/rse/protocols/webdav.py
+++ b/lib/rucio/rse/protocols/webdav.py
@@ -185,12 +185,15 @@ class Default(protocol.RSEProtocol):
                 # Trying to get the proxy from the default location
                 proxy_path = '/tmp/x509up_u%s' % os.geteuid()
                 if os.path.isfile(proxy_path):
-                    x509 = proxy_path
+                    self.cert = (proxy_path, proxy_path)
                 elif self.auth_token:
+                    # If no proxy is found, we set the cert to None and use the auth_token
+                    self.cert = None
                     pass
                 else:
                     raise exception.RSEAccessDenied('X509_USER_PROXY is not set')
-            self.cert = (x509, x509)
+            else:
+                self.cert = (x509, x509)
 
         try:
             self.timeout = credentials['timeout']

--- a/lib/rucio/web/ui/flask/common/utils.py
+++ b/lib/rucio/web/ui/flask/common/utils.py
@@ -15,12 +15,14 @@
 
 import html
 import re
+from collections.abc import Iterable
 from json import dumps, load
 from os.path import dirname, join
 from time import time
+from typing import Any, Optional
 from urllib.parse import quote, unquote
 
-from flask import make_response, redirect, render_template, request
+from flask import Response, make_response, redirect, render_template, request
 
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.exception import CannotAuthenticate
@@ -100,7 +102,14 @@ def prepare_saml_request(environ, data):
     return None
 
 
-def add_cookies(response, cookie={}):
+def add_cookies(response: Response, cookie: Optional[Iterable[dict[str, Any]]] = None) -> Response:
+    """
+    Adds cookies to the response object.
+    :param response: Flask response object
+    :param cookie: list of dictionaries containing cookies to add
+    :returns: response object with cookies added
+    """
+    cookie = cookie or []
     for int_cookie in cookie:
         response.set_cookie(**int_cookie)
 


### PR DESCRIPTION
Issue: #5169 
This PR serves two purposes:

1. Removes all instances of mutable default parameters (e.g. rses=[], filters={})
2. Type hints all the parameters in the functions where the mutable parameters appear. #6588 