### PR TITLE
Documentation: Fix typos in docstrings, comments and variable names; …

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -166,7 +166,7 @@ def exception_handler(function):
                     used_account = '%s (from rucio.cfg)' % config_get('client', 'account')
                 except:
                     pass
-                try:  # are we overriden by the environment?
+                try:  # are we overridden by the environment?
                     used_account = '%s (from RUCIO_ACCOUNT)' % os.environ['RUCIO_ACCOUNT']
                 except:
                     pass
@@ -1550,7 +1550,7 @@ def list_rse_attributes(args):
     """
     client = get_client(args)
     attributes = client.list_rse_attributes(rse=args.rse)
-    table = [(k + ':', str(v)) for (k, v) in sorted(attributes.items())]  # columns hav mixed datatypes
+    table = [(k + ':', str(v)) for (k, v) in sorted(attributes.items())]  # columns have mixed datatypes
     print(tabulate(table, tablefmt='plain', disable_numparse=True))  # disabling number parsing
     return SUCCESS
 

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -385,7 +385,7 @@ def set_limits(args):
             try:
                 byte_limit = int(limit_input)
             except ValueError:
-                logger.error('The limit could not be set. Either you misspelled infinity or your input could not be converted to integer or you used a wrong pattern. Please use a format like 10GB with B,KB,MB,GB,TB,PB as units (not case sensistive)')
+                logger.error('The limit could not be set. Either you misspelled infinity or your input could not be converted to integer or you used a wrong pattern. Please use a format like 10GB with B,KB,MB,GB,TB,PB as units (not case sensitive)')
                 return FAILURE
 
     client.set_account_limit(account=args.account, rse=args.rse, bytes_=byte_limit, locality=locality)
@@ -1383,7 +1383,7 @@ def get_parser():
     oparser.add_argument('--oidc-refresh-lifetime', dest='oidc_refresh_lifetime', default=None, help='Max lifetime in hours for this an access token will be refreshed by asynchronous Rucio daemon. '
                          + 'If not specified, refresh will be stopped after 4 days. This option is effective only if --oidc-scope includes offline_access scope for a refresh token to be granted to Rucio.')  # NOQA: W503
     oparser.add_argument('--oidc-issuer', dest='oidc_issuer', default=None,
-                         help='Defines which Identity Provider is goign to be used. The issuer string must correspond '
+                         help='Defines which Identity Provider is going to be used. The issuer string must correspond '
                          + 'to the keys configured in the /etc/idpsecrets.json auth server configuration file.')  # NOQA: W503
 
     # Options for the x509  auth_strategy
@@ -1708,7 +1708,7 @@ def get_parser():
                                                                   '    $ rucio-admin identity delete --account jdoe --type X509 --id \'CN=Joe Doe,CN=707658,CN=jdoe,OU=Users,OU=Organic Units,DC=cern,DC=ch\'\n'
                                                                   '    Deleted identity: CN=Joe Doe,CN=707658,CN=jdoe,OU=Users,OU=Organic Units,DC=cern,DC=ch\n'
                                                                   '\n'
-                                                                  'Note: if the identity was accidentaly deleted, use add option.\n'
+                                                                  'Note: if the identity was accidentally deleted, use add option.\n'
                                                                   '\n')
     identity_delete_parser.set_defaults(which='identity_delete')
     identity_delete_parser.add_argument('--account', dest='account', action='store', help='Account name', required=True)
@@ -1956,7 +1956,7 @@ def get_parser():
                                                               '    $ rucio-admin rse add-protocol --hostname jdoes.test.org --scheme gsiftp --prefix \'/atlasdatadisk/rucio/\' --port 8443 JDOE_DATADISK\n'
                                                               '\n'
                                                               'Note: no printed stdout.\n'
-                                                              'Note: examples of optional parametres::\n'
+                                                              'Note: examples of optional parameters::\n'
                                                               '\n'
                                                               '    --space-token DATADISK\n'
                                                               '    --web-service-path \'/srm/managerv2?SFN=\'\n'
@@ -2110,7 +2110,7 @@ def get_parser():
 
     # The config subparser
     config_parser = subparsers.add_parser('config',
-                                          help='Configuration methods. The global configuration of data mangement system can by modified.',
+                                          help='Configuration methods. The global configuration of data management system can by modified.',
                                           formatter_class=argparse.RawDescriptionHelpFormatter,
                                           epilog='''e.g. quotas, daemons, rses''')
     config_subparser = config_parser.add_subparsers(dest='config_subcommand', **required_arg)
@@ -2311,9 +2311,9 @@ def get_parser():
     declare_bad_file_replicas_parser.add_argument('--inputfile', dest='inputfile', nargs='?', action='store', help='File containing list of bad items')
     declare_bad_file_replicas_parser.add_argument('--allow-collection', dest='allow_collection', action='store_true', help='Allow passing a collection DID as bad item')
 
-    declare_bad_file_replicas_parser.add_argument('--lfns', dest='lfns', nargs='?', action='store', help='File cotaining list of LFNs for bad replicas. Requires --rse and --scope')
-    declare_bad_file_replicas_parser.add_argument('--scope', dest='scope', nargs='?', action='store', help='Common scope for bad replicas secified with LFN list, ignored wthout --lfns')
-    declare_bad_file_replicas_parser.add_argument('--rse', dest='rse', nargs='?', action='store', help='Common RSE for bad replicas secified with LFN list, ignored wthout --lfns')
+    declare_bad_file_replicas_parser.add_argument('--lfns', dest='lfns', nargs='?', action='store', help='File containing list of LFNs for bad replicas. Requires --rse and --scope')
+    declare_bad_file_replicas_parser.add_argument('--scope', dest='scope', nargs='?', action='store', help='Common scope for bad replicas specified with LFN list, ignored without --lfns')
+    declare_bad_file_replicas_parser.add_argument('--rse', dest='rse', nargs='?', action='store', help='Common RSE for bad replicas specified with LFN list, ignored without --lfns')
 
     # The declare-temporary-unavailable command
     declare_temporary_unavailable_replicas_parser = rep_subparser.add_parser('declare-temporary-unavailable',

--- a/bin/rucio-auditor
+++ b/bin/rucio-auditor
@@ -129,7 +129,7 @@ def main(args):
             time.sleep(RETRY_AFTER)
 
             # Avoid infinite loop if an alternative check() implementation doesn't
-            # decrement the number of attemps and keeps pushing failed checks.
+            # decrement the number of attempts and keeps pushing failed checks.
             tmp_list = []
             while not retry.empty():
                 tmp_list.append(retry.get())
@@ -149,7 +149,7 @@ def get_parser():
     """
     Returns the argparse parser.
     """
-    parser = argparse.ArgumentParser(description="The auditor daemon is the one responsable for the detection of inconsistencies on storage, i.e.: dark data discovery.",
+    parser = argparse.ArgumentParser(description="The auditor daemon is the one responsible for the detection of inconsistencies on storage, i.e.: dark data discovery.",
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
         '--nprocs',

--- a/bin/rucio-automatix
+++ b/bin/rucio-automatix
@@ -27,7 +27,7 @@ def get_parser():
     """
     Returns the argparse parser.
     """
-    parser = argparse.ArgumentParser(description="Automatix is a daemon used to inject random generated files to an RSE. It is used to continuosly check that an RSE is reachable and operating as spected.")
+    parser = argparse.ArgumentParser(description="Automatix is a daemon used to inject random generated files to an RSE. It is used to continuously check that an RSE is reachable and operating as expected.")
     parser.add_argument("--run-once", action="store_true", default=False, help='Runs one loop iteration')
     parser.add_argument("--input-file", action="store", default="/opt/rucio/etc/automatix.json", type=str, help='Automatix configuration')
     parser.add_argument("--threads-per-process", action="store", default=1, type=int, help='Total number of workers per process')

--- a/bin/rucio-conveyor-finisher
+++ b/bin/rucio-conveyor-finisher
@@ -27,7 +27,7 @@ def get_parser():
     """
     Returns the argparse parser.
     """
-    parser = argparse.ArgumentParser(description="Conveyor is a group of daemons to manage file transfers. The conveyor-finisher is the resposible to update Rucio internal state after the transfer has finished.")
+    parser = argparse.ArgumentParser(description="Conveyor is a group of daemons to manage file transfers. The conveyor-finisher is the responsible to update Rucio internal state after the transfer has finished.")
     parser.add_argument("--run-once", action="store_true", default=False,
                         help='One iteration only')
     parser.add_argument("--total-threads", action="store", default=1, type=int,

--- a/bin/rucio-conveyor-submitter
+++ b/bin/rucio-conveyor-submitter
@@ -34,7 +34,7 @@ Upload a file and create a replication rule::
   $ rucio add-rule mock:file 1 MOCK2
   $ rucio-admin rse add-distance MOCK2 MOCK --distance 1
 
-The rule should replicate the file from RSE MOCK to RSE MOCK2. Therefor a distance between these RSEs is needed.
+The rule should replicate the file from RSE MOCK to RSE MOCK2. Therefore a distance between these RSEs is needed.
 
 Check transfer requests for the DID::
 
@@ -56,7 +56,7 @@ Check again the transfer requests for the DID::
     session.get_session().query(models.Request).filter_by(scope='mock', name='file').first()
     # {'request_type': TRANSFER, 'state': SUBMITTED', ...}
 
-A tranfer request got created by executing the transfer. Depending on the transfer submission, the request state can be different. In this example the transfer got submitted successfully.
+A transfer request got created by executing the transfer. Depending on the transfer submission, the request state can be different. In this example the transfer got submitted successfully.
 
 When run in multi-VO mode, by default the daemon will run on RSEs from all VOs::
 

--- a/bin/rucio-judge-evaluator
+++ b/bin/rucio-judge-evaluator
@@ -113,11 +113,11 @@ Check the replicas for the DID mock:file::
   from rucio.db.sqla import session, models
   session.get_session().query(models.RSEFileAssociation).filter_by(name='file', scope='mock').first()
   // [{'name': 'file','lock_cnt': 1, 'state': COPYING, 'scope': 'mock', 'rse_id': 'f81f366593754c01b0c340fa5ea0ab90'},
-  //  {'scope': 'mock', 'rse_id': '1330d5daee37474c88ba888101d7b859', 'name': 'file', 'state': AVAIABLE, 'lock_cnt': 1}]
+  //  {'scope': 'mock', 'rse_id': '1330d5daee37474c88ba888101d7b859', 'name': 'file', 'state': AVAILABLE, 'lock_cnt': 1}]
 
 The DID mock:file has now two replicas with one lock each.
 As the file replica is attached to the dataset and the rule for the dataset specifies another RSE MOCK instead of the upload RSE, it has to be replicated to this RSE.
-Therefor a second replica in state COPYING got created on RSE MOCK.
+Therefore a second replica in state COPYING got created on RSE MOCK.
     ''', formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
     parser.add_argument("--threads", action="store", default=1, type=int, help='Concurrency control: total number of threads for this process')

--- a/bin/rucio-necromancer
+++ b/bin/rucio-necromancer
@@ -30,7 +30,7 @@ def get_parser():
     parser = argparse.ArgumentParser(description="The Necromancer daemon is responsible for managing bad replicas. If a replica that got declared bad has other replicas, it will try to recover it by requesting a new transfer. If there are no replicas anymore, then the file gets marked as lost.", epilog='''
 Lost replica:
 In this example the file gets uploaded and will only have this replica as there are no replication rules. If it gets declared bad, there will be no replica to recover from.
-Therefor the replica gets marked as lost.
+Therefore the replica gets marked as lost.
 
 Upload a file::
 

--- a/bin/rucio-oauth-manager
+++ b/bin/rucio-oauth-manager
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-OAuth Manager is a daemon which is reponsible for:
+OAuth Manager is a daemon which is responsible for:
 - deletion of expired access tokens (in case there is a valid refresh token, expired access tokens will be kept until refresh_token expires as well.)
 - deletion of expired OAuth session parameters
 - refreshing access tokens via their refresh tokens.
@@ -32,7 +32,7 @@ def get_parser():
     """
     parser = argparse.ArgumentParser(description='''
 
-OAuth Manager is a daemon which is reponsible for:
+OAuth Manager is a daemon which is responsible for:
 - deletion of expired access tokens (in case there is a valid refresh token,
   expired access tokens will be kept until refresh_token expires as well.)
 - deletion of expired OAuth session parameters

--- a/bin/rucio-replica-recoverer
+++ b/bin/rucio-replica-recoverer
@@ -67,7 +67,7 @@ $ id0=`uuidgen`
 $ id1=`uuidgen`
 $ id2=`uuidgen`
 $ id3=`uuidgen`
-$ echo "file available on MOCK_RECOVERY and decalred suspicious on MOCK_SUSPICIOUS  (11 times)" > /tmp/file_available_suspicious'_'$id1
+$ echo "file available on MOCK_RECOVERY and declared suspicious on MOCK_SUSPICIOUS  (11 times)" > /tmp/file_available_suspicious'_'$id1
 $ echo "file available on MOCK_RECOVERY and declared suspicious on MOCK_SUSPICIOUS  (11 times) and 1 time bad/deleted/lost on MOCK_SUSPICIOUS" > /tmp/file_available_suspicious_and_bad'_'$id2
 $ echo "file declared as unavailable on MOCK_RECOVERY and declared as suspicious 11 times on MOCK_SUSPICIOUS" > /tmp/file_notavailable_suspicious'_'$id3
 
@@ -228,7 +228,7 @@ Note that attempting the use the ``--vos`` argument when in single-VO mode will 
   2020-07-28 15:21:33,349 5488    WARNING Ignoring argument vos, this is only applicable in a multi-VO setup.
 ''', formatter_class=argparse.RawDescriptionHelpFormatter)  # NOQA: E501
     parser.add_argument("--nattempts", action="store", default=5, help='Minimum count of suspicious file replica appearance in bad_replicas table. Default value is 5.')
-    parser.add_argument("--younger-than", action="store", default=5, help='Consider all file replicas logged in bad_replicas table since speicified number of younger-than days. Default value is 5.')
+    parser.add_argument("--younger-than", action="store", default=5, help='Consider all file replicas logged in bad_replicas table since specified number of younger-than days. Default value is 5.')
     parser.add_argument('--vos', nargs='+', type=str, help='Optional list of VOs to consider. Only used in multi-VO mode.')
     parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only.')
     parser.add_argument("--limit-suspicious-files-on-rse", action="store", default=5, help='Maximum number of suspicious replicas on an RSE before that RSE is considered problematic and the suspicious replicas on that RSE are declared "TEMPORARY_UNAVAILABLE". Default value is 5.')

--- a/etc/docker/dev/README.rst
+++ b/etc/docker/dev/README.rst
@@ -111,7 +111,7 @@ When all the daemons ran you will be able to find the events in Kibana. If you r
 
 Additionally, there is also a Grafana server running with one simple dashboard. You can access it at http://localhost:3000. The default credentials are "admin/admin". Also ActiveMQ web console can be accessed at http://localhost:8161.
 
-If you would like to continously create some transfers and events there are scripts available for that. Open two different shells and in one run::
+If you would like to continuously create some transfers and events there are scripts available for that. Open two different shells and in one run::
 
     create_monit_data
 

--- a/etc/ldap.cfg.template
+++ b/etc/ldap.cfg.template
@@ -12,7 +12,7 @@ ldap_host = ldap-host.domain.name
 baseDN = dc=foo,dc=bar,dc=domain,dc=
 searchFilter = (objectClass=OpenLDAPperson)
 
-# set as DEFAULT to use annonymous bind
+# set as DEFAULT to use anonymous bind
 username = DEFAULT
 # Leave blank for prompt
 password =

--- a/etc/sql/oracle/procedures.sql
+++ b/etc/sql/oracle/procedures.sql
@@ -478,7 +478,7 @@ EXECUTE IMMEDIATE 'ALTER SESSION SET hash_area_size=2100000000';
 -- rep_type = 1 if non locked rule with no expiration data. Permanent data
 -- rep_type = 0 if non locked rule with expiration date. Temporary data
 -- 28th May 2018, version 1.6, added check for the number or rows when the CURRTIME is null
--- 10th Oct 2017, version 1.5, The CURRTIME is populated only at the end of the work because of the Monit Flume JDBC sorce
+-- 10th Oct 2017, version 1.5, The CURRTIME is populated only at the end of the work because of the Monit Flume JDBC source
 -- Direct select - insert instead of passing data via collection.
 -- Added 3 more metrics (columns to the RUCIO_ACCOUNTING_TAB and HIST tables) on which is based the computation TIER, SPACETOKEN, GRP_DATATYPE
 

--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -112,7 +112,7 @@ class AccountClient(BaseClient):
 
         :param type: The account type
         :param identity: The identity key name. For example x509 DN, or a username.
-        :param filters: A dictionnary key:account attribute to use for the filtering
+        :param filters: A dictionary key:account attribute to use for the filtering
 
         :return: a list containing account info dictionary for all rucio accounts.
         :raises AccountNotFound: if account doesn't exist.

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -235,7 +235,7 @@ class BaseClient:
         if self.auth_type == 'oidc':
             if not creds:
                 creds = {}
-            # if there are defautl values, check if rucio.cfg does not specify them, otherwise put default
+            # if there are default values, check if rucio.cfg does not specify them, otherwise put default
             if 'oidc_refresh_lifetime' not in creds or creds['oidc_refresh_lifetime'] is None:
                 creds['oidc_refresh_lifetime'] = config_get('client', 'oidc_refresh_lifetime', False, None)
             if 'oidc_issuer' not in creds or creds['oidc_issuer'] is None:
@@ -615,7 +615,7 @@ class BaseClient:
 
         else:
             print("\nAccording to the OAuth2/OIDC standard you should NOT be sharing \n"
-                  + "your password with any 3rd party appplication, therefore, \n"  # NOQA: W503
+                  + "your password with any 3rd party application, therefore, \n"  # NOQA: W503
                   + "we strongly discourage you from following this --oidc-auto approach.")  # NOQA: W503
             print("-------------------------------------------------------------------------")
             auth_res = self._send_request(auth_url, get_token=True)
@@ -658,7 +658,7 @@ class BaseClient:
 
         self.auth_token = result.headers['x-rucio-auth-token']
         if self.auth_oidc_refresh_active:
-            self.logger.debug("Reseting the token expiration epoch file content.")
+            self.logger.debug("Resetting the token expiration epoch file content.")
             # reset the token expiration epoch file content
             # at new CLI OIDC authentication
             self.token_exp_epoch = None

--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -47,7 +47,7 @@ class DIDClient(BaseClient):
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), 'dids', 'search'])
 
         # stringify dates.
-        if isinstance(filters, dict):   # backwards compatability for filters as single {}
+        if isinstance(filters, dict):   # backwards compatibility for filters as single {}
             filters = [filters]
         for or_group in filters:
             for key, value in or_group.items():

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -265,7 +265,7 @@ class DownloadClient:
             force_scheme                   - Optional: force a specific scheme to download this item. (Default: None)
             base_dir                       - Optional: base directory where the downloaded files will be stored. (Default: '.')
             no_subdir                      - Optional: If true, files are written directly into base_dir. (Default: False)
-            nrandom                        - Optional: if the DID addresses a dataset, nrandom files will be randomly choosen for download from the dataset
+            nrandom                        - Optional: if the DID addresses a dataset, nrandom files will be randomly chosen for download from the dataset
             ignore_checksum                - Optional: If true, skips the checksum validation between the downloaded file and the rucio catalouge. (Default: False)
             transfer_timeout               - Optional: Timeout time for the download protocols. (Default: None)
             transfer_speed_timeout         - Optional: Minimum allowed transfer speed (in KBps). Ignored if transfer_timeout set. Otherwise, used to compute default timeout (Default: 500)
@@ -671,10 +671,10 @@ class DownloadClient:
 
         # if the file was downloaded with success, it can be linked to pcache
         if pcache:
-            logger(logging.INFO, 'File %s is going to be registerred into pcache.' % dest_file_path)
+            logger(logging.INFO, 'File %s is going to be registered into pcache.' % dest_file_path)
             try:
                 pcache_state, hardlink_state = pcache.check_and_link(src=pfn, storage_root=storage_prefix, local_src=first_dest_file_path)
-                logger(logging.INFO, 'File %s is now registerred into pcache.' % first_dest_file_path)
+                logger(logging.INFO, 'File %s is now registered into pcache.' % first_dest_file_path)
             except Exception as e:
                 logger(logging.WARNING, 'Failed to load file to pcache: %s' % str(e))
 
@@ -741,7 +741,7 @@ class DownloadClient:
             rse                            - Optional: rse name (e.g. 'CERN-PROD_DATADISK') or rse expression from where to download
             base_dir                       - Optional: base directory where the downloaded files will be stored. (Default: '.')
             no_subdir                      - Optional: If true, files are written directly into base_dir. (Default: False)
-            nrandom                        - Optional: if the DID addresses a dataset, nrandom files will be randomly choosen for download from the dataset
+            nrandom                        - Optional: if the DID addresses a dataset, nrandom files will be randomly chosen for download from the dataset
             ignore_checksum                - Optional: If true, skips the checksum validation between the downloaded file and the rucio catalouge. (Default: False)
             check_local_with_filesize_only - Optional: If true, already downloaded files will not be validated by checksum.
 
@@ -798,7 +798,7 @@ class DownloadClient:
 
         :param rpc_secret: the secret for the RPC proxy
 
-        :returns: a tupel with the process and the rpc proxy objects
+        :returns: a tuple with the process and the rpc proxy objects
 
         :raises RucioException: if the process or the proxy could not be created
         """
@@ -958,7 +958,7 @@ class DownloadClient:
                 # workaround: only consider first dest file path for aria2c download
                 dest_file_path = next(iter(item['dest_file_paths']))
 
-                # ensure we didnt miss the active state (e.g. a very fast download)
+                # ensure we didn't miss the active state (e.g. a very fast download)
                 start_time = item.setdefault('transferStart', time.time())
                 end_time = item.setdefault('transferEnd', time.time())
 
@@ -1093,7 +1093,7 @@ class DownloadClient:
             self.extraction_tools = [tool for tool in self.extraction_tools if tool.is_useable()]
             if len(self.extraction_tools) < 1:
                 logger(logging.WARNING, 'Archive resolution is enabled but no extraction tool is available. '
-                                        'Sources whose protocol doesnt support extraction wont be considered for download.')
+                                        'Sources whose protocol does not support extraction will not be considered for download.')
 
         # if excluding tapes, we need to list them first
         tape_rses = []
@@ -1110,7 +1110,7 @@ class DownloadClient:
         for item in input_items:
             resolved_dids = list(self._resolve_one_item_dids(item))
             if not resolved_dids:
-                logger(logging.WARNING, 'An item didnt have any DIDs after resolving the input: %s.' % item.get('did', item))
+                logger(logging.WARNING, 'An item did not have any DIDs after resolving the input: %s.' % item.get('did', item))
             item['dids'] = resolved_dids
             for did in resolved_dids:
                 did_to_input_items.setdefault(DID(did), []).append(item)
@@ -1342,7 +1342,7 @@ class DownloadClient:
             file_item['dest_file_paths'] = list(dest_file_paths)
             file_item['temp_file_path'] = '%s.part' % file_item['dest_file_paths'][0]
 
-            # the file did str ist not an unique key for this dict because multiple calls of list_replicas
+            # the file did str is not an unique key for this dict because multiple calls of list_replicas
             # could result in the same DID multiple times. So we're using the id of the dictionary objects
             fiid = id(file_item)
             fiid_to_file_item[fiid] = file_item
@@ -1500,7 +1500,7 @@ class DownloadClient:
         Splits a given DID string (e.g. 'scope1:name.file') into its scope and name part
         (This function is meant to be used as class internal only)
 
-        :param did_str: the DID string that will be splitted
+        :param did_str: the DID string that will be split
 
         :returns: the scope- and name part of the given DID
 
@@ -1538,7 +1538,7 @@ class DownloadClient:
         :param dest_dir_name: name of the destination directory
         :param no_subdir: if no subdirectory should be created
 
-        :returns: the absolut path of the destination directory
+        :returns: the absolute path of the destination directory
         """
         # append dest_dir_name, if subdir should be used
         if dest_dir_name.startswith('/'):

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -83,7 +83,7 @@ class RSEClient(BaseClient):
         Update RSE properties like availability or name.
 
         :param rse: the name of the new rse.
-        :param  parameters: A dictionnary with property (name, read, write, delete as keys).
+        :param  parameters: A dictionary with property (name, read, write, delete as keys).
         """
         path = 'rses/' + rse
         url = build_url(choice(self.list_hosts), path=path)
@@ -341,7 +341,7 @@ class RSEClient(BaseClient):
 
         :param rse: the RSE name.
         :param scheme: identifier of the protocol.
-        :param data: A dict providing the new values of the protocol attibutes.
+        :param data: A dict providing the new values of the protocol attributes.
                      Keys must match column names in database.
         :param hostname: hostname of the protocol.
         :param port: port of the protocol.
@@ -512,7 +512,7 @@ class RSEClient(BaseClient):
         :param rse: The RSE name.
         :param filters: dictionary of attributes by which the results should be filtered.
 
-        :returns:  list of dictionnaries.
+        :returns:  list of dictionaries.
         """
         path = [self.RSE_BASEURL, rse, 'usage', 'history']
         path = '/'.join(path)
@@ -593,7 +593,7 @@ class RSEClient(BaseClient):
 
         :param source: The source.
         :param destination: The destination.
-        :param parameters: A dictionnary with property.
+        :param parameters: A dictionary with property.
         """
         path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)
@@ -612,7 +612,7 @@ class RSEClient(BaseClient):
 
         :param source: The source.
         :param destination: The destination.
-        :param parameters: A dictionnary with property.
+        :param parameters: A dictionary with property.
         """
         path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -458,7 +458,7 @@ class UploadClient:
             try:
                 guid = output.splitlines()[-1].split()[0].replace('-', '').lower()
             except Exception:
-                raise RucioException('Error extracting GUID from ouput of pool_extractFileIdentifier')
+                raise RucioException('Error extracting GUID from output of pool_extractFileIdentifier')
         elif guid:
             guid = guid.replace('-', '')
         else:
@@ -740,7 +740,7 @@ class UploadClient:
 
     def _create_protocol(self, rse_settings, operation, impl=None, force_scheme=None, domain='wan'):
         """
-        Protol construction.
+        Protocol construction.
         :param rse_settings:        rse_settings
         :param operation:           activity, e.g. read, write, delete etc.
         :param force_scheme:        custom scheme

--- a/lib/rucio/common/dumper/__init__.py
+++ b/lib/rucio/common/dumper/__init__.py
@@ -167,7 +167,7 @@ def temp_file(
 
     - `directory`: working path to create the temporal and the final file.
     - `final_name`: Path of the final file, relative to `directory`.
-       If the `final_name` is omitted or None the renaming step is ommited,
+       If the `final_name` is omitted or None the renaming step is omitted,
        leaving the temporal file with the results.
     - `binary`: whether to open the file in binary mode (default: False).
 
@@ -235,13 +235,13 @@ def to_datetime(str_or_datetime: Union[datetime.datetime, str]) -> Optional[date
             'Trying to parse "%s" date with resolution of milliseconds',
             str_or_datetime,
         )
-        miliseconds = int(MILLISECONDS_RE.search(str_or_datetime).group(1))
+        milliseconds = int(MILLISECONDS_RE.search(str_or_datetime).group(1))
         str_or_datetime = MILLISECONDS_RE.sub('', str_or_datetime)
         date = datetime.datetime.strptime(
             str_or_datetime,
             DATETIME_FORMAT,
         )
-        date = date + datetime.timedelta(microseconds=miliseconds * 1000)
+        date = date + datetime.timedelta(microseconds=milliseconds * 1000)
     return date
 
 
@@ -314,7 +314,7 @@ def gfal_download_to_file(url: str, file_: "IO") -> None:
         chunk = infile.read(CHUNK_SIZE)
     except gfal2.GError as e:
         if e.code == 70:
-            logger.debug('GError(70) raised, using GRIDFTP PLUGIN:STAT_ON_OPEN=False workarround to download %s', url)
+            logger.debug('GError(70) raised, using GRIDFTP PLUGIN:STAT_ON_OPEN=False workaround to download %s', url)
             ctx.set_opt_boolean('GRIDFTP PLUGIN', 'STAT_ON_OPEN', False)
             infile = ctx.open(url, 'r')
             chunk = infile.read(CHUNK_SIZE)

--- a/lib/rucio/common/dumper/consistency.py
+++ b/lib/rucio/common/dumper/consistency.py
@@ -66,7 +66,7 @@ class Consistency(data_models.DataModel):
             Parser to have consistent paths in storage dumps.
 
             :param line: String with one line of a dump.
-            :returns: Path formated as in the Rucio Replica Dumps.
+            :returns: Path formatted as in the Rucio Replica Dumps.
             '''
             relative = path_parsing.remove_prefix(
                 prefix_components,
@@ -291,7 +291,7 @@ def gnu_sort(file_path, prefix=None, delimiter=None, fieldspec=None, cache_dir=D
 
     :param prefix: If given the output file will be named <prefix>_sorted.
     Otherwise the prefix is the name of the input file.
-    :param delimiter: Delimiter character if the data is formated in
+    :param delimiter: Delimiter character if the data is formatted in
     columns (argument of -t in the sort command).
     :param fieldspec: String with the specification of column or columns
     to be used to sort (argument -k in the sort command).
@@ -329,7 +329,7 @@ def gnu_sort(file_path, prefix=None, delimiter=None, fieldspec=None, cache_dir=D
 
 
 def populate_args(argparser):
-    # Option to download the rucio replica dumps automaticaly
+    # Option to download the rucio replica dumps automatically
     parser = argparser.add_parser(
         'consistency',
         help='Consistency check to verify possible lost files and dark data '

--- a/lib/rucio/common/dumper/data_models.py
+++ b/lib/rucio/common/dumper/data_models.py
@@ -43,7 +43,7 @@ class DataModel:
     def __init__(self, *args):
         if len(args) != len(self.SCHEMA):
             raise TypeError(
-                'Wrong number of parameters (fields) to initalize {0} '
+                'Wrong number of parameters (fields) to initialize {0} '
                 'instance. {1} given, {2} expected:\n{3}'.format(
                     type(self).__name__,
                     len(args),

--- a/lib/rucio/common/pcache.py
+++ b/lib/rucio/common/pcache.py
@@ -69,7 +69,7 @@ def run_cmd(args, timeout=0):
         # Collect the output when the command completes
         stdout = p.communicate()[0][:-1]
 
-        # Commmand completed in time, cancel the alarm
+        # Command completed in time, cancel the alarm
         if (timeout > 0):
             signal.alarm(0)
 
@@ -97,7 +97,7 @@ def run_cmd(args, timeout=0):
 
 def get_process_children(pid):
 
-    # Get a list of all pids assocaited with a given pid
+    # Get a list of all pids associated with a given pid
     p = subprocess.Popen(args='ps --no-headers -o pid --ppid %d' % pid,
                          shell=True,
                          stdout=subprocess.PIPE,

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -223,7 +223,7 @@ CHECKSUM_KEY = 'supported_checksums'
 
 def is_checksum_valid(checksum_name):
     """
-    A simple function to check wether a checksum algorithm is supported.
+    A simple function to check whether a checksum algorithm is supported.
     Relies on GLOBALLY_SUPPORTED_CHECKSUMS to allow for expandability.
 
     :param checksum_name: The name of the checksum to be verified.
@@ -235,7 +235,7 @@ def is_checksum_valid(checksum_name):
 
 def set_preferred_checksum(checksum_name):
     """
-    A simple function to check wether a checksum algorithm is supported.
+    A simple function to check whether a checksum algorithm is supported.
     Relies on GLOBALLY_SUPPORTED_CHECKSUMS to allow for expandability.
 
     :param checksum_name: The name of the checksum to be verified.
@@ -673,7 +673,7 @@ def rse_supported_protocol_operations():
 
 
 def rse_supported_protocol_domains():
-    """ Returns a list with all supoorted RSE protocol domains."""
+    """ Returns a list with all supported RSE protocol domains."""
     return ['lan', 'wan']
 
 
@@ -1650,7 +1650,7 @@ def get_thread_with_periodic_running_function(interval, action, graceful_stop):
     """
     Get a thread where a function runs periodically.
 
-    :param interval: Interval in seconds when the action fucntion should run.
+    :param interval: Interval in seconds when the action function should run.
     :param action: Function, that should run periodically.
     :param graceful_stop: Threading event used to check for graceful stop.
     """
@@ -1862,7 +1862,7 @@ class retry:
     def __init__(self, func, *args, **kwargs):
         '''
         :param func: a method that should be executed with retries
-        :param args: parametres of the func
+        :param args: parameters of the func
         :param kwargs: key word arguments of the func
         '''
         self.func, self.args, self.kwargs = func, args, kwargs
@@ -2086,7 +2086,7 @@ def check_policy_package_version(package):
 class Availability:
     """
     This util class acts as a translator between the availability stored as
-    integer and as boolen values.
+    integer and as boolean values.
 
     `None` represents a missing value. This lets a user update a specific value
     without altering the other ones. If it needs to be evaluated, it will

--- a/lib/rucio/core/authentication.py
+++ b/lib/rucio/core/authentication.py
@@ -519,7 +519,7 @@ def validate_auth_token(token: str, *, session: "Session") -> "dict[str, Any]":
     if value is NO_VALUE:  # no cached entry found
         value = query_token(token, session=session)
         if not value:
-            # identify JWT access token and validte
+            # identify JWT access token and validate
             # & save it in Rucio if scope and audience are correct
             if len(token.split(".")) == 3:
                 value = validate_jwt(token, session=session)

--- a/lib/rucio/core/credential.py
+++ b/lib/rucio/core/credential.py
@@ -40,7 +40,7 @@ def get_signed_url(rse_id: str, service: str, operation: str, url: str, lifetime
     """
     Get a signed URL for a particular service and operation.
 
-    The signed URL will be valid for 1 hour but can be overriden.
+    The signed URL will be valid for 1 hour but can be overridden.
 
     :param rse_id: The ID of the RSE that the URL points to.
     :param service: The service to authorise, either 'gcs', 's3' or 'swift'.

--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -341,7 +341,7 @@ def attach_dids_to_dids(
             raise exception.DataIdentifierNotFound("Data identifier '%s:%s' not found" % (attachment['scope'], attachment['name']))
         first_iteration = False
 
-    # Remove all duplicated dictionnaries from the list
+    # Remove all duplicated dictionaries from the list
     # (convert the list of dictionaries into a list of tuple, then to a set of tuple
     # to remove duplicates, then back to a list of unique dictionaries)
     parent_dids = [dict(tup) for tup in set(tuple(dictionary.items()) for dictionary in parent_dids)]
@@ -477,7 +477,7 @@ def __add_files_to_archive(parent_did, files_temp_table, files, account, ignore_
         raise exception.RucioException(error.args)
 
     if not parent_did.is_archive:
-        # mark tha archive file as is_archive
+        # mark the archive file as is_archive
         parent_did.is_archive = True
 
         # mark parent datasets as is_archive = True
@@ -859,7 +859,7 @@ def __add_files_to_archive_without_temp_tables(scope, name, files, account, igno
     )
     archive_did = session.execute(stmt).scalar()
     if not archive_did.is_archive:
-        # mark tha archive file as is_archive
+        # mark the archive file as is_archive
         archive_did.is_archive = True
 
         # mark parent datasets as is_archive = True
@@ -2884,7 +2884,7 @@ def remove_dids_from_followed(dids, account, *, session: "Session"):
 @transactional_session
 def trigger_event(scope, name, event_type, payload, *, session: "Session"):
     """
-    Records changes occuring in the did to the FollowEvents table
+    Records changes occurring in the did to the FollowEvents table
 
     :param scope: The scope name.
     :param name: The data identifier name.
@@ -2900,7 +2900,7 @@ def trigger_event(scope, name, event_type, payload, *, session: "Session"):
             name=name
         )
         for did in session.execute(stmt).scalars().all():
-            # Create a new event using teh specified parameters.
+            # Create a new event using the specified parameters.
             new_event = models.FollowEvents(scope=scope, name=name, account=did.account,
                                             did_type=did.did_type, event_type=event_type, payload=payload)
             new_event.save(session=session, flush=False)
@@ -2924,7 +2924,7 @@ def create_reports(total_workers, worker_number, *, session: "Session"):
         models.FollowEvents.created_at
     )
 
-    # Use hearbeat mechanism to select a chunck of events based on the hashed account
+    # Use heartbeat mechanism to select a chunk of events based on the hashed account
     stmt = filter_thread_work(session=session, query=stmt, total_threads=total_workers, thread_id=worker_number, hash_variable='account')
 
     try:

--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -215,7 +215,7 @@ def list_dids(scope=None, filters=None, did_type='collection', ignore_case=False
     :returns: List of dids satisfying metadata criteria.
     :raises: InvalidMetadata
     """
-    # backwards compatability for filters as single {}.
+    # backwards compatibility for filters as single {}.
     if isinstance(filters, dict):
         filters = [filters]
 

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -197,7 +197,7 @@ class DidColumnMeta(DidMetaPlugin):
             'file': [DIDType.FILE]
         }
 
-        # backwards compatability for filters as single {}.
+        # backwards compatibility for filters as single {}.
         if isinstance(filters, dict):
             filters = [filters]
 

--- a/lib/rucio/core/did_meta_plugins/filter_engine.py
+++ b/lib/rucio/core/did_meta_plugins/filter_engine.py
@@ -100,7 +100,7 @@ class FilterEngine:
 
         :param model_class: The word.
         :param model_class: The SQL model class.
-        :params: strict: Enforce that keywords must be coercable to a model attribute.
+        :params: strict: Enforce that keywords must be coercible to a model attribute.
         :returns: The coerced attribute if successful or (if strict is False) the word if not.
         :raises: KeyNotFound
         """
@@ -199,7 +199,7 @@ class FilterEngine:
         Typecasting of values is also attempted.
 
         :param model_class: The SQL model class.
-        :param strict_coerce: Enforce that keywords must be coercable to a model attribute.
+        :param strict_coerce: Enforce that keywords must be coercible to a model attribute.
         :returns: The set of mandatory model attributes to be used in the filter query.
         :raises: MissingModuleException, DIDFilterSyntaxError
         """

--- a/lib/rucio/core/did_meta_plugins/json_meta.py
+++ b/lib/rucio/core/did_meta_plugins/json_meta.py
@@ -143,7 +143,7 @@ class JSONDidMeta(DidMetaPlugin):
         if not ignore_dids:
             ignore_dids = set()
 
-        # backwards compatability for filters as single {}.
+        # backwards compatibility for filters as single {}.
         if isinstance(filters, dict):
             filters = [filters]
 

--- a/lib/rucio/core/did_meta_plugins/mongo_meta.py
+++ b/lib/rucio/core/did_meta_plugins/mongo_meta.py
@@ -142,7 +142,7 @@ class MongoDidMeta(DidMetaPlugin):
         if not ignore_dids:
             ignore_dids = set()
 
-        # backwards compatability for filters as single {}.
+        # backwards compatibility for filters as single {}.
         if isinstance(filters, dict):
             filters = [filters]
 

--- a/lib/rucio/core/did_meta_plugins/postgres_meta.py
+++ b/lib/rucio/core/did_meta_plugins/postgres_meta.py
@@ -251,7 +251,7 @@ class ExternalPostgresJSONDidMeta(DidMetaPlugin):
         if not ignore_dids:
             ignore_dids = set()
 
-        # backwards compatability for filters as single {}.
+        # backwards compatibility for filters as single {}.
         if isinstance(filters, dict):
             filters = [filters]
 

--- a/lib/rucio/core/identity.py
+++ b/lib/rucio/core/identity.py
@@ -205,7 +205,7 @@ def get_default_account(identity: str, type_: IdentityType, oldest_if_none: bool
 
     :param identity: The identity key name. For example, x509DN, or a username.
     :param type_: The type of the authentication (x509, gss, userpass, saml, oidc).
-    :param oldest_if_none: If True and no default account it found the oldes known
+    :param oldest_if_none: If True and no default account it found the oldest known
                            account of that identity will be chosen, if False and
                            no default account is found, exception will be raised.
     :param session: The database session to use.

--- a/lib/rucio/core/lock.py
+++ b/lib/rucio/core/lock.py
@@ -214,7 +214,7 @@ def get_files_and_replica_locks_of_dataset(scope, name, nowait=False, restrict_r
     Get all the files of a dataset and, if existing, all locks of the file.
 
     :param scope:          Scope of the dataset
-    :param name:           Name of the datset
+    :param name:           Name of the dataset
     :param nowait:         Nowait parameter for the FOR UPDATE statement
     :param restrict_rses:  Possible RSE_ids to filter on.
     :param only_stuck:     If true, only get STUCK locks.

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -380,7 +380,7 @@ def get_auth_oidc(account: str, *, session: "Session", **kwargs) -> str:
               OR a redirection url to be used in user's browser for authentication.
     """
     # TO-DO - implement a check if that account already has a valid
-    # token withthe required scope and audience and return such token !
+    # token with the required scope and audience and return such token !
     auth_scope = kwargs.get('auth_scope', EXPECTED_OIDC_SCOPE)
     if not auth_scope:
         auth_scope = EXPECTED_OIDC_SCOPE
@@ -756,8 +756,8 @@ def get_token_for_account_operation(account: str, req_audience: str = None, req_
         # supported by Rucio server (have OIDC admin client registered as well)
         # that is why we take the issuer of the account identity that has an active/valid token
         # and look for admin account identity which has this issuer assigned
-        # requestor should always have at least one active subject token unless it is root
-        # this is why we first discover if the requestor is root or not
+        # requester should always have at least one active subject token unless it is root
+        # this is why we first discover if the requester is root or not
         get_token_for_adminacc = False
         admin_identity = None
         admin_issuer = None
@@ -767,10 +767,10 @@ def get_token_for_account_operation(account: str, req_audience: str = None, req_
         preferred_issuer = None
         for token in account_tokens:
             preferred_issuer = token.identity.split(", ")[1].split("=")[1]
-        # loop through all OIDC identities registerd for the account of the requestor
+        # loop through all OIDC identities registered for the account of the requester
         for identity in identities:
             issuer = identity.split(", ")[1].split("=")[1]
-            # compare the account of the requestor with the account of the admin
+            # compare the account of the requester with the account of the admin
             if account == admin_iss_acc_idt_dict[issuer][0]:
                 # take first matching case which means root is requesting OIDC authentication
                 admin_identity = admin_iss_acc_idt_dict[issuer][1]

--- a/lib/rucio/core/quarantined_replica.py
+++ b/lib/rucio/core/quarantined_replica.py
@@ -37,7 +37,7 @@ def add_quarantined_replicas(rse_id: str, replicas: list[dict[str, Any]], *, ses
     :param session:  The database session in use.
     """
 
-    # Exlude files that have a registered replica.  This is a
+    # Exclude files that have a registered replica.  This is a
     # safeguard against potential issues in the Auditor.
     file_clause = []
     for replica in replicas:

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -794,7 +794,7 @@ def _build_list_replicas_pfn(
     """
     Generate the PFN for the given scope/name on the rse.
     If needed, sign the PFN url
-    If relevant, add the server-side root proxy to te pfn url
+    If relevant, add the server-side root proxy to the pfn url
     """
     pfn: str = list(protocol.lfns2pfns(lfns={'scope': scope.external,
                                              'name': name,
@@ -935,7 +935,7 @@ def _list_replicas(replicas, show_pfns, schemes, files_wo_replica, client_locati
                     t_scope = scope
                     t_name = name
 
-                if 'determinism_type' in protocol.attributes:  # PFN is cachable
+                if 'determinism_type' in protocol.attributes:  # PFN is cacheable
                     try:
                         path = pfns_cache['%s:%s:%s' % (protocol.attributes['determinism_type'], t_scope.internal, t_name)]
                     except KeyError:  # No cache entry scope:name found for this protocol
@@ -1324,7 +1324,7 @@ def list_replicas(
             # leave us with less than nrandom replicas.
             nrandom * 4
         )
-        # Re-use input temp table. We don't need its content anymore
+        # Reuse input temp table. We don't need its content anymore
         random_dids_temp_table = input_dids_temp_table
         session.execute(delete(random_dids_temp_table))
         session.execute(insert(random_dids_temp_table).from_select(['scope', 'name'], stmt))
@@ -2469,7 +2469,7 @@ def get_and_lock_file_replicas(scope, name, nowait=False, restrict_rses=None, *,
 @transactional_session
 def get_source_replicas(scope, name, source_rses=None, *, session: "Session"):
     """
-    Get soruce replicas for a specific scope:name.
+    Get source replicas for a specific scope:name.
 
     :param scope:          The scope of the did.
     :param name:           The name of the did.
@@ -3435,7 +3435,7 @@ def get_suspicious_files(rse_expression, available_elsewhere, filter_=None, logg
     Keyword Arguments:
     :param younger_than: Datetime object to select the replicas which were declared since younger_than date. Default value = 10 days ago.
     :param nattempts: The minimum number of replica appearances in the bad_replica DB table from younger_than date. Default value = 0.
-    :param nattempts_exact: If True, then only replicas with exactly 'nattempts' appearences in the bad_replica DB table are retrieved. Replicas with more appearences are ignored.
+    :param nattempts_exact: If True, then only replicas with exactly 'nattempts' appearances in the bad_replica DB table are retrieved. Replicas with more appearances are ignored.
     :param rse_expression: The RSE expression where the replicas are located.
     :param filter_: Dictionary of attributes by which the RSE results should be filtered. e.g.: {'availability_write': True}
     :param exclude_states: List of states which eliminates replicas from search result if any of the states in the list
@@ -3524,7 +3524,7 @@ def get_suspicious_files(rse_expression, available_elsewhere, filter_=None, logg
     # finally, the results are grouped by RSE, scope, name and required to have
     # at least 'nattempts' occurrences in the result of the query per replica.
     # If nattempts_exact, then only replicas are required to have exactly
-    # 'nattempts' occurences.
+    # 'nattempts' occurrences.
     if nattempts_exact:
         query_result = query.group_by(models.RSEFileAssociation.rse_id, bad_replicas_alias.scope, bad_replicas_alias.name).having(func.count() == nattempts).all()
     else:

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1292,7 +1292,7 @@ def cancel_request_did(scope, name, dest_rse_id, request_type=RequestType.TRANSF
         )
         reqs = session.execute(stmt).all()
         if not reqs:
-            logger(logging.WARNING, 'Tried to cancel non-existant request for DID %s:%s at RSE %s' % (scope, name, get_rse_name(rse_id=dest_rse_id, session=session)))
+            logger(logging.WARNING, 'Tried to cancel non-existent request for DID %s:%s at RSE %s' % (scope, name, get_rse_name(rse_id=dest_rse_id, session=session)))
     except IntegrityError as error:
         raise RucioException(error.args)
 
@@ -2054,7 +2054,7 @@ def release_waiting_requests_per_free_volume(
 
     :param dest_rse_id: The destination RSE id.
     :param source_rse_id: The source RSE id
-    :param volume: The maximum volume in bytes that should be transfered.
+    :param volume: The maximum volume in bytes that should be transferred.
     :param session: The database session.
     """
 
@@ -2136,7 +2136,7 @@ def create_base_query_grouped_fifo(
     else:  # dialect == 'postgresql'
         coalesce_func = func.coalesce
 
-    # query DIDs that are attached to a collection and add a column indicating the order of attachment in case of mulitple attachments
+    # query DIDs that are attached to a collection and add a column indicating the order of attachment in case of multiple attachments
     attachment_order_subquery = select(
         models.DataIdentifierAssociation.child_name,
         models.DataIdentifierAssociation.child_scope,
@@ -2279,13 +2279,13 @@ def release_waiting_requests_grouped_fifo(
 ):
     """
     Release waiting requests. Transfer requests that were requested first, get released first (FIFO).
-    Also all requests to DIDs that are attached to the same dataset get released, if one children of the dataset is choosed to be released (Grouped FIFO).
+    Also all requests to DIDs that are attached to the same dataset get released, if one children of the dataset is chosen to be released (Grouped FIFO).
 
     :param dest_rse_id: The destination rse id
     :param source_rse_id: The source RSE id.
     :param count: The count to be released. If None, release all waiting requests.
     :param deadline: Maximal waiting time in hours until a dataset gets released.
-    :param volume: The maximum volume in bytes that should be transfered.
+    :param volume: The maximum volume in bytes that should be transferred.
     :param session: The database session.
     """
 

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -203,7 +203,7 @@ class RseData:
         # query, but this seems wasteful under normal operation: the caller of the current function probably
         # got the list of RSE IDs from list_rses (or another source which checks for deleted rses).
         #
-        # Instead, directly fetch all RSEs, which allows to reduce the number (and complexity) of other queries bellow
+        # Instead, directly fetch all RSEs, which allows to reduce the number (and complexity) of other queries below
         stmt = select(
             models.RSE
         ).join_from(

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -62,9 +62,9 @@ def parse_expression(expression, filter_=None, *, session: "Session"):
             elif (char == ')'):
                 parantheses_close_count += 1
             if (parantheses_close_count > parantheses_open_count):
-                raise InvalidRSEExpression('Problem with parantheses.')
+                raise InvalidRSEExpression('Problem with parentheses.')
         if (parantheses_open_count != parantheses_close_count):
-            raise InvalidRSEExpression('Problem with parantheses.')
+            raise InvalidRSEExpression('Problem with parentheses.')
 
         # Check the expression pattern
         match = re.match(PATTERN, expression)
@@ -169,7 +169,7 @@ def __resolve_primitive_expression(expression):
     """
     Resolve a primitive expression and return a RSEAttribute object
 
-    :param expression:    String of the expresssion
+    :param expression:    String of the expression
     :returns:             Tuple of RSEAttribute, primitive expression
     """
     primitiveexpression = re.match(PRIMITIVE, expression).group()
@@ -190,7 +190,7 @@ def __resolve_primitive_expression(expression):
 
 def __extract_term(expression):
     """
-    Extract a term from an expression with parantheses
+    Extract a term from an expression with parentheses
 
     :param expression:  The expression starting with a '('
     :return:            The extracted term string

--- a/lib/rucio/core/rse_selector.py
+++ b/lib/rucio/core/rse_selector.py
@@ -128,7 +128,7 @@ class RSESelector:
 
         self.rses = rses_with_enough_quota
         if len(self.rses) < self.copies:
-            raise InsufficientAccountLimit('There is insufficient quota on any of the target RSE\'s to fullfill the operation.')
+            raise InsufficientAccountLimit('There is insufficient quota on any of the target RSE\'s to fulfill the operation.')
 
         # don't consider removing rses based on the total space here - because files already on the RSE are taken into account
         # it is possible to have no space but still be able to fulfil the rule
@@ -162,12 +162,12 @@ class RSESelector:
             existing_rse_size = {}
         rses = [rse for rse in rses if rse['space_left'] >= size - existing_rse_size.get(rse['rse_id'], 0)]
         if len(rses) < count:
-            raise RSEOverQuota('There is insufficient space on any of the target RSE\'s to fullfill the operation.')
+            raise RSEOverQuota('There is insufficient space on any of the target RSE\'s to fulfill the operation.')
 
         # Remove rses which do not have enough local quota
         rses = [rse for rse in rses if rse['quota_left'] > size]
         if len(rses) < count:
-            raise InsufficientAccountLimit('There is insufficient quota on any of the target RSE\'s to fullfill the operation.')
+            raise InsufficientAccountLimit('There is insufficient quota on any of the target RSE\'s to fulfill the operation.')
 
         # Remove rses which do not have enough global quota
         rses_with_enough_quota = []
@@ -181,7 +181,7 @@ class RSESelector:
                 rses_with_enough_quota.append(rse)
         rses = rses_with_enough_quota
         if len(rses) < count:
-            raise InsufficientAccountLimit('There is insufficient quota on any of the target RSE\'s to fullfill the operation.')
+            raise InsufficientAccountLimit('There is insufficient quota on any of the target RSE\'s to fulfill the operation.')
 
         for copy in range(count):
             # Remove rses already in the result set
@@ -189,7 +189,7 @@ class RSESelector:
             rses_dict = {}
             for rse in rses:
                 rses_dict[rse['rse_id']] = rse
-            # Prioritize the preffered rses
+            # Prioritize the preferred rses
             preferred_rses = [rses_dict[rse_id] for rse_id in preferred_rse_ids if rse_id in rses_dict]
             if prioritize_order_over_weight and preferred_rses:
                 rse = (preferred_rses[0]['rse_id'], preferred_rses[0]['staging_area'], preferred_rses[0]['availability_write'])
@@ -217,7 +217,7 @@ class RSESelector:
         Update the internal quota value.
 
         :param rse:      RSE tuple to update.
-        :param size:     Size to substract.
+        :param size:     Size to subtract.
         """
 
         for element in self.rses:

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -1102,7 +1102,7 @@ def list_associated_rules_for_file(
     :param session: The database session in use.
     :raises:        RucioException
     """
-    rucio.core.did.get_did(scope=scope, name=name, session=session)  # Check if the did acually exists
+    rucio.core.did.get_did(scope=scope, name=name, session=session)  # Check if the did actually exists
     stmt = select(
         models.ReplicationRule,
         models.DataIdentifier.bytes
@@ -1253,8 +1253,8 @@ def repair_rule(
     """
 
     # Rule error cases:
-    # (A) A rule get's an exception on rule-creation. This can only be the MissingSourceReplica exception.
-    # (B) A rule get's an error when re-evaluated: InvalidRSEExpression, InvalidRuleWeight, InsufficientTargetRSEs, RSEWriteBlocked
+    # (A) A rule gets an exception on rule-creation. This can only be the MissingSourceReplica exception.
+    # (B) A rule gets an error when re-evaluated: InvalidRSEExpression, InvalidRuleWeight, InsufficientTargetRSEs, RSEWriteBlocked
     #     InsufficientAccountLimit. The re-evaluation has to be done again and potential missing locks have to be
     #     created.
     # (C) Transfers fail and mark locks (and the rule) as STUCK. All STUCK locks have to be repaired.
@@ -2746,7 +2746,7 @@ def generate_rule_notifications(
                         pass
 
     elif rule.state == RuleState.REPLICATING and rule.notification == RuleNotification.PROGRESS and replicating_locks_before:
-        # For RuleNotification PROGRESS rules, also notifiy when REPLICATING thresholds are passed
+        # For RuleNotification PROGRESS rules, also notify when REPLICATING thresholds are passed
         if __progress_class(replicating_locks_before, total_locks) != __progress_class(rule.locks_replicating_cnt, total_locks):
             try:
                 did = rucio.core.did.get_did(scope=rule.scope, name=rule.name, session=session)
@@ -2816,7 +2816,7 @@ def generate_email_for_rule_ok_notification(
         add_message(event_type='email',
                     payload={'body': email_body,
                              'to': [email],
-                             'subject': '[RUCIO] Replication rule %s has been succesfully transferred' % (str(rule.id))},
+                             'subject': '[RUCIO] Replication rule %s has been successfully transferred' % (str(rule.id))},
                     session=session)
 
 
@@ -3008,7 +3008,7 @@ def examine_rule(
 
     :param rule_id:            Replication rule id
     :param session:            Session of the db.
-    :returns:                  Dictionary of informations
+    :returns:                  Dictionary of information
     """
     result = {'rule_error': None,
               'transfers': []}
@@ -3230,7 +3230,7 @@ def __find_missing_locks_and_create_them(
     :param source_replicas:    Dict holding source replicas.
     :param rseselector:        The RSESelector to be used.
     :param rule:               The rule.
-    :param source_rses:        RSE ids for eglible source RSEs.
+    :param source_rses:        RSE ids for eligible source RSEs.
     :param session:            Session of the db.
     :param logger:             Optional decorated logger that can be passed from the calling daemons or servers.
     :raises:                   InsufficientAccountLimit, IntegrityError, InsufficientTargetRSEs
@@ -3339,7 +3339,7 @@ def __find_stuck_locks_and_repair_them(
     :param source_replicas:    Dict holding source replicas.
     :param rseselector:        The RSESelector to be used.
     :param rule:               The rule.
-    :param source_rses:        RSE ids of eglible source RSEs.
+    :param source_rses:        RSE ids of eligible source RSEs.
     :param session:            Session of the db.
     :param logger:             Optional decorated logger that can be passed from the calling daemons or servers.
     :raises:                   InsufficientAccountLimit, IntegrityError, InsufficientTargetRSEs
@@ -3555,7 +3555,7 @@ def __evaluate_did_attach(
     logger: LoggerFunction = logging.log
 ) -> None:
     """
-    Evaluate a parent did which has new childs
+    Evaluate a parent did which has new children
 
     :param eval_did:  The did object in use.
     :param session:   The database session in use.
@@ -3807,7 +3807,7 @@ def __resolve_did_to_locks_and_replicas(
            dict[tuple[str, str], models.RSEFileAssociation],
            dict[tuple[str, str], str]]:
     """
-    Resolves a did to its constituent childs and reads the locks and replicas of all the constituent files.
+    Resolves a did to its constituent children and reads the locks and replicas of all the constituent files.
 
     :param did:            The db object of the did the rule is applied on.
     :param nowait:         Nowait parameter for the FOR UPDATE statement.
@@ -3914,7 +3914,7 @@ def __resolve_dids_to_locks_and_replicas(
            dict[tuple[str, str], models.RSEFileAssociation],
            dict[tuple[str, str], str]]:
     """
-    Resolves a list of dids to its constituent childs and reads the locks and replicas of all the constituent files.
+    Resolves a list of dids to its constituent children and reads the locks and replicas of all the constituent files.
 
     :param dids:           The list of DataIdentifierAssociation objects.
     :param nowait:         Nowait parameter for the FOR UPDATE statement.
@@ -4094,7 +4094,7 @@ def __create_locks_replicas_transfers(
     :param rseselector:        The RSESelector to be used.
     :param rule:               The rule.
     :param preferred_rse_ids:  Preferred RSE's to select.
-    :param source_rses:        RSE ids of eglible source replicas.
+    :param source_rses:        RSE ids of eligible source replicas.
     :param session:            Session of the db.
     :param logger:             Optional decorated logger that can be passed from the calling daemons or servers.
     :raises:                   InsufficientAccountLimit, IntegrityError, InsufficientTargetRSEs, RSEOverQuota

--- a/lib/rucio/core/rule_grouping.py
+++ b/lib/rucio/core/rule_grouping.py
@@ -62,7 +62,7 @@ def apply_rule_grouping(
     :param rseselector:        The RSESelector to be used.
     :param rule:               The rule object.
     :param preferred_rse_ids:  Preferred RSE's to select.
-    :param source_rses:        RSE ids of eglible source replicas.
+    :param source_rses:        RSE ids of eligible source replicas.
     :param session:            Session of the db.
     :returns:                  Dict of replicas to create, Dict of locks to create, List of transfers to create
     :raises:                   InsufficientQuota, InsufficientTargetRSEs, RSEOverQuota
@@ -133,7 +133,7 @@ def repair_stuck_locks_and_apply_rule_grouping(
     :param source_replicas:    Dict holding all source_replicas.
     :param rseselector:        The RSESelector to be used.
     :param rule:               The rule object.
-    :param source_rses:        RSE ids of eglible source_rses.
+    :param source_rses:        RSE ids of eligible source_rses.
     :param session:            Session of the db.
     :returns:                  List of replicas to create, List of locks to create, List of transfers to create, List of locks to Delete
     :raises:                   InsufficientQuota, InsufficientTargetRSEs
@@ -234,7 +234,7 @@ def __apply_rule_to_files_none_grouping(datasetfiles, locks, replicas, source_re
     :param rseselector:        The RSESelector to be used.
     :param rule:               The rule object.
     :param preferred_rse_ids:  Preferred RSE's to select.
-    :param source_rses:        RSE ids of eglible source replicas.
+    :param source_rses:        RSE ids of eligible source replicas.
     :param session:            Session of the db.
     :returns:                  replicas_to_create, locks_to_create, transfers_to_create
     :raises:                   InsufficientAccountLimit, InsufficientTargetRSEs
@@ -315,7 +315,7 @@ def __apply_rule_to_files_all_grouping(datasetfiles, locks, replicas, source_rep
     :param rseselector:        The RSESelector to be used.
     :param rule:               The rule object.
     :param preferred_rse_ids:  Preferred RSE's to select.
-    :param source_rses:        RSE ids of eglible source replicas.
+    :param source_rses:        RSE ids of eligible source replicas.
     :param session:            Session of the db.
     :returns:                  replicas_to_create, locks_to_create, transfers_to_create
     :raises:                   InsufficientQuota, InsufficientTargetRSEs
@@ -435,7 +435,7 @@ def __apply_rule_to_files_dataset_grouping(datasetfiles, locks, replicas, source
     :param rseselector:        The RSESelector to be used.
     :param rule:               The rule object.
     :param preferred_rse_ids:  Preferred RSE's to select.
-    :param source_rses:        RSE ids of eglible source replicas.
+    :param source_rses:        RSE ids of eligible source replicas.
     :param session:            Session of the db.
     :returns:                  replicas_to_create, locks_to_create, transfers_to_create
     :raises:                   InsufficientQuota, InsufficientTargetRSEs
@@ -552,7 +552,7 @@ def __repair_stuck_locks_with_none_grouping(datasetfiles, locks, replicas, sourc
     :param source_replicas:    Dict holding all source_replicas.
     :param rseselector:        The RSESelector to be used.
     :param rule:               The rule object.
-    :param source_rses:        RSE ids of eglible source replicas.
+    :param source_rses:        RSE ids of eligible source replicas.
     :param session:            Session of the db.
     :param logger:             Optional decorated logger that can be passed from the calling daemons or servers.
     :returns:                  replicas_to_create, locks_to_create, transfers_to_create, locks_to_delete
@@ -595,7 +595,7 @@ def __repair_stuck_locks_with_none_grouping(datasetfiles, locks, replicas, sourc
                 # Check if this is a STUCK lock due to source_replica filtering
                 if source_rses:
                     associated_replica = [replica for replica in replicas[(file['scope'], file['name'])] if replica.rse_id == lock.rse_id][0]
-                    # Check if there is an eglible source replica for this lock
+                    # Check if there is an eligible source replica for this lock
                     if set(source_replicas.get((file['scope'], file['name']), [])).intersection(source_rses) and (selector_rse_dict.get(lock.rse_id, {}).get('availability_write', True) or rule.ignore_availability):
                         __update_lock_replica_and_create_transfer(lock=lock,
                                                                   replica=associated_replica,
@@ -659,7 +659,7 @@ def __repair_stuck_locks_with_all_grouping(datasetfiles, locks, replicas, source
     :param source_replicas:    Dict holding all source_replicas.
     :param rseselector:        The RSESelector to be used.
     :param rule:               The rule object.
-    :param source_rses:        RSE ids of eglible source replicas.
+    :param source_rses:        RSE ids of eligible source replicas.
     :param session:            Session of the db.
     :param logger:             Optional decorated logger that can be passed from the calling daemons or servers.
     :returns:                  replicas_to_create, locks_to_create, transfers_to_create, locks_to_delete
@@ -702,7 +702,7 @@ def __repair_stuck_locks_with_all_grouping(datasetfiles, locks, replicas, source
                 # Check if this is a STUCK lock due to source_replica filtering
                 if source_rses:
                     associated_replica = [replica for replica in replicas[(file['scope'], file['name'])] if replica.rse_id == lock.rse_id][0]
-                    # Check if there is an eglible source replica for this lock
+                    # Check if there is an eligible source replica for this lock
                     if set(source_replicas.get((file['scope'], file['name']), [])).intersection(source_rses) and (selector_rse_dict.get(lock.rse_id, {}).get('availability_write', True) or rule.ignore_availability):
                         __update_lock_replica_and_create_transfer(lock=lock,
                                                                   replica=associated_replica,
@@ -735,7 +735,7 @@ def __repair_stuck_locks_with_dataset_grouping(datasetfiles, locks, replicas, so
     :param source_replicas:    Dict holding all source_replicas.
     :param rseselector:        The RSESelector to be used.
     :param rule:               The rule object.
-    :param source_rses:        RSE ids of eglible source replicas.
+    :param source_rses:        RSE ids of eligible source replicas.
     :param session:            Session of the db.
     :param logger:             Optional decorated logger that can be passed from the calling daemons or servers.
     :returns:                  replicas_to_create, locks_to_create, transfers_to_create, locks_to_delete
@@ -778,7 +778,7 @@ def __repair_stuck_locks_with_dataset_grouping(datasetfiles, locks, replicas, so
                 # Check if this is a STUCK lock due to source_replica filtering
                 if source_rses:
                     associated_replica = [replica for replica in replicas[(file['scope'], file['name'])] if replica.rse_id == lock.rse_id][0]
-                    # Check if there is an eglible source replica for this lock
+                    # Check if there is an eligible source replica for this lock
                     if set(source_replicas.get((file['scope'], file['name']), [])).intersection(source_rses) and (selector_rse_dict.get(lock.rse_id, {}).get('availability_write', True) or rule.ignore_availability):
                         __update_lock_replica_and_create_transfer(lock=lock,
                                                                   replica=associated_replica,
@@ -845,7 +845,7 @@ def __create_lock_and_replica(file, dataset, rule, rse_id, staging_area, availab
     :param availability_write:   Boolean variable if the RSE is write enabled.
     :param locks_to_create:      Dictionary of the locks to create.
     :param locks:                Dictionary of all locks.
-    :param source_rses:          RSE ids of eglible source replicas.
+    :param source_rses:          RSE ids of eligible source replicas.
     :param replicas_to_create:   Dictionary of the replicas to create.
     :param replicas:             Dictionary of the replicas.
     :param source_replicas:      Dictionary of the source replicas.
@@ -927,7 +927,7 @@ def __create_lock_and_replica(file, dataset, rule, rse_id, staging_area, availab
             available_source_replica = True
             if source_rses:
                 available_source_replica = False
-                # Check if there is an eglible source replica for this lock
+                # Check if there is an eligible source replica for this lock
                 if set(source_replicas.get((file['scope'], file['name']), [])).intersection(source_rses):
                     available_source_replica = True
             new_lock = __create_lock(rule=rule,
@@ -974,7 +974,7 @@ def __create_lock_and_replica(file, dataset, rule, rse_id, staging_area, availab
         available_source_replica = True
         if source_rses:
             available_source_replica = False
-            # Check if there is an eglible source replica for this lock
+            # Check if there is an eligible source replica for this lock
             if set(source_replicas.get((file['scope'], file['name']), [])).intersection(source_rses):
                 available_source_replica = True
 
@@ -1308,7 +1308,7 @@ def apply_rule(did, rule, rses, source_rses, rseselector, *, session: "Session",
             datasets.append((did.scope, did.name, ))
         elif did.did_type == DIDType.CONTAINER:
             for child_dataset in rucio.core.did.list_child_datasets(scope=did.scope, name=did.name, session=session):
-                # ensure theer are no duplicates
+                # ensure there are no duplicates
                 newds = (child_dataset['scope'], child_dataset['name'], )
                 if newds not in datasets:
                     datasets.append(newds)

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -1106,7 +1106,7 @@ class SkipSchemeMissmatch(PathDistance):
     def apply(self, ctx: RequestRankingContext, source: RequestSource) -> "Optional[int | _SkipSource]":
         path = cast(PathDistance._RankingContext, ctx).paths_for_rws.get(source.rse)
         # path == None means that there is no path;
-        # path == [] means that a path exists (according to distances) but cannot be used (scheme missmatch)
+        # path == [] means that a path exists (according to distances) but cannot be used (scheme mismatch)
         if path is not None and not path:
             return SKIP_SOURCE
 

--- a/lib/rucio/core/vo.py
+++ b/lib/rucio/core/vo.py
@@ -51,7 +51,7 @@ def add_vo(vo: str, description: str, email: str, *, session: "Session") -> None
     New root user will have account name 'root' and a userpass identity with username: 'root@<vo>' and password: 'password'
 
     :param vo: 3-letter unique tag for a VO.
-    :param descrition: Descriptive string for the VO (e.g. Full name).
+    :param description: Descriptive string for the VO (e.g. Full name).
     :param email: Contact email for the VO.
     :param session: The db session in use.
     """
@@ -139,7 +139,7 @@ def map_vo(vo: str) -> str:
     Converts a long VO name into the internal short (three letter)
     tag mapping.
     Mappings are loaded from the vo-map section of the config database table.
-    If a mapping is not found, the orignal is returned unchanged.
+    If a mapping is not found, the original is returned unchanged.
     :param vo: The long VO name string.
     :returns: The short VO name string.
     """

--- a/lib/rucio/daemons/auditor/__init__.py
+++ b/lib/rucio/daemons/auditor/__init__.py
@@ -208,7 +208,7 @@ def check(queue, retry, terminate, logpipe, cache_dir, results_dir, keep_dumps, 
 
     while not terminate.is_set():
         try:
-            rse, attemps = queue.get(timeout=30)
+            rse, attempts = queue.get(timeout=30)
         except Queue.Empty:
             continue
         start = datetime.now()
@@ -220,7 +220,7 @@ def check(queue, retry, terminate, logpipe, cache_dir, results_dir, keep_dumps, 
                 process_output(output)
         except:
             elapsed = (datetime.now() - start).total_seconds() / 60
-            logger.error('Check of "%s" failed in %d minutes, %d remaining attemps', rse, elapsed, attemps, exc_info=True)
+            logger.error('Check of "%s" failed in %d minutes, %d remaining attempts', rse, elapsed, attempts, exc_info=True)
             success = False
         else:
             elapsed = (datetime.now() - start).total_seconds() / 60
@@ -234,8 +234,8 @@ def check(queue, retry, terminate, logpipe, cache_dir, results_dir, keep_dumps, 
             for fil in remove:
                 os.remove(fil)
 
-        if not success and attemps > 0:
-            retry.put((rse, attemps - 1))
+        if not success and attempts > 0:
+            retry.put((rse, attempts - 1))
 
 
 def activity_logger(logpipes, logfilename, terminate):

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -41,7 +41,7 @@ OBJECTSTORE_NUM_TRIES = 30
 class Parser(ConfigParser.RawConfigParser):
     '''
     RawConfigParser subclass that doesn't modify the the name of the options
-    and removes any quotes arround the string values.
+    and removes any quotes around the string values.
     '''
     remove_quotes_re = re.compile(r"^'(.+)'$")
     remove_double_quotes_re = re.compile(r'^"(.+)"$')
@@ -218,7 +218,7 @@ def parse_configuration(conf_dirs=__DUMPERCONFIGDIRS):
 def download_rse_dump(rse, configuration, date=None, destdir=DUMPS_CACHE_DIR):
     '''
     Downloads the dump for the given ddmendpoint. If this endpoint does not
-    follow the standarized method to publish the dumps it should have an
+    follow the standardized method to publish the dumps it should have an
     entry in the `configuration` object describing how to download the dump.
 
     `rse` is the DDMEndpoint name.
@@ -226,7 +226,7 @@ def download_rse_dump(rse, configuration, date=None, destdir=DUMPS_CACHE_DIR):
     `configuration` is a RawConfigParser subclass.
 
     `date` is a datetime instance with the date of the desired dump or None
-    to download the lastest available dump.
+    to download the latest available dump.
 
     `destdir` is the directory where the dump will be saved (the final component
     in the path is created if it doesn't exist).

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -230,7 +230,7 @@ def run_once(heartbeat_handler: "HeartbeatHandler", inputfile: str, **_kwargs) -
         upload_client = UploadClient(client)
         ret = upload_client.upload(files)
         if ret == 0:
-            logger(logging.INFO, "%s sucessfully registered" % dsn)
+            logger(logging.INFO, "%s successfully registered" % dsn)
             METRICS.counter(name="addnewdataset.done").inc()
             METRICS.counter(name="addnewfile.done").inc(nbfiles)
             METRICS.timer(name='datasetinjection').observe(stopwatch.elapsed)

--- a/lib/rucio/daemons/badreplicas/minos.py
+++ b/lib/rucio/daemons/badreplicas/minos.py
@@ -111,7 +111,7 @@ def __clean_unknown_replicas(pfns: list, vo: str, logger: "Callable") -> dict:
 def __update_temporary_unavailable(chunk: list, reason: str, expires_at: datetime, account: "InternalAccount", logger: "Callable") -> None:
     """
     Update temporary unavailable replicas one by one
-    :param chunk: List of unvailable replicas to update
+    :param chunk: List of unavailable replicas to update
     :param reason: Reason of the temporary unavailable replica
     :param expires_at: Expiration date of the temporary unavailability
     :param account: Account who declared the replica

--- a/lib/rucio/daemons/bb8/common.py
+++ b/lib/rucio/daemons/bb8/common.py
@@ -704,7 +704,7 @@ def rebalance_rse(
         except Exception as error:
             logger(
                 logging.ERROR,
-                "Exception %s occured while rebalancing %s:%s, rule_id: %s!",
+                "Exception %s occurred while rebalancing %s:%s, rule_id: %s!",
                 str(error),
                 scope,
                 name,

--- a/lib/rucio/daemons/common.py
+++ b/lib/rucio/daemons/common.py
@@ -41,7 +41,7 @@ class HeartbeatHandler:
         """
         :param executable: the executable name which will be set in heartbeats
         :param renewal_interval: the interval at which the heartbeat will be renewed in the database.
-        Calls to live() in-between intervals will re-use the locally cached heartbeat.
+        Calls to live() in-between intervals will reuse the locally cached heartbeat.
         """
         self.executable = executable
         self._hash_executable = None
@@ -179,7 +179,7 @@ def db_workqueue(
 
     :param once: Whether to stop after one iteration
     :param graceful_stop: the threading.Event() object used for graceful stop of the daemon
-    :param executable: the name of the executable used for hearbeats
+    :param executable: the name of the executable used for heartbeats
     :param partition_wait_time: time to wait for database partition rebalancing before starting the actual daemon loop
     :param sleep_time: time to sleep between the iterations of the daemon
     :param activities: optional list of activities on which to work. The run_once_fnc will be called on activities one by one.

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -210,7 +210,7 @@ def stop(signum: Optional[int] = None, frame: Optional[FrameType] = None) -> Non
 
 def run(once=False, total_threads=1, sleep_time=60, activities=None, bulk=100, db_bulk=1000):
     """
-    Starts up the conveyer threads.
+    Starts up the conveyor threads.
     """
     setup_logging(process_name=DAEMON_NAME)
 
@@ -416,7 +416,7 @@ def __handle_terminated_replicas(replicas, logger=logging.log):
 @transactional_session
 def __update_bulk_replicas(replicas, *, session, logger=logging.log):
     """
-    Used by finisher to handle available and unavailable replicas blongs to same rule in bulk way.
+    Used by finisher to handle available and unavailable replicas belongs to same rule in bulk way.
 
     :param replicas:              List of replicas.
     :param session:               The database session to use.

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -94,7 +94,7 @@ def _fetch_requests(
         # only keep transfers which don't have any transfertool set, or have one equal to TRANSFER_TOOL
         transfs_tmp = [t for t in transfs if not t['transfertool'] or t['transfertool'] == transfertool]
         if len(transfs_tmp) != len(transfs):
-            logger(logging.INFO, 'Skipping %i transfers because of missmatched transfertool', len(transfs) - len(transfs_tmp))
+            logger(logging.INFO, 'Skipping %i transfers because of mismatched transfertool', len(transfs) - len(transfs_tmp))
         transfs = transfs_tmp
 
     if transfs:
@@ -254,7 +254,7 @@ def run(
         total_threads=1
 ):
     """
-    Starts up the conveyer threads.
+    Starts up the conveyor threads.
     """
     setup_logging(process_name=DAEMON_NAME)
 

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -93,7 +93,7 @@ def run(
         sleep_time=600
 ):
     """
-    Starts up the conveyer threads.
+    Starts up the conveyor threads.
     """
     setup_logging(process_name=DAEMON_NAME)
 

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -341,7 +341,7 @@ def run(
         **_kwargs
 ):
     """
-    Starts up the conveyer threads.
+    Starts up the conveyor threads.
     """
     setup_logging(process_name=DAEMON_NAME)
 

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -99,7 +99,7 @@ def stop(signum: Optional[int] = None, frame: Optional[FrameType] = None) -> Non
 
 def run(once=False, sleep_time=600):
     """
-    Starts up the conveyer threads.
+    Starts up the conveyor threads.
     """
     setup_logging(process_name=DAEMON_NAME)
 

--- a/lib/rucio/daemons/hermes/hermes.py
+++ b/lib/rucio/daemons/hermes/hermes.py
@@ -389,7 +389,7 @@ def aggregate_to_influx(
     and submit them to a InfluxDB endpoint
 
     :param messages:           The list of messages.
-    :param bin_size:           The size of the bins for the aggreagation (e.g. 10m, 1h, etc.).
+    :param bin_size:           The size of the bins for the aggregation (e.g. 10m, 1h, etc.).
     :param endpoint:           The InfluxDB endpoint were to send the messages.
     :param logger:             The logger object.
 

--- a/lib/rucio/daemons/oauthmanager/oauthmanager.py
+++ b/lib/rucio/daemons/oauthmanager/oauthmanager.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-OAuth Manager is a daemon which is reponsible for:
+OAuth Manager is a daemon which is responsible for:
 - deletion of expired access tokens (in case there is a valid refresh token,
   expired access tokens will be kept until refresh_token expires as well.)
 - deletion of expired OAuth session parameters
@@ -114,7 +114,7 @@ def run_once(heartbeat_handler: HeartbeatHandler, max_rows: int, sleep_time: int
             METRICS.counter('exceptions.{exception}').labels(exception=err.__class__.__name__).inc()
 
     try:
-        # waiting 1 sec as DBs does not store milisecond and tokens
+        # waiting 1 sec as DBs does not store millisecond and tokens
         # eligible for deletion after refresh might not get deleted otherwise
         graceful_stop.wait(1)
 

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -195,7 +195,7 @@ def delete_from_storage(heartbeat_handler, hb_payload, replicas, prot, rse_info,
                 add_message('deletion-failed', deletion_dict)
                 noaccess_attempts += 1
                 if noaccess_attempts >= auto_exclude_threshold:
-                    logger(logging.INFO, 'Too many (%d) NOACCESS attempts for %s. RSE will be temporarly excluded.', noaccess_attempts, rse_name)
+                    logger(logging.INFO, 'Too many (%d) NOACCESS attempts for %s. RSE will be temporarily excluded.', noaccess_attempts, rse_name)
                     REGION.set('temporary_exclude_%s' % rse_id, True)
                     METRICS.gauge('excluded_rses.{rse}').labels(rse=rse_name).set(1)
 
@@ -227,7 +227,7 @@ def delete_from_storage(heartbeat_handler, hb_payload, replicas, prot, rse_info,
             if replica['scope'].vo != 'def':
                 payload['vo'] = replica['scope'].vo
             add_message('deletion-failed', payload)
-        logger(logging.INFO, 'Cannot connect to %s. RSE will be temporarly excluded.', rse_name)
+        logger(logging.INFO, 'Cannot connect to %s. RSE will be temporarily excluded.', rse_name)
         REGION.set('temporary_exclude_%s' % rse_id, True)
         EXCLUDED_RSE_GAUGE.labels(rse=rse_name).set(1)
     finally:
@@ -521,7 +521,7 @@ def _run_once(rses_to_process, chunk_size, greedy, scheme,
 
         result = REGION.get('temporary_exclude_%s' % rse.id, expiration_time=auto_exclude_timeout)
         if not isinstance(result, NoValue):
-            logger(logging.WARNING, 'Too many failed attempts for %s in last cycle. RSE is temporarly excluded.', rse.name)
+            logger(logging.WARNING, 'Too many failed attempts for %s in last cycle. RSE is temporarily excluded.', rse.name)
             EXCLUDED_RSE_GAUGE.labels(rse=rse.name).set(1)
             continue
         EXCLUDED_RSE_GAUGE.labels(rse=rse.name).set(0)
@@ -609,7 +609,7 @@ def _run_once(rses_to_process, chunk_size, greedy, scheme,
                 # Then finally delete the replicas
                 del_start = time.time()
                 delete_replicas(rse_id=rse.id, files=deleted_files)
-                logger(logging.DEBUG, 'delete_replicas successed on %s : %s replicas in %s seconds', rse.name, len(deleted_files), time.time() - del_start)
+                logger(logging.DEBUG, 'delete_replicas succeeded on %s : %s replicas in %s seconds', rse.name, len(deleted_files), time.time() - del_start)
                 METRICS.counter('deletion.done').inc(len(deleted_files))
         except RSEProtocolNotSupported:
             logger(logging.WARNING, 'Protocol %s not supported on %s', scheme, rse.name)

--- a/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
+++ b/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py
@@ -150,7 +150,7 @@ def run_once(heartbeat_handler: Any, younger_than: int, nattempts: int, vos: Opt
         json_file = open(json_file_name, mode="r")
         logger(logging.INFO, "JSON file has been opened.")
     except:
-        logger(logging.WARNING, "An error occured while trying to open the JSON file.")
+        logger(logging.WARNING, "An error occurred while trying to open the JSON file.")
         must_sleep = True
         return must_sleep
 
@@ -408,7 +408,7 @@ def run_once(heartbeat_handler: Any, younger_than: int, nattempts: int, vos: Opt
         auditor = 0
         checksum = 0
 
-        # Label suspicious replicas as bad if they have oher copies on other RSEs (that aren't also marked as suspicious).
+        # Label suspicious replicas as bad if they have other copies on other RSEs (that aren't also marked as suspicious).
         # If they are the last remaining copies, deal with them differently.
         for rse_key in list(recoverable_replicas[vo].keys()):
             files_to_be_declared_bad = []

--- a/lib/rucio/daemons/storage/consistency/actions.py
+++ b/lib/rucio/daemons/storage/consistency/actions.py
@@ -611,7 +611,7 @@ def deckard(scope, rse, dark_min_age, dark_threshold_percent, miss_threshold_per
                                    max_files_at_site, old_enough_run, force_proceed)
             else:
                 logger(logging.INFO, 'There is no other run for this RSE at least %d days older,\
-                 so cannot safely proceed with dark files deleteion.' % minagedark)
+                 so cannot safely proceed with dark files deletion.' % minagedark)
 
             process_miss_files(path, scope, rse, latest_run, max_miss_fraction,
                                max_files_at_site, old_enough_run, force_proceed)

--- a/lib/rucio/daemons/transmogrifier/transmogrifier.py
+++ b/lib/rucio/daemons/transmogrifier/transmogrifier.py
@@ -69,7 +69,7 @@ def __get_rule_dict(rule_dict: dict, subscription: dict) -> dict:
     """
     Internal method to clean and enrich the rule_dict coming from the subscription.
 
-    :param rule_dict: The rule dictionnary coming from a subscription.
+    :param rule_dict: The rule dictionary coming from a subscription.
     :param subscription: The subscription associated to the rule.
     :return: A dictionary that contains all the parameters associated to the rule.
     """
@@ -214,7 +214,7 @@ def __split_rule_select_rses(
 
 def get_subscriptions(logger: Callable = logging.log) -> list[dict]:
     """
-    A method to extract the list of active subscriptions and exclued the one that have bad RSE expression.
+    A method to extract the list of active subscriptions and exclude the one that have bad RSE expression.
     :param logger: The logger.
     :return: The list of active subscriptions.
     """
@@ -297,7 +297,7 @@ def __is_matching_subscription(subscription, did, metadata):
 
     :param subscription: The subscription dictionary.
     :param did: The DID dictionary
-    :param metadata: The metadata dictionnary for the DID
+    :param metadata: The metadata dictionary for the DID
     :return: True/False
     """
     if metadata["hidden"]:

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -873,7 +873,7 @@ class RSEProtocols(BASE, ModelBase):
     __tablename__ = 'rse_protocols'
     rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
     scheme: Mapped[str] = mapped_column(String(255))
-    hostname: Mapped[str] = mapped_column(String(255), server_default='')  # For protocol without host e.g. POSIX on local file systems localhost is assumed as beeing default
+    hostname: Mapped[str] = mapped_column(String(255), server_default='')  # For protocol without host e.g. POSIX on local file systems localhost is assumed as being default
     port: Mapped[int] = mapped_column(Integer, server_default='0')  # like host, for local protocol the port 0 is assumed to be default
     prefix: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
     impl: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -158,7 +158,7 @@ def psql_convert_decimal_to_float(dbapi_conn, connection_rec):
 
 
 def my_on_connect(dbapi_con, connection_record):
-    """ Adds information to track performance and ressource by module.
+    """ Adds information to track performance and resource by module.
         Info are recorded in the V$SESSION and V$SQLAREA views.
     """
     caller = basename(sys.argv[0])
@@ -323,7 +323,7 @@ def _update_session_wrapper(wrapper, wrapped):
     """
     In addition to the work done by functools.update_wrapper, this function also preservers
     the signature of the initial function. With the exception that the 'session' parameter
-    is overriden to have a default value of 'None'.
+    is overridden to have a default value of 'None'.
 
     wrapper is the function to be updated
     wrapped is the original function

--- a/lib/rucio/db/sqla/util.py
+++ b/lib/rucio/db/sqla/util.py
@@ -366,7 +366,7 @@ def _create_temp_table(name, *columns, primary_key=None, oracle_global_name=None
     oracle_table_is_global = False
     if session.bind.dialect.name == 'oracle':
         # Retrieve the list of global temporary tables on oracle.
-        # If the requested table is found to be global, re-use it,
+        # If the requested table is found to be global, reuse it,
         # otherwise create a private temporary table with random name
         global_temp_tables = list_oracle_global_temp_tables(session=session)
         if oracle_global_name is None:

--- a/lib/rucio/gateway/account_limit.py
+++ b/lib/rucio/gateway/account_limit.py
@@ -35,7 +35,7 @@ def get_rse_account_usage(rse, vo='def', *, session: "Session"):
     :param rse:      The RSE name.
     :param vo:       The VO to act on.
     :param session:  The database session in use.
-    :return:         List of dictionnaries.
+    :return:         List of dictionaries.
     """
     rse_id = get_rse_id(rse=rse, vo=vo, session=session)
 

--- a/lib/rucio/gateway/rse.py
+++ b/lib/rucio/gateway/rse.py
@@ -243,7 +243,7 @@ def get_rse_protocols(rse, issuer, vo='def', *, session: "Session"):
     :param vo: The VO to act on.
     :param session: The database session in use.
 
-    :returns: A dict with all supported protocols and their attibutes.
+    :returns: A dict with all supported protocols and their attributes.
     """
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     return rse_module.get_rse_protocols(rse_id, session=session)
@@ -440,7 +440,7 @@ def update_rse(rse, parameters, issuer, vo='def', *, session: "Session"):
     Update RSE properties like availability or name.
 
     :param rse: the name of the new rse.
-    :param parameters: A dictionnary with property (name, read, write, delete as keys).
+    :param parameters: A dictionary with property (name, read, write, delete as keys).
     :param issuer: The issuer account.
     :param vo: The VO to act on.
     :param session: The database session in use.

--- a/lib/rucio/rse/protocols/bittorrent.py
+++ b/lib/rucio/rse/protocols/bittorrent.py
@@ -120,7 +120,7 @@ class Default(RSEProtocol):
                 raise exception.RSEFileNameNotSupported('Invalid prefix: provided \'%s\', expected \'%s\'' % ('/'.join(path.split('/')[0:len(self.attributes['prefix'].split('/')) - 1]),
                                                                                                               self.attributes['prefix']))  # len(...)-1 due to the leading '/
 
-            # Spliting parsed.path into prefix, path, filename
+            # Splitting parsed.path into prefix, path, filename
             prefix = self.attributes['prefix']
             path = path.partition(self.attributes['prefix'])[2]
             path = '/'.join(path.split('/')[:-1])

--- a/lib/rucio/rse/protocols/cache.py
+++ b/lib/rucio/rse/protocols/cache.py
@@ -40,7 +40,7 @@ class Default(protocol.RSEProtocol):
 
     def path2pfn(self, path):
         """
-            Retruns a fully qualified PFN for the file referred by path.
+            Returns a fully qualified PFN for the file referred by path.
 
             :param path: The path to the file.
 

--- a/lib/rucio/rse/protocols/dummy.py
+++ b/lib/rucio/rse/protocols/dummy.py
@@ -29,7 +29,7 @@ class Default(protocol.RSEProtocol):
 
     def path2pfn(self, path):
         """
-            Retruns a fully qualified PFN for the file referred by path.
+            Returns a fully qualified PFN for the file referred by path.
 
             :param path: The path to the file.
 

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -125,7 +125,7 @@ class Default(protocol.RSEProtocol):
             if not path.startswith(self.attributes['prefix']):
                 raise exception.RSEFileNameNotSupported('Invalid prefix: provided \'%s\', expected \'%s\'' % ('/'.join(path.split('/')[0:len(self.attributes['prefix'].split('/')) - 1]),
                                                                                                               self.attributes['prefix']))  # len(...)-1 due to the leading '/
-            # Spliting path into prefix, path, filename
+            # Splitting path into prefix, path, filename
             prefix = self.attributes['prefix']
             path = path.partition(self.attributes['prefix'])[2]
             name = path.split('/')[-1]
@@ -230,7 +230,7 @@ class Default(protocol.RSEProtocol):
         :param transfer_timeout: Transfer timeout (in seconds)
 
         :raises DestinationNotAccessible: if the destination storage was not accessible.
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
         :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'downloading file from {} to {}'.format(path, dest))
@@ -260,7 +260,7 @@ class Default(protocol.RSEProtocol):
         :param transfer_timeout: Transfer timeout (in seconds)
 
         :raises DestinationNotAccessible: if the destination storage was not accessible.
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
         :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'uploading file from {} to {}'.format(source, target))
@@ -293,7 +293,7 @@ class Default(protocol.RSEProtocol):
 
         :param path: path to the to be deleted file
 
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
         :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'deleting file {}'.format(path))
@@ -317,7 +317,7 @@ class Default(protocol.RSEProtocol):
         :param new_path: path to the new file on the storage
 
         :raises DestinationNotAccessible: if the destination storage was not accessible.
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
         :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'renaming file from {} to {}'.format(path, new_path))
@@ -369,7 +369,7 @@ class Default(protocol.RSEProtocol):
 
             :param path: path to file
 
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
 
             :returns: a dict with two keys, filesize and an element of GLOBALLY_SUPPORTED_CHECKSUMS.
         """
@@ -553,7 +553,7 @@ class Default(protocol.RSEProtocol):
 
         :returns: a list with dict containing 'totalsize' and 'unusedsize'
 
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
         """
         endpoint_basepath = self.path2pfn(self.attributes['prefix'])
         self.logger(logging.DEBUG, 'getting space usage from {}'.format(endpoint_basepath))

--- a/lib/rucio/rse/protocols/globus.py
+++ b/lib/rucio/rse/protocols/globus.py
@@ -41,7 +41,7 @@ class GlobusRSEProtocol(RSEProtocol):
 
     def lfns2pfns(self, lfns):
         """
-            Retruns a fully qualified PFN for the file referred by path.
+            Returns a fully qualified PFN for the file referred by path.
 
             :param path: The path to the file.
 
@@ -79,7 +79,7 @@ class GlobusRSEProtocol(RSEProtocol):
 
     def parse_pfns(self, pfns):
         """
-            Splits the given PFN into the parts known by the protocol. It is also checked if the provided protocol supportes the given PFNs.
+            Splits the given PFN into the parts known by the protocol. It is also checked if the provided protocol supports the given PFNs.
 
             :param pfns: a list of a fully qualified PFNs
 
@@ -116,7 +116,7 @@ class GlobusRSEProtocol(RSEProtocol):
                 raise exception.RSEFileNameNotSupported('Invalid prefix: provided \'%s\', expected \'%s\'' % ('/'.join(path.split('/')[0:len(self.attributes['prefix'].split('/')) - 1]),
                                                                                                               self.attributes['prefix']))  # len(...)-1 due to the leading '/
 
-            # Spliting parsed.path into prefix, path, filename
+            # Splitting parsed.path into prefix, path, filename
             prefix = self.attributes['prefix']
             path = path.partition(self.attributes['prefix'])[2]
             name = path.split('/')[-1]
@@ -189,7 +189,7 @@ class GlobusRSEProtocol(RSEProtocol):
 
             :param path: path to the to be deleted file
 
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         if self.globus_endpoint_id:

--- a/lib/rucio/rse/protocols/gsiftp.py
+++ b/lib/rucio/rse/protocols/gsiftp.py
@@ -52,12 +52,12 @@ class Default(protocol.RSEProtocol):
 
         :returns: a list with dict containing 'totalsize' and 'unusedsize'
 
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
         """
         rse_name = self.rse['rse']
         dest = '/tmp/rucio-gsiftp-site-size_' + rse_name
         space_usage_url = ''
-        # url of space usage json, woud be nicer to have it in rse_settings
+        # url of space usage json, would be nicer to have it in rse_settings
         agis = requests.get('http://atlas-agis-api.cern.ch/request/ddmendpoint/query/list/?json').json()
         agis_token = ''
         for res in agis:

--- a/lib/rucio/rse/protocols/http_cache.py
+++ b/lib/rucio/rse/protocols/http_cache.py
@@ -41,7 +41,7 @@ class Default(ngarc.Default):
 
     def path2pfn(self, path):
         """
-            Retruns a fully qualified PFN for the file referred by path.
+            Returns a fully qualified PFN for the file referred by path.
 
             :param path: The path to the file.
 

--- a/lib/rucio/rse/protocols/mock.py
+++ b/lib/rucio/rse/protocols/mock.py
@@ -30,7 +30,7 @@ class Default(protocol.RSEProtocol):
 
     def path2pfn(self, path):
         """
-            Retruns a fully qualified PFN for the file referred by path.
+            Returns a fully qualified PFN for the file referred by path.
 
             :param path: The path to the file.
 

--- a/lib/rucio/rse/protocols/ngarc.py
+++ b/lib/rucio/rse/protocols/ngarc.py
@@ -64,7 +64,7 @@ class Default(protocol.RSEProtocol):
 
     def path2pfn(self, path):
         """
-            Retruns a fully qualified PFN for the file referred by path.
+            Returns a fully qualified PFN for the file referred by path.
 
             :param path: The path to the file.
 

--- a/lib/rucio/rse/protocols/posix.py
+++ b/lib/rucio/rse/protocols/posix.py
@@ -47,7 +47,7 @@ class Default(protocol.RSEProtocol):
         """
             Establishes the actual connection to the referred RSE.
 
-            :param credentials: needed to establish a connection with the stroage.
+            :param credentials: needed to establish a connection with the storage.
 
             :raises RSEAccessDenied: if no connection could be established.
         """
@@ -65,13 +65,13 @@ class Default(protocol.RSEProtocol):
             :param transfer_timeout Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
          """
         try:
             shutil.copy(self.pfn2path(pfn), dest)
         except OSError as e:
-            try:  # To check if the error happend local or remote
+            try:  # To check if the error happened local or remote
                 with open(dest, 'wb'):
                     pass
                 call(['rm', '-rf', dest])
@@ -95,7 +95,7 @@ class Default(protocol.RSEProtocol):
             :param transfer_timeout Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         target = self.pfn2path(target)
@@ -126,7 +126,7 @@ class Default(protocol.RSEProtocol):
 
             :param pfn: pfn to the to be deleted file
 
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         try:
@@ -142,7 +142,7 @@ class Default(protocol.RSEProtocol):
             :param new_path: path to the new file on the storage
 
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         path = self.pfn2path(pfn)
@@ -223,7 +223,7 @@ class Symlink(Default):
             :param dest: Name and path of the files when stored at the client
             :param transfer_timeout Transfer timeout (in seconds) - dummy
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
          """
         path = self.pfn2path(pfn)

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -293,7 +293,7 @@ class RSEProtocol:
 
     def lfns2pfns(self, lfns):
         """
-            Retruns a fully qualified PFN for the file referred by path.
+            Returns a fully qualified PFN for the file referred by path.
 
             :param path: The path to the file.
 
@@ -334,7 +334,7 @@ class RSEProtocol:
         return pfns
 
     def __lfns2pfns_client(self, lfns):
-        """ Provides the path of a replica for non-deterministic sites. Will be assigned to get path by the __init__ method if neccessary.
+        """ Provides the path of a replica for non-deterministic sites. Will be assigned to get path by the __init__ method if necessary.
 
             :param scope: list of DIDs
 
@@ -359,7 +359,7 @@ class RSEProtocol:
         return self.translator.path(scope, name)
 
     def _get_path_nondeterministic_server(self, scope, name):  # pylint: disable=invalid-name
-        """ Provides the path of a replica for non-deterministic sites. Will be assigned to get path by the __init__ method if neccessary. """
+        """ Provides the path of a replica for non-deterministic sites. Will be assigned to get path by the __init__ method if necessary. """
         vo = get_rse_vo(self.rse['id'])  # pylint: disable=E0601
         scope = InternalScope(scope, vo=vo)  # pylint: disable=E0601
         rep = replica.get_replica(scope=scope, name=name, rse_id=self.rse['id'])  # pylint: disable=E0601
@@ -377,7 +377,7 @@ class RSEProtocol:
 
     def parse_pfns(self, pfns):
         """
-            Splits the given PFN into the parts known by the protocol. It is also checked if the provided protocol supportes the given PFNs.
+            Splits the given PFN into the parts known by the protocol. It is also checked if the provided protocol supports the given PFNs.
 
             :param pfns: a list of a fully qualified PFNs
 
@@ -417,7 +417,7 @@ class RSEProtocol:
                 raise exception.RSEFileNameNotSupported('Invalid prefix: provided \'%s\', expected \'%s\'' % ('/'.join(path.split('/')[0:len(prefix.split('/')) - 1]),
                                                                                                               prefix))  # len(...)-1 due to the leading '/
 
-            # Spliting parsed.path into prefix, path, filename
+            # Splitting parsed.path into prefix, path, filename
             path = path.partition(prefix)[2]
             name = path.split('/')[-1]
             path = '/'.join(path.split('/')[:-1])
@@ -462,7 +462,7 @@ class RSEProtocol:
             :param transfer_timeout: Transfer timeout (in seconds)
 
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
          """
         raise NotImplementedError
@@ -477,7 +477,7 @@ class RSEProtocol:
             :param transfer_timeout: Transfer timeout (in seconds)
 
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         raise NotImplementedError
@@ -488,7 +488,7 @@ class RSEProtocol:
 
             :param path: path to the to be deleted file
 
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         raise NotImplementedError
@@ -500,7 +500,7 @@ class RSEProtocol:
             :param new_path: path to the new file on the storage
 
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         raise NotImplementedError
@@ -511,7 +511,7 @@ class RSEProtocol:
 
             :returns: a list with dict containing 'totalsize' and 'unusedsize'
 
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
         """
         raise NotImplementedError
 
@@ -521,7 +521,7 @@ class RSEProtocol:
 
             :param path: path to file
 
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
 
             :returns: a dict with two keys, filesize and adler32 of the file provided in path.

--- a/lib/rucio/rse/protocols/rclone.py
+++ b/lib/rucio/rse/protocols/rclone.py
@@ -168,7 +168,7 @@ class Default(protocol.RSEProtocol):
 
         :param path: path to file
 
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
 
         :returns: a dict with two keys, filesize and an element of GLOBALLY_SUPPORTED_CHECKSUMS.
         """
@@ -298,7 +298,7 @@ class Default(protocol.RSEProtocol):
             :param transfer_timeout: Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'rclone.put: filename: {} target: {}'.format(filename, target))
@@ -324,7 +324,7 @@ class Default(protocol.RSEProtocol):
 
             :param pfn: Physical file name
 
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'rclone.delete: pfn: {}'.format(pfn))
@@ -346,7 +346,7 @@ class Default(protocol.RSEProtocol):
             :param pfn:      Current physical file name
             :param new_pfn  New physical file name
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'rclone.rename: pfn: {}'.format(pfn))

--- a/lib/rucio/rse/protocols/rfio.py
+++ b/lib/rucio/rse/protocols/rfio.py
@@ -32,7 +32,7 @@ class Default(protocol.RSEProtocol):
         """
             Establishes the actual connection to the referred RSE.
 
-            :param credentials: needed to establish a connection with the stroage.
+            :param credentials: needed to establish a connection with the storage.
 
             :raises RSEAccessDenied: if no connection could be established.
         """
@@ -42,7 +42,7 @@ class Default(protocol.RSEProtocol):
 
     def path2pfn(self, path):
         """
-            Retruns a fully qualified PFN for the file referred by path.
+            Returns a fully qualified PFN for the file referred by path.
 
             :param path: The path to the file.
 
@@ -80,7 +80,7 @@ class Default(protocol.RSEProtocol):
             :param transfer_timeout: Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         if not self.exists(dirname(target)):
@@ -127,7 +127,7 @@ class Default(protocol.RSEProtocol):
         if not ret['path'].startswith(self.rse['prefix']):
             raise exception.RSEFileNameNotSupported('Invalid prefix: provided \'%s\', expected \'%s\'' % ('/'.join(ret['path'].split('/')[0:len(self.rse['prefix'].split('/')) - 1]),
                                                                                                           self.rse['prefix']))  # len(...)-1 due to the leading '/
-        # Spliting parsed.path into prefix, path, filename
+        # Splitting parsed.path into prefix, path, filename
         ret['prefix'] = self.rse['prefix']
         ret['path'] = ret['path'].partition(self.rse['prefix'])[2]
         ret['name'] = ret['path'].split('/')[-1]

--- a/lib/rucio/rse/protocols/srm.py
+++ b/lib/rucio/rse/protocols/srm.py
@@ -119,7 +119,7 @@ class Default(protocol.RSEProtocol):
                 raise exception.RSEFileNameNotSupported('Invalid prefix: provided \'%s\', expected \'%s\'' % ('/'.join(path.split('/')[0:len(self.attributes['prefix'].split('/')) - 1]),
                                                                                                               self.attributes['prefix']))  # len(...)-1 due to the leading '/
 
-            # Spliting path into prefix, path, filename
+            # Splitting path into prefix, path, filename
             prefix = self.attributes['prefix']
             path = path.partition(self.attributes['prefix'])[2]
             name = path.split('/')[-1]
@@ -167,7 +167,7 @@ class Default(protocol.RSEProtocol):
     def connect(self):
         """
         Establishes the actual connection to the referred RSE.
-        As a quick and dirty impelementation we just use this method to check if the lcg tools are available.
+        As a quick and dirty implementation we just use this method to check if the lcg tools are available.
         If we decide to use gfal, init should be done here.
 
         :raises RSEAccessDenied: Cannot connect.
@@ -193,7 +193,7 @@ class Default(protocol.RSEProtocol):
         :param transfer_timeout: Transfer timeout (in seconds)
 
         :raises DestinationNotAccessible: if the destination storage was not accessible.
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
         :raises SourceNotFound: if the source file was not found on the referred storage.
         """
 
@@ -223,7 +223,7 @@ class Default(protocol.RSEProtocol):
         :param transfer_timeout: Transfer timeout (in seconds)
 
         :raises DestinationNotAccessible: if the destination storage was not accessible.
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
         :raises SourceNotFound: if the source file was not found on the referred storage.
         """
 
@@ -253,7 +253,7 @@ class Default(protocol.RSEProtocol):
         Deletes a file from the connected RSE.
 
         :param path: path to the to be deleted file
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
         :raises SourceNotFound: if the source file was not found on the referred storage.
         """
 
@@ -282,7 +282,7 @@ class Default(protocol.RSEProtocol):
         :param path: path to the current file on the storage
         :param new_path: path to the new file on the storage
         :raises DestinationNotAccessible: if the destination storage was not accessible.
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
         :raises SourceNotFound: if the source file was not found on the referred storage.
         """
 

--- a/lib/rucio/rse/protocols/ssh.py
+++ b/lib/rucio/rse/protocols/ssh.py
@@ -85,7 +85,7 @@ class Default(protocol.RSEProtocol):
 
         :param path: path to file
 
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
 
         :returns: a dict with two keys, filesize and an element of GLOBALLY_SUPPORTED_CHECKSUMS.
         """
@@ -218,7 +218,7 @@ class Default(protocol.RSEProtocol):
             :param transfer_timeout: Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'ssh.put: filename: {} target: {}'.format(filename, target))
@@ -245,7 +245,7 @@ class Default(protocol.RSEProtocol):
 
             :param pfn: Physical file name
 
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'ssh.delete: pfn: {}'.format(pfn))
@@ -267,7 +267,7 @@ class Default(protocol.RSEProtocol):
             :param pfn:      Current physical file name
             :param new_pfn  New physical file name
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'ssh.rename: pfn: {}'.format(pfn))
@@ -298,7 +298,7 @@ class Rsync(Default):
 
         :param path: path to file
 
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
 
         :returns: a dict with two keys, filesize and an element of GLOBALLY_SUPPORTED_CHECKSUMS.
         """
@@ -390,7 +390,7 @@ class Rsync(Default):
             :param transfer_timeout: Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'rsync.put: filename: {} target: {}'.format(filename, target))

--- a/lib/rucio/rse/protocols/storm.py
+++ b/lib/rucio/rse/protocols/storm.py
@@ -59,7 +59,7 @@ class Default(protocol.RSEProtocol):
 
     def path2pfn(self, path):
         """
-            Retruns a fully qualified PFN for the file referred by path.
+            Returns a fully qualified PFN for the file referred by path.
 
             :param path: The path to the file.
 

--- a/lib/rucio/rse/protocols/webdav.py
+++ b/lib/rucio/rse/protocols/webdav.py
@@ -478,7 +478,7 @@ class Default(protocol.RSEProtocol):
 
             :param path: path to file
 
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
             :raises RSEAccessDenied: in case of permission issue.
 
@@ -527,7 +527,7 @@ class Default(protocol.RSEProtocol):
 
         :returns: a list with dict containing 'totalsize' and 'unusedsize'
 
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
         """
         endpoint_basepath = self.path2pfn('')
         headers = {'Depth': '0'}

--- a/lib/rucio/rse/protocols/xrootd.py
+++ b/lib/rucio/rse/protocols/xrootd.py
@@ -88,7 +88,7 @@ class Default(protocol.RSEProtocol):
 
         :param path: path to file
 
-        :raises ServiceUnavailable: if some generic error occured in the library.
+        :raises ServiceUnavailable: if some generic error occurred in the library.
 
         :returns: a dict with two keys, filesize and an element of GLOBALLY_SUPPORTED_CHECKSUMS.
         """
@@ -232,7 +232,7 @@ class Default(protocol.RSEProtocol):
             :param transfer_timeout: Transfer timeout (in seconds) - dummy
 
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'xrootd.put: filename: {} target: {}'.format(filename, target))
@@ -257,7 +257,7 @@ class Default(protocol.RSEProtocol):
 
             :param pfn: Physical file name
 
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'xrootd.delete: pfn: {}'.format(pfn))
@@ -279,7 +279,7 @@ class Default(protocol.RSEProtocol):
             :param pfn:      Current physical file name
             :param new_pfn  New physical file name
             :raises DestinationNotAccessible: if the destination storage was not accessible.
-            :raises ServiceUnavailable: if some generic error occured in the library.
+            :raises ServiceUnavailable: if some generic error occurred in the library.
             :raises SourceNotFound: if the source file was not found on the referred storage.
         """
         self.logger(logging.DEBUG, 'xrootd.rename: pfn: {}'.format(pfn))

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -156,7 +156,7 @@ def file_generator(size: int = 2, namelen: int = 10) -> str:
 def make_temp_file(dir_: str, data: str) -> str:
     """
     Creates a temporal file and write `data` on it.
-    :param data: String to be writen on the created file.
+    :param data: String to be written on the created file.
     :returns: Name of the temporal file.
     """
     fd, path = tempfile.mkstemp(dir=dir_)

--- a/lib/rucio/tests/common_server.py
+++ b/lib/rucio/tests/common_server.py
@@ -115,7 +115,7 @@ def cleanup_db_deps(model, select_rows_stmt, *, session=None):
 
 
 def reset_config_table():
-    """ Clear the config table and install any default entires needed for the tests.
+    """ Clear the config table and install any default entries needed for the tests.
     """
     db_session = get_session()
     db_session.query(models.Config).delete()

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -419,7 +419,7 @@ def bulk_group_transfers(
         bring_online: Optional[int] = None,
         default_lifetime: Optional[int] = None) -> list[dict[str, Any]]:
     """
-    Group transfers in bulk based on certain criterias
+    Group transfers in bulk based on certain criteria
 
     :param transfer_paths:           List of transfer paths to group. Each path is a list of single-hop transfers.
     :param policy:                   Policy to use to group.
@@ -522,7 +522,7 @@ class Fts3TransferStatusReport(TransferStatusReport):
         self._reason = None
         self._src_rse = None
         self._fts_address = self.external_host
-        # Supported db fields bellow:
+        # Supported db fields below:
         self.state = None
         self.external_id = None
         self.started_at = None
@@ -1233,7 +1233,7 @@ class FTS3Transfertool(Transfertool):
         """
         Get the list of banned Storage Elements.
 
-        :returns: Detailed dictionnary of banned Storage Elements.
+        :returns: Detailed dictionary of banned Storage Elements.
         """
 
         try:
@@ -1459,7 +1459,7 @@ class FTS3Transfertool(Transfertool):
                                                                        FTS_STATE.FINISHEDDIRTY,
                                                                        FTS_STATE.CANCELED,
                                                                        FTS_STATE.FINISHED]:
-                    # multipe source replicas jobs is still running. should wait
+                    # multiple source replicas jobs is still running. should wait
                     responses[transfer_id] = {}
                     continue
 

--- a/lib/rucio/transfertool/fts3_plugins.py
+++ b/lib/rucio/transfertool/fts3_plugins.py
@@ -37,7 +37,7 @@ class FTS3TapeMetadataPlugin(PolicyPackageAlgorithms):
 
     def __init__(self, policy_algorithm: str) -> None:
         """
-        :param policy_algorithm: policy algorithm indentifier - choose from any of the policy package algorithms registered under the `fts3_tape_metadata_plugins` group.
+        :param policy_algorithm: policy algorithm identifier - choose from any of the policy package algorithms registered under the `fts3_tape_metadata_plugins` group.
         """
         super().__init__()
         self.transfer_limit = config_get_int(

--- a/lib/rucio/transfertool/globus.py
+++ b/lib/rucio/transfertool/globus.py
@@ -23,7 +23,7 @@ from .globus_library import bulk_check_xfers, bulk_submit_xfer, submit_xfer
 
 def bulk_group_transfers(transfer_paths, policy='single', group_bulk=200):
     """
-    Group transfers in bulk based on certain criterias
+    Group transfers in bulk based on certain criteria
 
     :param transfer_paths:  List of (potentially multihop) transfer paths to group. Each path is a list of single-hop transfers.
     :param policy:          Policy to use to group.

--- a/lib/rucio/transfertool/transfertool.py
+++ b/lib/rucio/transfertool/transfertool.py
@@ -69,7 +69,7 @@ class TransferStatusReport(metaclass=ABCMeta):
         self.__request = request  # Optional: DB request. If provided, saves us a database call to fetch it by request_id
         self.__initialized = False
 
-        # Supported db fields bellow
+        # Supported db fields below
         self.state = None
 
     @abstractmethod

--- a/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
@@ -24,7 +24,7 @@ class LocalAccountLimit(ErrorHandlingMethodView):
     def post(self, account, rse):
         """
         ---
-        summary: Create or update a local accont limit
+        summary: Create or update a local account limit
         tags:
           - Account Limit
         parameters:

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -570,8 +570,8 @@ class GlobalAccountLimits(ErrorHandlingMethodView):
     def get(self, account, rse_expression=None):
         """
         ---
-        summary: Get gloabl limit
-        description: Get the current gloabl limits for an account on a specific RSE expression.
+        summary: Get global limit
+        description: Get the current global limits for an account on a specific RSE expression.
         tags:
           - Account
         parameters:

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -108,7 +108,7 @@ class ErrorHandlingMethodView(MethodView):
                 return generate_http_error_flask(
                     status_code=500,
                     exc=error.__class__.__name__,
-                    exc_msg='An unknown Database Exception has ocurred.',
+                    exc_msg='An unknown Database Exception has occurred.',
                     headers=headers
                 )
 

--- a/lib/rucio/web/rest/flaskapi/v1/credentials.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credentials.py
@@ -60,7 +60,7 @@ class SignURL(ErrorHandlingMethodView):
               Access-Control-Allow-Headers:
                 schema:
                   type: string
-                description: The http access controll request headers.
+                description: The http access control request headers.
               Access-Control-Allow-Methods:
                 schema:
                   type: string
@@ -75,7 +75,7 @@ class SignURL(ErrorHandlingMethodView):
                 schema:
                   type: string
                   enum: ['X-Rucio-Auth-Token']
-                description: The exposed access controll header.
+                description: The exposed access control header.
           404:
             description: Not found
         """
@@ -116,7 +116,7 @@ class SignURL(ErrorHandlingMethodView):
           required: false
         - name: url
           in: query
-          description: The Url of the authentification.
+          description: The Url of the authentication.
           schema:
             type: string
           required: true

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -108,7 +108,7 @@ class Scope(ErrorHandlingMethodView):
             content:
               application/x-json-stream:
                 schema:
-                  description: Line seperated dictionary of dids.
+                  description: Line separated dictionary of dids.
                   type: array
                   items:
                     type: object
@@ -259,7 +259,7 @@ class Search(ErrorHandlingMethodView):
         if filters is not None:
             filters = ast.literal_eval(filters)
         else:
-            # backwards compatability for created*, length* and name filters passed through as request args
+            # backwards compatibility for created*, length* and name filters passed through as request args
             filters = {}
             for arg, value in request.args.copy().items():
                 if arg not in ['type', 'limit', 'long', 'recursive']:
@@ -781,7 +781,7 @@ class Attachment(ErrorHandlingMethodView):
             content:
               application/x-json-stream:
                 schema:
-                  description: The contents of a did. Items are line seperated.
+                  description: The contents of a did. Items are line separated.
                   type: array
                   items:
                     type: object
@@ -994,7 +994,7 @@ class AttachmentHistory(ErrorHandlingMethodView):
             content:
               application/x-json-stream:
                 schema:
-                  description: The dids with their information and history. Elements are seperated by new line characters.
+                  description: The dids with their information and history. Elements are separated by new line characters.
                   type: array
                   items:
                     type: object
@@ -1102,7 +1102,7 @@ class Files(ErrorHandlingMethodView):
                             description: The adler32 checksum.
                             type: string
                           lumiblocknr:
-                            description: The lumi block nr. Only availabe if `long` is defined in the query.
+                            description: The lumi block nr. Only available if `long` is defined in the query.
                             type: integer
                     - description: All replica information.
                       type: array
@@ -1318,7 +1318,7 @@ class Meta(ErrorHandlingMethodView):
             content:
               application/json:
                 schema:
-                  description: A data identifer with all attributes.
+                  description: A data identifier with all attributes.
                   type: object
           401:
             description: Invalid Auth Token
@@ -1362,7 +1362,7 @@ class Meta(ErrorHandlingMethodView):
                 - meta
                 properties:
                   meta:
-                    description: The metadata to add. A dictionary containg the metadata name as key and the value as value.
+                    description: The metadata to add. A dictionary containing the metadata name as key and the value as value.
                     type: object
                   recursive:
                     description: Flag if the metadata should be applied recirsively to children.
@@ -1509,7 +1509,7 @@ class SingleMeta(ErrorHandlingMethodView):
           406:
             description: Not acceptable
           409:
-            description: Matadata already exists
+            description: Metadata already exists
           400:
             description: Invalid key or value
         """
@@ -1699,7 +1699,7 @@ class BulkMeta(ErrorHandlingMethodView):
             content:
               application/json:
                 schema:
-                  description: A list of metadata identifiers for the dids. Seperated by new lines.
+                  description: A list of metadata identifiers for the dids. Separated by new lines.
                   type: array
                   items:
                     description: The metadata for one did.
@@ -1735,7 +1735,7 @@ class AssociatedRules(ErrorHandlingMethodView):
     def get(self, scope_name):
         """
         ---
-        summary: Get accociated rules
+        summary: Get associated rules
         description: Gets all associated rules for a file.
         tags:
           - Data Identifiers
@@ -1752,7 +1752,7 @@ class AssociatedRules(ErrorHandlingMethodView):
             content:
               application/x-json-stream:
                 schema:
-                  description: All associated rules for a file. Items are seperated by new line character.
+                  description: All associated rules for a file. Items are separated by new line character.
                   type: array
                   items:
                     description: A replication rule associated with the file. Has more fields than listed here.
@@ -1823,7 +1823,7 @@ class GUIDLookup(ErrorHandlingMethodView):
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of all datasets associated with the guid. Items are seperated by new line character.
+                  description: A list of all datasets associated with the guid. Items are separated by new line character.
                   type: array
                   items:
                     description: A dataset associated with a guid.
@@ -2027,7 +2027,7 @@ class NewDIDs(ErrorHandlingMethodView):
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of the recent dids. Items are seperated by new line characters.
+                  description: A list of the recent dids. Items are separated by new line characters.
                   type: array
                   items:
                     description: A did.

--- a/lib/rucio/web/rest/flaskapi/v1/import.py
+++ b/lib/rucio/web/rest/flaskapi/v1/import.py
@@ -80,7 +80,7 @@ class Import(ErrorHandlingMethodView):
                           description: The email of an account.
                           type: string
                         identities:
-                          description: The identiies accociated with an account. Deletes old identites and adds the newly defined ones.
+                          description: The identities associated with an account. Deletes old identities and adds the newly defined ones.
                           type: array
                           items:
                             description: One identity associated with an account.

--- a/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
@@ -60,10 +60,10 @@ class LifetimeException(ErrorHandlingMethodView):
                         type: string
                         enum: ['F', 'D', 'C', 'A', 'X', 'Y', 'Z']
                       account:
-                        description: The account accociated with the lifetime exception.
+                        description: The account associated with the lifetime exception.
                         type: string
                       pattern:
-                        description: The patter of the lifetime exception.
+                        description: The pattern of the lifetime exception.
                         type: string
                       comments:
                         description: The comments of the lifetime exception.
@@ -208,7 +208,7 @@ class LifetimeExceptionId(ErrorHandlingMethodView):
                         description: The account associated with the lifetime exception.
                         type: string
                       pattern:
-                        description: The patter of the lifetime exception.
+                        description: The pattern of the lifetime exception.
                         type: string
                       comments:
                         description: The comments of the lifetime exception.

--- a/lib/rucio/web/rest/flaskapi/v1/main.py
+++ b/lib/rucio/web/rest/flaskapi/v1/main.py
@@ -53,7 +53,7 @@ def apply_endpoints(app, modules):
     for blueprint_module in modules:
         # Legacy patch - TODO Remove in 38.0.0
         if blueprint_module == "meta":
-            logging.log(logging.WARNING, "Endpoint `meta` is depreciated and will be removed in future releaases")
+            logging.log(logging.WARNING, "Endpoint `meta` is depreciated and will be removed in future releases")
             blueprint_module = "meta_conventions"
         try:
             # searches for module names locally

--- a/lib/rucio/web/rest/flaskapi/v1/meta_conventions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/meta_conventions.py
@@ -37,7 +37,7 @@ class MetaConventions(ErrorHandlingMethodView):
               application/json:
                 schema:
                   type: array
-                  descripton: List of all DID keys.
+                  description: List of all DID keys.
                   items:
                     type: string
                     description: Data Itentifier key
@@ -69,7 +69,7 @@ class MetaConventions(ErrorHandlingMethodView):
                 type: object
                 properties:
                   key_type:
-                    description: The key tpye.
+                    description: The key type.
                     type: string
                   value_type:
                     description: The value type.

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -393,7 +393,7 @@ class Replicas(ErrorHandlingMethodView):
                           description: The pfn of the replica.
                           type: string
                         error_message:
-                          description: The error message if an error occured.
+                          description: The error message if an error occurred.
                           type: string
                         broken_rule_id:
                           description: The id of the broken rule if one was found.
@@ -1126,7 +1126,7 @@ class BadReplicasStates(ErrorHandlingMethodView):
                       - type: object
                         properties:
                           scope:
-                            description: The scope fo the replica.
+                            description: The scope of the replica.
                             type: string
                           name:
                             description: The name of the replica.
@@ -1137,7 +1137,7 @@ class BadReplicasStates(ErrorHandlingMethodView):
                       - type: object
                         properties:
                           scope:
-                            description: The scope fo the replica.
+                            description: The scope of the replica.
                             type: string
                           name:
                             description: The name of the replica.

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -38,7 +38,7 @@ class RequestGet(ErrorHandlingMethodView):
         """
         ---
         summary: Get Request
-        description: Get a request for a given DID to a destinaion RSE.
+        description: Get a request for a given DID to a destination RSE.
         tags:
           - Requests
         parameters:
@@ -102,7 +102,7 @@ class RequestGet(ErrorHandlingMethodView):
                       description: The numbers of attempted retires.
                       type: integer
                     err_msg:
-                      description: An error message if one occured.
+                      description: An error message if one occurred.
                       type: string
                     previous_attempt_id:
                       description: The id of the previous attempt.
@@ -132,7 +132,7 @@ class RequestGet(ErrorHandlingMethodView):
                       description: The time the request got started.
                       type: string
                     transferred_at:
-                      description: The time the request got transfered.
+                      description: The time the request got transferred.
                       type: string
                     estimated_at:
                       description: The time the request got estimated.
@@ -144,7 +144,7 @@ class RequestGet(ErrorHandlingMethodView):
                       description: The estimation of the started at value.
                       type: string
                     estimated_transferred_at:
-                      description: The estimation of the transfered at value.
+                      description: The estimation of the transferred at value.
                       type: string
                     staging_started_at:
                       description: The time the staging got started.
@@ -203,7 +203,7 @@ class RequestHistoryGet(ErrorHandlingMethodView):
         """
         ---
         summary: Get Historical Request
-        description: List a hostorical request for a given DID to a destination RSE.
+        description: List a historical request for a given DID to a destination RSE.
         tags:
           - Requests
         parameters:
@@ -267,7 +267,7 @@ class RequestHistoryGet(ErrorHandlingMethodView):
                       description: The numbers of attempted retires.
                       type: integer
                     err_msg:
-                      description: An error message if one occured.
+                      description: An error message if one occurred.
                       type: string
                     previous_attempt_id:
                       description: The id of the previous attempt.
@@ -297,7 +297,7 @@ class RequestHistoryGet(ErrorHandlingMethodView):
                       description: The time the request got started.
                       type: string
                     transferred_at:
-                      description: The time the request got transfered.
+                      description: The time the request got transferred.
                       type: string
                     estimated_at:
                       description: The time the request got estimated.
@@ -309,7 +309,7 @@ class RequestHistoryGet(ErrorHandlingMethodView):
                       description: The estimation of the started at value.
                       type: string
                     estimated_transferred_at:
-                      description: The estimation of the transfered at value.
+                      description: The estimation of the transferred at value.
                       type: string
                     staging_started_at:
                       description: The time the staging got started.
@@ -419,7 +419,7 @@ class RequestList(ErrorHandlingMethodView):
             content:
               application/x-json-stream:
                 schema:
-                  description: All requests matching the arguments. Seperated by the new line character.
+                  description: All requests matching the arguments. Separated by the new line character.
                   type: array
                   items:
                     description: A request.
@@ -464,7 +464,7 @@ class RequestList(ErrorHandlingMethodView):
                         description: The numbers of attempted retires.
                         type: integer
                       err_msg:
-                        description: An error message if one occured.
+                        description: An error message if one occurred.
                         type: string
                       previous_attempt_id:
                         description: The id of the previous attempt.
@@ -494,7 +494,7 @@ class RequestList(ErrorHandlingMethodView):
                         description: The time the request got started.
                         type: string
                       transferred_at:
-                        description: The time the request got transfered.
+                        description: The time the request got transferred.
                         type: string
                       estimated_at:
                         description: The time the request got estimated.
@@ -506,7 +506,7 @@ class RequestList(ErrorHandlingMethodView):
                         description: The estimation of the started at value.
                         type: string
                       estimated_transferred_at:
-                        description: The estimation of the transfered at value.
+                        description: The estimation of the transferred at value.
                         type: string
                       staging_started_at:
                         description: The time the staging got started.
@@ -654,7 +654,7 @@ class RequestHistoryList(ErrorHandlingMethodView):
             content:
               application/x-json-stream:
                 schema:
-                  description: All requests matching the arguments. Seperated by a new line character.
+                  description: All requests matching the arguments. Separated by a new line character.
                   type: array
                   items:
                     description: A request.
@@ -699,7 +699,7 @@ class RequestHistoryList(ErrorHandlingMethodView):
                         description: The numbers of attempted retires.
                         type: integer
                       err_msg:
-                        description: An error message if one occured.
+                        description: An error message if one occurred.
                         type: string
                       previous_attempt_id:
                         description: The id of the previous attempt.
@@ -729,7 +729,7 @@ class RequestHistoryList(ErrorHandlingMethodView):
                         description: The time the request got started.
                         type: string
                       transferred_at:
-                        description: The time the request got transfered.
+                        description: The time the request got transferred.
                         type: string
                       estimated_at:
                         description: The time the request got estimated.
@@ -741,7 +741,7 @@ class RequestHistoryList(ErrorHandlingMethodView):
                         description: The estimation of the started at value.
                         type: string
                       estimated_transferred_at:
-                        description: The estimation of the transfered at value.
+                        description: The estimation of the transferred at value.
                         type: string
                       staging_started_at:
                         description: The time the staging got started.

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -240,8 +240,8 @@ class RSE(ErrorHandlingMethodView):
                     description: The rse type.
                     type: string
                     enum: ["DISK", "TAPE"]
-                  latitute:
-                    description: The latitute of the RSE.
+                  latitude:
+                    description: The latitude of the RSE.
                     type: number
                   longitude:
                     description: The longitude of the RSE.
@@ -381,8 +381,8 @@ class RSE(ErrorHandlingMethodView):
                     description: The rse type.
                     type: string
                     enum: ["DISK", "TAPE"]
-                  latitute:
-                    description: The latitute of the RSE.
+                  latitude:
+                    description: The latitude of the RSE.
                     type: number
                   longitude:
                     description: The longitude of the RSE.
@@ -475,8 +475,8 @@ class RSE(ErrorHandlingMethodView):
                       description: The rse type.
                       type: string
                       enum: ["DISK", "TAPE"]
-                    latitute:
-                      description: The latitute of the RSE.
+                    latitude:
+                      description: The latitude of the RSE.
                       type: number
                     longitude:
                       description: The longitude of the RSE.
@@ -822,7 +822,7 @@ class ProtocolList(ErrorHandlingMethodView):
           401:
             description: Invalid Auth Token
           404:
-            description: RSE not found or RSE Operation, RSE Protocal Doman, RSE Protocol not supported
+            description: RSE not found or RSE Operation, RSE Protocol Domain, RSE Protocol not supported
           406:
             description: Not acceptable
         """
@@ -873,7 +873,7 @@ class LFNS2PFNS(ErrorHandlingMethodView):
             type: string
         - name: operation
           in: query
-          description: Optional query argument to select the protoco for read-vs-writes.
+          description: Optional query argument to select the protocol for read-vs-writes.
           schema:
             type: string
         responses:
@@ -890,7 +890,7 @@ class LFNS2PFNS(ErrorHandlingMethodView):
           401:
             description: Invalid Auth Token
           404:
-            description: RSE not found or RSE Protocol or RSE Protocl Domain not supported
+            description: RSE not found or RSE Protocol or RSE Protocol Domain not supported
           406:
             description: Not acceptable
         """
@@ -1350,7 +1350,7 @@ class Protocol(ErrorHandlingMethodView):
         """
         ---
         summary: Delete Protocol Attributes
-        description: Delete all protocol attibutes.
+        description: Delete all protocol attributes.
         tags:
           - Rucio Storage Elements
         parameters:
@@ -1848,7 +1848,7 @@ class Distance(ErrorHandlingMethodView):
                   type: array
                   items:
                     type: object
-                    description: One distance betweeen source and destination.
+                    description: One distance between source and destination.
                     properties:
                       src_rse_id:
                         description: The source rse id.
@@ -2175,7 +2175,7 @@ class QoSPolicy(ErrorHandlingMethodView):
                   type: array
                   items:
                     type: object
-                    porperties:
+                    properties:
                       rse_id:
                         description: The rse id.
                         type: string

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -793,16 +793,16 @@ class RuleAnalysis(ErrorHandlingMethodView):
                             description: The name of the lock.
                           rse_id:
                             type: string
-                            description: The rse_id of the transfered lock.
+                            description: The rse_id of the transferred lock.
                           rse:
                             type: object
-                            description: Information about the rse of the transfered lock.
+                            description: Information about the rse of the transferred lock.
                           attempts:
                             type: integer
                             description: The number of attempts.
                           last_error:
                             type: string
-                            description: The last error that occured.
+                            description: The last error that occurred.
                           last_source:
                             type: string
                             description: The last source.

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -147,7 +147,7 @@ class Subscription(ErrorHandlingMethodView):
                   - options
                 properties:
                   options:
-                    description: The values for the new subcription.
+                    description: The values for the new subscription.
                     type: object
                     properties:
                       filter:
@@ -164,7 +164,7 @@ class Subscription(ErrorHandlingMethodView):
                         type: string
                         format: date-time
                       retroactive:
-                        description: If the retroactive is actiavted for a subscription.
+                        description: If the retroactive is activated for a subscription.
                         type: boolean
                       priority:
                         description: The priority/policyid for the subscription. Stored as policyid.
@@ -234,7 +234,7 @@ class Subscription(ErrorHandlingMethodView):
                   - options
                 properties:
                   options:
-                    description: The values for the new subcription.
+                    description: The values for the new subscription.
                     type: object
                     required:
                       - filter
@@ -257,7 +257,7 @@ class Subscription(ErrorHandlingMethodView):
                         type: string
                         format: date-time
                       retroactive:
-                        description: If the retroactive is actiavted for a subscription.
+                        description: If the retroactive is activated for a subscription.
                         type: boolean
                       priority:
                         description: The priority/policyid for the subscription. Stored as policyid.

--- a/lib/rucio/web/ui/flask/templates/account.html
+++ b/lib/rucio/web/ui/flask/templates/account.html
@@ -54,7 +54,7 @@
     </div>
   </div>
 
-  <div id="identites" class="columns panel">
+  <div id="identities" class="columns panel">
     <h4>Account Identities</h4>
     <div id="loading_id">
       <div class="row"><div class="small-1 small-centered columns">

--- a/lib/rucio/web/ui/flask/templates/rse.html
+++ b/lib/rucio/web/ui/flask/templates/rse.html
@@ -22,7 +22,7 @@
 {{ super() }}
 <div id="result" class="row" data-equalizer>
     <div id="rse_info" class="columns panel">
-        <h4>Informations</h4>
+        <h4>Information</h4>
         <div class="row" id="loadingInfo">
             <div class="small-1 small-centered columns">
                 <img src="/media/spinner.gif">

--- a/lib/rucio/web/ui/flask/templates/rse_add_protocol.html
+++ b/lib/rucio/web/ui/flask/templates/rse_add_protocol.html
@@ -99,7 +99,7 @@
             </div>
             <br>
             <div>
-                <h3>Informations</h3>
+                <h3>Information</h3>
                 <div class="row collapse">
                     <div class="large-1 columns">
                         <label for="hostname" class="left inline">Hostname</label>

--- a/lib/rucio/web/ui/flask/templates/subscription.html
+++ b/lib/rucio/web/ui/flask/templates/subscription.html
@@ -31,7 +31,7 @@
 </div>
 <div class="row">
   <div class="columns large-1">
-     <div id="subscription_editor" class="button small expand">Edit subcription</div>
+     <div id="subscription_editor" class="button small expand">Edit subscription</div>
  </div>
 </div>
 

--- a/lib/rucio/web/ui/static/did.js
+++ b/lib/rucio/web/ui/static/did.js
@@ -645,7 +645,7 @@ create_and_move_dataset = function(scope, name, dids) {
                                              },
                                              error: function(jqXHR, textStatus, errorThrown) {
                                                  console.log(jqXHR);
-                                                 alert('An error has ocurred: Could not attach correct files to temporary dataset.');
+                                                 alert('An error has occurred: Could not attach correct files to temporary dataset.');
                                              }
                                          });
                                      },
@@ -666,7 +666,7 @@ create_and_move_dataset = function(scope, name, dids) {
                         },
                         error: function(jqXHR, textStatus, errorThrown) {
                             console.log(jqXHR);
-                            alert('An error has ocurred: Could not get files for dataset.');
+                            alert('An error has occurred: Could not get files for dataset.');
                         }
                     });
                 } else {
@@ -700,14 +700,14 @@ create_and_move_dataset = function(scope, name, dids) {
                         },
                         error: function(jqXHR, textStatus, errorThrown) {
                             console.log(jqXHR);
-                            alert('An error has ocurred: Could not determine locks for replication rule.');
+                            alert('An error has occurred: Could not determine locks for replication rule.');
                         }
                     });
                 }
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR);
-                alert('An error has ocurred. Could not check whether rule already exists.');
+                alert('An error has occurred. Could not check whether rule already exists.');
             }
         });
     } else {
@@ -730,14 +730,14 @@ create_and_move_dataset = function(scope, name, dids) {
                 error: function(jqXHR, textStatus, errorThrown) {
                     console.log(jqXHR);
                     removeDatasetFromStorage(scope, name);
-                    alert('An error has ocurred: Could not attach files to newly created temporary dataset.');
+                    alert('An error has occurred: Could not attach files to newly created temporary dataset.');
                 }
                 });
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.log(jqXHR);
                 removeDatasetFromStorage(scope, name);
-                alert('An error has ocurred: Could not create temporary dataset.');
+                alert('An error has occurred: Could not create temporary dataset.');
             }
         });
     }

--- a/lib/rucio/web/ui/static/http_monitoring_account_details.js
+++ b/lib/rucio/web/ui/static/http_monitoring_account_details.js
@@ -141,9 +141,9 @@ function loadData(date, account) {
 
 function fillTable(csv,date) {
   var tbl_data = [],
-      splitted = csv.split('\n');
-  for(var i=0; i < splitted.length; i++) {
-    cols = splitted[i].split('\t');
+      split = csv.split('\n');
+  for(var i=0; i < split.length; i++) {
+    cols = split[i].split('\t');
     if(cols[0] == "") continue;
     var caption = '';
     if (/^\w+\s+\/(dids|replicas)\/\S+?\/.+$/.test(cols[2])) {

--- a/lib/rucio/web/ui/static/http_monitoring_accounts.js
+++ b/lib/rucio/web/ui/static/http_monitoring_accounts.js
@@ -46,9 +46,9 @@ function loadData(date) {
 
 function fillTable(csv,date) {
   var tbl_data = [],
-      splitted = csv.split('\n');
-  for(var i=0; i < splitted.length; i++) {
-    cols = splitted[i].split('\t');
+      split = csv.split('\n');
+  for(var i=0; i < split.length; i++) {
+    cols = split[i].split('\t');
     if((cols.length < 5) || (isNaN(cols[2])) || (isNaN(cols[3])) || (isNaN(cols[4])))
       continue;
     if(cols[0] == "") continue;

--- a/lib/rucio/web/ui/static/http_monitoring_apiclass_details.js
+++ b/lib/rucio/web/ui/static/http_monitoring_apiclass_details.js
@@ -49,9 +49,9 @@ function filterByAPIClass(csv, apiclass) {
 
 function fillTable(csv,date) {
   var tbl_data = [],
-      splitted = csv.split('\n');
-  for(var i=0; i < splitted.length; i++) {
-    cols = splitted[i].split('\t');
+      split = csv.split('\n');
+  for(var i=0; i < split.length; i++) {
+    cols = split[i].split('\t');
     if((cols.length < 7) || (isNaN(cols[4])) || (isNaN(cols[5])) || (isNaN(cols[6])))
       continue;
     tbl_data.push([

--- a/lib/rucio/web/ui/static/http_monitoring_apiclasses.js
+++ b/lib/rucio/web/ui/static/http_monitoring_apiclasses.js
@@ -43,11 +43,11 @@ function fillTable(csv,date) {
   var tbl_data = [],
       cols = undefined,
       classID = undefined,
-      splitted = csv.split('\n'),
+      split = csv.split('\n'),
       aggregatedData = {};
-  for(var i=0; i < splitted.length; i++) {
-    if (splitted == '') continue;
-    cols = splitted[i].split('\t');
+  for(var i=0; i < split.length; i++) {
+    if (split == '') continue;
+    cols = split[i].split('\t');
     if((cols.length < 7) || (isNaN(cols[4])) || (isNaN(cols[5])) || (isNaN(cols[6])))
       continue;
     classID = cols[2].match(/^(\w+\.\w+)/)[1];

--- a/lib/rucio/web/ui/static/http_monitoring_resources.js
+++ b/lib/rucio/web/ui/static/http_monitoring_resources.js
@@ -32,9 +32,9 @@ function loadData(date) {
 
 function fillTable(csv,date) {
   var tbl_data = [],
-      splitted = csv.split('\n');
-  for(var i=0; i < splitted.length; i++) {
-    cols = splitted[i].split('\t');
+      split = csv.split('\n');
+  for(var i=0; i < split.length; i++) {
+    cols = split[i].split('\t');
     if((cols.length < 5) || (isNaN(cols[2])) || (isNaN(cols[3])) || (isNaN(cols[4])))
       continue
     var caption = '';

--- a/lib/rucio/web/ui/static/http_monitoring_scriptid_details.js
+++ b/lib/rucio/web/ui/static/http_monitoring_scriptid_details.js
@@ -100,9 +100,9 @@ function filterByScript(csv, scriptID) {
 
 function fillTable(csv,date) {
   var tbl_data = [],
-      splitted = csv.split('\n');
-  for(var i=0; i < splitted.length; i++) {
-    cols = splitted[i].split('\t');
+      split = csv.split('\n');
+  for(var i=0; i < split.length; i++) {
+    cols = split[i].split('\t');
     if((cols.length < 7) || (isNaN(cols[4])) || (isNaN(cols[5])) || (isNaN(cols[6])))
       continue;
     tbl_data.push([

--- a/lib/rucio/web/ui/static/http_monitoring_scriptids.js
+++ b/lib/rucio/web/ui/static/http_monitoring_scriptids.js
@@ -34,11 +34,11 @@ function fillTable(csv,date) {
   var tbl_data = [],
       cols = undefined,
       scriptID = undefined,
-      splitted = csv.split('\n'),
+      split = csv.split('\n'),
       aggregatedData = {};
-  for(var i=0; i < splitted.length; i++) {
-    if (splitted == '') continue;
-    cols = splitted[i].split('\t');
+  for(var i=0; i < split.length; i++) {
+    if (split == '') continue;
+    cols = split[i].split('\t');
     if((cols.length < 7) || (isNaN(cols[4])) || (isNaN(cols[5])) || (isNaN(cols[6])))
       continue;
     scriptID = cols[3];

--- a/lib/rucio/web/ui/static/http_monitoring_utils.js
+++ b/lib/rucio/web/ui/static/http_monitoring_utils.js
@@ -62,7 +62,7 @@ function csv2chart(csv, legendIndices, dataColumn, top, aggregate, scale) {
   return data;
 }
 
-function drawDoubleChart(traget, title, main, sub, series, top) {
+function drawDoubleChart(target, title, main, sub, series, top) {
   var colors = Highcharts.getOptions().colors,
       data = {},
       mainData = [],
@@ -144,7 +144,7 @@ function drawDoubleChart(traget, title, main, sub, series, top) {
   }
 
   // Create the chart
-  $(traget).highcharts({
+  $(target).highcharts({
       chart: {
           type: 'pie'
       },
@@ -305,7 +305,7 @@ function syncTabs(summaryTableSelector) {
         }
       });
       $('#drilldowns > li.active > a').first().click();
-      //Toggeling columns in summary table
+      //Toggling columns in summary table
       summaryTable =  $(summaryTableSelector).DataTable();
       summaryTable.columns([1,2,3]).visible(false);;
       summaryTable.column($(this).attr('data-column')).visible(true);

--- a/lib/rucio/web/ui/static/jquery.quicksearch.js
+++ b/lib/rucio/web/ui/static/jquery.quicksearch.js
@@ -67,7 +67,7 @@
 		};
 
 		/*
- * 		 * External API so that users can perform search programatically.
+ * 		 * External API so that users can perform search programmatically.
  * 		 		 * */
 		this.search = function (submittedVal) {
 			val = submittedVal;

--- a/lib/rucio/web/ui/static/rse_account_usage.js
+++ b/lib/rucio/web/ui/static/rse_account_usage.js
@@ -422,7 +422,7 @@ function done_editing(container) {
     container.removeClass('editing');
     $("#resulttable").DataTable().cell(container).data(new_bytes);
 
-    // Check if value changed, and thus cell should be marked as 'updated' i.e. if delta greate than 1%
+    // Check if value changed, and thus cell should be marked as 'updated' i.e. if delta is greater than 1%
     if (delta_bytes && (new_bytes > 0)) {
         container.addClass('updated');
         container.attr('data-info', 'Delta: ' + filesize(delta_bytes, {'base': 10}));

--- a/lib/rucio/web/ui/static/rucio.js
+++ b/lib/rucio/web/ui/static/rucio.js
@@ -502,7 +502,7 @@ RucioClient.prototype.create_rule = function(options) {
     if (options.weight == '') { options.weight = null; };
     if (options.lifetime == '') { options.lifetime = null; };
     if (options.source_replica_expression == '') { options.source_replica_expression = null; };
-    if (options.nofity == '') { options.notify = null; };
+    if (options.notify == '') { options.notify = null; };
     jQuery.ajax({url: url,
                  crossDomain: true,
                  type: 'POST',
@@ -1342,7 +1342,7 @@ RucioClient.prototype.list_heartbeats = function(options) {
         });
 };
 
-/* retrieve a singel data identifier */
+/* retrieve a single data identifier */
 RucioClient.prototype.get_did = function(options) {
     check_token();
     var url = this.url + '/dids/' + options.scope + '/' + options.name;

--- a/lib/rucio/web/ui/static/rule.js
+++ b/lib/rucio/web/ui/static/rule.js
@@ -396,8 +396,8 @@ function add_boost_button() {
                     $('#boost_message').html('<font color="red">Cannot increase priority at the moment.</font>');
                     return;
                 }
-                excpt = JSON.parse(jqXHR.responseText)
-                $('#boost_message').html('<font color="red">' + excpt['ExceptionMessage'] + '</font>');
+                except = JSON.parse(jqXHR.responseText)
+                $('#boost_message').html('<font color="red">' + except['ExceptionMessage'] + '</font>');
             }
         })
     });

--- a/tests/mocks/mock_http_server.py
+++ b/tests/mocks/mock_http_server.py
@@ -25,7 +25,7 @@ class MockServer:
     class Handler(SimpleHTTPRequestHandler):
         def send_code_and_message(self, code, headers, message):
             """
-            Helper which wraps the quite-low-level BaseHTTPRequestHandler primitives and is used to send reponses.
+            Helper which wraps the quite-low-level BaseHTTPRequestHandler primitives and is used to send responses.
             """
             self.send_response(code)
             self.send_header("Content-type", "text/plain")

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -39,7 +39,7 @@ class TestAccountCoreGateway:
         del_account(usr, 'root', vo=vo)
 
     def test_update_account(self, vo):
-        """ ACCOUNT (CORE): Test changing and quering account parameters """
+        """ ACCOUNT (CORE): Test changing and querying account parameters """
         usr = account_name_generator()
         add_account(usr, 'USER', 'rucio@email.com', 'root', vo=vo)
         assert get_account_info(usr, vo=vo)['status'] == AccountStatus.ACTIVE  # Should be active by default
@@ -128,8 +128,8 @@ def test_get_user_success(rest_client, auth_token):
 
 def test_get_user_failure(rest_client, auth_token):
     """ ACCOUNT (REST): send a GET with a wrong user test the error """
-    reponse = rest_client.get('/accounts/wronguser', headers=headers(auth(auth_token)))
-    assert reponse.status_code == 404
+    response = rest_client.get('/accounts/wronguser', headers=headers(auth(auth_token)))
+    assert response.status_code == 404
 
 
 def test_del_user_success(rest_client, auth_token):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -278,7 +278,7 @@ def test_saml_fail(vo, rest_client):
 
 @pytest.mark.noparallel(reason='adds many tokens')
 def test_many_tokens(vo, root_account, db_session):
-    """AUTHENTIFICATION (REST): Error when deleting too many tokens."""
+    """AUTHENTICATION (REST): Error when deleting too many tokens."""
     for i in range(2000):
         models.Token(account=root_account, token="dummytoken" + str(i), ip='127.0.0.1', expired_at=datetime.datetime.utcnow()).save(session=db_session)
     db_session.commit()

--- a/tests/test_bad_replica.py
+++ b/tests/test_bad_replica.py
@@ -248,7 +248,7 @@ def test_client_add_list_bad_replicas(rse_factory, replica_client, did_client):
 
     list_rep.extend(['srm://%s.cern.ch/test_%s/%s/%s' % (rse2_id, rse2_id, tmp_scope, generate_uuid()), ])
     with pytest.raises(InvalidType):
-        # this should fail becase the replica list will now contain a mix of PFNs and dictionaries
+        # this should fail because the replica list will now contain a mix of PFNs and dictionaries
         replica_client.declare_bad_file_replicas(list_rep, 'This is a good reason')
 
 

--- a/tests/test_bin_rucio.py
+++ b/tests/test_bin_rucio.py
@@ -617,7 +617,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out, err)
         # add files to dataset
-        cmd = 'rucio attach {0} {3}:{1} {3}:{2}'.format(tmp_dataset, tmp_file1[5:], tmp_file2[5:], self.user)  # triming '/tmp/' from filename
+        cmd = 'rucio attach {0} {3}:{1} {3}:{2}'.format(tmp_dataset, tmp_file1[5:], tmp_file2[5:], self.user)  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
@@ -637,7 +637,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out, err)
         # download files
-        cmd = 'rucio -v download --dir /tmp {0}:{1}'.format(self.user, tmp_file1[5:])  # triming '/tmp/' from filename
+        cmd = 'rucio -v download --dir /tmp {0}:{1}'.format(self.user, tmp_file1[5:])  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
@@ -655,7 +655,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out, err)
         # download files
-        cmd = 'rucio -v download --dir /tmp {0}:{1}'.format(self.user, tmp_file1[5:-2] + '*')  # triming '/tmp/' from filename
+        cmd = 'rucio -v download --dir /tmp {0}:{1}'.format(self.user, tmp_file1[5:-2] + '*')  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
@@ -711,7 +711,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out, err)
         # download files
-        cmd = 'rucio -v download --dir /tmp {0}:{1} --impl {2}'.format(self.user, tmp_file1[5:], impl)  # triming '/tmp/' from filename
+        cmd = 'rucio -v download --dir /tmp {0}:{1} --impl {2}'.format(self.user, tmp_file1[5:], impl)  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
@@ -729,7 +729,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out, err)
         # download files
-        cmd = 'rucio -v download --dir /tmp {0}:{1} --impl {2}'.format(self.user, tmp_file1[5:-2] + '*', impl)  # triming '/tmp/' from filename
+        cmd = 'rucio -v download --dir /tmp {0}:{1} --impl {2}'.format(self.user, tmp_file1[5:-2] + '*', impl)  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
@@ -758,7 +758,7 @@ class TestBinRucio:
         print(out, err)
         assert exitcode == 0
         # download files with --no-subdir
-        cmd = 'rucio -v download --no-subdir --dir /tmp {0}:{1}'.format(self.user, tmp_file[5:])  # triming '/tmp/' from filename
+        cmd = 'rucio -v download --no-subdir --dir /tmp {0}:{1}'.format(self.user, tmp_file[5:])  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
@@ -770,7 +770,7 @@ class TestBinRucio:
         print(out, err)
         assert tmp_file[5:] in out
         # download again with --no-subdir
-        cmd = 'rucio -v download --no-subdir --dir /tmp {0}:{1}'.format(self.user, tmp_file[5:])  # triming '/tmp/' from filename
+        cmd = 'rucio -v download --no-subdir --dir /tmp {0}:{1}'.format(self.user, tmp_file[5:])  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
@@ -902,7 +902,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out, err)
         # download files
-        cmd = 'rucio download --dir /tmp --transfer-timeout 3 --transfer-speed-timeout 1000 {0}:{1}'.format(self.user, tmp_file1[5:])  # triming '/tmp/' from filename
+        cmd = 'rucio download --dir /tmp --transfer-timeout 3 --transfer-speed-timeout 1000 {0}:{1}'.format(self.user, tmp_file1[5:])  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
@@ -1046,7 +1046,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out, err)
         # add files to dataset
-        cmd = 'rucio attach {0} {1}:{2}'.format(tmp_dataset, self.user, tmp_file1[5:])  # triming '/tmp/' from filename
+        cmd = 'rucio attach {0} {1}:{2}'.format(tmp_dataset, self.user, tmp_file1[5:])  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
@@ -1054,11 +1054,11 @@ class TestBinRucio:
         os.remove(tmp_file1)
 
         # download dataset
-        cmd = 'rucio -v download --dir /tmp {0}'.format(tmp_dataset)  # triming '/tmp/' from filename
+        cmd = 'rucio -v download --dir /tmp {0}'.format(tmp_dataset)  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
-        search = '{0} successfully downloaded'.format(tmp_file1[5:])  # triming '/tmp/' from filename
+        search = '{0} successfully downloaded'.format(tmp_file1[5:])  # trimming '/tmp/' from filename
         assert re.search(search, err) is not None
 
     def test_download_file_check_by_size(self):
@@ -1070,18 +1070,18 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out, err)
         # download files
-        cmd = 'rucio -v download --dir /tmp {0}:{1}'.format(self.user, tmp_file1[5:])  # triming '/tmp/' from filename
+        cmd = 'rucio -v download --dir /tmp {0}:{1}'.format(self.user, tmp_file1[5:])  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
         # Alter downloaded file
-        cmd = 'echo "dummy" >> /tmp/{}/{}'.format(self.user, tmp_file1[5:])  # triming '/tmp/' from filename
+        cmd = 'echo "dummy" >> /tmp/{}/{}'.format(self.user, tmp_file1[5:])  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
         assert exitcode == 0
         # Download file again and check for mismatch
-        cmd = 'rucio -v download --check-local-with-filesize-only --dir /tmp {0}:{1}'.format(self.user, tmp_file1[5:])  # triming '/tmp/' from filename
+        cmd = 'rucio -v download --check-local-with-filesize-only --dir /tmp {0}:{1}'.format(self.user, tmp_file1[5:])  # trimming '/tmp/' from filename
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
@@ -1104,7 +1104,7 @@ class TestBinRucio:
 
         # add files
         tmp_file1 = file_generator()
-        file_name = tmp_file1[5:]  # triming '/tmp/' from filename
+        file_name = tmp_file1[5:]  # trimming '/tmp/' from filename
         cmd = 'rucio upload --rse {0} --scope {1} {2}'.format(tmp_rse, self.user, tmp_file1)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1159,7 +1159,7 @@ class TestBinRucio:
         print(out)
         # add quota
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1172,7 +1172,7 @@ class TestBinRucio:
         print(out, err)
         # add quota
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1185,7 +1185,7 @@ class TestBinRucio:
         print(out, err)
         # add quota
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1196,7 +1196,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out)
         assert not err
-        rule = out[:-1]  # triming new line character
+        rule = out[:-1]  # trimming new line character
         assert re.match(r'^\w+$', rule)
         # check if rule exist for the file
         cmd = "rucio list-rules {0}:{1}".format(self.user, tmp_file1[5:])
@@ -1221,7 +1221,7 @@ class TestBinRucio:
         print(out, err)
         # add quota
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASRULEDELAYED'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1237,7 +1237,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out, err)
         assert not err
-        rule = out[:-1]  # triming new line character
+        rule = out[:-1]  # trimming new line character
         cmd = "rucio rule-info {0}".format(rule)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1268,7 +1268,7 @@ class TestBinRucio:
         print(out)
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
 
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASDELETERULE'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1317,7 +1317,7 @@ class TestBinRucio:
         print(out)
         # add quota
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1330,7 +1330,7 @@ class TestBinRucio:
         print(out, err)
         # add quota
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1343,7 +1343,7 @@ class TestBinRucio:
         print(out, err)
         # add quota
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1354,7 +1354,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out)
         assert not err
-        rule = out[:-1]  # triming new line character
+        rule = out[:-1]  # trimming new line character
         assert re.match(r'^\w+$', rule)
 
         # move rule
@@ -1364,7 +1364,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out)
         assert not err
-        new_rule = out[:-1]  # triming new line character
+        new_rule = out[:-1]  # trimming new line character
 
         # check if rule exist for the file
         cmd = "rucio list-rules {0}:{1}".format(self.user, tmp_file1[5:])
@@ -1389,7 +1389,7 @@ class TestBinRucio:
         print(out)
         # add quota
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1402,7 +1402,7 @@ class TestBinRucio:
         print(out, err)
         # add quota
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1415,7 +1415,7 @@ class TestBinRucio:
         print(out, err)
         # add quota
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASSCRATCHDISK'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1426,7 +1426,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out)
         assert not err
-        rule = out[:-1]  # triming new line character
+        rule = out[:-1]  # trimming new line character
         assert re.match(r'^\w+$', rule)
         # move rule
         new_rule_expr = "spacetoken=ATLASSCRATCHDISK|spacetoken=ATLASSD"
@@ -1437,7 +1437,7 @@ class TestBinRucio:
         exitcode, out, err = execute(cmd)
         print(out, err)
         assert not err
-        new_rule_id = out[:-1]  # triming new line character
+        new_rule_id = out[:-1]  # trimming new line character
 
         # check if rule exist for the file
         cmd = "rucio list-rules {0}:{1}".format(self.user, tmp_file1[5:])
@@ -1484,7 +1484,7 @@ class TestBinRucio:
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
-        # delete the fisical file
+        # delete the physical file
         cmd = "find /tmp/rucio_rse/ -name {0} |xargs rm".format(tmp_file1[5:])
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -1524,7 +1524,7 @@ class TestBinRucio:
         remove(tmp_file2)
         remove(tmp_file3)
         # attach the files to the dataset
-        cmd = 'rucio attach {0} {1}:{2} {1}:{3}'.format(tmp_dsn, self.user, tmp_file2[5:], tmp_file3[5:])  # triming '/tmp/' from filenames
+        cmd = 'rucio attach {0} {1}:{2} {1}:{3}'.format(tmp_dsn, self.user, tmp_file2[5:], tmp_file3[5:])  # trimming '/tmp/' from filenames
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out)
@@ -1557,7 +1557,7 @@ class TestBinRucio:
         remove(tmp_file2)
         remove(tmp_file3)
         # detach the files to the dataset
-        cmd = 'rucio detach {0} {1}:{2} {1}:{3}'.format(tmp_dsn, self.user, tmp_file2[5:], tmp_file3[5:])  # triming '/tmp/' from filenames
+        cmd = 'rucio detach {0} {1}:{2} {1}:{3}'.format(tmp_dsn, self.user, tmp_file2[5:], tmp_file3[5:])  # trimming '/tmp/' from filenames
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out)
@@ -1586,7 +1586,7 @@ class TestBinRucio:
         print(err)
         remove(tmp_file1)
         # attach the files to the dataset
-        cmd = 'rucio attach {0} {1}:{2}'.format(tmp_dsn, self.user, tmp_file1[5:])  # triming '/tmp/' from filenames
+        cmd = 'rucio attach {0} {1}:{2}'.format(tmp_dsn, self.user, tmp_file1[5:])  # trimming '/tmp/' from filenames
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out)
@@ -1624,7 +1624,7 @@ class TestBinRucio:
         print(err)
         remove(tmp_file1)
         # attach the files to the dataset
-        cmd = 'rucio detach {0} {1}:{2}'.format(tmp_dsn, self.user, 'file_ghost')  # triming '/tmp/' from filenames
+        cmd = 'rucio detach {0} {1}:{2}'.format(tmp_dsn, self.user, 'file_ghost')  # trimming '/tmp/' from filenames
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out)
@@ -1682,7 +1682,7 @@ class TestBinRucio:
         print(out)
         print(err)
 
-        # Checking if the execution was successfull and if the DIDs belong together
+        # Checking if the execution was successful and if the DIDs belong together
         assert re.search('DIDs successfully attached', out) is not None
         cmd = 'rucio list-content {0}'.format(tmp_dsn_did)
         print(self.marker + cmd)
@@ -1711,7 +1711,7 @@ class TestBinRucio:
         print(err)
         remove(did_file_path)
 
-        # Checking if the execution was successfull and if the DIDs belong together
+        # Checking if the execution was successful and if the DIDs belong together
         assert re.search('DIDs successfully attached', out) is not None
         cmd = 'rucio list-content {0}'.format(tmp_dsn_did)
         print(self.marker + cmd)
@@ -2183,7 +2183,7 @@ class TestBinRucio:
         print(out)
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
 
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value ATLASDELETERULE'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
@@ -2230,7 +2230,7 @@ class TestBinRucio:
         print(out)
         self.account_client.set_local_account_limit('root', tmp_rse, -1)
 
-        # add rse atributes
+        # add rse attributes
         cmd = 'rucio-admin rse set-attribute --rse {0} --key spacetoken --value MARIOSPACEODYSSEY'.format(tmp_rse)
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@ from rucio.common.utils import generate_uuid
 class TestConfigCore:
 
     def test_get_config_sections(self):
-        """ CONFIG (CORE): Retreive configuration section only """
+        """ CONFIG (CORE): Retrieve configuration section only """
         expected_sections = [str(generate_uuid()), str(generate_uuid())]
         for section in expected_sections:
             core_config.set(section, str(generate_uuid()), str(generate_uuid()))
@@ -32,7 +32,7 @@ class TestConfigCore:
             assert section in sections
 
     def test_get_and_set_section_option(self):
-        """ CONFIG (CORE): Retreive configuration option only """
+        """ CONFIG (CORE): Retrieve configuration option only """
         # get and set
         section = str(generate_uuid())
         option = str(generate_uuid())

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -224,7 +224,7 @@ def test_multihop_intermediate_replica_lifecycle(vo, did_factory, root_account, 
         replica = __wait_for_replica_transfer(dst_rse_id=jump_rse_id, **did)
         assert replica['state'] == ReplicaState.AVAILABLE
 
-        # ensure tha the ranking was correct for all sources and intermediate rses
+        # ensure that the ranking was correct for all sources and intermediate rses
         assert __get_source(request_id=request['id'], src_rse_id=src_rse1_id, **did).ranking == 0
         assert __get_source(request_id=request['id'], src_rse_id=jump_rse_id, **did).ranking == 0
         assert __get_source(request_id=request['id'], src_rse_id=src_rse2_id, **did).ranking == 0
@@ -301,7 +301,7 @@ def test_fts_non_recoverable_failures_handled_on_multihop(vo, did_factory, root_
     with pytest.raises(RequestNotFound):
         request_core.get_request_by_did(rse_id=jump_rse_id, **did)
     request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
-    # ensure tha the ranking was correctly decreased for the whole path
+    # ensure that the ranking was correctly decreased for the whole path
     assert __get_source(request_id=request['id'], src_rse_id=jump_rse_id, **did).ranking == -1
     assert __get_source(request_id=request['id'], src_rse_id=src_rse_id, **did).ranking == -1
     assert request['state'] == RequestState.QUEUED
@@ -541,7 +541,7 @@ def test_multihop_receiver_on_failure(vo, did_factory, replica_client, root_acco
         with pytest.raises(RequestNotFound):
             request_core.get_request_by_did(rse_id=jump_rse_id, **did)
         request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
-        # ensure tha the ranking was correctly decreased for the whole path
+        # ensure that the ranking was correctly decreased for the whole path
         assert __get_source(request_id=request['id'], src_rse_id=jump_rse_id, **did).ranking == -1
         assert __get_source(request_id=request['id'], src_rse_id=src_rse_id, **did).ranking == -1
         assert request['state'] == RequestState.QUEUED
@@ -1288,7 +1288,7 @@ def test_file_exists_handled(overwrite_on_tape_topology, caches_mock):
 def test_overwrite_corrupted_files(overwrite_on_tape_topology, core_config_mock, caches_mock):
     """
     If a transfer fails because the destination exists, and the size+checksums of the destination file are wrong,
-    the next submission must be performed according to the overwrite_corrupted_files config paramenter.
+    the next submission must be performed according to the overwrite_corrupted_files config parameter.
     """
     rse1_id, rse2_id, rse3_id, did1, did2 = overwrite_on_tape_topology(did1_corrupted=True, did2_corrupted=True)
     all_rses = [rse1_id, rse2_id, rse3_id]
@@ -1717,7 +1717,7 @@ def test_transfer_plugins(rse_factory, did_factory, root_account, file_config_mo
     request_fast = request_core.get_request_by_did(rse_id=dst_rse_id, **did_fast)
     request_slow = request_core.get_request_by_did(rse_id=dst_rse_id, **did_slow)
 
-    # Does not impact the actual prority of the transfer - is read by placement algorithm not fts3.
+    # Does not impact the actual priority of the transfer - is read by placement algorithm not fts3.
     assert request_fast['state'] != RequestState.SUBMISSION_FAILED
     assert request_slow['state'] != RequestState.SUBMISSION_FAILED
     assert request_fast['state'] != RequestState.FAILED

--- a/tests/test_dumper_data_model.py
+++ b/tests/test_dumper_data_model.py
@@ -99,7 +99,7 @@ CERN-PROD_DATADISK	data12_8TeV	ESD.04972924._000218.pool.root.1	a6152bbc	2498690
         assert self._DataConcrete.csv_header() == 'a,b,c,d,e,f,g,h'
 
     def test_formated_fields(self):
-        """ test formated fields """
+        """ test formatted fields """
         assert self.data_concrete.formated_fields(print_fields=('a', 'e')) == ['aa', '42']
 
     def test_csv(self):
@@ -219,7 +219,7 @@ class TestCompleteDataset:
 
     @staticmethod
     def test_creation_with_7_parameters():
-        """ test ceation with 7 parameters """
+        """ test creation with 7 parameters """
         complete_dataset = data_models.CompleteDataset(
             'RSE',
             'scope',

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -77,7 +77,7 @@ def test_userpass(rest_client, auth_token):
 
 
 def test_verify_userpass_identity():
-    """ Test if an idenity exists in the db, mapping to at least one account. """
+    """ Test if an identity exists in the db, mapping to at least one account. """
     if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
         vo = {'vo': get_vo()}
     else:
@@ -107,7 +107,7 @@ def test_verify_userpass_identity():
 
 
 def test_verify_x509_identity():
-    """ Test if an x509 idenity exists in the db, mapped to at least one account. """
+    """ Test if an x509 identity exists in the db, mapped to at least one account. """
     if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
         vo = {'vo': get_vo()}
     else:

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -180,7 +180,7 @@ def importer_example_data(vo, jdoe_account):
     add_identity(example_data.identity_to_be_removed, IdentityType.X509, email='email')
     add_account_identity(example_data.identity_to_be_removed, IdentityType.X509, example_data.old_account_2, 'email')
 
-    # Identity that already exsits but should be added to the account
+    # Identity that already exists but should be added to the account
     example_data.identity_to_be_added_to_account = rse_name_generator()
     add_identity(example_data.identity_to_be_added_to_account, IdentityType.X509, email='email')
 

--- a/tests/test_judge_repairer.py
+++ b/tests/test_judge_repairer.py
@@ -260,7 +260,7 @@ class TestJudgeRepairer:
         assert (RuleState.STUCK == get_rule(rule_id)['state'])
         rule_repairer(once=True)
 
-        # Stil assert STUCK because of delays:
+        # Still assert STUCK because of delays:
         assert (RuleState.STUCK == get_rule(rule_id)['state'])
         assert (get_replica_locks(scope=files[2]['scope'], name=files[2]['name'])[0].rse_id == get_replica_locks(scope=files[3]['scope'], name=files[3]['name'])[0].rse_id)
         # assert (RuleState.REPLICATING == get_rule(rule_id)['state'])

--- a/tests/test_multi_vo.py
+++ b/tests/test_multi_vo.py
@@ -632,7 +632,7 @@ class TestVORestAPI:
         assert accounts_short == accounts_long
 
     def test_rest_vomap_bad(self, rest_client):
-        """ MULTI VO (REST): Test that we get a bad paramter (400) error with an invalid (out of spec) VO name. """
+        """ MULTI VO (REST): Test that we get a bad parameter (400) error with an invalid (out of spec) VO name. """
         # VO names cannot include an exclaimation mark
         response = rest_client.get('/auth/userpass', headers=headers(loginhdr('root', 'ddmlab', 'secret'), vohdr("BadVO!")))
         assert response.status_code == 400

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -171,7 +171,7 @@ class MockADMINClientISSOIDC(MagicMock):
         oidc_tokens['scope'] = request_args['scope']
         oidc_tokens['audience'] = request_args['audience']
         oidc_tokens['id_token'] = {'sub': request_args['client_id'], 'iss': 'https://test_issuer/'}
-        # we need to passs the full dict in the access_token key again in order to have  a chance to bypas the token validation method
+        # we need to pass the full dict in the access_token key again in order to have  a chance to bypass the token validation method
         access_token = encode_access_token([oidc_tokens['access_token'], oidc_tokens['scope'],
                                            oidc_tokens['audience'], request_args['client_id'], 'https://test_issuer/'])
         oidc_tokens['access_token'] = access_token
@@ -223,7 +223,7 @@ class MockClientOIDC(MagicMock):
         oidc_tokens['scope'] = request_args['scope']
         oidc_tokens['audience'] = request_args['audience']
         oidc_tokens['id_token'] = {'sub': user_sub, 'iss': user_issuer}
-        # we need to passs the full dict in the access_token key again in order to have  a chance to bypas the token validation method
+        # we need to pass the full dict in the access_token key again in order to have  a chance to bypass the token validation method
         access_token = encode_access_token([oidc_tokens['access_token'], oidc_tokens['scope'],
                                            oidc_tokens['audience'], user_sub, user_issuer])
         oidc_tokens['access_token'] = access_token
@@ -240,7 +240,7 @@ class MockADMINClientOtherISSOIDC(MagicMock):
         oidc_tokens['scope'] = request_args['scope']
         oidc_tokens['audience'] = request_args['audience']
         oidc_tokens['id_token'] = {'sub': request_args['client_id'], 'iss': 'https://test_other_issuer/'}
-        # we need to passs the full dict in the access_token key again in order to have  a chance to bypas the token validation method
+        # we need to pass the full dict in the access_token key again in order to have  a chance to bypass the token validation method
         access_token = encode_access_token([oidc_tokens['access_token'], oidc_tokens['scope'],
                                            oidc_tokens['audience'], request_args['client_id'], 'https://test_other_issuer/'])
         oidc_tokens['access_token'] = access_token
@@ -278,7 +278,7 @@ class TestAuthCoreAPIoidc:
         self.accountstring = self.accountstring.lower()
         self.account = InternalAccount(self.accountstring, **self.vo)
         self.adminaccountstring = 'admin_' + rndstr()[:-1]  # Too long to use full string
-        print("ADMIN ACOUNT STRING: ", self.adminaccountstring)
+        print("ADMIN ACCOUNT STRING: ", self.adminaccountstring)
         self.adminaccountstring = self.adminaccountstring.lower()
         self.adminaccount = InternalAccount(self.adminaccountstring, **self.vo)
         self.adminaccSUB = str('adminSUB' + rndstr()).lower()
@@ -331,7 +331,7 @@ class TestAuthCoreAPIoidc:
         auth_url = get_auth_oidc(account, session=session, **kwargs)
         print("[get_auth_init_and_mock_response] got auth_url:", auth_url)
         # get the state from the auth_url and add an arbitrary code value to the query string
-        # to mimick a return of IdP with authz_code
+        # to mimic a return of IdP with authz_code
         urlparsed = urlparse(auth_url)
         if ('_polling' in auth_url) or (not polling and not auto):
             auth_url = redirect_auth_oidc(urlparsed.query, session=session)
@@ -403,7 +403,7 @@ class TestAuthCoreAPIoidc:
 
             Runs the Test:
 
-            - requesting token with parameters without coresponding
+            - requesting token with parameters without corresponding
               DB entry (in oauth_Requests table)
 
             End:
@@ -566,7 +566,7 @@ class TestAuthCoreAPIoidc:
             End:
 
             - checking if the right token is saved in the DB and if it is present
-              in the return dict of the get_token_oidc fucntion
+              in the return dict of the get_token_oidc function
         """
         mock_oidc_client.side_effect = get_mock_oidc_client
         auth_init_response = self.get_auth_init_and_mock_response(code_response=rndstr(), account=InternalAccount('webui', **self.vo), session=self.db_session)
@@ -1703,7 +1703,7 @@ class TestAuthCoreAPIoidc:
         user_sub = 'knownsub'
         req_admin = False
         # ---------------------------
-        # giving a USER a subject token - ned to bypass the usual auth grant flow
+        # giving a USER a subject token - need to bypass the usual auth grant flow
         # as that is not the purpose of this test
         preexisting_user_access_token_strpart = rndstr()
         request_args = {'scope': EXPECTED_OIDC_SCOPE,
@@ -1790,7 +1790,7 @@ class TestAuthCoreAPIoidc:
         user_sub = 'knownsub'
         req_admin = False
         # ---------------------------
-        # giving a USER a subject token - ned to bypass the usual auth grant flow
+        # giving a USER a subject token - need to bypass the usual auth grant flow
         # as that is not the purpose of this test
         preexisting_user_access_token_strpart = rndstr()
         request_args = {'scope': EXPECTED_OIDC_SCOPE,

--- a/tests/test_reaper.py
+++ b/tests/test_reaper.py
@@ -427,7 +427,7 @@ def test_archive_of_deleted_dids(vo, did_factory, root_account, core_config_mock
     'rucio.daemons.reaper.reaper.REGION'
 ]}], indirect=True)
 def test_run_on_non_existing_scheme(vo, caches_mock):
-    """ REAPER (DAEMON): Mock test the reaper daemon with a speficied scheme."""
+    """ REAPER (DAEMON): Mock test the reaper daemon with a specified scheme."""
     [cache_region] = caches_mock
     scope = InternalScope('data13_hip', vo=vo)
 

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -940,7 +940,7 @@ def test_client_add_temporary_unavailable_pfns(rse_factory, mock_scope, replica_
         did['state'] = ReplicaState.TEMPORARY_UNAVAILABLE
         rep.append(did)
 
-    time.sleep(10)  # Test broken if minos_tu_expiration excuted immediately. Threading effect ?
+    time.sleep(10)  # Test broken if minos_tu_expiration executed immediately. Threading effect ?
     # Run the minos expiration
     minos_tu_expiration(once=True)
     # Check the state in the replica table

--- a/tests/test_replica_recoverer.py
+++ b/tests/test_replica_recoverer.py
@@ -96,8 +96,8 @@ class TestReplicaRecoverer:
             # checking if Rucio upload went OK
             assert exitcode == 0
 
-        # Explaination of the fictional data types:
-        # testtypedeclarebad: Files are speficied to be declared bad
+        # Explanation of the fictional data types:
+        # testtypedeclarebad: Files are specified to be declared bad
         # testtypeignore: Files are specified to be ignored
         # testtypenopolicy: Files either have no policy or no recognised policy and are ignored by default
 
@@ -391,7 +391,7 @@ class TestReplicaRecoverer:
         # tmp_file13   unavailable                              suspicious (available)                    scope_declarebad            testtypedryrun
         # ----------------------------------------------------------------------------------------------------------------------------------------------------
 
-            - Explaination: Suspicious replicas that are the last remaining copy (unavailable on rse4recovery) are handeled differently depending
+            - Explanation: Suspicious replicas that are the last remaining copy (unavailable on rse4recovery) are handled differently depending
                             by their metadata "datatype".
                             - Files that are the last remaining copy, but do not have a data type, are automatically ignored. For this reason, testing
                               just the scope policies (tmp_file7 and tmp_file8) still requires a data type.
@@ -400,7 +400,7 @@ class TestReplicaRecoverer:
                             - testtypenopolicy files are of a fictional type that doesn't have a specified policy, meaning they should be ignored by default.
                             - scope_declarebad files belong to a fictional scope that has the policy of being declared bad.
                             - scope_nopolicy files belong to a fictional scope that doesn't have a specified policy, meaning they should be ignored by default.
-                            If a policiy is set for the file type and the scope, then the policiy for the file type takes priority (meaning tmp_file9 should be
+                            If a policy is set for the file type and the scope, then the policy for the file type takes priority (meaning tmp_file9 should be
                             ignored).
 
             Runs the Test:

--- a/tests/test_rse_expression_parser.py
+++ b/tests/test_rse_expression_parser.py
@@ -83,7 +83,7 @@ class TestRSEExpressionParserCore:
             rse_expression_parser.parse_expression("TEST_RSE1|", **self.filter)
 
     def test_wrong_parantheses(self):
-        """ RSE_EXPRESSION_PARSER (CORE) Test invalid rse expression: wrong parantheses """
+        """ RSE_EXPRESSION_PARSER (CORE) Test invalid rse expression: wrong parentheses """
         with pytest.raises(InvalidRSEExpression):
             rse_expression_parser.parse_expression("TEST_RSE1)", **self.filter)
 
@@ -124,7 +124,7 @@ class TestRSEExpressionParserCore:
         assert value == expected
 
     def test_parantheses(self):
-        """ RSE_EXPRESSION_PARSER (CORE) Test parantheses """
+        """ RSE_EXPRESSION_PARSER (CORE) Test parentheses """
         value = sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("(%s)" % self.tag1, **self.filter)])
         expected = sorted([self.rse1_id, self.rse2_id, self.rse3_id])
         assert value == expected

--- a/tests/test_rse_lfn2path.py
+++ b/tests/test_rse_lfn2path.py
@@ -123,7 +123,7 @@ class TestDeterministicTranslation:
         assert translator.path("foo", "bar") == "static_register_value2"
 
     def test_attr_mapping(self):
-        """LFN2PFN: Verify we can map using rse and attrs (Successs)"""
+        """LFN2PFN: Verify we can map using rse and attrs (Success)"""
         def rse_algorithm(scope, name, rse, rse_attrs, proto_attrs):
             """Test LFN2PATH function for exercising the different RSE/proto attrs."""
             tier = rse_attrs.get("tier", "T1")

--- a/tests/test_schema_cms.py
+++ b/tests/test_schema_cms.py
@@ -195,7 +195,7 @@ class TestSchemaCMS:
     def test_attachment(self):
         """ CMS SCHEMA (COMMON): Test CMS attachment"""
 
-        # no need to re-test did pattrens
+        # no need to re-test did patterns
         dids = [{
             'scope': 'cms',
             'name': '/store/mc/Fall10/DYToMuMu_M-20_TuneZ2_7TeV-pythia6/AODSIM/START38_V12-v1/0003/C0F3344F-6EC8-DF11-8ED6-E41F13181020.root',

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -38,8 +38,8 @@ class TestScopeCoreApi:
         """ SCOPE (CORE): Is scope owner """
         scope = InternalScope(scope_name_generator(), vo=vo)
         add_scope(scope=scope, account=jdoe_account)
-        anwser = is_scope_owner(scope=scope, account=jdoe_account)
-        assert anwser is True
+        answer = is_scope_owner(scope=scope, account=jdoe_account)
+        assert answer is True
 
 
 def test_scope_success(rest_client, auth_token):

--- a/tests/test_transfer_plugins.py
+++ b/tests/test_transfer_plugins.py
@@ -205,7 +205,7 @@ def test_collocation_hints(file_config_mock, did_factory, rse_factory, root_acco
     }
 ], indirect=True)
 def test_multiple_plugin_concat(file_config_mock, did_factory, rse_factory, root_account):
-    """When multiple plugins are used (like prority and collocation), both logics are applied"""
+    """When multiple plugins are used (like priority and collocation), both logics are applied"""
 
     mock_did = did_factory.random_file_did()
     transfer_path = _make_transfer_path(mock_did, rse_factory, root_account)

--- a/tools/add_header
+++ b/tools/add_header
@@ -21,7 +21,7 @@ to let the user know about a possible change. A general file type, defining
 which files should get headers, has to be a class inherited from the
 `HeaderTemplate` abstract class. The class gets registered automatically and is
 accessible through the `header_template_factory` function. The implementation
-for each file get's selected by the `is_file_suitable` method provided by the
+for each file gets selected by the `is_file_suitable` method provided by the
 template. Other methods to get information about the currently used header and
 the new header have to be provided too.
 """
@@ -30,8 +30,8 @@ import argparse
 import logging
 import os
 import sys
-from collections.abc import Iterator, ValuesView
 from abc import ABC, abstractmethod
+from collections.abc import Iterator, ValuesView
 from enum import Enum, auto
 from typing import Optional
 
@@ -89,7 +89,7 @@ def exit_code_from_result_states(states: ValuesView[ResultStates]) -> int:
 
 def print_result_states(states: dict[str, ResultStates]) -> None:
     """
-    Prints the result states in a redable format for the user.
+    Prints the result states in a readable format for the user.
 
     :param states: A dict with a file name as key and the corresponding ResultState.
     """
@@ -417,7 +417,7 @@ def process_file(file_path: str, dry_run: bool) -> ResultStates:
     Processes one file. Modifies the file if necessary.
 
     :param file_path: Path to the file.
-    :param dry_run: If True, the header wont be changed.
+    :param dry_run: If True, the header won't be changed.
     :returns: A ResultState corresponding to the action performed on or the
               state of the file.
     """
@@ -444,7 +444,7 @@ def process_files(files: list[str], dry_run: bool, disable_progress_bar: bool) -
     Processes all files and prints the result.
 
     :param files: The files to process.
-    :param dry_run: If True, the headers wont be changed.
+    :param dry_run: If True, the headers won't be changed.
     :param disable_progress_bar: If True, disables the progress bar.
     :returns: A dictionary mapping the files to the corresponding ResultStates
               they are in.

--- a/tools/convert_database_vo.py
+++ b/tools/convert_database_vo.py
@@ -72,7 +72,7 @@ def rename_vo(old_vo, new_vo, insert_new_vo=False, description=None, email=None,
     :param description:    Full description of the new VO, unused if `insert_new_vo` is False.
     :param email:          Admin email for the new VO, unused if `insert_new_vo` is False.
     :param commit_changes: If True then changes are made against the database directly.
-                           If False, then nothing is commited and the commands needed are dumped to be run later.
+                           If False, then nothing is committed and the commands needed are dumped to be run later.
     :param skip_history:   If True then tables without FKC containing historical data will not be converted to save time.
     """
     success = True
@@ -165,7 +165,7 @@ def rename_vo(old_vo, new_vo, insert_new_vo=False, description=None, email=None,
     except:
         success = False
         print(format_exc())
-        print('Exception occured, changes not committed to DB.')
+        print('Exception occurred, changes not committed to DB.')
 
     if commit_changes and success:
         trans.commit()
@@ -179,7 +179,7 @@ def remove_vo(vo, commit_changes=False, skip_history=False):
 
     :param vo:             The 3 character string for the VO being removed from the DB.
     :param commit_changes: If True then changes are made against the database directly.
-                           If False, then nothing is commited and the commands needed are dumped to be run later.
+                           If False, then nothing is committed and the commands needed are dumped to be run later.
     :param skip_history:   If True then tables without FKC containing historical data will not be converted to save time.
     """
     success = True
@@ -265,7 +265,7 @@ def remove_vo(vo, commit_changes=False, skip_history=False):
     except:
         success = False
         print(format_exc())
-        print('Exception occured, changes not committed to DB.')
+        print('Exception occurred, changes not committed to DB.')
 
     if commit_changes and success:
         trans.commit()
@@ -282,7 +282,7 @@ def convert_to_mvo(new_vo, description, email, create_super_root=False, commit_c
     :param email:             Admin email for the new VO.
     :param create_super_root: If True and the renaming was successful, then create a super_root account at VO def.
     :param commit_changes:    If True then changes are made against the database directly.
-                              If False, then nothing is commited and the commands needed are dumped to be run later.
+                              If False, then nothing is committed and the commands needed are dumped to be run later.
     :param skip_history:      If True then tables without FKC containing historical data will not be converted to save time.
     """
     if not config_get_bool('common', 'multi_vo', False, False):
@@ -311,7 +311,7 @@ def convert_to_svo(old_vo, delete_vos=False, commit_changes=False, skip_history=
     :param old_vo:         The 3 character string for the old VO.
     :param delete_vos:     If True then all entries associated with a VO other than `old_vo` will be deleted.
     :param commit_changes: If True then changes are made against the database directly and the old super_root account will be (soft) deleted.
-                           If False, then nothing is commited and the commands needed are dumped to be run later.
+                           If False, then nothing is committed and the commands needed are dumped to be run later.
     :param skip_history:   If True then tables without FKC containing historical data will not be converted to save time.
     """
     if not config_get_bool('common', 'multi_vo', False, False):

--- a/tools/count_missing_type_annotations_utils.sh
+++ b/tools/count_missing_type_annotations_utils.sh
@@ -15,17 +15,17 @@
 # limitations under the License.
 
 # Script with all tools to count the missing python type annotations in the
-# project. Installes all necessary python packages temporarly if needed. To use
-# it run: `scource count_missing_annotations_utils.sh`.
+# project. Installs all necessary python packages temporarily if needed. To use
+# it run: `source count_missing_annotations_utils.sh`.
 
 set -e
 
 
 ensure_install() {
-    # Checks if a python package is installed via pip. It installes the package,
+    # Checks if a python package is installed via pip. It installs the package,
     # and removes it after the script run automatically.
     #
-    # All debug output is redirected to the stderr stream, to not interfear with
+    # All debug output is redirected to the stderr stream, to not interfere with
     # other output.
     #
     # :param $1: The name of the pip package.

--- a/tools/generate-release-notes.py
+++ b/tools/generate-release-notes.py
@@ -78,7 +78,7 @@ def get_issue_component_type(issue):
 def print_issues(issues, section_title):
     if not issues:
         return
-    # Generate the formated printout
+    # Generate the formatted printout
     bugs = [issue for issue in issues if issue['type'] == 'bug']
     bugs = sorted(bugs, key=lambda k: "%s %d" % (k['component'], k['number']))
     enhancements = [issue for issue in issues if issue['type'] == 'enhancement']

--- a/tools/monitoring/visualization/rucio-internal.json
+++ b/tools/monitoring/visualization/rucio-internal.json
@@ -1308,7 +1308,7 @@
     ]
   },
   "timezone": "",
-  "title": "RUCIO Internel",
+  "title": "RUCIO Internal",
   "uid": "ngBq2aQmk",
   "version": 24
 }

--- a/tools/test/matrix_parser.py
+++ b/tools/test/matrix_parser.py
@@ -68,15 +68,15 @@ def parse_matrix(fhandle) -> list:
     newproduct_dicts = list()
     for pdo in product_dicts:
         extraval_dict = {key: val for key, val in pdo.items() if isinstance(val, tuple)}
-        statics = {key: val for key, val in pdo.items() if key not in extraval_dict}
+        statistics = {key: val for key, val in pdo.items() if key not in extraval_dict}
         if len(extraval_dict) == 0:
-            newproduct_dicts.append(statics)
+            newproduct_dicts.append(statistics)
         else:
             for extrakey, extraval in extraval_dict.items():
                 normval, extra = extraval
                 extra = extract_mapped_list(extra)
                 for values in itertools.product(*extra.values()):
-                    newproduct_dicts.append({**statics, extrakey: normval, **dict(zip(extra.keys(), values))})
+                    newproduct_dicts.append({**statistics, extrakey: normval, **dict(zip(extra.keys(), values))})
     product_dicts = newproduct_dicts
 
     # apply allowlist


### PR DESCRIPTION
Used the tool "codespell" to identify the typos. Will look into the possibility of adding something like this in the precommit script in order to do spell checking at commit time (probably best not to have it as part of GH Actions, though, as there might be annoying situations where we want to ignore it)