### PR TITLE
Add deletion & archiving for custom metadata: Closes 5484

### DIFF
--- a/lib/rucio/alembicrevision.py
+++ b/lib/rucio/alembicrevision.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ALEMBIC_REVISION = 'a08fa8de1545'  # the current alembic head revision
+ALEMBIC_REVISION = 'b0070f3695c8'  # the current alembic head revision

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
 
     from sqlalchemy.orm import Session
 
+    from rucio.common.types import InternalScope
+
 
 class DidColumnMeta(DidMetaPlugin):
     """
@@ -280,6 +282,17 @@ class DidColumnMeta(DidMetaPlugin):
         :param key: Key of the metadata.
         """
         raise NotImplementedError('The DidColumnMeta plugin does not currently support deleting metadata.')
+
+    def on_delete(self, scope: "InternalScope", name: str, archive: bool = False, session: "Optional[Session]" = None) -> None:
+        """
+        Method called when a did is deleted.
+
+        :param scope: The scope of the did.
+        :param name: The name of the did.
+        :param archive: Flag to indicate if the metadata should be archived when the did is deleted.
+        :param session: The database session in use.
+        """
+        pass
 
     def manages_key(self, key, *, session: "Optional[Session]" = None):
         # Build list of which keys are managed by this plugin.

--- a/lib/rucio/core/did_meta_plugins/did_meta_plugin_interface.py
+++ b/lib/rucio/core/did_meta_plugins/did_meta_plugin_interface.py
@@ -54,6 +54,20 @@ class DidMetaPlugin(metaclass=ABCMeta):
         """
         pass
 
+    def get_metadata_archived(self,
+                              scope: "InternalScope",
+                              name: str,
+                              *,
+                              session: "Optional[Session]" = None):
+        """
+        Get archived data identifier metadata
+
+        :param scope: The scope name.
+        :param name: The data identifier name.
+        :param session: The database session in use.
+        """
+        pass
+
     @abstractmethod
     def set_metadata(
         self,
@@ -116,6 +130,22 @@ class DidMetaPlugin(metaclass=ABCMeta):
         :param scope: The scope of the did.
         :param name: The name of the did.
         :param key: Key of the metadata.
+        :param session: The database session in use.
+        """
+        pass
+
+    @abstractmethod
+    def on_delete(self,
+                  scope: "InternalScope",
+                  name: str,
+                  archive: bool = False,
+                  session: "Optional[Session]" = None):
+        """
+        Method called when a did is deleted.
+
+        :param scope: The scope of the did.
+        :param name: The name of the did.
+        :param archive: Flag to indicate if the metadata should be archived when the did is deleted.
         :param session: The database session in use.
         """
         pass

--- a/lib/rucio/core/did_meta_plugins/mongo_meta.py
+++ b/lib/rucio/core/did_meta_plugins/mongo_meta.py
@@ -79,6 +79,16 @@ class MongoDidMeta(DidMetaPlugin):
             raise exception.DataIdentifierNotFound(f"No metadata found for did '{scope}:{name}'")
         return doc
 
+    def get_metadata_archived(self, scope, name, *, session: "Optional[Session]" = None):
+        """
+        Get archived did metadata.
+
+        :param scope: The scope name.
+        :param name: The data identifier name.
+        :param session: The database session in use.
+        """
+        raise NotImplementedError
+
     def set_metadata(self, scope, name, key, value, recursive=False, *, session: "Optional[Session]" = None):
         """
         Set single metadata key.
@@ -136,6 +146,17 @@ class MongoDidMeta(DidMetaPlugin):
             self.col.update_one({"_id": "{}:{}".format(scope.internal, name)}, {'$unset': meta})
         except Exception as e:
             raise exception.DataIdentifierNotFound(e)
+
+    def on_delete(self, scope: "InternalScope", name: str, archive: bool = False, session: "Optional[Session]" = None) -> None:
+        """
+        Method called when a did is deleted.
+
+        :param scope: The scope of the did.
+        :param name: The name of the did.
+        :param archive: Flag to indicate if the metadata should be archived when the did is deleted.
+        :param session: The database session in use.
+        """
+        pass
 
     def list_dids(self, scope, filters, did_type='collection', ignore_case=False, limit=None,
                   offset=None, long=False, recursive=False, ignore_dids=None, *, session: "Optional[Session]" = None):

--- a/lib/rucio/db/sqla/migrate_repo/versions/b0070f3695c8_add_deletedidmeta_table.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/b0070f3695c8_add_deletedidmeta_table.py
@@ -1,0 +1,57 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+''' Add deleted_did_meta table '''
+
+import sqlalchemy as sa
+from alembic import context
+from alembic.op import create_index, create_primary_key, create_table, drop_table
+
+from rucio.db.sqla.constants import DIDType
+from rucio.db.sqla.types import JSON
+
+# Alembic revision identifiers
+revision = 'b0070f3695c8'
+down_revision = 'a08fa8de1545'
+
+
+def upgrade():
+    '''
+    Upgrade the database to this revision
+    '''
+
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        create_table('deleted_did_meta',
+                     sa.Column('scope', sa.String(25)),
+                     sa.Column('name', sa.String(255)),
+                     sa.Column('did_type', sa.Enum(DIDType,
+                                                   name='DEL_DID_META_DID_TYPE_CHK',
+                                                   create_constraint=True,
+                                                   values_callable=lambda obj: [e.value for e in obj])),
+                     sa.Column('meta', JSON()),
+                     sa.Column('created_at', sa.DateTime),
+                     sa.Column('updated_at', sa.DateTime),
+                     sa.Column('deleted_at', sa.DateTime))
+
+        create_primary_key('DEL_DID_META_PK', 'deleted_did_meta', ['scope', 'name'])
+        create_index('DEL_DID_META_DID_TYPE_IDX', 'deleted_did_meta', ['did_type'])
+
+
+def downgrade():
+    '''
+    Downgrade the database to the previous revision
+    '''
+
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        drop_table('deleted_did_meta')

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -90,6 +90,8 @@ def _oracle_json_constraint(target, connection, **kw):
         if oracle_version >= 12:
             if target.name == 'did_meta':
                 target.append_constraint(CheckConstraint('META IS JSON', 'ORACLE_META_JSON_CHK'))
+            if target.name == 'deleted_did_meta':
+                target.append_constraint(CheckConstraint('META IS JSON', 'ORACLE_DELETE_META_JSON_CHK'))
             if target.name == 'virtual_placements':
                 target.append_constraint(CheckConstraint('PLACEMENTS IS JSON', 'ORACLE_PLACEMENTS_JSON_CHK'))
 
@@ -474,6 +476,19 @@ class DidMeta(BASE, ModelBase):
     _table_args = (PrimaryKeyConstraint('scope', 'name', name='DID_META_PK'),
                    ForeignKeyConstraint(['scope', 'name'], ['dids.scope', 'dids.name'], name='DID_META_FK'),
                    Index('DID_META_DID_TYPE_IDX', 'did_type'))
+
+
+class DeletedDidMeta(BASE, ModelBase):
+    __tablename__ = 'deleted_did_meta'
+    scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
+    name: Mapped[str] = mapped_column(String(get_schema_value('NAME_LENGTH')))
+    did_type: Mapped[Optional[DIDType]] = mapped_column(Enum(DIDType, name='DEL_DID_META_DID_TYPE_CHK',
+                                                             create_constraint=True,
+                                                             values_callable=lambda obj: [e.value for e in obj]))
+    meta: Mapped[Optional[Union[str, dict[str, Any]]]] = mapped_column(JSON())
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    _table_args = (PrimaryKeyConstraint('scope', 'name', name='DEL_DID_META_PK'),
+                   Index('DEL_DID_META_DID_TYPE_IDX', 'did_type'))
 
 
 class DeletedDataIdentifier(BASE, ModelBase):

--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -39,6 +39,8 @@ skip_multivo = pytest.mark.skipif('SUITE' in os.environ and os.environ['SUITE'] 
                                   reason="does not work for multiVO")
 skip_non_belleii = pytest.mark.skipif(not ('POLICY' in os.environ and os.environ['POLICY'] == 'belleii'),
                                       reason="specific belleii tests")
+skip_client = pytest.mark.skipif('SUITE' in os.environ and os.environ['SUITE'] == 'client',
+                                 reason="does not work for client suite")
 
 
 def is_influxdb_available() -> bool:
@@ -267,3 +269,10 @@ def remove_config(func: Callable) -> Callable:
 
 
 RSE_namedtuple = namedtuple('RSE_namedtuple', ['name', 'id'])
+
+
+@skip_client
+def skip_without_json():
+    from rucio.db.sqla.util import json_implemented
+    if not json_implemented():
+        pytest.skip("JSON support is not implemented in this database")

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -40,11 +40,12 @@ from rucio.core.did import (
     set_status,
     touch_dids,
 )
+from rucio.core.did_meta_plugins.json_meta import JSONDidMeta
 from rucio.core.replica import add_replica, get_replica
 from rucio.db.sqla.constants import DIDType
 from rucio.db.sqla.util import json_implemented
 from rucio.gateway import did, scope
-from rucio.tests.common import did_name_generator, rse_name_generator, scope_name_generator
+from rucio.tests.common import did_name_generator, rse_name_generator, scope_name_generator, skip_without_json
 
 
 def skip_without_json():
@@ -67,7 +68,18 @@ class TestDIDCore:
                  'did_type': DIDType.DATASET} for i in range(5)]
         for dsn in dsns:
             add_did(scope=mock_scope, name=dsn['name'], did_type='DATASET', account=root_account)
+            meta = get_metadata(scope=mock_scope, name=dsn['name'])
+            assert isinstance(meta, dict)
+            assert meta != {}
         delete_dids(dids=dsns, account=root_account)
+        for dsn in dsns:
+            with pytest.raises(DataIdentifierNotFound):
+                get_metadata(scope=mock_scope, name=dsn['name'])
+        if json_implemented():
+            j = JSONDidMeta()
+            for dsn in dsns:
+                with pytest.raises(DataIdentifierNotFound):
+                    j.get_metadata_archived(dsn['scope'], dsn['name'])
 
     def test_touch_dids_atime(self, mock_scope, root_account):
         """ DATA IDENTIFIERS (CORE): Touch dids accessed_at timestamp"""


### PR DESCRIPTION
Borrows heavily from @cserf's request (https://github.com/rucio/rucio/pull/5604).

- Added metadata deletion trigger to both JSON and ExternalPostgresJSON plugins.
- Attached trigger to `delete_dids ` (core/did) and` __cleanup_after_replica_deletion` (core/replica) functions.
- Added archiving ability to JSON plugin.
- Added unit testing for archiving/delete.

