### PR TITLE
Dependencies: Configure dependabot to only allow security updates for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,4 @@ updates:
       python-packages:
         patterns:
           - "*"
+    open-pull-requests-limit: 0  # Only allow security updates


### PR DESCRIPTION
Part of #6663

For information, see: https://docs.github.com/github/managing-security-vulnerabilities/configuring-dependabot-security-updates

> If you only require security updates and want to exclude version updates, you can set open-pull-requests-limit to 0 in order to prevent version updates for a given package-ecosystem.