### PR TITLE
Pin MySQL to 8.3

### DIFF
--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -152,7 +152,7 @@ services:
         soft: 10240
         hard: 10240
   ftsdb:
-    image: docker.io/mysql:8
+    image: docker.io/mysql:8.3
     platform: linux/amd64
     profiles:
       - storage

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       - POSTGRES_PASSWORD=rucio
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
   mysql8:
-    image: docker.io/mysql:8
+    image: docker.io/mysql:8.3
     platform: linux/amd64
     profiles:
       - mysql8


### PR DESCRIPTION
- 3e8ee5fb1dff0d60a3e1396c5230c1d640b336d8 fixes #6751 (pinning `ftsdb` to `mysql:8.3`)
- d6dc4e65fb6d2523346f041bb1587be5424ff4aa fixes #6747 (pinning `mysql8` to `mysql:8.3`)