### PR TITLE
Testing: Ruff, Ignore UP037

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ ignore = [
     "UP030", # Use implicit references for positional format fields
     "UP031", # Use format specifiers instead of percent format
     "UP032", # Use f-string instead of `format` call
+    "UP037", # Remove quotes from type annotation. Seeing possible false positives caused by https://github.com/astral-sh/ruff/pull/11485
     "S101",  # Pending https://github.com/rucio/rucio/issues/6680
     "S105",  # Pending https://github.com/rucio/rucio/issues/6696
     "S108",  # Pending https://github.com/rucio/rucio/issues/6655


### PR DESCRIPTION
Ruff 0.4.5 changes the logic used to detect UP037, mainly via this PR: https://github.com/astral-sh/ruff/pull/11485.

I am seeing some possible false positive due to this, e.g.:

> Error: lib/rucio/core/authentication.py:571:27: UP037 Remove quotes from type annotation

where it asks to remove quotes from  a type
that's only imported in a type-checking block.

This is a very new Ruff version so it's best to check back at a later point to see if this is a common issue for other repositories too.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
