### PR TITLE
Testing: Add type annotations to client/scopeclient

### DIFF
--- a/lib/rucio/client/scopeclient.py
+++ b/lib/rucio/client/scopeclient.py
@@ -27,7 +27,11 @@ class ScopeClient(BaseClient):
 
     SCOPE_BASEURL = 'accounts'
 
-    def add_scope(self, account, scope):
+    def add_scope(
+            self,
+            account: str,
+            scope: str
+    ) -> bool:
         """
         Sends the request to add a new scope.
 
@@ -47,7 +51,7 @@ class ScopeClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def list_scopes(self):
+    def list_scopes(self) -> list[str]:
         """
         Sends the request to list all scopes.
 
@@ -64,7 +68,7 @@ class ScopeClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
 
-    def list_scopes_for_account(self, account):
+    def list_scopes_for_account(self, account: str) -> list[str]:
         """
         Sends the request to list all scopes for a rucio account.
 


### PR DESCRIPTION
Part of #6588.

This failure:

```
Found 1 new problems in /home/runner/work/rucio/rucio/lib/rucio/client/uploadclient.py
  - 1 errors with message """Argument of type "Unknown | str | None" cannot be assigned to parameter "account" of type "str" in function "list_scopes_for_account"
                               Type "Unknown | str | None" is incompatible with type "str"
                                 "None" is incompatible with "str"""".
    Candidates: line 388
```

Is due to an issue in `uploadclient`, where `self.client.account` might be `None`, but it's passed directly to `list_scopes_for_account` without checking first. This will be fixed in a separate PR for the `uploadclient` type annotations.