### PR TITLE
Dependencies: Fix dev requirements to include server requirements

### DIFF
--- a/requirements/requirements.dev.in
+++ b/requirements/requirements.dev.in
@@ -1,5 +1,5 @@
 # All dependencies needed to develop/test rucio should be defined here
--c requirements.server.txt
+-r requirements.server.txt
 pytest==7.4.3
 pytest-xdist==3.5.0                                         # Used for parallel testing
 pyflakes==3.1.0                                             # Passive checker of Python programs

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -4,34 +4,97 @@
 #
 #    pip-compile requirements/requirements.dev.in
 #
+aiohttp==3.9.5
+    # via
+    #   -r requirements/requirements.server.txt
+    #   geoip2
+aiosignal==1.3.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   aiohttp
+alembic==1.12.1
+    # via -r requirements/requirements.server.txt
+annotated-types==0.6.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   pydantic
 apispec[yaml]==6.3.0
     # via
     #   -r requirements/requirements.dev.in
     #   apispec-webframeworks
 apispec-webframeworks==1.1.0
     # via -r requirements/requirements.dev.in
+argcomplete==3.1.6
+    # via -r requirements/requirements.server.txt
 astroid==3.0.1
     # via
     #   -r requirements/requirements.dev.in
     #   pylint
+async-timeout==4.0.3
+    # via
+    #   -r requirements/requirements.server.txt
+    #   aiohttp
+    #   redis
+attrs==23.2.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   aiohttp
+    #   jsonschema
+    #   referencing
+bcrypt==4.1.2
+    # via
+    #   -r requirements/requirements.server.txt
+    #   paramiko
 black==23.12.1
     # via docspec-python
+blinker==1.8.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   flask
+boto3==1.29.5
+    # via -r requirements/requirements.server.txt
+botocore==1.32.7
+    # via
+    #   -r requirements/requirements.server.txt
+    #   boto3
+    #   s3transfer
 build==1.2.1
     # via pip-tools
+cachetools==5.3.3
+    # via
+    #   -r requirements/requirements.server.txt
+    #   google-auth
 certifi==2024.2.2
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
     #   requests
+cffi==1.16.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   cryptography
+    #   pynacl
 charset-normalizer==3.3.2
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
     #   requests
 click==8.1.7
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
     #   black
+    #   flask
     #   pip-tools
     #   pydoc-markdown
+cryptography==42.0.5
+    # via
+    #   -r requirements/requirements.server.txt
+    #   globus-sdk
+    #   oic
+    #   paramiko
+    #   pyjwt
+    #   pyspnego
+    #   requests-kerberos
+cx-oracle==8.3.0
+    # via -r requirements/requirements.server.txt
 databind==4.5.1
     # via
     #   databind-core
@@ -44,6 +107,15 @@ databind-json==4.5.1
     # via
     #   docspec
     #   pydoc-markdown
+decorator==5.1.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   dogpile-cache
+    #   gssapi
+defusedxml==0.7.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   oic
 deprecated==1.2.14
     # via
     #   databind
@@ -53,6 +125,14 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
+dnspython==2.6.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   pymongo
+docopt==0.6.2
+    # via
+    #   -r requirements/requirements.server.txt
+    #   stomp-py
 docspec==2.2.1
     # via
     #   docspec-python
@@ -61,6 +141,8 @@ docspec-python==2.2.1
     # via pydoc-markdown
 docstring-parser==0.11
     # via pydoc-markdown
+dogpile-cache==1.2.2
+    # via -r requirements/requirements.server.txt
 exceptiongroup==1.2.1
     # via pytest
 execnet==2.1.1
@@ -69,31 +151,107 @@ filelock==3.14.0
     # via virtualenv
 flake8==6.1.0
     # via -r requirements/requirements.dev.in
+flask==3.0.0
+    # via -r requirements/requirements.server.txt
+frozenlist==1.4.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   aiohttp
+    #   aiosignal
+future==1.0.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   pyjwkest
+geoip2==4.7.0
+    # via -r requirements/requirements.server.txt
+globus-sdk==3.32.0
+    # via -r requirements/requirements.server.txt
+google-auth==2.23.4
+    # via -r requirements/requirements.server.txt
+greenlet==3.0.3
+    # via
+    #   -r requirements/requirements.server.txt
+    #   sqlalchemy
+gssapi==1.8.3
+    # via
+    #   -r requirements/requirements.server.txt
+    #   pyspnego
 idna==2.10
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
     #   requests
+    #   yarl
 importlib-metadata==7.1.0
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
     #   build
+    #   flask
     #   yapf
 iniconfig==2.0.0
     # via pytest
+isodate==0.6.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   python3-saml
 isort==5.13.2
     # via pylint
+itsdangerous==2.2.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   flask
 jinja2==3.1.3
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
+    #   flask
     #   pydoc-markdown
+jmespath==1.0.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   boto3
+    #   botocore
+jsonschema==4.20.0
+    # via -r requirements/requirements.server.txt
+jsonschema-specifications==2023.12.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   jsonschema
+kerberos==1.3.1
+    # via -r requirements/requirements.server.txt
+krb5==0.5.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   pyspnego
+libtorrent==2.0.9
+    # via -r requirements/requirements.server.txt
+lxml==5.2.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   python3-saml
+    #   xmlsec
+mako==1.3.3
+    # via
+    #   -r requirements/requirements.server.txt
+    #   alembic
+    #   oic
 markupsafe==2.1.5
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
     #   jinja2
+    #   mako
+    #   werkzeug
+maxminddb==2.6.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   geoip2
 mccabe==0.7.0
     # via
     #   flake8
     #   pylint
+multidict==6.0.5
+    # via
+    #   -r requirements/requirements.server.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nr-date==2.1.0
@@ -104,15 +262,24 @@ nr-util==0.8.12
     # via
     #   docspec-python
     #   pydoc-markdown
+oic==1.6.1
+    # via -r requirements/requirements.server.txt
 packaging==24.0
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
     #   apispec
     #   black
     #   build
     #   pytest
+    #   qbittorrent-api
+paramiko==3.4.0
+    # via -r requirements/requirements.server.txt
 pathspec==0.12.1
     # via black
+pbr==6.0.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   stevedore
 pip-tools==7.4.1
     # via -r requirements/requirements.dev.in
 platformdirs==4.2.1
@@ -123,41 +290,164 @@ platformdirs==4.2.1
     #   yapf
 pluggy==1.5.0
     # via pytest
+prometheus-client==0.19.0
+    # via -r requirements/requirements.server.txt
+psycopg2-binary==2.9.9
+    # via -r requirements/requirements.server.txt
+pyasn1==0.6.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   google-auth
 pycodestyle==2.11.0
     # via
     #   -r requirements/requirements.dev.in
     #   flake8
+pycparser==2.22
+    # via
+    #   -r requirements/requirements.server.txt
+    #   cffi
+pycryptodomex==3.20.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   oic
+    #   pyjwkest
+pydantic==2.7.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   pydantic-settings
+pydantic-core==2.18.2
+    # via
+    #   -r requirements/requirements.server.txt
+    #   pydantic
+pydantic-settings==2.2.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   oic
 pydoc-markdown==4.8.2
     # via -r requirements/requirements.dev.in
 pyflakes==3.1.0
     # via
     #   -r requirements/requirements.dev.in
     #   flake8
+pyjwkest==1.4.2
+    # via
+    #   -r requirements/requirements.server.txt
+    #   oic
+pyjwt[crypto]==2.8.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   globus-sdk
+pykerberos==1.2.4
+    # via -r requirements/requirements.server.txt
 pylint==3.0.2
     # via -r requirements/requirements.dev.in
+pymemcache==4.0.0
+    # via -r requirements/requirements.server.txt
+pymongo==4.6.3
+    # via -r requirements/requirements.server.txt
+pymysql==1.1.0
+    # via -r requirements/requirements.server.txt
+pynacl==1.5.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   paramiko
 pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
+pyspnego[kerberos]==0.10.2
+    # via
+    #   -r requirements/requirements.server.txt
+    #   requests-kerberos
 pytest==7.4.3
     # via
     #   -r requirements/requirements.dev.in
     #   pytest-xdist
 pytest-xdist==3.5.0
     # via -r requirements/requirements.dev.in
+python-dateutil==2.8.2
+    # via
+    #   -r requirements/requirements.server.txt
+    #   botocore
+python-dotenv==1.0.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   pydantic-settings
+python-magic==0.4.27
+    # via -r requirements/requirements.server.txt
+python-swiftclient==4.4.0
+    # via -r requirements/requirements.server.txt
+python3-saml==1.16.0
+    # via -r requirements/requirements.server.txt
 pytz==2023.3.post1
     # via -r requirements/requirements.dev.in
 pyyaml==6.0.1
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
     #   apispec
     #   pydoc-markdown
+qbittorrent-api==2023.11.57
+    # via -r requirements/requirements.server.txt
+redis==5.0.1
+    # via -r requirements/requirements.server.txt
+referencing==0.35.1
+    # via
+    #   -r requirements/requirements.server.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.32.2
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
+    #   geoip2
+    #   globus-sdk
+    #   oic
     #   pydoc-markdown
+    #   pyjwkest
+    #   python-swiftclient
+    #   qbittorrent-api
+    #   requests-kerberos
+requests-kerberos==0.14.0
+    # via -r requirements/requirements.server.txt
+rpds-py==0.18.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   jsonschema
+    #   referencing
+rsa==4.9
+    # via
+    #   -r requirements/requirements.server.txt
+    #   google-auth
+s3transfer==0.7.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   boto3
 sh==2.0.6
     # via -r requirements/requirements.dev.in
+six==1.16.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   isodate
+    #   pyjwkest
+    #   python-dateutil
+sqlalchemy==2.0.23
+    # via
+    #   -r requirements/requirements.server.txt
+    #   alembic
+statsd==4.0.1
+    # via -r requirements/requirements.server.txt
+stevedore==5.2.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   dogpile-cache
+stomp-py==8.1.0
+    # via -r requirements/requirements.server.txt
+tabulate==0.9.0
+    # via -r requirements/requirements.server.txt
 tomli==2.0.1
     # via
     #   black
@@ -175,32 +465,56 @@ typeapi==2.2.1
     # via databind
 typing-extensions==4.11.0
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
+    #   alembic
     #   astroid
     #   black
     #   databind
+    #   dogpile-cache
+    #   globus-sdk
     #   nr-util
+    #   pydantic
+    #   pydantic-core
     #   pylint
+    #   sqlalchemy
     #   typeapi
 urllib3==1.26.18
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
+    #   botocore
+    #   qbittorrent-api
     #   requests
 virtualenv==20.24.7
     # via -r requirements/requirements.dev.in
 watchdog==4.0.0
     # via pydoc-markdown
+websocket-client==1.8.0
+    # via
+    #   -r requirements/requirements.server.txt
+    #   stomp-py
+werkzeug==3.0.2
+    # via
+    #   -r requirements/requirements.server.txt
+    #   flask
 wheel==0.43.0
     # via pip-tools
 wrapt==1.16.0
     # via deprecated
+xmlsec==1.3.13
+    # via
+    #   -r requirements/requirements.server.txt
+    #   python3-saml
 xmltodict==0.13.0
     # via -r requirements/requirements.dev.in
 yapf==0.40.2
     # via pydoc-markdown
+yarl==1.9.4
+    # via
+    #   -r requirements/requirements.server.txt
+    #   aiohttp
 zipp==3.18.1
     # via
-    #   -c requirements/requirements.server.txt
+    #   -r requirements/requirements.server.txt
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
"-c" simply constraints the requirements in the current file according to the file passed after "-c". "-r" is the correct option to use in this case, as it includes the server requirements in the compiled dev requirements file.

