### PR TITLE
Core & Internals: rename SURL to (non-deterministic) PFN #5129

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -54,7 +54,7 @@ from rucio.common.exception import (
     ScopeNotFound,
 )
 from rucio.common.extra import import_extras
-from rucio.common.utils import StoreAndDeprecateWarningAction, chunks, clean_surls, construct_surl, extract_scope, get_bytes_value_from_string, parse_response, render_json, sizefmt
+from rucio.common.utils import StoreAndDeprecateWarningAction, chunks, clean_pfns, construct_non_deterministic_pfn, extract_scope, get_bytes_value_from_string, parse_response, render_json, sizefmt
 from rucio.rse import rsemanager as rsemgr
 
 EXTRA_MODULES = import_extras(['argcomplete'])
@@ -1148,21 +1148,21 @@ def declare_bad_file_replicas(args):
             list_bad_pfns = []
             cnt += 1
             previous_pattern = None
-            for surl in clean_surls(chunk):
+            for pfn in clean_pfns(chunk):
                 unknown = True
                 if previous_pattern:
-                    if previous_pattern in surl:
-                        list_bad_pfns.append(surl)
+                    if previous_pattern in pfn:
+                        list_bad_pfns.append(pfn)
                         unknown = False
                         continue
                 for pattern in prot_dict:
-                    if pattern in surl:
+                    if pattern in pfn:
                         previous_pattern = prot_dict[pattern]
-                        list_bad_pfns.append(surl)
+                        list_bad_pfns.append(pfn)
                         unknown = False
                         break
                 if unknown:
-                    print('Cannot find any RSE associated to %s' % surl)
+                    print('Cannot find any RSE associated to %s' % pfn)
             client.add_bad_pfns(pfns=list_bad_pfns, reason=args.reason, state='BAD', expires_at=None)
             ndeclared = len(list_bad_pfns)
             tot_file_declared += ndeclared
@@ -1251,7 +1251,7 @@ def list_pfns(args):
                         logger.warning('The file has multiple parents')
                     for did in parents:
                         if did['type'] == 'DATASET':
-                            path = construct_surl(did['name'], scope, name, naming_convention=naming_convention)
+                            path = construct_non_deterministic_pfn(did['name'], scope, name, naming_convention=naming_convention)
                             pfn = ''.join([proto.attributes['scheme'],
                                            '://',
                                            proto.attributes['hostname'],

--- a/bin/rucio-replica-recoverer
+++ b/bin/rucio-replica-recoverer
@@ -183,8 +183,8 @@ Terminal output:
 
 2019-02-19 14:39:24,114 709 INFO  replica_recoverer[0/0]: ready to query replicas at RSEs like *MOCK*, declared as suspicious in the last 3 days at least 10 times and which are available on other RSEs.
 2019-02-19 14:39:24,124 709 INFO  replica_recoverer[0/0]: suspicious replica query took 0.0101511478424 seconds, total of 1 replicas were found. [{'scope': 'mock', 'cnt': 11L, 'name': 'file_available_suspicious_5180be3e-4ebc-4c34-b528-efbfd09f067e', 'rse': 'MOCK_SUSPICIOUS'}]
-2019-02-19 14:39:24,125 709 INFO  replica_recoverer[0/0]: looking for replica surls.
-2019-02-19 14:39:24,160 709 INFO  replica_recoverer[0/0]: found 1/1 surls (took 0.035572052002 seconds) - declaring them as bad replicas now.
+2019-02-19 14:39:24,125 709 INFO  replica_recoverer[0/0]: looking for replica pfns.
+2019-02-19 14:39:24,160 709 INFO  replica_recoverer[0/0]: found 1/1 pfns (took 0.035572052002 seconds) - declaring them as bad replicas now.
 2019-02-19 14:39:24,160 709 INFO  replica_recoverer[0/0]: ready to declare 1 bad replica(s) on MOCK_SUSPICIOUS: ['file://localhost:0/tmp/rucio_rse1/mock/1f/6b/file_available_suspicious_5180be3e-4ebc-4c34-b528-efbfd09f067e'].
 2019-02-19 14:39:24,188 709 INFO  replica_recoverer[0/0]: finished declaring bad replicas on MOCK_SUSPICIOUS.
 2019-02-19 14:39:24,192 709 INFO  replica_recoverer[0/0]: graceful stop done

--- a/lib/rucio/common/plugins.py
+++ b/lib/rucio/common/plugins.py
@@ -78,7 +78,7 @@ class PolicyPackageAlgorithms:
     def _register_all_policy_package_algorithms(cls: type[PolicyPackageAlgorithmsT]) -> None:
         '''
         Loads all the algorithms of a given type from the policy package(s) and registers them
-        :param algorithm_type: the type of algorithm to register (e.g. 'surl', 'lfn2pfn')
+        :param algorithm_type: the type of algorithm to register (e.g. 'lfn2pfn')
         :param dictionary: the dictionary to register them in
         :param vo: the name of the relevant VO (None for single VO)
         '''
@@ -133,6 +133,10 @@ class PolicyPackageAlgorithms:
 
             if hasattr(module, 'get_algorithms'):
                 all_algorithms = module.get_algorithms()
+
+                # for backward compatibility, rename 'surl' to 'non_deterministic_pfn' here
+                if 'surl' in all_algorithms:
+                    all_algorithms['non_deterministic_pfn'] = all_algorithms['surl']
 
                 # check that the names are correctly prefixed for multi-VO
                 if vo:

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -735,57 +735,58 @@ def my_key_generator(namespace: str, fn: Callable, **kw) -> Callable[..., str]:
     return generate_key
 
 
-SurlAlgorithmsT = TypeVar('SurlAlgorithmsT', bound='SurlAlgorithms')
+NonDeterministicPFNAlgorithmsT = TypeVar('NonDeterministicPFNAlgorithmsT', bound='NonDeterministicPFNAlgorithms')
 
 
-class SurlAlgorithms(PolicyPackageAlgorithms):
+class NonDeterministicPFNAlgorithms(PolicyPackageAlgorithms):
     """
-    Handle SURL construction, including registration of SURL algorithms from policy packages
+    Handle PFN construction for non-deterministic RSEs, including registration of algorithms
+    from policy packages
     """
 
-    _algorithm_type = 'surl'
+    _algorithm_type = 'non_deterministic_pfn'
 
     def __init__(self) -> None:
         """
-        Initialises a SURL construction object
+        Initialises a non-deterministic PFN construction object
         """
         super().__init__()
 
-    def construct_surl(self, dsn: str, scope: str, filename: str, naming_convention: str) -> str:
+    def construct_non_deterministic_pfn(self, dsn: str, scope: Optional[str], filename: str, naming_convention: str) -> str:
         """
-        Calls the correct algorithm to generate a SURL
+        Calls the correct algorithm to generate a non-deterministic PFN
         """
         return self.get_algorithm(naming_convention)(dsn, scope, filename)
 
     @classmethod
-    def supports(cls: type[SurlAlgorithmsT], naming_convention: str) -> bool:
+    def supports(cls: type[NonDeterministicPFNAlgorithmsT], naming_convention: str) -> bool:
         """
-        Checks whether a SURL algorithm is supported
+        Checks whether a non-deterministic PFN algorithm is supported
         """
         return super()._supports(cls._algorithm_type, naming_convention)
 
     @classmethod
-    def _module_init_(cls: type[SurlAlgorithmsT]) -> None:
+    def _module_init_(cls: type[NonDeterministicPFNAlgorithmsT]) -> None:
         """
-        Registers the included SURL algorithms
+        Registers the included non-deterministic PFN algorithms
         """
-        cls.register('T0', cls.construct_surl_T0)
-        cls.register('DQ2', cls.construct_surl_DQ2)
-        cls.register('BelleII', cls.construct_surl_BelleII)
+        cls.register('T0', cls.construct_non_deterministic_pfn_T0)
+        cls.register('DQ2', cls.construct_non_deterministic_pfn_DQ2)
+        cls.register('BelleII', cls.construct_non_deterministic_pfn_BelleII)
 
     @classmethod
-    def get_algorithm(cls: type[SurlAlgorithmsT], naming_convention: str) -> Callable[[str, str, str], str]:
+    def get_algorithm(cls: type[NonDeterministicPFNAlgorithmsT], naming_convention: str) -> Callable[[str, Optional[str], str], str]:
         """
-        Looks up a SURL algorithm by name
+        Looks up a non-deterministic PFN algorithm by name
         """
         return super()._get_one_algorithm(cls._algorithm_type, naming_convention)
 
     @classmethod
-    def register(cls: type[SurlAlgorithmsT], name: str, fn_construct_surl: Callable[[str, str, str], Optional[str]]) -> None:
+    def register(cls: type[NonDeterministicPFNAlgorithmsT], name: str, fn_construct_non_deterministic_pfn: Callable[[str, Optional[str], str], Optional[str]]) -> None:
         """
-        Register a new SURL algorithm
+        Register a new non-deterministic PFN algorithm
         """
-        algorithm_dict = {name: fn_construct_surl}
+        algorithm_dict = {name: fn_construct_non_deterministic_pfn}
         super()._register(cls._algorithm_type, algorithm_dict)
 
     @staticmethod
@@ -825,13 +826,13 @@ class SurlAlgorithms(PolicyPackageAlgorithms):
         return stripped_tag
 
     @staticmethod
-    def construct_surl_DQ2(dsn: str, scope: str, filename: str) -> str:
+    def construct_non_deterministic_pfn_DQ2(dsn: str, scope: Optional[str], filename: str) -> str:
         """
-        Defines relative SURL for new replicas. This method
+        Defines relative PFN for new replicas. This method
         contains DQ2 convention. To be used for non-deterministic sites.
         Method imported from DQ2.
 
-        @return: relative SURL for new replica.
+        @return: relative PFN for new replica.
         @rtype: str
         """
         # check how many dots in dsn
@@ -841,17 +842,17 @@ class SurlAlgorithms(PolicyPackageAlgorithms):
         if nfields == 0:
             return '/other/other/%s' % (filename)
         elif nfields == 1:
-            stripped_dsn = SurlAlgorithms.__strip_dsn(dsn)
+            stripped_dsn = NonDeterministicPFNAlgorithms.__strip_dsn(dsn)
             return '/other/%s/%s' % (stripped_dsn, filename)
         elif nfields == 2:
             project = fields[0]
-            stripped_dsn = SurlAlgorithms.__strip_dsn(dsn)
+            stripped_dsn = NonDeterministicPFNAlgorithms.__strip_dsn(dsn)
             return '/%s/%s/%s' % (project, stripped_dsn, filename)
         elif nfields < 5 or re.match('user*|group*', fields[0]):
             project = fields[0]
             f2 = fields[1]
             f3 = fields[2]
-            stripped_dsn = SurlAlgorithms.__strip_dsn(dsn)
+            stripped_dsn = NonDeterministicPFNAlgorithms.__strip_dsn(dsn)
             return '/%s/%s/%s/%s/%s' % (project, f2, f3, stripped_dsn, filename)
         else:
             project = fields[0]
@@ -859,17 +860,17 @@ class SurlAlgorithms(PolicyPackageAlgorithms):
             if nfields == 5:
                 tag = 'other'
             else:
-                tag = SurlAlgorithms.__strip_tag(fields[-1])
-            stripped_dsn = SurlAlgorithms.__strip_dsn(dsn)
+                tag = NonDeterministicPFNAlgorithms.__strip_tag(fields[-1])
+            stripped_dsn = NonDeterministicPFNAlgorithms.__strip_dsn(dsn)
             return '/%s/%s/%s/%s/%s' % (project, dataset_type, tag, stripped_dsn, filename)
 
     @staticmethod
-    def construct_surl_T0(dsn: str, scope: str, filename: str) -> Optional[str]:
+    def construct_non_deterministic_pfn_T0(dsn: str, scope: Optional[str], filename: str) -> Optional[str]:
         """
-        Defines relative SURL for new replicas. This method
+        Defines relative PFN for new replicas. This method
         contains Tier0 convention. To be used for non-deterministic sites.
 
-        @return: relative SURL for new replica.
+        @return: relative PFN for new replica.
         @rtype: str
         """
         fields = dsn.split('.')
@@ -884,9 +885,9 @@ class SurlAlgorithms(PolicyPackageAlgorithms):
             return '/other/other/other/other/%s' % (filename)
 
     @staticmethod
-    def construct_surl_BelleII(dsn: str, scope: str, filename: str) -> str:
+    def construct_non_deterministic_pfn_BelleII(dsn: str, scope: Optional[str], filename: str) -> str:
         """
-        Defines relative SURL for Belle II specific replicas.
+        Defines relative PFN for Belle II specific replicas.
         This method contains the Belle II convention.
         To be used for non-deterministic Belle II sites.
         DSN (or datablock in the Belle II naming) contains /
@@ -900,37 +901,37 @@ class SurlAlgorithms(PolicyPackageAlgorithms):
             return '%s/%s' % (dsn, filename)
 
 
-_DEFAULT_SURL = 'DQ2'
-SurlAlgorithms._module_init_()
+_DEFAULT_NON_DETERMINISTIC_PFN = 'DQ2'
+NonDeterministicPFNAlgorithms._module_init_()
 
 
-def construct_surl(dsn: str, scope: str, filename: str, naming_convention: Optional[str] = None) -> str:
+def construct_non_deterministic_pfn(dsn: str, scope: Optional[str], filename: str, naming_convention: Optional[str] = None) -> str:
     """
-    Applies non-deterministic source url convention to the given replica.
+    Applies non-deterministic PFN convention to the given replica.
     use the naming_convention to call the actual function which will do the job.
-    Rucio administrators can potentially register additional surl generation algorithms,
+    Rucio administrators can potentially register additional PFN generation algorithms,
     which are not implemented inside this main rucio repository, so changing the
     argument list must be done with caution.
     """
-    surl_algorithms = SurlAlgorithms()
-    if naming_convention is None or not SurlAlgorithms.supports(naming_convention):
-        naming_convention = _DEFAULT_SURL
-    return surl_algorithms.construct_surl(dsn, scope, filename, naming_convention)
+    pfn_algorithms = NonDeterministicPFNAlgorithms()
+    if naming_convention is None or not NonDeterministicPFNAlgorithms.supports(naming_convention):
+        naming_convention = _DEFAULT_NON_DETERMINISTIC_PFN
+    return pfn_algorithms.construct_non_deterministic_pfn(dsn, scope, filename, naming_convention)
 
 
-def clean_surls(surls: Iterable[str]) -> list[str]:
+def clean_pfns(pfns: Iterable[str]) -> list[str]:
     res = []
-    for surl in surls:
-        if surl.startswith('srm'):
-            surl = re.sub(':[0-9]+/', '/', surl)
-            surl = re.sub(r'/srm/managerv1\?SFN=', '', surl)
-            surl = re.sub(r'/srm/v2/server\?SFN=', '', surl)
-            surl = re.sub(r'/srm/managerv2\?SFN=', '', surl)
-        if '?GoogleAccessId' in surl:
-            surl = surl.split('?GoogleAccessId')[0]
-        if '?X-Amz' in surl:
-            surl = surl.split('?X-Amz')[0]
-        res.append(surl)
+    for pfn in pfns:
+        if pfn.startswith('srm'):
+            pfn = re.sub(':[0-9]+/', '/', pfn)
+            pfn = re.sub(r'/srm/managerv1\?SFN=', '', pfn)
+            pfn = re.sub(r'/srm/v2/server\?SFN=', '', pfn)
+            pfn = re.sub(r'/srm/managerv2\?SFN=', '', pfn)
+        if '?GoogleAccessId' in pfn:
+            pfn = pfn.split('?GoogleAccessId')[0]
+        if '?X-Amz' in pfn:
+            pfn = pfn.split('?X-Amz')[0]
+        res.append(pfn)
     res.sort()
     return res
 

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -2836,7 +2836,7 @@ def get_source_rse(request_id, src_url, *, session: "Session", logger=logging.lo
                 src_rse_name = get_rse_name(src_rse_id, session=session)
                 logger(logging.DEBUG, "Find rse name %s for %s" % (src_rse_name, src_url))
                 return src_rse_name, src_rse_id
-        # cannot find matched surl
+        # cannot find matched source url
         logger(logging.WARNING, 'Cannot get correct RSE for source url: %s' % (src_url))
         return None, None
     except Exception:

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -31,7 +31,7 @@ from rucio.common import constants
 from rucio.common.config import config_get, config_get_list
 from rucio.common.constants import SUPPORTED_PROTOCOLS, RseAttr
 from rucio.common.exception import InvalidRSEExpression, RequestNotFound, RSEProtocolNotSupported, RucioException, UnsupportedOperation
-from rucio.common.utils import construct_surl
+from rucio.common.utils import construct_non_deterministic_pfn
 from rucio.core import did
 from rucio.core import message as message_core
 from rucio.core import request as request_core
@@ -231,7 +231,7 @@ class DirectTransferImplementation(DirectTransfer):
             # DQ2 path always starts with /, but prefix might not end with /
             naming_convention = dst.rse.attributes.get(RseAttr.NAMING_CONVENTION, None)
             if rws.scope.external is not None:
-                dest_path = construct_surl(dsn, rws.scope.external, rws.name, naming_convention)
+                dest_path = construct_non_deterministic_pfn(dsn, rws.scope.external, rws.name, naming_convention)
             if dst.rse.is_tape():
                 if rws.retry_count or rws.activity == 'Recovery':
                     dest_path = '%s_%i' % (dest_path, int(time.time()))

--- a/lib/rucio/daemons/tracer/kronos.py
+++ b/lib/rucio/daemons/tracer/kronos.py
@@ -142,8 +142,8 @@ class AMQConsumer:
                                     self.__logger(logging.ERROR, 'Missing url in the following trace : ' + str(report))
                                 else:
                                     try:
-                                        surl = report['url']
-                                        declare_bad_file_replicas([surl, ], reason=reason, issuer=InternalAccount('root', vo=report['vo']), status=BadFilesStatus.SUSPICIOUS)
+                                        pfn = report['url']
+                                        declare_bad_file_replicas([pfn, ], reason=reason, issuer=InternalAccount('root', vo=report['vo']), status=BadFilesStatus.SUSPICIOUS)
                                         self.__logger(logging.INFO, 'Declare suspicious file %s with reason %s' % (report['url'], reason))
                                     except Exception as error:
                                         self.__logger(logging.ERROR, 'Failed to declare suspicious file' + str(error))

--- a/tests/test_bad_replica.py
+++ b/tests/test_bad_replica.py
@@ -19,7 +19,7 @@ import pytest
 
 from rucio.client.rseclient import RSEClient
 from rucio.common.exception import InvalidType, RucioException, UnsupportedOperation
-from rucio.common.utils import clean_surls, generate_uuid
+from rucio.common.utils import clean_pfns, generate_uuid
 from rucio.core.did import delete_dids
 from rucio.core.replica import add_replicas, declare_bad_file_replicas, get_bad_pfns, get_bad_replicas_backlog, get_pfn_to_rse, get_replicas_state, list_bad_replicas, list_bad_replicas_status, list_replicas
 from rucio.daemons.badreplicas.minos import run as minos_run
@@ -91,7 +91,7 @@ def test_add_list_bad_replicas(rse_factory, mock_scope, root_account):
     assert list(r.keys()) == [rse2_id]
     list1 = r[rse2_id]
     list1.sort()
-    list2 = ['%s Already declared' % clean_surls([rep])[0] for rep in replicas]
+    list2 = ['%s Already declared' % clean_pfns([rep])[0] for rep in replicas]
     list2.sort()
     assert list1 == list2
 
@@ -361,7 +361,7 @@ def test_client_add_temporary_unavailable_pfns(rse_factory, mock_scope, replica_
         bad_pfns[res['pfn']] = (res['state'], res['reason'], res['expires_at'])
 
     for pfn in list_rep:
-        pfn = str(clean_surls([pfn])[0])
+        pfn = str(clean_pfns([pfn])[0])
         assert pfn in bad_pfns
         assert bad_pfns[pfn][0] == BadPFNStatus.TEMPORARY_UNAVAILABLE
         assert bad_pfns[pfn][1] == reason_str

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -29,7 +29,7 @@ from rucio.client.ruleclient import RuleClient
 from rucio.common.constants import RseAttr
 from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifierNotFound, InputValidationError, ReplicaIsLocked, ReplicaNotFound, RucioException, ScopeNotFound
 from rucio.common.schema import get_schema_value
-from rucio.common.utils import clean_surls, generate_uuid, parse_response
+from rucio.common.utils import clean_pfns, generate_uuid, parse_response
 from rucio.core.config import set as cconfig_set
 from rucio.core.did import add_did, attach_dids, get_did, get_did_atime, list_files, set_status
 from rucio.core.replica import add_bad_dids, add_replica, add_replicas, delete_replicas, get_bad_pfns, get_replica, get_replica_atime, get_replicas_state, get_RSEcoverage_of_dataset, list_replicas, set_tombstone, touch_replica, update_replica_state
@@ -911,7 +911,7 @@ def test_client_add_temporary_unavailable_pfns(rse_factory, mock_scope, replica_
         bad_pfns[res['pfn']] = (res['state'], res['reason'], res['expires_at'])
 
     for pfn in list_rep:
-        pfn = str(clean_surls([pfn])[0])
+        pfn = str(clean_pfns([pfn])[0])
         assert pfn in bad_pfns
         assert bad_pfns[pfn][0] == BadPFNStatus.TEMPORARY_UNAVAILABLE
         assert bad_pfns[pfn][1] == reason_str
@@ -975,7 +975,7 @@ def test_client_declare_bad_pfns(rse_factory, mock_scope, replica_client):
         bad_pfns[res['pfn']] = (res['state'], res['reason'], res['expires_at'])
 
     for pfn in list_rep:
-        pfn = str(clean_surls([pfn])[0])
+        pfn = str(clean_pfns([pfn])[0])
         assert pfn in bad_pfns
         assert bad_pfns[pfn][0] == BadPFNStatus.BAD
         assert bad_pfns[pfn][1] == reason_str


### PR DESCRIPTION
This PR renames 'surl' to something clearer throughout the code. When a non-deterministic PFN is intended (such as in the SURL algorithms), it has been renamed to `non_deterministic_pfn`. In other places it has been renamed simply to `pfn` (for example, `clean_surls` has become `clean_pfns`) where this makes more sense.

I will also submit a documentation PR to rename 'surl' and clarify the differences between deterministic and non-deterministic PFN algorithms.