### PR TITLE
commons: support conda env #6833

### DIFF
--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -708,7 +708,8 @@ def get_config_dirs() -> list[str]:
     """
     Returns all available configuration directories in order:
     - $RUCIO_HOME/etc/
-    - $VIRTUAL_ENV/etc/
+    - $VIRTUAL_ENV/etc/  
+    - $CONDA_ENV/etc
     - /opt/rucio/
     """
     configdirs = []
@@ -718,6 +719,9 @@ def get_config_dirs() -> list[str]:
 
     if 'VIRTUAL_ENV' in os.environ:
         configdirs.append('%s/etc/' % os.environ['VIRTUAL_ENV'])
+
+    if 'CONDA_PREFIX' in os.environ:
+        configdirs.append('%s/etc/' % os.environ['CONDA_PREFIX'])
 
     configdirs.append('/opt/rucio/etc/')
 

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -708,7 +708,7 @@ def get_config_dirs() -> list[str]:
     """
     Returns all available configuration directories in order:
     - $RUCIO_HOME/etc/
-    - $VIRTUAL_ENV/etc/  
+    - $VIRTUAL_ENV/etc/
     - $CONDA_ENV/etc
     - /opt/rucio/
     """

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -709,7 +709,7 @@ def get_config_dirs() -> list[str]:
     Returns all available configuration directories in order:
     - $RUCIO_HOME/etc/
     - $VIRTUAL_ENV/etc/
-    - $CONDA_ENV/etc
+    - $CONDA_PREFIX/etc
     - /opt/rucio/
     """
     configdirs = []


### PR DESCRIPTION
Now common/config.py supports virtualenv. With this PR it supports also conda / mamba environments.