### PR TITLE
Add SortingAlgorithmNotSupported and type annotations to client/downloadclient

### DIFF
--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -25,7 +25,7 @@ import subprocess
 import time
 from queue import Empty, Queue, deque
 from threading import Thread
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from rucio import version
 from rucio.client.client import Client
@@ -35,6 +35,13 @@ from rucio.common.exception import InputValidationError, NoFilesDownloaded, NotA
 from rucio.common.pcache import Pcache
 from rucio.common.utils import CHECKSUM_ALGO_DICT, GLOBALLY_SUPPORTED_CHECKSUMS, PREFERRED_CHECKSUM, adler32, detect_client_location, execute, extract_scope, generate_uuid, parse_replicas_from_file, parse_replicas_from_string, send_trace, sizefmt
 from rucio.rse import rsemanager as rsemgr
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+    from xmlrpc.client import ServerProxy as RPCServerProxy
+
+    from rucio.common.constants import SORTING_ALGORITHMS_LITERAL
+    from rucio.common.types import LoggerFunction
 
 
 @enum.unique
@@ -54,7 +61,13 @@ class FileDownloadState(str, enum.Enum):
 
 class BaseExtractionTool:
 
-    def __init__(self, program_name, useability_check_args, extract_args, logger=logging.log):
+    def __init__(
+            self,
+            program_name: str,
+            useability_check_args: str,
+            extract_args: str,
+            logger: "LoggerFunction" = logging.log
+    ):
         """
         Initialises a extraction tool object
 
@@ -69,7 +82,7 @@ class BaseExtractionTool:
         self.logger = logger
         self.is_useable_result = None
 
-    def is_useable(self):
+    def is_useable(self) -> bool:
         """
         Checks if the extraction tool is installed and usable
 
@@ -89,7 +102,12 @@ class BaseExtractionTool:
             self.logger(logging.DEBUG, error)
         return self.is_usable_result
 
-    def try_extraction(self, archive_file_path, file_to_extract, dest_dir_path):
+    def try_extraction(
+            self,
+            archive_file_path: str,
+            file_to_extract: str,
+            dest_dir_path: str
+    ) -> bool:
         """
         Calls the extraction program to extract a file from an archive
 
@@ -119,7 +137,14 @@ class BaseExtractionTool:
 
 class DownloadClient:
 
-    def __init__(self, client=None, logger=None, tracing=True, check_admin=False, check_pcache=False):
+    def __init__(
+            self,
+            client: Optional[Client] = None,
+            logger: Optional["LoggerFunction"] = None,
+            tracing: bool = True,
+            check_admin: bool = False,
+            check_pcache: bool = False
+    ):
         """
         Initialises the basic settings for an DownloadClient object
 
@@ -266,7 +291,7 @@ class DownloadClient:
         trace_custom_fields: Optional[dict[str, Any]] = None,
         traces_copy_out: Optional[list[dict[str, Any]]] = None,
         deactivate_file_download_exceptions: bool = False,
-        sort: Optional[str] = None
+        sort: Optional["SORTING_ALGORITHMS_LITERAL"] = None
     ) -> list[dict[str, Any]]:
         """
         Download items with given DIDs. This function can also download datasets and wildcarded DIDs.
@@ -439,7 +464,14 @@ class DownloadClient:
                 thread.kill_received = True
         return list(output_queue.queue)
 
-    def _download_worker(self, input_queue, output_queue, trace_custom_fields, traces_copy_out, log_prefix):
+    def _download_worker(
+            self,
+            input_queue: Queue,
+            output_queue: Queue,
+            trace_custom_fields: dict[str, Any],
+            traces_copy_out: Optional[list[dict[str, Any]]],
+            log_prefix: str
+    ) -> None:
         """
         This function runs as long as there are items in the input queue,
         downloads them and stores the output in the output queue.
@@ -475,7 +507,7 @@ class DownloadClient:
                 output_queue.put(item)
 
     @staticmethod
-    def _compute_actual_transfer_timeout(item):
+    def _compute_actual_transfer_timeout(item: dict[str, Any]) -> int:
         """
         Merge the two options related to timeout into the value which will be used for protocol download.
         :param item: dictionary that describes the item to download
@@ -487,11 +519,11 @@ class DownloadClient:
         # establishing connections and download of small files
         transfer_speed_timeout_static_increment = 60
 
-        transfer_timeout = item.get('merged_options', {}).get('transfer_timeout')
+        transfer_timeout: Optional[int] = item.get('merged_options', {}).get('transfer_timeout')
         if transfer_timeout is not None:
             return transfer_timeout
 
-        transfer_speed_timeout = item.get('merged_options', {}).get('transfer_speed_timeout')
+        transfer_speed_timeout: Optional[int] = item.get('merged_options', {}).get('transfer_speed_timeout')
         bytes_ = item.get('bytes')
         if not bytes_ or transfer_speed_timeout is None:
             return default_transfer_timeout
@@ -504,7 +536,13 @@ class DownloadClient:
         timeout = bytes_ // transfer_speed_timeout + transfer_speed_timeout_static_increment
         return timeout
 
-    def _download_item(self, item, trace, traces_copy_out, log_prefix=''):
+    def _download_item(
+            self,
+            item: dict[str, Any],
+            trace: dict[str, Any],
+            traces_copy_out: Optional[list[dict[str, Any]]],
+            log_prefix: str = ''
+    ) -> dict[str, Any]:
         """
         Downloads the given item and sends traces for success/failure.
         (This function is meant to be used as class internal only)
@@ -769,7 +807,7 @@ class DownloadClient:
         trace_custom_fields: Optional[dict[str, Any]] = None,
         filters: Optional[dict[str, Any]] = None,
         deactivate_file_download_exceptions: bool = False,
-        sort: Optional[str] = None
+        sort: Optional["SORTING_ALGORITHMS_LITERAL"] = None
     ) -> list[dict[str, Any]]:
         """
         Uses aria2c to download the items with given DIDs. This function can also download datasets and wildcarded DIDs.
@@ -832,7 +870,7 @@ class DownloadClient:
 
         return self._check_output(output_items, deactivate_file_download_exceptions=deactivate_file_download_exceptions)
 
-    def _start_aria2c_rpc(self, rpc_secret):
+    def _start_aria2c_rpc(self, rpc_secret: str) -> tuple[subprocess.Popen, "RPCServerProxy"]:
         """
         Starts aria2c in RPC mode as a subprocess. Also creates
         the RPC proxy instance.
@@ -1066,7 +1104,7 @@ class DownloadClient:
 
         return items
 
-    def _resolve_one_item_dids(self, item):
+    def _resolve_one_item_dids(self, item: dict[str, Any]) -> "Iterator[dict[str, Any]]":
         """
         Resolve scopes or wildcard DIDs to lists of full did names:
         :param item: One input item
@@ -1099,7 +1137,11 @@ class DownloadClient:
             if not any_did_resolved and '*' not in did_name:
                 yield {'scope': scope, 'name': did_name}
 
-    def _resolve_and_merge_input_items(self, input_items, sort=None):
+    def _resolve_and_merge_input_items(
+            self,
+            input_items: list[dict[str, Any]],
+            sort: Optional["SORTING_ALGORITHMS_LITERAL"] = None
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         """
         This function takes the input items given to download_dids etc.
         and resolves the sources.
@@ -1276,7 +1318,7 @@ class DownloadClient:
 
         return did_to_input_items, merged_items_with_sources
 
-    def _options_from_input_items(self, input_items):
+    def _options_from_input_items(self, input_items: "Iterable[dict[str, Any]]") -> dict[str, Any]:
         """
         Best-effort generation of download options from multiple input items which resolve to the same file DID.
         This is done to download each file DID only once, even if it is requested multiple times via overlapping
@@ -1317,7 +1359,11 @@ class DownloadClient:
                 options['transfer_speed_timeout'] = float(new_transfer_speed_timeout)
         return options
 
-    def _prepare_items_for_download(self, did_to_input_items, file_items):
+    def _prepare_items_for_download(
+            self,
+            did_to_input_items: dict[str, Any],
+            file_items: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         """
         Optimises the amount of files to download
         (This function is meant to be used as class internal only)
@@ -1544,7 +1590,7 @@ class DownloadClient:
                 download_packs.append(file_item)
         return download_packs
 
-    def _split_did_str(self, did_str):
+    def _split_did_str(self, did_str: str) -> tuple[str, str]:
         """
         Splits a given DID string (e.g. 'scope1:name.file') into its scope and name part
         (This function is meant to be used as class internal only)
@@ -1577,7 +1623,12 @@ class DownloadClient:
 
         return did_scope, did_name
 
-    def _prepare_dest_dir(self, base_dir, dest_dir_name, no_subdir):
+    def _prepare_dest_dir(
+            self,
+            base_dir: str,
+            dest_dir_name: str,
+            no_subdir: Optional[bool]
+    ) -> str:
         """
         Builds the final destination path for a file and creates the
         destination directory if it's not existent.
@@ -1599,7 +1650,11 @@ class DownloadClient:
 
         return dest_dir_path
 
-    def _check_output(self, output_items, deactivate_file_download_exceptions=False):
+    def _check_output(
+            self,
+            output_items: list[dict[str, Any]],
+            deactivate_file_download_exceptions: bool = False
+    ) -> list[dict[str, Any]]:
         """
         Checks if all files were successfully downloaded
         (This function is meant to be used as class internal only)
@@ -1629,7 +1684,7 @@ class DownloadClient:
 
         return output_items
 
-    def _send_trace(self, trace):
+    def _send_trace(self, trace: dict[str, Any]) -> None:
         """
         Checks if sending trace is allowed and send the trace.
 
@@ -1638,7 +1693,7 @@ class DownloadClient:
         if self.tracing:
             send_trace(trace, self.client.trace_host, self.client.user_agent)
 
-    def preferred_impl(self, sources):
+    def preferred_impl(self, sources: list[dict[str, Any]]) -> Optional[str]:
         """
             Finds the optimum protocol impl preferred by the client and
             supported by the remote RSE.
@@ -1702,7 +1757,10 @@ class DownloadClient:
         return supported_impl
 
 
-def _verify_checksum(item, path):
+def _verify_checksum(
+        item: dict[str, Any],
+        path: str
+) -> tuple[bool, Optional[str], Optional[str]]:
     rucio_checksum = item.get(PREFERRED_CHECKSUM)
     local_checksum = None
     checksum_algo = CHECKSUM_ALGO_DICT.get(PREFERRED_CHECKSUM)

--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -49,6 +49,7 @@ if config_get_bool('transfers', 'srm_https_compatibility', raise_exception=False
     SCHEME_MAP['davs'].append('srm')
 
 SORTING_ALGORITHMS_LITERAL = Literal['geoip', 'closeness', 'custom_table', 'dynamic', 'ranking', 'random']
+SORTING_ALGORITHMS = list(get_args(SORTING_ALGORITHMS_LITERAL))
 
 SUPPORTED_PROTOCOLS_LITERAL = Literal['gsiftp', 'srm', 'root', 'davs', 'http', 'https', 'file', 'storm', 'srm+https', 'scp', 'rsync', 'rclone', 'magnet']
 SUPPORTED_PROTOCOLS = list(get_args(SUPPORTED_PROTOCOLS_LITERAL))

--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -48,6 +48,8 @@ if config_get_bool('transfers', 'srm_https_compatibility', raise_exception=False
     SCHEME_MAP['srm'].append('davs')
     SCHEME_MAP['davs'].append('srm')
 
+SORTING_ALGORITHMS_LITERAL = Literal['geoip', 'closeness', 'custom_table', 'dynamic', 'ranking', 'random']
+
 SUPPORTED_PROTOCOLS_LITERAL = Literal['gsiftp', 'srm', 'root', 'davs', 'http', 'https', 'file', 'storm', 'srm+https', 'scp', 'rsync', 'rclone', 'magnet']
 SUPPORTED_PROTOCOLS = list(get_args(SUPPORTED_PROTOCOLS_LITERAL))
 

--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1089,3 +1089,13 @@ class DeprecationError(RucioException):
         super(DeprecationError, self).__init__(*args, **kwargs)
         self._message = 'Command or function has been deprecated.'
         self.error_code = 105
+
+
+class SortingAlgorithmNotSupported(RucioException):
+    """
+    Sorting algorithm is not supported.
+    """
+    def __init__(self, *args, **kwargs):
+        super(SortingAlgorithmNotSupported, self).__init__(*args, **kwargs)
+        self._message = 'Sorting algorithm is not supported.'
+        self.error_code = 106

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1138,7 +1138,7 @@ def pid_exists(pid: int) -> bool:
         return True
 
 
-def sizefmt(num: Union[int, float], human: bool = True) -> str:
+def sizefmt(num: Union[int, float, None], human: bool = True) -> str:
     """
     Print human readable file sizes
     """

--- a/lib/rucio/core/replica_sorter.py
+++ b/lib/rucio/core/replica_sorter.py
@@ -35,7 +35,7 @@ from rucio.common.exception import InvalidRSEExpression
 from rucio.core.rse_expression_parser import parse_expression
 
 if TYPE_CHECKING:
-    from rucio.common.constants import SORTING_ALGORITHMS_LITERAL
+    from rucio.common.constants import SORTING_ALGORITHMS
 
 REGION = make_region_memcached(expiration_time=900, function_key_generator=utils.my_key_generator)
 
@@ -251,7 +251,7 @@ def site_selector(replicas, site, vo):
     return result
 
 
-def sort_replicas(dictreplica: dict, client_location: dict, selection: Optional["SORTING_ALGORITHMS_LITERAL"] = None) -> list:
+def sort_replicas(dictreplica: dict, client_location: dict, selection: Optional[str] = None) -> list:
     """
     General sorting method for a dictionary of replicas. Returns the List of replicas.
 

--- a/lib/rucio/core/replica_sorter.py
+++ b/lib/rucio/core/replica_sorter.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 from math import asin, cos, radians, sin, sqrt
 from pathlib import Path
 from tempfile import TemporaryDirectory, TemporaryFile
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, Union
 from urllib.parse import urlparse
 
 import geoip2.database
@@ -31,11 +31,9 @@ from dogpile.cache.api import NO_VALUE
 from rucio.common import utils
 from rucio.common.cache import make_region_memcached
 from rucio.common.config import config_get, config_get_bool, config_get_int
-from rucio.common.exception import InvalidRSEExpression
+from rucio.common.constants import SORTING_ALGORITHMS
+from rucio.common.exception import InvalidRSEExpression, SortingAlgorithmNotSupported
 from rucio.core.rse_expression_parser import parse_expression
-
-if TYPE_CHECKING:
-    from rucio.common.constants import SORTING_ALGORITHMS
 
 REGION = make_region_memcached(expiration_time=900, function_key_generator=utils.my_key_generator)
 
@@ -263,8 +261,11 @@ def sort_replicas(dictreplica: dict, client_location: dict, selection: Optional[
     """
     if len(dictreplica) == 0:
         return []
+
     if not selection:
         selection = 'geoip'
+    elif selection not in SORTING_ALGORITHMS:
+        raise SortingAlgorithmNotSupported('Sorting algorithm: %s is not supported. Supported protocols: %s' % (selection, SORTING_ALGORITHMS))
 
     items = [(key, value) for key, value in dictreplica.items()]
     # safety check, TODO: remove if all dictreplica values are 4-tuple with priority as second item
@@ -286,8 +287,6 @@ def sort_replicas(dictreplica: dict, client_location: dict, selection: Optional[
         replicas = sort_ranking(dictreplica, client_location)
     elif selection == 'random':
         replicas = sort_random(dictreplica)
-    else:
-        replicas = list(dictreplica.keys())
 
     return replicas
 

--- a/lib/rucio/core/replica_sorter.py
+++ b/lib/rucio/core/replica_sorter.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 from math import asin, cos, radians, sin, sqrt
 from pathlib import Path
 from tempfile import TemporaryDirectory, TemporaryFile
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 from urllib.parse import urlparse
 
 import geoip2.database
@@ -35,7 +35,7 @@ from rucio.common.exception import InvalidRSEExpression
 from rucio.core.rse_expression_parser import parse_expression
 
 if TYPE_CHECKING:
-    from typing import Optional
+    from rucio.common.constants import SORTING_ALGORITHMS_LITERAL
 
 REGION = make_region_memcached(expiration_time=900, function_key_generator=utils.my_key_generator)
 
@@ -251,7 +251,7 @@ def site_selector(replicas, site, vo):
     return result
 
 
-def sort_replicas(dictreplica: dict, client_location: dict, selection: "Optional[str]" = None) -> list:
+def sort_replicas(dictreplica: dict, client_location: dict, selection: Optional["SORTING_ALGORITHMS_LITERAL"] = None) -> list:
     """
     General sorting method for a dictionary of replicas. Returns the List of replicas.
 

--- a/lib/rucio/web/rest/flaskapi/v1/redirect.py
+++ b/lib/rucio/web/rest/flaskapi/v1/redirect.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 from flask import Blueprint, Flask, redirect, request
 from werkzeug.datastructures import Headers
 
-from rucio.common.exception import DataIdentifierNotFound, ReplicaNotFound
+from rucio.common.exception import DataIdentifierNotFound, ReplicaNotFound, SortingAlgorithmNotSupported
 from rucio.core.replica_sorter import site_selector, sort_replicas
 from rucio.gateway.replica import list_replicas
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, extract_vo, generate_http_error_flask, parse_scope_name, try_stream
@@ -178,7 +178,7 @@ class MetaLinkRedirector(ErrorHandlingMethodView):
                 yield '</metalink>\n'
 
             return try_stream(generate(), content_type='application/metalink4+xml')
-        except (DataIdentifierNotFound, ReplicaNotFound) as error:
+        except (DataIdentifierNotFound, ReplicaNotFound, SortingAlgorithmNotSupported) as error:
             return generate_http_error_flask(404, error, headers=headers)
 
 
@@ -341,7 +341,7 @@ class HeaderRedirector(ErrorHandlingMethodView):
                 return response
 
             return 'no redirection possible - file does not exist', 404, headers
-        except ReplicaNotFound as error:
+        except (ReplicaNotFound, SortingAlgorithmNotSupported) as error:
             return generate_http_error_flask(404, error, headers=headers)
 
 

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -22,7 +22,21 @@ from flask import Flask, Response, request
 
 from rucio.common.config import config_get, config_get_int
 from rucio.common.constants import SUPPORTED_PROTOCOLS
-from rucio.common.exception import AccessDenied, DataIdentifierAlreadyExists, DataIdentifierNotFound, Duplicate, InvalidObject, InvalidPath, InvalidType, ReplicaIsLocked, ReplicaNotFound, ResourceTemporaryUnavailable, RSENotFound, ScopeNotFound
+from rucio.common.exception import (
+    AccessDenied,
+    DataIdentifierAlreadyExists,
+    DataIdentifierNotFound,
+    Duplicate,
+    InvalidObject,
+    InvalidPath,
+    InvalidType,
+    ReplicaIsLocked,
+    ReplicaNotFound,
+    ResourceTemporaryUnavailable,
+    RSENotFound,
+    ScopeNotFound,
+    SortingAlgorithmNotSupported,
+)
 from rucio.common.utils import APIEncoder, parse_response, render_json
 from rucio.core.replica_sorter import sort_replicas
 from rucio.db.sqla.constants import BadFilesStatus
@@ -252,7 +266,7 @@ class Replicas(ErrorHandlingMethodView):
             else:
                 response_generator = _generate_json_response(rfiles)
             return try_stream(response_generator, content_type=content_type)
-        except DataIdentifierNotFound as error:
+        except (DataIdentifierNotFound, SortingAlgorithmNotSupported) as error:
             return generate_http_error_flask(404, error)
 
     def post(self):
@@ -736,10 +750,8 @@ class ListReplicas(ErrorHandlingMethodView):
             else:
                 response_generator = _generate_json_response(rfiles)
             return try_stream(response_generator, content_type=content_type)
-        except InvalidObject as error:
+        except (InvalidObject, DataIdentifierNotFound, SortingAlgorithmNotSupported) as error:
             return generate_http_error_flask(400, error)
-        except DataIdentifierNotFound as error:
-            return generate_http_error_flask(404, error)
 
 
 class ReplicasDIDs(ErrorHandlingMethodView):


### PR DESCRIPTION
On the pyright failures:

```
Found 3 new problems in /home/runner/work/rucio/rucio/lib/rucio/client/downloadclient.py
  - 2 errors with message """Argument of type "str | None" cannot be assigned to parameter "vo" of type "str" in function "get_rse_info"
                               Type "str | None" is incompatible with type "str"
                                 "None" is incompatible with "str"""".
    Candidates: line 664, 1731
  - 1 errors with message """Argument of type "str | None" cannot be assigned to parameter "account" of type "str" in function "list_account_attributes"
                               Type "str | None" is incompatible with type "str"
                                 "None" is incompatible with "str"""".
    Candidates: line 173
```

These will both be fixed by https://github.com/rucio/rucio/pull/6840/commits/481f1529ad2a5e7a0f881b451525986536d99b8f (from this PR: https://github.com/rucio/rucio/pull/6840) once it's merged