### PR TITLE
Testing: Add type annotations to daemons/bb8

### DIFF
--- a/lib/rucio/daemons/bb8/common.py
+++ b/lib/rucio/daemons/bb8/common.py
@@ -185,11 +185,11 @@ def _list_rebalance_rule_candidates_dump(rse_id, mode=None, logger=logging.log):
     candidates = []
     rules = {}
     rse_dump_urls = __dump_url(rse_id=rse_id)
-    rse_dump_urls.reverse()
     resp = None
     if not rse_dump_urls:
         logger(logging.DEBUG, "URL of the dump was not built from template.")
         return candidates
+    rse_dump_urls.reverse()
     success = False
     while not success and len(rse_dump_urls):
         url = rse_dump_urls.pop()

--- a/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
@@ -34,7 +34,7 @@ total_rebalance_volume = 0
 
 
 # groupdisks
-def group_space(site):
+def group_space(site: str) -> int:
     """
     groupdisks of given site
     contributing to primaries

--- a/lib/rucio/daemons/bb8/t2_background_rebalance.py
+++ b/lib/rucio/daemons/bb8/t2_background_rebalance.py
@@ -34,7 +34,7 @@ total_rebalance_volume = 0
 
 
 # groupdisks
-def group_space(site):
+def group_space(site: str) -> int:
     """
     groupdisks of given site
     contributing to primaries


### PR DESCRIPTION
Part of #6588.

On the test failure:

```
 Found 1 new problems in /home/runner/work/rucio/rucio/lib/rucio/daemons/bb8/nuclei_background_rebalance.py
  - 1 errors with message """Argument of type "str | bool | None" cannot be assigned to parameter "site" of type "str" in function "group_space"
                               Type "str | bool | None" is incompatible with type "str"
                                 "bool" is incompatible with "str"""".
    Candidates: line 64
Found 1 new problems in /home/runner/work/rucio/rucio/lib/rucio/daemons/bb8/t2_background_rebalance.py
  - 1 errors with message """Argument of type "str | bool | None" cannot be assigned to parameter "site" of type "str" in function "group_space"
                               Type "str | bool | None" is incompatible with type "str"
                                 "bool" is incompatible with "str"""".
    Candidates: line 64
```

This occurs because `get_rse_attribute` returns `bool` for certain keys: https://github.com/rucio/rucio/blob/6d7b368dcd5261e9e39cbe57d47b698aac77c8e6/lib/rucio/core/rse.py#L974

However, in the context where the error occurs, the key used is `SITE`, which would return a `str`:

https://github.com/rucio/rucio/blob/6d7b368dcd5261e9e39cbe57d47b698aac77c8e6/lib/rucio/daemons/bb8/t2_background_rebalance.py#L63

To fix this, we should overload `get_rse_attribute` to return `Optional[bool]` when `key: Literal[all the bool RseAttr]`, and `Optional[str]` when `key: Literal[all the str RseAttr]`.