### PR TITLE
Daemons: C3PO, minor fixes + type annotations

### DIFF
--- a/lib/rucio/daemons/c3po/algorithms/simple.py
+++ b/lib/rucio/daemons/c3po/algorithms/simple.py
@@ -15,6 +15,7 @@
 import logging
 from operator import itemgetter
 from random import shuffle
+from typing import TYPE_CHECKING, Any
 
 from rucio.common.exception import DataIdentifierNotFound
 from rucio.core.did import get_did
@@ -23,6 +24,9 @@ from rucio.daemons.c3po.collectors.agis import MappingCollector
 from rucio.daemons.c3po.collectors.workload import WorkloadCollector
 from rucio.db.sqla.constants import ReplicaState
 
+if TYPE_CHECKING:
+    from rucio.common.types import InternalScope
+
 
 class PlacementAlgorithm:
     def __init__(self):
@@ -30,20 +34,20 @@ class PlacementAlgorithm:
         self._wc = WorkloadCollector()
         self.__setup_penalties()
 
-    def __setup_penalties(self):
+    def __setup_penalties(self) -> None:
         self._penalties = {}
         for panda_site in self._wc.get_sites():
             site = self._mc.panda_to_site(panda_site)
             self._penalties[site] = 0.1
 
-    def __update_penalties(self):
+    def __update_penalties(self) -> None:
         for site, penalty in self._penalties.items():
             if penalty > 0.1:
                 self._penalties[site] = penalty - 0.1
 
-    def place(self, did):
+    def place(self, did: tuple['InternalScope', str]) -> dict[str, Any]:
         self.__update_penalties()
-        decision = {'did': '{}:{}'.format(did['scope'].internal, did['name'])}
+        decision: dict[str, Any] = {'did': '{}:{}'.format(did['scope'].internal, did['name'])}  # type: ignore (did is treated as a dict here, and as a tuple everywhere else)
         try:
             meta = get_did(did[0], did[1])
         except DataIdentifierNotFound:

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space.py
@@ -14,6 +14,7 @@
 
 import logging
 from operator import itemgetter
+from typing import TYPE_CHECKING, Any
 
 from rucio.common.config import config_get, config_get_int
 from rucio.common.exception import DataIdentifierNotFound
@@ -25,6 +26,9 @@ from rucio.daemons.c3po.collectors.free_space import FreeSpaceCollector
 from rucio.daemons.c3po.utils.dataset_cache import DatasetCache
 from rucio.daemons.c3po.utils.popularity import get_popularity
 from rucio.db.sqla.constants import ReplicaState
+
+if TYPE_CHECKING:
+    from rucio.common.types import InternalScope
 
 
 class PlacementAlgorithm:
@@ -44,19 +48,19 @@ class PlacementAlgorithm:
 
         self.__setup_penalties()
 
-    def __setup_penalties(self):
+    def __setup_penalties(self) -> None:
         self._penalties = {}
         for rse_id in self._rses:
             self._penalties[rse_id] = 1.0
 
-    def __update_penalties(self):
+    def __update_penalties(self) -> None:
         for rse_id, penalty in self._penalties.items():
             if penalty > 1.0:
                 self._penalties[rse_id] = penalty - 1
 
-    def place(self, did):
+    def place(self, did: tuple['InternalScope', str]) -> dict[str, Any]:
         self.__update_penalties()
-        decision = {'did': '{}:{}'.format(did[0].internal, did[1])}
+        decision: dict[str, Any] = {'did': '{}:{}'.format(did[0].internal, did[1])}
         if (did[0].external is not None) and (not did[0].external.startswith('data')) and (not did[0].external.startswith('mc')):
             decision['error_reason'] = 'not a data or mc dataset'
             return decision

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space.py
@@ -57,7 +57,7 @@ class PlacementAlgorithm:
     def place(self, did):
         self.__update_penalties()
         decision = {'did': '{}:{}'.format(did[0].internal, did[1])}
-        if (not did[0].external.startswith('data')) and (not did[0].external.startswith('mc')):
+        if (did[0].external is not None) and (not did[0].external.startswith('data')) and (not did[0].external.startswith('mc')):
             decision['error_reason'] = 'not a data or mc dataset'
             return decision
 

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop.py
@@ -14,6 +14,7 @@
 
 import logging
 from operator import itemgetter
+from typing import TYPE_CHECKING, Any
 
 from rucio.common.config import config_get, config_get_int
 from rucio.common.exception import DataIdentifierNotFound
@@ -25,6 +26,9 @@ from rucio.daemons.c3po.collectors.free_space import FreeSpaceCollector
 from rucio.daemons.c3po.utils.expiring_dataset_cache import ExpiringDatasetCache
 from rucio.daemons.c3po.utils.popularity import get_popularity
 from rucio.db.sqla.constants import ReplicaState
+
+if TYPE_CHECKING:
+    from rucio.common.types import InternalScope
 
 
 class PlacementAlgorithm:
@@ -44,19 +48,19 @@ class PlacementAlgorithm:
 
         self.__setup_penalties()
 
-    def __setup_penalties(self):
+    def __setup_penalties(self) -> None:
         self._penalties = {}
         for rse_id in self._rses:
             self._penalties[rse_id] = 1.0
 
-    def __update_penalties(self):
+    def __update_penalties(self) -> None:
         for rse_id, penalty in self._penalties.items():
             if penalty > 1.0:
                 self._penalties[rse_id] = penalty - 1
 
-    def place(self, did):
+    def place(self, did: tuple['InternalScope', str]) -> dict[str, Any]:
         self.__update_penalties()
-        decision = {'did': '{}:{}'.format(did[0].internal, did[1])}
+        decision: dict[str, Any] = {'did': '{}:{}'.format(did[0].internal, did[1])}
         if (self._added_cache.check_dataset(decision['did'])):
             decision['error_reason'] = 'already added replica for this did in the last 24h'
             return decision

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop.py
@@ -61,7 +61,7 @@ class PlacementAlgorithm:
             decision['error_reason'] = 'already added replica for this did in the last 24h'
             return decision
 
-        if (not did[0].external.startswith('data')) and (not did[0].external.startswith('mc')):
+        if (did[0].external is not None) and (not did[0].external.startswith('data')) and (not did[0].external.startswith('mc')):
             decision['error_reason'] = 'not a data or mc dataset'
             return decision
 

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
@@ -14,6 +14,7 @@
 
 import logging
 from operator import itemgetter
+from typing import TYPE_CHECKING, Any
 
 from rucio.common.config import config_get, config_get_int
 from rucio.common.constants import RseAttr
@@ -30,12 +31,26 @@ from rucio.daemons.c3po.utils.popularity import get_popularity
 from rucio.daemons.c3po.utils.timeseries import RedisTimeSeries
 from rucio.db.sqla.constants import ReplicaState
 
+if TYPE_CHECKING:
+    from rucio.common.types import InternalScope
+
 
 class PlacementAlgorithm:
     """
     Placement algorithm that focusses on free space on T2 DATADISK RSEs. It incorporates network metrics for placement decisions.
     """
-    def __init__(self, datatypes, dest_rse_expr, max_bytes_hour, max_files_hour, max_bytes_hour_rse, max_files_hour_rse, min_popularity, min_recent_requests, max_replicas):
+    def __init__(
+            self,
+            datatypes: str,
+            dest_rse_expr: str,
+            max_bytes_hour: int,
+            max_files_hour: int,
+            max_bytes_hour_rse: int,
+            max_files_hour_rse: int,
+            min_popularity: int,
+            min_recent_requests: int,
+            max_replicas: int
+    ):
         self._fsc = FreeSpaceCollector()
         self._nmc = NetworkMetricsCollector()
         self._added_cache = ExpiringDatasetCache(config_get('c3po', 'redis_host'), config_get_int('c3po', 'redis_port'), timeout=86400)
@@ -68,7 +83,7 @@ class PlacementAlgorithm:
 
         self._print_params()
 
-    def _print_params(self):
+    def _print_params(self) -> None:
         logging.debug('Parameter Overview:')
         logging.debug('Algorithm: t2_free_space_only_pop_with_network')
         logging.debug('Datatypes: %s' % ','.join(self._datatypes))
@@ -77,7 +92,7 @@ class PlacementAlgorithm:
         logging.debug('Min recent requests / Min popularity: %d / %d' % (self._min_recent_requests, self._min_popularity))
         logging.debug('Max existing replicas: %d' % self._max_replicas)
 
-    def __update_penalties(self):
+    def __update_penalties(self) -> None:
         for rse_id, penalty in self._dst_penalties.items():
             if penalty < 100.0:
                 self._dst_penalties[rse_id] += 10.0
@@ -86,8 +101,8 @@ class PlacementAlgorithm:
             if penalty < 100.0:
                 self._src_penalties[rse_id] += 10.0
 
-    def check_did(self, did):
-        decision = {'did': '{}:{}'.format(did[0].internal, did[1])}
+    def check_did(self, did: tuple['InternalScope', str]) -> dict[str, Any]:
+        decision: dict[str, Any] = {'did': '{}:{}'.format(did[0].internal, did[1])}
         if (self._added_cache.check_dataset(decision['did'])):
             decision['error_reason'] = 'already added replica for this did in the last 24h'
             return decision
@@ -147,7 +162,7 @@ class PlacementAlgorithm:
 
         return decision
 
-    def place(self, did):
+    def place(self, did: tuple['InternalScope', str]) -> dict[str, Any]:
         self.__update_penalties()
         self._added_bytes.trim()
         self._added_files.trim()
@@ -189,10 +204,10 @@ class PlacementAlgorithm:
                     net_metrics = self._nmc.getMbps(src_site, metric_type)
                     if net_metrics:
                         break
-                if len(net_metrics) == 0:
+                if len(net_metrics) == 0:  # type: ignore
                     continue
                 available_reps[src_rse_id] = {}
-                for dst_site, mbps in net_metrics.items():
+                for dst_site, mbps in net_metrics.items():  # type: ignore
                     if src_site == dst_site:
                         continue
                     if dst_site in self._sites:

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
@@ -92,7 +92,7 @@ class PlacementAlgorithm:
             decision['error_reason'] = 'already added replica for this did in the last 24h'
             return decision
 
-        if (not did[0].external.startswith('data')) and (not did[0].external.startswith('mc')):
+        if (did[0].external is not None) and (not did[0].external.startswith('data')) and (not did[0].external.startswith('mc')):
             decision['error_reason'] = 'not a data or mc dataset'
             return decision
 

--- a/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
+++ b/lib/rucio/daemons/c3po/algorithms/t2_free_space_only_pop_with_network.py
@@ -156,7 +156,7 @@ class PlacementAlgorithm:
             decision['error_reason'] = 'problems connecting to ES'
             return decision
 
-        if (last_accesses < self._min_recent_requests) and (pop < self._min_popularity):
+        if (last_accesses < self._min_recent_requests) and (decision['popularity'] < self._min_popularity):
             decision['error_reason'] = 'did not popular enough'
             return decision
 

--- a/lib/rucio/daemons/c3po/c3po.py
+++ b/lib/rucio/daemons/c3po/c3po.py
@@ -23,7 +23,7 @@ from json import dumps
 from queue import Queue
 from threading import Event, Thread
 from time import sleep
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 from uuid import uuid4
 
 from requests import post
@@ -42,13 +42,17 @@ from rucio.daemons.c3po.collectors.workload import WorkloadCollector
 
 if TYPE_CHECKING:
     from types import FrameType
-    from typing import Optional
 
 GRACEFUL_STOP = Event()
 DAEMON_NAME = 'c3po'
 
 
-def read_free_space(once=False, thread=0, waiting_time=1800, sleep_time=10):
+def read_free_space(
+        once: bool = False,
+        thread: int = 0,
+        waiting_time: int = 1800,
+        sleep_time: int = 10
+) -> None:
     """
     Thread to collect the space usage information for RSEs.
     """
@@ -65,7 +69,12 @@ def read_free_space(once=False, thread=0, waiting_time=1800, sleep_time=10):
         timer = 0
 
 
-def read_workload(once=False, thread=0, waiting_time=1800, sleep_time=10):
+def read_workload(
+        once: bool = False,
+        thread: int = 0,
+        waiting_time: int = 1800,
+        sleep_time: int = 10
+) -> None:
     """
     Thread to collect the workload information from PanDA.
     """
@@ -82,7 +91,12 @@ def read_workload(once=False, thread=0, waiting_time=1800, sleep_time=10):
         timer = 0
 
 
-def print_workload(once=False, thread=0, waiting_time=600, sleep_time=10):
+def print_workload(
+        once: bool = False,
+        thread: int = 0,
+        waiting_time: int = 600,
+        sleep_time: int = 10
+) -> None:
     """
     Thread to regularly output the workload to logs for debugging.
     """
@@ -100,7 +114,13 @@ def print_workload(once=False, thread=0, waiting_time=600, sleep_time=10):
         timer = 0
 
 
-def read_dids(once=False, thread=0, did_collector=None, waiting_time=60, sleep_time=10):
+def read_dids(
+        once: bool = False,
+        thread: int = 0,
+        did_collector: Optional[JediDIDCollector] = None,
+        waiting_time: int = 60,
+        sleep_time: int = 10
+) -> None:
     """
     Thread to collect DIDs for the placement algorithm.
     """
@@ -116,30 +136,36 @@ def read_dids(once=False, thread=0, did_collector=None, waiting_time=60, sleep_t
         timer = 0
 
 
-def add_rule(client, did, src_rse, dst_rse):
+def add_rule(
+        client: Client,
+        did: dict[str, str],
+        src_rse: str,
+        dst_rse: str
+) -> None:
     logging.debug('add rule for %s from %s to %s' % (did, src_rse, dst_rse))
     r = client.add_replication_rule([did, ], 1, dst_rse, lifetime=604800, account='c3po', source_replica_expression=src_rse, activity='Data Brokering', asynchronous=True)
     logging.debug(r)
 
 
-def place_replica(did_queue, 
-                  once=False,
-                  thread=0,
-                  did_queue=None,
-                  waiting_time=100,
-                  dry_run=False,
-                  sampling=False,
-                  algorithms='t2_free_space_only_pop_with_network',
-                  datatypes='NTUP,DAOD',
-                  dest_rse_expr='type=DATADISK',
-                  max_bytes_hour=100000000000000,
-                  max_files_hour=100000,
-                  max_bytes_hour_rse=50000000000000,
-                  max_files_hour_rse=10000,
-                  min_popularity=8,
-                  min_recent_requests=5,
-                  max_replicas=5,
-                  sleep_time=10):
+def place_replica(
+        did_queue: Queue,
+        once: bool = False,
+        thread: int = 0,
+        waiting_time: int = 100,
+        dry_run: bool = False,
+        sampling: bool = False,
+        algorithms: str = 't2_free_space_only_pop_with_network',
+        datatypes: str = 'NTUP,DAOD',
+        dest_rse_expr: str = 'type=DATADISK',
+        max_bytes_hour: int = 100000000000000,
+        max_files_hour: int = 100000,
+        max_bytes_hour_rse: int = 50000000000000,
+        max_files_hour_rse: int = 10000,
+        min_popularity: int = 8,
+        min_recent_requests: int = 5,
+        max_replicas: int = 5,
+        sleep_time: int = 10
+) -> None:
     """
     Thread to run the placement algorithm to decide if and where to put new replicas.
     """
@@ -150,17 +176,17 @@ def place_replica(did_queue,
         if 'algorithms' in c3po_options:
             algorithms = config_get('c3po', 'algorithms')
 
-        algorithms = algorithms.split(',')
+        algorithms_list = algorithms.split(',')
 
         if not dry_run:
-            if len(algorithms) != 1:
+            if len(algorithms_list) != 1:
                 logging.error('Multiple algorithms are only allowed in dry_run mode')
                 return
             client = Client(auth_type='x509_proxy', account='c3po', creds={'client_proxy': '/opt/rucio/etc/ddmadmin.long.proxy'})
 
         vo = client.vo
         instances = {}
-        for algorithm in algorithms:
+        for algorithm in algorithms_list:
             module_path = 'rucio.daemons.c3po.algorithms.' + algorithm
             module = __import__(module_path, globals(), locals(), ['PlacementAlgorithm'])
             instance = module.PlacementAlgorithm(datatypes, dest_rse_expr, max_bytes_hour, max_files_hour, max_bytes_hour_rse, max_files_hour_rse, min_popularity, min_recent_requests, max_replicas)
@@ -246,7 +272,7 @@ def place_replica(did_queue,
                     if (not dry_run) and create_rule:
                         # DO IT!
                         try:
-                            add_rule(client, {'scope': did[0].external, 'name': did[1]}, decision.get('source_rse'), decision.get('destination_rse'))
+                            add_rule(client, {'scope': did[0].external, 'name': did[1]}, decision.get('source_rse'), decision.get('destination_rse'))  # type: ignore
                         except exception.RucioException as e:
                             logging.debug(e)
 
@@ -255,34 +281,36 @@ def place_replica(did_queue,
         logging.critical(e)
 
 
-def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
+def stop(signum: Optional[int] = None, frame: Optional['FrameType'] = None) -> None:
     """
     Graceful exit.
     """
     GRACEFUL_STOP.set()
 
 
-def run(once=False,
-        threads=1,
-        only_workload=False,
-        dry_run=False,
-        sampling=False,
-        algorithms='t2_free_space_only_pop_with_network',
-        datatypes='NTUP,DAOD',
-        dest_rse_expr='type=DATADISK',
-        max_bytes_hour=100000000000000,
-        max_files_hour=100000,
-        max_bytes_hour_rse=50000000000000,
-        max_files_hour_rse=10000,
-        min_popularity=8,
-        min_recent_requests=5,
-        max_replicas=5,
-        waiting_time_read_free_space=1800,
-        waiting_time_read_workload=1800,
-        waiting_time_print_workload=600,
-        waiting_time_read_dids=60,
-        waiting_time_place_replica=100,
-        sleep_time=10):
+def run(
+        once: bool = False,
+        threads: int = 1,
+        only_workload: bool = False,
+        dry_run: bool = False,
+        sampling: bool = False,
+        algorithms: str = 't2_free_space_only_pop_with_network',
+        datatypes: str = 'NTUP,DAOD',
+        dest_rse_expr: str = 'type=DATADISK',
+        max_bytes_hour: int = 100000000000000,
+        max_files_hour: int = 100000,
+        max_bytes_hour_rse: int = 50000000000000,
+        max_files_hour_rse: int = 10000,
+        min_popularity: int = 8,
+        min_recent_requests: int = 5,
+        max_replicas: int = 5,
+        waiting_time_read_free_space: int = 1800,
+        waiting_time_read_workload: int = 1800,
+        waiting_time_print_workload: int = 600,
+        waiting_time_read_dids: int = 60,
+        waiting_time_place_replica: int = 100,
+        sleep_time: int = 10
+) -> None:
     """
     Starts up the main thread
     """

--- a/lib/rucio/daemons/c3po/c3po.py
+++ b/lib/rucio/daemons/c3po/c3po.py
@@ -111,7 +111,8 @@ def read_dids(once=False, thread=0, did_collector=None, waiting_time=60, sleep_t
             sleep(sleep_time)
             continue
 
-        did_collector.get_dids()
+        if did_collector is not None:
+            did_collector.get_dids()
         timer = 0
 
 

--- a/lib/rucio/daemons/c3po/c3po.py
+++ b/lib/rucio/daemons/c3po/c3po.py
@@ -122,7 +122,8 @@ def add_rule(client, did, src_rse, dst_rse):
     logging.debug(r)
 
 
-def place_replica(once=False,
+def place_replica(did_queue, 
+                  once=False,
                   thread=0,
                   did_queue=None,
                   waiting_time=100,

--- a/lib/rucio/daemons/c3po/collectors/agis.py
+++ b/lib/rucio/daemons/c3po/collectors/agis.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from json import loads
+from typing import Optional
 
 from requests import get
 
@@ -35,7 +36,7 @@ class MappingCollector:
             self._fetch_panda_mapping()
             self._fetch_ddm_mapping()
 
-        def _fetch_panda_mapping(self):
+        def _fetch_panda_mapping(self) -> None:
             '''
             _fetch_panda_mapping
             '''
@@ -50,7 +51,7 @@ class MappingCollector:
                     self.site_to_panda[entry['atlas_site']] = []
                 self.site_to_panda[entry['atlas_site']].append(entry['panda_resource'])
 
-        def _fetch_ddm_mapping(self):
+        def _fetch_ddm_mapping(self) -> None:
             '''
             _fetch_ddm_mapping
             '''
@@ -74,34 +75,34 @@ class MappingCollector:
         if not MappingCollector.instance:
             MappingCollector.instance = MappingCollector._MappingCollector()
 
-    def ddm_to_site(self, ddm):
+    def ddm_to_site(self, ddm: str) -> Optional[str]:
         '''
         ddm_to_site
         '''
-        if ddm not in self.instance.ddm_to_site:
+        if ddm not in self.instance.ddm_to_site:  # type: ignore
             return None
-        return self.instance.ddm_to_site[ddm]
+        return self.instance.ddm_to_site[ddm]  # type: ignore
 
-    def panda_to_site(self, panda):
+    def panda_to_site(self, panda: str) -> Optional[str]:
         '''
         panda_to_site
         '''
-        if panda not in self.instance.panda_to_site:
+        if panda not in self.instance.panda_to_site:  # type: ignore
             return None
-        return self.instance.panda_to_site[panda]
+        return self.instance.panda_to_site[panda]  # type: ignore
 
-    def site_to_ddm(self, site):
+    def site_to_ddm(self, site: str) -> Optional[str]:
         '''
         site_to_ddm
         '''
-        if site not in self.instance.site_to_ddm:
+        if site not in self.instance.site_to_ddm:  # type: ignore
             return None
-        return self.instance.site_to_ddm[site]
+        return self.instance.site_to_ddm[site]  # type: ignore
 
-    def site_to_panda(self, site):
+    def site_to_panda(self, site: str) -> Optional[str]:
         '''
         site_to_panda
         '''
-        if site not in self.instance.site_to_panda:
+        if site not in self.instance.site_to_panda:  # type: ignore
             return None
-        return self.instance.site_to_panda[site]
+        return self.instance.site_to_panda[site]  # type: ignore

--- a/lib/rucio/daemons/c3po/collectors/free_space.py
+++ b/lib/rucio/daemons/c3po/collectors/free_space.py
@@ -16,8 +16,13 @@
 Collector to get the SRM free and used information for DATADISK RSEs.
 """
 
+from typing import TYPE_CHECKING, Optional
+
 from rucio.db.sqla.models import RSEAttrAssociation, RSEUsage
 from rucio.db.sqla.session import read_session
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 
 class FreeSpaceCollector:
@@ -32,7 +37,11 @@ class FreeSpaceCollector:
             self.rses = {}
 
         @read_session
-        def _collect_free_space(self, *, session=None):
+        def _collect_free_space(
+            self,
+            *,
+            session: Optional["Session"] = None
+        ) -> None:
             """
             Retrieve free space from database
             """
@@ -48,14 +57,14 @@ class FreeSpaceCollector:
         if not FreeSpaceCollector.instance:
             FreeSpaceCollector.instance = FreeSpaceCollector._FreeSpaceCollector()
 
-    def collect_free_space(self):
+    def collect_free_space(self) -> None:
         """
         Execute the free space collector
         """
-        self.instance._collect_free_space()
+        self.instance._collect_free_space()  # type: ignore
 
-    def get_rse_space(self):
+    def get_rse_space(self) -> dict[str, dict[str, int]]:
         """
         Return the RSE space
         """
-        return self.instance.rses
+        return self.instance.rses  # type: ignore

--- a/lib/rucio/daemons/c3po/collectors/jedi_did.py
+++ b/lib/rucio/daemons/c3po/collectors/jedi_did.py
@@ -13,17 +13,27 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING, Optional
 
 from rucio.db.sqla.session import read_session
 
+if TYPE_CHECKING:
+    from queue import Queue
+
+    from sqlalchemy.orm import Session
+
 
 class JediDIDCollector:
-    def __init__(self, queue):
+    def __init__(self, queue: "Queue"):
         self.queue = queue
         self.max_tid = 0
 
     @read_session
-    def get_dids(self, *, session=None):
+    def get_dids(
+        self,
+        *,
+        session: Optional["Session"] = None
+    ) -> None:
         query = """select t.jeditaskid, t.username, t.status, d.datasetname from ATLAS_PANDA.JEDI_TASKS t
         inner join ATLAS_PANDA.JEDI_DATASETS d
         on t.jeditaskid = d.jeditaskid
@@ -31,7 +41,7 @@ class JediDIDCollector:
         and d.type = 'input'
         order by d.jeditaskid asc"""
 
-        tasks = session.execute(query)
+        tasks = session.execute(query)  # type: ignore
 
         for t in tasks.fetchall():
             status = t[2]

--- a/lib/rucio/daemons/c3po/collectors/mock_did.py
+++ b/lib/rucio/daemons/c3po/collectors/mock_did.py
@@ -17,6 +17,12 @@ Mock DID collector
 """
 
 from secrets import choice
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from multiprocessing import Queue
+
+    from _typeshed import FileDescriptorOrPath
 
 
 class MockDIDCollector:
@@ -24,11 +30,11 @@ class MockDIDCollector:
     Simple collector that reads dids from a file. Used to
     test the interface.
     """
-    def __init__(self, queue):
+    def __init__(self, queue: "Queue"):
         self._queue = queue
         self._read_file('/opt/rucio/etc/dids_mc15_13TeV.csv')
 
-    def _read_file(self, infile):
+    def _read_file(self, infile: "FileDescriptorOrPath") -> None:
         dids = []
         with open(infile, 'r') as f:
             f.readline()
@@ -40,6 +46,6 @@ class MockDIDCollector:
 
         self._dids = tuple(dids)
 
-    def get_dids(self):
+    def get_dids(self) -> None:
         did = choice(self._dids)
         self._queue.put(did)

--- a/lib/rucio/daemons/c3po/collectors/network_metrics.py
+++ b/lib/rucio/daemons/c3po/collectors/network_metrics.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from json import loads
+from typing import Optional
 
 from redis import StrictRedis
 
@@ -28,7 +29,11 @@ class NetworkMetricsCollector:
         self._r = StrictRedis(host=config_get('c3po-network-metrics', 'redis_host'), port=config_get_int('c3po-network-metrics', 'redis_port'))
         self._prefix = config_get('c3po-network-metrics', 'prefix')
 
-    def getMbps(self, src, type_):
+    def getMbps(
+            self,
+            src: str,
+            type_: str
+    ) -> Optional[dict[str, float]]:
         pattern = "%s#%s:*" % (self._prefix, src)
         keys = self._r.keys(pattern=pattern)
         if len(keys) == 0:
@@ -51,7 +56,11 @@ class NetworkMetricsCollector:
 
         return ret
 
-    def getQueuedFiles(self, src, dst):
+    def getQueuedFiles(
+            self,
+            src: str,
+            dst: str
+    ) -> int:
         key = "%s#%s:%s" % (self._prefix, src, dst)
         activities = loads(self._r.get(key)).get('files', {}).get('queued', {}).get('total', {})
 

--- a/lib/rucio/daemons/c3po/collectors/workload.py
+++ b/lib/rucio/daemons/c3po/collectors/workload.py
@@ -36,7 +36,10 @@ class WorkloadCollector:
         """
         Private class needed implement singleton.
         """
-        def __init__(self, delete_keys=False):
+        def __init__(
+                self,
+                delete_keys: bool = False
+        ):
             self._avg_jobs = {}
             self._cur_jobs = {}
             self._max_jobs = {}
@@ -48,7 +51,7 @@ class WorkloadCollector:
                 self._tms.delete_keys()
             self.reload_cache()
 
-        def reload_cache(self):
+        def reload_cache(self) -> None:
             self._tms.trim()
 
             for key in self._tms.get_keys():
@@ -60,7 +63,7 @@ class WorkloadCollector:
                     self._max_jobs[site] = max(job_series)
                     self._cur_jobs[site] = job_series[-1]
 
-        def collect_workload(self):
+        def collect_workload(self) -> None:
             start = time()
             resp = get(self._request_url, headers=self._request_headers)
             logging.debug("PanDA response took %fs" % (time() - start))
@@ -87,23 +90,23 @@ class WorkloadCollector:
         if not WorkloadCollector.instance:
             WorkloadCollector.instance = WorkloadCollector.__WorkloadCollector()
 
-    def get_avg_jobs(self, site):
-        return self.instance._avg_jobs[site]
+    def get_avg_jobs(self, site: str) -> float:
+        return self.instance._avg_jobs[site]  # type: ignore
 
-    def get_max_jobs(self, site):
-        return self.instance._max_jobs[site]
+    def get_max_jobs(self, site: str) -> int:
+        return self.instance._max_jobs[site]  # type: ignore
 
-    def get_cur_jobs(self, site):
-        return self.instance._cur_jobs[site]
+    def get_cur_jobs(self, site: str) -> int:
+        return self.instance._cur_jobs[site]  # type: ignore
 
-    def get_sites(self):
-        return list(self.instance._avg_jobs.keys())
+    def get_sites(self) -> list[str]:
+        return list(self.instance._avg_jobs.keys())  # type: ignore
 
-    def get_job_info(self, site):
+    def get_job_info(self, site: str) -> tuple[int, float, int]:
         return (self.get_cur_jobs(site), self.get_avg_jobs(site), self.get_max_jobs(site))
 
-    def get_series(self, site):
-        return self.instance._tms.get_series(site)
+    def get_series(self, site: str) -> tuple[int]:
+        return self.instance._tms.get_series(site)  # type: ignore
 
-    def collect_workload(self):
-        self.instance.collect_workload()
+    def collect_workload(self) -> None:
+        self.instance.collect_workload()  # type: ignore

--- a/lib/rucio/daemons/c3po/utils/dataset_cache.py
+++ b/lib/rucio/daemons/c3po/utils/dataset_cache.py
@@ -12,26 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from rucio.daemons.c3po.utils.timeseries import RedisTimeSeries
+
+if TYPE_CHECKING:
+    from rucio.common.types import InternalScope
 
 
 class DatasetCache:
     """
     Utility to count the accesses of the datasets during the last day.
     """
-    def __init__(self, redis_host, redis_port, timeout=1, prefix='did_cache', delete_keys=False):
+    def __init__(
+            self,
+            redis_host: str,
+            redis_port: int,
+            timeout: int = 1,
+            prefix: str = 'did_cache',
+            delete_keys: bool = False
+    ):
         self._prefix = prefix + '_' + str(uuid4()).split('-')[0]
         self._tms = RedisTimeSeries(redis_host, redis_port, timeout, self._prefix)
 
         if delete_keys:
             self._tms.delete_keys()
 
-    def add_did(self, did):
+    def add_did(self, did: tuple['InternalScope', str]) -> None:
         self._tms.add_point('{}_{}'.format(did[0].internal, did[1]), 1)
 
-    def get_did(self, did):
+    def get_did(self, did: tuple['InternalScope', str]) -> int:
         self._tms.trim()
 
         series = self._tms.get_series('{}_{}'.format(did[0].internal, did[1]))

--- a/lib/rucio/daemons/c3po/utils/expiring_dataset_cache.py
+++ b/lib/rucio/daemons/c3po/utils/expiring_dataset_cache.py
@@ -24,18 +24,30 @@ class ExpiringDatasetCache:
     """
     Cache with expiring values to keep track of recently created replicas.
     """
-    def __init__(self, redis_host, redis_port, timeout=1, prefix='expiring_did_cache'):
+    def __init__(
+            self,
+            redis_host: str,
+            redis_port: int,
+            timeout: int = 1,
+            prefix: str = 'expiring_did_cache'
+    ):
         self._redis = StrictRedis(host=redis_host, port=redis_port)
         self._prefix = prefix + '_' + str(uuid4()).split('-')[0]
         self._timeout = timeout
 
-    def add_dataset(self, dataset):
+    def add_dataset(
+            self,
+            dataset: str
+    ) -> None:
         """ Adds a datasets to cache with lifetime """
         key = ':'.join((self._prefix, dataset))
         self._redis.set(key, 1)
         self._redis.expire(key, self._timeout)
 
-    def check_dataset(self, dataset):
+    def check_dataset(
+            self,
+            dataset: str
+    ) -> bool:
         """ Checks if dataset is still in cache """
         key = ':'.join((self._prefix, dataset))
         if self._redis.get(key) is None:

--- a/lib/rucio/daemons/c3po/utils/expiring_list.py
+++ b/lib/rucio/daemons/c3po/utils/expiring_list.py
@@ -25,7 +25,7 @@ class ExpiringList:
     Simple list with time based element expiration
     """
 
-    def __init__(self, timeout=1):
+    def __init__(self, timeout: int = 1):
         self._lock = Lock()
         self._timeout = timeout
         self._items = deque()
@@ -37,26 +37,26 @@ class ExpiringList:
             self._items.append(item)
             Timer(self._timeout, self._expire).start()
 
-    def __len__(self):
+    def __len__(self) -> int:
         """
         Return number of active events
         """
         with self._lock:
             return len(self._items)
 
-    def _expire(self):
+    def _expire(self) -> None:
         """
         Remove any expired events
         """
         with self._lock:
             self._items.popleft()
 
-    def to_set(self):
+    def to_set(self) -> set:
         """
         Return items as a set
         """
         return set(self._items)
 
-    def __str__(self):
+    def __str__(self) -> str:
         with self._lock:
             return str(self._items)

--- a/lib/rucio/daemons/c3po/utils/popularity.py
+++ b/lib/rucio/daemons/c3po/utils/popularity.py
@@ -14,11 +14,15 @@
 
 import logging
 from json import dumps, loads
+from typing import TYPE_CHECKING, Optional
 
 from requests import post
 from requests.auth import HTTPBasicAuth
 
 from rucio.common.config import config_get, config_get_options
+
+if TYPE_CHECKING:
+    from rucio.common.types import InternalScope
 
 ELASTIC_URL = config_get('es-atlas', 'url')
 
@@ -36,7 +40,7 @@ else:
 URL = ELASTIC_URL + '/atlas_rucio-popularity-*/_search'
 
 
-def get_popularity(did):
+def get_popularity(did: tuple['InternalScope', str]) -> Optional[int]:
     """
     Query the popularity for a given DID in the ElasticSearch popularity db.
     """


### PR DESCRIPTION
The minor fixes are broken down into the different commits, other than f00fd6eb6c5bfe865a16e422d0503f0a2ef10b99 which is solely about type annotations.

The `# type: ignore` comments are for `instance` being None before being initialized. There's also a couple other type ignore comments where needed.