### PR TITLE
Rucio 35 release dependency upgrade

### DIFF
--- a/requirements/requirements.dev.in
+++ b/requirements/requirements.dev.in
@@ -1,17 +1,17 @@
 # All dependencies needed to develop/test rucio should be defined here
 -r requirements.server.txt
 pytest==7.4.3
-pytest-xdist==3.5.0                                         # Used for parallel testing
+pytest-xdist==3.5.0, <3.6                                   # Used for parallel testing; config-related issues >= 3.6 (could be fixed in Python 3.10)
 pyflakes==3.1.0                                             # Passive checker of Python programs
 flake8==6.1.0                                               # Wrapper around PyFlakes&pep8; python_version < '3.9'
 pycodestyle==2.11.0                                         # New package replacing pep8; python_version < '3.9'
 pylint==3.0.2
 astroid==3.0.1
-virtualenv==20.24.7                                         # Virtual Python Environment builder
+virtualenv==20.26.3                                         # Virtual Python Environment builder
 xmltodict==0.13.0                                           # Makes working with XML feel like you are working with JSON
 pytz==2023.3.post1                                          # World timezone definitions, modern and historical
 pydoc-markdown==4.8.2                                       # Used for generating Markdown documentation for docusaurus
-sh==2.0.6                                                   # Convenience library for running subprocesses in Python
-apispec==6.3.0                                              # Generate OpenApi definition out of pydoc comments
+sh==2.0.7                                                   # Convenience library for running subprocesses in Python
+apispec==6.6.1                                              # Generate OpenApi definition out of pydoc comments
 apispec-webframeworks                                       # Integration of apispec in Flask
 pip-tools==7.4.1                                            # Generate requirements files with pinned dependencies

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -12,19 +12,19 @@ aiosignal==1.3.1
     # via
     #   -r requirements.server.txt
     #   aiohttp
-alembic==1.12.1
+alembic==1.13.2
     # via -r requirements.server.txt
 annotated-types==0.7.0
     # via
     #   -r requirements.server.txt
     #   pydantic
-apispec[yaml]==6.3.0
+apispec[yaml]==6.6.1
     # via
     #   -r requirements.dev.in
     #   apispec-webframeworks
 apispec-webframeworks==1.1.0
     # via -r requirements.dev.in
-argcomplete==3.1.6
+argcomplete==3.4.0
     # via -r requirements.server.txt
 astroid==3.0.1
     # via
@@ -51,9 +51,9 @@ blinker==1.8.2
     # via
     #   -r requirements.server.txt
     #   flask
-boto3==1.29.5
+boto3==1.34.142
     # via -r requirements.server.txt
-botocore==1.32.7
+botocore==1.34.143
     # via
     #   -r requirements.server.txt
     #   boto3
@@ -162,11 +162,11 @@ future==1.0.0
     # via
     #   -r requirements.server.txt
     #   pyjwkest
-geoip2==4.7.0
+geoip2==4.8.0
     # via -r requirements.server.txt
-globus-sdk==3.32.0
+globus-sdk==3.41.0
     # via -r requirements.server.txt
-google-auth==2.23.4
+google-auth==2.32.0
     # via -r requirements.server.txt
 greenlet==3.0.3
     # via
@@ -209,7 +209,7 @@ jmespath==1.0.1
     #   -r requirements.server.txt
     #   boto3
     #   botocore
-jsonschema==4.20.0
+jsonschema==4.23.0
     # via -r requirements.server.txt
 jsonschema-specifications==2023.12.1
     # via
@@ -262,7 +262,7 @@ nr-util==0.8.12
     # via
     #   docspec-python
     #   pydoc-markdown
-oic==1.6.1
+oic==1.7.0
     # via -r requirements.server.txt
 packaging==24.1
     # via
@@ -290,7 +290,7 @@ platformdirs==4.2.2
     #   yapf
 pluggy==1.5.0
     # via pytest
-prometheus-client==0.19.0
+prometheus-client==0.20.0
     # via -r requirements.server.txt
 psycopg2-binary==2.9.9
     # via -r requirements.server.txt
@@ -348,7 +348,7 @@ pylint==3.0.2
     # via -r requirements.dev.in
 pymemcache==4.0.0
     # via -r requirements.server.txt
-pymongo==4.6.3
+pymongo==4.8.0
     # via -r requirements.server.txt
 pymysql==1.1.1
     # via -r requirements.server.txt
@@ -370,7 +370,7 @@ pytest==7.4.3
     #   pytest-xdist
 pytest-xdist==3.5.0
     # via -r requirements.dev.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements.server.txt
     #   botocore
@@ -380,7 +380,7 @@ python-dotenv==1.0.1
     #   pydantic-settings
 python-magic==0.4.27
     # via -r requirements.server.txt
-python-swiftclient==4.4.0
+python-swiftclient==4.6.0
     # via -r requirements.server.txt
 python3-saml==1.16.0
     # via -r requirements.server.txt
@@ -411,7 +411,7 @@ requests==2.32.3
     #   python-swiftclient
     #   qbittorrent-api
     #   requests-kerberos
-requests-kerberos==0.14.0
+requests-kerberos==0.15.0
     # via -r requirements.server.txt
 rpds-py==0.19.0
     # via
@@ -422,11 +422,11 @@ rsa==4.9
     # via
     #   -r requirements.server.txt
     #   google-auth
-s3transfer==0.7.0
+s3transfer==0.10.2
     # via
     #   -r requirements.server.txt
     #   boto3
-sh==2.0.6
+sh==2.0.7
     # via -r requirements.dev.in
 six==1.16.0
     # via
@@ -484,7 +484,7 @@ urllib3==1.26.19
     #   botocore
     #   qbittorrent-api
     #   requests
-virtualenv==20.24.7
+virtualenv==20.26.3
     # via -r requirements.dev.in
 watchdog==4.0.1
     # via pydoc-markdown

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -14,7 +14,7 @@ aiosignal==1.3.1
     #   aiohttp
 alembic==1.12.1
     # via -r requirements.server.txt
-annotated-types==0.6.0
+annotated-types==0.7.0
     # via
     #   -r requirements.server.txt
     #   pydantic
@@ -41,13 +41,13 @@ attrs==23.2.0
     #   aiohttp
     #   jsonschema
     #   referencing
-bcrypt==4.1.2
+bcrypt==4.1.3
     # via
     #   -r requirements.server.txt
     #   paramiko
 black==23.12.1
     # via docspec-python
-blinker==1.8.1
+blinker==1.8.2
     # via
     #   -r requirements.server.txt
     #   flask
@@ -84,7 +84,7 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   pydoc-markdown
-cryptography==42.0.5
+cryptography==42.0.8
     # via
     #   -r requirements.server.txt
     #   globus-sdk
@@ -95,15 +95,15 @@ cryptography==42.0.5
     #   requests-kerberos
 cx-oracle==8.3.0
     # via -r requirements.server.txt
-databind==4.5.1
+databind==4.5.2
     # via
     #   databind-core
     #   databind-json
-databind-core==4.5.1
+databind-core==4.5.2
     # via
     #   docspec
     #   pydoc-markdown
-databind-json==4.5.1
+databind-json==4.5.2
     # via
     #   docspec
     #   pydoc-markdown
@@ -147,11 +147,11 @@ exceptiongroup==1.2.1
     # via pytest
 execnet==2.1.1
     # via pytest-xdist
-filelock==3.14.0
+filelock==3.15.4
     # via virtualenv
 flake8==6.1.0
     # via -r requirements.dev.in
-flask==3.0.0
+flask==3.0.3
     # via -r requirements.server.txt
 frozenlist==1.4.1
     # via
@@ -176,12 +176,12 @@ gssapi==1.8.3
     # via
     #   -r requirements.server.txt
     #   pyspnego
-idna==2.10
+idna==3.7
     # via
     #   -r requirements.server.txt
     #   requests
     #   yarl
-importlib-metadata==7.1.0
+importlib-metadata==8.0.0
     # via
     #   -r requirements.server.txt
     #   build
@@ -199,7 +199,7 @@ itsdangerous==2.2.0
     # via
     #   -r requirements.server.txt
     #   flask
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   -r requirements.server.txt
     #   flask
@@ -223,12 +223,12 @@ krb5==0.5.1
     #   pyspnego
 libtorrent==2.0.9
     # via -r requirements.server.txt
-lxml==5.2.1
+lxml==5.2.2
     # via
     #   -r requirements.server.txt
     #   python3-saml
     #   xmlsec
-mako==1.3.3
+mako==1.3.5
     # via
     #   -r requirements.server.txt
     #   alembic
@@ -239,7 +239,7 @@ markupsafe==2.1.5
     #   jinja2
     #   mako
     #   werkzeug
-maxminddb==2.6.1
+maxminddb==2.6.2
     # via
     #   -r requirements.server.txt
     #   geoip2
@@ -264,7 +264,7 @@ nr-util==0.8.12
     #   pydoc-markdown
 oic==1.6.1
     # via -r requirements.server.txt
-packaging==24.0
+packaging==24.1
     # via
     #   -r requirements.server.txt
     #   apispec
@@ -282,7 +282,7 @@ pbr==6.0.0
     #   stevedore
 pip-tools==7.4.1
     # via -r requirements.dev.in
-platformdirs==4.2.1
+platformdirs==4.2.2
     # via
     #   black
     #   pylint
@@ -316,15 +316,15 @@ pycryptodomex==3.20.0
     #   -r requirements.server.txt
     #   oic
     #   pyjwkest
-pydantic==2.7.1
+pydantic==2.8.2
     # via
     #   -r requirements.server.txt
     #   pydantic-settings
-pydantic-core==2.18.2
+pydantic-core==2.20.1
     # via
     #   -r requirements.server.txt
     #   pydantic
-pydantic-settings==2.2.1
+pydantic-settings==2.3.4
     # via
     #   -r requirements.server.txt
     #   oic
@@ -360,7 +360,7 @@ pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
-pyspnego[kerberos]==0.10.2
+pyspnego[kerberos]==0.11.0
     # via
     #   -r requirements.server.txt
     #   requests-kerberos
@@ -393,14 +393,14 @@ pyyaml==6.0.1
     #   pydoc-markdown
 qbittorrent-api==2023.11.57
     # via -r requirements.server.txt
-redis==5.0.1
+redis==5.0.7
     # via -r requirements.server.txt
 referencing==0.35.1
     # via
     #   -r requirements.server.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.2
+requests==2.32.3
     # via
     #   -r requirements.server.txt
     #   geoip2
@@ -413,7 +413,7 @@ requests==2.32.2
     #   requests-kerberos
 requests-kerberos==0.14.0
     # via -r requirements.server.txt
-rpds-py==0.18.0
+rpds-py==0.19.0
     # via
     #   -r requirements.server.txt
     #   jsonschema
@@ -434,7 +434,7 @@ six==1.16.0
     #   isodate
     #   pyjwkest
     #   python-dateutil
-sqlalchemy==2.0.23
+sqlalchemy==2.0.31
     # via
     #   -r requirements.server.txt
     #   alembic
@@ -444,7 +444,7 @@ stevedore==5.2.0
     # via
     #   -r requirements.server.txt
     #   dogpile-cache
-stomp-py==8.1.0
+stomp-py==8.1.2
     # via -r requirements.server.txt
 tabulate==0.9.0
     # via -r requirements.server.txt
@@ -459,11 +459,11 @@ tomli==2.0.1
     #   yapf
 tomli-w==1.0.0
     # via pydoc-markdown
-tomlkit==0.12.4
+tomlkit==0.13.0
     # via pylint
-typeapi==2.2.1
+typeapi==2.2.3
     # via databind
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -r requirements.server.txt
     #   alembic
@@ -486,7 +486,7 @@ urllib3==1.26.19
     #   requests
 virtualenv==20.24.7
     # via -r requirements.dev.in
-watchdog==4.0.0
+watchdog==4.0.1
     # via pydoc-markdown
 websocket-client==1.8.0
     # via
@@ -512,7 +512,7 @@ yarl==1.9.4
     # via
     #   -r requirements.server.txt
     #   aiohttp
-zipp==3.19.1
+zipp==3.19.2
     # via
     #   -r requirements.server.txt
     #   importlib-metadata

--- a/requirements/requirements.server.in
+++ b/requirements/requirements.server.in
@@ -1,24 +1,24 @@
 # All dependencies needed to run rucio server/daemons should be defined here
-requests==2.32.2                                            # Python HTTP for Humans.
-urllib3==1.26.19                                            # HTTP library with thread-safe connection pooling, file post, etc.
+requests==2.32.3                                            # Python HTTP for Humans.
+urllib3==1.26.19, <2                                        # HTTP library with thread-safe connection pooling, file post, etc. to be updated to 2.0 once Python 3.10 is the minimum version: https://github.com/boto/botocore/issues/3138
 dogpile.cache==1.2.2                                        # Caching API plugins (1.1.2 is the first version to support pymemcache)
 tabulate==0.9.0                                             # Pretty-print tabular data
 jsonschema==4.20.0                                          # For JSON schema validation (Policy modules)
-SQLAlchemy==2.0.23                                          # DB backend
+SQLAlchemy==2.0.31                                          # DB backend
 alembic==1.12.1                                             # Lightweight database migration tool for SQLAlchemy
 pymemcache==4.0.0                                           # A comprehensive, fast, pure-Python memcached client (Used by Dogpile)
 python-dateutil==2.8.2                                      # Extensions to the standard datetime module
-stomp.py==8.1.0                                             # ActiveMQ Messaging Protocol
+stomp.py==8.1.2                                             # ActiveMQ Messaging Protocol
 statsd==4.0.1                                               # Needed to log into graphite with more than 1 Hz
 geoip2==4.7.0                                               # GeoIP2 API (for IPv6 support)
 google-auth==2.23.4                                         # Google authentication library for Python
-redis==5.0.1                                                # Python client for Redis key-value store
-Flask==3.0.0                                                # Python web framework
+redis==5.0.7                                                # Python client for Redis key-value store
+Flask==3.0.3                                                # Python web framework
 werkzeug==3.0.3                                             # WSGI library
 oic==1.6.1                                                  # for authentication via OpenID Connect protocol
 prometheus_client==0.19.0                                   # Python client for the Prometheus monitoring system
 boto3==1.29.5                                               # S3 boto protocol (new version)
-xmlsec==1.3.13                                              # Required to install pyproject.toml-based projects; 1.3.14 excluded due to https://github.com/xmlsec/python-xmlsec/issues/314
+xmlsec==1.3.13, !=1.3.14                                    # Required to install pyproject.toml-based projects; 1.3.14 excluded due to https://github.com/xmlsec/python-xmlsec/issues/314
 
 # All dependencies needed in extras for rucio server/daemons should be defined here
 paramiko==3.4.0                                             # ssh_extras; SSH2 protocol library (also needed in the server)

--- a/requirements/requirements.server.in
+++ b/requirements/requirements.server.in
@@ -3,37 +3,37 @@ requests==2.32.3                                            # Python HTTP for Hu
 urllib3==1.26.19, <2                                        # HTTP library with thread-safe connection pooling, file post, etc. to be updated to 2.0 once Python 3.10 is the minimum version: https://github.com/boto/botocore/issues/3138
 dogpile.cache==1.2.2                                        # Caching API plugins (1.1.2 is the first version to support pymemcache)
 tabulate==0.9.0                                             # Pretty-print tabular data
-jsonschema==4.20.0                                          # For JSON schema validation (Policy modules)
+jsonschema==4.23.0                                          # For JSON schema validation (Policy modules)
 SQLAlchemy==2.0.31                                          # DB backend
-alembic==1.12.1                                             # Lightweight database migration tool for SQLAlchemy
+alembic==1.13.2                                             # Lightweight database migration tool for SQLAlchemy
 pymemcache==4.0.0                                           # A comprehensive, fast, pure-Python memcached client (Used by Dogpile)
-python-dateutil==2.8.2                                      # Extensions to the standard datetime module
+python-dateutil==2.9.0.post0                                # Extensions to the standard datetime module
 stomp.py==8.1.2                                             # ActiveMQ Messaging Protocol
 statsd==4.0.1                                               # Needed to log into graphite with more than 1 Hz
-geoip2==4.7.0                                               # GeoIP2 API (for IPv6 support)
-google-auth==2.23.4                                         # Google authentication library for Python
+geoip2==4.8.0                                               # GeoIP2 API (for IPv6 support)
+google-auth==2.32.0                                         # Google authentication library for Python
 redis==5.0.7                                                # Python client for Redis key-value store
 Flask==3.0.3                                                # Python web framework
 werkzeug==3.0.3                                             # WSGI library
-oic==1.6.1                                                  # for authentication via OpenID Connect protocol
-prometheus_client==0.19.0                                   # Python client for the Prometheus monitoring system
-boto3==1.29.5                                               # S3 boto protocol (new version)
+oic==1.7.0                                                  # for authentication via OpenID Connect protocol
+prometheus_client==0.20.0                                   # Python client for the Prometheus monitoring system
+boto3==1.34.142                                             # S3 boto protocol (new version)
 xmlsec==1.3.13, !=1.3.14                                    # Required to install pyproject.toml-based projects; 1.3.14 excluded due to https://github.com/xmlsec/python-xmlsec/issues/314
 
 # All dependencies needed in extras for rucio server/daemons should be defined here
 paramiko==3.4.0                                             # ssh_extras; SSH2 protocol library (also needed in the server)
 kerberos==1.3.1                                             # kerberos_extras for client and server
 pykerberos==1.2.4                                           # kerberos_extras for client and server
-requests-kerberos==0.14.0                                   # kerberos_extras for client and server
-python-swiftclient==4.4.0                                   # swift_extras
-argcomplete==3.1.6                                          # argcomplete_extras; Bash tab completion for argparse
+requests-kerberos==0.15.0                                   # kerberos_extras for client and server
+python-swiftclient==4.6.0                                   # swift_extras
+argcomplete==3.4.0                                          # argcomplete_extras; Bash tab completion for argparse
 python-magic==0.4.27                                        # dumper_extras; File type identification using libmagic
 cx_oracle==8.3.0                                            # oracle_extras
 psycopg2-binary==2.9.9                                      # postgresql_extras
 PyMySQL==1.1.1                                              # mysql_extras
 PyYAML==6.0.1                                               # globus_extras and used for reading test configuration files
-globus-sdk==3.32.0                                          # globus_extras
+globus-sdk==3.41.0                                          # globus_extras
 python3-saml==1.16.0                                        # saml_extras
-pymongo==4.6.3                                              # pymongo (metadata plugin)
+pymongo==4.8.0                                              # pymongo (metadata plugin)
 libtorrent==2.0.9                                           # Support for the bittorrent transfertool
 qbittorrent-api==2023.11.57                                 # qBittorrent plugin for the bittorrent tranfsertool

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -8,11 +8,11 @@ aiohttp==3.9.5
     # via geoip2
 aiosignal==1.3.1
     # via aiohttp
-alembic==1.12.1
+alembic==1.13.2
     # via -r requirements.server.in
 annotated-types==0.7.0
     # via pydantic
-argcomplete==3.1.6
+argcomplete==3.4.0
     # via -r requirements.server.in
 async-timeout==4.0.3
     # via
@@ -27,9 +27,9 @@ bcrypt==4.1.3
     # via paramiko
 blinker==1.8.2
     # via flask
-boto3==1.29.5
+boto3==1.34.142
     # via -r requirements.server.in
-botocore==1.32.7
+botocore==1.34.143
     # via
     #   boto3
     #   s3transfer
@@ -75,11 +75,11 @@ frozenlist==1.4.1
     #   aiosignal
 future==1.0.0
     # via pyjwkest
-geoip2==4.7.0
+geoip2==4.8.0
     # via -r requirements.server.in
-globus-sdk==3.32.0
+globus-sdk==3.41.0
     # via -r requirements.server.in
-google-auth==2.23.4
+google-auth==2.32.0
     # via -r requirements.server.in
 greenlet==3.0.3
     # via sqlalchemy
@@ -101,7 +101,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.20.0
+jsonschema==4.23.0
     # via -r requirements.server.in
 jsonschema-specifications==2023.12.1
     # via jsonschema
@@ -130,7 +130,7 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-oic==1.6.1
+oic==1.7.0
     # via -r requirements.server.in
 packaging==24.1
     # via qbittorrent-api
@@ -138,7 +138,7 @@ paramiko==3.4.0
     # via -r requirements.server.in
 pbr==6.0.0
     # via stevedore
-prometheus-client==0.19.0
+prometheus-client==0.20.0
     # via -r requirements.server.in
 psycopg2-binary==2.9.9
     # via -r requirements.server.in
@@ -168,7 +168,7 @@ pykerberos==1.2.4
     # via -r requirements.server.in
 pymemcache==4.0.0
     # via -r requirements.server.in
-pymongo==4.6.3
+pymongo==4.8.0
     # via -r requirements.server.in
 pymysql==1.1.1
     # via -r requirements.server.in
@@ -176,7 +176,7 @@ pynacl==1.5.0
     # via paramiko
 pyspnego[kerberos]==0.11.0
     # via requests-kerberos
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements.server.in
     #   botocore
@@ -184,7 +184,7 @@ python-dotenv==1.0.1
     # via pydantic-settings
 python-magic==0.4.27
     # via -r requirements.server.in
-python-swiftclient==4.4.0
+python-swiftclient==4.6.0
     # via -r requirements.server.in
 python3-saml==1.16.0
     # via -r requirements.server.in
@@ -208,7 +208,7 @@ requests==2.32.3
     #   python-swiftclient
     #   qbittorrent-api
     #   requests-kerberos
-requests-kerberos==0.14.0
+requests-kerberos==0.15.0
     # via -r requirements.server.in
 rpds-py==0.19.0
     # via
@@ -216,7 +216,7 @@ rpds-py==0.19.0
     #   referencing
 rsa==4.9
     # via google-auth
-s3transfer==0.7.0
+s3transfer==0.10.2
     # via boto3
 six==1.16.0
     # via
@@ -263,3 +263,6 @@ yarl==1.9.4
     # via aiohttp
 zipp==3.19.2
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -10,7 +10,7 @@ aiosignal==1.3.1
     # via aiohttp
 alembic==1.12.1
     # via -r requirements.server.in
-annotated-types==0.6.0
+annotated-types==0.7.0
     # via pydantic
 argcomplete==3.1.6
     # via -r requirements.server.in
@@ -23,9 +23,9 @@ attrs==23.2.0
     #   aiohttp
     #   jsonschema
     #   referencing
-bcrypt==4.1.2
+bcrypt==4.1.3
     # via paramiko
-blinker==1.8.1
+blinker==1.8.2
     # via flask
 boto3==1.29.5
     # via -r requirements.server.in
@@ -45,7 +45,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via flask
-cryptography==42.0.5
+cryptography==42.0.8
     # via
     #   globus-sdk
     #   oic
@@ -67,7 +67,7 @@ docopt==0.6.2
     # via stomp-py
 dogpile-cache==1.2.2
     # via -r requirements.server.in
-flask==3.0.0
+flask==3.0.3
     # via -r requirements.server.in
 frozenlist==1.4.1
     # via
@@ -85,17 +85,17 @@ greenlet==3.0.3
     # via sqlalchemy
 gssapi==1.8.3
     # via pyspnego
-idna==2.10
+idna==3.7
     # via
     #   requests
     #   yarl
-importlib-metadata==7.1.0
+importlib-metadata==8.0.0
     # via flask
 isodate==0.6.1
     # via python3-saml
 itsdangerous==2.2.0
     # via flask
-jinja2==3.1.3
+jinja2==3.1.4
     # via flask
 jmespath==1.0.1
     # via
@@ -111,11 +111,11 @@ krb5==0.5.1
     # via pyspnego
 libtorrent==2.0.9
     # via -r requirements.server.in
-lxml==5.2.1
+lxml==5.2.2
     # via
     #   python3-saml
     #   xmlsec
-mako==1.3.3
+mako==1.3.5
     # via
     #   alembic
     #   oic
@@ -124,7 +124,7 @@ markupsafe==2.1.5
     #   jinja2
     #   mako
     #   werkzeug
-maxminddb==2.6.1
+maxminddb==2.6.2
     # via geoip2
 multidict==6.0.5
     # via
@@ -132,7 +132,7 @@ multidict==6.0.5
     #   yarl
 oic==1.6.1
     # via -r requirements.server.in
-packaging==24.0
+packaging==24.1
     # via qbittorrent-api
 paramiko==3.4.0
     # via -r requirements.server.in
@@ -154,11 +154,11 @@ pycryptodomex==3.20.0
     # via
     #   oic
     #   pyjwkest
-pydantic==2.7.1
+pydantic==2.8.2
     # via pydantic-settings
-pydantic-core==2.18.2
+pydantic-core==2.20.1
     # via pydantic
-pydantic-settings==2.2.1
+pydantic-settings==2.3.4
     # via oic
 pyjwkest==1.4.2
     # via oic
@@ -174,7 +174,7 @@ pymysql==1.1.1
     # via -r requirements.server.in
 pynacl==1.5.0
     # via paramiko
-pyspnego[kerberos]==0.10.2
+pyspnego[kerberos]==0.11.0
     # via requests-kerberos
 python-dateutil==2.8.2
     # via
@@ -192,13 +192,13 @@ pyyaml==6.0.1
     # via -r requirements.server.in
 qbittorrent-api==2023.11.57
     # via -r requirements.server.in
-redis==5.0.1
+redis==5.0.7
     # via -r requirements.server.in
 referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.2
+requests==2.32.3
     # via
     #   -r requirements.server.in
     #   geoip2
@@ -210,7 +210,7 @@ requests==2.32.2
     #   requests-kerberos
 requests-kerberos==0.14.0
     # via -r requirements.server.in
-rpds-py==0.18.0
+rpds-py==0.19.0
     # via
     #   jsonschema
     #   referencing
@@ -223,7 +223,7 @@ six==1.16.0
     #   isodate
     #   pyjwkest
     #   python-dateutil
-sqlalchemy==2.0.23
+sqlalchemy==2.0.31
     # via
     #   -r requirements.server.in
     #   alembic
@@ -231,11 +231,11 @@ statsd==4.0.1
     # via -r requirements.server.in
 stevedore==5.2.0
     # via dogpile-cache
-stomp-py==8.1.0
+stomp-py==8.1.2
     # via -r requirements.server.in
 tabulate==0.9.0
     # via -r requirements.server.in
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   alembic
     #   dogpile-cache
@@ -261,5 +261,5 @@ xmlsec==1.3.13
     #   python3-saml
 yarl==1.9.4
     # via aiohttp
-zipp==3.19.1
+zipp==3.19.2
     # via importlib-metadata


### PR DESCRIPTION
Fixes #6890 

No major server dependency upgrades present as part of this release.

Some `dev` dependencies caused issues and were not upgraded, see the readme in #6890 