### PR TITLE
Transfers: add overwrite_when_only_on_disk FTS logic

### DIFF
--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -358,7 +358,7 @@ def build_job_params(
         # "transfers -> overwrite_corrupted_files setting. The logic behind this flag is that
         # it will update the rws (RequestWithSources) with the "overwrite" attribute set to True
         # after finding an 'Destination file exists and overwrite is not enabled' error message
-        overwrite_corrupted_files = last_hop.dst.rws.attributes.ge('overwrite', False)
+        overwrite_corrupted_files = last_hop.rws.attributes.ge('overwrite', False)
         if overwrite_corrupted_files:
             overwrite = True  # both for DISK and TAPE
 

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -388,6 +388,7 @@ def build_job_params(
                   'job_metadata': {
                       'issuer': 'rucio',
                       'multi_sources': False,
+                      'overwrite_when_only_on_disk': overwrite_when_only_on_disk,
                   },
                   'overwrite': overwrite,
                   'overwrite_when_only_on_disk': overwrite_when_only_on_disk,

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -449,17 +449,10 @@ def build_job_params(
         overwrite_hop = False
 
     else:
-        overwrite_hop = True
-        for transfer_hop in transfer_path[:-1]:
-            # Only allow overwrite if all hops in multihop allow it
-            h_overwrite = transfer_hop.rws.attributes.get('overwrite', True)
+        # Set `overwrite_hop` to `True` only if all hops allow it
+        overwrite_hop = all(transfer_hop.rws.attributes.get('overwrite', True) for transfer_hop in transfer_path[:-1])
+        job_params['overwrite'] = overwrite_hop and job_params['overwrite']
 
-            # if one hop cannot be overwritten, quit early
-            job_params['overwrite'] = h_overwrite and job_params['overwrite']
-            # Allow overwrite_hop if all intermediate hops allow it (ignoring the last hop)
-            overwrite_hop = h_overwrite and overwrite_hop
-            if h_overwrite is False:
-                break
     if not job_params['overwrite'] and overwrite_hop:
         job_params['overwrite_hop'] = overwrite_hop
 

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -455,13 +455,11 @@ def build_job_params(
             h_overwrite = transfer_hop.rws.attributes.get('overwrite', True)
 
             # if one hop cannot be overwritten, quit early
-            if h_overwrite is False:
-                break
-
             job_params['overwrite'] = h_overwrite and job_params['overwrite']
             # Allow overwrite_hop if all intermediate hops allow it (ignoring the last hop)
             overwrite_hop = h_overwrite and overwrite_hop
-
+            if h_overwrite is False:
+                break
     if not job_params['overwrite'] and overwrite_hop:
         job_params['overwrite_hop'] = overwrite_hop
 

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -341,12 +341,12 @@ def build_job_params(
         # FTS v3.12.12 introduced a new boolean parameter "overwrite_when_only_on_disk" that controls if the file can be overwritten
         # in TAPE enabled RSEs ONLY IF the file is on the disk buffer and not yet commited to tape media.
         # This functionality should reduce the number of stuck files in the disk buffer that are not migrated to tape media (for whatever reason).
-        # Please be aware that FTS does not guarantee an atomic operation from the time it checks for existence of the file on disk and tape and 
+        # Please be aware that FTS does not guarantee an atomic operation from the time it checks for existence of the file on disk and tape and
         # the moment the file is overwritten, so there is a race condition that could overwrite the file on the tape media
-        overwrite = last_hop.dst.rse.attributes.get('overwrite', False) # honour RSE configuration to force overwrite
+        overwrite = last_hop.dst.rse.attributes.get('overwrite', False)  # honour RSE configuration to force overwrite
         overwrite_when_only_on_disk = last_hop.dst.rse.attributes.get('overwrite_when_only_on_disk', False)
         # setting both flags is incompatible, so we opt in for the safest approach: "overwrite_when_only_on_disk"
-        # this is aligned with FTS implementation: see 
+        # this is aligned with FTS implementation: see
         if overwrite and overwrite_when_only_on_disk:
             overwrite = False
 

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -358,7 +358,7 @@ def build_job_params(
         # "transfers -> overwrite_corrupted_files setting. The logic behind this flag is that
         # it will update the rws (RequestWithSources) with the "overwrite" attribute set to True
         # after finding an 'Destination file exists and overwrite is not enabled' error message
-        overwrite_corrupted_files = last_hop.rws.attributes.ge('overwrite', False)
+        overwrite_corrupted_files = last_hop.rws.attributes.get('overwrite', False)
         if overwrite_corrupted_files:
             overwrite = True  # both for DISK and TAPE
 

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -321,6 +321,8 @@ def build_job_params(
 ) -> dict[str, Any]:
     """
     Prepare the job parameters which will be passed to FTS transfertool
+    Please refer to https://fts3-docs.web.cern.ch/fts3-docs/fts-rest/docs/bulk.html#parameters
+    for the list of parameters.
     """
 
     # The last hop is the main request (the one which triggered the whole transfer),
@@ -328,13 +330,28 @@ def build_job_params(
     last_hop = transfer_path[-1]
     first_hop = transfer_path[0]
 
-    overwrite, bring_online_local = True, None
+    # Overwriting by default is set to True for non TAPE RSEs.
+    # Tape RSEs can force overwrite by setting the "overwrite" attribute to True.
+    overwrite, overwrite_when_only_on_disk, bring_online_local = True, False, None
     if first_hop.src.rse.is_tape_or_staging_required():
         # Activate bring_online if it was requested by first hop
         # We don't allow multihop via a tape, so bring_online should not be set on any other hop
         bring_online_local = bring_online
     if last_hop.dst.rse.is_tape():
-        overwrite = False
+        # FTS v3.12.12 introduced a new boolean parameter "overwrite_when_only_on_disk" that controls if the file can be overwritten
+        # in TAPE enabled RSEs ONLY IF the file is on the disk buffer and not yet commited to tape media.
+        # This functionality should reduce the number of stuck files in the disk buffer that are not migrated to tape media (for whatever reason).
+        # Please be aware that FTS does not guarantee an atomic operation from the time it checks for existence of the file on disk and tape and 
+        # the moment the file is overwritten, so there is a race condition that could overwrite the file on the tape media
+        overwrite = last_hop.dst.rse.attributes.get('overwrite', False) # honour RSE configuration to force overwrite
+        overwrite_when_only_on_disk = last_hop.dst.rse.attributes.get('overwrite_when_only_on_disk', False)
+        # setting both flags is incompatible, so we opt in for the safest approach: "overwrite_when_only_on_disk"
+        # this is aligned with FTS implementation: see 
+        if overwrite and overwrite_when_only_on_disk:
+            overwrite = False
+
+    logger(logging.DEBUG, 'Is it tape?: %s %s overwrite_when_only_on_disk:%s' % (last_hop.dst.rse.name, last_hop.dst.rse.is_tape(), overwrite_when_only_on_disk))
+    logger(logging.DEBUG, 'RSE attributes are: %s' % (last_hop.dst.rse.attributes))
 
     # Get dest space token
     dest_protocol = last_hop.protocol_factory.protocol(last_hop.dst.rse, last_hop.dst.scheme, last_hop.operation_dest)
@@ -354,7 +371,8 @@ def build_job_params(
                       'issuer': 'rucio',
                       'multi_sources': False,
                   },
-                  'overwrite': last_hop.rws.attributes.get('overwrite', overwrite),
+                  'overwrite': overwrite,
+                  'overwrite_when_only_on_disk': overwrite_when_only_on_disk,
                   'priority': last_hop.rws.priority}
 
     if len(transfer_path) > 1:
@@ -399,16 +417,31 @@ def build_job_params(
         elif 'default' in max_time_in_queue:
             job_params['max_time_in_queue'] = max_time_in_queue['default']
 
-    overwrite_hop = True
-    for transfer_hop in transfer_path[:-1]:
-        # Only allow overwrite if all hops in multihop allow it
-        h_overwrite = transfer_hop.rws.attributes.get('overwrite', True)
-        job_params['overwrite'] = h_overwrite and job_params['overwrite']
-        # Allow overwrite_hop if all intermediate hops allow it (ignoring the last hop)
-        overwrite_hop = h_overwrite and overwrite_hop
+    # Refer to https://its.cern.ch/jira/browse/FTS-1749 for full details (login needed), extract below:
+    # Why the overwrite_hop parameter is needed?
+    # Rucio decides that a multihop transfer is needed DISK1 --> DISK2 --> TAPE1 in order to put the file on tape. For some reason, the file already exist at DISK2.
+    # Rucio doesn't know about this file on DISK2. It could be either a correct or corrupted file. This can be due to a previous issue on Rucio side, FTS side, network side, etc (many possible reasons).
+    # Normally, Rucio allows overwrite towards any disk destination, but denies overwrite towards a tape destination. However, in this case, because the destination of the multihop is a tape, DISK2 cannot be overwritten.
+    # Proposed solution
+    # Provide an --overwrite-hop submission option, which instructs FTS to overwrite all transfers except for the destination within a multihop submission.
+
+    # direct transfers, is not multihop
+    if len(transfer_path) == 1:
+        overwrite_hop = False
+
+    else:
+        overwrite_hop = True
+        for transfer_hop in transfer_path[:-1]:
+            # Only allow overwrite if all hops in multihop allow it
+            h_overwrite = transfer_hop.rws.attributes.get('overwrite', True)
+            job_params['overwrite'] = h_overwrite and job_params['overwrite']
+            # Allow overwrite_hop if all intermediate hops allow it (ignoring the last hop)
+            overwrite_hop = h_overwrite and overwrite_hop
+
     if not job_params['overwrite'] and overwrite_hop:
         job_params['overwrite_hop'] = overwrite_hop
 
+    logger(logging.DEBUG, 'Job parameters are : %s' % (job_params))
     return job_params
 
 
@@ -447,6 +480,7 @@ def bulk_group_transfers(
             max_time_in_queue=max_time_in_queue,
             logger=logger
         )
+        logger(logging.DEBUG, 'bulk_group_transfers: Job parameters are: %s' % (job_params))
         if job_params['job_metadata'].get('multi_sources') or job_params['job_metadata'].get('multihop'):
             # for multi-hop and multi-source transfers, no bulk submission.
             fts_jobs.append({'transfers': transfer_path[0:group_bulk], 'job_params': job_params})
@@ -492,6 +526,7 @@ def bulk_group_transfers(
     # split transfer groups to have at most group_bulk elements in each one
     for group in grouped_transfers.values():
         job_params = group['job_params']
+        logger(logging.DEBUG, 'bulk_group_transfers: grouped_transfers.values(): Job parameters are: %s' % (job_params))
         for transfer_paths in chunks(group['transfers'], group_bulk):
             fts_jobs.append({'transfers': transfer_paths, 'job_params': job_params})
 


### PR DESCRIPTION
The following PR allows Rucio to tag transfers to overwrite the disk buffer of tape endpoints and not the tape file when the following conditions are met:
- the RSE has the following attributes/settings configured:
  - RSE needs to be of type TAPE
  - overwrite_when_only_on_disk attribute is set to True
 - the FTS instance configures the tape endpoint with the the field `overwrite_disk_enabled` set to `1`

FTS transfer jobs will be created with this new job parameter and will be classified with the **Overwrite flag**  equal to `D` or `Q`, example below:

<img width="1255" alt="Screenshot 2024-07-11 at 16 06 58" src="https://github.com/rucio/rucio/assets/5175912/ad05f6cc-92b7-48e9-8f89-da2e6e1f9153">

The valid values as of 11/07/2024 are:
```
        Y -- overwrite enabled
        R -- overwrite enabled only on FTS retries
        M -- overwrite enabled only for intermediary hops
        D -- overwrite-when-only-on-disk feature enabled (overwrite if destination file has only disk locality)
        Q -- overwrite-hop + overwrite-when-only-on-disk behavior
```
 
In the FST logs the transfer will contain the following values:

```
...
    INFO    Thu, 11 Jul 2024 14:18:44 +0200; Transfer accepted
    INFO    Thu, 11 Jul 2024 14:18:44 +0200; Proxy: /tmp/x509up_hxxx
    INFO    Thu, 11 Jul 2024 14:18:44 +0200; VO: cms
    INFO    Thu, 11 Jul 2024 14:18:44 +0200; Job id: b655d08c-3f7f-11ef-a237-fa163ef11e82
    INFO    Thu, 11 Jul 2024 14:18:44 +0200; File id: 1933293193
    INFO    Thu, 11 Jul 2024 14:18:44 +0200; Source url: davs://eoscms.cern.ch:443/eos/cms/store/test/rucio/int/store/mc/HC/GenericTTbar/AODSIM/CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/00000/F04D2A27-1B76-E711-8DEF-02163E01501A.root
    INFO    Thu, 11 Jul 2024 14:18:44 +0200; Dest url: davs://eosctacms.cern.ch:8444//eos/ctacms/archivetest/cms/store/test/rucio/int/store/mc/HC/GenericTTbar/AODSIM/CMSSW_9_2_6_91X_mcRun1_realistic_v2-v2/00000/F04D2A27-1B76-E711-8DEF-02163E01501A.root
    INFO    Thu, 11 Jul 2024 14:18:44 +0200; Overwrite enabled: 0
--> INFO    Thu, 11 Jul 2024 14:18:44 +0200; Overwrite when only on disk: 1
    INFO    Thu, 11 Jul 2024 14:18:44 +0200; Disable delegation: 0
    INFO    Thu, 11 Jul 2024 14:18:44 +0200; Disable local streaming: 0
    INFO    Thu, 11 Jul 2024 14:18:44 +0200; Skip eviction of source file: 0
....
```

The PR includes some DEBUG calls to make it easier to debug in runtime.


Overwrite configuration options for transfers are depicted below:
<img width="2596" alt="Screenshot 2024-07-12 at 13 52 14" src="https://github.com/user-attachments/assets/e2c7fa89-50a5-44d2-9ea7-7887ec76b391">


This PR also fixes a wrong hardcoded logic that set overwrite_hop when the transfer was not multi_hop: https://github.com/rucio/rucio/pull/6903/files#diff-10fdb713ecac24728050341f83e17dbe7cc3f1f5a317823860677917579caea2R449

