### PR TITLE
Core & Internals: Migrate distance.py to SQLA2 #6640

### DIFF
--- a/lib/rucio/core/distance.py
+++ b/lib/rucio/core/distance.py
@@ -14,6 +14,7 @@
 
 from typing import TYPE_CHECKING, Any, Optional
 
+from sqlalchemy import and_, delete, select, update
 from sqlalchemy.exc import DatabaseError, IntegrityError
 from sqlalchemy.orm import aliased
 
@@ -58,19 +59,23 @@ def get_distances(src_rse_id: Optional[str] = None, dest_rse_id: Optional[str] =
     """
 
     try:
-        query = session.query(Distance)
+        stmt = select(
+            Distance
+        )
         if src_rse_id:
-            query = query.filter(Distance.src_rse_id == src_rse_id)
+            stmt = stmt.where(
+                Distance.src_rse_id == src_rse_id
+            )
         if dest_rse_id:
-            query = query.filter(Distance.dest_rse_id == dest_rse_id)
+            stmt = stmt.where(
+                Distance.dest_rse_id == dest_rse_id
+            )
 
         distances = []
-        tmp = query.all()
-        if tmp:
-            for t in tmp:
-                t2 = t.to_dict()
-                t2['ranking'] = t2['distance']  # Compatibility with old clients
-                distances.append(t2)
+        for t in session.execute(stmt).scalars().all():
+            t2 = t.to_dict()
+            t2['ranking'] = t2['distance']  # Compatibility with old clients
+            distances.append(t2)
         return distances
     except IntegrityError as error:
         raise exception.RucioException(error.args)
@@ -87,14 +92,20 @@ def delete_distances(src_rse_id: Optional[str] = None, dest_rse_id: Optional[str
     """
 
     try:
-        query = session.query(Distance)
+        stmt = delete(
+            Distance
+        )
 
         if src_rse_id:
-            query = query.filter(Distance.src_rse_id == src_rse_id)
+            stmt = stmt.where(
+                Distance.src_rse_id == src_rse_id
+            )
         if dest_rse_id:
-            query = query.filter(Distance.dest_rse_id == dest_rse_id)
+            stmt = stmt.where(
+                Distance.dest_rse_id == dest_rse_id
+            )
 
-        query.delete()
+        session.execute(stmt)
     except IntegrityError as error:
         raise exception.RucioException(error.args)
 
@@ -110,12 +121,21 @@ def update_distances(src_rse_id: Optional[str] = None, dest_rse_id: Optional[str
     :param session: The database session to use.
     """
     try:
-        query = session.query(Distance)
+        stmt = update(
+            Distance
+        )
         if src_rse_id:
-            query = query.filter(Distance.src_rse_id == src_rse_id)
+            stmt = stmt.where(
+                Distance.src_rse_id == src_rse_id
+            )
         if dest_rse_id:
-            query = query.filter(Distance.dest_rse_id == dest_rse_id)
-        query.update({Distance.distance: distance})
+            stmt = stmt.where(
+                Distance.dest_rse_id == dest_rse_id
+            )
+        stmt = stmt.values({
+            Distance.distance: distance
+        })
+        session.execute(stmt)
     except IntegrityError as error:
         raise exception.RucioException(error.args)
 
@@ -129,7 +149,10 @@ def list_distances(filter_: Optional[dict[str, Any]] = None, *, session: "Sessio
     :param session: The database session in use.
     """
     filter_ = filter_ or {}
-    return [distance.to_dict() for distance in session.query(Distance).all()]
+    stmt = select(
+        Distance
+    )
+    return [distance.to_dict() for distance in session.execute(stmt).scalars().all()]
 
 
 @read_session
@@ -145,12 +168,21 @@ def export_distances(vo: str = 'def', *, session: "Session") -> dict[str, Any]:
     try:
         rse_src = aliased(RSE)
         rse_dest = aliased(RSE)
-        query = session.query(Distance, rse_src.id, rse_dest.id)\
-                       .join(rse_src, rse_src.id == Distance.src_rse_id)\
-                       .join(rse_dest, rse_dest.id == Distance.dest_rse_id)\
-                       .filter(rse_src.vo == vo)\
-                       .filter(rse_dest.vo == vo)
-        for result in query.all():
+        stmt = select(
+            Distance,
+            rse_src.id,
+            rse_dest.id
+        ).join(
+            rse_src,
+            rse_src.id == Distance.src_rse_id
+        ).join(
+            rse_dest,
+            rse_dest.id == Distance.dest_rse_id
+        ).where(
+            and_(rse_src.vo == vo,
+                 rse_dest.vo == vo)
+        )
+        for result in session.execute(stmt).all():
             distance = result[0]
             src_id = result[1]
             dst_id = result[2]

--- a/lib/rucio/core/distance.py
+++ b/lib/rucio/core/distance.py
@@ -91,20 +91,15 @@ def delete_distances(src_rse_id: Optional[str] = None, dest_rse_id: Optional[str
     :param session: The database session to use.
     """
 
+    if not dest_rse_id or not src_rse_id:
+        return
     try:
         stmt = delete(
             Distance
+        ).where(
+            and_(Distance.src_rse_id == src_rse_id,
+                 Distance.dest_rse_id == dest_rse_id)
         )
-
-        if src_rse_id:
-            stmt = stmt.where(
-                Distance.src_rse_id == src_rse_id
-            )
-        if dest_rse_id:
-            stmt = stmt.where(
-                Distance.dest_rse_id == dest_rse_id
-            )
-
         session.execute(stmt)
     except IntegrityError as error:
         raise exception.RucioException(error.args)
@@ -120,19 +115,15 @@ def update_distances(src_rse_id: Optional[str] = None, dest_rse_id: Optional[str
     :param distance: The new distance to set
     :param session: The database session to use.
     """
+    if not dest_rse_id or not src_rse_id:
+        return
     try:
         stmt = update(
             Distance
-        )
-        if src_rse_id:
-            stmt = stmt.where(
-                Distance.src_rse_id == src_rse_id
-            )
-        if dest_rse_id:
-            stmt = stmt.where(
-                Distance.dest_rse_id == dest_rse_id
-            )
-        stmt = stmt.values({
+        ).where(
+            and_(Distance.src_rse_id == src_rse_id,
+                 Distance.dest_rse_id == dest_rse_id)
+        ).values({
             Distance.distance: distance
         })
         session.execute(stmt)


### PR DESCRIPTION
Part of https://github.com/rucio/rucio/issues/6640

1. Migrating core/distance.py to SQLAlchemy 2.0
2. Added guard clauses in `update_distances` and `delete_distances` to prevent unintentionally modifying/deleting distances en masse. The way these functions are currently called programmatically prohibits this behavior, but to prevent this accidentally from happening in the future I've added them. This also makes the queries a bit nicer.