### PR TITLE
Be able to get PFN to scope-name translation function from the policy package

### DIFF
--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -42,19 +42,21 @@ class RSEDeterministicScopeTranslation(PolicyPackageAlgorithms):
         Translates a pfn dictionary into a scope and name
     """
 
-    _algorithm_type = "pfn2scope_name"
+    _algorithm_type = "pfn2lfn"
 
     def __init__(self, vo: str = 'def'):
         super().__init__()
         self.register("def", RSEDeterministicScopeTranslation._default)
         self.register("atlas", RSEDeterministicScopeTranslation._atlas)
         policy_module = vo
+        logger = logging.getLogger(__name__)
         try:
             # Use the function defined in the policy package if it's configured so
             algo_type = self._algorithm_type
             algorithm_name = config.config_get('policy', self._algorithm_type)
         except (NoOptionError, NoSectionError, RuntimeError):
             # Don't use a function from the policy package. Use one defined in this class according to vo
+            logger.debug("PFN2LFN function will not be fetched from the policy package")
             algo_type = self.__class__.__name__
             if super()._supports(self.__class__.__name__, policy_module):
                 algorithm_name = policy_module

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -20,7 +20,7 @@ import hashlib
 import logging
 from collections.abc import Callable, Mapping
 from configparser import NoOptionError, NoSectionError
-from typing import TypeVar, Any
+from typing import Any, TypeVar
 from urllib.parse import urlparse
 
 from rucio.common import config, exception

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -20,7 +20,7 @@ import hashlib
 import logging
 from collections.abc import Callable, Mapping
 from configparser import NoOptionError, NoSectionError
-from typing import TypeVar
+from typing import TypeVar, Any
 from urllib.parse import urlparse
 
 from rucio.common import config, exception
@@ -58,7 +58,7 @@ class RSEDeterministicScopeTranslation(PolicyPackageAlgorithms):
             # Don't use a function from the policy package. Use one defined in this class according to vo
             logger.debug("PFN2LFN function will not be fetched from the policy package")
             algo_type = self.__class__.__name__
-            if super()._supports(self.__class__.__name__, policy_module):
+            if super()._supports(algo_type, policy_module):
                 algorithm_name = policy_module
             else:
                 algorithm_name = "def"
@@ -66,7 +66,7 @@ class RSEDeterministicScopeTranslation(PolicyPackageAlgorithms):
         self.parser = self.get_parser(algo_type, algorithm_name)
 
     @classmethod
-    def get_parser(cls, algorithm_type, algorithm_name):
+    def get_parser(cls, algorithm_type: str, algorithm_name: str) -> Callable[..., Any]:
         return super()._get_one_algorithm(algorithm_type, algorithm_name)
 
     @classmethod


### PR DESCRIPTION
Fixes #6817 

This PR makes `RSEDeterministicScopeTranslation` get the parser function from the policy package if it's configured so. O/w it works as before, i.e. use the `atlas` or `default` function from the same class according to the VO.
