### PR TITLE
Refactor SQLA models `UUID` type hints and add type annotations to account_limit

### DIFF
--- a/lib/rucio/common/types.py
+++ b/lib/rucio/common/types.py
@@ -181,6 +181,38 @@ class RSEAccountCounterDict(TypedDict):
     account: InternalAccount
     rse_id: str
 
+    
+class RSEAccountUsageDict(TypedDict):
+    rse_id: str
+    rse: str
+    account: InternalAccount
+    used_files: int
+    used_bytes: int
+    quota_bytes: int
+
+
+class RSEGlobalAccountUsageDict(TypedDict):
+    rse_expression: str
+    bytes: int
+    files: int
+    bytes_limit: int
+    bytes_remaining: int
+
+
+class RSELocalAccountUsageDict(TypedDict):
+    rse_id: str
+    rse: str
+    bytes: int
+    files: int
+    bytes_limit: int
+    bytes_remaining: int
+
+
+class RSEResolvedGlobalAccountLimitDict(TypedDict):
+    resolved_rses: str
+    resolved_rse_ids: list[str]
+    limit: float
+
 
 class RuleDict(TypedDict):
     account: InternalAccount

--- a/lib/rucio/common/types.py
+++ b/lib/rucio/common/types.py
@@ -181,7 +181,7 @@ class RSEAccountCounterDict(TypedDict):
     account: InternalAccount
     rse_id: str
 
-    
+
 class RSEAccountUsageDict(TypedDict):
     rse_id: str
     rse: str

--- a/lib/rucio/core/account_limit.py
+++ b/lib/rucio/core/account_limit.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
 
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.sql import func, literal, select
@@ -27,9 +27,11 @@ from rucio.db.sqla.session import read_session, transactional_session
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+    from rucio.common.types import InternalAccount, RSEAccountUsageDict, RSEGlobalAccountUsageDict, RSELocalAccountUsageDict, RSEResolvedGlobalAccountLimitDict
+
 
 @read_session
-def get_rse_account_usage(rse_id, *, session: "Session"):
+def get_rse_account_usage(rse_id: str, *, session: "Session") -> list["RSEAccountUsageDict"]:
     """
     Returns the account limit and usage for all accounts on a RSE.
 
@@ -89,7 +91,7 @@ def get_rse_account_usage(rse_id, *, session: "Session"):
 
 
 @read_session
-def get_global_account_limits(account=None, *, session: "Session"):
+def get_global_account_limits(account: Optional["InternalAccount"] = None, *, session: "Session") -> dict[str, "RSEResolvedGlobalAccountLimitDict"]:
     """
     Returns the global account limits for the account.
 
@@ -128,7 +130,7 @@ def get_global_account_limits(account=None, *, session: "Session"):
 
 
 @read_session
-def get_global_account_limit(account, rse_expression, *, session: "Session"):
+def get_global_account_limit(account: "InternalAccount", rse_expression: str, *, session: "Session") -> Union[int, float, None]:
     """
     Returns the global account limit for the account on the rse expression.
 
@@ -154,7 +156,7 @@ def get_global_account_limit(account, rse_expression, *, session: "Session"):
 
 
 @read_session
-def get_local_account_limit(account, rse_id, *, session: "Session"):
+def get_local_account_limit(account: "InternalAccount", rse_id: str, *, session: "Session") -> Union[int, float, None]:
     """
     Returns the account limit for the account on the rse.
 
@@ -180,7 +182,7 @@ def get_local_account_limit(account, rse_id, *, session: "Session"):
 
 
 @read_session
-def get_local_account_limits(account, rse_ids=None, *, session: "Session"):
+def get_local_account_limits(account: "InternalAccount", rse_ids: Optional[list[str]] = None, *, session: "Session") -> dict[str, int]:
     """
     Returns the account limits for the account on the list of rses.
 
@@ -225,7 +227,7 @@ def get_local_account_limits(account, rse_ids=None, *, session: "Session"):
 
 
 @transactional_session
-def set_local_account_limit(account, rse_id, bytes_, *, session: "Session"):
+def set_local_account_limit(account: "InternalAccount", rse_id: str, bytes_: int, *, session: "Session") -> None:
     """
     Returns the limits for the account on the rse.
 
@@ -248,7 +250,7 @@ def set_local_account_limit(account, rse_id, bytes_, *, session: "Session"):
 
 
 @transactional_session
-def set_global_account_limit(account, rse_expression, bytes_, *, session: "Session"):
+def set_global_account_limit(account: "InternalAccount", rse_expression: str, bytes_: int, *, session: "Session") -> None:
     """
     Sets the global limit for the account on a RSE expression.
 
@@ -271,7 +273,7 @@ def set_global_account_limit(account, rse_expression, bytes_, *, session: "Sessi
 
 
 @transactional_session
-def delete_local_account_limit(account, rse_id, *, session: "Session"):
+def delete_local_account_limit(account: "InternalAccount", rse_id: str, *, session: "Session") -> bool:
     """
     Deletes a local account limit.
 
@@ -295,7 +297,7 @@ def delete_local_account_limit(account, rse_id, *, session: "Session"):
 
 
 @transactional_session
-def delete_global_account_limit(account, rse_expression, *, session: "Session"):
+def delete_global_account_limit(account: "InternalAccount", rse_expression: str, *, session: "Session") -> bool:
     """
     Deletes a global account limit.
 
@@ -319,7 +321,7 @@ def delete_global_account_limit(account, rse_expression, *, session: "Session"):
 
 
 @transactional_session
-def get_local_account_usage(account, rse_id=None, *, session: "Session"):
+def get_local_account_usage(account: "InternalAccount", rse_id: Optional[str] = None, *, session: "Session") -> list["RSELocalAccountUsageDict"]:
     """
     Read the account usage and connect it with (if available) the account limits of the account.
 
@@ -370,7 +372,7 @@ def get_local_account_usage(account, rse_id=None, *, session: "Session"):
 
 
 @transactional_session
-def get_global_account_usage(account, rse_expression=None, *, session: "Session"):
+def get_global_account_usage(account: "InternalAccount", rse_expression: Optional[str] = None, *, session: "Session") -> list["RSEGlobalAccountUsageDict"]:
     """
     Read the account usage and connect it with the global account limits of the account.
 

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -562,7 +562,7 @@ class DeletedDataIdentifier(BASE, ModelBase):
 class UpdatedDID(BASE, ModelBase):
     """Represents the recently updated dids"""
     __tablename__ = 'updated_dids'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
     name: Mapped[str] = mapped_column(String(get_schema_value('NAME_LENGTH')))
     rule_evaluation_action: Mapped[DIDReEvaluation] = mapped_column(Enum(DIDReEvaluation, name='UPDATED_DIDS_RULE_EVAL_ACT_CHK',
@@ -579,7 +579,7 @@ class BadReplicas(BASE, ModelBase):
     __tablename__ = 'bad_replicas'
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
     name: Mapped[str] = mapped_column(String(get_schema_value('NAME_LENGTH')))
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     reason: Mapped[Optional[str]] = mapped_column(String(255))
     state: Mapped[BadFilesStatus] = mapped_column(Enum(BadFilesStatus, name='BAD_REPLICAS_STATE_CHK',
                                                        create_constraint=True,
@@ -616,7 +616,7 @@ class BadPFNs(BASE, ModelBase):
 class QuarantinedReplica(BASE, ModelBase):
     """Represents the quarantined replicas"""
     __tablename__ = 'quarantined_replicas'
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     path: Mapped[str] = mapped_column(String(1024))
     bytes: Mapped[Optional[int]] = mapped_column(BigInteger)
     md5: Mapped[Optional[str]] = mapped_column(String(32))
@@ -631,7 +631,7 @@ class QuarantinedReplica(BASE, ModelBase):
 class QuarantinedReplicaHistory(BASE, ModelBase):
     """Represents the quarantined replicas history"""
     __tablename__ = 'quarantined_replicas_history'
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     path: Mapped[str] = mapped_column(String(1024))
     bytes: Mapped[Optional[int]] = mapped_column(BigInteger)
     md5: Mapped[Optional[str]] = mapped_column(String(32))
@@ -771,7 +771,7 @@ class DataIdentifierAssociationHistory(BASE, ModelBase):
 class RSE(BASE, SoftModelBase):
     """Represents a Rucio Location"""
     __tablename__ = 'rses'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     rse: Mapped[str] = mapped_column(String(255))
     vo: Mapped[str] = mapped_column(String(3), nullable=False, server_default='def')
     rse_type: Mapped[RSEType] = mapped_column(Enum(RSEType, name='RSES_TYPE_CHK',
@@ -809,7 +809,7 @@ class RSE(BASE, SoftModelBase):
 class RSELimit(BASE, ModelBase):
     """Represents RSE limits"""
     __tablename__ = 'rse_limits'
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     name: Mapped[str] = mapped_column(String(255))
     value: Mapped[int] = mapped_column(BigInteger)
     _table_args = (PrimaryKeyConstraint('rse_id', 'name', name='RSE_LIMITS_PK'),
@@ -819,7 +819,7 @@ class RSELimit(BASE, ModelBase):
 class TransferLimit(BASE, ModelBase):
     """Represents limits used to throttle transfer requests"""
     __tablename__ = 'transfer_limits'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     rse_expression: Mapped[str] = mapped_column(String(3000))
     activity: Mapped[Optional[str]] = mapped_column(String(50))
     direction: Mapped[TransferLimitDirection] = mapped_column(Enum(TransferLimitDirection, name='TRANSFER_LIMITS_DIRECTION_TYPE_CHK',
@@ -840,8 +840,8 @@ class TransferLimit(BASE, ModelBase):
 class RSETransferLimit(BASE, ModelBase):
     """Represents the binding of a transfer limit to an RSE as result of TransferLimit.rse_expression dereference"""
     __tablename__ = 'rse_transfer_limits'
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
-    limit_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
+    limit_id: Mapped[str] = mapped_column(GUID())
     _table_args = (PrimaryKeyConstraint('rse_id', 'limit_id', name='RSE_TRANSFER_LIMITS_PK'),
                    Index('RSE_TRANSFER_LIMITS_LIMIT_ID_IDX', 'limit_id', 'rse_id'),
                    ForeignKeyConstraint(['rse_id'], ['rses.id'], name='RSE_TRANSFER_LIMITS_RSE_ID_FK'),
@@ -851,7 +851,7 @@ class RSETransferLimit(BASE, ModelBase):
 class RSEUsage(BASE, ModelBase):
     """Represents location usage"""
     __tablename__ = 'rse_usage'
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     source: Mapped[str] = mapped_column(String(255))
     used: Mapped[Optional[int]] = mapped_column(BigInteger)
     free: Mapped[Optional[int]] = mapped_column(BigInteger)
@@ -863,7 +863,7 @@ class RSEUsage(BASE, ModelBase):
 class RSEUsageHistory(BASE, ModelBase):
     """Represents location usage history"""
     __tablename__ = 'rse_usage_history'
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     source: Mapped[str] = mapped_column(String(255))
     used: Mapped[Optional[int]] = mapped_column(BigInteger)
     free: Mapped[Optional[int]] = mapped_column(BigInteger)
@@ -874,8 +874,8 @@ class RSEUsageHistory(BASE, ModelBase):
 class UpdatedRSECounter(BASE, ModelBase):
     """Represents the recently updated RSE counters"""
     __tablename__ = 'updated_rse_counters'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
+    rse_id: Mapped[str] = mapped_column(GUID())
     files: Mapped[int] = mapped_column(BigInteger)
     bytes: Mapped[int] = mapped_column(BigInteger)
     _table_args = (PrimaryKeyConstraint('id', name='UPDATED_RSE_CNTRS_PK'),
@@ -886,7 +886,7 @@ class UpdatedRSECounter(BASE, ModelBase):
 class RSEAttrAssociation(BASE, ModelBase):
     """Represents the map between RSEs and tags"""
     __tablename__ = 'rse_attr_map'
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     key: Mapped[str] = mapped_column(String(255))
     value: Mapped[Optional[Union[bool, str]]] = mapped_column(BooleanString(255))
     _table_args = (PrimaryKeyConstraint('rse_id', 'key', name='RSE_ATTR_MAP_PK'),
@@ -897,7 +897,7 @@ class RSEAttrAssociation(BASE, ModelBase):
 class RSEProtocols(BASE, ModelBase):
     """Represents supported protocols of RSEs (Rucio Storage Elements)"""
     __tablename__ = 'rse_protocols'
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     scheme: Mapped[str] = mapped_column(String(255))
     hostname: Mapped[str] = mapped_column(String(255), server_default='')  # For protocol without host e.g. POSIX on local file systems localhost is assumed as being default
     port: Mapped[int] = mapped_column(Integer, server_default='0')  # like host, for local protocol the port 0 is assumed to be default
@@ -920,7 +920,7 @@ class RSEProtocols(BASE, ModelBase):
 class RSEQoSAssociation(BASE, ModelBase):
     """Represents the mapping of RSEs"""
     __tablename__ = 'rse_qos_map'
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     qos_policy: Mapped[str] = mapped_column(String(64))
     _table_args = (PrimaryKeyConstraint('rse_id', 'qos_policy', name='RSE_QOS_MAP_PK'),
                    ForeignKeyConstraint(['rse_id'], ['rses.id'], name='RSE_QOS_MAP_RSE_ID_FK'))
@@ -930,7 +930,7 @@ class AccountLimit(BASE, ModelBase):
     """Represents account limits"""
     __tablename__ = 'account_limits'
     account: Mapped[InternalAccount] = mapped_column(InternalAccountString(get_schema_value('ACCOUNT_LENGTH')))
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     bytes: Mapped[Optional[int]] = mapped_column(BigInteger)
     _table_args = (PrimaryKeyConstraint('account', 'rse_id', name='ACCOUNT_LIMITS_PK'),
                    ForeignKeyConstraint(['account'], ['accounts.account'], name='ACCOUNT_LIMITS_ACCOUNT_FK'),
@@ -951,7 +951,7 @@ class AccountUsage(BASE, ModelBase):
     """Represents account usage"""
     __tablename__ = 'account_usage'
     account: Mapped[InternalAccount] = mapped_column(InternalAccountString(get_schema_value('ACCOUNT_LENGTH')))
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     files: Mapped[int] = mapped_column(BigInteger)
     bytes: Mapped[int] = mapped_column(BigInteger)
     _table_args = (PrimaryKeyConstraint('account', 'rse_id', name='ACCOUNT_USAGE_PK'),
@@ -963,7 +963,7 @@ class AccountUsageHistory(BASE, ModelBase):
     """Represents account usage history"""
     __tablename__ = 'account_usage_history'
     account: Mapped[InternalAccount] = mapped_column(InternalAccountString(get_schema_value('ACCOUNT_LENGTH')))
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     files: Mapped[int] = mapped_column(BigInteger)
     bytes: Mapped[int] = mapped_column(BigInteger)
     _table_args = (PrimaryKeyConstraint('account', 'rse_id', 'updated_at', name='ACCOUNT_USAGE_HISTORY_PK'),)
@@ -972,7 +972,7 @@ class AccountUsageHistory(BASE, ModelBase):
 class RSEFileAssociation(BASE, ModelBase):
     """Represents the map between locations and files"""
     __tablename__ = 'replicas'
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
     name: Mapped[str] = mapped_column(String(get_schema_value('NAME_LENGTH')))
     bytes: Mapped[int] = mapped_column(BigInteger)
@@ -1005,7 +1005,7 @@ class CollectionReplica(BASE, ModelBase):
     did_type: Mapped[DIDType] = mapped_column(Enum(DIDType, name='COLLECTION_REPLICAS_TYPE_CHK',
                                                    create_constraint=True,
                                                    values_callable=lambda obj: [e.value for e in obj]))
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     bytes: Mapped[int] = mapped_column(BigInteger)
     length: Mapped[int] = mapped_column(BigInteger)
     available_bytes: Mapped[Optional[int]] = mapped_column(BigInteger)
@@ -1026,7 +1026,7 @@ class CollectionReplica(BASE, ModelBase):
 class UpdatedCollectionReplica(BASE, ModelBase):
     """Represents updates to replicas for datasets/collections"""
     __tablename__ = 'updated_col_rep'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
     name: Mapped[str] = mapped_column(String(get_schema_value('NAME_LENGTH')))
     did_type: Mapped[DIDType] = mapped_column(Enum(DIDType, name='UPDATED_COL_REP_TYPE_CHK',
@@ -1042,7 +1042,7 @@ class UpdatedCollectionReplica(BASE, ModelBase):
 class RSEFileAssociationHistory(BASE, ModelBase):
     """Represents a short history of the deleted replicas"""
     __tablename__ = 'replicas_history'
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
     name: Mapped[str] = mapped_column(String(get_schema_value('NAME_LENGTH')))
     bytes: Mapped[int] = mapped_column(BigInteger)
@@ -1054,7 +1054,7 @@ class RSEFileAssociationHistory(BASE, ModelBase):
 class ReplicationRule(BASE, ModelBase):
     """Represents data identifier replication rules"""
     __tablename__ = 'rules'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     subscription_id: Mapped[Optional[uuid.UUID]] = mapped_column(GUID())
     account: Mapped[InternalAccount] = mapped_column(InternalAccountString(get_schema_value('ACCOUNT_LENGTH')))
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
@@ -1127,7 +1127,7 @@ class ReplicationRule(BASE, ModelBase):
 class ReplicationRuleHistoryRecent(BASE, ModelBase):
     """Represents replication rules in the recent history"""
     __tablename__ = 'rules_hist_recent'
-    id: Mapped[uuid.UUID] = mapped_column(GUID())
+    id: Mapped[str] = mapped_column(GUID())
     subscription_id: Mapped[Optional[uuid.UUID]] = mapped_column(GUID())
     account: Mapped[InternalAccount] = mapped_column(InternalAccountString(get_schema_value('ACCOUNT_LENGTH')))
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
@@ -1175,7 +1175,7 @@ class ReplicationRuleHistoryRecent(BASE, ModelBase):
 class ReplicationRuleHistory(BASE, ModelBase):
     """Represents replication rules in the longterm history"""
     __tablename__ = 'rules_history'
-    id: Mapped[uuid.UUID] = mapped_column(GUID())
+    id: Mapped[str] = mapped_column(GUID())
     subscription_id: Mapped[Optional[uuid.UUID]] = mapped_column(GUID())
     account: Mapped[InternalAccount] = mapped_column(InternalAccountString(get_schema_value('ACCOUNT_LENGTH')))
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
@@ -1224,8 +1224,8 @@ class ReplicaLock(BASE, ModelBase):
     __tablename__ = 'locks'
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
     name: Mapped[str] = mapped_column(String(get_schema_value('NAME_LENGTH')))
-    rule_id: Mapped[uuid.UUID] = mapped_column(GUID())
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rule_id: Mapped[str] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     account: Mapped[InternalAccount] = mapped_column(InternalAccountString(get_schema_value('ACCOUNT_LENGTH')))
     bytes: Mapped[Optional[int]] = mapped_column(BigInteger)
     state: Mapped[LockState] = mapped_column(Enum(LockState, name='LOCKS_STATE_CHK',
@@ -1246,8 +1246,8 @@ class DatasetLock(BASE, ModelBase):
     __tablename__ = 'dataset_locks'
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
     name: Mapped[str] = mapped_column(String(get_schema_value('NAME_LENGTH')))
-    rule_id: Mapped[uuid.UUID] = mapped_column(GUID())
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rule_id: Mapped[str] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     account: Mapped[InternalAccount] = mapped_column(InternalAccountString(get_schema_value('ACCOUNT_LENGTH')))
     state: Mapped[LockState] = mapped_column(Enum(LockState, name='DATASET_LOCKS_STATE_CHK',
                                                   create_constraint=True,
@@ -1269,9 +1269,9 @@ class DatasetLock(BASE, ModelBase):
 class UpdatedAccountCounter(BASE, ModelBase):
     """Represents the recently updated Account counters"""
     __tablename__ = 'updated_account_counters'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     account: Mapped[InternalAccount] = mapped_column(InternalAccountString(get_schema_value('ACCOUNT_LENGTH')))
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
     files: Mapped[int] = mapped_column(BigInteger)
     bytes: Mapped[int] = mapped_column(BigInteger)
     _table_args = (PrimaryKeyConstraint('id', name='UPDATED_ACCNT_CNTRS_PK'),
@@ -1283,7 +1283,7 @@ class UpdatedAccountCounter(BASE, ModelBase):
 class Request(BASE, ModelBase):
     """Represents a request for a single file with a third party service"""
     __tablename__ = 'requests'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     request_type: Mapped[RequestType] = mapped_column(Enum(RequestType, name='REQUESTS_TYPE_CHK',
                                                            create_constraint=True,
                                                            values_callable=lambda obj: [e.value for e in obj]),
@@ -1294,7 +1294,7 @@ class Request(BASE, ModelBase):
                                                    create_constraint=True,
                                                    values_callable=lambda obj: [e.value for e in obj]),
                                               default=DIDType.FILE)
-    dest_rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    dest_rse_id: Mapped[str] = mapped_column(GUID())
     source_rse_id: Mapped[Optional[uuid.UUID]] = mapped_column(GUID())
     attributes: Mapped[Optional[str]] = mapped_column(String(4000))
     state: Mapped[RequestState] = mapped_column(Enum(RequestState, name='REQUESTS_STATE_CHK',
@@ -1344,9 +1344,9 @@ class Request(BASE, ModelBase):
 class TransferHop(BASE, ModelBase):
     """Represents source files for transfers"""
     __tablename__ = 'transfer_hops'
-    request_id: Mapped[uuid.UUID] = mapped_column(GUID())
-    next_hop_request_id: Mapped[uuid.UUID] = mapped_column(GUID())
-    initial_request_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    request_id: Mapped[str] = mapped_column(GUID())
+    next_hop_request_id: Mapped[str] = mapped_column(GUID())
+    initial_request_id: Mapped[str] = mapped_column(GUID())
     _table_args = (PrimaryKeyConstraint('request_id', 'next_hop_request_id', 'initial_request_id', name='TRANSFER_HOPS_PK'),
                    ForeignKeyConstraint(['initial_request_id'], ['requests.id'], name='TRANSFER_HOPS_INIT_REQ_ID_FK'),
                    ForeignKeyConstraint(['request_id'], ['requests.id'], name='TRANSFER_HOPS_REQ_ID_FK'),
@@ -1358,7 +1358,7 @@ class TransferHop(BASE, ModelBase):
 class RequestHistory(BASE, ModelBase):
     """Represents request history"""
     __tablename__ = 'requests_history'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     request_type: Mapped[RequestType] = mapped_column(Enum(RequestType, name='REQUESTS_HIST_TYPE_CHK',
                                                            create_constraint=True,
                                                            values_callable=lambda obj: [e.value for e in obj]),
@@ -1369,7 +1369,7 @@ class RequestHistory(BASE, ModelBase):
                                                    create_constraint=True,
                                                    values_callable=lambda obj: [e.value for e in obj]),
                                               default=DIDType.FILE)
-    dest_rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    dest_rse_id: Mapped[str] = mapped_column(GUID())
     source_rse_id: Mapped[Optional[uuid.UUID]] = mapped_column(GUID())
     attributes: Mapped[Optional[str]] = mapped_column(String(4000))
     state: Mapped[RequestState] = mapped_column(Enum(RequestState, name='REQUESTS_HIST_STATE_CHK',
@@ -1410,11 +1410,11 @@ class RequestHistory(BASE, ModelBase):
 class Source(BASE, ModelBase):
     """Represents source files for transfers"""
     __tablename__ = 'sources'
-    request_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    request_id: Mapped[str] = mapped_column(GUID())
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
     name: Mapped[str] = mapped_column(String(get_schema_value('NAME_LENGTH')))
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
-    dest_rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
+    dest_rse_id: Mapped[str] = mapped_column(GUID())
     url: Mapped[Optional[str]] = mapped_column(String(2048))
     bytes: Mapped[Optional[int]] = mapped_column(BigInteger)
     ranking: Mapped[Optional[int]] = mapped_column(Integer())
@@ -1432,11 +1432,11 @@ class Source(BASE, ModelBase):
 class SourceHistory(BASE, ModelBase):
     """Represents history of source files for transfers"""
     __tablename__ = 'sources_history'
-    request_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    request_id: Mapped[str] = mapped_column(GUID())
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
     name: Mapped[str] = mapped_column(String(get_schema_value('NAME_LENGTH')))
-    rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
-    dest_rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    rse_id: Mapped[str] = mapped_column(GUID())
+    dest_rse_id: Mapped[str] = mapped_column(GUID())
     url: Mapped[Optional[str]] = mapped_column(String(2048))
     bytes: Mapped[Optional[int]] = mapped_column(BigInteger)
     ranking: Mapped[Optional[int]] = mapped_column(Integer())
@@ -1451,8 +1451,8 @@ class SourceHistory(BASE, ModelBase):
 class Distance(BASE, ModelBase):
     """Represents distance between rses"""
     __tablename__ = 'distances'
-    src_rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
-    dest_rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    src_rse_id: Mapped[str] = mapped_column(GUID())
+    dest_rse_id: Mapped[str] = mapped_column(GUID())
     distance: Mapped[Optional[int]] = mapped_column(Integer())
     _table_args = (PrimaryKeyConstraint('src_rse_id', 'dest_rse_id', name='DISTANCES_PK'),
                    ForeignKeyConstraint(['src_rse_id'], ['rses.id'], name='DISTANCES_SRC_RSES_FK'),
@@ -1463,11 +1463,11 @@ class Distance(BASE, ModelBase):
 class TransferStats(BASE, ModelBase):
     """Represents counters for transfer link usage"""
     __tablename__ = 'transfer_stats'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     resolution: Mapped[int] = mapped_column(Integer)
     timestamp: Mapped[datetime] = mapped_column(DateTime)
-    dest_rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
-    src_rse_id: Mapped[uuid.UUID] = mapped_column(GUID())
+    dest_rse_id: Mapped[str] = mapped_column(GUID())
+    src_rse_id: Mapped[str] = mapped_column(GUID())
     activity: Mapped[Optional[str]] = mapped_column(String(50))
     files_done: Mapped[int] = mapped_column(BigInteger)
     bytes_done: Mapped[int] = mapped_column(BigInteger)
@@ -1481,7 +1481,7 @@ class TransferStats(BASE, ModelBase):
 class Subscription(BASE, ModelBase):
     """Represents a subscription"""
     __tablename__ = 'subscriptions'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     name: Mapped[str] = mapped_column(String(64))
     filter: Mapped[Optional[str]] = mapped_column(String(4000))
     replication_rules: Mapped[Optional[str]] = mapped_column(String(4000))
@@ -1508,7 +1508,7 @@ class Subscription(BASE, ModelBase):
 class SubscriptionHistory(BASE, ModelBase):
     """Represents a subscription history"""
     __tablename__ = 'subscriptions_history'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     name: Mapped[str] = mapped_column(String(64))
     filter: Mapped[Optional[str]] = mapped_column(String(4000))
     replication_rules: Mapped[Optional[str]] = mapped_column(String(4000))
@@ -1569,7 +1569,7 @@ class OAuthRequest(BASE, ModelBase):
 class Message(BASE, ModelBase):
     """Represents the event messages"""
     __tablename__ = 'messages'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     event_type: Mapped[str] = mapped_column(String(256))
     payload: Mapped[str] = mapped_column(String(4000))
     payload_nolimit: Mapped[Optional[str]] = mapped_column(Text)
@@ -1583,7 +1583,7 @@ class Message(BASE, ModelBase):
 class MessageHistory(BASE, ModelBase):
     """Represents the history of event messages"""
     __tablename__ = 'messages_history'
-    id: Mapped[uuid.UUID] = mapped_column(GUID())
+    id: Mapped[str] = mapped_column(GUID())
     event_type: Mapped[Optional[str]] = mapped_column(String(1024))
     payload: Mapped[Optional[str]] = mapped_column(String(4000))
     payload_nolimit: Mapped[Optional[str]] = mapped_column(Text)
@@ -1649,7 +1649,7 @@ class NamingConvention(BASE, ModelBase):
 class LifetimeExceptions(BASE, ModelBase):
     """Represents the exceptions to the lifetime model"""
     __tablename__ = 'lifetime_except'
-    id: Mapped[uuid.UUID] = mapped_column(GUID(), default=utils.generate_uuid)
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
     scope: Mapped[InternalScope] = mapped_column(InternalScopeString(get_schema_value('SCOPE_LENGTH')))
     name: Mapped[str] = mapped_column(String(get_schema_value('NAME_LENGTH')))
     did_type: Mapped[DIDType] = mapped_column(Enum(DIDType, name='LIFETIME_EXCEPT_TYPE_CHK',

--- a/lib/rucio/gateway/account_limit.py
+++ b/lib/rucio/gateway/account_limit.py
@@ -56,10 +56,10 @@ def get_local_account_limits(account, vo='def', *, session: "Session"):
     :returns: The account limits.
     """
 
-    account = InternalAccount(account, vo=vo)
+    internal_account = InternalAccount(account, vo=vo)
 
     rse_instead_id = {}
-    for elem in account_limit_core.get_local_account_limits(account=account, session=session).items():
+    for elem in account_limit_core.get_local_account_limits(account=internal_account, session=session).items():
         rse_instead_id[get_rse_name(rse_id=elem[0], session=session)] = elem[1]
     return rse_instead_id
 
@@ -79,10 +79,10 @@ def get_local_account_limit(account, rse, vo='def', *, session: "Session"):
     :returns: The account limit.
     """
 
-    account = InternalAccount(account, vo=vo)
+    internal_account = InternalAccount(account, vo=vo)
 
     rse_id = get_rse_id(rse=rse, vo=vo, session=session)
-    return {rse: account_limit_core.get_local_account_limit(account=account, rse_id=rse_id, session=session)}
+    return {rse: account_limit_core.get_local_account_limit(account=internal_account, rse_id=rse_id, session=session)}
 
 
 @read_session
@@ -99,11 +99,11 @@ def get_global_account_limits(account, vo='def', *, session: "Session"):
     :returns: The account limits.
     """
     if account:
-        account = InternalAccount(account, vo=vo)
+        internal_account = InternalAccount(account, vo=vo)
     else:
-        account = InternalAccount('*', vo=vo)
+        internal_account = InternalAccount('*', vo=vo)
 
-    return account_limit_core.get_global_account_limits(account=account, session=session)
+    return account_limit_core.get_global_account_limits(account=internal_account, session=session)
 
 
 @read_session
@@ -121,9 +121,9 @@ def get_global_account_limit(account, rse_expression, vo='def', *, session: "Ses
     :returns: The account limit.
     """
 
-    account = InternalAccount(account, vo=vo)
+    internal_account = InternalAccount(account, vo=vo)
 
-    return {rse_expression: account_limit_core.get_global_account_limit(account=account, rse_expression=rse_expression, session=session)}
+    return {rse_expression: account_limit_core.get_global_account_limit(account=internal_account, rse_expression=rse_expression, session=session)}
 
 
 @transactional_session
@@ -144,12 +144,12 @@ def set_local_account_limit(account, rse, bytes_, issuer, vo='def', *, session: 
     if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_local_account_limit', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not set account limits.' % (issuer))
 
-    account = InternalAccount(account, vo=vo)
+    internal_account = InternalAccount(account, vo=vo)
 
-    if not account_exists(account=account, session=session):
-        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (account))
+    if not account_exists(account=internal_account, session=session):
+        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (internal_account))
 
-    account_limit_core.set_local_account_limit(account=account, rse_id=rse_id, bytes_=bytes_, session=session)
+    account_limit_core.set_local_account_limit(account=internal_account, rse_id=rse_id, bytes_=bytes_, session=session)
 
 
 @transactional_session
@@ -169,12 +169,12 @@ def set_global_account_limit(account, rse_expression, bytes_, issuer, vo='def', 
     if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_global_account_limit', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not set account limits.' % (issuer))
 
-    account = InternalAccount(account, vo=vo)
+    internal_account = InternalAccount(account, vo=vo)
 
-    if not account_exists(account=account, session=session):
-        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (account))
+    if not account_exists(account=internal_account, session=session):
+        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (internal_account))
 
-    account_limit_core.set_global_account_limit(account=account, rse_expression=rse_expression, bytes_=bytes_, session=session)
+    account_limit_core.set_global_account_limit(account=internal_account, rse_expression=rse_expression, bytes_=bytes_, session=session)
 
 
 @transactional_session
@@ -196,12 +196,12 @@ def delete_local_account_limit(account, rse, issuer, vo='def', *, session: "Sess
     if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='delete_local_account_limit', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not delete account limits.' % (issuer))
 
-    account = InternalAccount(account, vo=vo)
+    internal_account = InternalAccount(account, vo=vo)
 
-    if not account_exists(account=account, session=session):
-        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (account))
+    if not account_exists(account=internal_account, session=session):
+        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (internal_account))
 
-    return account_limit_core.delete_local_account_limit(account=account, rse_id=rse_id, session=session)
+    return account_limit_core.delete_local_account_limit(account=internal_account, rse_id=rse_id, session=session)
 
 
 @transactional_session
@@ -222,12 +222,12 @@ def delete_global_account_limit(account, rse_expression, issuer, vo='def', *, se
     if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='delete_global_account_limit', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not delete global account limits.' % (issuer))
 
-    account = InternalAccount(account, vo=vo)
+    internal_account = InternalAccount(account, vo=vo)
 
-    if not account_exists(account=account, session=session):
-        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (account))
+    if not account_exists(account=internal_account, session=session):
+        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (internal_account))
 
-    return account_limit_core.delete_global_account_limit(account=account, rse_expression=rse_expression, session=session)
+    return account_limit_core.delete_global_account_limit(account=internal_account, rse_expression=rse_expression, session=session)
 
 
 @read_session
@@ -252,12 +252,12 @@ def get_local_account_usage(account, rse, issuer, vo='def', *, session: "Session
     if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='get_local_account_usage', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not list account usage.' % (issuer))
 
-    account = InternalAccount(account, vo=vo)
+    internal_account = InternalAccount(account, vo=vo)
 
-    if not account_exists(account=account, session=session):
-        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (account))
+    if not account_exists(account=internal_account, session=session):
+        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (internal_account))
 
-    return [gateway_update_return_dict(d, session=session) for d in account_limit_core.get_local_account_usage(account=account, rse_id=rse_id, session=session)]
+    return [gateway_update_return_dict(d, session=session) for d in account_limit_core.get_local_account_usage(account=internal_account, rse_id=rse_id, session=session)]
 
 
 @read_session
@@ -278,9 +278,9 @@ def get_global_account_usage(account, rse_expression, issuer, vo='def', *, sessi
     if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='get_global_account_usage', kwargs=kwargs, session=session):
         raise rucio.common.exception.AccessDenied('Account %s can not list global account usage.' % (issuer))
 
-    account = InternalAccount(account, vo=vo)
+    internal_account = InternalAccount(account, vo=vo)
 
-    if not account_exists(account=account, session=session):
-        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (account))
+    if not account_exists(account=internal_account, session=session):
+        raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (internal_account))
 
-    return [gateway_update_return_dict(d, session=session) for d in account_limit_core.get_global_account_usage(account=account, rse_expression=rse_expression, session=session)]
+    return [gateway_update_return_dict(d, session=session) for d in account_limit_core.get_global_account_usage(account=internal_account, rse_expression=rse_expression, session=session)]

--- a/lib/rucio/gateway/account_limit.py
+++ b/lib/rucio/gateway/account_limit.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Union
 
 import rucio.common.exception
 import rucio.gateway.permission
-from rucio.common.types import InternalAccount
+from rucio.common.types import InternalAccount, RSEResolvedGlobalAccountLimitDict
 from rucio.common.utils import gateway_update_return_dict
 from rucio.core import account_limit as account_limit_core
 from rucio.core.account import account_exists
@@ -28,7 +28,12 @@ if TYPE_CHECKING:
 
 
 @read_session
-def get_rse_account_usage(rse, vo='def', *, session: "Session"):
+def get_rse_account_usage(
+    rse: str,
+    vo: str = 'def',
+    *,
+    session: "Session"
+) -> list[dict[str, Any]]:
     """
     Returns the account limit and usage for all for all accounts on a RSE.
 
@@ -43,7 +48,12 @@ def get_rse_account_usage(rse, vo='def', *, session: "Session"):
 
 
 @read_session
-def get_local_account_limits(account, vo='def', *, session: "Session"):
+def get_local_account_limits(
+    account: str,
+    vo: str = 'def',
+    *,
+    session: "Session"
+) -> dict[str, Any]:
     """
     Lists the limitation names/values for the specified account name.
 
@@ -65,7 +75,13 @@ def get_local_account_limits(account, vo='def', *, session: "Session"):
 
 
 @read_session
-def get_local_account_limit(account, rse, vo='def', *, session: "Session"):
+def get_local_account_limit(
+    account: str,
+    rse: str,
+    vo: str = 'def',
+    *,
+    session: "Session"
+) -> dict[str, Union[int, float, None]]:
     """
     Lists the limitation names/values for the specified account name and rse name.
 
@@ -86,7 +102,12 @@ def get_local_account_limit(account, rse, vo='def', *, session: "Session"):
 
 
 @read_session
-def get_global_account_limits(account, vo='def', *, session: "Session"):
+def get_global_account_limits(
+    account: str,
+    vo: str = 'def',
+    *,
+    session: "Session"
+) -> dict[str, RSEResolvedGlobalAccountLimitDict]:
     """
     Lists the limitation names/values for the specified account name.
 
@@ -107,7 +128,13 @@ def get_global_account_limits(account, vo='def', *, session: "Session"):
 
 
 @read_session
-def get_global_account_limit(account, rse_expression, vo='def', *, session: "Session"):
+def get_global_account_limit(
+    account: str,
+    rse_expression: str,
+    vo: str = 'def',
+    *,
+    session: "Session"
+) -> dict[str, dict[str, RSEResolvedGlobalAccountLimitDict]]:
     """
     Lists the limitation names/values for the specified account name and rse expression.
 
@@ -127,9 +154,17 @@ def get_global_account_limit(account, rse_expression, vo='def', *, session: "Ses
 
 
 @transactional_session
-def set_local_account_limit(account, rse, bytes_, issuer, vo='def', *, session: "Session"):
+def set_local_account_limit(
+    account: str,
+    rse: str,
+    bytes_: int,
+    issuer: str,
+    vo: str = 'def',
+    *,
+    session: "Session"
+) -> None:
     """
-    Set an account limit..
+    Set an account limit.
 
     :param account: The account name.
     :param rse:     The rse name.
@@ -153,7 +188,15 @@ def set_local_account_limit(account, rse, bytes_, issuer, vo='def', *, session: 
 
 
 @transactional_session
-def set_global_account_limit(account, rse_expression, bytes_, issuer, vo='def', *, session: "Session"):
+def set_global_account_limit(
+    account: str,
+    rse_expression: str,
+    bytes_: int,
+    issuer: str,
+    vo: str = 'def',
+    *,
+    session: "Session"
+) -> None:
     """
     Set a global account limit.
 
@@ -178,9 +221,16 @@ def set_global_account_limit(account, rse_expression, bytes_, issuer, vo='def', 
 
 
 @transactional_session
-def delete_local_account_limit(account, rse, issuer, vo='def', *, session: "Session"):
+def delete_local_account_limit(
+    account: str,
+    rse: str,
+    issuer: str,
+    vo: str = 'def',
+    *,
+    session: "Session"
+) -> bool:
     """
-    Delete an account limit..
+    Delete an account limit.
 
     :param account: The account name.
     :param rse:     The rse name.
@@ -205,7 +255,14 @@ def delete_local_account_limit(account, rse, issuer, vo='def', *, session: "Sess
 
 
 @transactional_session
-def delete_global_account_limit(account, rse_expression, issuer, vo='def', *, session: "Session"):
+def delete_global_account_limit(
+    account: str,
+    rse_expression: str,
+    issuer: str,
+    vo: str = 'def',
+    *,
+    session: "Session"
+) -> bool:
     """
     Delete a global account limit..
 
@@ -231,7 +288,14 @@ def delete_global_account_limit(account, rse_expression, issuer, vo='def', *, se
 
 
 @read_session
-def get_local_account_usage(account, rse, issuer, vo='def', *, session: "Session"):
+def get_local_account_usage(
+    account: str,
+    rse: str,
+    issuer: str,
+    vo: str = 'def',
+    *,
+    session: "Session"
+) -> list[dict[str, Any]]:
     """
     Get the account usage and connect it with (if available) the account limits of the account.
 
@@ -261,7 +325,14 @@ def get_local_account_usage(account, rse, issuer, vo='def', *, session: "Session
 
 
 @read_session
-def get_global_account_usage(account, rse_expression, issuer, vo='def', *, session: "Session"):
+def get_global_account_usage(
+    account: str,
+    rse_expression: str,
+    issuer: str,
+    vo: str = 'def',
+    *,
+    session: "Session"
+) -> list[dict[str, Any]]:
     """
     Get the account usage and connect it with (if available) the account limits of the account.
 


### PR DESCRIPTION
Part of #6588. The `UUID` type hints are changed to `str` per discussion with Dimitrios