### PR TITLE
Core & Internals: Migrate volatile_replica to SQLA20 #6640

### DIFF
--- a/lib/rucio/core/volatile_replica.py
+++ b/lib/rucio/core/volatile_replica.py
@@ -16,9 +16,8 @@ from collections.abc import Iterable
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import and_, exists, insert, or_, update
+from sqlalchemy import and_, delete, exists, insert, or_, select, true, update
 from sqlalchemy.exc import NoResultFound
-from sqlalchemy.sql.expression import select
 
 from rucio.common import exception
 from rucio.core.rse import get_rse_name
@@ -41,7 +40,13 @@ def add_volatile_replicas(rse_id: str, replicas: Iterable[dict[str, Any]], *, se
     """
     # first check that the rse is a volatile one
     try:
-        session.query(models.RSE).filter_by(id=rse_id, volatile=True).one()
+        stmt = select(
+            models.RSE
+        ).where(
+            and_(models.RSE.id == rse_id,
+                 models.RSE.volatile == true())
+        )
+        session.execute(stmt).one()
     except NoResultFound:
         raise exception.UnsupportedOperation('No volatile rse found for %s !'
                                              % get_rse_name(rse_id=rse_id, session=session))
@@ -50,7 +55,7 @@ def add_volatile_replicas(rse_id: str, replicas: Iterable[dict[str, Any]], *, se
     for replica in replicas:
         file_clause.append(and_(models.DataIdentifier.scope == replica['scope'],
                                 models.DataIdentifier.name == replica['name'],
-                                ~exists(select(1).prefix_with("/*+ INDEX(REPLICAS REPLICAS_PK) */", dialect='oracle'))
+                                ~exists(select(1).prefix_with('/*+ INDEX(REPLICAS REPLICAS_PK) */', dialect='oracle'))
                                 .where(and_(models.RSEFileAssociation.scope == replica['scope'],
                                             models.RSEFileAssociation.name == replica['name'],
                                             models.RSEFileAssociation.rse_id == rse_id))))
@@ -59,20 +64,31 @@ def add_volatile_replicas(rse_id: str, replicas: Iterable[dict[str, Any]], *, se
                                    models.RSEFileAssociation.rse_id == rse_id))
     if replica_clause:
         now = datetime.utcnow()
-        stmt = update(models.RSEFileAssociation).\
-            prefix_with("/*+ index(REPLICAS REPLICAS_PK) */", dialect='oracle').\
-            where(or_(*replica_clause)).\
-            execution_options(synchronize_session=False).\
-            values(updated_at=now, tombstone=now)
+        stmt = update(
+            models.RSEFileAssociation
+        ).prefix_with(
+            '/*+ INDEX(REPLICAS REPLICAS_PK) */',
+            dialect='oracle'
+        ).where(
+            or_(*replica_clause)
+        ).execution_options(
+            synchronize_session=False
+        ).values({
+            models.RSEFileAssociation.updated_at: now,
+            models.RSEFileAssociation.tombstone: now
+        })
         session.execute(stmt)
 
     if file_clause:
-        file_query = session.query(models.DataIdentifier.scope,
-                                   models.DataIdentifier.name,
-                                   models.DataIdentifier.bytes,
-                                   models.DataIdentifier.md5,
-                                   models.DataIdentifier.adler32).\
-            filter(or_(*file_clause))
+        stmt = select(
+            models.DataIdentifier.scope,
+            models.DataIdentifier.name,
+            models.DataIdentifier.bytes,
+            models.DataIdentifier.md5,
+            models.DataIdentifier.adler32
+        ).filter(
+            or_(*file_clause)
+        )
 
         new_replicas = [
             {
@@ -86,10 +102,13 @@ def add_volatile_replicas(rse_id: str, replicas: Iterable[dict[str, Any]], *, se
                 'bytes': bytes_,
                 'md5': md5
             }
-            for scope, name, bytes_, md5, adler32 in file_query
+            for scope, name, bytes_, md5, adler32 in session.execute(stmt).all()
         ]
         if new_replicas:
-            session.execute(insert(models.RSEFileAssociation), new_replicas)
+            stmt = insert(
+                models.RSEFileAssociation
+            )
+            session.execute(stmt, new_replicas)
 
 
 @transactional_session
@@ -103,7 +122,13 @@ def delete_volatile_replicas(rse_id: str, replicas: Iterable[dict[str, Any]], *,
     """
     # first check that the rse is a volatile one
     try:
-        session.query(models.RSE).filter_by(id=rse_id, volatile=True).one()
+        stmt = select(
+            models.RSE
+        ).where(
+            and_(models.RSE.id == rse_id,
+                 models.RSE.volatile == true())
+        )
+        session.execute(stmt).one()
     except NoResultFound:
         raise exception.UnsupportedOperation('No volatile rse found for %s !'
                                              % get_rse_name(rse_id=rse_id, session=session))
@@ -114,7 +139,12 @@ def delete_volatile_replicas(rse_id: str, replicas: Iterable[dict[str, Any]], *,
                                models.RSEFileAssociation.name == replica['name']))
 
     if conditions:
-        session.query(models.RSEFileAssociation).\
-            filter(models.RSEFileAssociation.rse_id == rse_id).\
-            filter(or_(*conditions)).\
-            delete(synchronize_session=False)
+        stmt = delete(
+            models.RSEFileAssociation
+        ).where(
+            and_(models.RSEFileAssociation.rse_id == rse_id,
+                 or_(*conditions))
+        ).execution_options(
+            synchronize_session=False
+        )
+        session.execute(stmt)


### PR DESCRIPTION
Part of https://github.com/rucio/rucio/issues/6640

Migrating core/volatile_replica.py to SQLAlchemy 2.0