### PR TITLE
Documentation: Fix filename extension in references to README

### DIFF
--- a/MANIFEST.in.client
+++ b/MANIFEST.in.client
@@ -2,7 +2,7 @@ include MANIFEST.in pylintrc
 include AUTHORS
 include LICENSE
 include ChangeLog
-include README.rst
+include README.md
 include setuputil.py
 include setup.py
 include setup.cfg

--- a/MANIFEST.in.rucio
+++ b/MANIFEST.in.rucio
@@ -2,7 +2,7 @@ include MANIFEST.in pylintrc
 include AUTHORS
 include LICENSE
 include ChangeLog
-include README.rst
+include README.md
 include setuputil.py
 include setup.py
 include setup.cfg

--- a/MANIFEST.in.webui
+++ b/MANIFEST.in.webui
@@ -2,7 +2,7 @@ include MANIFEST.in pylintrc
 include AUTHORS
 include LICENSE
 include ChangeLog
-include README.rst
+include README.md
 include setuputil.py
 include setup.py
 include setup.cfg

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ force-manifest  = 1
 
 [metadata]
 description-file =
-    README.rst
+    README.md
 
 [egg_info]
 tag_build =


### PR DESCRIPTION
#6617 - README.rst was converted to README.md in commit d2d5983, but these files still referenced README.rst. Updated them to the new file extension.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
