### PR TITLE
Remove assert statements outside of tests 

### DIFF
--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -1196,7 +1196,9 @@ def declare_temporary_unavailable_replicas(args):
     else:
         bad_files = args.listbadfiles
 
-    assert args.duration is not None, "Duration should have been set, something went wrong!"
+    if args.duration is None:
+        raise ValueError("Duration should have been set, something went wrong!")
+
     expiration_date = (datetime.datetime.utcnow() + datetime.timedelta(seconds=args.duration)).isoformat()
 
     chunk_size = 10000

--- a/bin/rucio-auditor
+++ b/bin/rucio-auditor
@@ -21,6 +21,7 @@ import signal
 import sys
 import textwrap
 import time
+from configparser import NoSectionError
 from datetime import datetime
 from functools import partial
 from multiprocessing import Event, Pipe, Process, Queue
@@ -29,6 +30,7 @@ import rucio.common.config as config
 import rucio.common.dumper as dumper
 import rucio.daemons.auditor
 from rucio.client.rseclient import RSEClient
+from rucio.common.exception import RSENotFound
 
 
 def setup_pipe_logger(pipe, loglevel):
@@ -48,14 +50,17 @@ def main(args):
     RETRY_AFTER = 60 * 60 * 24 * 14  # Two weeks
 
     nprocs = args.nprocs
-    assert nprocs >= 1
+    if nprocs < 1:
+        raise RuntimeError("No Processes to Run")
+
     if args.rses is None:
         rses_gen = RSEClient().list_rses()
     else:
         rses_gen = RSEClient().list_rses(args.rses)
 
     rses = [entry['rse'] for entry in rses_gen]
-    assert len(rses) > 0
+    if len(rses) <= 0:
+        raise RSENotFound("No RSEs found to audit.")
 
     procs = []
     queue = Queue()
@@ -69,7 +74,9 @@ def main(args):
     logpipes.append(mainlogr)
     logger = setup_pipe_logger(mainlogw, loglevel)
 
-    assert config.config_has_section('auditor')
+    if not config.config_has_section('auditor'):
+        raise NoSectionError("Auditor section required in config to run the auditor daemon.")
+
     cache_dir = config.config_get('auditor', 'cache')
     results_dir = config.config_get('auditor', 'results')
 

--- a/bin/rucio-dumper
+++ b/bin/rucio-dumper
@@ -95,9 +95,10 @@ if __name__ == "__main__":
         record_type = data_models.CompleteDataset
     elif args.subcommand == 'dump-replicas':
         record_type = data_models.Replica
-    else:
-        assert args.subcommand in consistency.subcommands
+    elif args.subcommand in consistency.subcommands:
         record_type = consistency.Consistency
+    else:
+        raise ValueError("Record type not set! Cannot dump files.")
 
     if 'filter' in args and args.filter:
         user_filter = data_models.Filter(args.filter, record_type).match
@@ -113,8 +114,8 @@ if __name__ == "__main__":
     fields = set(record_type.get_fieldnames())
 
     if 'group_by' in args and args.group_by:
-        # FIXME: Better checking
-        assert args.group_by in fields
+        if args.group_by not in fields:
+            raise ValueError("Group_by option %s not supported." % args.group_by)
         fields = [args.group_by]
         data_iter = data
         data_dict = {}
@@ -125,7 +126,8 @@ if __name__ == "__main__":
             data_dict[key].append(record)
 
         if 'sum' in args and args.sum:
-            assert args.sum in set(record_type.get_fieldnames())
+            if args.sum not in set(record_type.get_fieldnames()):
+                raise ValueError("Sum option %s for record type %s not supported.\nChoice from %s" % (args.sum, args.record_type, set(record_type.get_fieldnames())))
             fields.append(args.sum)
             data = []
             for key, value in data_dict.items():

--- a/lib/rucio/client/lockclient.py
+++ b/lib/rucio/client/lockclient.py
@@ -69,8 +69,8 @@ class LockClient(BaseClient):
         """
 
         # convert did list to list of dictionaries
-
-        assert all(did.get("type", "dataset") in ("dataset", "container") for did in dids), "did type can be either 'container' or 'dataset'"
+        if not all(did.get("type", "dataset") in ("dataset", "container") for did in dids):
+            raise ValueError("DID type can be either 'container' or 'dataset'")
 
         path = '/'.join([self.LOCKS_BASEURL, "bulk_locks_for_dids"])
         url = build_url(choice(self.list_hosts), path=path)

--- a/lib/rucio/common/dumper/__init__.py
+++ b/lib/rucio/common/dumper/__init__.py
@@ -81,7 +81,8 @@ def mkdir(dir_: "StrOrBytesPath") -> None:
     try:
         os.mkdir(dir_)
     except OSError as error:
-        assert error.errno == 17  # noqa: S101
+        if error.errno != 17:
+            raise error
 
 
 def cacert_config(config: "ModuleType", rucio_home: str) -> Optional[Union["FileDescriptorOrPath", Literal[False]]]:

--- a/lib/rucio/common/dumper/__init__.py
+++ b/lib/rucio/common/dumper/__init__.py
@@ -81,7 +81,7 @@ def mkdir(dir_: "StrOrBytesPath") -> None:
     try:
         os.mkdir(dir_)
     except OSError as error:
-        assert error.errno == 17
+        assert error.errno == 17  # noqa: S101
 
 
 def cacert_config(config: "ModuleType", rucio_home: str) -> Optional[Union["FileDescriptorOrPath", Literal[False]]]:

--- a/lib/rucio/common/dumper/consistency.py
+++ b/lib/rucio/common/dumper/consistency.py
@@ -42,7 +42,7 @@ class Consistency(data_models.DataModel):
             next_date_fname = data_models.Replica.download(
                 ddm_endpoint, next_date, cache_dir=cache_dir)
             if (prev_date_fname is None) or (next_date_fname is None):
-                raise ValueError("Both prev_data_fname and next_date_fname are required for subcommand='consistency'")
+                raise ValueError("Both prev_date_fname and next_date_fname are required for subcommand='consistency'; found prev_data_fname=%s and next_date_fname=%s" % (prev_date_fname, next_date_fname))
         elif subcommand == 'consistency-manual':
             pass
         else:
@@ -168,8 +168,8 @@ def min3(*values):
     Minimum between the 3 values ignoring None
     '''
     values = [value for value in values if value is not None]
-    if len(values) <= 0:
-        raise ValueError("Not enough values to sort.")  # Need a better error message, but this function doesn't have a lot of info.
+    if len(values) == 0:
+        raise ValueError("Input contains 0 non-null values.")
     return min(values)
 
 
@@ -304,7 +304,7 @@ def gnu_sort(file_path, prefix=None, delimiter=None, fieldspec=None, cache_dir=D
     memory and it is relatively fast if used with the environment variable
     LC_ALL set to C as in this function.
     '''
-    if (delimiter is None and fieldspec is not None) or (delimiter is not None and fieldspec is None):
+    if (delimiter is not None) ^ (fieldspec is not None):
         raise ValueError("Either both delimiter and fieldspec is set, or neither are.")
     if delimiter is None:
         cmd_line = 'LC_ALL=C sort {0} > {1}'
@@ -392,8 +392,12 @@ def _parse_args_consistency(args):
         error('The storage dump filename must be of the form '
               '"dump_YYYYMMDD" where the date correspond to the date '
               'of the newest files included')
+
+    date_str = date_str.group(1)
+    if date_str is None:
+        error('Invalid date {0}'.format(date_str))
     try:
-        args_dict['date'] = date = datetime.datetime.strptime(date_str.group(1), '%Y%m%d')
+        args_dict['date'] = date = datetime.datetime.strptime(date_str, '%Y%m%d')
     except ValueError:
         error('Invalid date {0}'.format(date_str))
 

--- a/lib/rucio/common/dumper/data_models.py
+++ b/lib/rucio/common/dumper/data_models.py
@@ -232,9 +232,9 @@ class CompleteDataset(DataModel):
         if len(args) == 8:
             logger.warning('Extra parameter\nrse: %s\ndataset: %s\n', self.rse, self.name)
             self.state = args[7]
-        elif len(args) <= 8:
-            self.state = None
         else:
+            self.state = None
+        if len(args) > 8:
             raise ValueError("Too many arguments, must be 8 or less. Instead passed %s" % len(args))
 
 
@@ -262,9 +262,7 @@ class Replica(DataModel):
 
         if len(args) == 8:
             logger.warning('Missing parameter\nrse: %s\ndataset: %s\n', self.rse, self.name)
-        elif len(args) <= 9:
-            pass
-        else:
+        elif len(args) > 9:
             raise ValueError("Too many arguments. Must be 9 or less, instead passed %s" % len(args))
 
 

--- a/lib/rucio/common/dumper/data_models.py
+++ b/lib/rucio/common/dumper/data_models.py
@@ -150,20 +150,17 @@ class DataModel:
         logger = logging.getLogger('auditor.data_models')
         requests_session = get_requests_session()
         if date == 'latest':
-            url = ''.join((cls.BASE_URL, cls.URI, '?rse={0}'.format(rse)))
+            url = ''.join((cls.BASE_URL, cls.URI, '?rse={0}'.format(rse)))  # type: ignore
             request_headers = requests_session.head(url)
             for field in request_headers.headers['content-disposition'].split(';'):
                 if field.startswith('filename='):
                     date = field.split('=')[1].split('_')[-1].split('.')[0]
 
+        elif isinstance(date, datetime.datetime):
+            date = date.strftime('%d-%m-%Y')
+            url = ''.join((cls.BASE_URL, cls.URI, '?rse={0}&date={1}'.format(rse, date)))  # type: ignore
         else:
-            assert isinstance(date, datetime.datetime)
-            date = date.strftime('%d-%m-%Y')  # pylint: disable=no-member
-            url = ''.join((
-                cls.BASE_URL,
-                cls.URI,
-                '?rse={0}&date={1}'.format(rse, date),
-            ))
+            raise ValueError("Passed date (%s) must be a datetime object or 'latest'." % date)
 
         if not os.path.isdir(cache_dir):
             os.mkdir(cache_dir)
@@ -235,9 +232,10 @@ class CompleteDataset(DataModel):
         if len(args) == 8:
             logger.warning('Extra parameter\nrse: %s\ndataset: %s\n', self.rse, self.name)
             self.state = args[7]
-        else:
+        elif len(args) <= 8:
             self.state = None
-        assert len(args) <= 8
+        else:
+            raise ValueError("Too many arguments, must be 8 or less. Instead passed %s" % len(args))
 
 
 class Replica(DataModel):
@@ -264,7 +262,10 @@ class Replica(DataModel):
 
         if len(args) == 8:
             logger.warning('Missing parameter\nrse: %s\ndataset: %s\n', self.rse, self.name)
-        assert len(args) <= 9
+        elif len(args) <= 9:
+            pass
+        else:
+            raise ValueError("Too many arguments. Must be 9 or less, instead passed %s" % len(args))
 
 
 class Filter:
@@ -292,7 +293,8 @@ class Filter:
         for expr in filter_str.split(','):
             key, expected = expr.split('=')
             # Better checks required
-            assert key in record_class.get_fieldnames()
+            if key not in record_class.get_fieldnames():
+                raise ValueError("Key %s not supported." % key)
             parser = list(filter(lambda t: t[0] == key, record_class.SCHEMA))[0][1]
             self.conditions.append(self._Condition(
                 comparator=operator.eq,

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1941,7 +1941,8 @@ class StoreAndDeprecateWarningAction(argparse.Action):
             option_strings=option_strings,
             dest=dest,
             **kwargs)
-        assert new_option_string in option_strings
+        if new_option_string not in option_strings:
+            raise ValueError("%s not supported as a string option." % new_option_string)
         self.new_option_string = new_option_string
 
     def __call__(self, parser, namespace, values, option_string: Optional[str] = None):
@@ -1979,7 +1980,8 @@ class StoreTrueAndDeprecateWarningAction(argparse._StoreConstAction):
             default=default,
             required=required,
             help=help)
-        assert new_option_string in option_strings
+        if new_option_string not in option_strings:
+            raise ValueError("%s not supported as a string option." % new_option_string)
         self.new_option_string = new_option_string
 
     def __call__(self, parser, namespace, values, option_string: Optional[str] = None):

--- a/lib/rucio/core/lock.py
+++ b/lib/rucio/core/lock.py
@@ -113,7 +113,7 @@ def get_dataset_locks_bulk(dids: Iterable[dict[str, Any]], *, session: "Session"
 @stream_session
 def get_dataset_locks_by_rse_id(rse_id: str, *, session: "Session") -> Iterator[dict[str, Any]]:
     """
-    Get the dataset locks of an RSE.l   r
+    Get the dataset locks of an RSE.
 
     :param rse_id:         RSE id to get the locks from.
     :param session:        The db session.

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -103,6 +103,7 @@ def _token_cache_get(
             METRICS.counter('token_cache.invalid').inc()
             return None
     else:
+        METRICS.counter('token_cache.invalid').inc()
         return None
 
     now = datetime.utcnow().timestamp()

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -96,11 +96,13 @@ def _token_cache_get(
         METRICS.counter('token_cache.miss').inc()
         return None
 
-    try:
-        assert isinstance(value, str)
-        payload = JWT().unpack(value).payload()
-    except Exception:
-        METRICS.counter('token_cache.invalid').inc()
+    if isinstance(value, str):
+        try:
+            payload = JWT().unpack(value).payload()
+        except Exception:
+            METRICS.counter('token_cache.invalid').inc()
+            return None
+    else:
         return None
 
     now = datetime.utcnow().timestamp()

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -86,7 +86,7 @@ def mkdir(dir_: str) -> None:
     try:
         os.mkdir(dir_)
     except OSError as e:
-        assert e.errno == 17
+        assert e.errno == 17  # noqa: S101
 
 
 def get_newest(

--- a/lib/rucio/daemons/auditor/srmdumps.py
+++ b/lib/rucio/daemons/auditor/srmdumps.py
@@ -85,8 +85,9 @@ def mkdir(dir_: str) -> None:
     '''
     try:
         os.mkdir(dir_)
-    except OSError as e:
-        assert e.errno == 17  # noqa: S101
+    except OSError as error:
+        if error.errno != 17:
+            raise error
 
 
 def get_newest(

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -273,6 +273,8 @@ def get_maker() -> sessionmaker:
         May assign __MAKER if not already assigned.
     """
     global _MAKER, _ENGINE
+    if not _ENGINE:
+        raise RuntimeError("Could not form database engine.")
     if not _MAKER:
         # turn on sqlAlchemy 2.0 with future=True.
         _MAKER = sessionmaker(bind=_ENGINE, autocommit=False, autoflush=True, expire_on_commit=True, future=True)
@@ -292,7 +294,7 @@ def get_session() -> scoped_session:
         finally:
             _LOCK.release()
     if not _MAKER:
-        raise RuntimeError("Database schema not in place, cannot make session.")
+        raise RuntimeError("Session factory is not defined.")
     session = scoped_session(_MAKER)
     return session
 

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -234,7 +234,8 @@ def get_engine() -> 'Engine':
             event.listen(_ENGINE, 'connect', _fk_pragma_on_connect)
         elif 'oracle' in sql_connection:
             event.listen(_ENGINE, 'connect', my_on_connect)
-    assert _ENGINE
+    if not _ENGINE:
+        raise RuntimeError("Could not form database engine.")
     return _ENGINE
 
 
@@ -272,7 +273,6 @@ def get_maker() -> sessionmaker:
         May assign __MAKER if not already assigned.
     """
     global _MAKER, _ENGINE
-    assert _ENGINE
     if not _MAKER:
         # turn on sqlAlchemy 2.0 with future=True.
         _MAKER = sessionmaker(bind=_ENGINE, autocommit=False, autoflush=True, expire_on_commit=True, future=True)
@@ -291,7 +291,8 @@ def get_session() -> scoped_session:
             get_maker()
         finally:
             _LOCK.release()
-    assert _MAKER
+    if not _MAKER:
+        raise RuntimeError("Database schema not in place, cannot make session.")
     session = scoped_session(_MAKER)
     return session
 

--- a/lib/rucio/db/sqla/util.py
+++ b/lib/rucio/db/sqla/util.py
@@ -125,7 +125,8 @@ def drop_everything() -> None:
             conn.execute(DropSchema(schema, cascade=True))
 
         if engine.dialect.name == 'postgresql':
-            assert isinstance(inspector, PGInspector), 'expected a PGInspector'
+            if not isinstance(inspector, PGInspector):
+                raise ValueError('expected a PGInspector')
             for enum in inspector.get_enums(schema='*'):
                 sqlalchemy.Enum(**enum).drop(bind=conn)
 
@@ -313,7 +314,8 @@ def try_drop_constraint(constraint_name: str, table_name: str) -> None:
     try:
         op.drop_constraint(constraint_name, table_name)
     except DatabaseError as e:
-        assert 'nonexistent constraint' in str(e)
+        if 'nonexistent constraint' not in str(e):
+            raise DatabaseError(e)
 
 
 def list_oracle_global_temp_tables(session: "Session") -> list[str]:

--- a/lib/rucio/db/sqla/util.py
+++ b/lib/rucio/db/sqla/util.py
@@ -315,7 +315,7 @@ def try_drop_constraint(constraint_name: str, table_name: str) -> None:
         op.drop_constraint(constraint_name, table_name)
     except DatabaseError as e:
         if 'nonexistent constraint' not in str(e):
-            raise DatabaseError(e)
+            raise RuntimeError(e)
 
 
 def list_oracle_global_temp_tables(session: "Session") -> list[str]:

--- a/lib/rucio/transfertool/fts3_plugins.py
+++ b/lib/rucio/transfertool/fts3_plugins.py
@@ -119,13 +119,14 @@ class FTS3TapeMetadataPlugin(PolicyPackageAlgorithms):
         """Check the to-be-submitted file transfer params are both json encodable and under the size limit for transfer"""
         try:
             hints_json = json.dumps(hint_dict)
-            assert sys.getsizeof(hints_json) < self.transfer_limit
+            in_tranfer_limit = sys.getsizeof(hints_json) < self.transfer_limit
 
         except TypeError as e:
             raise InvalidRequest("Request malformed, cannot encode to JSON", e)
-        except AssertionError as e:
+
+        if not in_tranfer_limit:
             raise InvalidRequest(
-                f"Request too large, decrease to less than {self.transfer_limit}", e
+                f"Request too large, decrease to less than {self.transfer_limit}"
             )
 
     def hints(self, hint_kwargs: dict) -> dict[str, Any]:

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -453,10 +453,11 @@ class Attachments(ErrorHandlingMethodView):
         if isinstance(parameters, list):
             attachments = parameters
             ignore_duplicate = False
-        else:
-            assert isinstance(parameters, dict)
+        elif isinstance(parameters, dict):
             attachments = param_get(parameters, 'attachments')
             ignore_duplicate = param_get(parameters, 'ignore_duplicate', default=False)
+        else:
+            return generate_http_error_flask(406, exc="Invalid attachment format.")
 
         try:
             attach_dids_to_dids(attachments=attachments, ignore_duplicate=ignore_duplicate, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))


### PR DESCRIPTION
Addresses #6680 

Removes asserts through a combination of swapping asserts to more verbose errors, minor refactors to avoid them in the first place, and manually ignoring the linter. 