### PR TITLE
Database: Update psycopg2-binary intp psycopg3 #6669

### DIFF
--- a/etc/docker/test/extra/rucio_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_postgres14.cfg
@@ -1,5 +1,5 @@
 [database]
-default = postgres://rucio:rucio@postgres14/rucio
+default = postgresql+psycopg://rucio:rucio@postgres14/rucio
 schema = dev
 pool_size = 20
 max_overflow = 20

--- a/etc/docker/test/extra/rucio_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_postgres14.cfg
@@ -1,5 +1,5 @@
 [database]
-default = postgresql://rucio:rucio@postgres14/rucio
-schema=dev
+default = postgres://rucio:rucio@postgres14/rucio
+schema = dev
 pool_size = 20
 max_overflow = 20

--- a/lib/rucio/core/did_meta_plugins/postgres_meta.py
+++ b/lib/rucio/core/did_meta_plugins/postgres_meta.py
@@ -80,6 +80,9 @@ class ExternalPostgresJSONDidMeta(DidMetaPlugin):
             user=user,
             password=password)
 
+        # makes Rucio receive Decimal from Postgres as float
+        self.client.adapters.register_loader("numeric", psycopg.types.numeric.FloatLoader)
+
         # set search_path to include database schema by default
         cur = self.client.cursor()
         cur.execute("SET search_path TO %s", db_schema)

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -149,26 +149,6 @@ def mysql_convert_decimal_to_float(
     return converter
 
 
-def psql_convert_decimal_to_float(dbapi_conn, connection_rec) -> None:
-    """
-    The default datatype returned by psycopg2 for numerics is decimal.Decimal.
-    This type cannot be serialised to JSON, therefore we need to autoconvert to floats.
-
-    :param dbapi_conn: DBAPI connection
-    :param connection_rec: connection record
-    """
-
-    try:
-        import psycopg2.extensions  # pylint: disable=import-error
-    except:
-        raise RucioException('Trying to use PostgreSQL without psycopg2 or psycopg2-binary installed!')
-
-    DEC2FLOAT = psycopg2.extensions.new_type(psycopg2.extensions.DECIMAL.values,
-                                             'DEC2FLOAT',
-                                             lambda value, curs: float(value) if value is not None else None)
-    psycopg2.extensions.register_type(DEC2FLOAT)
-
-
 def my_on_connect(dbapi_con, connection_record) -> None:
     """ Adds information to track performance and resource by module.
         Info are recorded in the V$SESSION and V$SQLAREA views.
@@ -228,8 +208,6 @@ def get_engine() -> 'Engine':
         _ENGINE = create_engine(sql_connection, future=True, **params)
         if 'mysql' in sql_connection:
             event.listen(_ENGINE, 'checkout', mysql_ping_listener)
-        elif 'postgresql' in sql_connection:
-            event.listen(_ENGINE, 'connect', psql_convert_decimal_to_float)
         elif 'sqlite' in sql_connection:
             event.listen(_ENGINE, 'connect', _fk_pragma_on_connect)
         elif 'oracle' in sql_connection:

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -292,7 +292,7 @@ pluggy==1.5.0
     # via pytest
 prometheus-client==0.20.0
     # via -r requirements.server.txt
-psycopg2-binary==2.9.9
+psycopg==3.2.1
     # via -r requirements.server.txt
 pyasn1==0.6.0
     # via

--- a/requirements/requirements.server.in
+++ b/requirements/requirements.server.in
@@ -29,7 +29,7 @@ python-swiftclient==4.6.0                                   # swift_extras
 argcomplete==3.4.0                                          # argcomplete_extras; Bash tab completion for argparse
 python-magic==0.4.27                                        # dumper_extras; File type identification using libmagic
 cx_oracle==8.3.0                                            # oracle_extras
-psycopg==3.2.1                                              # postgresql
+psycopg[binary,pool]==3.2.1                                 # postgresql
 PyMySQL==1.1.1                                              # mysql_extras
 PyYAML==6.0.1                                               # globus_extras and used for reading test configuration files
 globus-sdk==3.41.0                                          # globus_extras

--- a/requirements/requirements.server.in
+++ b/requirements/requirements.server.in
@@ -29,7 +29,7 @@ python-swiftclient==4.6.0                                   # swift_extras
 argcomplete==3.4.0                                          # argcomplete_extras; Bash tab completion for argparse
 python-magic==0.4.27                                        # dumper_extras; File type identification using libmagic
 cx_oracle==8.3.0                                            # oracle_extras
-psycopg2-binary==2.9.9                                      # postgresql_extras
+psycopg==3.2.1                                              # postgresql
 PyMySQL==1.1.1                                              # mysql_extras
 PyYAML==6.0.1                                               # globus_extras and used for reading test configuration files
 globus-sdk==3.41.0                                          # globus_extras

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -140,7 +140,7 @@ pbr==6.0.0
     # via stevedore
 prometheus-client==0.20.0
     # via -r requirements.server.in
-psycopg2-binary==2.9.9
+psycopg==3.2.1
     # via -r requirements.server.in
 pyasn1==0.6.0
     # via

--- a/setuputil.py
+++ b/setuputil.py
@@ -83,7 +83,7 @@ server_requirements_table = {
     ],
     'oracle': ['cx_oracle'],
     'mongo': ['pymongo'],
-    'postgresql': ['psycopg2-binary'],
+    'postgresql': ['psycopg'],
     'mysql': ['PyMySQL'],
     'kerberos': [
         'kerberos',

--- a/setuputil.py
+++ b/setuputil.py
@@ -83,7 +83,7 @@ server_requirements_table = {
     ],
     'oracle': ['cx_oracle'],
     'mongo': ['pymongo'],
-    'postgresql': ['psycopg'],
+    'postgresql': ['psycopg[binary]'],
     'mysql': ['PyMySQL'],
     'kerberos': [
         'kerberos',

--- a/setuputil.py
+++ b/setuputil.py
@@ -83,7 +83,7 @@ server_requirements_table = {
     ],
     'oracle': ['cx_oracle'],
     'mongo': ['pymongo'],
-    'postgresql': ['psycopg[binary]'],
+    'postgresql': ['psycopg[binary,pool]'],
     'mysql': ['PyMySQL'],
     'kerberos': [
         'kerberos',


### PR DESCRIPTION
This PR aims at upgrading all the calls to psycopg2 functions into psycopg3 ones. 
Three changes are done here. Each one have an independent commit:

1. Update the function calls in "core/did_meta_plugins/postgres_meta.py"
2. Remove the custom type caster from postgres' DECIMAL into Python's float as it is built-in psycopg3
3. Update the requirements setup

N.B. Some tests in this PR are failing because the containers used in the tests install `psycopg2-binary` and don't have `psycopg` (package name for psycopg3)
