### PR TITLE
Policies: allow permission checks to optionally return message #6580

### DIFF
--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -103,13 +103,31 @@ def load_permission_for_vo(vo: str) -> None:
     permission_modules[vo] = module
 
 
+class PermissionResult:
+    """
+    Represents the result of a permission check, allowing an optional message to be
+    included to give the user more information.
+    """
+    def __init__(self, allowed: bool, message: "Optional[str]" = "") -> None:
+        self.allowed = allowed
+        self.message = message
+
+    # allow this to be tested as a bool for backwards compatibility
+    def __bool__(self) -> bool:
+        return self.allowed
+
+
 def has_permission(
         issuer: "InternalAccount",
         action: str,
         kwargs: dict[str, Any],
         *,
         session: "Optional[Session]" = None
-) -> bool:
+) -> PermissionResult:
     if issuer.vo not in permission_modules:
         load_permission_for_vo(issuer.vo)
-    return permission_modules[issuer.vo].has_permission(issuer, action, kwargs, session=session)
+    result = permission_modules[issuer.vo].has_permission(issuer, action, kwargs, session=session)
+    # continue to support policy packages that just return a boolean and no message
+    if isinstance(result, bool):
+        result = PermissionResult(result)
+    return result

--- a/lib/rucio/gateway/account.py
+++ b/lib/rucio/gateway/account.py
@@ -59,8 +59,9 @@ def add_account(
     validate_schema(name='account', obj=account, vo=vo)
 
     kwargs = {'account': account, 'type': type_}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='add_account', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not add account' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='add_account', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not add account. %s' % (issuer, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 
@@ -85,8 +86,9 @@ def del_account(
 
     """
     kwargs = {'account': account}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='del_account', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not delete account' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='del_account', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not delete account. %s' % (issuer, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 
@@ -137,8 +139,9 @@ def update_account(
     """
     validate_schema(name='account', obj=account, vo=vo)
     kwargs = {}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='update_account', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not change %s  of the account' % (issuer, key))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='update_account', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not change %s  of the account. %s' % (issuer, key, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 
@@ -254,8 +257,9 @@ def add_account_attribute(
     validate_schema(name='account_attribute', obj=value, vo=vo)
 
     kwargs = {'account': account, 'key': key, 'value': value}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='add_attribute', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not add attributes' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='add_attribute', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not add attributes. %s' % (issuer, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 
@@ -281,8 +285,9 @@ def del_account_attribute(
     :param session: The database session in use.
     """
     kwargs = {'account': account, 'key': key}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='del_attribute', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not delete attribute' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='del_attribute', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not delete attribute. %s' % (issuer, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 

--- a/lib/rucio/gateway/account_limit.py
+++ b/lib/rucio/gateway/account_limit.py
@@ -141,8 +141,9 @@ def set_local_account_limit(account, rse, bytes_, issuer, vo='def', *, session: 
     rse_id = get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'account': account, 'rse': rse, 'rse_id': rse_id, 'bytes': bytes_}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_local_account_limit', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not set account limits.' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_local_account_limit', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not set account limits. %s' % (issuer, auth_result.message))
 
     account = InternalAccount(account, vo=vo)
 
@@ -166,8 +167,9 @@ def set_global_account_limit(account, rse_expression, bytes_, issuer, vo='def', 
     """
 
     kwargs = {'account': account, 'rse_expression': rse_expression, 'bytes': bytes_}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_global_account_limit', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not set account limits.' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_global_account_limit', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not set account limits. %s' % (issuer, auth_result.message))
 
     account = InternalAccount(account, vo=vo)
 
@@ -193,8 +195,9 @@ def delete_local_account_limit(account, rse, issuer, vo='def', *, session: "Sess
 
     rse_id = get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'account': account, 'rse': rse, 'rse_id': rse_id}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='delete_local_account_limit', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not delete account limits.' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='delete_local_account_limit', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not delete account limits. %s' % (issuer, auth_result.message))
 
     account = InternalAccount(account, vo=vo)
 
@@ -219,8 +222,9 @@ def delete_global_account_limit(account, rse_expression, issuer, vo='def', *, se
     """
 
     kwargs = {'account': account, 'rse_expression': rse_expression}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='delete_global_account_limit', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not delete global account limits.' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='delete_global_account_limit', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not delete global account limits. %s' % (issuer, auth_result.message))
 
     account = InternalAccount(account, vo=vo)
 
@@ -249,8 +253,9 @@ def get_local_account_usage(account, rse, issuer, vo='def', *, session: "Session
     if rse:
         rse_id = get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'account': account, 'rse': rse, 'rse_id': rse_id}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='get_local_account_usage', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not list account usage.' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='get_local_account_usage', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not list account usage. %s' % (issuer, auth_result.message))
 
     account = InternalAccount(account, vo=vo)
 
@@ -275,8 +280,9 @@ def get_global_account_usage(account, rse_expression, issuer, vo='def', *, sessi
     """
 
     kwargs = {'account': account, 'rse_expression': rse_expression}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='get_global_account_usage', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not list global account usage.' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='get_global_account_usage', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not list global account usage. %s' % (issuer, auth_result.message))
 
     account = InternalAccount(account, vo=vo)
 

--- a/lib/rucio/gateway/authentication.py
+++ b/lib/rucio/gateway/authentication.py
@@ -170,8 +170,9 @@ def get_auth_token_user_pass(
     """
 
     kwargs = {'account': account, 'username': username, 'password': password}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_user_pass', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('User with identity %s can not log to account %s' % (username, account))
+    auth_result = permission.has_permission(issuer=account, vo=vo, action='get_auth_token_user_pass', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('User with identity %s can not log to account %s. %s' % (username, account, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 
@@ -204,8 +205,9 @@ def get_auth_token_gss(
     """
 
     kwargs = {'account': account, 'gsscred': gsscred}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_gss', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('User with identity %s can not log to account %s' % (gsscred, account))
+    auth_result = permission.has_permission(issuer=account, vo=vo, action='get_auth_token_gss', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('User with identity %s can not log to account %s. %s' % (gsscred, account, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 
@@ -241,8 +243,9 @@ def get_auth_token_x509(
         account = identity.get_default_account(dn, IdentityType.X509).external
 
     kwargs = {'account': account, 'dn': dn}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_x509', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('User with identity %s can not log to account %s' % (dn, account))
+    auth_result = permission.has_permission(issuer=account, vo=vo, action='get_auth_token_x509', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('User with identity %s can not log to account %s. %s' % (dn, account, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 
@@ -275,8 +278,9 @@ def get_auth_token_ssh(
     """
 
     kwargs = {'account': account, 'signature': signature}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_ssh', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('User with provided signature can not log to account %s' % account)
+    auth_result = permission.has_permission(issuer=account, vo=vo, action='get_auth_token_ssh', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('User with provided signature can not log to account %s. %s' % (account, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 
@@ -307,8 +311,9 @@ def get_ssh_challenge_token(
     """
 
     kwargs = {'account': account}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_ssh', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('User can not get challenge token for account %s' % account)
+    auth_result = permission.has_permission(issuer=account, vo=vo, action='get_auth_token_ssh', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('User can not get challenge token for account %s. %s' % (account, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 
@@ -340,8 +345,9 @@ def get_auth_token_saml(
     """
 
     kwargs = {'account': account, 'saml_nameid': saml_nameid}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_auth_token_saml', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('User with identity %s can not log to account %s' % (saml_nameid, account))
+    auth_result = permission.has_permission(issuer=account, vo=vo, action='get_auth_token_saml', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('User with identity %s can not log to account %s. %s' % (saml_nameid, account, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 

--- a/lib/rucio/gateway/config.py
+++ b/lib/rucio/gateway/config.py
@@ -43,8 +43,9 @@ def sections(issuer: Optional[str] = None, vo: str = 'def', *, session: "Session
     """
 
     kwargs = {'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_sections', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot retrieve sections' % issuer)
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='config_sections', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot retrieve sections. %s' % (issuer, auth_result.message))
     return config.sections(session=session)
 
 
@@ -60,8 +61,9 @@ def add_section(section: str, issuer: Optional[str] = None, vo: str = 'def', *, 
     """
 
     kwargs = {'issuer': issuer, 'section': section}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_add_section', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot add section %s' % (issuer, section))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='config_add_section', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot add section %s. %s' % (issuer, section, auth_result.message))
     return config.add_section(section, session=session)
 
 
@@ -78,8 +80,9 @@ def has_section(section: str, issuer: Optional[str] = None, vo: str = 'def', *, 
     """
 
     kwargs = {'issuer': issuer, 'section': section}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_has_section', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot check existence of section %s' % (issuer, section))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='config_has_section', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot check existence of section %s. %s' % (issuer, section, auth_result.message))
     return config.has_section(section, session=session)
 
 
@@ -96,8 +99,9 @@ def options(section: str, issuer: Optional[str] = None, vo: str = 'def', *, sess
     """
 
     kwargs = {'issuer': issuer, 'section': section}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_options', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot retrieve options from section %s' % (issuer, section))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='config_options', kwargs=kwargs, session=session)
+    if auth_result.allowed:
+        raise exception.AccessDenied('%s cannot retrieve options from section %s. %s' % (issuer, section, auth_result.message))
     return config.options(section, session=session)
 
 
@@ -115,8 +119,9 @@ def has_option(section: str, option: str, issuer: Optional[str] = None, vo: str 
     """
 
     kwargs = {'issuer': issuer, 'section': section, 'option': option}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_has_option', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot check existence of option %s from section %s' % (issuer, option, section))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='config_has_option', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot check existence of option %s from section %s. %s' % (issuer, option, section, auth_result.message))
     return config.has_option(section, option, session=session)
 
 
@@ -137,8 +142,9 @@ def get(section: str, option: str, issuer: Optional[str] = None, vo: str = 'def'
     """
 
     kwargs = {'issuer': issuer, 'section': section, 'option': option}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_get', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot retrieve option %s from section %s' % (issuer, option, section))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='config_get', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot retrieve option %s from section %s. %s' % (issuer, option, section, auth_result.message))
     return config.get(section, option, session=session, convert_type_fnc=convert_to_any_type)
 
 
@@ -156,8 +162,9 @@ def items(section: str, issuer: Optional[str] = None, vo: str = 'def', *, sessio
     """
 
     kwargs = {'issuer': issuer, 'section': section}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_items', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot retrieve options and values from section %s' % (issuer, section))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='config_items', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot retrieve options and values from section %s. %s' % (issuer, section, auth_result.message))
     return config.items(section, session=session, convert_type_fnc=convert_to_any_type)
 
 
@@ -175,8 +182,9 @@ def set(section: str, option: str, value: Any, issuer: Optional[str] = None, vo:
     """
 
     kwargs = {'issuer': issuer, 'section': section, 'option': option, 'value': value}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_set', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot set option %s to %s in section %s' % (issuer, option, value, section))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='config_set', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot set option %s to %s in section %s. %s' % (issuer, option, value, section, auth_result.message))
     return config.set(section, option, value, session=session)
 
 
@@ -193,8 +201,9 @@ def remove_section(section: str, issuer: Optional[str] = None, vo: str = 'def', 
     """
 
     kwargs = {'issuer': issuer, 'section': section}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_remove_section', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot remove section %s' % (issuer, section))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='config_remove_section', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot remove section %s. %s' % (issuer, section, auth_result.message))
     return config.remove_section(section, session=session)
 
 
@@ -212,6 +221,7 @@ def remove_option(section: str, option: str, issuer: Optional[str] = None, vo: s
     """
 
     kwargs = {'issuer': issuer, 'section': section, 'option': option}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='config_remove_option', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot remove option %s from section %s' % (issuer, option, section))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='config_remove_option', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot remove option %s from section %s. %s' % (issuer, option, section, auth_result.message))
     return config.remove_option(section, option, session=session)

--- a/lib/rucio/gateway/credential.py
+++ b/lib/rucio/gateway/credential.py
@@ -57,13 +57,10 @@ def get_signed_url(
     """
 
     kwargs = {'account': account}
-    if not permission.has_permission(issuer=account, vo=vo, action='get_signed_url', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not get signed URL for rse=%s, service=%s, operation=%s, url=%s, lifetime=%s' % (account,
-                                                                                                                                      rse,
-                                                                                                                                      service,
-                                                                                                                                      operation,
-                                                                                                                                      url,
-                                                                                                                                      lifetime))
+    auth_result = permission.has_permission(issuer=account, vo=vo, action='get_signed_url', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not get signed URL for rse=%s, service=%s, operation=%s, url=%s, lifetime=%s. %s' %
+                                     (account, rse, service, operation, url, lifetime, auth_result.message))
 
     # look up RSE ID for name
     rse_id = get_rse_id(rse, vo=vo, session=session)

--- a/lib/rucio/gateway/did.py
+++ b/lib/rucio/gateway/did.py
@@ -119,8 +119,9 @@ def add_did(
     validate_schema(name='dids', obj=dids, vo=vo)
     validate_schema(name='rse', obj=rse, vo=vo)
     kwargs = {'scope': scope, 'name': name, 'type': did_type, 'issuer': issuer, 'account': account, 'statuses': statuses, 'meta': meta, 'rules': rules, 'lifetime': lifetime}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='add_did', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not add data identifier to scope %s' % (issuer, scope))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='add_did', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not add data identifier to scope %s. %s' % (issuer, scope, auth_result.message))
 
     owner_account = None if account is None else InternalAccount(account, vo=vo)
     issuer_account = InternalAccount(issuer, vo=vo)
@@ -178,8 +179,9 @@ def add_dids(
             d['rse_id'] = rse_id
 
     kwargs = {'issuer': issuer, 'dids': dids}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='add_dids', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not bulk add data identifier' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='add_dids', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not bulk add data identifier. %s' % (issuer, auth_result.message))
 
     issuer_account = InternalAccount(issuer, vo=vo)
     for d in dids:
@@ -219,8 +221,9 @@ def attach_dids(
         attachment['rse_id'] = rse_id
 
     kwargs = {'scope': scope, 'name': name, 'attachment': attachment}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='attach_dids', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not add data identifiers to %s:%s' % (issuer, scope, name))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='attach_dids', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not add data identifiers to %s:%s. %s' % (issuer, scope, name, auth_result.message))
 
     internal_scope = InternalScope(scope, vo=vo)
     issuer_account = InternalAccount(issuer, vo=vo)
@@ -268,8 +271,9 @@ def attach_dids_to_dids(
                 rse_id = get_rse_id(rse=a['rse'], vo=vo, session=session)
             a['rse_id'] = rse_id
 
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='attach_dids_to_dids', kwargs={'attachments': attachments}, session=session):
-        raise AccessDenied('Account %s can not add data identifiers' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='attach_dids_to_dids', kwargs={'attachments': attachments}, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not add data identifiers. %s' % (issuer, auth_result.message))
 
     issuer_account = InternalAccount(issuer, vo=vo)
     for attachment in attachments:
@@ -304,8 +308,9 @@ def detach_dids(
     :param session: The database session in use.
     """
     kwargs = {'scope': scope, 'name': name, 'dids': dids, 'issuer': issuer}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='detach_dids', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not detach data identifiers from %s:%s' % (issuer, scope, name))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='detach_dids', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not detach data identifiers from %s:%s. %s' % (issuer, scope, name, auth_result.message))
 
     internal_scope = InternalScope(scope, vo=vo)
     for d in dids:
@@ -544,8 +549,9 @@ def set_metadata(
     if key in RESERVED_KEYS:
         raise AccessDenied('Account %s can not change this metadata value to data identifier %s:%s' % (issuer, scope, name))
 
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not add metadata to data identifier %s:%s' % (issuer, scope, name))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not add metadata to data identifier %s:%s. %s' % (issuer, scope, name, auth_result.message))
 
     internal_scope = InternalScope(scope, vo=vo)
     return did.set_metadata(scope=internal_scope, name=name, key=key, value=value, recursive=recursive, session=session)
@@ -579,8 +585,9 @@ def set_metadata_bulk(
         if key in RESERVED_KEYS:
             raise AccessDenied('Account %s can not change the value of the metadata key %s to data identifier %s:%s' % (issuer, key, scope, name))
 
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata_bulk', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not add metadata to data identifier %s:%s' % (issuer, scope, name))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata_bulk', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not add metadata to data identifier %s:%s. %s' % (issuer, scope, name, auth_result.message))
 
     internal_scope = InternalScope(scope, vo=vo)
     return did.set_metadata_bulk(scope=internal_scope, name=name, meta=meta, recursive=recursive, session=session)
@@ -607,8 +614,9 @@ def set_dids_metadata_bulk(
 
     for entry in dids:
         kwargs = {'scope': entry['scope'], 'name': entry['name'], 'meta': entry['meta'], 'issuer': issuer}
-        if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata_bulk', kwargs=kwargs, session=session):
-            raise AccessDenied('Account %s can not add metadata to data identifier %s:%s' % (issuer, entry['scope'], entry['name']))
+        auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_metadata_bulk', kwargs=kwargs, session=session)
+        if not auth_result.allowed:
+            raise AccessDenied('Account %s can not add metadata to data identifier %s:%s. %s' % (issuer, entry['scope'], entry['name'], auth_result.message))
         entry['scope'] = InternalScope(entry['scope'], vo=vo)
         meta = entry['meta']
         for key in meta:
@@ -710,8 +718,9 @@ def set_status(
     :param session: The database session in use.
     """
 
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_status', kwargs={'scope': scope, 'name': name, 'issuer': issuer}, session=session):
-        raise AccessDenied('Account %s can not set status on data identifier %s:%s' % (issuer, scope, name))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='set_status', kwargs={'scope': scope, 'name': name, 'issuer': issuer}, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not set status on data identifier %s:%s. %s' % (issuer, scope, name, auth_result.message))
 
     internal_scope = InternalScope(scope, vo=vo)
 
@@ -792,8 +801,9 @@ def create_did_sample(
     :param session: The database session in use.
     """
     kwargs = {'issuer': issuer, 'scope': output_scope}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='create_did_sample', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not bulk add data identifier' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='create_did_sample', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not bulk add data identifier. %s' % (issuer, auth_result.message))
 
     input_internal_scope = InternalScope(input_scope, vo=vo)
     output_internal_scope = InternalScope(output_scope, vo=vo)
@@ -821,8 +831,9 @@ def resurrect(
     :param session: The database session in use.
     """
     kwargs = {'issuer': issuer}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='resurrect', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not resurrect data identifiers' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='resurrect', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not resurrect data identifiers. %s' % (issuer, auth_result.message))
     validate_schema(name='dids', obj=dids, vo=vo)
 
     for d in dids:
@@ -938,8 +949,9 @@ def remove_did_from_followed(
     :param issuer: The issuer account
     """
     kwargs = {'scope': scope, 'issuer': issuer}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='remove_did_from_followed', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not remove data identifiers from followed table' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='remove_did_from_followed', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not remove data identifiers from followed table. %s' % (issuer, auth_result.message))
 
     internal_scope = InternalScope(scope, vo=vo)
     internal_account = InternalAccount(account, vo=vo)
@@ -963,8 +975,9 @@ def remove_dids_from_followed(
     :param session: The database session in use.
     """
     kwargs = {'dids': dids, 'issuer': issuer}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='remove_dids_from_followed', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not bulk remove data identifiers from followed table' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='remove_dids_from_followed', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not bulk remove data identifiers from followed table. %s' % (issuer, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
     return did.remove_dids_from_followed(dids=dids, account=internal_account, session=session)

--- a/lib/rucio/gateway/dirac.py
+++ b/lib/rucio/gateway/dirac.py
@@ -68,14 +68,16 @@ def add_files(
     for rse in rses:
         rse_id = rses[rse]
         kwargs = {'rse': rse, 'rse_id': rse_id}
-        if not has_permission(issuer=issuer, action='add_replicas', kwargs=kwargs, vo=vo, session=session):
-            raise AccessDenied('Account %s can not add file replicas on %s for VO %s' % (issuer, rse, vo))
+        auth_result = has_permission(issuer=issuer, action='add_replicas', kwargs=kwargs, vo=vo, session=session)
+        if not auth_result.allowed:
+            raise AccessDenied('Account %s can not add file replicas on %s for VO %s. %s' % (issuer, rse, vo, auth_result.message))
         if not has_permission(issuer=issuer, action='skip_availability_check', kwargs=kwargs, vo=vo, session=session):
             ignore_availability = False
 
     # Check if the issuer can add the files
     kwargs = {'issuer': issuer, 'dids': dids}
-    if not has_permission(issuer=issuer, action='add_dids', kwargs=kwargs, vo=vo, session=session):
-        raise AccessDenied('Account %s can not bulk add data identifier for VO %s' % (issuer, vo))
+    auth_result = has_permission(issuer=issuer, action='add_dids', kwargs=kwargs, vo=vo, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not bulk add data identifier for VO %s. %s' % (issuer, vo, auth_result.message))
 
     dirac.add_files(lfns=lfns, account=issuer, ignore_availability=ignore_availability, parents_metadata=parents_metadata, vo=vo, session=session)

--- a/lib/rucio/gateway/exporter.py
+++ b/lib/rucio/gateway/exporter.py
@@ -35,8 +35,9 @@ def export_data(issuer: str, distance: bool = True, vo: str = 'def', *, session:
     :param session: The database session in use.
     """
     kwargs = {'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='export', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not export data' % issuer)
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='export', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not export data. %s' % (issuer, auth_result.message))
 
     data = exporter.export_data(distance=distance, vo=vo, session=session)
     rses = {}

--- a/lib/rucio/gateway/heartbeat.py
+++ b/lib/rucio/gateway/heartbeat.py
@@ -37,8 +37,9 @@ def list_heartbeats(issuer: Optional[str] = None, vo: str = 'def', *, session: "
     """
 
     kwargs = {'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='list_heartbeats', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot list heartbeats' % issuer)
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='list_heartbeats', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot list heartbeats. %s' % (issuer, auth_result.message))
     return heartbeat.list_heartbeats(session=session)
 
 
@@ -69,6 +70,7 @@ def create_heartbeat(
 
     """
     kwargs = {'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='send_heartbeats', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot send heartbeats' % issuer)
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='send_heartbeats', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot send heartbeats. %s' % (issuer, auth_result.message))
     heartbeat.live(executable=executable, hostname=hostname, pid=pid, thread=thread, older_than=older_than, payload=payload, session=session)

--- a/lib/rucio/gateway/identity.py
+++ b/lib/rucio/gateway/identity.py
@@ -72,8 +72,9 @@ def del_identity(
     """
     converted_id_type = IdentityType[id_type.upper()]
     kwargs = {'accounts': identity.list_accounts_for_identity(identity_key, converted_id_type, session=session)}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='del_identity', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not delete identity' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='del_identity', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not delete identity. %s' % (issuer, auth_result.message))
 
     return identity.del_identity(identity_key, converted_id_type, session=session)
 
@@ -105,8 +106,9 @@ def add_account_identity(
     :param session: The database session in use.
     """
     kwargs = {'identity': identity_key, 'type': id_type, 'account': account}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_account_identity', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not add account identity' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='add_account_identity', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not add account identity. %s' % (issuer, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 
@@ -147,8 +149,9 @@ def del_account_identity(
     :param session: The database session in use.
     """
     kwargs = {'account': account}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='del_account_identity', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not delete account identity' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='del_account_identity', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not delete account identity. %s' % (issuer, auth_result.message))
 
     internal_account = InternalAccount(account, vo=vo)
 

--- a/lib/rucio/gateway/importer.py
+++ b/lib/rucio/gateway/importer.py
@@ -37,8 +37,9 @@ def import_data(data: dict[str, Any], issuer: str, vo: str = 'def', *, session: 
     """
     kwargs = {'issuer': issuer}
     validate_schema(name='import', obj=data, vo=vo)
-    if not permission.has_permission(issuer=issuer, vo=vo, action='import', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not import data' % issuer)
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='import', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not import data. %s' % (issuer, auth_result.message))
 
     for account in data.get('accounts', []):
         account['account'] = InternalAccount(account['account'], vo=vo)

--- a/lib/rucio/gateway/lifetime_exception.py
+++ b/lib/rucio/gateway/lifetime_exception.py
@@ -115,6 +115,7 @@ def update_exception(
     :param session:    The database session in use.
     """
     kwargs = {'exception_id': exception_id, 'vo': vo}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='update_lifetime_exceptions', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not update lifetime exceptions' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='update_lifetime_exceptions', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not update lifetime exceptions. %s' % (issuer, auth_result.message))
     return lifetime_exception.update_exception(exception_id=exception_id, state=state, session=session)

--- a/lib/rucio/gateway/meta_conventions.py
+++ b/lib/rucio/gateway/meta_conventions.py
@@ -66,8 +66,9 @@ def add_key(key: str, key_type: Union[KeyType, str], issuer: "InternalAccount", 
     :param session: The database session in use.
     """
     kwargs = {'key': key, 'key_type': key_type, 'value_type': value_type, 'value_regexp': value_regexp}
-    if not has_permission(issuer=issuer, vo=vo, action='add_key', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not add key' % (issuer))
+    auth_result = has_permission(issuer=issuer, vo=vo, action='add_key', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not add key. %s' % (issuer, auth_result.message))
     return meta_conventions.add_key(key=key, key_type=key_type, value_type=value_type, value_regexp=value_regexp, session=session)
 
 
@@ -82,6 +83,7 @@ def add_value(key: str, value: str, issuer: "InternalAccount", vo: str = 'def', 
     :param session: The database session in use.
     """
     kwargs = {'key': key, 'value': value}
-    if not has_permission(issuer=issuer, vo=vo, action='add_value', kwargs=kwargs, session=session):
-        raise AccessDenied('Account %s can not add value %s to key %s' % (issuer, value, key))
+    auth_result = has_permission(issuer=issuer, vo=vo, action='add_value', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not add value %s to key %s. %s' % (issuer, value, key, auth_result.message))
     return meta_conventions.add_value(key=key, value=value, session=session)

--- a/lib/rucio/gateway/permission.py
+++ b/lib/rucio/gateway/permission.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from rucio.common.exception import RSENotFound
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core import permission
+from rucio.core.permission import PermissionResult
 from rucio.core.rse import get_rse_id
 from rucio.db.sqla.session import read_session
 
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
 
 
 @read_session
-def has_permission(issuer: str, action: str, kwargs: dict[str, Any], vo: str = 'def', *, session: "Session") -> bool:
+def has_permission(issuer: str, action: str, kwargs: dict[str, Any], vo: str = 'def', *, session: "Session") -> PermissionResult:
     """
     Checks if an account has the specified permission to
     execute an action with parameters.

--- a/lib/rucio/gateway/quarantined_replica.py
+++ b/lib/rucio/gateway/quarantined_replica.py
@@ -57,8 +57,9 @@ def quarantine_file_replicas(
     if rse_id is None:
         rse_id = get_rse_id(rse, vo=vo, session=session)
 
-    if not permission.has_permission(issuer, 'quarantine_file_replicas', {}, vo=vo, session=session):
-        raise exception.AccessDenied('Account %s can not quarantine replicas' % (issuer))
+    auth_result = permission.has_permission(issuer, 'quarantine_file_replicas', {}, vo=vo, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not quarantine replicas. %s' % (issuer, auth_result.message))
 
     replica_infos = []
     for r in replicas:

--- a/lib/rucio/gateway/replica.py
+++ b/lib/rucio/gateway/replica.py
@@ -119,11 +119,12 @@ def declare_bad_file_replicas(replicas, reason, issuer, vo='def', force=False, *
     rse_id_to_name = invert_dict(rse_map)   # RSE id -> RSE name
 
     for rse_id in rse_ids_to_check:
-        if not permission.has_permission(issuer=issuer, vo=vo, action='declare_bad_file_replicas',
-                                         kwargs={"rse_id": rse_id},
-                                         session=session):
-            raise exception.AccessDenied('Account %s can not declare bad replicas in RSE %s' %
-                                         (issuer, rse_id_to_name.get(rse_id, rse_id)))
+        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='declare_bad_file_replicas',
+                                                kwargs={"rse_id": rse_id},
+                                                session=session)
+        if not auth_result.allowed:
+            raise exception.AccessDenied('Account %s can not declare bad replicas in RSE %s. %s' %
+                                         (issuer, rse_id_to_name.get(rse_id, rse_id), auth_result.message))
 
     undeclared = replica.declare_bad_file_replicas(replicas_lst, reason=reason,
                                                    issuer=InternalAccount(issuer, vo=vo),
@@ -159,8 +160,9 @@ def declare_suspicious_file_replicas(pfns, reason, issuer, vo='def', *, session:
     :param session: The database session in use.
     """
     kwargs = {}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='declare_suspicious_file_replicas', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not declare suspicious replicas' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='declare_suspicious_file_replicas', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not declare suspicious replicas. %s' % (issuer, auth_result.message))
 
     issuer = InternalAccount(issuer, vo=vo)
 
@@ -276,8 +278,9 @@ def add_replicas(rse, files, issuer, ignore_availability=False, vo='def', *, ses
     rse_id = get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_replicas', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not add file replicas on %s' % (issuer, rse))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='add_replicas', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not add file replicas on %s. %s' % (issuer, rse, auth_result.message))
     if not permission.has_permission(issuer=issuer, vo=vo, action='skip_availability_check', kwargs=kwargs, session=session):
         ignore_availability = False
 
@@ -309,8 +312,9 @@ def delete_replicas(rse, files, issuer, ignore_availability=False, vo='def', *, 
     rse_id = get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='delete_replicas', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not delete file replicas on %s' % (issuer, rse))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='delete_replicas', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not delete file replicas on %s. %s' % (issuer, rse, auth_result.message))
     if not permission.has_permission(issuer=issuer, vo=vo, action='skip_availability_check', kwargs=kwargs, session=session):
         ignore_availability = False
 
@@ -338,8 +342,9 @@ def update_replicas_states(rse, files, issuer, vo='def', *, session: "Session"):
     rse_id = get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='update_replicas_states', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not update file replicas state on %s' % (issuer, rse))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='update_replicas_states', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not update file replicas state on %s. %s' % (issuer, rse, auth_result.message))
     replicas = []
     for file in files:
         rep = file
@@ -455,8 +460,9 @@ def add_bad_pfns(pfns, issuer, state, reason=None, expires_at=None, vo='def', *,
     :returns: True is successful.
     """
     kwargs = {'state': state}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_bad_pfns', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not declare bad PFNs' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='add_bad_pfns', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not declare bad PFNs. %s' % (issuer, auth_result.message))
 
     if expires_at and datetime.datetime.utcnow() <= expires_at and expires_at > datetime.datetime.utcnow() + datetime.timedelta(days=30):
         raise exception.InputValidationError('The given duration of %s days exceeds the maximum duration of 30 days.' % (expires_at - datetime.datetime.utcnow()).days)
@@ -483,8 +489,9 @@ def add_bad_dids(dids, rse, issuer, state, reason=None, expires_at=None, vo='def
     :returns: The list of replicas not declared bad
     """
     kwargs = {'state': state}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_bad_pfns', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not declare bad PFN or DIDs' % issuer)
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='add_bad_pfns', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not declare bad PFN or DIDs. %s' % (issuer, auth_result.message))
 
     issuer = InternalAccount(issuer, vo=vo)
     rse_id = get_rse_id(rse=rse, session=session)
@@ -522,8 +529,9 @@ def set_tombstone(rse, scope, name, issuer, vo='def', *, session: "Session"):
 
     rse_id = get_rse_id(rse, vo=vo, session=session)
 
-    if not permission.has_permission(issuer=issuer, vo=vo, action='set_tombstone', kwargs={}, session=session):
-        raise exception.AccessDenied('Account %s can not set tombstones' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='set_tombstone', kwargs={}, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not set tombstones. %s' % (issuer, auth_result.message))
 
     scope = InternalScope(scope, vo=vo)
     replica.set_tombstone(rse_id, scope, name, session=session)

--- a/lib/rucio/gateway/request.py
+++ b/lib/rucio/gateway/request.py
@@ -53,8 +53,9 @@ def queue_requests(
     """
 
     kwargs = {'requests': requests, 'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='queue_requests', kwargs=kwargs, session=session):
-        raise exception.AccessDenied(f'{issuer} can not queue request')
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='queue_requests', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied(f'{issuer} can not queue request. {auth_result.message}')
 
     for req in requests:
         req['scope'] = InternalScope(req['scope'], vo=vo)  # type: ignore (type reassignment)
@@ -85,8 +86,9 @@ def cancel_request(
     """
 
     kwargs = {'account': account, 'issuer': issuer, 'request_id': request_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='cancel_request_', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('%s cannot cancel request %s' % (account, request_id))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='cancel_request_', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('%s cannot cancel request %s. %s' % (account, request_id, auth_result.message))
 
     raise NotImplementedError
 
@@ -119,8 +121,9 @@ def cancel_request_did(
     dest_rse_id = get_rse_id(rse=dest_rse, vo=vo, session=session)
 
     kwargs = {'account': account, 'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='cancel_request_did', kwargs=kwargs, session=session):
-        raise exception.AccessDenied(f'{account} cannot cancel {request_type} request for {scope}:{name}')
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='cancel_request_did', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied(f'{account} cannot cancel {request_type} request for {scope}:{name}. {auth_result.message}')
 
     internal_scope = InternalScope(scope, vo=vo)
     return request.cancel_request_did(internal_scope, name, dest_rse_id, request_type, session=session)
@@ -149,8 +152,9 @@ def get_next(
     """
 
     kwargs = {'account': account, 'issuer': issuer, 'request_type': request_type, 'state': state}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='get_next', kwargs=kwargs, session=session):
-        raise exception.AccessDenied(f'{account} cannot get the next request of type {request_type} in state {state}')
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='get_next', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied(f'{account} cannot get the next request of type {request_type} in state {state}. {auth_result.message}')
 
     reqs = request.get_and_mark_next(request_type, state, session=session)
     return [gateway_update_return_dict(r, session=session) for r in reqs]
@@ -180,8 +184,9 @@ def get_request_by_did(
     rse_id = get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'scope': scope, 'name': name, 'rse': rse, 'rse_id': rse_id, 'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='get_request_by_did', kwargs=kwargs, session=session):
-        raise exception.AccessDenied(f'{issuer} cannot retrieve the request DID {scope}:{name} to RSE {rse}')
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='get_request_by_did', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied(f'{issuer} cannot retrieve the request DID {scope}:{name} to RSE {rse}. {auth_result.message}')
 
     internal_scope = InternalScope(scope, vo=vo)
     req = request.get_request_by_did(internal_scope, name, rse_id, session=session)
@@ -213,8 +218,9 @@ def get_request_history_by_did(
     rse_id = get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'scope': scope, 'name': name, 'rse': rse, 'rse_id': rse_id, 'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='get_request_history_by_did', kwargs=kwargs, session=session):
-        raise exception.AccessDenied(f'{issuer} cannot retrieve the request DID {scope}:{name} to RSE {rse}')
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='get_request_history_by_did', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied(f'{issuer} cannot retrieve the request DID {scope}:{name} to RSE {rse}. {auth_result.message}')
 
     internal_scope = InternalScope(scope, vo=vo)
     req = request.get_request_history_by_did(internal_scope, name, rse_id, session=session)
@@ -245,8 +251,9 @@ def list_requests(
     dst_rse_ids = [get_rse_id(rse=rse, vo=vo, session=session) for rse in dst_rses]
 
     kwargs = {'src_rse_id': src_rse_ids, 'dst_rse_id': dst_rse_ids, 'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='list_requests', kwargs=kwargs, session=session):
-        raise exception.AccessDenied(f'{issuer} cannot list requests from RSEs {src_rses} to RSEs {dst_rses}')
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='list_requests', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied(f'{issuer} cannot list requests from RSEs {src_rses} to RSEs {dst_rses}. {auth_result.message}')
 
     for req in request.list_requests(src_rse_ids, dst_rse_ids, states, session=session):
         req = req.to_dict()
@@ -279,8 +286,9 @@ def list_requests_history(
     dst_rse_ids = [get_rse_id(rse=rse, vo=vo, session=session) for rse in dst_rses]
 
     kwargs = {'src_rse_id': src_rse_ids, 'dst_rse_id': dst_rse_ids, 'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='list_requests_history', kwargs=kwargs, session=session):
-        raise exception.AccessDenied(f'{issuer} cannot list requests from RSEs {src_rses} to RSEs {dst_rses}')
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='list_requests_history', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied(f'{issuer} cannot list requests from RSEs {src_rses} to RSEs {dst_rses}. {auth_result.message}')
 
     for req in request.list_requests_history(src_rse_ids, dst_rse_ids, states, offset, limit, session=session):
         req = req.to_dict()
@@ -315,7 +323,8 @@ def get_request_metrics(
     if dst_rse:
         dst_rse_id = get_rse_id(rse=dst_rse, vo=vo, session=session)
     kwargs = {'issuer': issuer}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='get_request_metrics', kwargs=kwargs, session=session):
-        raise exception.AccessDenied(f'{issuer} cannot get request statistics')
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='get_request_metrics', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied(f'{issuer} cannot get request statistics. {auth_result.message}')
 
     return request.get_request_metrics(dest_rse_id=dst_rse_id, src_rse_id=src_rse_id, activity=activity, group_by_rse_attribute=group_by_rse_attribute, session=session)

--- a/lib/rucio/gateway/rse.py
+++ b/lib/rucio/gateway/rse.py
@@ -61,8 +61,9 @@ def add_rse(rse, issuer, vo='def', deterministic=True, volatile=False, city=None
     """
     validate_schema(name='rse', obj=rse, vo=vo)
     kwargs = {'rse': rse}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_rse', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not add RSE' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='add_rse', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not add RSE. %s' % (issuer, auth_result.message))
 
     return rse_module.add_rse(rse, vo=vo, deterministic=deterministic, volatile=volatile, city=city,
                               region_code=region_code, country_name=country_name, staging_area=staging_area,
@@ -102,8 +103,9 @@ def del_rse(rse, issuer, vo='def', *, session: "Session"):
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='del_rse', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not delete RSE' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='del_rse', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not delete RSE. %s' % (issuer, auth_result.message))
 
     return rse_module.del_rse(rse_id, session=session)
 
@@ -142,8 +144,9 @@ def del_rse_attribute(rse, key, issuer, vo='def', *, session: "Session"):
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id, 'key': key}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='del_rse_attribute', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not delete RSE attributes' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='del_rse_attribute', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not delete RSE attributes. %s' % (issuer, auth_result.message))
 
     return rse_module.del_rse_attribute(rse_id=rse_id, key=key, session=session)
 
@@ -164,8 +167,9 @@ def add_rse_attribute(rse, key, value, issuer, vo='def', *, session: "Session"):
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id, 'key': key, 'value': value}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_rse_attribute', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not add RSE attributes' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='add_rse_attribute', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not add RSE attributes. %s' % (issuer, auth_result.message))
 
     return rse_module.add_rse_attribute(rse_id=rse_id, key=key, value=value, session=session)
 
@@ -227,8 +231,9 @@ def add_protocol(rse, issuer, vo='def', *, session: "Session", **data):
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_protocol', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not add protocols to RSE %s' % (issuer, rse))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='add_protocol', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not add protocols to RSE %s. %s' % (issuer, rse, auth_result.message))
     rse_module.add_protocol(rse_id, data['data'], session=session)
 
 
@@ -265,8 +270,9 @@ def del_protocols(rse, scheme, issuer, vo='def', hostname=None, port=None, *, se
     """
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='del_protocol', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not delete protocols from RSE %s' % (issuer, rse))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='del_protocol', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not delete protocols from RSE %s. %s' % (issuer, rse, auth_result.message))
     rse_module.del_protocols(rse_id=rse_id, scheme=scheme, hostname=hostname, port=port, session=session)
 
 
@@ -286,8 +292,9 @@ def update_protocols(rse, scheme, data, issuer, vo='def', hostname=None, port=No
     """
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='update_protocol', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not update protocols from RSE %s' % (issuer, rse))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='update_protocol', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not update protocols from RSE %s. %s' % (issuer, rse, auth_result.message))
     rse_module.update_protocols(rse_id=rse_id, scheme=scheme, hostname=hostname, port=port, data=data, session=session)
 
 
@@ -310,8 +317,9 @@ def set_rse_usage(rse, source, used, free, issuer, files=None, vo='def', *, sess
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
 
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='set_rse_usage', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not update RSE usage information for RSE %s' % (issuer, rse))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='set_rse_usage', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not update RSE usage information for RSE %s. %s' % (issuer, rse, auth_result.message))
 
     return rse_module.set_rse_usage(rse_id=rse_id, source=source, used=used, free=free, files=files, session=session)
 
@@ -374,8 +382,9 @@ def set_rse_limits(rse, name, value, issuer, vo='def', *, session: "Session"):
     """
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='set_rse_limits', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not update RSE limits for RSE %s' % (issuer, rse))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='set_rse_limits', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not update RSE limits for RSE %s. %s' % (issuer, rse, auth_result.message))
 
     return rse_module.set_rse_limits(rse_id=rse_id, name=name, value=value, session=session)
 
@@ -395,8 +404,9 @@ def delete_rse_limits(rse, name, issuer, vo='def', *, session: "Session"):
     """
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='delete_rse_limits', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not update RSE limits for RSE %s' % (issuer, rse))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='delete_rse_limits', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not update RSE limits for RSE %s. %s' % (issuer, rse, auth_result.message))
 
     return rse_module.delete_rse_limits(rse_id=rse_id, name=name, session=session)
 
@@ -448,8 +458,9 @@ def update_rse(rse, parameters, issuer, vo='def', *, session: "Session"):
     """
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse': rse, 'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='update_rse', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not update RSE' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='update_rse', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not update RSE. %s' % (issuer, auth_result.message))
     return rse_module.update_rse(rse_id=rse_id, parameters=parameters, session=session)
 
 
@@ -466,8 +477,9 @@ def add_distance(source, destination, issuer, vo='def', distance=None, *, sessio
     :param session: The database session in use.
     """
     kwargs = {'source': source, 'destination': destination}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='add_distance', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not add RSE distances' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='add_distance', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not add RSE distances. %s' % (issuer, auth_result.message))
     try:
         return distance_module.add_distance(src_rse_id=rse_module.get_rse_id(source, vo=vo, session=session),
                                             dest_rse_id=rse_module.get_rse_id(destination, vo=vo, session=session),
@@ -490,8 +502,9 @@ def update_distance(source, destination, distance, issuer, vo='def', *, session:
     :param session: The database session to use.
     """
     kwargs = {'source': source, 'destination': destination}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='update_distance', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not update RSE distances' % (issuer))
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='update_distance', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not update RSE distances. %s' % (issuer, auth_result.message))
 
     return distance_module.update_distances(src_rse_id=rse_module.get_rse_id(source, vo=vo, session=session),
                                             dest_rse_id=rse_module.get_rse_id(destination, vo=vo, session=session),
@@ -530,8 +543,9 @@ def delete_distance(source, destination, issuer, vo='def', *, session: "Session"
     :param session: The database session in use.
     """
     kwargs = {'source': source, 'destination': destination}
-    if not permission.has_permission(issuer=issuer, vo=vo, action='delete_distance', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not update RSE distances' % issuer)
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='delete_distance', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not update RSE distances. %s' % (issuer, auth_result.message))
 
     return distance_module.delete_distances(src_rse_id=rse_module.get_rse_id(source, vo=vo, session=session),
                                             dest_rse_id=rse_module.get_rse_id(destination, vo=vo, session=session),
@@ -555,8 +569,9 @@ def add_qos_policy(rse, qos_policy, issuer, vo='def', *, session: "Session"):
 
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse_id': rse_id}
-    if not permission.has_permission(issuer=issuer, action='add_qos_policy', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s cannot add QoS policies to RSE %s' % (issuer, rse))
+    auth_result = permission.has_permission(issuer=issuer, action='add_qos_policy', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s cannot add QoS policies to RSE %s. %s' % (issuer, rse, auth_result.message))
 
     return rse_module.add_qos_policy(rse_id, qos_policy, session=session)
 
@@ -577,8 +592,9 @@ def delete_qos_policy(rse, qos_policy, issuer, vo='def', *, session: "Session"):
 
     rse_id = rse_module.get_rse_id(rse=rse, vo=vo, session=session)
     kwargs = {'rse_id': rse}
-    if not permission.has_permission(issuer=issuer, action='delete_qos_policy', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s cannot delete QoS policies from RSE %s' % (issuer, rse))
+    auth_result = permission.has_permission(issuer=issuer, action='delete_qos_policy', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s cannot delete QoS policies from RSE %s. %s' % (issuer, rse, auth_result.message))
 
     return rse_module.delete_qos_policy(rse_id, qos_policy, session=session)
 

--- a/lib/rucio/gateway/scope.py
+++ b/lib/rucio/gateway/scope.py
@@ -68,8 +68,9 @@ def add_scope(
     validate_schema(name='scope', obj=scope, vo=vo)
 
     kwargs = {'scope': scope, 'account': account}
-    if not rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='add_scope', kwargs=kwargs, session=session):
-        raise rucio.common.exception.AccessDenied('Account %s can not add scope' % (issuer))
+    auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='add_scope', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise rucio.common.exception.AccessDenied('Account %s can not add scope. %s' % (issuer, auth_result.message))
 
     internal_scope = InternalScope(scope, vo=vo)
     internal_account = InternalAccount(account, vo=vo)

--- a/lib/rucio/gateway/subscription.py
+++ b/lib/rucio/gateway/subscription.py
@@ -65,8 +65,9 @@ def add_subscription(
     :param session: The database session in use.
     :returns: subscription_id
     """
-    if not has_permission(issuer=issuer, vo=vo, action='add_subscription', kwargs={'account': account}, session=session):
-        raise AccessDenied('Account %s can not add subscription' % (issuer))
+    auth_result = has_permission(issuer=issuer, vo=vo, action='add_subscription', kwargs={'account': account}, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not add subscription. %s' % (issuer, auth_result.message))
     try:
         if filter_:
             if not isinstance(filter_, dict):
@@ -120,8 +121,9 @@ def update_subscription(
     :param session: The database session in use.
     :raises: SubscriptionNotFound if subscription is not found
     """
-    if not has_permission(issuer=issuer, vo=vo, action='update_subscription', kwargs={'account': account}, session=session):
-        raise AccessDenied('Account %s can not update subscription' % (issuer))
+    auth_result = has_permission(issuer=issuer, vo=vo, action='update_subscription', kwargs={'account': account}, session=session)
+    if not auth_result.allowed:
+        raise AccessDenied('Account %s can not update subscription. %s' % (issuer, auth_result.message))
     try:
         if not isinstance(metadata, dict):
             raise TypeError('metadata should be a dict')

--- a/lib/rucio/gateway/vo.py
+++ b/lib/rucio/gateway/vo.py
@@ -44,8 +44,9 @@ def add_vo(new_vo: str, issuer: str, description: Optional[str] = None, email: O
     validate_schema('vo', new_vo, vo=vo)
 
     kwargs = {}
-    if not has_permission(issuer=issuer, action='add_vo', kwargs=kwargs, vo=vo, session=session):
-        raise exception.AccessDenied('Account {} cannot add a VO'.format(issuer))
+    auth_result = has_permission(issuer=issuer, action='add_vo', kwargs=kwargs, vo=vo, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account {} cannot add a VO. {}'.format(issuer, auth_result.message))
 
     vo_core.add_vo(vo=new_vo, description=description, email=email, session=session)
 
@@ -60,8 +61,9 @@ def list_vos(issuer: str, vo: str = 'def', *, session: "Session") -> list[dict[s
     :param session: The database session in use.
     '''
     kwargs = {}
-    if not has_permission(issuer=issuer, action='list_vos', kwargs=kwargs, vo=vo, session=session):
-        raise exception.AccessDenied('Account {} cannot list VOs'.format(issuer))
+    auth_result = has_permission(issuer=issuer, action='list_vos', kwargs=kwargs, vo=vo, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account {} cannot list VOs. {}'.format(issuer, auth_result.message))
 
     return vo_core.list_vos(session=session)
 
@@ -94,8 +96,9 @@ def recover_vo_root_identity(
     """
     kwargs = {}
     root_vo = vo_core.map_vo(root_vo)
-    if not has_permission(issuer=issuer, vo=vo, action='recover_vo_root_identity', kwargs=kwargs, session=session):
-        raise exception.AccessDenied('Account %s can not recover root identity' % (issuer))
+    auth_result = has_permission(issuer=issuer, vo=vo, action='recover_vo_root_identity', kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account %s can not recover root identity. %s' % (issuer, auth_result.message))
 
     account = InternalAccount('root', vo=root_vo)
 
@@ -116,7 +119,8 @@ def update_vo(updated_vo: str, parameters: dict[str, Any], issuer: str, vo: str 
     """
     kwargs = {}
     updated_vo = vo_core.map_vo(updated_vo)
-    if not has_permission(issuer=issuer, action='update_vo', kwargs=kwargs, vo=vo, session=session):
-        raise exception.AccessDenied('Account {} cannot update VO'.format(issuer))
+    auth_result = has_permission(issuer=issuer, action='update_vo', kwargs=kwargs, vo=vo, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied('Account {} cannot update VO. {}'.format(issuer, auth_result.message))
 
     return vo_core.update_vo(vo=updated_vo, parameters=parameters, session=session)


### PR DESCRIPTION
This PR allows permission checks to optionally return a message giving further details on the reason for failure. It also modifies the gateway layer to include this message in the exceptions it raises. I have tried to make it as backward compatible as possible - permission checks that return a simple boolean and callers that expect a boolean should both still work as before.
