### PR TITLE
Core: Add option to order_by parameters in core.did.list_parent_dids

### DIFF
--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -1869,11 +1869,15 @@ def list_parent_dids(
     stmt = select(
         models.DataIdentifierAssociation.scope,
         models.DataIdentifierAssociation.name,
-        models.DataIdentifierAssociation.did_type
+        models.DataIdentifierAssociation.did_type,
+        models.DataIdentifier.created_at
     ).where(
         and_(models.DataIdentifierAssociation.child_scope == scope,
-             models.DataIdentifierAssociation.child_name == name)
+             models.DataIdentifierAssociation.child_name == name,
+             models.DataIdentifier.scope == models.DataIdentifierAssociation.scope,
+             models.DataIdentifier.name == models.DataIdentifierAssociation.name)
     )
+
     for did in session.execute(stmt).yield_per(5):
         yield {'scope': did.scope, 'name': did.name, 'type': did.did_type}
 

--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -1853,6 +1853,7 @@ def list_content_history(
 def list_parent_dids(
     scope: "InternalScope",
     name: str,
+    order_by: Optional[list[str]] = None,
     *,
     session: "Session"
 ) -> "Iterator[dict[str, Any]]":
@@ -1861,10 +1862,14 @@ def list_parent_dids(
 
     :param scope:     The scope.
     :param name:      The name.
+    :param order_by:  List of parameters to order the query by. Possible values: ['scope', 'name', 'did_type', 'created_at'].
     :param session:   The database session.
     :returns:         List of dids.
     :rtype:           Generator.
     """
+
+    if order_by is None:
+        order_by = []
 
     stmt = select(
         models.DataIdentifierAssociation.scope,
@@ -1876,6 +1881,8 @@ def list_parent_dids(
              models.DataIdentifierAssociation.child_name == name,
              models.DataIdentifier.scope == models.DataIdentifierAssociation.scope,
              models.DataIdentifier.name == models.DataIdentifierAssociation.name)
+    ).order_by(
+        *order_by
     )
 
     for did in session.execute(stmt).yield_per(5):


### PR DESCRIPTION
fixes #7002

- not adding this to gateway and client for now. Before we do that, let's consider:
    - if we want to abstract this "dynamic `order_by` parameters" logic to a decorator, and:
    - if we want to provide this at gateway or client levels, instead of just having it in core for use by other core function.

- no new unit test for this particular case as `list_parent_dids` is currently not unit tested. We should address all these methods without unit tests as part of the test overhaul work.