### PR TITLE
Clients: Rich command-line client outputs #6987

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -67,6 +67,7 @@ Individual contributors to the source code
 - Aksel Lunde Aase <aksel.lunde.aase@gmail.com>, 2022
 - Elena Gazzarrini <gazzarrini.elena@gmail.com>, 2022-2023
 - Maximilian Linhoff, <maximilian.linhoff@tu-dortmund.de>, 2024
+- Eric Banzuzi, <eric.banzuzi@gmail.com>, 2024
 
 Organisations employing contributors
 ------------------------------------

--- a/bin/rucio
+++ b/bin/rucio
@@ -32,11 +32,19 @@ from datetime import datetime
 from functools import wraps
 from typing import Optional
 
+from rich.console import Console
+from rich.padding import Padding
+from rich.status import Status
+from rich.text import Text
+from rich.theme import Theme
+from rich.traceback import install
+from rich.tree import Tree
 from tabulate import tabulate
 
 # rucio module has the same name as this executable module, so this rule fails. pylint: disable=no-name-in-module
 from rucio import version
 from rucio.client import Client
+from rucio.client.richclient import MAX_TRACEBACK_WIDTH, MIN_CONSOLE_WIDTH, CLITheme, generate_table, get_cli_config, get_pager, print_output, setup_rich_logger
 from rucio.common.client import detect_client_location
 from rucio.common.config import config_get, config_get_float
 from rucio.common.constants import ReplicaState
@@ -74,9 +82,15 @@ FAILURE = 1
 DEFAULT_SECURE_PORT = 443
 DEFAULT_PORT = 80
 
+# Setting up rich console.
+console = Console(theme=Theme(CLITheme.LOG_THEMES), soft_wrap=True)
+console.width = max(MIN_CONSOLE_WIDTH, console.width)
+
 logger = logging.log
 gfal2_logger = logging.getLogger("gfal2")
 tablefmt = 'psql'
+cli_config = get_cli_config()
+spinner = Status('Initializing spinner', spinner=CLITheme.SPINNER, spinner_style=CLITheme.SPINNER_STYLE, console=console)
 
 
 def setup_gfal2_logger(logger):
@@ -166,18 +180,21 @@ def exception_handler(function):
                 used_account = None
                 try:  # get the configured account from the configuration file
                     used_account = '%s (from rucio.cfg)' % config_get('client', 'account')
-                except:
+                except Exception:
                     pass
                 try:  # are we overridden by the environment?
                     used_account = '%s (from RUCIO_ACCOUNT)' % os.environ['RUCIO_ACCOUNT']
-                except:
+                except Exception:
                     pass
                 logger.error('Specified account %s does not have an associated identity.' % used_account)
             else:
-                logger.debug(traceback.format_exc())
+                if logger.level == logging.DEBUG and cli_config == 'rich':
+                    logger.exception(error)
+                else:
+                    logger.debug(traceback.format_exc())
                 contact = config_get('policy', 'support', raise_exception=False)
                 support = ('Please follow up with all relevant information at: ' + contact) if contact else ''
-                logger.error('\nThe object is missing this property: %s\n'
+                logger.error('The object is missing this property: %s\n'
                              'This should never happen. Please rerun the last command with the "-v" option to gather more information.\n'
                              '%s' % (str(error), support))
             return FAILURE
@@ -194,13 +211,20 @@ def exception_handler(function):
                 devnull = os.open(os.devnull, os.O_WRONLY)
                 os.dup2(devnull, sys.stdout.fileno())
                 return SUCCESS
-            logger.debug(traceback.format_exc())
-            logger.error(error)
+
+            if cli_config == 'rich':
+                if logger.level == logging.DEBUG:
+                    logger.exception(error)
+                else:
+                    logger.error(error)
+            else:
+                logger.debug(traceback.format_exc())
+                logger.error(error)
             contact = config_get('policy', 'support', raise_exception=False)
             support = ("If it's a problem concerning your experiment or if you're unsure what to do, please follow up at: %s\n" % contact) if contact else ''
             contact = config_get('policy', 'support_rucio', default='https://github.com/rucio/rucio/issues')
             support += "If you're sure there is a problem with Rucio itself, please follow up at: " + contact
-            logger.error('\nRucio exited with an unexpected/unknown error.\n'
+            logger.error('Rucio exited with an unexpected/unknown error.\n'
                          'Please rerun the last command with the "-v" option to gather more information.\n'
                          '%s' % support)
             return FAILURE
@@ -294,8 +318,14 @@ def whoami_account(args):
     """
     client = get_client(args)
     info = client.whoami()
-    for k in info:
-        print(k.ljust(10) + ' : ' + str(info[k]))
+    if cli_config == 'rich':
+        keyword_styles = {**CLITheme.ACCOUNT_STATUS, **CLITheme.ACCOUNT_TYPE}
+        table_data = [(k, Text(str(v), style=keyword_styles.get(str(v), 'default'))) for (k, v) in sorted(info.items())]
+        table = generate_table(table_data, col_alignments=['left', 'left'], row_styles=['none'])
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        for k in info:
+            print(k.ljust(10) + ' : ' + str(info[k]))
     return SUCCESS
 
 
@@ -330,6 +360,10 @@ def list_dataset_replicas(args):
             result[dsn] = {}
         result[dsn][replica['rse']] = [replica['rse'], replica['available_length'], replica['length']]
 
+    if cli_config == 'rich':
+        spinner.update(status='Fetching dataset replicas')
+        spinner.start()
+
     if len(args.dids) == 1:
         scope, name = get_scope(args.dids[0], client)
         dmeta = client.get_metadata(scope, name)
@@ -342,22 +376,39 @@ def list_dataset_replicas(args):
 
     if args.deep or len(datasets) < 2:
         for did in datasets:
-            dsn = "%s:%s" % (did['scope'], did['name'])
+            dsn = f"{did['scope']}:{did['name']}"
             for rep in client.list_dataset_replicas(scope=did['scope'], name=did['name'], deep=args.deep):
                 _append_result(dsn=dsn, replica=rep)
     else:
         for rep in client.list_dataset_replicas_bulk(dids=datasets):
-            dsn = "%s:%s" % (rep['scope'], rep['name'])
+            dsn = f"{rep['scope']}:{rep['name']}"
             _append_result(dsn=dsn, replica=rep)
 
     if args.csv:
         for dsn in result:
             for rse in list(result[dsn].values()):
                 print(rse[0], rse[1], rse[2], sep=',')
+
+        if cli_config == 'rich':
+            spinner.stop()
     else:
-        for dsn in result:
-            print('\nDATASET: %s' % (dsn))
-            print(tabulate(list(result[dsn].values()), tablefmt=tablefmt, headers=['RSE', 'FOUND', 'TOTAL']))
+        output = []
+        for i, dsn in enumerate(result):
+            if cli_config == 'rich':
+                if i > 0:
+                    output.append(Text(f'\nDATASET: {dsn}', style=CLITheme.TEXT_HIGHLIGHT))
+                elif len(result) > 1:
+                    output.append(Text(f'DATASET: {dsn}', style=CLITheme.TEXT_HIGHLIGHT))
+
+                table = generate_table(list(result[dsn].values()), headers=['RSE', 'FOUND', 'TOTAL'], col_alignments=['left', 'right', 'right'])
+                output.append(table)
+            else:
+                print(f'\nDATASET: {dsn}')
+                print(tabulate(list(result[dsn].values()), tablefmt=tablefmt, headers=['RSE', 'FOUND', 'TOTAL']))
+
+        if cli_config == 'rich':
+            spinner.stop()
+            print_output(*output, console=console, no_pager=args.no_pager)
     return SUCCESS
 
 
@@ -376,7 +427,7 @@ def list_file_replicas(args):
     if args.protocols:
         protocols = args.protocols.split(',')
 
-    table = []
+    table_data = []
     dids = []
     if args.missing and not args.rses:
         print('Cannot use --missing without specifying a RSE')
@@ -385,9 +436,13 @@ def list_file_replicas(args):
         print('The substitution parameter must equal --link="/pfn/dir:/dst/dir"')
         return FAILURE
 
+    if cli_config == 'rich':
+        spinner.update(status='Fetching file replicas')
+        spinner.start()
+
     for did in args.dids:
         scope, name = get_scope(did, client)
-        client.get_metadata(scope=scope, name=name)  # break with Exception before streaming replicas if DID does not exist
+        client.get_metadata(scope=scope, name=name)  # Break with Exception before streaming replicas if DID does not exist.
         dids.append({'scope': scope, 'name': name})
 
     replicas = client.list_replicas(dids, schemes=protocols,
@@ -401,14 +456,24 @@ def list_file_replicas(args):
     rses = [rse["rse"] for rse in client.list_rses(rse_expression=args.rses)]
 
     if args.metalink:
-        print(replicas[:-1])  # last character is newline, no need to print that
+        print(replicas[:-1])  # Last character is newline, no need to print that.
         return SUCCESS
 
     if args.missing:
         for replica, rse in itertools.product(replicas, rses):
             if 'states' in replica and rse in replica['states'] and replica['states'].get(rse) != 'AVAILABLE':
-                table.append([replica['scope'], replica['name'], "({0}) {1}".format(ReplicaState[replica['states'].get(rse)].value, rse)])
-        print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE', 'NAME', '(STATE) RSE']))
+                if cli_config == 'rich':
+                    replica_state = f"[{CLITheme.REPLICA_STATE.get(ReplicaState[replica['states'].get(rse)].value, 'default')}]{ReplicaState[replica['states'].get(rse)].value}[/]"
+                    table_data.append([replica['scope'], replica['name'], '({0}) {1}'.format(replica_state, rse)])
+                else:
+                    table_data.append([replica['scope'], replica['name'], "({0}) {1}".format(ReplicaState[replica['states'].get(rse)].value, rse)])
+        if cli_config == 'rich':
+            table = generate_table(table_data, headers=['SCOPE', 'NAME', '(STATE) RSE'], col_alignments=['left', 'left', 'left'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
+        else:
+            print(tabulate(table_data, tablefmt=tablefmt, headers=['SCOPE', 'NAME', '(STATE) RSE']))
+
     elif args.link:
         pfn_dir, dst_dir = args.link.split(':')
         if args.rses:
@@ -428,13 +493,23 @@ def list_file_replicas(args):
                 for pfn in replica['pfns']:
                     rse = replica['pfns'][pfn]['rse']
                     if replica['rses'].get(rse):
-                        print(pfn)
+                        if cli_config == 'rich':
+                            table_data.append([pfn])
+                        else:
+                            print(pfn)
         else:
             for replica in replicas:
                 for pfn in replica['pfns']:
                     rse = replica['pfns'][pfn]['rse']
                     if replica['rses'][rse]:
-                        print(pfn)
+                        if cli_config == 'rich':
+                            table_data.append([pfn])
+                        else:
+                            print(pfn)
+        if cli_config == 'rich':
+            table = generate_table(table_data, headers=['PFN'], col_alignments=['left'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
     else:
         if args.all_states:
             header = ['SCOPE', 'NAME', 'FILESIZE', 'ADLER32', '(STATE) RSE: REPLICA']
@@ -445,16 +520,37 @@ def list_file_replicas(args):
                 for pfn in replica['pfns']:
                     rse = replica['pfns'][pfn]['rse']
                     if args.all_states:
-                        rse_string = '({2}) {0}: {1}'.format(rse, pfn, ReplicaState[replica['states'][rse]].value)
+                        if cli_config == 'rich':
+                            replica_state = f"[{CLITheme.REPLICA_STATE.get(ReplicaState[replica['states'][rse]].value, 'default')}]{ReplicaState[replica['states'][rse]].value}[/]"
+                            # Less does not display hyperlinks well if the table is very wide.
+                            if args.no_pager:
+                                rse_string = f'({replica_state}) {rse}: [u bright_blue link={pfn}]{pfn}[/]'
+                            else:
+                                rse_string = f'({replica_state}) {rse}: [u bright_blue]{pfn}[/]'
+                        else:
+                            rse_string = '({2}) {0}: {1}'.format(rse, pfn, ReplicaState[replica['states'][rse]].value)
                     else:
-                        rse_string = '{0}: {1}'.format(rse, pfn)
+                        if cli_config == 'rich':
+                            # Less does not display hyperlinks well if the table is very wide.
+                            if args.no_pager:
+                                rse_string = f'{rse}: [u bright_blue link={pfn}]{pfn}[/]'
+                            else:
+                                rse_string = f'{rse}: [u bright_blue]{pfn}[/]'
+                        else:
+                            rse_string = '{0}: {1}'.format(rse, pfn)
                     if args.rses:
                         for selected_rse in rses:
                             if rse == selected_rse:
-                                table.append([replica['scope'], replica['name'], sizefmt(replica['bytes'], args.human), replica['adler32'], rse_string])
+                                table_data.append([replica['scope'], replica['name'], sizefmt(replica['bytes'], args.human), replica['adler32'], rse_string])
                     else:
-                        table.append([replica['scope'], replica['name'], sizefmt(replica['bytes'], args.human), replica['adler32'], rse_string])
-        print(tabulate(table, tablefmt=tablefmt, headers=header, disable_numparse=True))
+                        table_data.append([replica['scope'], replica['name'], sizefmt(replica['bytes'], args.human), replica['adler32'], rse_string])
+
+        if cli_config == 'rich':
+            table = generate_table(table_data, headers=header, col_alignments=['left', 'left', 'right', 'left', 'left'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
+        else:
+            print(tabulate(table_data, tablefmt=tablefmt, headers=header, disable_numparse=True))
     return SUCCESS
 
 
@@ -559,7 +655,7 @@ def list_dids(args):
     client = get_client(args)
     filters = {}
     type_ = 'collection'
-    table = []
+    table_data = []
 
     try:
         scope, name = get_scope(args.did[0], client)
@@ -570,16 +666,16 @@ def list_dids(args):
         name = '*'
 
     if scope not in client.list_scopes():
-        logger.error('Scope not found')
+        logger.error('Scope not found.')
         return FAILURE
 
     if args.recursive and '*' in name:
-        logger.error('Option recursive cannot be used with wildcards')
+        logger.error('Option recursive cannot be used with wildcards.')
         return FAILURE
     else:
         if filters:
             if ('name' in filters) and (name != '*'):
-                logger.error('Must have a wildcard in did name if filtering by name')
+                logger.error('Must have a wildcard in did name if filtering by name.')
                 return FAILURE
 
     try:
@@ -600,15 +696,29 @@ def list_dids(args):
         logger.error(e)
         return FAILURE
 
+    if cli_config == 'rich':
+        spinner.update(status='Fetching DIDs')
+        spinner.start()
+
     for did in client.list_dids(scope, filters=filters, did_type=type_, long=True, recursive=args.recursive):
-        table.append(['%s:%s' % (did['scope'], did['name']), did['did_type']])
+        if cli_config == 'rich':
+            table_data.append([f"{did['scope']}:{did['name']}", Text(did['did_type'], style=CLITheme.DID_TYPE.get(did['did_type'], 'default'))])
+        else:
+            table_data.append([f"{did['scope']}:{did['name']}", did['did_type']])
 
-    if args.short:
-        for did, _ in table:
-            print(did)
+    if cli_config == 'rich':
+        if args.short:
+            table = generate_table([[did] for did, _ in table_data], headers=['SCOPE:NAME'], col_alignments=['left'])
+        else:
+            table = generate_table(table_data, headers=['SCOPE:NAME', '[DID TYPE]'], col_alignments=['left', 'left'])
+        spinner.stop()
+        print_output(table, console=console, no_pager=args.no_pager)
     else:
-        print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
-
+        if args.short:
+            for did, _ in table_data:
+                print(did)
+        else:
+            print(tabulate(table_data, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
     return SUCCESS
 
 
@@ -619,7 +729,7 @@ def list_dids_extended(args):
 
     List the data identifiers for a given scope (DEPRECATED).
     """
-    logger.error("This command has been deprecated. Please use list_dids instead.")
+    logger.error("This command has been deprecated. Please use list-dids instead.")
     return FAILURE
 
 
@@ -630,11 +740,19 @@ def list_scopes(args):
 
     List scopes.
     """
-    # For the moment..
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching scopes')
+        spinner.start()
+
     scopes = client.list_scopes()
-    for scope in scopes:
-        print(scope)
+    if cli_config == 'rich':
+        table = generate_table([[scope] for scope in sorted(scopes)], headers=['SCOPE'], col_alignments=['left'])
+        spinner.stop()
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        for scope in scopes:
+            print(scope)
     return SUCCESS
 
 
@@ -646,20 +764,32 @@ def list_files(args):
     List data identifier contents.
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching files')
+        spinner.start()
+
     if args.csv:
         for did in args.dids:
             scope, name = get_scope(did, client)
             for f in client.list_files(scope=scope, name=name):
                 guid = f['guid']
                 if guid:
-                    guid = '%s-%s-%s-%s-%s' % (guid[0:8], guid[8:12], guid[12:16], guid[16:20], guid[20:32])
+                    guid = f'{guid[0:8]}-{guid[8:12]}-{guid[12:16]}-{guid[16:20]}-{guid[20:32]}'
                 else:
                     guid = '(None)'
                 print('{}:{}'.format(f['scope'], f['name']), guid, f['adler32'], sizefmt(f['bytes'], args.human), f['events'], sep=',')
+        if cli_config == 'rich':
+            spinner.stop()
         return SUCCESS
     elif args.LOCALPATH:
-
-        print('''<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+        full_str = ''
+        if cli_config == 'rich':
+            header = '''<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!DOCTYPE POOLFILECATALOG SYSTEM "InMemory">
+<POOLFILECATALOG>'''
+            full_str = header
+        else:
+            print('''<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!DOCTYPE POOLFILECATALOG SYSTEM "InMemory">
 <POOLFILECATALOG>''')
 
@@ -677,15 +807,23 @@ def list_files(args):
             for f in client.list_files(scope=scope, name=name):
                 guid = f['guid']
                 if guid:
-                    guid = '%s-%s-%s-%s-%s' % (guid[0:8], guid[8:12], guid[12:16], guid[16:20], guid[20:32])
+                    guid = f'{guid[0:8]}-{guid[8:12]}-{guid[12:16]}-{guid[16:20]}-{guid[20:32]}'
                 else:
                     guid = '(None)'
-                print(file_str % (guid, args.LOCALPATH, f['name'], f['name']))
 
-        print('</POOLFILECATALOG>')
+                if cli_config == 'rich':
+                    full_str += '\n' + file_str % (guid, args.LOCALPATH, f['name'], f['name'])
+                else:
+                    print(file_str % (guid, args.LOCALPATH, f['name'], f['name']))
+
+        if cli_config == 'rich':
+            spinner.stop()
+            print_output(full_str + '\n</POOLFILECATALOG>', console=console, no_pager=True)
+        else:
+            print('</POOLFILECATALOG>')
         return SUCCESS
     else:
-        table = []
+        table_data = []
         for did in args.dids:
             totfiles = 0
             totsize = 0
@@ -698,15 +836,25 @@ def list_files(args):
                     totevents += int(file.get('events', 0))
                 guid = file['guid']
                 if guid:
-                    guid = '%s-%s-%s-%s-%s' % (guid[0:8], guid[8:12], guid[12:16], guid[16:20], guid[20:32])
+                    guid = f'{guid[0:8]}-{guid[8:12]}-{guid[12:16]}-{guid[16:20]}-{guid[20:32]}'
                 else:
                     guid = '(None)'
-                table.append(['%s:%s' % (file['scope'], file['name']), guid, 'ad:%s' % file['adler32'], sizefmt(file['bytes'], args.human), file['events']])
-            print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', 'GUID', 'ADLER32', 'FILESIZE', 'EVENTS'], disable_numparse=True))
-            print('Total files : %s' % totfiles)
-            print('Total size : %s' % sizefmt(totsize, args.human))
-            if totevents:
-                print('Total events : %s' % totevents)
+                table_data.append([f"{file['scope']}:{file['name']}", guid, f"ad:{file['adler32']}", sizefmt(file['bytes'], args.human), file['events']])
+
+            if cli_config == 'rich':
+                table = generate_table(table_data, headers=['SCOPE:NAME', 'GUID', 'ADLER32', 'FILESIZE', 'EVENTS'], col_alignments=['left', 'left', 'left', 'right', 'right'])
+                summary_data = [['Total files', str(totfiles)], ['Total size', sizefmt(totsize, args.human)]]
+                if totevents:
+                    summary_data.append(['Total events', str(totevents)])
+                summary_table = generate_table(summary_data, col_alignments=['left', 'left'], row_styles=['none'])
+                spinner.stop()
+                print_output(table, summary_table, console=console, no_pager=args.no_pager)
+            else:
+                print(tabulate(table_data, tablefmt=tablefmt, headers=['SCOPE:NAME', 'GUID', 'ADLER32', 'FILESIZE', 'EVENTS'], disable_numparse=True))
+                print('Total files : %s' % totfiles)
+                print('Total size : %s' % sizefmt(totsize, args.human))
+                if totevents:
+                    print('Total events : %s' % totevents)
         return SUCCESS
 
 
@@ -718,16 +866,32 @@ def list_content(args):
     List data identifier contents.
     """
     client = get_client(args)
-    table = []
+    table_data = []
+    if cli_config == 'rich':
+        spinner.update(status='Fetching dataset contents')
+        spinner.start()
+
     for did in args.dids:
         scope, name = get_scope(did, client)
         for content in client.list_content(scope=scope, name=name):
-            table.append(['%s:%s' % (content['scope'], content['name']), content['type'].upper()])
-    if args.short:
-        for did, dummy in table:
-            print(did)
+            if cli_config == 'rich':
+                table_data.append([f"{content['scope']}:{content['name']}", Text(content['type'].upper(), style=CLITheme.DID_TYPE.get(content['type'].upper(), 'default'))])
+            else:
+                table_data.append([f"{content['scope']}:{content['name']}", content['type'].upper()])
+
+    if cli_config == 'rich':
+        if args.short:
+            table = generate_table([[did] for did, _ in table_data], headers=['SCOPE:NAME'], col_alignments=['left'])
+        else:
+            table = generate_table(table_data, headers=['SCOPE:NAME', '[DID TYPE]'], col_alignments=['left', 'left'])
+        spinner.stop()
+        print_output(table, console=console, no_pager=args.no_pager)
     else:
-        print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
+        if args.short:
+            for did, dummy in table_data:
+                print(did)
+        else:
+            print(tabulate(table_data, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
     return SUCCESS
 
 
@@ -739,12 +903,25 @@ def list_content_history(args):
     List data identifier contents.
     """
     client = get_client(args)
-    table = []
+    table_data = []
+    if cli_config == 'rich':
+        spinner.update(status='Fetching content history')
+        spinner.start()
+
     for did in args.dids:
         scope, name = get_scope(did, client)
         for content in client.list_content_history(scope=scope, name=name):
-            table.append(['%s:%s' % (content['scope'], content['name']), content['type'].upper()])
-    print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
+            if cli_config == 'rich':
+                table_data.append([f"{content['scope']}:{content['name']}", Text(content['type'].upper(), style=CLITheme.DID_TYPE.get(content['type'].upper(), 'default'))])
+            else:
+                table_data.append([f"{content['scope']}:{content['name']}", content['type'].upper()])
+
+    if cli_config == 'rich':
+        table = generate_table(table_data, headers=['SCOPE:NAME', '[DID TYPE]'], col_alignments=['left', 'left'])
+        spinner.stop()
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        print(tabulate(table_data, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
     return SUCCESS
 
 
@@ -756,24 +933,43 @@ def list_parent_dids(args):
     List parent data identifier.
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching parent DIDs')
+        spinner.start()
+
     if args.pfns:
         dict_datasets = {}
+        output = []
         for res in client.get_did_from_pfns(args.pfns):
             for key in res:
                 if key not in dict_datasets:
                     dict_datasets[key] = []
                 for rule in client.list_associated_rules_for_file(res[key]['scope'], res[key]['name']):
-                    if '%s:%s' % (rule['scope'], rule['name']) not in dict_datasets[key]:
-                        dict_datasets[key].append('%s:%s' % (rule['scope'], rule['name']))
-        for pfn in dict_datasets:
-            print('PFN: ', pfn)
-            print('Parents: ', ','.join(dict_datasets[pfn]))
+                    if f"{rule['scope']}:{rule['name']}" not in dict_datasets[key]:
+                        dict_datasets[key].append(f"{rule['scope']}:{rule['name']}")
+
+        for i, pfn in enumerate(dict_datasets):
+            if cli_config == 'rich':
+                parent_tree = Tree('')
+                for parent in dict_datasets[pfn]:
+                    parent_tree.add(parent)
+                table = generate_table([['PFN', pfn], ['Parents', parent_tree]], col_alignments=['left', 'left'], row_styles=['none'])
+                output.append(table)
+            else:
+                print('PFN: ', pfn)
+                print('Parents: ', ','.join(dict_datasets[pfn]))
+
+        if cli_config == 'rich':
+            spinner.stop()
+            print_output(*output, console=console, no_pager=args.no_pager)
     elif args.guids:
+        output = []
         guids = []
         for input_ in args.guids:
             try:
                 uuid.UUID(input_)
             except ValueError:
+                print(f'Ignoring invalid GUID: {input_}')
                 continue
         dict_datasets = {}
         for guid in guids:
@@ -781,17 +977,38 @@ def list_parent_dids(args):
                 if guid not in dict_datasets:
                     dict_datasets[guid] = []
                 for rule in client.list_associated_rules_for_file(did['scope'], did['name']):
-                    if '%s:%s' % (rule['scope'], rule['name']) not in dict_datasets[guid]:
-                        dict_datasets[guid].append('%s:%s' % (rule['scope'], rule['name']))
-        for guid in dict_datasets:
-            print('GUID: ', guid)
-            print('Parents : ', ','.join(dict_datasets[guid]))
+                    if f"{rule['scope']}:{rule['name']}" not in dict_datasets[guid]:
+                        dict_datasets[guid].append(f"{rule['scope']}:{rule['name']}")
+
+        for i, guid in enumerate(dict_datasets):
+            if cli_config == 'rich':
+                parent_tree = Tree('')
+                for parent in dict_datasets[guid]:
+                    parent_tree.add(parent)
+                table = generate_table([['GUID', guid], ['Parents', parent_tree]], col_alignments=['left', 'left'], row_styles=['none'])
+                output.append(table)
+            else:
+                print('GUID: ', guid)
+                print('Parents : ', ','.join(dict_datasets[guid]))
+
+        if cli_config == 'rich':
+            spinner.stop()
+            print_output(*output, console=console, no_pager=args.no_pager)
     elif args.did:
-        table = []
+        table_data = []
         scope, name = get_scope(args.did, client)
         for dataset in client.list_parent_dids(scope=scope, name=name):
-            table.append(['%s:%s' % (dataset['scope'], dataset['name']), dataset['type']])
-        print(tabulate(table, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
+            if cli_config == 'rich':
+                table_data.append([f"{dataset['scope']}:{dataset['name']}", Text(dataset['type'], style=CLITheme.DID_TYPE.get(dataset['type'], 'default'))])
+            else:
+                table_data.append([f"{dataset['scope']}:{dataset['name']}", dataset['type']])
+
+        if cli_config == 'rich':
+            table = generate_table(table_data, headers=['SCOPE:NAME', '[DID TYPE]'], col_alignments=['left', 'left'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
+        else:
+            print(tabulate(table_data, tablefmt=tablefmt, headers=['SCOPE:NAME', '[DID TYPE]']))
     else:
         print('At least one option has to be given. Use -h to list the options.')
         return FAILURE
@@ -836,13 +1053,32 @@ def stat(args):
     List attributes and statuses about data identifiers..
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching DID stats')
+        spinner.start()
+        keyword_styles = {**CLITheme.BOOLEAN, **CLITheme.DID_TYPE}
+
+    output = []
     for i, did in enumerate(args.dids):
-        if i > 0:
-            print('------')
         scope, name = get_scope(did, client)
         info = client.get_did(scope=scope, name=name, dynamic_depth='DATASET')
-        table = [(k + ':', str(v)) for (k, v) in sorted(info.items())]
-        print(tabulate(table, tablefmt='plain', disable_numparse=True))
+        if cli_config == 'rich':
+            if i > 0:
+                output.append(Text(f'\nDID: {did}', style=CLITheme.TEXT_HIGHLIGHT))
+            elif len(args.dids) > 1:
+                output.append(Text(f'DID: {did}', style=CLITheme.TEXT_HIGHLIGHT))
+            table_data = [(k, Text(str(v), style=keyword_styles.get(str(v), 'default'))) for (k, v) in sorted(info.items())]
+            table = generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left'])
+            output.append(table)
+        else:
+            if i > 0:
+                print('------')
+            table = [(k + ':', str(v)) for (k, v) in sorted(info.items())]
+            print(tabulate(table, tablefmt='plain', disable_numparse=True))
+
+    if cli_config == 'rich':
+        spinner.stop()
+        print_output(*output, console=console, no_pager=args.no_pager)
     return SUCCESS
 
 
@@ -875,8 +1111,7 @@ def erase(args):
             try:
                 # set lifetime to expire in 24 hours (value is in seconds).
                 client.set_metadata(scope=scope, name=name, key='lifetime', value=86400)
-                logger.info('CAUTION! erase operation is irreversible after 24 hours. To cancel this operation you can run the following command:')
-                print("rucio erase --undo {0}:{1}".format(scope, name))
+                logger.info('CAUTION! erase operation is irreversible after 24 hours. To cancel this operation you can run the following command:\n rucio erase --undo {0}:{1}'.format(scope, name))
             except RucioException as error:
                 logger.warning('Failed to erase DID: %s' % did)
                 logger.debug('Error: %s' % error)
@@ -1020,7 +1255,7 @@ def download(args):
     item_defaults['check_local_with_filesize_only'] = args.check_local_with_filesize_only
     archive_did = args.archive_did
     if archive_did:
-        logger.warning("Archives are treated transparently. --archive-did option is being obsoleted.")  # TODO
+        logger.warning("Archives are treated transparently. --archive-did option is being obsoleted.")
 
     # Get filters
     filters = {}
@@ -1169,13 +1404,32 @@ def get_metadata(args):
     else:
         plugin = config_get('client', 'metadata_default_plugin', default='DID_COLUMN')
 
+    if cli_config == 'rich':
+        spinner.update(status='Fetching metadata')
+        spinner.start()
+        keyword_styles = {**CLITheme.BOOLEAN, **CLITheme.DID_TYPE, **CLITheme.AVAILABILITY}
+
+    output = []
     for i, did in enumerate(args.dids):
-        if i > 0:
-            print('------')
         scope, name = get_scope(did, client)
         meta = client.get_metadata(scope=scope, name=name, plugin=plugin)
-        table = [(k + ':', str(v)) for (k, v) in sorted(meta.items())]
-        print(tabulate(table, tablefmt='plain', disable_numparse=True))
+        if cli_config == 'rich':
+            if i > 0:
+                output.append(Text(f'\nDID: {did}', style=CLITheme.TEXT_HIGHLIGHT))
+            elif len(args.dids) > 1:
+                output.append(Text(f'DID: {did}', style=CLITheme.TEXT_HIGHLIGHT))
+            table_data = [(k, Text(str(v), style=keyword_styles.get(str(v), 'default'))) for (k, v) in sorted(meta.items())]
+            table = generate_table(table_data, col_alignments=['left', 'left'], row_styles=['none'])
+            output.append(table)
+        else:
+            if i > 0:
+                print('------')
+            table = [(k + ':', str(v)) for (k, v) in sorted(meta.items())]
+            print(tabulate(table, tablefmt='plain', disable_numparse=True))
+
+    if cli_config == 'rich':
+        spinner.stop()
+        print_output(*output, console=console, no_pager=args.no_pager)
     return SUCCESS
 
 
@@ -1198,7 +1452,7 @@ def set_metadata(args):
 @exception_handler
 def delete_metadata(args):
     """
-    %(prog)s set_metadata [options] <field1=value1 field2=value2 ...>
+    %(prog)s delete-metadata [options] <field1=value1 field2=value2 ...>
 
     Delete data identifier metadata
     """
@@ -1385,47 +1639,80 @@ def info_rule(args):
     Retrieve information about a rule.
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching rule info')
+        spinner.start()
+
     if args.examine:
+        output = []
         analysis = client.examine_replication_rule(rule_id=args.rule_id)
-        print('Status of the replication rule: %s' % analysis['rule_error'])
-        if analysis['transfers']:
-            print('STUCK Requests:')
-            for transfer in analysis['transfers']:
-                print('  %s:%s' % (transfer['scope'], transfer['name']))
-                print('    RSE:                  %s' % str(transfer['rse']))
-                print('    Attempts:             %s' % str(transfer['attempts']))
-                print('    Last Retry:           %s' % str(transfer['last_time']))
-                print('    Last error:           %s' % str(transfer['last_error']))
-                print('    Last source:          %s' % str(transfer['last_source']))
-                print('    Available sources:    %s' % ', '.join([source[0] for source in transfer['sources'] if source[1]]))
-                print('    Blocklisted sources:  %s' % ', '.join([source[0] for source in transfer['sources'] if not source[1]]))
+        if cli_config == 'rich':
+            keyword_styles = {**CLITheme.BOOLEAN, **CLITheme.DID_TYPE, **CLITheme.RULE_STATE}
+            rule_status = " ".join([f'[{keyword_styles.get(word, "default")}]{word}[/]' for word in analysis['rule_error'].split()])
+            output.append(f'Status of the replication rule: {rule_status}')
+            if analysis['transfers']:
+                output.append('[b]STUCK Requests:[/]')
+                for transfer in analysis['transfers']:
+                    output.append(Padding.indent(Text(f"{transfer['scope']}:{transfer['name']}", style=CLITheme.SUBHEADER_HIGHLIGHT), 2))
+                    table_data = [['RSE:', str(transfer['rse'])],
+                                  ['Attempts:', str(transfer['attempts'])],
+                                  ['Last retry:', str(transfer['last_time'])],
+                                  ['Last error:', str(transfer['last_source'])],
+                                  ['Available sources:', ', '.join([source[0] for source in transfer['sources'] if source[1]])],
+                                  ['Blocklisted sources:', ', '.join([source[0] for source in transfer['sources'] if not source[1]])]]
+                    table = generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left'])
+                    output.append(Padding.indent(table, 2))
+
+            spinner.stop()
+            print_output(*output, console=console, no_pager=args.no_pager)
+        else:
+            analysis = client.examine_replication_rule(rule_id=args.rule_id)
+            print('Status of the replication rule: %s' % analysis['rule_error'])
+            if analysis['transfers']:
+                print('STUCK Requests:')
+                for transfer in analysis['transfers']:
+                    print('  %s:%s' % (transfer['scope'], transfer['name']))
+                    print('    RSE:                  %s' % str(transfer['rse']))
+                    print('    Attempts:             %s' % str(transfer['attempts']))
+                    print('    Last Retry:           %s' % str(transfer['last_time']))
+                    print('    Last error:           %s' % str(transfer['last_error']))
+                    print('    Last source:          %s' % str(transfer['last_source']))
+                    print('    Available sources:    %s' % ', '.join([source[0] for source in transfer['sources'] if source[1]]))
+                    print('    Blocklisted sources:  %s' % ', '.join([source[0] for source in transfer['sources'] if not source[1]]))
     else:
         rule = client.get_replication_rule(rule_id=args.rule_id)
-        print("Id:                         %s" % rule['id'])
-        print("Account:                    %s" % rule['account'])
-        print("Scope:                      %s" % rule['scope'])
-        print("Name:                       %s" % rule['name'])
-        print("RSE Expression:             %s" % rule['rse_expression'])
-        print("Copies:                     %s" % rule['copies'])
-        print("State:                      %s" % rule['state'])
-        print("Locks OK/REPLICATING/STUCK: %s/%s/%s" % (rule['locks_ok_cnt'], rule['locks_replicating_cnt'], rule['locks_stuck_cnt']))
-        print("Grouping:                   %s" % rule['grouping'])
-        print("Expires at:                 %s" % rule['expires_at'])
-        print("Locked:                     %s" % rule['locked'])
-        print("Weight:                     %s" % rule['weight'])
-        print("Created at:                 %s" % rule['created_at'])
-        print("Updated at:                 %s" % rule['updated_at'])
-        print("Error:                      %s" % rule['error'])
-        print("Subscription Id:            %s" % rule['subscription_id'])
-        print("Source replica expression:  %s" % rule['source_replica_expression'])
-        print("Activity:                   %s" % rule['activity'])
-        print("Comment:                    %s" % rule['comments'])
-        print("Ignore Quota:               %s" % rule['ignore_account_limit'])
-        print("Ignore Availability:        %s" % rule['ignore_availability'])
-        print("Purge replicas:             %s" % rule['purge_replicas'])
-        print("Notification:               %s" % rule['notification'])
-        print("End of life:                %s" % rule['eol_at'])
-        print("Child Rule Id:              %s" % rule['child_rule_id'])
+        if cli_config == 'rich':
+            keyword_styles = {**CLITheme.BOOLEAN, **CLITheme.DID_TYPE, **CLITheme.RULE_STATE}
+            table_data = [(k, Text(str(v), style=keyword_styles.get(str(v), 'default'))) for k, v in sorted(rule.items())]
+            table = generate_table(table_data, col_alignments=['left', 'left'], row_styles=['none'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
+        else:
+            print("Id:                         %s" % rule['id'])
+            print("Account:                    %s" % rule['account'])
+            print("Scope:                      %s" % rule['scope'])
+            print("Name:                       %s" % rule['name'])
+            print("RSE Expression:             %s" % rule['rse_expression'])
+            print("Copies:                     %s" % rule['copies'])
+            print("State:                      %s" % rule['state'])
+            print("Locks OK/REPLICATING/STUCK: %s/%s/%s" % (rule['locks_ok_cnt'], rule['locks_replicating_cnt'], rule['locks_stuck_cnt']))
+            print("Grouping:                   %s" % rule['grouping'])
+            print("Expires at:                 %s" % rule['expires_at'])
+            print("Locked:                     %s" % rule['locked'])
+            print("Weight:                     %s" % rule['weight'])
+            print("Created at:                 %s" % rule['created_at'])
+            print("Updated at:                 %s" % rule['updated_at'])
+            print("Error:                      %s" % rule['error'])
+            print("Subscription Id:            %s" % rule['subscription_id'])
+            print("Source replica expression:  %s" % rule['source_replica_expression'])
+            print("Activity:                   %s" % rule['activity'])
+            print("Comment:                    %s" % rule['comments'])
+            print("Ignore Quota:               %s" % rule['ignore_account_limit'])
+            print("Ignore Availability:        %s" % rule['ignore_availability'])
+            print("Purge replicas:             %s" % rule['purge_replicas'])
+            print("Notification:               %s" % rule['notification'])
+            print("End of life:                %s" % rule['eol_at'])
+            print("Child Rule Id:              %s" % rule['child_rule_id'])
     return SUCCESS
 
 
@@ -1437,6 +1724,10 @@ def list_rules(args):
     List rules.
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching rules')
+        spinner.start()
+
     if args.rule_id:
         rules = [client.get_replication_rule(args.rule_id)]
     elif args.file:
@@ -1481,55 +1772,93 @@ def list_rules(args):
         for rule in rules:
             print(rule['id'],
                   rule['account'],
-                  '%s:%s' % (rule['scope'], rule['name']),
-                  '%s[%d/%d/%d]' % (rule['state'], rule['locks_ok_cnt'], rule['locks_replicating_cnt'], rule['locks_stuck_cnt']),
+                  f"{rule['scope']}:{rule['name']}",
+                  f"{rule['state']}[{rule['locks_ok_cnt']}/{rule['locks_replicating_cnt']}/{rule['locks_stuck_cnt']}]",
                   rule['rse_expression'],
                   rule['copies'],
                   sizefmt(rule['bytes'], args.human) if rule['bytes'] is not None else 'N/A',
                   rule['expires_at'],
                   rule['created_at'],
                   sep=',')
+
+        if cli_config == 'rich':
+            spinner.stop()
     else:
-        table = []
+        table_data = []
         for rule in rules:
-            table.append([rule['id'],
-                          rule['account'],
-                          '%s:%s' % (rule['scope'], rule['name']),
-                          '%s[%d/%d/%d]' % (rule['state'], rule['locks_ok_cnt'], rule['locks_replicating_cnt'], rule['locks_stuck_cnt']),
-                          rule['rse_expression'],
-                          rule['copies'],
-                          sizefmt(rule['bytes'], args.human) if rule['bytes'] is not None else 'N/A',
-                          rule['expires_at'],
-                          rule['created_at']])
-        print(tabulate(table, tablefmt='simple', headers=['ID', 'ACCOUNT', 'SCOPE:NAME', 'STATE[OK/REPL/STUCK]', 'RSE_EXPRESSION', 'COPIES', 'SIZE', 'EXPIRES (UTC)', 'CREATED (UTC)'], disable_numparse=True))
+            if cli_config == 'rich':
+                table_data.append([rule['id'],
+                                   rule['account'],
+                                   f"{rule['scope']}:{rule['name']}",
+                                   f"[{CLITheme.RULE_STATE.get(rule['state'], 'default')}]{rule['state']}[/][{rule['locks_ok_cnt']}/{rule['locks_replicating_cnt']}/{rule['locks_stuck_cnt']}]",
+                                   rule['rse_expression'],
+                                   rule['copies'],
+                                   sizefmt(rule['bytes'], args.human) if rule['bytes'] is not None else 'N/A',
+                                   rule['expires_at'],
+                                   rule['created_at']])
+            else:
+                table_data.append([rule['id'],
+                                   rule['account'],
+                                   f"{rule['scope']}:{rule['name']}",
+                                   f"{rule['state']}[{rule['locks_ok_cnt']}/{rule['locks_replicating_cnt']}/{rule['locks_stuck_cnt']}]",
+                                   rule['rse_expression'],
+                                   rule['copies'],
+                                   sizefmt(rule['bytes'], args.human) if rule['bytes'] is not None else 'N/A',
+                                   rule['expires_at'],
+                                   rule['created_at']])
+
+        if cli_config == 'rich':
+            table = generate_table(table_data, headers=['ID', 'ACCOUNT', 'SCOPE:NAME', 'STATE[OK/REPL/STUCK]', 'RSE EXPRESSION', 'COPIES', 'SIZE', 'EXPIRES (UTC)', 'CREATED (UTC)'],
+                                   col_alignments=['left', 'left', 'left', 'right', 'left', 'right', 'right', 'left', 'left'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
+        else:
+            print(tabulate(table_data, tablefmt='simple', headers=['ID', 'ACCOUNT', 'SCOPE:NAME', 'STATE[OK/REPL/STUCK]', 'RSE_EXPRESSION', 'COPIES', 'SIZE', 'EXPIRES (UTC)', 'CREATED (UTC)'], disable_numparse=True))
     return SUCCESS
 
 
 @exception_handler
 def list_rules_history(args):
     """
-    %(prog)s list-rules_history ...
+    %(prog)s list-rules-history ...
 
     List replication rules history for a DID.
     """
     rule_dict = []
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching rules history')
+        spinner.start()
+
     scope, name = get_scope(args.did, client)
+    table_data = []
     for rule in client.list_replication_rule_full_history(scope, name):
         if rule['rule_id'] not in rule_dict:
             rule_dict.append(rule['rule_id'])
-            print('-' * 40)
-            print('Rule insertion')
-            print('Account : %s' % rule['account'])
-            print('RSE expression : %s' % (rule['rse_expression']))
-            print('Time : %s' % (rule['created_at']))
+            if cli_config == 'rich':
+                table_data.append(['Insertion', rule['account'], rule['rse_expression'], rule['created_at']])
+            else:
+                print('-' * 40)
+                print('Rule insertion')
+                print('Account : %s' % rule['account'])
+                print('RSE expression : %s' % (rule['rse_expression']))
+                print('Time : %s' % (rule['created_at']))
         else:
             rule_dict.remove(rule['rule_id'])
-            print('-' * 40)
-            print('Rule deletion')
-            print('Account : %s' % rule['account'])
-            print('RSE expression : %s' % (rule['rse_expression']))
-            print('Time : %s' % (rule['updated_at']))
+            if cli_config == 'rich':
+                table_data.append(['Deletion', rule['account'], rule['rse_expression'], rule['updated_at']])
+            else:
+                print('-' * 40)
+                print('Rule deletion')
+                print('Account : %s' % rule['account'])
+                print('RSE expression : %s' % (rule['rse_expression']))
+                print('Time : %s' % (rule['updated_at']))
+
+    if cli_config == 'rich':
+        table_data = sorted(table_data, key=lambda entry: entry[-1], reverse=True)
+        table = generate_table(table_data, headers=['ACTION', 'ACCOUNT', 'RSE EXPRESSION', 'TIME'])
+        spinner.stop()
+        print_output(table, console=console, no_pager=args.no_pager)
     return SUCCESS
 
 
@@ -1542,10 +1871,18 @@ def list_rses(args):
 
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching RSEs')
+        spinner.start()
 
     rses = client.list_rses(args.rses)
-    for rse in rses:
-        print('%(rse)s' % rse)
+    if cli_config == 'rich':
+        table = generate_table([[rse['rse']] for rse in sorted(rses, key=lambda elem: elem['rse'])], headers=['RSE'], col_alignments=['left'])
+        spinner.stop()
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        for rse in rses:
+            print('%(rse)s' % rse)
     return SUCCESS
 
 
@@ -1567,14 +1904,25 @@ def list_suspicious_replicas(args):
         younger_than = args.younger_than
     if args.nattempts:
         nattempts = args.nattempts
+
+    if cli_config == 'rich':
+        spinner.update(status='Fetching suspicious replicas')
+        spinner.start()
+
     # Generator is a list with one entry, which itself is a list of lists.
     replicas_gen = client.list_suspicious_replicas(rse_expression, younger_than, nattempts)
     for i in replicas_gen:
         replicas = i
-    table = []
+    table_data = []
     for rep in replicas:
-        table.append([rep['rse'], rep['scope'], rep['created_at'], rep['cnt'], rep['name']])
-    print(tabulate(table, headers=(['RSE Expression:', 'Scope:', 'Created at:', 'Nattempts:', 'File Name:'])))
+        table_data.append([rep['rse'], rep['scope'], rep['created_at'], rep['cnt'], rep['name']])
+
+    if cli_config == 'rich':
+        table = generate_table(table_data, headers=['RSE EXPRESSION', 'SCOPE', 'CREATED AT', 'N-ATTEMPTS', 'FILE NAME'], col_alignments=['left', 'left', 'left', 'right', 'left'])
+        spinner.stop()
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        print(tabulate(table_data, headers=(['RSE Expression:', 'Scope:', 'Created at:', 'Nattempts:', 'File Name:'])))
     return SUCCESS
 
 
@@ -1588,8 +1936,15 @@ def list_rse_attributes(args):
     """
     client = get_client(args)
     attributes = client.list_rse_attributes(rse=args.rse)
-    table = [(k + ':', str(v)) for (k, v) in sorted(attributes.items())]  # columns have mixed datatypes
-    print(tabulate(table, tablefmt='plain', disable_numparse=True))  # disabling number parsing
+
+    if cli_config == 'rich':
+        keyword_styles = {**CLITheme.BOOLEAN, **CLITheme.RSE_TYPE}
+        table_data = [(k, Text(str(v), style=keyword_styles.get(str(v), 'default'))) for k, v in sorted(attributes.items())]  # columns have mixed datatypes
+        table = generate_table(table_data, col_alignments=['left', 'left'], row_styles=['none'])
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        table = [(k + ':', str(v)) for (k, v) in sorted(attributes.items())]  # columns have mixed datatypes
+        print(tabulate(table, tablefmt='plain', disable_numparse=True))  # disabling number parsing
     return SUCCESS
 
 
@@ -1602,34 +1957,80 @@ def list_rse_usage(args):
 
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching RSE usage')
+        spinner.start()
+
     all_usages = client.get_rse_usage(rse=args.rse, filters={'per_account': args.show_accounts})
     select_usages = [u for u in all_usages if u['source'] not in ('srm', 'gsiftp', 'webdav')]
-    print('USAGE:')
+
+    if cli_config == 'rich':
+        output = []
+        table_data = []
+        header = ['SOURCE', 'USED', 'FILES', 'FREE', 'TOTAL', 'UPDATED AT']
+        header_account_data = ['ACCOUNT', 'USED', 'PERCENTAGE %']
+        key2id = {header[i].lower().replace(' ', '_'): i for i in range(len(header))}
+        account_data = {}
     for usage in select_usages:
-        print('------')
+        if cli_config == 'rich':
+            row = [''] * len(header)
         for elem in usage:
-            if (elem in ['free', 'total'] and usage['source'] != 'storage' or elem == 'files' and usage['source'] != 'rucio'):
+            if elem in ['free', 'total'] and usage['source'] != 'storage' or elem == 'files' and usage['source'] != 'rucio':
                 continue
             elif elem in ['used', 'free', 'total']:
-                print('  {0}: {1}'.format(elem, sizefmt(usage[elem], args.human)))
-            elif elem == 'account_usages':
-                account_usages_title = '  per account:'
-                if not usage[elem]:
-                    account_usages_title += ' no usage'
+                if cli_config == 'rich':
+                    row[key2id[elem]] = sizefmt(usage[elem], args.human)
                 else:
-                    print(account_usages_title)
-                    print('  ------')
-                    col_width = max(len(str(entry[1])) for account in usage[elem] for entry in list(account.items())) + 16
-                    for account in usage[elem]:
-                        base_string = '    '
-                        used_string = 'used: {0}'.format(sizefmt(account['used'], args.human))
-                        account_string = 'account: {0}'.format(account['account'])
-                        percentage_string = 'percentage: {0}'.format(account['percentage'])
-                        print(base_string + account_string.ljust(col_width) + used_string.ljust(col_width) + percentage_string.ljust(col_width))
+                    print('  {0}: {1}'.format(elem, sizefmt(usage[elem], args.human)))
+            elif elem == 'account_usages':
+                if cli_config == 'rich':
+                    if usage[elem]:
+                        for account in usage[elem]:
+                            if cli_config == 'rich':
+                                account_data[usage['source']].append([account['account'], sizefmt(account['used'], args.human), str(account['percentage'])])
+                else:
+                    account_usages_title = '  per account:'
+                    if not usage[elem]:
+                        account_usages_title += ' no usage'
+                    else:
+                        print(account_usages_title)
                         print('  ------')
+                        col_width = max(len(str(entry[1])) for account in usage[elem] for entry in list(account.items())) + 16
+                        for account in usage[elem]:
+                            base_string = '    '
+                            used_string = 'used: {0}'.format(sizefmt(account['used'], args.human))
+                            account_string = 'account: {0}'.format(account['account'])
+                            percentage_string = 'percentage: {0}'.format(account['percentage'])
+                            print(base_string + account_string.ljust(col_width) + used_string.ljust(col_width) + percentage_string.ljust(col_width))
+                            print('  ------')
             else:
-                print('  {0}: {1}'.format(elem, usage[elem]))
-    print('------')
+                if cli_config == 'rich':
+                    if elem in key2id:
+                        row[key2id[elem]] = str(usage[elem])
+                    if elem == 'source':
+                        account_data[usage[elem]] = []
+                else:
+                    print('  {0}: {1}'.format(elem, usage[elem]))
+
+        if cli_config == 'rich':
+            table_data.append(row)
+
+    if cli_config == 'rich':
+        table = generate_table(table_data, headers=header, col_alignments=['left', 'right', 'right', 'right', 'right', 'left'])
+        output.append(table)
+
+        if args.show_accounts:
+            output.append('\n[b]USAGE PER ACCOUNT:')
+            for source in account_data:
+                if len(account_data[source]) > 0:
+                    output.append(Padding.indent(Text(f'source: {source}', style=CLITheme.SUBHEADER_HIGHLIGHT), 2))
+                    account_table = generate_table(account_data[source], headers=header_account_data, col_alignments=['left', 'right', 'right'])
+                    output.append(Padding.indent(account_table, 2))
+
+        spinner.stop()
+        print_output(*output, console=console, no_pager=args.no_pager)
+    else:
+        print('------')
     return SUCCESS
 
 
@@ -1642,24 +2043,40 @@ def list_account_limits(args):
 
     """
     client = get_client(args)
-    table = []
+    if cli_config == 'rich':
+        spinner.update(status='Fetching account limits')
+        spinner.start()
+
     if args.rse:
         limits = client.get_local_account_limit(account=args.limit_account, rse=args.rse)
     else:
         limits = client.get_local_account_limits(account=args.limit_account)
-    for limit in list(limits.items()):
-        table.append([limit[0], sizefmt(limit[1], args.human)])
-    table.sort()
-    print(tabulate(table, tablefmt=tablefmt, headers=['RSE', 'LIMIT']))
 
-    table = []
+    table_data = []
+    for limit in list(limits.items()):
+        table_data.append([limit[0], sizefmt(limit[1], args.human)])
+    table_data.sort()
+
+    if cli_config == 'rich':
+        table1 = generate_table(table_data, headers=['RSE', 'LIMIT'], col_alignments=['left', 'right'])
+    else:
+        print(tabulate(table_data, tablefmt=tablefmt, headers=['RSE', 'LIMIT']))
+
+    table_data = []
     limits = client.get_global_account_limits(account=args.limit_account)
     for limit in list(limits.items()):
         if (args.rse and args.rse in limit[1]['resolved_rses']) or not args.rse:
-            table.append([limit[0], sizefmt(limit[1]['limit'], args.human)])
-    table.sort()
-    print(tabulate(table, tablefmt=tablefmt, headers=['RSE EXPRESSION', 'LIMIT']))
+            table_data.append([limit[0], sizefmt(limit[1]['limit'], args.human)])
+    table_data.sort()
 
+    if cli_config == 'rich':
+        table2 = generate_table(table_data, headers=['RSE EXPRESSION', 'LIMIT'], col_alignments=['left', 'right'])
+    else:
+        print(tabulate(table_data, tablefmt=tablefmt, headers=['RSE EXPRESSION', 'LIMIT']))
+
+    if cli_config == 'rich':
+        spinner.stop()
+        print_output(table1, table2, console=console, no_pager=args.no_pager)
     return SUCCESS
 
 
@@ -1672,26 +2089,38 @@ def list_account_usage(args):
 
     """
     client = get_client(args)
-    table = []
-    if args.rse:
-        usage = client.get_local_account_usage(account=args.usage_account, rse=args.rse)
-    else:
-        usage = client.get_local_account_usage(account=args.usage_account)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching account usage')
+        spinner.start()
+
+    usage = client.get_local_account_usage(account=args.usage_account, rse=args.rse)
+    table_data = []
     for item in usage:
         remaining = 0 if float(item['bytes_remaining']) < 0 else float(item['bytes_remaining'])
-        table.append([item['rse'], sizefmt(item['bytes'], args.human), sizefmt(item['bytes_limit'], args.human), sizefmt(remaining, args.human)])
-    table.sort()
-    print(tabulate(table, tablefmt=tablefmt, headers=['RSE', 'USAGE', 'LIMIT', 'QUOTA LEFT']))
+        table_data.append([item['rse'], sizefmt(item['bytes'], args.human), sizefmt(item['bytes_limit'], args.human), sizefmt(remaining, args.human)])
+    table_data.sort()
 
-    table = []
+    if cli_config == 'rich':
+        table1 = generate_table(table_data, headers=['RSE', 'USAGE', 'LIMIT', 'QUOTA LEFT'], col_alignments=['left', 'right', 'right', 'right'])
+    else:
+        print(tabulate(table_data, tablefmt=tablefmt, headers=['RSE', 'USAGE', 'LIMIT', 'QUOTA LEFT']))
+
+    table_data = []
     usage = client.get_global_account_usage(account=args.usage_account)
     for item in usage:
         if (args.rse and args.rse in item['rse_expression']) or not args.rse:
             remaining = 0 if float(item['bytes_remaining']) < 0 else float(item['bytes_remaining'])
-            table.append([item['rse_expression'], sizefmt(item['bytes'], args.human), sizefmt(item['bytes_limit'], args.human), sizefmt(remaining, args.human)])
-    table.sort()
-    print(tabulate(table, tablefmt=tablefmt, headers=['RSE EXPRESSION', 'USAGE', 'LIMIT', 'QUOTA LEFT']))
+            table_data.append([item['rse_expression'], sizefmt(item['bytes'], args.human), sizefmt(item['bytes_limit'], args.human), sizefmt(remaining, args.human)])
+    table_data.sort()
 
+    if cli_config == 'rich':
+        table2 = generate_table(table_data, headers=['RSE EXPRESSION', 'USAGE', 'LIMIT', 'QUOTA LEFT'], col_alignments=['left', 'right', 'right', 'right'])
+    else:
+        print(tabulate(table_data, tablefmt=tablefmt, headers=['RSE EXPRESSION', 'USAGE', 'LIMIT', 'QUOTA LEFT']))
+
+    if cli_config == 'rich':
+        spinner.stop()
+        print_output(table1, table2, console=console, no_pager=args.no_pager)
     return SUCCESS
 
 
@@ -1704,19 +2133,36 @@ def list_datasets_rse(args):
 
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching datasets at RSE')
+        spinner.start()
+
     if args.long:
-        table = []
+        table_data = []
         for dsn in client.list_datasets_per_rse(args.rse):
-            table.append(['%s:%s' % (dsn['scope'], dsn['name']), '%s/%s' % (str(dsn['available_length']), str(dsn['length'])), '%s/%s' % (str(dsn['available_bytes']), str(dsn['bytes']))])
-        table.sort()
-        print(tabulate(table, tablefmt=tablefmt, headers=['DID', 'LOCAL FILES/TOTAL FILES', 'LOCAL BYTES/TOTAL BYTES']))
+            table_data.append([f"{dsn['scope']}:{dsn['name']}"
+                               f"{str(dsn['available_length'])}/{str(dsn['length'])}",
+                               f"{str(dsn['available_bytes'])}/{str(dsn['bytes'])}"])
+
+        if cli_config == 'rich':
+            table_data.sort()
+            table = generate_table(table_data, headers=['SCOPE:NAME', 'LOCAL FILES/TOTAL FILES', 'LOCAL BYTES/TOTAL BYTES'], col_alignments=['left', 'right', 'right'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
+        else:
+            print(tabulate(table_data, tablefmt=tablefmt, headers=['DID', 'LOCAL FILES/TOTAL FILES', 'LOCAL BYTES/TOTAL BYTES']))
     else:
-        dsns = list(set(['%s:%s' % (dsn['scope'], dsn['name']) for dsn in client.list_datasets_per_rse(args.rse)]))
+        dsns = list(set([f"{dsn['scope']}:{dsn['name']}" for dsn in client.list_datasets_per_rse(args.rse)]))
         dsns.sort()
-        print("SCOPE:NAME")
-        print('----------')
-        for dsn in dsns:
-            print(dsn)
+        if cli_config == 'rich':
+            table = generate_table([[dsn] for dsn in dsns], headers=['SCOPE:NAME'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
+        else:
+            print("SCOPE:NAME")
+            print('----------')
+            for dsn in dsns:
+                print(dsn)
     return SUCCESS
 
 
@@ -1789,7 +2235,7 @@ def add_lifetime_exception(args):
     if containers:
         logger.warning('One or more DIDs are containers. They will be resolved into a list of datasets to request exception. Full list below')
         for container in containers:
-            logger.info('Resolving %s:%s into datasets :' % (container['scope'], container['name']))
+            logger.info('Resolving %s:%s into datasets:' % (container['scope'], container['name']))
             list_datasets = __resolve_containers_to_datasets(container['scope'], container['name'], client)
             for chunk in chunks(list_datasets, chunk_limit):
                 for meta in client.get_metadata_bulk(chunk):
@@ -1803,7 +2249,7 @@ def add_lifetime_exception(args):
                         datasets.append({'scope': scope, 'name': name})
 
     if not datasets:
-        logger.error('Nothing to submit')
+        logger.error('Nothing to submit.')
         return SUCCESS
     try:
         client.add_exception(dids=datasets, account=client.account, pattern='', comments=reason, expires_at=expiration)
@@ -1811,11 +2257,18 @@ def add_lifetime_exception(args):
         logger.error(err)
         return FAILURE
     except Exception:
-        logger.error('Failure to submit exception. Please retry')
-        logger.debug(traceback.format_exc())
+        error_message = 'Failure to submit exception. Please retry.'
+        if cli_config == 'rich':
+            if logger.level == logging.DEBUG:
+                logger.exception(error_message)
+            else:
+                logger.error(error_message)
+        else:
+            logger.error(error_message)
+            logger.debug(traceback.format_exc())
         return FAILURE
 
-    logger.info('Exception successfully submitted. Summary below')
+    logger.info('Exception successfully submitted. Summary below:')
     for cnt, error in enumerate(error_types):
         print('{0:100} {1:6d}'.format(error, summary[cnt]))
     return SUCCESS
@@ -1870,6 +2323,7 @@ def get_parser():
     oparser.add_argument('--robot', '-R', dest="human", default=True, action='store_false', help="All output in bytes and without the units. This output format is preferred by parsers and scripts.")
     oparser.add_argument('--user-agent', '-U', dest="user_agent", default='rucio-clients', action='store', help="Rucio User Agent")
     oparser.add_argument('--vo', dest="vo", metavar="VO", default=None, help="VO to authenticate at. Only used in multi-VO mode.")
+    oparser.add_argument("--no-pager", dest="no_pager", default=False, action='store_true', help=argparse.SUPPRESS)
 
     # Options for the userpass or OIDC auth_strategy
     oparser.add_argument('-u', '--user', dest='username', default=None, help='username')
@@ -2273,7 +2727,7 @@ You can filter by key/value, e.g.::
     list_content_history_parser.set_defaults(function=list_content_history)
     list_content_history_parser.add_argument(dest='dids', nargs='+', action='store', help='List of space separated data identifiers.')
 
-# The upload subparser
+    # The upload subparser
     upload_parser = subparsers.add_parser('upload', help='Upload method.')
     upload_parser.set_defaults(function=upload)
     upload_parser.add_argument('--rse', dest='rse', action='store', help='Rucio Storage Element (RSE) name.', required=True).completer = rse_completer
@@ -2533,11 +2987,30 @@ if __name__ == '__main__':
         sys.exit(FAILURE)
 
     args = oparser.parse_args(arguments)
+    pager = get_pager()
 
-    logger = setup_logger(module_name=__name__, logger_name='user', verbose=args.verbose)
+    if cli_config == 'rich':
+        install(console=console, word_wrap=True, width=min(console.width, MAX_TRACEBACK_WIDTH))  # Make rich exception tracebacks the default.
+        logger = setup_rich_logger(module_name=__name__, logger_name='user', verbose=args.verbose, console=console)
+    else:
+        logger = setup_logger(module_name=__name__, logger_name='user', verbose=args.verbose)
+
     start_time = time.time()
     result = args.function(args)
     end_time = time.time()
-    if args.verbose:
-        print("Completed in %-0.4f sec." % (end_time - start_time))
+    if cli_config == 'rich':
+        spinner.stop()
+    if console.is_terminal and not args.no_pager:
+        command_output = console.end_capture()
+        if command_output == '' and args.verbose:
+            print("Completed in %-0.4f sec." % (end_time - start_time))
+        else:
+            if args.verbose:
+                command_output += "Completed in %-0.4f sec." % (end_time - start_time)
+            # Ignore SIGINT during pager execution.
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            pager(command_output)
+    else:
+        if args.verbose:
+            print("Completed in %-0.4f sec." % (end_time - start_time))
     sys.exit(result)

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -28,10 +28,18 @@ from configparser import NoOptionError, NoSectionError
 from functools import wraps
 from textwrap import dedent
 
+from rich.console import Console
+from rich.padding import Padding
+from rich.status import Status
+from rich.text import Text
+from rich.theme import Theme
+from rich.traceback import install
+from rich.tree import Tree
 from tabulate import tabulate
 
 from rucio import version
 from rucio.client import Client
+from rucio.client.richclient import MAX_TRACEBACK_WIDTH, MIN_CONSOLE_WIDTH, CLITheme, generate_table, get_cli_config, get_pager, print_output, setup_rich_logger
 from rucio.common.config import config_get
 from rucio.common.constants import RseAttr
 from rucio.common.exception import (
@@ -71,9 +79,14 @@ SUCCESS = 0
 FAILURE = 1
 DEFAULT_PORT = 443
 
-logger = logging.getLogger("user")
+# Setting up rich console.
+console = Console(theme=Theme(CLITheme.LOG_THEMES), soft_wrap=True)
+console.width = max(MIN_CONSOLE_WIDTH, console.width)
 
+logger = logging.getLogger("user")
 tablefmt = 'psql'
+cli_config = get_cli_config()
+spinner = Status('Initializing spinner', spinner=CLITheme.SPINNER, spinner_style=CLITheme.SPINNER_STYLE, console=console)
 
 
 def setup_logger(logger):
@@ -88,9 +101,6 @@ def setup_logger(logger):
         return func
     hdlr.emit = emit_decorator(hdlr.emit)
     logger.addHandler(hdlr)
-
-
-setup_logger(logger)
 
 
 def signal_handler(signal, frame):
@@ -183,9 +193,15 @@ def exception_handler(function):
                 devnull = os.open(os.devnull, os.O_WRONLY)
                 os.dup2(devnull, sys.stdout.fileno())
                 return SUCCESS
-            logger.error(error)
-            logger.error('Rucio exited with an unexpected/unknown error, please provide the traceback below to the developers.')
-            logger.debug(traceback.format_exc())
+            if cli_config == 'rich':
+                if logger.level == logging.DEBUG:
+                    logger.exception(error)
+                else:
+                    logger.error(error)
+            else:
+                logger.debug(traceback.format_exc())
+                logger.error(error)
+            logger.error('Rucio exited with an unexpected/unknown error, please provide the traceback above to the developers.')
             return FAILURE
     return new_funct
 
@@ -328,12 +344,21 @@ def list_accounts(args):
     """
     client = get_client(args)
     filters = {}
+    if cli_config == 'rich':
+        spinner.update(status='Fetching accounts')
+        spinner.start()
+
     if args.filters:
         for key, value in [(_.split('=')[0], _.split('=')[1]) for _ in args.filters.split(',')]:
             filters[key] = value
     accounts = client.list_accounts(identity=args.identity, account_type=args.account_type, filters=filters)
-    for account in accounts:
-        print(account['account'])
+    if cli_config == 'rich':
+        table = generate_table([[account['account']] for account in accounts], headers=['ACCOUNT'], col_alignments=['left'])
+        spinner.stop()
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        for account in accounts:
+            print(account['account'])
     return SUCCESS
 
 
@@ -347,8 +372,14 @@ def info_account(args):
     """
     client = get_client(args)
     info = client.get_account(account=args.account)
-    for k in info:
-        print(k.ljust(10) + ' : ' + str(info[k]))
+    if cli_config == 'rich':
+        keyword_style = {**CLITheme.ACCOUNT_STATUS, **CLITheme.ACCOUNT_TYPE}
+        table_data = [(k, Text(str(v), style=keyword_style.get(str(v), 'default'))) for k, v in sorted(info.items())]
+        table = generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left'])
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        for k in info:
+            print(k.ljust(10) + ' : ' + str(info[k]))
     return SUCCESS
 
 
@@ -360,9 +391,16 @@ def list_identities(args):
     List all identities on an account.
     """
     client = get_client(args)
+    table_data = []
     identities = client.list_identities(account=args.account)
     for identity in identities:
-        print('Identity: %(identity)s,\ttype: %(type)s' % identity)
+        if cli_config == 'rich':
+            table_data.append([identity['identity'], identity['type']])
+        else:
+            print('Identity: %(identity)s,\ttype: %(type)s' % identity)
+    if cli_config == 'rich':
+        table = generate_table(table_data, headers=['IDENTITY', 'TYPE'], col_alignments=['left', 'left'])
+        print_output(table, console=console, no_pager=args.no_pager)
     return SUCCESS
 
 
@@ -406,7 +444,7 @@ def get_limits(args):
     locality = args.locality.lower()
     limits = client.get_account_limits(account=args.account, rse_expression=args.rse, locality=locality)
     for rse in limits:
-        print('Quota on %s for %s : %s' % (rse, args.account, sizefmt(limits[rse], True)))
+        print('Quota on %s for %s: %s' % (rse, args.account, sizefmt(limits[rse], True)))
     return SUCCESS
 
 
@@ -495,9 +533,19 @@ def list_rses(args):
 
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching RSEs')
+        spinner.start()
+
     rses = client.list_rses()
-    for rse in rses:
-        print('%(rse)s' % rse)
+    if cli_config == 'rich':
+        table_data = [[rse['rse']] for rse in sorted(rses, key=lambda elem: elem['rse'])]
+        table = generate_table(table_data, headers=['RSE'], col_alignments=['left'])
+        spinner.stop()
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        for rse in rses:
+            print(rse['rse'])
     return SUCCESS
 
 
@@ -538,39 +586,129 @@ def info_rse(args):
 
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching RSE info')
+        spinner.start()
+
     rseinfo = client.get_rse(rse=args.rse)
     attributes = client.list_rse_attributes(rse=args.rse)
     usage = client.get_rse_usage(rse=args.rse)
     rse_limits = client.get_rse_limits(args.rse)
-    print('Settings:')
-    print('=========')
-    for key in sorted(rseinfo):
-        if key != 'protocols':
-            print('  ' + key + ': ' + str(rseinfo[key]))
-    print('Attributes:')
-    print('===========')
-    for attribute in sorted(attributes):
-        print('  ' + attribute + ': ' + str(attributes[attribute]))
-    print('Protocols:')
-    print('==========')
-    for protocol in sorted(rseinfo['protocols'], key=lambda x: x['scheme']):
-        print('  ' + protocol['scheme'])
-        for item in sorted(protocol):
-            if item == 'domains':
-                print('    ' + item + ': \'' + json.dumps(protocol[item]) + '\'')
-            else:
-                print('    ' + item + ': ' + str(protocol[item]))
-    print('Usage:')
-    print('======')
-    for elem in sorted(usage, key=lambda x: x['source']):
-        print('  ' + elem['source'])
-        for item in sorted(elem):
-            print('    ' + item + ': ' + str(elem[item]))
-    print('RSE limits:')
-    print('===========')
-    for limit in rse_limits:
-        print('  ' + limit + ': ' + str(rse_limits[limit]) + ' B')
 
+    if cli_config == 'rich':
+        keyword_styles = {**CLITheme.BOOLEAN, **CLITheme.RSE_TYPE}
+        output = []
+        table_data = []
+    else:
+        print('Settings:')
+        print('=========')
+    for i, key in enumerate(sorted(rseinfo)):
+        if cli_config == 'rich':
+            if i == 0:
+                output.append('[b]Settings:[/]')
+            if key != 'protocols':
+                table_data.append([key, Text(str(rseinfo[key]), style=keyword_styles.get(str(rseinfo[key]), 'default'))])
+        else:
+            if key != 'protocols':
+                print('  ' + key + ': ' + str(rseinfo[key]))
+
+    if cli_config == 'rich':
+        table = generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left'])
+        output.append(table)
+        table_data = []
+    else:
+        print('Attributes:')
+        print('===========')
+    for i, attribute in enumerate(sorted(attributes)):
+        if cli_config == 'rich':
+            if i == 0:
+                output.append('\n[b]Attributes:[/]')
+            table_data.append([attribute, Text(str(attributes[attribute]), style=keyword_styles.get(str(attributes[attribute]), 'default'))])
+        else:
+            print('  ' + attribute + ': ' + str(attributes[attribute]))
+
+    if cli_config == 'rich':
+        table = generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left'])
+        output.append(table)
+    else:
+        print('Protocols:')
+        print('==========')
+    for i, protocol in enumerate(sorted(rseinfo['protocols'], key=lambda x: x['scheme'])):
+        if cli_config == 'rich':
+            if i == 0:
+                output.append('\n[b]Protocols:[/]')
+            output.append(Padding.indent(Text(protocol['scheme'], style=CLITheme.SUBHEADER_HIGHLIGHT), 2))
+        else:
+            print('  ' + protocol['scheme'])
+
+        table_data = []
+        for item in sorted(protocol):
+            if cli_config == 'rich':
+                if item == 'domains':
+                    tree = Tree('')
+                    for domain, values in protocol[item].items():
+                        branch = tree.add(f'[{CLITheme.JSON_STR}]{domain}')
+                        for k, v in values.items():
+                            branch.add(f'[{CLITheme.JSON_STR}]{k}[/]: [{CLITheme.JSON_NUM}]{v}[/]')
+                    table_data.append([item, tree])
+                else:
+                    table_data.append([item, Text(str(protocol[item]), style=keyword_styles.get(protocol[item], 'default'))])
+            else:
+                if item == 'domains':
+                    print('    ' + item + ': \'' + json.dumps(protocol[item]) + '\'')
+                else:
+                    print('    ' + item + ': ' + str(protocol[item]))
+
+    if cli_config == 'rich':
+        table = generate_table(table_data, col_alignments=['left', 'left'], row_styles=['none'])
+        output.append(Padding.indent(table, 2))
+
+        header = ['SOURCE', 'USED', 'FILES', 'FREE', 'TOTAL', 'UPDATED AT']
+        key2id = {header[i].lower().replace(' ', '_'): i for i in range(len(header))}
+        table_data = []
+    else:
+        print('Usage:')
+        print('======')
+    for i, elem in enumerate(sorted(usage, key=lambda x: x['source'])):
+        if cli_config == 'rich':
+            if i == 0:
+                output.append('\n[b]Usage:[/]')
+
+            row = [''] * len(header)
+            row[0] = elem['source']
+            for item in sorted(elem):
+                if item in ['used', 'free', 'total']:
+                    row[key2id[item]] = sizefmt(elem[item], True)
+                elif item != 'source' and item in key2id:
+                    row[key2id[item]] = str(elem[item])
+            table_data.append(row)
+        else:
+            print('  ' + elem['source'])
+            for item in sorted(elem):
+                print('    ' + item + ': ' + str(elem[item]))
+
+    if cli_config == 'rich':
+        if len(table_data) > 0:
+            usage_table = generate_table(table_data, headers=header, col_alignments=['left', 'right', 'right', 'right', 'right', 'left'])
+            output.append(usage_table)
+        table_data = []
+    else:
+        print('RSE limits:')
+        print('===========')
+    for i, limit in enumerate(rse_limits):
+        if cli_config == 'rich':
+            if i == 0:
+                output.append('\n[b]RSE limits:[/]')
+            table_data.append([limit, str(rse_limits[limit]) + ' B'])
+        else:
+            print('  ' + limit + ': ' + str(rse_limits[limit]) + ' B')
+
+    if cli_config == 'rich':
+        if len(table_data) > 0:
+            table = generate_table(table_data, row_styles=['none'], col_alignments=['left', 'right'])
+            output.append(table)
+        spinner.stop()
+        print_output(*output, console=console, no_pager=args.no_pager)
     return SUCCESS
 
 
@@ -598,9 +736,13 @@ def get_attribute_rse(args):
     """
     client = get_client(args)
     attributes = client.list_rse_attributes(rse=args.rse)
-    for k in attributes:
-        print(k + ': ' + str(attributes[k]))
-
+    if cli_config == 'rich':
+        table_data = [(k, Text(str(v), style=CLITheme.BOOLEAN.get(str(v), 'default'))) for k, v in sorted(attributes.items())]
+        table = generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left'])
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        for k in attributes:
+            print(k + ': ' + str(attributes[k]))
     return SUCCESS
 
 
@@ -641,10 +783,18 @@ def get_distance_rses(args):
     """
     client = get_client(args)
     distance_info = client.get_distance(args.source, args.destination)
-    if distance_info:
-        print('Distance information from %s to %s: distance=%d' % (args.source, args.destination, distance_info[0]['distance']))
+    if cli_config == 'rich':
+        if distance_info:
+            table = generate_table([[args.source, args.destination, str(distance_info[0]['distance'])]], headers=['SOURCE', 'DESTINATION', 'DISTANCE'],
+                                   col_alignments=['left', 'left', 'right'])
+            print_output(table, console=console, no_pager=args.no_pager)
+        else:
+            print(f"No distance set from {args.source} to {args.destination}")
     else:
-        print("No distance set from %s to %s" % (args.source, args.destination))
+        if distance_info:
+            print('Distance information from %s to %s: distance=%d' % (args.source, args.destination, distance_info[0]['distance']))
+        else:
+            print("No distance set from %s to %s" % (args.source, args.destination))
     return SUCCESS
 
 
@@ -763,9 +913,19 @@ def list_qos_policies(args):
     List all QoS policies of an RSE.
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching QoS policies')
+        spinner.start()
+
     qos_policies = client.list_qos_policies(args.rse)
-    for qos_policy in sorted(qos_policies):
-        print(qos_policy)
+    if cli_config == 'rich':
+        qos_policies = [[qos_policy] for qos_policy in sorted(qos_policies)]
+        table = generate_table(qos_policies, headers=['QOS POLICY'], col_alignments=['left'])
+        spinner.stop()
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        for qos_policy in sorted(qos_policies):
+            print(qos_policy)
     return SUCCESS
 
 
@@ -783,7 +943,6 @@ def set_limit_rse(args):
             logger.info('Set RSE limit successfully for %s: %s = %s' % (args.rse, args.name, args.value))
     except ValueError:
         logger.error('The RSE limit value must be an integer')
-
     return SUCCESS
 
 
@@ -801,7 +960,6 @@ def delete_limit_rse(args):
     else:
         if client.delete_rse_limits(args.rse, args.name):
             logger.info('Deleted RSE limit successfully for %s: %s' % (args.rse, args.name))
-
     return SUCCESS
 
 
@@ -828,13 +986,23 @@ def list_scopes(args):
 
     """
     client = get_client(args)
+    if cli_config == 'rich':
+        spinner.update(status='Fetching scopes')
+        spinner.start()
+
     if args.account:
         scopes = client.list_scopes_for_account(args.account)
     else:
         scopes = client.list_scopes()
-    for scope in scopes:
-        if 'mock' not in scope:
-            print(scope)
+    if cli_config == 'rich':
+        scopes = [[scope] for scope in sorted(scopes) if 'mock' not in scope]
+        table = generate_table(scopes, headers=['SCOPE'], col_alignments=['left'])
+        spinner.stop()
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        for scope in scopes:
+            if 'mock' not in scope:
+                print(scope)
     return SUCCESS
 
 
@@ -930,13 +1098,61 @@ def list_subscriptions(args):
         account = args.issuer
     else:
         account = client.account
+
+    if cli_config == 'rich':
+        spinner.update(status='Fetching subscriptions')
+        spinner.start()
+        keyword_styles = {**CLITheme.SUBSCRIPTION_STATE, **CLITheme.BOOLEAN}
+
     subs = client.list_subscriptions(name=args.name, account=account)
     for sub in subs:
+        table_data = []
         if args.long:
-            print('\n'.join('%s: %s' % (str(k), str(v)) for (k, v) in list(sub.items())))
-            print()
+            if cli_config == 'rich':
+                for k, v in sorted(sub.items()):
+                    if k == 'filter':
+                        filter_tree = Tree('')
+                        for filter, values in json.loads(sub['filter']).items():
+                            values_str = ', '.join(values)
+                            filter_tree.add(f'[{CLITheme.JSON_STR}]{filter}[/]: {values_str}')
+                        table_data.append(['filter', filter_tree])
+                    elif k == 'replication_rules':
+                        rule_tree = Tree('')
+                        for i, rule in enumerate(json.loads(sub['replication_rules'])):
+                            branch = rule_tree.add(Text('rule:', style='default'))
+                            for k, v in rule.items():
+                                branch.add(f'[{CLITheme.JSON_STR}]{k}[/]: {v}')
+                        table_data.append(['replication_rules', rule_tree])
+                    else:
+                        table_data.append([str(k), Text(str(v), style=keyword_styles.get(str(v), 'default'))])
+            else:
+                print('\n'.join('%s: %s' % (str(k), str(v)) for (k, v) in list(sub.items())))
+                print()
         else:
-            print("%s: %s %s\n  priority: %s\n  filter: %s\n  rules: %s\n  comments: %s" % (sub['account'], sub['name'], sub['state'], sub['policyid'], sub['filter'], sub['replication_rules'], sub.get('comments', '')))
+            if cli_config == 'rich':
+                table_data.append(['account', sub['account']])
+                table_data.append(['comments', sub.get('comments', '')])
+                filter_tree = Tree('')
+                for filter, values in json.loads(sub['filter']).items():
+                    values_str = ', '.join(values)
+                    filter_tree.add(f'[green]{filter}[/]: {values_str}')
+                table_data.append(['filter', filter_tree])
+                table_data.append(['name', sub['name']])
+                table_data.append(['policyid', str(sub['policyid'])])
+                rule_tree = Tree('')
+                for i, rule in enumerate(json.loads(sub['replication_rules'])):
+                    branch = rule_tree.add(Text('rule:', style='default'))
+                    for k, v in rule.items():
+                        branch.add(f'[{CLITheme.JSON_STR}]{k}[/]: {v}')
+                table_data.append(['replication_rules', rule_tree])
+                table_data.append(['state', Text(str(sub['state']), keyword_styles.get(str(sub['state']), 'default'))])
+            else:
+                print("%s: %s %s\n  priority: %s\n  filter: %s\n  rules: %s\n  comments: %s" % (sub['account'], sub['name'], sub['state'], sub['policyid'], sub['filter'], sub['replication_rules'], sub.get('comments', '')))
+
+        if cli_config == 'rich':
+            table = generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
     return SUCCESS
 
 
@@ -986,10 +1202,15 @@ def list_account_attributes(args):
     client = get_client(args)
     account = args.account or client.account
     attributes = next(client.list_account_attributes(account))
-    table = []
+    table_data = []
     for attr in attributes:
-        table.append([attr['key'], attr['value']])
-    print(tabulate(table, tablefmt=tablefmt, headers=['Key', 'Value']))
+        table_data.append([attr['key'], attr['value']])
+
+    if cli_config == 'rich':
+        table = generate_table(table_data, headers=['Key', 'Value'], col_alignments=['left', 'left'])
+        print_output(table, console=console, no_pager=args.no_pager)
+    else:
+        print(tabulate(table_data, tablefmt=tablefmt, headers=['Key', 'Value']))
     return SUCCESS
 
 
@@ -1126,9 +1347,9 @@ def declare_bad_file_replicas(args):
         non_declared = client.declare_bad_file_replicas(bad_files_pfns, args.reason)
         for rse in non_declared:
             for pfn in non_declared[rse]:
-                print('%s : PFN %s cannot be declared.' % (rse, pfn))
+                print('%s: PFN %s cannot be declared.' % (rse, pfn))
     else:
-        print('Getting the information about RSE protocols. It can take several seconds')
+        print('Getting the information about RSE protocols. It can take several seconds.')
         dict_rse = client.export_data(distance=False)
         prot_dict = {}
         for rse, dict_attr in dict_rse['rses'].items():
@@ -1263,7 +1484,7 @@ def list_pfns(args):
                                            path if not path.startswith('/') else path[1:]])
                             print(pfn)
                 else:
-                    logger.error('Unexpected error')
+                    logger.error('Unexpected error.')
                     return FAILURE
             else:
                 print(result)
@@ -1281,26 +1502,47 @@ def import_data(args):
     client = get_client(args)
     import_file_path = args.file_path
     data = None
-    print('Start reading file.')
+    if cli_config == 'rich':
+        spinner.update(status='Reading file')
+        spinner.start()
+
     try:
         with open(import_file_path) as import_file:
             data_string = import_file.read()
             data = parse_response(data_string)
     except ValueError as error:
-        print('There was problem with decoding your file.')
-        print(error)
+        if cli_config == 'rich':
+            spinner.stop()
+            print_output(f'{CLITheme.FAILURE_ICON} There was problem with decoding your file.', console=console, no_pager=True)
+            logger.error(error)
+        else:
+            print('There was problem with decoding your file.')
+            print(error)
         return FAILURE
     except OSError as error:
-        print('There was a problem with reading your file.')
-        print(error)
+        if cli_config == 'rich':
+            spinner.stop()
+            print_output(f'{CLITheme.FAILURE_ICON} There was a problem with reading your file.', console=console, no_pager=True)
+            logger.error(error)
+        else:
+            print('There was a problem with reading your file.')
+            print(error)
         return FAILURE
 
     if data:
         client.import_data(data)
-        print('Data successfully imported.')
+        if cli_config == 'rich':
+            spinner.stop()
+            print_output(f'{CLITheme.SUCCESS_ICON} Data successfully imported.', console=console, no_pager=True)
+        else:
+            print('Data successfully imported.')
         return SUCCESS
     else:
-        print('Nothing to import.')
+        if cli_config == 'rich':
+            spinner.stop()
+            print_output('Nothing to import.', console=console, no_pager=True)
+        else:
+            print('Nothing to import.')
         return FAILURE
 
 
@@ -1314,17 +1556,32 @@ def export_data(args):
     """
     client = get_client(args)
     destination_file_path = args.file_path
-    print('Start querying data.')
+    if cli_config == 'rich':
+        spinner.update(status='Querying data')
+        spinner.start()
+    else:
+        print('Start querying data.')
+
     data = client.export_data()
     try:
         with open(destination_file_path, 'w+') as destination_file:
             destination_file.write(render_json(**data))
-            print('File successfully written.')
-        print('Data successfully exported to %s' % args.file_path)
+            if cli_config != 'rich':
+                print('File successfully written.')
+        if cli_config == 'rich':
+            spinner.stop()
+            print_output(f'{CLITheme.SUCCESS_ICON} Data successfully exported to {args.file_path}', console=console, no_pager=True)
+        else:
+            print('Data successfully exported to %s' % args.file_path)
         return SUCCESS
     except OSError as error:
-        print('There was a problem with reading your file.')
-        print(error)
+        if cli_config == 'rich':
+            spinner.stop()
+            print_output(f'{CLITheme.FAILURE_ICON} There was a problem with reading your file.', console=console, no_pager=True)
+            logger.error(error)
+        else:
+            print('There was a problem with reading your file.')
+            print(error)
         return FAILURE
 
 
@@ -1368,6 +1625,7 @@ def get_parser():
     oparser.add_argument('-S', '--auth-strategy', dest="auth_strategy", default=None, help="Authentication strategy (userpass, x509, ssh ...)")
     oparser.add_argument('-T', '--timeout', dest="timeout", type=float, default=None, help="Set all timeout values to SECONDS")
     oparser.add_argument('--vo', dest="vo", metavar="VO", default=None, help="VO to authenticate at. Only used in multi-VO mode.")
+    oparser.add_argument("--no-pager", dest="no_pager", default=False, action='store_true', help=argparse.SUPPRESS)
 
     # Options for the userpass auth_strategy
     oparser.add_argument('-u', '--user', dest='username', default=None, help='username')
@@ -2383,6 +2641,7 @@ if __name__ == '__main__':
         oparser.print_help()
         sys.exit(FAILURE)
 
+    pager = get_pager()
     commands = {'add_account': add_account,
                 'list_accounts': list_accounts,
                 'list_account_attributes': list_account_attributes,
@@ -2436,12 +2695,31 @@ if __name__ == '__main__':
                 'delete_limit_rse': delete_limit_rse,
                 }
 
-    if args.verbose:
-        logger.setLevel(logging.DEBUG)
+    if cli_config == 'rich':
+        install(console=console, word_wrap=True, width=min(console.width, MAX_TRACEBACK_WIDTH))  # Make rich exception tracebacks the default.
+        logger = setup_rich_logger(module_name=__name__, logger_name='user', verbose=args.verbose, console=console)
+    else:
+        setup_logger(logger)
+        if args.verbose:
+            logger.setLevel(logging.DEBUG)
+
     start_time = time.time()
     command = commands.get(args.which)
     result = command(args)
     end_time = time.time()
-    if args.verbose:
-        print("Completed in %-0.4f sec." % (end_time - start_time))
+    if cli_config == 'rich':
+        spinner.stop()
+    if console.is_terminal and not args.no_pager:
+        command_output = console.end_capture()
+        if command_output == '' and args.verbose:
+            print("Completed in %-0.4f sec." % (end_time - start_time))
+        else:
+            if args.verbose:
+                command_output += "Completed in %-0.4f sec." % (end_time - start_time)
+            # Ignore SIGINT during pager execution.
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            pager(command_output)
+    else:
+        if args.verbose:
+            print("Completed in %-0.4f sec." % (end_time - start_time))
     sys.exit(result)

--- a/lib/rucio/client/richclient.py
+++ b/lib/rucio/client/richclient.py
@@ -1,0 +1,324 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import pydoc
+import re
+import subprocess
+import sys
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+from rich import box
+from rich.console import Console, JustifyMethod, RenderableType
+from rich.logging import RichHandler
+from rich.table import Table
+from rich.text import Text
+
+from rucio.common.config import config_get
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from rich.style import StyleType
+
+
+MIN_CONSOLE_WIDTH = 80
+MAX_TRACEBACK_WIDTH = 120  # Slightly higher than default width of rich.traceback (100).
+
+
+class CLITheme:
+    """
+    Class to define styles for Rich widgets and prints in the CLI.
+    """
+    TABLE_FMT = box.SQUARE
+
+    TEXT_HIGHLIGHT = 'grey50'  # Used to highlight prints between tables, e.g. get_metadata or stat.
+    SUBHEADER_HIGHLIGHT = 'cyan'  # Used to highlight prints between tables for a section, e.g. protocols or usage per account.
+    SPINNER = 'dots2'
+    SPINNER_STYLE = 'green'
+
+    JSON_STR = 'green'
+    JSON_NUM = 'bold cyan'
+
+    SUCCESS_ICON = '[bold green]\u2714[/]'
+    FAILURE_ICON = '[bold red]\u2717[/]'
+
+    LOG_THEMES = {
+        'logging.level.info': 'default',
+        'logging.level.warning': 'bold yellow',
+        'logging.level.debug': 'dim',
+        'logging.level.critical': 'default on red',
+        'repr.bool_true': 'green',
+        'repr.bool_false': 'red',
+        'log.time': 'turquoise4'
+    }
+
+    DID_TYPE = {
+        'CONTAINER': 'bold dodger_blue1',
+        'DATASET': 'bold orange3',
+        'FILE': 'bold default',
+        'COLLECTION': 'bold green',
+        'ALL': 'bold magenta',
+        'DERIVED': 'bold magenta'
+    }
+
+    BOOLEAN = {
+        'True': 'green',
+        'False': 'red'
+    }
+
+    RULE_STATE = {
+        'OK': 'bold green',
+        'REPLICATING': 'bold default',
+        'STUCK': 'bold orange3',
+        'WAITING APPROVAL': 'bold dodger_blue1',
+        'INJECT': 'bold medium_purple3',
+        'SUSPENDED': 'bold red'
+    }
+
+    RSE_TYPE = {
+        'DISK': 'bold dodger_blue1',
+        'TAPE': 'bold orange3',
+        'UNKNOWN': 'bold'
+    }
+
+    SUBSCRIPTION_STATE = {
+        'ACTIVE': 'bold green',
+        'INACTIVE': 'bold',
+        'NEW': 'bold dodger_blue1',
+        'UPDATED': 'bold green',
+        'BROKEN': 'bold red',
+        'UNKNOWN': 'bold orange3'
+    }
+
+    AVAILABILITY = {
+        'AVAILABLE': 'bold green',
+        'DELETED': 'bold',
+        'LOST': 'bold red',
+        'UNKNOWN': 'bold orange3'
+    }
+
+    ACCOUNT_STATUS = {
+        'ACTIVE': 'bold green',
+        'SUSPENDED': 'bold red',
+        'DELETED': 'bold'
+    }
+
+    REPLICA_STATE = {
+        'A': 'bold green',
+        'U': 'bold red',
+        'C': 'bold default',
+        'B': 'bold dodger_blue1',
+        'D': 'bold red',
+        'T': 'bold orange3'
+    }
+
+    ACCOUNT_TYPE = {
+        'USER': 'default',
+        'GROUP': 'medium_purple3',
+        'SERVICE': 'yellow'
+    }
+
+
+def setup_rich_logger(
+    module_name: Optional[str] = None,
+    logger_name: Optional[str] = None,
+    logger_level: Optional[int] = None,
+    verbose: bool = False,
+    console: Optional[Console] = None
+) -> logging.Logger:
+    """
+    Factory method to set logger with RichHandler.
+
+    The function is a copy of the method in rucio.common.utils setup_logger() with minor changes.
+
+    :param module_name: __name__ of the module that is calling this method
+    :param logger_name: name of the logger, typically name of the module.
+    :param logger_level: if not given, fetched from config.
+    :param verbose: verbose option set in bin/rucio
+    :param console: Rich console object
+    :returns: logger with RichHandler
+    """
+    # Helper method for cfg check.
+    def _force_cfg_log_level(cfg_option: str) -> bool:
+        cfg_forced_modules = config_get('logging', cfg_option, raise_exception=False, default=None, clean_cached=True, check_config_table=False)
+        if cfg_forced_modules and module_name is not None:
+            if re.match(str(cfg_forced_modules), module_name):
+                return True
+        return False
+
+    if not logger_name:
+        if not module_name:
+            logger_name = 'user'
+        else:
+            logger_name = module_name.split('.')[-1]
+    logger = logging.getLogger(logger_name)
+
+    # Extracting the log level.
+    if not logger_level:
+        logger_level = logging.INFO
+        if verbose:
+            logger_level = logging.DEBUG
+
+        # Overriding by the config.
+        cfg_levels = (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR)
+        for level in cfg_levels:
+            cfg_opt = 'forceloglevel' + logging.getLevelName(level)
+            if _force_cfg_log_level(cfg_opt):
+                logger_level = level
+
+    logger.setLevel(logger_level)
+
+    def add_handler(logger: logging.Logger,
+                    console: Optional[Console] = None,
+                    verbose: bool = False) -> None:
+
+        def time_formatter(timestamp: datetime) -> Text:
+            return Text(f"[{timestamp.isoformat(sep=' ', timespec='milliseconds')}]")
+
+        console = console or Console()
+        handler = RichHandler(rich_tracebacks=True, markup=True, show_path=verbose, show_time=verbose, console=console, tracebacks_width=min(console.width, MAX_TRACEBACK_WIDTH),
+                              tracebacks_word_wrap=True, log_time_format=time_formatter)
+        logger.addHandler(handler)
+
+    # Setting handler and formatter.
+    if not logger.handlers:
+        add_handler(logger, console, verbose)
+
+    return logger
+
+
+def _format_value(value: Optional[Union[RenderableType, int, float, bool, datetime]] = None) -> RenderableType:
+    """
+    Formats the value based on its type for Rich Table.
+
+    A helper function to format the value to Rich RenderableType.
+
+    :param value: value to format
+    :returns: formatted value
+    """
+    if value is None or str(value) == 'None':
+        return ''
+    if isinstance(value, bool):
+        return CLITheme.BOOLEAN[str(value)]
+    if isinstance(value, (int, float, datetime)):
+        return str(value)
+    return value
+
+
+def generate_table(
+    rows: 'Sequence[Sequence[Union[RenderableType, int, float, bool, datetime]]]',
+    headers: Optional['Sequence[RenderableType]'] = None,
+    row_styles: Optional['Sequence[StyleType]'] = None,
+    col_alignments: Optional[list[JustifyMethod]] = None,
+    table_format: box.Box = CLITheme.TABLE_FMT,
+) -> Table:
+    """
+    Generates a Rich Table object from given input rows.
+
+    The elements in each row can be either plain strings or Rich renderable objects.
+    Passing strings will display them as simple text, while using Rich objects
+    allows you to introduce additional structure, styling, and widgets (e.g. Text, Trees) into
+    the table. Strings with style markup will be rendered as styled text.
+
+    :param table_format: style of the table
+    :param headers: list of headers
+    :param rows: list of rows
+    :param col_alignments: list of column alignments
+    :param row_styles: list of row styles
+    :returns: a Rich Table object
+    """
+    table = Table(box=table_format, show_header=headers is not None and len(headers) > 0)
+    table.row_styles = row_styles or ['none', 'dim']
+
+    if len(rows) == 0:
+        if headers:
+            for header in headers:
+                table.add_column(header)
+        return table
+
+    # Auto-detect on first row, numerical values on the right.
+    col_alignments = col_alignments or ['right' if str(col).isnumeric() else 'left' for col in rows[0]]
+    headers = headers or [''] * len(rows[0])
+    while len(headers) > len(col_alignments):
+        col_alignments.append('left')
+
+    for header, alignment in zip(headers, col_alignments):
+        table.add_column(header, overflow='fold', justify=alignment)
+
+    for row in rows:
+        row = [_format_value(col) for col in row]
+        table.add_row(*row)
+    return table
+
+
+def print_output(
+    *output: Any,
+    console: Console,
+    no_pager: bool = False
+) -> None:
+    """
+    Prints the objects using the specified Rich console object. Optionally disables the pager if specified.
+
+    The function works similarly to Rich's `console.print()` method but provides additional control over the pager feature.
+
+    :param output: objects to print to the terminal
+    :param console: Rich console object
+    :param no_pager: flag to disable the pager
+    """
+    if console.is_terminal:
+        if no_pager:
+            console.print(*output)
+        else:
+            console.width = sys.maxsize   # Overwrite auto-detected console width.
+            console.begin_capture()
+            console.print(*output)
+    else:
+        console.width = sys.maxsize
+        console.print(*output)
+
+
+def get_cli_config() -> str:
+    """
+    Returns the CLI type from the config file.
+
+    :returns: CLI type (Rich or tabulate)
+    """
+    cli_type = config_get('experimental', 'cli', raise_exception=False, default='tabulate').lower()
+    if cli_type not in ['rich', 'tabulate']:
+        cli_type = 'tabulate'
+    return cli_type
+
+
+def get_pager() -> 'Callable[[str], None]':
+    """
+    Returns the pager function based on the terminal availability.
+
+    :returns: pager
+    """
+    default_pager = 'less'
+    try:
+        result = subprocess.run([default_pager], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        less_available = result.returncode == 0
+    except Exception:
+        less_available = False
+
+    def less_pager_function(text: str) -> None:
+        """Use the 'less' pager with -FRSXKM options."""
+        pydoc.pipepager(text, f'{default_pager} -FRSXKM')
+
+    if less_available:
+        return less_pager_function
+    return pydoc.pager

--- a/requirements/requirements.client.txt
+++ b/requirements/requirements.client.txt
@@ -5,6 +5,7 @@ dogpile-cache>=1.2.2                                        # Caching API plugin
 tabulate>=0.9.0                                             # Pretty-print tabular data
 jsonschema>=4.20.0                                          # For JSON schema validation (Policy modules)
 packaging>=24.1                                             # Packaging utilities
+rich>=13.7.1                                                # For Rich terminal display
 
 # All dependencies needed in extras for rucio client should be defined here
 paramiko>=3.4.0                                             # ssh_extras; SSH2 protocol library (also needed in the server)

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -239,6 +239,10 @@ mako==1.3.5
     #   -r requirements.server.txt
     #   alembic
     #   oic
+markdown-it-py==3.0.0
+    # via
+    #   -r requirements.server.txt
+    #   rich
 markupsafe==2.1.5
     # via
     #   -r requirements.server.txt
@@ -253,6 +257,10 @@ mccabe==0.7.0
     # via
     #   flake8
     #   pylint
+mdurl==0.1.2
+    # via
+    #   -r requirements.server.txt
+    #   markdown-it-py
 multidict==6.0.5
     # via
     #   -r requirements.server.txt
@@ -343,6 +351,10 @@ pyflakes==3.1.0
     # via
     #   -r requirements.dev.in
     #   flake8
+pygments==2.18.0
+    # via
+    #   -r requirements.server.txt
+    #   rich
 pyjwkest==1.4.2
     # via
     #   -r requirements.server.txt
@@ -424,6 +436,8 @@ requests==2.32.3
     #   qbittorrent-api
     #   requests-kerberos
 requests-kerberos==0.15.0
+    # via -r requirements.server.txt
+rich==13.7.1
     # via -r requirements.server.txt
 rpds-py==0.19.0
     # via

--- a/requirements/requirements.server.in
+++ b/requirements/requirements.server.in
@@ -38,3 +38,4 @@ python3-saml==1.16.0                                        # saml_extras
 pymongo==4.8.0                                              # pymongo (metadata plugin)
 libtorrent==2.0.9                                           # Support for the bittorrent transfertool
 qbittorrent-api==2023.11.57                                 # qBittorrent plugin for the bittorrent tranfsertool
+rich==13.7.1                                                # For Rich terminal display

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -121,6 +121,8 @@ mako==1.3.5
     # via
     #   alembic
     #   oic
+markdown-it-py==3.0.0
+    # via rich
 markupsafe==2.1.5
     # via
     #   jinja2
@@ -128,6 +130,8 @@ markupsafe==2.1.5
     #   werkzeug
 maxminddb==2.6.2
     # via geoip2
+mdurl==0.1.2
+    # via markdown-it-py
 multidict==6.0.5
     # via
     #   aiohttp
@@ -164,6 +168,8 @@ pydantic-core==2.20.1
     # via pydantic
 pydantic-settings==2.3.4
     # via oic
+pygments==2.18.0
+    # via rich
 pyjwkest==1.4.2
     # via oic
 pyjwt[crypto]==2.8.0
@@ -213,6 +219,8 @@ requests==2.32.3
     #   qbittorrent-api
     #   requests-kerberos
 requests-kerberos==0.15.0
+    # via -r requirements.server.in
+rich==13.7.1
     # via -r requirements.server.in
 rpds-py==0.19.0
     # via

--- a/setuputil.py
+++ b/setuputil.py
@@ -29,6 +29,7 @@ clients_requirements_table = {
         'tabulate',
         'jsonschema',
         'dataclasses',
+        'rich',
     ],
     'ssh': ['paramiko'],
     'kerberos': [


### PR DESCRIPTION
For more details, view issue #6987.

###  Key changes:
-  Adds rich as a dependency
- Adds the CLI outputs using Rich for all the commands in `bin/rucio` and `bin/rucio-admin`.
- Adds a configuration option to choose between Rich or tabulate for CLI output.  Users can specify this in the config file by adding `cli = rich` in the `[experimental]` section. If the option `cli` does not exist or has a value other than `rich`, the tabulate CLI will be used by default.
- Implemented paging for outputs (`less -FRSXMK`) when the output exceeds the terminal size.
- Option `--no-pager ` to disable paging.

### Pager:

The paging is now done with `pydoc`, similarly as rich `console.pager()` does it. Here the steps of `console.pager()` is done manually so that the the command methods return the `SUCCESS` code before displaying the output and waiting for pager response. Rich only allows to use `console.pager()` as through a context manager, meaning that the method would only return `SUCCESS` when the user exits the pager.

### Dimming colors in rows:

I've decided to only apply dimming to have alternating coloring of rows only to the tables in which the numbe rof entries in unknown beforehand. This would mean that it is applied to all tables except the ones showing key-value pairs. The commands without alternating colors are: `rucio whoami`, `rucio get-metadata`, `rucio stat`, ` rucio list-rse-attributes`, `rucio rule-info`, `rucio-admin subscription list`, `rucio-admin account info`,  `rucio-admin rse get-attribute` and `attributes` `settings` `protocols` in `rucio-admin rse info`. I felt like dimming in the key-value tables was not such a natural effect.


### Styles:

I tried to choose a colour palette that highlights states with semantic colours to indicate whether something is positive, negative or neutral. For other types, the chosen colours are contrast colours, aiming to give clear separability without imposing emotional connotations. The chosen colours in a default mac terminal can be seen below:

<img width="215" alt="cli_palette" src="https://github.com/user-attachments/assets/0f52fc95-0622-4be7-a844-b1daaf434d59">
<img width="197" alt="cli_plaette_on_white" src="https://github.com/user-attachments/assets/7c1dc3f0-9f6e-4b0f-8379-002e05bfc591">

They might differ slightly in other terminal applications.
