### PR TITLE
Client: Allow account to be None in BaseClient constructor

### DIFF
--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -137,6 +137,7 @@ class BaseClient:
             self.logger.debug('No trace_host passed. Using rucio_host instead')
 
         self.list_hosts = [self.host]
+        self.account = account
         self.ca_cert = ca_cert
         self.auth_token = ""
         self.headers = {}
@@ -171,9 +172,7 @@ class BaseClient:
                     self.logger.debug('No ca_cert found in configuration. Falling back to Mozilla default CA bundle (certifi).')
                     self.ca_cert = True
 
-        if account is not None:
-            self.account = account
-        else:
+        if account is None:
             self.logger.debug('No account passed. Trying to get it from the RUCIO_ACCOUNT environment variable or the config file.')
             try:
                 self.account = environ['RUCIO_ACCOUNT']


### PR DESCRIPTION
Partially reverts https://github.com/rucio/rucio/commit/b3e3b31f7e3265491cfbe330aab561e1cda52198 to fix #7028

The typing errors (https://github.com/rdimaio/rucio/actions/runs/10468813387/job/28990505604) are due to some methods expecting `account` to exist. In practice, these methods are called after `account` has been set, but since that's done at runtime, the static type checker does not see them. We can address these at a later point.