### PR TITLE
Testing: Remove unused gacl; fix #7034

### DIFF
--- a/etc/gacl
+++ b/etc/gacl
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<gacl>
- <entry>
-  <any-user/>
-  <allow><read/><list/></allow>
- </entry>
-</gacl>


### PR DESCRIPTION
This gacl file was likely initially created for testing purposes. It is unused at the moment. There is an equivalent gacl file in use in containers/server: https://github.com/rucio/containers/blob/master/server/gacl, as well as in the ATLAS Rucio installation.