### PR TITLE
Core & Internals: distinguish between ImportError and ModuleNotFoundError #7030

### DIFF
--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -962,11 +962,11 @@ class NoDistance(RucioException):
 
 class PolicyPackageNotFound(RucioException):
     """
-    The policy package specified in the config file cannot be loaded.
+    The policy package specified in the config file was not found
     """
     def __init__(self, *args, **kwargs):
         super(PolicyPackageNotFound, self).__init__(*args, **kwargs)
-        self._message = 'The specified policy package cannot be loaded'
+        self._message = 'The specified policy package was not found'
         self.error_code = 93
 
 
@@ -1099,3 +1099,13 @@ class SortingAlgorithmNotSupported(RucioException):
         super(SortingAlgorithmNotSupported, self).__init__(*args, **kwargs)
         self._message = 'Sorting algorithm is not supported.'
         self.error_code = 106
+
+
+class ErrorLoadingPolicyPackage(RucioException):
+    """
+    An error occurred while loading the policy package.
+    """
+    def __init__(self, *args, **kwargs):
+        super(ErrorLoadingPolicyPackage, self).__init__(*args, **kwargs)
+        self._message = 'An error occurred while loading the specified policy package'
+        self.error_code = 107

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -60,8 +60,10 @@ if not multivo:
 
     try:
         module = importlib.import_module(POLICY)
-    except ImportError:
+    except ModuleNotFoundError:
         raise exception.PolicyPackageNotFound('Module ' + POLICY + ' not found')
+    except ImportError:
+        raise exception.ErrorLoadingPolicyPackage('An error occurred while loading module ' + POLICY)
 
     schema_modules["def"] = module
     scope_name_regexps.append(module.SCOPE_NAME_REGEXP)
@@ -90,8 +92,10 @@ def load_schema_for_vo(vo: str) -> None:
 
     try:
         module = importlib.import_module(POLICY)
-    except ImportError:
+    except ModuleNotFoundError:
         raise exception.PolicyPackageNotFound('Module ' + POLICY + ' not found')
+    except ImportError:
+        raise exception.ErrorLoadingPolicyPackage('An error occurred while loading module ' + POLICY)
 
     schema_modules[vo] = module
 

--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -61,8 +61,10 @@ for meta_module_path in METADATA_PLUGIN_MODULE_PATHS:
         base_class = meta_module_path.split(".")[-1]
         metadata_plugin_module = getattr(importlib.import_module(base_module), base_class)()
         METADATA_PLUGIN_MODULES.append(metadata_plugin_module)
-    except ImportError:
+    except ModuleNotFoundError:
         raise exception.PolicyPackageNotFound('Module ' + meta_module_path + ' not found')
+    except ImportError:
+        raise exception.ErrorLoadingPolicyPackage('An error occurred while loading module ' + meta_module_path)
 
 # Set restricted character set for metadata in form character: reason
 #

--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -68,8 +68,10 @@ if not multivo:
 
     try:
         module = importlib.import_module(POLICY)
-    except ImportError:
+    except ModuleNotFoundError:
         raise exception.PolicyPackageNotFound('Module ' + POLICY + ' not found')
+    except ImportError:
+        raise exception.ErrorLoadingPolicyPackage('An error occurred while loading module ' + POLICY)
 
     permission_modules["def"] = module
 
@@ -97,8 +99,10 @@ def load_permission_for_vo(vo: str) -> None:
 
     try:
         module = importlib.import_module(POLICY)
-    except ImportError:
+    except ModuleNotFoundError:
         raise exception.PolicyPackageNotFound('Module ' + POLICY + ' not found')
+    except ImportError:
+        raise exception.ErrorLoadingPolicyPackage('An error occurred while loading module ' + POLICY)
 
     permission_modules[vo] = module
 


### PR DESCRIPTION
This updates the policy package code to differentiate between `ModuleNotFoundError` and the more generic `ImportError` when loading a module.