### PR TITLE
Database: Standardize sqla model name DIDMetaConventionsConstraints to singular #6717

### DIFF
--- a/lib/rucio/core/meta_conventions.py
+++ b/lib/rucio/core/meta_conventions.py
@@ -121,7 +121,7 @@ def add_value(key: str, value: str, *, session: "Session") -> None:
     :raises KeyNotFound: Key not in metadata conventions table
     :raises InvalidValueForKey: Value conflicts with rse expression for key values or does not have the correct type
     """
-    new_value = models.DIDMetaConventionsConstraints(key=key, value=value)
+    new_value = models.DIDMetaConventionsConstraint(key=key, value=value)
     try:
         new_value.save(session=session)
     except IntegrityError as error:
@@ -170,9 +170,9 @@ def list_values(key: str, *, session: "Session") -> list[str]:
     :returns: A list containing all values.
     """
     statement = select(
-        models.DIDMetaConventionsConstraints.value
+        models.DIDMetaConventionsConstraint.value
     ).where(
-        models.DIDMetaConventionsConstraints.key == key
+        models.DIDMetaConventionsConstraint.key == key
     )
     return list(session.execute(statement).scalars().all())
 
@@ -193,10 +193,10 @@ def validate_meta(meta: dict, did_type: DIDType, *, session: "Session") -> None:
     if did_type == DIDType.DATASET and key in meta:
         try:
             statement = select(
-                models.DIDMetaConventionsConstraints.value
+                models.DIDMetaConventionsConstraint.value
             ).where(
-                and_(models.DIDMetaConventionsConstraints.value == meta[key],
-                     models.DIDMetaConventionsConstraints.key == key)
+                and_(models.DIDMetaConventionsConstraint.value == meta[key],
+                     models.DIDMetaConventionsConstraint.key == key)
             )
             session.execute(statement).one()
         except NoResultFound:

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -661,7 +661,7 @@ class DIDMetaConventionsKey(BASE, ModelBase):
                    CheckConstraint('is_enum IS NOT NULL', name='DID_KEYS_IS_ENUM_NN'))
 
 
-class DIDMetaConventionsConstraints(BASE, ModelBase):
+class DIDMetaConventionsConstraint(BASE, ModelBase):
     """Represents a map for constraint values a DID metadata key must follow """
     __tablename__ = 'did_key_map'
     key: Mapped[str] = mapped_column(String(255))


### PR DESCRIPTION
Part of #6717

This used to have a singular name before ea765b7.

I'm wondering whether `DIDMetaConventionConstraint` would be more accurate? This would mean a change to `DIDMetaConventionsKey` as well.
