### PR TITLE
Clients: Creates 'BaseClient.authenticated_account' after authentication

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -1286,7 +1286,7 @@ def delete_rule(args):
         scope, name = get_scope(args.rule_id, client)
         rules = client.list_did_rules(scope=scope, name=name)
         if args.rule_account is None:
-            account = client.account
+            account = client.authenticated_account
         else:
             account = args.rule_account
         deletion_success = False
@@ -1804,7 +1804,7 @@ def add_lifetime_exception(args):
         logger.error('Nothing to submit')
         return SUCCESS
     try:
-        client.add_exception(dids=datasets, account=client.account, pattern='', comments=reason, expires_at=expiration)
+        client.add_exception(dids=datasets, account=client.authenticated_account, pattern='', comments=reason, expires_at=expiration)
     except UnsupportedOperation as err:
         logger.error(err)
         return FAILURE

--- a/bin/rucio-admin
+++ b/bin/rucio-admin
@@ -908,7 +908,7 @@ def add_subscription(args):
     elif args.issuer:
         account = args.issuer
     else:
-        account = client.account
+        account = client.authenticated_account
     subscription_id = client.add_subscription(name=args.name, account=account, filter_=json.loads(args.filter), replication_rules=json.loads(args.replication_rules),
                                               comments=args.comments, lifetime=args.lifetime, retroactive=False, dry_run=False, priority=args.priority)
     print('Subscription added %s' % (subscription_id))
@@ -929,7 +929,7 @@ def list_subscriptions(args):
     elif args.issuer:
         account = args.issuer
     else:
-        account = client.account
+        account = client.authenticated_account
     subs = client.list_subscriptions(name=args.name, account=account)
     for sub in subs:
         if args.long:
@@ -954,7 +954,7 @@ def update_subscription(args):
     elif args.issuer:
         account = args.issuer
     else:
-        account = client.account
+        account = client.authenticated_account
     client.update_subscription(name=args.name, account=account, filter_=json.loads(args.filter), replication_rules=json.loads(args.replication_rules),
                                comments=args.comments, lifetime=args.lifetime, retroactive=False, dry_run=False, priority=args.priority)
     return SUCCESS
@@ -984,7 +984,7 @@ def list_account_attributes(args):
 
     """
     client = get_client(args)
-    account = args.account or client.account
+    account = args.account or client.authenticated_account
     attributes = next(client.list_account_attributes(account))
     table = []
     for attr in attributes:

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -176,7 +176,7 @@ class DownloadClient:
         self.is_tape_excluded = True
         self.is_admin = False
         if check_admin:
-            account_attributes = list(self.client.list_account_attributes(self.client.account))
+            account_attributes = list(self.client.list_account_attributes(self.client.authenticated_account))
             for attr in account_attributes[0]:
                 if attr['key'] == 'admin':
                     self.is_admin = attr['value'] is True
@@ -188,7 +188,7 @@ class DownloadClient:
         self.trace_tpl = {}
         self.trace_tpl['hostname'] = self.client_location['fqdn']
         self.trace_tpl['localSite'] = self.client_location['site']
-        self.trace_tpl['account'] = self.client.account
+        self.trace_tpl['account'] = self.client.authenticated_account
         if self.client.vo != 'def':
             self.trace_tpl['vo'] = self.client.vo
         self.trace_tpl['eventType'] = 'download'

--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -133,7 +133,7 @@ class SubscriptionClient(BaseClient):
         :raises: exception.NotFound if subscription is not found
         """
         if not account:
-            account = self.account
+            account = self.authenticated_account
         if retroactive:
             raise NotImplementedError('Retroactive mode is not implemented')
         path = self.SUB_BASEURL + '/' + account + '/' + name  # type: ignore

--- a/lib/rucio/client/touchclient.py
+++ b/lib/rucio/client/touchclient.py
@@ -53,7 +53,7 @@ class TouchClient(BaseClient):
 
         trace['eventType'] = 'touch'
         trace['clientState'] = 'DONE'
-        trace['account'] = self.account
+        trace['account'] = self.authenticated_account
         if self.vo != 'def':
             trace['vo'] = self.vo
 

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -78,13 +78,13 @@ class UploadClient:
         self.tracing = tracing
         if not self.tracing:
             logger(logging.DEBUG, 'Tracing is turned off.')
-        self.default_file_scope: Final[str] = 'user.' + self.client.account
+        self.default_file_scope: Final[str] = 'user.' + self.client.authenticated_account
         self.rses = {}
         self.rse_expressions = {}
 
         self.trace: "TraceBaseDict" = {
             'hostname': socket.getfqdn(),
-            'account': self.client.account,
+            'account': self.client.authenticated_account,
             'eventType': 'upload',
             'eventVersion': version.RUCIO_VERSION[0],
             'vo': self.client.vo if self.client.vo != 'def' else None
@@ -408,11 +408,11 @@ class UploadClient:
         # verification whether the scope exists
         account_scopes = []
         try:
-            account_scopes = self.client.list_scopes_for_account(self.client.account)
+            account_scopes = self.client.list_scopes_for_account(self.client.authenticated_account)
         except ScopeNotFound:
             pass
         if account_scopes and file['did_scope'] not in account_scopes:
-            logger(logging.WARNING, 'Scope {} not found for the account {}.'.format(file['did_scope'], self.client.account))
+            logger(logging.WARNING, 'Scope {} not found for the account {}.'.format(file['did_scope'], self.client.authenticated_account))
 
         rse = file['rse']
         dataset_did_str = file.get('dataset_did_str')
@@ -424,7 +424,7 @@ class UploadClient:
                 self.client.add_dataset(scope=file['dataset_scope'],
                                         name=file['dataset_name'],
                                         meta=file.get('dataset_meta'),
-                                        rules=[{'account': self.client.account,
+                                        rules=[{'account': self.client.authenticated_account,
                                                 'copies': 1,
                                                 'rse_expression': rse,
                                                 'grouping': 'DATASET',


### PR DESCRIPTION
Addresses #7062 

Changes references of BaseClient.account to BaseClient.authenticated_account, to differentiate between the client.account used as a client arg and the user account used for auth. 