### PR TITLE
Testing: Add 'default' under patch in codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 coverage:
   status:
     patch:
-      paths:
-        - "lib/rucio/version*"
-        - "lib/rucio/common/*"
+      default:
+        paths:
+          - "lib/rucio/version*"
+          - "lib/rucio/common/*"


### PR DESCRIPTION
Syntax of previous codecov.yml was invalid as 'default' was missing.