### PR TITLE
Core & Internals: TraceValidationSchemaNotFound, remove unused kwargs logic

### DIFF
--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1110,7 +1110,7 @@ class TraceValidationSchemaNotFound(RucioException):
     """
     Trace validation schema not found.
     """
-    def __init__(self, *args, **kwargs):
-        super(TraceValidationSchemaNotFound, self).__init__(*args, **kwargs)
+    def __init__(self, *args):
+        super(TraceValidationSchemaNotFound, self).__init__(*args)
         self._message = 'Trace validation schema not found.'
         self.error_code = 108


### PR DESCRIPTION
Part of #7066, this was added in a parallel PR and slipped through