### PR TITLE
ui, server: make userpass login optional

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -185,7 +185,9 @@ class UserPass(ErrorHandlingMethodView):
         headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
         headers.add('Cache-Control', 'post-check=0, pre-check=0')
         headers['Pragma'] = 'no-cache'
-
+        USERPASS_SUPPORT = config_get('webui', 'userpass_support', False, True)
+        if not USERPASS_SUPPORT:
+            return generate_http_error_flask(400, CannotAuthenticate.__name__, 'Cannot authenticate via userpass credentials as it is not supported.', headers=self.get_headers())
         vo = extract_vo(request.headers)
         account = request.headers.get('X-Rucio-Account', default=None)
         username = request.headers.get('X-Rucio-Username', default=None)

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -185,9 +185,6 @@ class UserPass(ErrorHandlingMethodView):
         headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
         headers.add('Cache-Control', 'post-check=0, pre-check=0')
         headers['Pragma'] = 'no-cache'
-        USERPASS_SUPPORT = config_get('webui', 'userpass_support', False, True)
-        if not USERPASS_SUPPORT:
-            return generate_http_error_flask(400, CannotAuthenticate.__name__, 'Cannot authenticate via userpass credentials as it is not supported.', headers=self.get_headers())
         vo = extract_vo(request.headers)
         account = request.headers.get('X-Rucio-Account', default=None)
         username = request.headers.get('X-Rucio-Username', default=None)

--- a/lib/rucio/web/ui/flask/bp.py
+++ b/lib/rucio/web/ui/flask/bp.py
@@ -18,7 +18,7 @@ from flask import Blueprint, make_response, render_template, request
 from rucio.common.config import config_get, config_get_bool
 from rucio.gateway.authentication import get_auth_token_x509
 from rucio.web.rest.flaskapi.v1.common import generate_http_error_flask
-from rucio.web.ui.flask.common.utils import AUTH_ISSUERS, SAML_SUPPORT, authenticate, finalize_auth, get_token, oidc_auth, saml_auth, userpass_auth, x509token_auth
+from rucio.web.ui.flask.common.utils import AUTH_ISSUERS, SAML_SUPPORT, USERPASS_SUPPORT, authenticate, finalize_auth, get_token, oidc_auth, saml_auth, userpass_auth, x509token_auth
 
 MULTI_VO = config_get_bool('common', 'multi_vo', raise_exception=False, default=False)
 POLICY = config_get('policy', 'permission')
@@ -39,14 +39,14 @@ def auth():
         else:
             return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot get token')
     else:
-        return render_template('select_login_method.html', oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT)
+        return render_template('select_login_method.html', oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT)
 
 
 def login():
     if request.method == 'GET':
         account = request.args.get('account')
         vo = request.args.get('vo')
-        return render_template('login.html', account=account, vo=vo)
+        return render_template('login.html', account=account, vo=vo, userpass_support=USERPASS_SUPPORT)
     if request.method == 'POST':
         return userpass_auth()
 

--- a/lib/rucio/web/ui/flask/common/utils.py
+++ b/lib/rucio/web/ui/flask/common/utils.py
@@ -67,6 +67,9 @@ if not AUTH_TYPE:
     except:
         AUTH_ISSUERS = []
 
+# check if userpass login is enabled
+USERPASS_SUPPORT =  config_get_bool('webui', 'userpass_support', raise_exception=False, default=True)
+
 MULTI_VO = config_get_bool('common', 'multi_vo', raise_exception=False, default=False)
 
 # Additional error message that can have VO specific information for the user, e.g., support mailing list.
@@ -333,10 +336,10 @@ def x509token_auth(data=None):
                 ui_vo = valid_vos[0]
             else:
                 vos_with_desc = get_vo_descriptions(valid_vos)
-                return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, possible_vos=vos_with_desc)))
+                return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT, possible_vos=vos_with_desc)))
         else:
             vos_with_desc = get_vo_descriptions(ui_vo)
-            return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, possible_vos=vos_with_desc)))
+            return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT, possible_vos=vos_with_desc)))
 
     if not ui_account:
         if MULTI_VO:
@@ -395,10 +398,10 @@ def userpass_auth():
                 ui_vo = valid_vos[0]
             else:
                 vos_with_desc = get_vo_descriptions(valid_vos)
-                return render_template('login.html', account=ui_account, vo=None, possible_vos=vos_with_desc)
+                return render_template('login.html', account=ui_account, vo=None, possible_vos=vos_with_desc, userpass_support=USERPASS_SUPPORT)
         else:
             vos_with_desc = get_vo_descriptions(ui_vo)
-            return render_template('login.html', account=None, vo=None, possible_vos=vos_with_desc)
+            return render_template('login.html', account=None, vo=None, possible_vos=vos_with_desc, userpass_support=USERPASS_SUPPORT)
 
     if not ui_account:
         if MULTI_VO:
@@ -465,10 +468,10 @@ def saml_auth(method, data=None):
                     ui_vo = valid_vos[0]
                 else:
                     vos_with_desc = get_vo_descriptions(valid_vos)
-                    return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, possible_vos=vos_with_desc)))
+                    return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT, possible_vos=vos_with_desc)))
             else:
                 vos_with_desc = get_vo_descriptions(ui_vo)
-                return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, possible_vos=vos_with_desc)))
+                return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT, possible_vos=vos_with_desc)))
 
         if not ui_account:
             if MULTI_VO:
@@ -514,10 +517,10 @@ def saml_auth(method, data=None):
                         ui_vo = valid_vos[0]
                     else:
                         vos_with_desc = get_vo_descriptions(valid_vos)
-                        return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, possible_vos=vos_with_desc)))
+                        return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT, possible_vos=vos_with_desc)))
                 else:
                     vos_with_desc = get_vo_descriptions(ui_vo)
-                    return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, possible_vos=vos_with_desc)))
+                    return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT, possible_vos=vos_with_desc)))
 
             if not ui_account:
                 if MULTI_VO:
@@ -561,7 +564,7 @@ def oidc_auth(account, issuer, ui_vo=None):
             ui_vo = valid_vos[0]
         else:
             vos_with_desc = get_vo_descriptions(valid_vos)
-            return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, possible_vos=vos_with_desc)))
+            return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT, possible_vos=vos_with_desc)))
 
     if not issuer:
         return render_template("problem.html", msg="Please provide IdP issuer.")
@@ -600,7 +603,7 @@ def authenticate(template, title):
 
     # login without any known server config
     if not AUTH_TYPE:
-        return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT)), cookie)
+        return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT)), cookie)
     # for AUTH_TYPE predefined by the server continue
     else:
         if AUTH_TYPE == 'userpass':

--- a/lib/rucio/web/ui/flask/common/utils.py
+++ b/lib/rucio/web/ui/flask/common/utils.py
@@ -68,7 +68,7 @@ if not AUTH_TYPE:
         AUTH_ISSUERS = []
 
 # check if userpass login is enabled
-USERPASS_SUPPORT =  config_get_bool('webui', 'userpass_support', raise_exception=False, default=True)
+USERPASS_SUPPORT = config_get_bool('webui', 'userpass_support', raise_exception=False, default=True)
 
 MULTI_VO = config_get_bool('common', 'multi_vo', raise_exception=False, default=False)
 

--- a/lib/rucio/web/ui/flask/templates/login.html
+++ b/lib/rucio/web/ui/flask/templates/login.html
@@ -60,6 +60,7 @@
   </nav>
 
   <div id="content" style="margin: 1em;">
+    {% if userpass_support %}
     <div id="results" class="row">
 
       <div id="t_data" class="columns panel">
@@ -109,6 +110,13 @@
       </div>
     </div>
     <div id="loader"></div>
+    {% else %}
+    <div class="row">
+      <div class="large-6 columns text-align: center">
+        <h3>Userpass login is not supported. Please contact the administrator of your rucio instance. </h3>
+        <button class="button small postfix" onclick="javascript:history.go(-1)">Back</button>
+      </div>
+    {% endif %}
   </div>
 
 </body>

--- a/lib/rucio/web/ui/flask/templates/select_login_method.html
+++ b/lib/rucio/web/ui/flask/templates/select_login_method.html
@@ -66,7 +66,9 @@ function get_link_oidc(elmnt, base_url, issuer) {
   <p class="text-success text-center">Choose Login Method</p>
   <p>
     <a href="" class="btn btn-block btn-outline-primary btn-lg" role="button" onclick="get_link(this, 'x509')" height="auto"><i class="fab fa-2x icon-certificate vertical-align-middle"></i><span class="inline-block padding-bottom-2">   X509 Certificate</span></a>
+    {% if userpass_support %}
     <a href="" class="btn btn-block btn-outline-rucio btn-lg" role="button" onclick="get_link(this, 'login')" height="auto"> <i class="fab fa-2x icon-rucio vertical-align-middle"></i><span class="inline-block padding-bottom-2">   Rucio Userpass</span></a>
+    {% endif %}
     <!-- {% if saml_support %}
         <a href="" class="btn btn-block btn-outline-cern btn-lg" role="button" onclick="get_link(this, 'saml')" height="auto"> <i class="fab fa-2x icon-cern vertical-align-middle"></i><span class="inline-block padding-bottom-2">   CERN SSO Log-In</span></a>
     {% endif %} -->


### PR DESCRIPTION
Fix  #7045

## rucio.cfg
A boolean `userpass_support` attribute is added in the `webui` section of the rucio.cfg file. By default, userpass login is enabled. If the `userpass_support` is set to False, then the select_login_page will not show userpass_login as an option. Also, the login page will be disabled.
When userpass_support is disabled the UserPass endpoint will return a HTTP 400 (Bad Request) error.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
