### PR TITLE
Dependencies: Upgrade werkzeug (3.0.3 -> 3.0.6) due to security vulnerabilities

### DIFF
--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -504,7 +504,7 @@ websocket-client==1.8.0
     # via
     #   -r requirements.server.txt
     #   stomp-py
-werkzeug==3.0.3
+werkzeug==3.0.6
     # via
     #   -r requirements.server.txt
     #   flask

--- a/requirements/requirements.server.in
+++ b/requirements/requirements.server.in
@@ -14,7 +14,7 @@ geoip2==4.8.0                                               # GeoIP2 API (for IP
 google-auth==2.32.0                                         # Google authentication library for Python
 redis==5.0.7                                                # Python client for Redis key-value store
 Flask==3.0.3                                                # Python web framework
-werkzeug==3.0.3                                             # WSGI library
+werkzeug==3.0.6                                             # WSGI library
 oic==1.7.0                                                  # for authentication via OpenID Connect protocol
 prometheus_client==0.20.0                                   # Python client for the Prometheus monitoring system
 boto3==1.34.142                                             # S3 boto protocol (new version)

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -253,7 +253,7 @@ urllib3==1.26.19
     #   requests
 websocket-client==1.8.0
     # via stomp-py
-werkzeug==3.0.3
+werkzeug==3.0.6
     # via
     #   -r requirements.server.in
     #   flask


### PR DESCRIPTION
Relevant CVEs:
- CVE-2024-49766
- CVE-2024-49767
