### PR TITLE
Metadata: add UnsupportedMetadataPlugin exception handling Fix #7155

### DIFF
--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1139,3 +1139,13 @@ class PolicyPackageIsNotVersioned(PolicyPackageBaseException):
         super(PolicyPackageIsNotVersioned, self).__init__(package, *args)
         self._message = 'Policy package %s does not include information about which Rucio versions it supports.' % self.package
         self.error_code = 109
+
+
+class UnsupportedMetadataPlugin(RucioException):
+    """
+    Raised when attempting to use a metadata plugin that is not enabled on the server.
+    """
+    def __init__(self, *args):
+        super(UnsupportedMetadataPlugin, self).__init__(*args)
+        self._message = "The requested metadata plugin is not enabled on the server."
+        self.error_code = 110

--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -84,8 +84,9 @@ def get_metadata(scope, name, plugin="DID_COLUMN", *, session: "Session"):
     :param scope: The scope of the did.
     :param name: The data identifier name.
     :param plugin: (optional) Filter specific metadata plugins.
-    :returns: List of metadata for did.
-    :raises: NotImplementedError
+    :param session: (optional) The database session in use.
+    :returns: Dictionary containing metadata for did.
+    :raises: UnsupportedMetadataPlugin: If the specified plugin is not enabled/available
     """
     if plugin.lower() == "all":
         all_metadata = {}
@@ -97,7 +98,7 @@ def get_metadata(scope, name, plugin="DID_COLUMN", *, session: "Session"):
         for metadata_plugin in METADATA_PLUGIN_MODULES:
             if metadata_plugin.get_plugin_name().lower() == plugin.lower():
                 return metadata_plugin.get_metadata(scope, name, session=session)
-    raise NotImplementedError('Metadata plugin "%s" is not enabled on the server.' % plugin)
+    raise exception.UnsupportedMetadataPlugin(f'Metadata plugin "{plugin}" is not enabled on the server.')
 
 
 @transactional_session

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -276,7 +276,7 @@ def generate_http_error_flask(
         exc_msg: Optional[str] = None,
         headers: Optional['HeadersType'] = None,
 ) -> "flask.Response":
-    """Utitily function to generate a complete HTTP error response.
+    """Utility function to generate a complete HTTP error response.
 
     :param status_code: The HTTP status code to generate a response for.
     :param exc: The name of the exception class or a RucioException object.

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -34,6 +34,7 @@ from rucio.common.exception import (
     RSENotFound,
     RuleNotFound,
     ScopeNotFound,
+    UnsupportedMetadataPlugin,
     UnsupportedOperation,
     UnsupportedStatus,
 )
@@ -1321,6 +1322,8 @@ class Meta(ErrorHandlingMethodView):
                 schema:
                   description: A data identifier with all attributes.
                   type: object
+          400:
+            description: Bad Request - Invalid metadata plugin specified
           401:
             description: Invalid Auth Token
           404:
@@ -1339,6 +1342,8 @@ class Meta(ErrorHandlingMethodView):
             return Response(render_json(**meta), content_type='application/json')
         except DataIdentifierNotFound as error:
             return generate_http_error_flask(404, error)
+        except UnsupportedMetadataPlugin as error:
+            return generate_http_error_flask(400, error)
 
     def post(self, scope_name):
         """


### PR DESCRIPTION
This PR addresses the issue #7155. When a `get_metadata` request is made now using an unsupported or disabled plugin, the server will raise a specific UnsupportedMetadataPlugin exception. 