### PR TITLE
REST & API: Ensure proper Access-Control-Request-Headers handling in CORS middleware

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -69,7 +69,7 @@ class CORSMiddleware:
                 response: Response = Response(status=200)
                 response.headers['Access-Control-Allow-Origin'] = request.origin
                 response.headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, OPTIONS'
-                response.headers['Access-Control-Allow-Headers'] = '*'
+                response.headers['Access-Control-Allow-Headers'] = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')  # type: ignore (value could be None)
                 response.headers['Access-Control-Allow-Credentials'] = 'true'
                 return response(environ, start_response)
             response: Response = Response(status=403)


### PR DESCRIPTION
Fix #7148 

Ensuring proper x509 authentication in the new version of the UI across all browsers requires concrete `Access-Control-Allow-Headers` instead of a wildcard (*). If the client certificate is explicitly included in a cross-origin request, the asterisk gets [treated as a literal character](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers#directives). Therefore, in accordance with https://github.com/rucio/rucio/blob/3f8b419609f7b776cff61267fcf6323054bf260c/lib/rucio/web/rest/flaskapi/v1/auth.py#L64
the CORS middleware should pipe the request headers from `Access-Control-Request-Headers`.