### PR TITLE
Dependencies: aiohttp 3.10.2 -> 3.10.11, fix security alert

### DIFF
--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -8,7 +8,7 @@ aiohappyeyeballs==2.3.5
     # via
     #   -r requirements.server.txt
     #   aiohttp
-aiohttp==3.10.2
+aiohttp==3.10.11
     # via
     #   -r requirements.server.txt
     #   geoip2
@@ -295,6 +295,10 @@ pluggy==1.5.0
     # via pytest
 prometheus-client==0.20.0
     # via -r requirements.server.txt
+propcache==0.2.0
+    # via
+    #   -r requirements.server.txt
+    #   yarl
 psycopg2-binary==2.9.9
     # via -r requirements.server.txt
 pyasn1==0.6.0
@@ -513,7 +517,7 @@ xmltodict==0.13.0
     # via -r requirements.dev.in
 yapf==0.40.2
     # via pydoc-markdown
-yarl==1.9.4
+yarl==1.17.2
     # via
     #   -r requirements.server.txt
     #   aiohttp

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.3.5
     # via aiohttp
-aiohttp==3.10.2
+aiohttp==3.10.11
     # via geoip2
 aiosignal==1.3.1
     # via aiohttp
@@ -142,6 +142,8 @@ pbr==6.0.0
     # via stevedore
 prometheus-client==0.20.0
     # via -r requirements.server.in
+propcache==0.2.0
+    # via yarl
 psycopg2-binary==2.9.9
     # via -r requirements.server.in
 pyasn1==0.6.0
@@ -261,7 +263,7 @@ xmlsec==1.3.13
     # via
     #   -r requirements.server.in
     #   python3-saml
-yarl==1.9.4
+yarl==1.17.2
     # via aiohttp
 zipp==3.19.2
     # via importlib-metadata


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
