### PR TITLE
Replace version_info checks with `requires-python` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[project]
+requires-python = ">=3.9"
+
 [tool.pytest.ini_options]
 pythonpath = [
   ".",

--- a/setup_rucio.py
+++ b/setup_rucio.py
@@ -19,10 +19,6 @@ import sys
 
 from setuptools import find_packages, setup
 
-if sys.version_info < (3, 9):
-    print('ERROR: Rucio Server requires at least Python 3.9 to run.')
-    sys.exit(1)
-
 try:
     from setuputil import get_rucio_version, match_define_requirements, server_requirements_table
 except ImportError:

--- a/setup_rucio_client.py
+++ b/setup_rucio_client.py
@@ -18,10 +18,6 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3, 9):
-    print('ERROR: Rucio Client requires at least Python 3.9 to run.')
-    sys.exit(1)
-
 try:
     from setuputil import clients_requirements_table, get_rucio_version, match_define_requirements
 except ImportError:

--- a/setup_webui.py
+++ b/setup_webui.py
@@ -17,10 +17,6 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3, 9):
-    print('ERROR: Rucio WebUI requires at least Python 3.9 to run.')
-    sys.exit(1)
-
 try:
     from setuputil import get_rucio_version
 except ImportError:


### PR DESCRIPTION
Fixes #7182

The recommended way to drop support for old Python versions is by using `requires-python`, as mentioned here:
- https://packaging.python.org/en/latest/guides/dropping-older-python-versions/
- https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#python-requires: "To actually restrict what Python versions a project can be installed on, use the [requires-python](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#requires-python) argument."