### PR TITLE
Add version_info checks again, pending migration to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[project]
-requires-python = ">=3.9"
-
 [tool.pytest.ini_options]
 pythonpath = [
   ".",

--- a/setup_rucio.py
+++ b/setup_rucio.py
@@ -19,6 +19,10 @@ import sys
 
 from setuptools import find_packages, setup
 
+if sys.version_info < (3, 9):  # noqa: UP036 (pending https://github.com/rucio/rucio/issues/6971)
+    print('ERROR: Rucio Server requires at least Python 3.9 to run.')
+    sys.exit(1)
+
 try:
     from setuputil import get_rucio_version, match_define_requirements, server_requirements_table
 except ImportError:

--- a/setup_rucio_client.py
+++ b/setup_rucio_client.py
@@ -18,6 +18,10 @@ import sys
 
 from setuptools import setup
 
+if sys.version_info < (3, 9):  # noqa: UP036 (pending https://github.com/rucio/rucio/issues/6971)
+    print('ERROR: Rucio Client requires at least Python 3.9 to run.')
+    sys.exit(1)
+
 try:
     from setuputil import clients_requirements_table, get_rucio_version, match_define_requirements
 except ImportError:

--- a/setup_webui.py
+++ b/setup_webui.py
@@ -17,6 +17,10 @@ import sys
 
 from setuptools import setup
 
+if sys.version_info < (3, 9):  # noqa: UP036 (pending https://github.com/rucio/rucio/issues/6971)
+    print('ERROR: Rucio Server requires at least Python 3.9 to run.')
+    sys.exit(1)
+
 try:
     from setuputil import get_rucio_version
 except ImportError:


### PR DESCRIPTION
To support the `project` setting in pyproject.toml, we'd have to restructure the build system to only use pyproject.toml and adding one pyproject.toml per package we want to build in their respective folders (one in clients, one in webui, and the server one at the top level)

Using `python_requires` in `setup.py` seems a bit flaky: https://stackoverflow.com/questions/19534896/enforcing-python-version-in-setup-py - so it's best to readd the version checks, adding a `noqa: UP036` for the linter error regarding Ruff using Python 3.9.

This issue will track migration to pyproject https://github.com/rucio/rucio/issues/6971

