### PR TITLE
Patch 6818 fix ci tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -98,7 +98,7 @@ jobs:
         shell: bash
         run: |
           docker login https://ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
-          docker-compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile storage --profile externalmetadata pull
+          docker compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile storage --profile externalmetadata pull
           i=0; until [ "$i" -ge 3 ]; do
             IMAGES=$(echo '${{ toJson(matrix.cfg) }}' | $GITHUB_WORKSPACE/dev/rucio/tools/test/build_images.py --output list \
                 --cache-repo ghcr.io/${{ github.repository }} --branch "${{ needs.setup.outputs.branch }}" \
@@ -119,7 +119,7 @@ jobs:
           sed -i 's;image: docker.io/rucio/rucio-dev.*;image: ${{ fromJSON(steps.images.outputs.images)[0] }};' \
               $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml
       - name: Start containers
-        run: docker-compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile storage --profile externalmetadata up -d
+        run: docker compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile storage --profile externalmetadata up -d
       - name: Initialize tests
         shell: bash
         run: |
@@ -173,4 +173,4 @@ jobs:
       - name: Test external metadata plugin (postgres)
         run: docker exec -t dev_rucio_1 tools/pytest.sh -v --tb=short tests/test_did_meta_plugins.py::TestDidMetaExternalPostgresJSON
       - name: Stop containers
-        run: docker-compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile storage --profile externalmetadata down
+        run: docker compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile storage --profile externalmetadata down

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -121,7 +121,7 @@ services:
     volumes:
       - ./oracle_setup.sh:/container-entrypoint-initdb.d/oracle_setup.sh:Z
   fts:
-    image: docker.io/rucio/fts
+    image: docker.io/rucio/test-fts
     profiles:
       - storage
     volumes:
@@ -143,7 +143,7 @@ services:
       - MYSQL_ROOT_PASSWORD=fts
       - MYSQL_DATABASE=fts
   xrd1:
-    image: docker.io/rucio/xrootd
+    image: docker.io/rucio/test-xrootd
     profiles:
       - storage
     environment:
@@ -157,7 +157,7 @@ services:
         soft: 10240
         hard: 10240
   xrd2:
-    image: docker.io/rucio/xrootd
+    image: docker.io/rucio/test-xrootd
     profiles:
       - storage
     environment:
@@ -171,7 +171,7 @@ services:
         soft: 10240
         hard: 10240
   xrd3:
-    image: docker.io/rucio/xrootd
+    image: docker.io/rucio/test-xrootd
     profiles:
       - storage
     environment:
@@ -185,7 +185,7 @@ services:
         soft: 10240
         hard: 10240
   xrd4:
-    image: docker.io/rucio/xrootd
+    image: docker.io/rucio/test-xrootd
     profiles:
       - storage
     environment:
@@ -210,7 +210,7 @@ services:
       - ../../certs/hostcert_minio.key.pem:/root/.minio/certs/private.key:Z
     command: ["server", "/data"]
   ssh1:
-    image: docker.io/rucio/ssh
+    image: docker.io/rucio/test-ssh
     profiles:
       - storage
     volumes:

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - X509_USER_KEY=/opt/rucio/etc/userkey.pem
       - RDBMS
   rucio:
+    container_name: dev_rucio_1
     image: docker.io/rucio/rucio-dev:latest-alma9
     entrypoint: ["/rucio_source/etc/docker/dev/rucio_entrypoint.sh"]
     command: ["httpd","-D","FOREGROUND"]

--- a/tools/test/run_tests.py
+++ b/tools/test/run_tests.py
@@ -280,7 +280,7 @@ def run_with_httpd(
     logs_dir: pathlib.Path,
     tests: list[str],
 ) -> bool:
-    compose_version = int(run('docker compose', 'version', '--short', return_stdout=True).decode().split('.')[0])
+    compose_version = int(run('docker', 'compose', 'version', '--short', return_stdout=True).decode().split('.')[0])
 
     with (NamedTemporaryFile() as compose_override_file):
         compose_override_content = yaml.dump({
@@ -308,7 +308,7 @@ def run_with_httpd(
         rucio_container = None
         try:
             # Start docker compose
-            run('docker compose', '-p', project, *up_down_args, 'up', '-d')
+            run('docker', 'compose', '-p', project, *up_down_args, 'up', '-d')
 
             # Retrieve container names from docker compose
             # or use pre-defined names for old, v1, docker compose
@@ -316,7 +316,7 @@ def run_with_httpd(
             if compose_version > 1:
                 rucio_container = next(filter(
                     lambda c: c['Service'] == 'rucio',
-                    json.loads(run('docker compose', '-p', project, 'ps', '--format', 'json', return_stdout=True))
+                    json.loads(run('docker', 'compose', '-p', project, 'ps', '--format', 'json', return_stdout=True))
                 ), {}).get('Name', rucio_container)
 
             # Running test.sh
@@ -356,7 +356,7 @@ def run_with_httpd(
                             file=sys.stderr,
                             flush=True,
                         )
-            run('docker compose', '-p', project, *up_down_args, 'down', '-t', '30', check=False)
+            run('docker', 'compose', '-p', project, *up_down_args, 'down', '-t', '30', check=False)
         return False
 
 

--- a/tools/test/run_tests.py
+++ b/tools/test/run_tests.py
@@ -280,7 +280,7 @@ def run_with_httpd(
     logs_dir: pathlib.Path,
     tests: list[str],
 ) -> bool:
-    compose_version = int(run('docker-compose', 'version', '--short', return_stdout=True).decode().split('.')[0])
+    compose_version = int(run('docker compose', 'version', '--short', return_stdout=True).decode().split('.')[0])
 
     with (NamedTemporaryFile() as compose_override_file):
         compose_override_content = yaml.dump({
@@ -294,7 +294,7 @@ def run_with_httpd(
                 }
             }
         })
-        print("Overriding docker-compose configuration with: \n", compose_override_content, flush=True)
+        print("Overriding docker compose configuration with: \n", compose_override_content, flush=True)
         with open(compose_override_file.name, 'w') as f:
             f.write(compose_override_content)
 
@@ -308,15 +308,15 @@ def run_with_httpd(
         rucio_container = None
         try:
             # Start docker compose
-            run('docker-compose', '-p', project, *up_down_args, 'up', '-d')
+            run('docker compose', '-p', project, *up_down_args, 'up', '-d')
 
             # Retrieve container names from docker compose
-            # or use pre-defined names for old, v1, docker-compose
+            # or use pre-defined names for old, v1, docker compose
             rucio_container = f'{project}_rucio_1'
             if compose_version > 1:
                 rucio_container = next(filter(
                     lambda c: c['Service'] == 'rucio',
-                    json.loads(run('docker-compose', '-p', project, 'ps', '--format', 'json', return_stdout=True))
+                    json.loads(run('docker compose', '-p', project, 'ps', '--format', 'json', return_stdout=True))
                 ), {}).get('Name', rucio_container)
 
             # Running test.sh
@@ -356,7 +356,7 @@ def run_with_httpd(
                             file=sys.stderr,
                             flush=True,
                         )
-            run('docker-compose', '-p', project, *up_down_args, 'down', '-t', '30', check=False)
+            run('docker compose', '-p', project, *up_down_args, 'down', '-t', '30', check=False)
         return False
 
 


### PR DESCRIPTION
Fix #6818 
Use `docker compose` over `docker-compose` to fix tests on release-32 LTS branch.

