### PR TITLE
Database: psycopg2 to psycopg migration #6669

### DIFF
--- a/etc/alembic.ini.template
+++ b/etc/alembic.ini.template
@@ -21,7 +21,7 @@
 sqlalchemy.url=oracle://user:pass@servicename
 version_table_schema=rucio
 
-#sqlalchemy.url=postgresql://rucio:rucio@psql-hostname:5432/rucio
+#sqlalchemy.url=postgresql+psycopg://rucio:rucio@psql-hostname:5432/rucio
 #version_table_schema=rucio
 
 #sqlalchemy.url=mysql+pymysql://rucio:rucio@rucio-hostname:3306/rucio

--- a/etc/alembic_offline.ini.template
+++ b/etc/alembic_offline.ini.template
@@ -21,7 +21,7 @@
 #sqlalchemy.url=oracle://user:pass@servicename
 #version_table_schema=rucio
 
-#sqlalchemy.url=postgresql://rucio:rucio@psql-hostname:5432/rucio
+#sqlalchemy.url=postgresql+psycopg://rucio:rucio@psql-hostname:5432/rucio
 #version_table_schema=rucio
 
 #sqlalchemy.url=mysql+pymysql://rucio:rucio@rucio-hostname:3306/rucio

--- a/etc/docker/test/extra/alembic_default.ini
+++ b/etc/docker/test/extra/alembic_default.ini
@@ -25,7 +25,7 @@ script_location = lib/rucio/db/sqla/migrate_repo/
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-sqlalchemy.url = postgresql://rucio:secret@ruciodb/rucio
+sqlalchemy.url = postgresql+psycopg://rucio:secret@ruciodb/rucio
 version_table_schema = dev
 
 # Logging configuration

--- a/etc/docker/test/extra/alembic_postgres14.ini
+++ b/etc/docker/test/extra/alembic_postgres14.ini
@@ -24,7 +24,7 @@ script_location = lib/rucio/db/sqla/migrate_repo/
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-sqlalchemy.url = postgresql://rucio:rucio@postgres14/rucio
+sqlalchemy.url = postgresql+psycopg://rucio:rucio@postgres14/rucio
 version_table_schema = dev
 
 # Logging configuration

--- a/etc/docker/test/extra/rucio_default.cfg
+++ b/etc/docker/test/extra/rucio_default.cfg
@@ -21,7 +21,7 @@ account = root
 request_retries = 3
 
 [database]
-default = postgresql://rucio:secret@ruciodb/rucio
+default = postgresql+psycopg://rucio:secret@ruciodb/rucio
 schema = dev
 echo=0
 pool_recycle=3600

--- a/etc/docker/test/extra/rucio_multi_vo_ts2_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_ts2_postgres14.cfg
@@ -6,7 +6,7 @@ multi_vo = True
 vo = testvo2
 
 [database]
-default = postgresql://rucio:rucio@postgres14/rucio
+default = postgresql+psycopg://rucio:rucio@postgres14/rucio
 schema = dev
 pool_size = 20
 max_overflow = 20

--- a/etc/docker/test/extra/rucio_multi_vo_tst_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_multi_vo_tst_postgres14.cfg
@@ -6,7 +6,7 @@ multi_vo = True
 vo = testvo1
 
 [database]
-default = postgresql://rucio:rucio@postgres14/rucio
+default = postgresql+psycopg://rucio:rucio@postgres14/rucio
 schema = dev
 pool_size = 20
 max_overflow = 20

--- a/etc/docker/test/extra/rucio_postgres14.cfg
+++ b/etc/docker/test/extra/rucio_postgres14.cfg
@@ -1,5 +1,5 @@
 [database]
-default = postgresql://rucio:rucio@postgres14/rucio
-schema=dev
+default = postgresql+psycopg://rucio:rucio@postgres14/rucio
+schema = dev
 pool_size = 20
 max_overflow = 20

--- a/etc/rucio.cfg.template
+++ b/etc/rucio.cfg.template
@@ -77,7 +77,7 @@ default = sqlite:////tmp/rucio.db
 #default = oracle://_____________:___________@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=______))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=_____________)))
 #schema=atlas_rucio  # only for cern oracle
 #default = mysql+pymysql://rucio:rucio@localhost/rucio
-#default = postgresql://rucio:rucio@localhost/rucio
+#default = postgresql+psycopg://rucio:rucio@localhost/rucio
 pool_recycle=3600
 echo=0
 pool_reset_on_return=rollback

--- a/etc/rucio_multi_vo.cfg.template
+++ b/etc/rucio_multi_vo.cfg.template
@@ -60,7 +60,7 @@ default = sqlite:////tmp/rucio.db
 #default = oracle://_____________:___________@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=______))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=_____________)))
 #schema=atlas_rucio  # only for cern oracle
 #default = mysql+pymysql://rucio:rucio@localhost/rucio
-#default = postgresql://rucio:rucio@localhost/rucio
+#default = postgresql+psycopg://rucio:rucio@localhost/rucio
 pool_recycle=3600
 echo=0
 pool_reset_on_return=rollback

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -49,7 +49,6 @@ if TYPE_CHECKING:
     R = TypeVar('R')
     CallableTypeVar = TypeVar('CallableTypeVar', bound='Callable[..., Any]')
 
-
 try:
     main_script = os.path.basename(sys.argv[0])
     CURRENT_COMPONENT = main_script.split('-')[1]
@@ -158,22 +157,20 @@ def mysql_convert_decimal_to_float(
 
 def psql_convert_decimal_to_float(dbapi_conn, connection_rec) -> None:
     """
-    The default datatype returned by psycopg2 for numerics is decimal.Decimal.
-    This type cannot be serialised to JSON, therefore we need to autoconvert to floats.
+    Configure the PostgreSQL connection to return numeric types as float instead of Decimal.
+    Psycopg3 provides this functionality through type adapters.
 
     :param dbapi_conn: DBAPI connection
     :param connection_rec: connection record
     """
-
     try:
-        import psycopg2.extensions  # pylint: disable=import-error
-    except:
-        raise RucioException('Trying to use PostgreSQL without psycopg2 or psycopg2-binary installed!')
-
-    DEC2FLOAT = psycopg2.extensions.new_type(psycopg2.extensions.DECIMAL.values,  # noqa: N806
-                                             'DEC2FLOAT',
-                                             lambda value, curs: float(value) if value is not None else None)
-    psycopg2.extensions.register_type(DEC2FLOAT)
+        import psycopg
+        # Register a global loader that converts numeric types to float
+        dbapi_conn.adapters.register_loader("numeric", psycopg.types.numeric.FloatLoader)
+    except ImportError:
+        raise RucioException('Trying to use PostgreSQL without psycopg installed!')
+    except Exception as error:
+        raise RucioException(f'Error setting up PostgreSQL Decimal to Float conversion: {str(error)}')
 
 
 def my_on_connect(dbapi_con, connection_record) -> None:
@@ -205,7 +202,7 @@ def _get_engine_poolclass(poolclass: str) -> Pool:
 
 
 def get_engine() -> 'Engine':
-    """ Creates a engine to a specific database.
+    """ Creates an engine to a specific database.
         :returns: engine
     """
     global _ENGINE
@@ -262,6 +259,7 @@ def get_dump_engine(
             print(statement.replace(')', ');\n'))
         else:
             print(statement)
+
     sql_connection = config_get(DATABASE_SECTION, 'default', check_config_table=False)
 
     engine = create_engine(sql_connection, echo=echo, strategy='mock', executor=dump)
@@ -388,12 +386,14 @@ def read_session(function: "Callable[P, R]"):
     This is useful if only SELECTs and the like are being done; anything involving
     INSERTs, UPDATEs etc should use transactional_session.
     '''
+
     @retrying(retry_on_exception=retry_if_db_connection_error,
               wait_fixed=500,
               stop_max_attempt_number=2)
     def new_funct(*args: "P.args", session: "Optional[Session]" = None, **kwargs):  # pylint:disable=missing-kwoa
         if isgeneratorfunction(function):
-            raise RucioException('read_session decorator should not be used with generator. Use stream_session instead.')
+            raise RucioException(
+                'read_session decorator should not be used with generator. Use stream_session instead.')
 
         if not session:
             session_scoped = get_session()
@@ -416,6 +416,7 @@ def read_session(function: "Callable[P, R]"):
             return function(*args, session=session, **kwargs)
         except Exception:
             raise
+
     return _update_session_wrapper(new_funct, function)
 
 
@@ -428,13 +429,15 @@ def stream_session(function: "Callable[P, R]"):
     This is useful if only SELECTs and the like are being done; anything involving
     INSERTs, UPDATEs etc should use transactional_session.
     '''
+
     @retrying(retry_on_exception=retry_if_db_connection_error,
               wait_fixed=500,
               stop_max_attempt_number=2)
     def new_funct(*args: "P.args", session: "Optional[Session]" = None, **kwargs):  # pylint:disable=missing-kwoa
 
         if not isgeneratorfunction(function):
-            raise RucioException('stream_session decorator should be used only with generator. Use read_session instead.')
+            raise RucioException(
+                'stream_session decorator should be used only with generator. Use read_session instead.')
 
         if not session:
             session_scoped = get_session()
@@ -470,6 +473,7 @@ def transactional_session(function: "Callable[P, R]") -> 'Callable':
 
     session is a sqlalchemy session, and you can get one calling get_session().
     '''
+
     def new_funct(
             *args: "P.args",
             session: "Optional[Session]" = None,
@@ -496,4 +500,5 @@ def transactional_session(function: "Callable[P, R]") -> 'Callable':
         else:
             result = function(*args, session=session, **kwargs)
         return result
+
     return _update_session_wrapper(new_funct, function)

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -1334,7 +1334,7 @@ class Protocol(ErrorHandlingMethodView):
                 vo=request.environ.get('vo'),
                 scheme=scheme,
                 hostname=hostname,
-                port=port,
+                port=int(port) if port else None,
                 data=parameters,
             )
         except InvalidObject as error:
@@ -1389,7 +1389,14 @@ class Protocol(ErrorHandlingMethodView):
             description: Rse not found or protocol not supported
         """
         try:
-            del_protocols(rse, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'), scheme=scheme, hostname=hostname, port=port)
+            del_protocols(
+                rse,
+                issuer=request.environ.get('issuer'),
+                vo=request.environ.get('vo'),
+                scheme=scheme,
+                hostname=hostname,
+                port=int(port) if port else None
+            )
         except (RSEProtocolNotSupported, RSENotFound) as error:
             return generate_http_error_flask(404, error)
 

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -309,8 +309,16 @@ propcache==0.2.0
     # via
     #   -r requirements.server.txt
     #   yarl
-psycopg2-binary==2.9.9
+psycopg[pool]==3.2.3
     # via -r requirements.server.txt
+psycopg-binary==3.2.3 ; implementation_name == "cpython"
+    # via
+    #   -r requirements.server.txt
+    #   psycopg
+psycopg-pool==3.2.4
+    # via
+    #   -r requirements.server.txt
+    #   psycopg
 pyasn1==0.6.0
     # via
     #   -r requirements.server.txt
@@ -500,6 +508,8 @@ typing-extensions==4.12.2
     #   dogpile-cache
     #   globus-sdk
     #   nr-util
+    #   psycopg
+    #   psycopg-pool
     #   pydantic
     #   pydantic-core
     #   pylint

--- a/requirements/requirements.server.in
+++ b/requirements/requirements.server.in
@@ -30,7 +30,8 @@ python-swiftclient==4.6.0                                   # swift_extras
 argcomplete==3.4.0                                          # argcomplete_extras; Bash tab completion for argparse
 python-magic==0.4.27                                        # dumper_extras; File type identification using libmagic
 cx_oracle==8.3.0                                            # oracle_extras
-psycopg2-binary==2.9.9                                      # postgresql_extras
+psycopg[pool]==3.2.3                                        # postgresql
+psycopg-binary==3.2.3; implementation_name=="cpython"       # postgresql binary optimizations
 PyMySQL==1.1.1                                              # mysql_extras
 PyYAML==6.0.1                                               # globus_extras and used for reading test configuration files
 globus-sdk==3.41.0                                          # globus_extras

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -148,8 +148,12 @@ prometheus-client==0.20.0
     # via -r requirements.server.in
 propcache==0.2.0
     # via yarl
-psycopg2-binary==2.9.9
+psycopg[pool]==3.2.3
     # via -r requirements.server.in
+psycopg-binary==3.2.3 ; implementation_name == "cpython"
+    # via -r requirements.server.in
+psycopg-pool==3.2.4
+    # via psycopg
 pyasn1==0.6.0
     # via
     #   pyasn1-modules
@@ -252,6 +256,8 @@ typing-extensions==4.12.2
     #   alembic
     #   dogpile-cache
     #   globus-sdk
+    #   psycopg
+    #   psycopg-pool
     #   pydantic
     #   pydantic-core
     #   sqlalchemy

--- a/setuputil.py
+++ b/setuputil.py
@@ -86,7 +86,7 @@ server_requirements_table = {
     ],
     'oracle': ['cx_oracle'],
     'mongo': ['pymongo'],
-    'postgresql': ['psycopg2-binary'],
+    'postgresql': ['psycopg[binary,pool]'],
     'mysql': ['PyMySQL'],
     'kerberos': [
         'kerberos',

--- a/setuputil.py
+++ b/setuputil.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 import subprocess
 import sys
 from typing import TYPE_CHECKING, Union
 
-from pkg_resources import parse_requirements, safe_name
+from pkg_resources import Requirement, parse_requirements
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -127,47 +127,118 @@ def get_rucio_version() -> str:
     return str(ver)
 
 
-def _build_requirements_table_by_key(requirements_table: "Mapping[str, Iterable[str]]") -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+def extract_requirement_with_extras(req_str: str) -> tuple[str, set[str]]:
+    """
+    Extracts the base-requirement specification (along with its extras) from a full-requirement specification string.
+
+    :param req_str: The full requirement specification (e.g., 'psycopg[binary,pool]').
+    :returns: Tuple of (base-requirement specification, set of its extras).
+    :raises ValueError: If the input string is invalid and cannot be parsed.
+    """
+    if not req_str or not isinstance(req_str, str):
+        raise ValueError("Input must be a non-empty string representing a requirement.")
+
+    try:
+        req = Requirement.parse(req_str)
+        return req.key, set(req.extras)
+    except Exception as e:
+        raise ValueError(f"Invalid dependency string '{req_str}': {e}")
+
+
+def build_requirements_table_by_key(
+        requirements_table: "Mapping[str, Iterable[str]]"
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """
+    Build lookup tables for requirements while preserving extras information.
+
+    :param requirements_table: A mapping where:
+        - Keys are feature groups (e.g., 'ssh', 'kerberos') or 'install_requires'.
+        - Values are iterables of full requirement specifications, potentially including extras (e.g., 'psycopg[pool]').
+
+    :returns: A tuple containing two dictionaries:
+        - base_req_to_group: Maps base requirements (e.g., 'psycopg') to a list of feature groups associated with it.
+        - extras_require: Maps feature groups to their respective lists of requirement specifications .
+    """
+    base_req_to_group: dict[str, list[str]] = {}
     extras_require: dict[str, list[str]] = {}
-    req_table_by_key: dict[str, list[str]] = {}
-    for group in requirements_table.keys():
-        if group != 'install_requires' and group not in extras_require:
-            extras_require[group] = []
-        for key in map(str.lower, map(safe_name, requirements_table[group])):
-            if key in req_table_by_key:
-                req_table_by_key[key].append(group)
-            else:
-                req_table_by_key[key] = [group]
-    return req_table_by_key, extras_require
+
+    for feature_group, requirements in requirements_table.items():
+        if feature_group != 'install_requires':
+            extras_require[feature_group] = []
+
+        for req in requirements:
+            base_req, base_req_extras = extract_requirement_with_extras(req)
+
+            # Handle first the identified base requirement
+            base_req_to_group.setdefault(base_req, []).append(feature_group)
+
+            # Handle also possible extras as separate base requirements
+            for extra_req in base_req_extras:
+                base_req_to_group.setdefault(extra_req, []).append(feature_group)
+
+    # Deduplicate lists to handle potential input redundancy or overlaps across groups
+    base_req_to_group = {key: list(set(groups)) for key, groups in base_req_to_group.items()}
+    extras_require = {key: list(set(reqs)) for key, reqs in extras_require.items()}
+
+    return base_req_to_group, extras_require
 
 
-def match_define_requirements(app_type: str, requirements_table: "Mapping[str, Iterable[str]]") -> tuple[list[str], dict[str, list[str]]]:
-    install_requires = []
-    req_table_by_key, extras_require = _build_requirements_table_by_key(requirements_table)
-    req_file_name = "requirements/requirements.{}.txt".format(app_type)
+def match_define_requirements(
+        app_type: str,
+        requirements_table: "Mapping[str, Iterable[str]]"
+) -> tuple[list[str], dict[str, list[str]]]:
+    """
+    Prepare and return the 'install_requires' and 'extras_require' objects for setuptools.setup().
 
+    :param app_type: The application type, which determines the requirements file to use (e.g., 'server', 'client').
+    :param requirements_table: A mapping where:
+        - Keys are feature groups (e.g., 'postgresql', 'oracle', or 'install_requires').
+        - Values are iterables of full requirement specifications.
+
+    :returns: A tuple containing:
+        - install_requires: A list of requirements (e.g., ['requests==2.32.3', 'urllib3==1.26.19']).
+        - extras_require: A dictionary mapping feature groups to their respective lists of requirements
+          (e.g., {'postgresql': ['psycopg[binary]==3.2.3'], 'oracle': ['cx_oracle==8.3.0']}).
+
+    :raises RuntimeError: If any `extras_require` feature group is empty or a requirements file is missing.
+    :raises ValueError: If the `requirements_table` is invalid.
+    """
+
+    install_requires: list[str] = []
+
+    # Build base requirement mappings and initial extras_require
+    base_req_to_group, extras_require = build_requirements_table_by_key(requirements_table)
+
+    # Construct the filename for the pip-compiled requirements file
+    req_file_name = f"requirements/requirements.{app_type}.txt"
+    if not os.path.exists(req_file_name):
+        raise RuntimeError(f"Requirements file '{req_file_name}' not found.")
+
+    # Read and parse the requirements file
     with open(req_file_name, 'r') as fhandle:
         for req in parse_requirements(fhandle.readlines()):
-            if req.key in req_table_by_key:
-                for group in req_table_by_key[req.key]:
-                    print("requirement found", group, req, file=sys.stderr)
-                    if group == 'install_requires':
+            if req.key in base_req_to_group:
+                for feature_group in base_req_to_group[req.key]:
+                    print("requirement found", feature_group, req, file=sys.stderr)
+                    if feature_group == 'install_requires':
                         install_requires.append(str(req))
                     else:
-                        extras_require[group].append(str(req))
+                        extras_require[feature_group].append(str(req))
+
             else:
                 print("requirement unused", req, "(from " + req.key + ")", file=sys.stderr)
         sys.stderr.flush()
 
-    for extra, deps in extras_require.items():
+    # Validate that all feature groups have at least one dependency
+    for feature_group, deps in extras_require.items():
         if not deps:
-            raise RuntimeError('Empty extra: {}'.format(extra))
+            raise RuntimeError(f"Empty feature group '{feature_group}' found in extras_require.")
 
     return install_requires, extras_require
 
 
 def list_all_requirements(app_type: str, requirements_table: "Mapping[str, Iterable[str]]") -> None:
-    req_table_by_key, _ = _build_requirements_table_by_key(requirements_table)
+    req_table_by_key, _ = build_requirements_table_by_key(requirements_table)
     req_file_name = "requirements/requirements.{}.txt".format(app_type)
 
     with open(req_file_name, 'r') as fhandle:


### PR DESCRIPTION
This PR upgrades the PostgreSQL driver from psycopg2 to psycopg (3). There has already been some work to tackle this (see #6993) but since I am following a quite different approach and the integration of those commits would yield a messy branch, I am starting a new one here and we can continue the discussion here.

A few important remarks:

I have added functionality to handle and parse requirements with “extras” (e.g., psycopg[binary,pool]).

While all tests are currently passing, we should remain cautious. Since `Psycopg` serves as the underlying driver for all `PostgreSQL` connections (used both indirectly through `SQLAlchemy` and directly in some parts of the code), there might still be edge cases that our tests have not detected.

For instance, I had to explicitly do casts of the port value at endpoints to an integer because `Psycopg` enforces stricter type handling compared to `Psycopg2`. The following method:

https://github.com/rucio/rucio/blob/594959f33b7d91892bee4d2147c7bbe1ec8b4dde/lib/rucio/core/rse.py#L1584-L1591

even though expects an optional integer for port, our tests (and possibly even production usage) are passing a string without raising an error in other contexts.

Additionally, the `postgres_meta.py` module directly interacts with Psycopg (bypassing SQLAlchemy and its models). I had to update the SQL statements to align with Psycopg’s stricter requirements. These changes call maybe for more thorough testing to ensure that all functionality remains intact and behaves as expected for this plugin.

