### PR TITLE
Daemons: Allow help menu to show even without config section set

### DIFF
--- a/bin/rucio-cache-client
+++ b/bin/rucio-cache-client
@@ -104,7 +104,7 @@ def get_parser():
          'operation': 'delete_replicas'
         }
 """
-    description = "This daemons is used to populate information of replicas on volatile storage."
+    description = "This daemon is used to populate information of replicas on volatile storage."
 
     if not config_has_section("message-cache"):
         defaults = {}

--- a/bin/rucio-cache-client
+++ b/bin/rucio-cache-client
@@ -29,7 +29,7 @@ from jsonschema import validate
 
 from rucio.client.didclient import DIDClient
 from rucio.client.rseclient import RSEClient
-from rucio.common.config import config_get, config_get_int
+from rucio.common.config import config_get_items, config_has_section
 from rucio.common.exception import DataIdentifierNotFound
 from rucio.common.schema import get_schema_value
 
@@ -104,17 +104,24 @@ def get_parser():
          'operation': 'delete_replicas'
         }
 """
-    oparser = argparse.ArgumentParser(description="This daemons is used to populate information of replicas on volatile storage.",
-                                      prog=os.path.basename(sys.argv[0]), add_help=True)
+    description = "This daemons is used to populate information of replicas on volatile storage."
+
+    if not config_has_section("message-cache"):
+        defaults = {}
+        message_append = "WARNING: section 'messaging-cache' not present in config! All arguments must be manually set!\n"
+        description = message_append + description
+    else:
+        defaults = config_get_items("message-cache")
+
+    oparser = argparse.ArgumentParser(description=description, prog=os.path.basename(sys.argv[0]), add_help=True)
 
     # Main arguments
-    oparser.add_argument('-b', '--broker', dest='broker', default=config_get('messaging-cache', 'brokers').split(',')[0], help='Message broker name')
-    oparser.add_argument('-p', '--port', dest='port', default=config_get_int('messaging-cache', 'port'), help='Message broker port')
-    oparser.add_argument('-c', '--certificate', dest='ssl_cert_file', default=config_get('messaging-cache', 'ssl_cert_file'), help='Certificate file')
-    oparser.add_argument('-k', '--certificate-key', dest='ssl_key_file', default=config_get('messaging-cache', 'ssl_key_file'), help='Certificate key file')
-    oparser.add_argument('-d', '--destination', dest='destination', default=config_get('messaging-cache', 'destination'), help="Message broker topic")
+    oparser.add_argument('-b', '--broker', dest='broker', default=defaults.get('brokers', '').split(',')[0], help='Message broker name')
+    oparser.add_argument('-p', '--port', dest='port', type=int, default=defaults.get('port'), help='Message broker port')
+    oparser.add_argument('-c', '--certificate', dest='ssl_cert_file', default=defaults.get('ssl_cert_file'), help='Certificate file')
+    oparser.add_argument('-k', '--certificate-key', dest='ssl_key_file', default=defaults.get('ssl_key_file'), help='Certificate key file')
+    oparser.add_argument('-d', '--destination', dest='destination', default=defaults.get('destination'), help="Message broker topic")
     oparser.add_argument('-m', '--message', dest='message', default=None, help=message_help)
-
     return oparser
 
 


### PR DESCRIPTION
Solves a documentation issue: https://github.com/rucio/documentation/issues/405

The Cache-Client daemon requires the `message-cache` section in the config to be set to use, but you can't know that without looking at the help menu. Which requires the section to be set. 

This change just sets defaults to `None` if the section is not present and adds a warning to the executable description.  