### PR TITLE
DRAFT: token: add required code for rucio as token issuer

### DIFF
--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -1909,8 +1909,8 @@ def determine_scope_for_rse(
 
 def determine_file_scope_for_path(
     rse_id: str,
-    file_path: str,
     scopes: 'Iterable[str]',
+    file_path: Optional[str],
     extra_scopes: Optional[list[str]] = None,
 ) -> str:
     """Construct the Scope claim for an RSE with file path."""
@@ -1928,7 +1928,7 @@ def determine_file_scope_for_path(
         if base_path := get_rse_attribute(rse_id, RseAttr.OIDC_BASE_PATH):  # type: ignore (session parameter missing)
             prefix = prefix.removeprefix(base_path)
         filtered_prefixes.add(prefix)
-    all_scopes = [f'{s}:{p}{file_path}' for s in scopes for p in filtered_prefixes]
+    all_scopes = [f'{s}:{p}{file_path or ""}' for s in scopes for p in filtered_prefixes]
     if extra_scopes:
         all_scopes += extra_scopes
     return ' '.join(sorted(all_scopes))

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -1915,6 +1915,8 @@ def determine_file_scope_for_path(
 ) -> str:
     """Construct the Scope claim for an RSE with file path."""
     rse_protocols = get_rse_protocols(rse_id)
+    if file_path:
+        file_path = file_path.lstrip("/")
     filtered_prefixes = set()
     for protocol in rse_protocols['protocols']:
         # Token support is exclusive to WebDAV.

--- a/lib/rucio/core/token_issuer.py
+++ b/lib/rucio/core/token_issuer.py
@@ -1,0 +1,169 @@
+
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import datetime
+import os
+import uuid
+from typing import Any, Optional
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+
+from rucio.common.config import config_get, config_get_bool, config_get_int
+
+ALLOWED_SCOPES = ["storage.read", "storage.write", "storage.modify", "storage.stage", "offline_access"]
+ISSUER = config_get('client', 'rucio_host')
+# TODO: decide on what should be sub for token
+SUB = "rucio-service"
+# kid should be some static value to encode token and put into jwks keys
+KID = "EB7520023DDB48AB02BACB61F84F3D66"
+# is there more alogrithm needed ?
+SUPPORTED_ALGORITHMS = ["RS256"]
+# should we have default audience ?
+DEFAULT_AUDIENCE = ISSUER
+ACCESS_TOKEN_LIFETIME = config_get_int('oidc', 'access_token_lifetime', raise_exception=False, default=21600)
+
+
+# Check if OIDC token issuer is enabled in config
+if config_get_bool("oidc", "rucio_token_issuer", raise_exception=False, default=False):
+    # Try to get keys from environment variables first
+    PRIVATE_KEY_PATH = os.getenv("OIDC_PRIVATE_KEY_PATH")
+    PUBLIC_KEY_PATH = os.getenv("OIDC_PUBLIC_KEY_PATH")
+
+    if not PRIVATE_KEY_PATH:
+        # If not set in environment, try to get from config
+        PRIVATE_KEY_PATH = config_get('oidc', 'oidc_private_key_path', raise_exception=True)
+
+    if not PUBLIC_KEY_PATH:
+        # If not set in environment, try to get from config
+        PUBLIC_KEY_PATH = config_get('oidc', 'oidc_public_key_path', raise_exception=True)
+
+    # Read private and public keys from the specified paths
+    with open(PRIVATE_KEY_PATH, "rb") as private_key_file:
+        PRIVATE_KEY_RS256 = serialization.load_pem_private_key(private_key_file.read(), password=None)
+
+    with open(PUBLIC_KEY_PATH, "rb") as public_key_file:
+        PUBLIC_KEY_RS256 = serialization.load_pem_public_key(public_key_file.read())
+
+
+def openid_config_resource() -> dict[str, Any]:
+    """ OpenID discovery """
+    res = {
+            "issuer": ISSUER,
+            "jwks_uri": f"{ISSUER}/jwks",
+            "scopes_supported": ALLOWED_SCOPES,
+            "response_types_supported": ["token"],
+            "grant_types_supported": [],
+            "claims_supported": ["sub", "aud"],
+        }
+    return res
+
+
+def jwks() -> dict[str, list[dict[str, Any]]]:
+    """Return JWKS configuration for public key discovery."""
+    numbers = PUBLIC_KEY_RS256.public_numbers()
+    return {
+        "keys": [
+            {
+                "alg": "RS256",
+                "kid": "RS256-1",
+                "use": "sig",
+                "kty": "RSA",
+                "n": base64.urlsafe_b64encode(numbers.n.to_bytes((numbers.n.bit_length() + 7) // 8, 'big')).decode('utf-8').rstrip('='),
+                "e": "AQAB",  # base64.urlsafe_b64encode(numbers.e.to_bytes((numbers.e.bit_length() + 7) // 8, 'big')).decode('utf-8').rstrip('='),
+            },
+        ]
+    }
+
+
+def _decode_token(token: str, algorithm: str = "RS256", verify_aud=False) -> dict[str, Any]:
+    """
+    Decodes a JWT token using the specified algorithm.
+
+    :param token: The JWT token to decode.
+    :param algorithm: The algorithm used to verify the signature (default: RS256).
+    :param verify_aud: Whether to verify the audience claim (default: False).
+    :return: A dictionary containing the decoded claims from the JWT.
+    """
+    return jwt.decode(token, PUBLIC_KEY_RS256, algorithms=[algorithm], options={"verify_aud": verify_aud})
+
+
+def _create_jwt_token(
+        scope: str,
+        audience: Optional[str] = DEFAULT_AUDIENCE,
+        algorithm: str = "RS256"
+) -> str:
+    """
+    Creates a JWT token with the specified parameters and optional expiration offset.
+    The function combines the payload creation and token encoding steps into one.
+
+    :param sub (str): Subject (usually the user identifier).
+    :param scope (str): Scope of the token.
+    :param audience (Optional[str]): Audience for the token. Defaults to the system's default if not provided.
+    :param algorithm (str): The algorithm to use for signing the token (default is "RS256").
+
+    Returns: The generated JWT token.
+    """
+    headers = {'kid': KID}
+    now = datetime.datetime.now(datetime.timezone.utc)
+    payload = {
+        "sub": SUB,
+        "iss": ISSUER,
+        "exp": now + datetime.timedelta(seconds=int(ACCESS_TOKEN_LIFETIME)),
+        "iat": now,
+        "nbf": now,
+        "jti": str(uuid.uuid4()),
+        "wlcg.ver": "1.0",
+        "scope": scope,
+        "aud": audience,
+    }
+    return jwt.encode(payload, PRIVATE_KEY_RS256, algorithm=algorithm, headers=headers)
+
+
+def request_access_token(
+    scope: str,
+    audience: Optional[str] = DEFAULT_AUDIENCE,
+    algorithm: str = "RS256"
+) -> dict[str, Any]:
+    """
+    Issues an access token.
+    https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+
+    :param sub: Subject (user ID or client ID).
+    :param scope: Scopes requested for the token.
+    :param audience: Audience for which the token is intended.
+    :param algorithm: The algorithm to use for token signing. Default is RS256.
+    :return: A dictionary containing the access token response.
+    """
+    scopes = scope.split()
+    scope_base_list = []
+    for sc in scopes:
+        scope_base = sc.split(":")[0]
+        scope_base_list.append(scope_base)
+    # Validate requested scopes against allowed scopes
+    invalid_scopes = [sc for sc in scopes if sc not in ALLOWED_SCOPES]
+    if invalid_scopes:
+        raise ValueError(f"Invalid scopes detected: {', '.join(invalid_scopes)}")
+
+    access_token = _create_jwt_token(scope, audience, algorithm)
+
+    response = {
+        "access_token": access_token,
+        "token_type": "Bearer",  # Token type as per RFC 6749 Section 7.1
+        "expires_in": ACCESS_TOKEN_LIFETIME,
+    }
+
+    return response

--- a/lib/rucio/core/token_issuer.py
+++ b/lib/rucio/core/token_issuer.py
@@ -25,7 +25,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 
 from rucio.common.config import config_get, config_get_bool, config_get_int
 
-ALLOWED_SCOPES = ["storage.read", "storage.write", "storage.modify", "storage.stage"]
+ALLOWED_SCOPES = ["storage.read", "storage.write", "storage.modify", "storage.stage", "fts"]
 # TODO: issuer should not contain port if standard port? use urlparse or is there better way ?
 ISSUER = config_get('client', 'rucio_host')
 # TODO: decide on what should be sub for token.

--- a/lib/rucio/core/token_issuer.py
+++ b/lib/rucio/core/token_issuer.py
@@ -25,7 +25,8 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 
 from rucio.common.config import config_get, config_get_bool, config_get_int
 
-ALLOWED_SCOPES = ["storage.read", "storage.write", "storage.modify", "storage.stage", "offline_access"]
+ALLOWED_SCOPES = ["storage.read", "storage.write", "storage.modify", "storage.stage"]
+# TODO: issuer should not contain port if standard port? use urlparse or is there better way ?
 ISSUER = config_get('client', 'rucio_host')
 # TODO: decide on what should be sub for token.
 # currently sub is sha256 SERVICE_NAME[:16]

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -626,7 +626,8 @@ def _run_once(
                 else:
                     # TODO: do we still create RSE level token ?
                     # if file level token then may be we need change some logic in delete_from_storage ?
-                    auth_token = request_access_token(scope=scope, audience=audience)
+                    auth_token_payload = request_access_token(scope=scope, audience=audience)
+                    auth_token = auth_token_payload["access_token"]
                 if auth_token:
                     logger(logging.INFO, 'Using a token to delete on RSE %s', rse.name)
                     prot = rsemgr.create_protocol(rse.info, 'delete', scheme=scheme, auth_token=auth_token, logger=logger)

--- a/lib/rucio/gateway/token_issuer.py
+++ b/lib/rucio/gateway/token_issuer.py
@@ -1,0 +1,30 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rucio.core import token_issuer
+
+
+def jwks() -> dict:
+    """
+    jwks url
+    """
+    res = token_issuer.jwks()
+    return res
+
+
+def openid_config_resource() -> dict:
+    """
+    openID discovery
+    """
+    return token_issuer.openid_config_resource()

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -1051,10 +1051,10 @@ class FTS3Transfertool(Transfertool):
                 [dest_lfn] = dest_protocol.parse_pfns([transfer.dest_url]).values()
                 dst_scope = determine_file_scope_for_path(rse_id=transfer.dst.rse.id, scopes=['storage.modify', 'storage.read'], file_path=dest_lfn['path'] + dest_lfn['name'])
                 token_payload = request_access_token(scope=dst_scope, audience=dst_audience)
-                t_file['source_tokens'].append(token_payload["access_token"])
+                t_file['destination_tokens'] = [token_payload["access_token"]]
             else:
                 dst_scope = determine_scope_for_rse(transfer.dst.rse.id, scopes=['storage.modify', 'storage.read'], extra_scopes=['offline_access'])
-            t_file['destination_tokens'] = [request_token(dst_audience, dst_scope)]
+                t_file['destination_tokens'] = [request_token(dst_audience, dst_scope)]
 
         if isinstance(self.scitags_exp_id, int):
             activity_id = self.scitags_activity_ids.get(rws.activity)

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -1036,7 +1036,7 @@ class FTS3Transfertool(Transfertool):
                 if config_get_bool("oidc", "rucio_token_issuer", raise_exception=False, default=False):
                     src_protocol = transfer.source_protocol(source)
                     [src_lfn] = src_protocol.parse_pfns([transfer.source_url(source)]).values()
-                    src_scope = determine_file_scope_for_path(rse_id=source.rse.id, scopes=['storage.read'], file_path=src_lfn['path'] + src_lfn['name'], extra_scopes=['offline_access'])
+                    src_scope = determine_file_scope_for_path(rse_id=source.rse.id, scopes=['storage.read'], file_path=src_lfn['path'] + src_lfn['name'])
                     token_payload = request_access_token(scope=src_scope, audience=src_audience)
                     t_file['source_tokens'].append(token_payload["access_token"])
                 else:
@@ -1049,7 +1049,7 @@ class FTS3Transfertool(Transfertool):
             if config_get_bool("oidc", "rucio_token_issuer", raise_exception=False, default=False):
                 dest_protocol = transfer.dest_protocol()
                 [dest_lfn] = dest_protocol.parse_pfns([transfer.dest_url]).values()
-                dst_scope = determine_file_scope_for_path(rse_id=transfer.dst.rse.id, scopes=['storage.modify', 'storage.read'], file_path=dest_lfn['path'] + dest_lfn['name'], extra_scopes=['offline_access'])
+                dst_scope = determine_file_scope_for_path(rse_id=transfer.dst.rse.id, scopes=['storage.modify', 'storage.read'], file_path=dest_lfn['path'] + dest_lfn['name'])
                 token_payload = request_access_token(scope=dst_scope, audience=dst_audience)
                 t_file['source_tokens'].append(token_payload["access_token"])
             else:

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -1036,7 +1036,7 @@ class FTS3Transfertool(Transfertool):
                 if config_get_bool("oidc", "rucio_token_issuer", raise_exception=False, default=False):
                     src_protocol = transfer.source_protocol(source)
                     [src_lfn] = src_protocol.parse_pfns([transfer.source_url(source)]).values()
-                    src_scope = determine_file_scope_for_path(rse_id=source.rse.id, scopes=['storage.read'], file_path=src_lfn['path'], extra_scopes=['offline_access'])
+                    src_scope = determine_file_scope_for_path(rse_id=source.rse.id, scopes=['storage.read'], file_path=src_lfn['path'] + src_lfn['name'], extra_scopes=['offline_access'])
                     token_payload = request_access_token(scope=src_scope, audience=src_audience)
                     t_file['source_tokens'].append(token_payload["access_token"])
                 else:
@@ -1049,7 +1049,7 @@ class FTS3Transfertool(Transfertool):
             if config_get_bool("oidc", "rucio_token_issuer", raise_exception=False, default=False):
                 dest_protocol = transfer.dest_protocol()
                 [dest_lfn] = dest_protocol.parse_pfns([transfer.dest_url]).values()
-                dst_scope = determine_file_scope_for_path(rse_id=transfer.dst.rse.id, scopes=['storage.modify', 'storage.read'], file_path=dest_lfn['path'], extra_scopes=['offline_access'])
+                dst_scope = determine_file_scope_for_path(rse_id=transfer.dst.rse.id, scopes=['storage.modify', 'storage.read'], file_path=dest_lfn['path'] + dest_lfn['name'], extra_scopes=['offline_access'])
                 token_payload = request_access_token(scope=dst_scope, audience=dst_audience)
                 t_file['source_tokens'].append(token_payload["access_token"])
             else:

--- a/lib/rucio/web/rest/flaskapi/v1/token_issuer.py
+++ b/lib/rucio/web/rest/flaskapi/v1/token_issuer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flask import Blueprint, Flask, jsonify
+from flask import Blueprint, Flask, Response, jsonify
 
 from rucio.gateway.token_issuer import jwks, openid_config_resource
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, generate_http_error_flask
@@ -21,7 +21,7 @@ from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_acc
 class JWKS(ErrorHandlingMethodView):
 
     @check_accept_header_wrapper_flask(['application/json'])
-    def get(self):
+    def get(self) -> Response:
         """
         ---
         summary: jwks info
@@ -40,10 +40,9 @@ class JWKS(ErrorHandlingMethodView):
 
 
 class OPENID_WELLKNOWN(ErrorHandlingMethodView):
-    """ dd"""
 
     @check_accept_header_wrapper_flask(['application/json'])
-    def get(self):
+    def get(self) -> Response:
         """
         ---
         summary: jwks info
@@ -61,7 +60,7 @@ class OPENID_WELLKNOWN(ErrorHandlingMethodView):
         return jsonify(res)
 
 
-def blueprint():
+def blueprint() -> Blueprint:
     public_bp = Blueprint('token_issuer', __name__)
 
     # Register JWKS view at /jwks
@@ -74,7 +73,7 @@ def blueprint():
     return public_bp
 
 
-def make_doc():
+def make_doc() -> Flask:
     """ Only used for sphinx documentation """
     doc_app = Flask(__name__)
     doc_app.register_blueprint(blueprint())

--- a/lib/rucio/web/rest/flaskapi/v1/token_issuer.py
+++ b/lib/rucio/web/rest/flaskapi/v1/token_issuer.py
@@ -14,6 +14,7 @@
 
 from flask import Blueprint, Flask, Response, jsonify
 
+from rucio.common.config import config_get_int
 from rucio.gateway.token_issuer import jwks, openid_config_resource
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, generate_http_error_flask
 
@@ -36,7 +37,10 @@ class JWKS(ErrorHandlingMethodView):
             res_jwks = jwks()
         except ValueError as error:
             generate_http_error_flask(500, str(error))
-        return jsonify(res_jwks)
+        response = jsonify(res_jwks)
+        jwks_cache_lifetime = config_get_int('oidc', 'jwks_cache_lifetime', raise_exception=False, default=21600)
+        response.headers['Cache-Control'] = f'public, max-age={jwks_cache_lifetime}'
+        return response
 
 
 class OPENID_WELLKNOWN(ErrorHandlingMethodView):

--- a/lib/rucio/web/rest/flaskapi/v1/token_issuer.py
+++ b/lib/rucio/web/rest/flaskapi/v1/token_issuer.py
@@ -1,0 +1,81 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from flask import Blueprint, Flask, jsonify
+
+from rucio.gateway.token_issuer import jwks, openid_config_resource
+from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, generate_http_error_flask
+
+
+class JWKS(ErrorHandlingMethodView):
+
+    @check_accept_header_wrapper_flask(['application/json'])
+    def get(self):
+        """
+        ---
+        summary: jwks info
+        description: get jwks info.
+        responses:
+          200:
+            description: OK
+          500:
+            description: Internal Server Error
+        """
+        try:
+            res_jwks = jwks()
+        except ValueError as error:
+            generate_http_error_flask(500, str(error))
+        return jsonify(res_jwks)
+
+
+class OPENID_WELLKNOWN(ErrorHandlingMethodView):
+    """ dd"""
+
+    @check_accept_header_wrapper_flask(['application/json'])
+    def get(self):
+        """
+        ---
+        summary: jwks info
+        description: get jwks info.
+        responses:
+          200:
+            description: OK
+          500:
+            description: Internal Server Error
+        """
+        try:
+            res = openid_config_resource()
+        except ValueError as error:
+            generate_http_error_flask(500, str(error))
+        return jsonify(res)
+
+
+def blueprint():
+    public_bp = Blueprint('token_issuer', __name__)
+
+    # Register JWKS view at /jwks
+    jwks_view = JWKS.as_view('jwks')
+    public_bp.add_url_rule('/jwks', view_func=jwks_view, methods=['GET'])
+
+    # Register OPENID_WELLKNOWN view at /.well-known/openid-configuration
+    wellknown_view = OPENID_WELLKNOWN.as_view('openid_wellknown')
+    public_bp.add_url_rule('/.well-known/openid-configuration', view_func=wellknown_view, methods=['GET'])
+    return public_bp
+
+
+def make_doc():
+    """ Only used for sphinx documentation """
+    doc_app = Flask(__name__)
+    doc_app.register_blueprint(blueprint())
+    return doc_app


### PR DESCRIPTION
relates to: #7262 
Draft PR to introduce rucio as token issuer. No oauth flow.  


1. Added core funcionality to get the access token.
   - Only one RS256 alogrithm is used to create token.
   - followed WLCG profile for token
2.   switch to activate this: `config_get_bool("oidc", "rucio_token_issuer")`
3. Two public endpoint : /jwks and /.well-known/openid-configuration
4. FTS3 transfer part calls the core to get file level scope acess token.
5. Repear call to get RSE level token. if File level scope token is needed some more changes required .
 
 No pytest is added. Will be added after further discussion.

If token exchange and refresh flow is needed , I have working example of how it can be done in rucio.

 decoded token:
 ```
 {
  'sub': 'rucio-service-a58ca938830d',
  'iss': 'https://rucio:443',
  'exp': 1734419522,
  'iat': 1734397922,
  'nbf': 1734397922,
  'jti': '55f8a8fe-e9ea-41eb-8328-a2da1b260e76',
  'wlcg.ver': '1.0',
  'scope': 'offline_access storage.read:/mydire/myfile.txt',
  'aud': 'https://mystorage.org'
}
 ```
 
/.well-known/openid-configuration endpoint: 
```
{
  'issuer': 'https://rucio:443',
  'jwks_uri': 'https://rucio:443/jwks',
  'scopes_supported': [
    'storage.read',
    'storage.write',
    'storage.modify',
    'storage.stage',
    'fts'
  ],
  'response_types_supported': [
    'token'
  ],
  'grant_types_supported': [
    
  ],
  'claims_supported': [
    'sub',
    'aud'
  ]
}
```
 
 /jwks enpoint:
 ```
{
  'keys': [
    {
      'alg': 'RS256',
      'kid': '6424aa58c2e7',
      'use': 'sig',
      'kty': 'RSA',
      'n': 'nvuHmFOUwG5DsFdhL70FVq0WWLj2jWmnFbAPNurwryMYCCcq40y2NJZ0mM_oX8EgFn8IUOugnQCk5aipaULjXMBi37qxOtebYwdWDVuvyF-_ngSVFdYCJQ9rvB7KYz5yn7ygJi09EZHUdW_AHJyIU5Xd_UZ2Vc_HtuhacWthHrBL6Vac7uhUky0Qy5fe5_2pnFWMfubRwjFGZywOeqaVaU9hPVL48ssSqLf-tdsmvOnZZLBibAM1yFqqNcqCX-M-fOxUBQcfGg522ZdRK9tGEua2A2yW3tWaP7aAseRoWjKKuwCGg7DoY38yET3GFOh4u7dash4lRybfoTasxH0-FQ',
      'e': 'AQAB'
    }
  ]
}
 ```  
 
 Test was done,  which fts and storage does for token validation
 ```
 import json

import jwt
import requests

# OpenID discovery endpoint URL (replace with the actual URL for your OpenID provider)
openid_discovery_url = 'https://rucio:443/.well-known/openid-configuration'

# Step 1: Fetch OpenID configuration to get the JWKS URL
response = requests.get(openid_discovery_url)
openid_config = response.json()

# Get the JWKS URL from the OpenID configuration
jwks_url = openid_config['jwks_uri']

# Step 2: Fetch the JWKS (JSON Web Key Set) from the URL
jwks_response = requests.get(jwks_url)
jwks = jwks_response.json()

# Step 3: Create a dictionary of public keys from the JWKS
public_keys = {}
for jwk in jwks['keys']:
    kid = jwk['kid']
    public_keys[kid] = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(jwk))

# Step 4: Decode the JWT token
token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjY0MjRhYTU4YzJlNyIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJydWNpby1zZXJ2aWNlLWE1OGNhOTM4ODMwZCIsImlzcyI6Imh0dHBzOi8vcnVjaW86NDQzIiwiZXhwIjoxNzM0NDE5NTIyLCJpYXQiOjE3MzQzOTc5MjIsIm5iZiI6MTczNDM5NzkyMiwianRpIjoiNTVmOGE4ZmUtZTllYS00MWViLTgzMjgtYTJkYTFiMjYwZTc2Iiwid2xjZy52ZXIiOiIxLjAiLCJzY29wZSI6Im9mZmxpbmVfYWNjZXNzIHN0b3JhZ2UucmVhZDovbXlkaXJlL215ZmlsZS50eHQiLCJhdWQiOiJodHRwczovL215c3RvcmFnZS5vcmcifQ.bMfb39C6yy2ASpYqeCu4ZtcYd80Huc2TFAdjKRqO7kaAV04ceUE3mvpuCwMdrC8OTNrHm4TP0gFEn4EMdZwqQNoqnTavMwZeGTXB2EjLBAhMYKgsMGY1X7c_Jvi0w1s938IiHBYWeTK3zcYrpd4aerCxy326X1SilYP8XcI8WF5E4BfdVaKeSA-u_frnS6pQ30bOv5n4TwdA29Ywkzs4flRy71GtjrChni70adGKDYCSWI43xWO2VSNKgHBuNuakRyQJdqX0L8pt19E2IUEIXVUNOYl90B0lHSpmLb0NO3fYSJJmzNLW2urpiz7nGZQ0dbgXkRx1h04iJ8Q_3gBBDw' 
kid = jwt.get_unverified_header(token)['kid']  # Get the 'kid' from the JWT header
key = public_keys.get(kid)  # Get the corresponding public key using 'kid'

if key is None:
    raise ValueError("Unable to find appropriate public key")

# Step 5: Decode and verify the JWT
payload = jwt.decode(token, key=key, algorithms=['RS256'])

# The 'payload' now contains the decoded JWT claims
print(payload)
 
 ```