### PR TITLE
Core: RseData, Refactor properties to use _get_loaded_attribute

### DIFF
--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -70,9 +70,7 @@ class RseData:
 
     @property
     def name(self) -> str:
-        if self._name is None:
-            raise ValueError(f'name not loaded for rse {self}')
-        return self._name
+        return self._get_loaded_attribute('name')
 
     @name.setter
     def name(self, name):
@@ -80,39 +78,27 @@ class RseData:
 
     @property
     def columns(self) -> dict[str, Any]:
-        if self._columns is None:
-            raise ValueError(f'columns not loaded for rse {self}')
-        return self._columns
+        return self._get_loaded_attribute('columns')
 
     @property
     def attributes(self) -> dict[str, Any]:
-        if self._attributes is None:
-            raise ValueError(f'attributes not loaded for rse {self}')
-        return self._attributes
+        return self._get_loaded_attribute('attributes')
 
     @property
     def info(self) -> types.RSESettingsDict:
-        if self._info is None:
-            raise ValueError(f'info not loaded for rse {self}')
-        return self._info
+        return self._get_loaded_attribute('info')
 
     @property
     def usage(self) -> list[dict[str, Any]]:
-        if self._usage is None:
-            raise ValueError(f'usage not loaded for rse {self}')
-        return self._usage
+        return self._get_loaded_attribute('usage')
 
     @property
     def limits(self) -> dict[str, Any]:
-        if self._limits is None:
-            raise ValueError(f'limits not loaded for rse {self}')
-        return self._limits
+        return self._get_loaded_attribute('limits')
 
     @property
     def transfer_limits(self):
-        if self._transfer_limits is None:
-            raise ValueError(f'transfer_limits not loaded for rse {self}')
-        return self._transfer_limits
+        return self._get_loaded_attribute('transfer_limits')
 
     def __hash__(self):
         return hash(self.id)

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -62,6 +62,12 @@ class RseData:
         self._limits = limits
         self._transfer_limits = transfer_limits
 
+    def _get_loaded_attribute(self, attribute_name: str) -> Any:
+        attribute = getattr(self, f'_{attribute_name}', None)
+        if attribute is None:
+            raise ValueError(f'{attribute_name} not loaded for rse {self}')
+        return attribute
+
     @property
     def name(self) -> str:
         if self._name is None:


### PR DESCRIPTION
The missing type annotation checker complains about the usage of `Any`:
```
lib/rucio/core/rse.py:65:64: ANN401 Dynamically typed expressions (typing.Any) are disallowed
```

We cannot use `Union` here because then it doesn't allow for specific return types for the properties that use this method; e.g. for `name`, you wouldn't be able to mark the return type as `str` because it'd say that the other return types could also occur. 
The workaround would be to use overloads with different literal inputs with the attribute names, but I do not think we should do it in this case, because we already have the property-specific return types annotated in the property function signatures themselves. Given this, I think `Any` is fine here.