### PR TITLE
Clients: Show command groups with descriptions #7252

### DIFF
--- a/lib/rucio/client/commands/command.py
+++ b/lib/rucio/client/commands/command.py
@@ -65,11 +65,17 @@ class Commands:
 
     @staticmethod
     def _add_parsers() -> argparse.ArgumentParser:
-        parser = argparse.ArgumentParser(description='CLI Rucio Client. (Use --legacy to view CLI from <36.0)')
+        all_commands = Commands._all_commands()
+        groups = ""
+        for command_name, command in all_commands.items():
+            help = command(None, None, None, None, None).module_help().split('\n')[0]  # type: ignore
+            groups += f"    {command_name.ljust(20)}{help}\n"
+        description = f'CLI Rucio Client. (Use --legacy to view CLI from <36.0)\n\nPossible Arguments:\n{groups} \nView `rucio <command> -h` for more information and subcommands.'
+        parser = argparse.ArgumentParser(description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
         Commands._main_parser(parser)
 
-        subparsers = parser.add_subparsers(dest="command", help="Command to execute, see `{command} -h` for more details and subcommands.")
-        for command in Commands._all_commands().values():
+        subparsers = parser.add_subparsers(dest="command", help=argparse.SUPPRESS)
+        for command in all_commands.values():
             command(None, None, None, None, None).parser(subparsers)  # type: ignore
 
         return parser


### PR DESCRIPTION
Changes the CLI help menu to show: 

```
usage: rucio [-h] [--version] [--config CONFIG] [--verbose] [-H ADDRESS] [--auth-host ADDRESS] [-a ISSUER] [-S AUTH_STRATEGY] [-T TIMEOUT] [--user-agent USER_AGENT] [--vo VO] [-u USERNAME] [-pwd PASSWORD]
             [--oidc-user OIDC_USERNAME] [--oidc-password OIDC_PASSWORD] [--oidc-scope OIDC_SCOPE] [--oidc-audience OIDC_AUDIENCE] [--oidc-auto] [--oidc-polling] [--oidc-refresh-lifetime OIDC_REFRESH_LIFETIME]
             [--oidc-issuer OIDC_ISSUER] [--certificate CERTIFICATE] [--client-key CLIENT_KEY] [--ca-certificate CA_CERTIFICATE]

CLI Rucio Client. (Use --legacy to view CLI from <36.0)

Possible Arguments:

    account             Methods to add or change accounts for users, groups, and services. Used to assign privileges.
    config              Manage the global settings.
    did                 Manage Data IDentifiers. Modify and access specific files and groups of files. DIDs are accessed by the pattern `scope`:`name`, where name can be a wildcard, but scope must be specified
    download            Download files
    replica             Interact with a Data IDentifier at a specific Rucio Service Element
    rse                 Manage Rucio Storage Elements - the sites where Rucio can place and access data.
    rule                Create rules that require a number of replicas at a defined set of remote Rucio Storage Elements (RSEs). Rules will initialize transfers between sites
    scope               Manage scopes - A namespace partition generally used to separate common data from user data
    subscription        Automate processing of specific rules, will create new rules on a schedule
    upload              Upload DIDs
    ping                
    whoami              
    lifetime-exception  Manage Lifetime Exceptions (to make protections against deletion from reaper daemons)
    test-server         
 
View `rucio <command> -h` for more information and subcommands.

optional arguments:
```
