### PR TITLE
Clients: Create positional and optional arguments #7250

### DIFF
--- a/lib/rucio/client/commands/account.py
+++ b/lib/rucio/client/commands/account.py
@@ -61,19 +61,19 @@ class Account(CommandBase):
 
     def add_namespace(self, parser: "ArgumentParser") -> None:
         parser.add_argument("--type", dest="accounttype", help="Account Type (USER, GROUP, SERVICE)", required=True)
-        parser.add_argument("-a", "--account", dest="account", help="Account name", required=True)
+        self._add_positional_option(parser, "account", dest="account", help="Account name", abbr='a')
         parser.add_argument("--email", dest="accountemail", help="Add an email address associated with the account")
 
     def show_namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-a", "--account", dest="account", help="Account name", required=True)
+        self._add_positional_option(parser, "account", dest="account", help="Account name", abbr='a')
 
     def update_namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-a", "--account", help="Account name", required=True)
+        self._add_positional_option(parser, "account", dest="account", help="Account name", abbr='a')
         parser.add_argument("--email", help="Account email")
         parser.add_argument("--ban", type=bool, choices=(True, False), help='Ban the account, to disable it. Use --ban False to unban.', default=None)
 
     def remove_namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-a", "--account", dest="acnt", action="store", help="Account name", required=True)
+        self._add_positional_option(parser, "account", dest="acnt", help="Account name", abbr='a')
 
     def _operations(self) -> dict[str, "OperationDict"]:
         return {
@@ -119,10 +119,18 @@ class Attribute(Account):
     def implemented_subcommands(self) -> dict[str, type[CommandBase]]:
         return {}
 
-    def namespace(self, subparser):
-        subparser.add_argument("-a", "--account", help="Account name")
-        subparser.add_argument("--key", dest="key", action="store", help="Attribute key")
-        subparser.add_argument("--value", dest="value", action="store", help="Attribute value")
+    def add_namespace(self, subparser):
+        self._add_positional_option(subparser, "account", dest="account", help="Account name", abbr='a')
+        self._add_positional_option(subparser, "key", dest="key", help="Attribute key")
+        self._add_positional_option(subparser, "value", dest="value", help="Attribute value")
+
+    def list_namespace(self, parser):
+        self._add_positional_option(parser, "account", dest="account", help="Account name", abbr='a')
+        parser.add_argument("--key", help="Attribute key")
+
+    def remove_namespace(self, parser):
+        self._add_positional_option(parser, "account", dest="account", help="Account name", abbr='a')
+        self._add_positional_option(parser, "key", dest="key", help="Attribute key", abbr='k')
 
     def usage_example(self) -> list[str]:
         return ["$ rucio account attribute list --account jdoe  # Show all attributes for jdoe",
@@ -130,9 +138,9 @@ class Attribute(Account):
 
     def _operations(self) -> dict[str, "OperationDict"]:
         return {
-            "list": {"call": self.list_, "docs": "List all account attributes"},
-            "add": {"call": self.add, "docs": "Add a new attribute to an account or update an existing one"},
-            "remove": {"call": self.remove, "docs": "Remove an existing account attribute"},
+            "list": {"call": self.list_, "docs": "List all account attributes", "namespace": self.list_namespace},
+            "add": {"call": self.add, "docs": "Add a new attribute to an account or update an existing one", "namespace": self.add_namespace},
+            "remove": {"call": self.remove, "docs": "Remove an existing account attribute", "namespace": self.remove_namespace},
         }
 
     def list_(self):
@@ -150,7 +158,7 @@ class Limit(Account):
         return "Manage storage limits for an account at a given RSE."
 
     def namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-a", "--account", dest="account", help="Account name", required=True)
+        self._add_positional_option(parser, "account", dest="account", help="Account name", abbr='a')
         parser.add_argument("--rses", "--rse-exp", dest='rse', action="store", help="RSE expression")
         parser.add_argument("--bytes", action="store", help='Value can be specified in bytes ("10000"), with a storage unit ("10GB"), or "infinity"')
         parser.add_argument("--locality", nargs="?", default="local", choices=["local", "global"], help="Global or local limit scope")
@@ -185,7 +193,7 @@ class Identity(Account):
         return "Manage identities on an account."
 
     def namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("--account", dest="account", action="store", help="Account name", required=True)
+        self._add_positional_option(parser, "account", dest="account", help="Account name", abbr='a')
         parser.add_argument("--type", dest="authtype", action="store", choices=["X509", "GSS", "USERPASS", "SSH", "SAML", "OIDC"], help="Authentication type")
         parser.add_argument("--id", dest="identity", action="store", help="Identity as a DNs for X509 IDs.")
         parser.add_argument("--email", dest="email", action="store", help="Email address associated with the identity")

--- a/lib/rucio/client/commands/did.py
+++ b/lib/rucio/client/commands/did.py
@@ -28,27 +28,28 @@ class DID(CommandBase):
         return "Manage Data IDentifiers. Modify and access specific files and groups of files. DIDs are accessed by the pattern `scope`:`name`, where name can be a wildcard, but scope must be specified"
 
     def list_namespace(self, parser: "ArgumentParser") -> None:
+        self._add_positional_option(parser, "did", dest="did", help="Data IDentifier pattern", abbr='d', nargs='?')  # ? denotes 0 or 1 argument
         parser.add_argument("--recursive", dest="recursive", action="store_true", help="List data identifiers recursively")
         parser.add_argument("--filter", help="Filter arguments in form `key=value,another_key=next_value`. Valid keys are name, type")
         parser.add_argument("--short", action="store_true", help="Just dump the list of DIDs")
-        parser.add_argument("-d", "--did", nargs=1, help="Data IDentifier pattern")
 
     def add_namespace(self, parser: "ArgumentParser") -> None:
         parser.add_argument("--type", dest='dtype', choices=("container", "dataset"), help="Add collection type DID")
         parser.add_argument("--monotonic", action="store_true", help="Monotonic status to True")
-        parser.add_argument("-d", "--did", action="store", help="The name of the dataset to add")
+        parser.add_argument("-d", "--did", action="store", help="The name of the dataset to add", required=True)
         parser.add_argument("--lifetime", dest="lifetime", action="store", type=int, help="Lifetime in seconds")
 
     def update_namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-d", "--did", dest="dids", nargs="+", help="List of space separated data identifiers")
+        self._add_positional_option(parser, "did", dest="dids", help="Data IDentifiers", abbr='d', nargs='*')
         parser.add_argument("--rse", "--rse-name", dest='rse', help="Touch Argument: The RSE of the DIDs that are touched")
 
-        parser.add_argument("--touch", action="store_true", help="Update the last updated time to the current time. Requires a RSE to be set")
-        parser.add_argument("--close", action="store_true", help="Set a collection-type DID to 'closed', so it cannot have more child DIDs added to it")
-        parser.add_argument("--open", action="store_true", help="Set a collection-type DID to 'open', so more DIDs may be added to it as children")
+        op_group = parser.add_mutually_exclusive_group(required=False)
+        op_group.add_argument("--touch", action="store_true", help="Update the last updated time to the current time. Requires a RSE to be set")
+        op_group.add_argument("--close", action="store_true", help="Set a collection-type DID to 'closed', so it cannot have more child DIDs added to it")
+        op_group.add_argument("--open", action="store_true", help="Set a collection-type DID to 'open', so more DIDs may be added to it as children")
 
     def show_namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-d", "--did", dest="dids", nargs="+", help="List of space separated data identifiers")
+        self._add_positional_option(parser, "did", dest="dids", help="Data IDentifiers", abbr='d', nargs='*')
         parser.add_argument("--parent", action="store_true", help="List the parents of the DID")
 
         # Both non-functional, but list_parents complains if not present
@@ -57,8 +58,8 @@ class DID(CommandBase):
         parser.add_argument("--guid", dest="guids", nargs="+", help=argparse.SUPPRESS)
 
     def remove_namespace(self, parser: "ArgumentParser") -> None:
+        self._add_positional_option(parser, "did", dest="dids", help="Data IDentifiers", abbr='d', nargs='*')
         parser.add_argument("--undo", action="store_true", help="Undo erase DIDs. Only works if has been less than 24 hours since erase operation")
-        parser.add_argument("-d", "--did", dest="dids", nargs="+", help="List of space separated data identifiers")
 
     def _operations(self) -> dict[str, "OperationDict"]:
         return {
@@ -85,6 +86,7 @@ class DID(CommandBase):
         ]
 
     def list_(self):
+        self.args.did = [self.args.did]
         list_dids(self.args, self.client, self.logger, self.console, self.spinner)
 
     def show(self):

--- a/lib/rucio/client/commands/download.py
+++ b/lib/rucio/client/commands/download.py
@@ -34,7 +34,7 @@ class Download(CommandBase):
 
         command_parser = parser.add_parser(self.PARSER_NAME, description=self._help(), formatter_class=argparse.RawDescriptionHelpFormatter)
 
-        command_parser.add_argument("-d", "--did", nargs="*", dest="dids", help="DIDs to download, as a space separated list", required=True)
+        self._add_positional_option(command_parser, "did", dest="dids", help="DIDs to download", abbr='d', nargs='*')
         command_parser.add_argument("--rses", "--rse-exp", help="The Rucio Storage Element (RSE) name or expression to download from", dest="rses")
         command_parser.add_argument("--dir", dest="dir", default=".", action="store", help="The directory to store the downloaded file")
         command_parser.add_argument("--allow-tape", action="store_true", default=False, help="Also consider tape endpoints as source of the download")

--- a/lib/rucio/client/commands/lifetime_exception.py
+++ b/lib/rucio/client/commands/lifetime_exception.py
@@ -42,10 +42,10 @@ class LifetimeException(CommandBase):
         }
 
     def usage_example(self) -> list[str]:
-        return ["$ rucio lifetime-exception add --inputfile myfile.txt --reason 'Needed for my analysis' --expiration 2015-10-30  # Add exceptions for all DIDs listed in myfile.txt"]
+        return ["$ rucio lifetime-exception add --file myfile.txt --reason 'Needed for my analysis' --expiration 2015-10-30  # Add exceptions for all DIDs listed in myfile.txt"]
 
     def namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-f", "--inputfile", help="File where the list of datasets requested to be extended are located")
+        self._add_positional_option(parser, "file", dest="inputfile", help="File where the list of datasets requested to be extended are located", abbr='f')
         parser.add_argument("--reason", help="The reason for the extension")
         parser.add_argument("-x", "--expiration", help="The expiration date format YYYY-MM-DD")
 

--- a/lib/rucio/client/commands/replica.py
+++ b/lib/rucio/client/commands/replica.py
@@ -39,8 +39,8 @@ class Replica(CommandBase):
         }
 
     def list_namespace(self, parser: "ArgumentParser") -> None:
+        self._add_positional_option(parser, "did", dest="dids", help="Data IDentifiers", abbr='d', nargs='*')
         parser.add_argument(dest='dtype', choices=("file", "dataset"), help="List either the replicas of a file or a dataset (and its contents)")
-        parser.add_argument("-d", "--did", dest="dids", nargs="+", action="store", help="List of space separated data identifiers.")
         parser.add_argument("--protocols", help="Protocol used to access a replicas (i.e. https, root, srm)", required=False)
         parser.add_argument(
             "--all-states",
@@ -73,7 +73,7 @@ class Replica(CommandBase):
         )
 
     def remove_namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-d", "--did", dest="dids", help="DIDs to access, as comma separated values")
+        self._add_positional_option(parser, "did", dest="dids", help="Data IDentifiers", abbr='d', nargs='?')
         parser.add_argument("--rse", "--rse-name", dest="rse", help="RSE Name")
 
     def implemented_subcommands(self) -> dict[str, type[CommandBase]]:

--- a/lib/rucio/client/commands/rse.py
+++ b/lib/rucio/client/commands/rse.py
@@ -70,8 +70,8 @@ class RSE(CommandBase):
         ]
 
     def namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("--rse", "--rse-name", help="RSE name", required=True)
-        parser.add_argument("--non-deterministic", action="store_true", help="Create RSE in non-deterministic mode")
+        self._add_positional_option(parser, "rse", dest="rse", help="RSE Name")
+        parser.add_argument("--non-deterministic", action="store_true", help="RSE in non-deterministic mode")
 
         parser.add_argument(
             "--setting",
@@ -83,6 +83,9 @@ class RSE(CommandBase):
 
     def list_namespace(self, parser: "ArgumentParser") -> None:
         parser.add_argument("--rses", "--rse-exp", dest="rses", help="RSE name or expression")
+
+    def show_namespace(self, parser: "ArgumentParser") -> None:
+        self._add_positional_option(parser, "rse", dest="rse", help="RSE Name")
 
     def list_(self):
         list_rses(self.args, self.client, self.logger, self.console, self.spinner)
@@ -112,7 +115,7 @@ class Attribute(RSE):
         }
 
     def namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("--rse", "--rse-name", help="RSE name", required=True)
+        self._add_positional_option(parser, "rse", dest="rse", help="RSE Name")
         parser.add_argument("--key", help="Attribute key")
         parser.add_argument("--value", help="Attribute value")
 

--- a/lib/rucio/client/commands/rule.py
+++ b/lib/rucio/client/commands/rule.py
@@ -75,7 +75,7 @@ class Rule(CommandBase):
         parser.add_argument("--all", dest="delete_all", action="store_true", default=False, help="Delete all the rules, even the ones that are not owned by the account")
 
     def show_namespace(self, parser: "ArgumentParser") -> None:
-        self._common_namespace(parser)
+        self._add_positional_option(parser, "rule-id", dest="rule_id", help="The rule ID, for accessing an existing rule.")
         parser.add_argument("--examine", action="store_true", help="Detailed analysis of transfer errors")
 
     def list_namespace(self, parser: "ArgumentParser") -> None:

--- a/lib/rucio/client/commands/scope.py
+++ b/lib/rucio/client/commands/scope.py
@@ -41,8 +41,8 @@ class Scope(CommandBase):
         parser.add_argument("-a", "--account", help="Account name for filtering, attribution")
 
     def add_namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-a", "--account", help="Account name for filtering, attribution", required=True)
-        parser.add_argument("-s", "--scope", help="Name of the new scope to add", required=True)
+        self._add_positional_option(parser, "account", dest="account", help="Account name for filtering, attribution", abbr='a')
+        self._add_positional_option(parser, "scope", dest="scope", help="Name of the new scope to add", abbr='s')
 
     def list_(self):
         list_scopes(self.args, self.client, self.logger, self.console, self.spinner)

--- a/lib/rucio/client/commands/subscription.py
+++ b/lib/rucio/client/commands/subscription.py
@@ -57,7 +57,7 @@ class Subscription(CommandBase):
         parser.add_argument("--long", action="store_true", help="Show extra subscription information, including creation and expiration dates")
 
     def touch_namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-d", "--did", dest="dids", help="List of DIDs (coma separated)", required=True)
+        self._add_positional_option(parser, "did", dest="dids", help="List of DIDs (coma separated)", abbr='d')
 
     def list_(self):
         list_subscriptions(self.args, self.client, self.logger, self.console, self.spinner)

--- a/lib/rucio/client/commands/upload.py
+++ b/lib/rucio/client/commands/upload.py
@@ -31,8 +31,7 @@ class Upload(CommandBase):
     def parser(self, parser: "argparse._SubParsersAction[ArgumentParser]") -> None:
 
         command_parser = parser.add_parser(self.PARSER_NAME, description=self._help(), formatter_class=argparse.RawDescriptionHelpFormatter)
-
-        command_parser.add_argument("--files", nargs="+", dest="args", help="Files and datasets to upload")
+        self._add_positional_option(command_parser, "files", dest="args", help="Files and datasets to upload", abbr='f', nargs='*')
         command_parser.add_argument('--rse', "--rse-name", dest='rse', action='store', help='Rucio Storage Element (RSE) name.',)
         command_parser.add_argument("--lifetime", type=int, help="Lifetime of the rule in second.")
         command_parser.add_argument("--expiration-date", help="The date when the rule expires in UTC, format: <year>-<month>-<day>-<hour>:<minute>:<second>. E.g. 2022-10-20-20:00:00")


### PR DESCRIPTION
Makes many arguments positional (listed below). 
* `--account` for `account [operation]`
* `--account` and  `--key/--value` for `account attribute [operation]`
* `--account` for `account limit [operation]`
* `--did` in `did list|update|show|remove`
* `--did` in `download`
* `--files` in `upload`
* `--inputfile` in `lifetime-exception add`
* `--did` in `replica list|remove`
* `--rse` in `rse add|update|remove|show`
* `--rse` in `rse attribute [operation]`
* `--rule-id` in `rule show`
* `--account` and `--scope` in `scope add`
* `--did` in `subscription show`

Introduces a private method in `CommandBase` that allows positional arguments to also be supplied via option flags. (e.g. `rucio did list scope:name` does the same thing as `rucio did list --did scope:name`, with this operation called out directly in the documentation. 