### PR TITLE
Database: Update template to latest standards #7295

### DIFF
--- a/lib/rucio/db/sqla/migrate_repo/script.py.mako
+++ b/lib/rucio/db/sqla/migrate_repo/script.py.mako
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-''' ${message} '''
+"""${message}"""    # noqa: D400, D415
 
 import sqlalchemy as sa
-
 from alembic import context
 from alembic.op import execute
 
@@ -26,34 +24,24 @@ down_revision = ${repr(down_revision)}
 
 
 def upgrade():
-    '''
-    Upgrade the database to this revision
-    '''
-
+    """Upgrade the database to this revision."""
     schema = context.get_context().version_table_schema + '.' if context.get_context().version_table_schema else ''
 
     if context.get_context().dialect.name == 'oracle':
         pass
-
     elif context.get_context().dialect.name == 'postgresql':
         pass
-
     elif context.get_context().dialect.name == 'mysql':
         pass
 
 
 def downgrade():
-    '''
-    Downgrade the database to the previous revision
-    '''
-
+    """Downgrade the database to the previous revision."""
     schema = context.get_context().version_table_schema + '.' if context.get_context().version_table_schema else ''
 
     if context.get_context().dialect.name == 'oracle':
         pass
-
     elif context.get_context().dialect.name == 'postgresql':
         pass
-
     elif context.get_context().dialect.name == 'mysql':
         pass


### PR DESCRIPTION
I won’t be surprised if the changes to the file-level docstring are unwanted (no surrounding whitespace, ending with a period), despite adhering to PEP 257. I don’t mind reverting.