### PR TITLE
Transfers: Use new token request procedure in the Poller #6407

### DIFF
--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -30,7 +30,7 @@ from requests.exceptions import RequestException
 from sqlalchemy.exc import DatabaseError
 
 import rucio.db.sqla.util
-from rucio.common.config import config_get, config_get_bool
+from rucio.common.config import config_get, config_get_bool, config_get_float
 from rucio.common.exception import DatabaseException, TransferToolTimeout, TransferToolWrongAnswer
 from rucio.common.logging import setup_logging
 from rucio.common.stopwatch import Stopwatch
@@ -170,11 +170,7 @@ def poller(
     """
     Main loop to check the status of a transfer primitive with a transfertool.
     """
-
-    timeout = config_get('conveyor', 'poll_timeout', default=None, raise_exception=False)
-    if timeout:
-        timeout = float(timeout)
-
+    timeout = config_get_float('conveyor', 'poll_timeout', default=None, raise_exception=False)
     multi_vo = config_get_bool('common', 'multi_vo', False, None)
     oidc_support = config_get_bool('conveyor', 'poller_oidc_support', default=False, raise_exception=False)
 

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -34,7 +34,6 @@ from rucio.common.config import config_get, config_get_bool, config_get_float
 from rucio.common.exception import DatabaseException, TransferToolTimeout, TransferToolWrongAnswer
 from rucio.common.logging import setup_logging
 from rucio.common.stopwatch import Stopwatch
-from rucio.common.types import LoggerFunction
 from rucio.common.utils import dict_chunks
 from rucio.core import request as request_core
 from rucio.core import transfer as transfer_core
@@ -48,6 +47,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from types import FrameType
 
+    from rucio.common.types import LoggerFunction
     from rucio.daemons.common import HeartbeatHandler
     from rucio.transfertool.transfertool import Transfertool
 
@@ -118,7 +118,7 @@ def _handle_requests(
         transfer_stats_manager: request_core.TransferStatsManager,
         oidc_support: bool,
         *,
-        logger: LoggerFunction = logging.log,
+        logger: "LoggerFunction" = logging.log,
 ) -> None:
     transfs.sort(key=lambda t: (t['external_host'] or '',
                                 t['scope'].vo if multi_vo else '',

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -873,7 +873,6 @@ class FTS3Transfertool(Transfertool):
 
     def __init__(self,
                  external_host: str,
-                 oidc_account: Optional[str] = None,
                  oidc_support: bool = False,
                  vo: Optional[str] = None,
                  group_bulk: int = 1,


### PR DESCRIPTION
Typically, changes to the configuration file should be reserved for major releases. Exceptionally for this case, since the original configuration option was already completely ineffective, I would recommend that it be included in the next minor release instead.