### PR TITLE
Refactor config to cache the parser instead of using a global variable, minor test refactorings, add tests for get_config and clean_cached_config

### DIFF
--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -17,6 +17,7 @@
 import configparser
 import json
 import os
+from functools import cache
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, overload
 
 from rucio.common import exception
@@ -656,7 +657,6 @@ def __config_get_table(
     :raises ConfigNotFound
     :raises DatabaseException
     """
-    global __CONFIG
     try:
         from rucio.core.config import get as core_config_get
         return core_config_get(section, option, default=default, session=session, use_cache=use_cache,
@@ -665,7 +665,7 @@ def __config_get_table(
         if raise_exception and default is None:
             raise err
         if clean_cached:
-            __CONFIG = None
+            clean_cached_config()
         return default
 
 
@@ -753,21 +753,15 @@ def get_rse_credentials(path_to_credentials_file: Optional[Union[str, os.PathLik
     return credentials
 
 
-__CONFIG = None
-
-
+@cache
 def get_config() -> configparser.ConfigParser:
     """Factory function for the configuration class. Returns the ConfigParser instance."""
-    global __CONFIG
-    if __CONFIG is None:
-        __CONFIG = Config()
-    return __CONFIG.parser
+    return Config().parser
 
 
 def clean_cached_config() -> None:
     """Deletes the cached config singleton instance."""
-    global __CONFIG
-    __CONFIG = None
+    get_config.cache_clear()
 
 
 class Config:

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -21,7 +21,7 @@ from functools import cache
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, overload
 
 from rucio.common import exception
-from rucio.common.exception import ConfigNotFound, DatabaseException
+from rucio.common.exception import ConfigLoadingError, ConfigNotFound, DatabaseException
 
 _T = TypeVar('_T')
 _U = TypeVar('_U')
@@ -784,7 +784,4 @@ class Config:
                     '\n\t' + '\n\t'.join(configs))
 
         if not self.parser.read(self.configfile) == [self.configfile]:
-            raise ConfigNotFound(
-                'Could not load Rucio configuration file. '
-                'Rucio tried loading the following configuration file:'
-                '\n\t' + self.configfile)
+            raise ConfigLoadingError(self.configfile)

--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1167,3 +1167,18 @@ class ChecksumCalculationError(RucioException):
         self.filepath = filepath
         self._message = 'An error occurred while calculating the %s checksum of file %s.' % (self.algorithm_name, self.filepath)
         self.error_code = 111
+
+
+class ConfigLoadingError(RucioException):
+    """
+    An error occurred while loading the configuration.
+    """
+    def __init__(
+            self,
+            config_file: str,
+            *args,
+            **kwargs
+    ):
+        super(ConfigLoadingError, self).__init__(*args, **kwargs)
+        self._message = 'Could not load Rucio configuration file. Rucio tried loading the following configuration file:\n\t %s' % (config_file)
+        self.error_code = 112

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -440,10 +440,14 @@ def db_session() -> "Iterator[scoped_session]":
 
 def __get_fixture_param(request: pytest.FixtureRequest) -> Any:
     fixture_param = getattr(request, "param", None)
-    if not fixture_param and request.instance:
+    try:
+        mark_iterable = request.instance.pytestmark
+    except AttributeError:
+        mark_iterable = None
+    if not fixture_param and mark_iterable:
         # Parametrize support is incomplete for legacy unittest test cases
         # Manually retrieve the parameters from the list of marks:
-        mark = next(iter(filter(lambda m: m.name == 'parametrize', request.instance.pytestmark)), None)
+        mark = next(iter(filter(lambda m: m.name == 'parametrize', mark_iterable)), None)
         if mark:
             fixture_param = mark.args[1][0]
     return fixture_param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -577,6 +577,22 @@ def core_config_mock(request: pytest.FixtureRequest) -> "Iterator[None]":
         yield
 
 
+@pytest.fixture(scope="session")
+def temp_config_file() -> "Iterator[ConfigParser]":
+    """
+    Session-scoped fixture that generates a temporary file and sets it as the Rucio config file.
+    Used to test when no Rucio config file is already present.
+    """
+    import tempfile
+
+    # Create a temporary file
+    with tempfile.NamedTemporaryFile(delete=True) as temp:
+        # Set the environment variable to the name of the temporary file
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("RUCIO_CONFIG", temp.name)
+            yield mp
+
+
 @pytest.fixture
 def file_config_mock(request: pytest.FixtureRequest) -> "Iterator[ConfigParser]":
     """

--- a/tests/rucio/common/test_config.py
+++ b/tests/rucio/common/test_config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from unittest.mock import patch
 
 import pytest
 
@@ -77,13 +76,12 @@ class TestConfig:
         config_call_2 = get_config()
         assert config_call_1 is config_call_2
 
-    @patch('rucio.common.config.Config')
-    def test_clean_cached_config(self, config_mock):
+    def test_clean_cached_config(self, temp_config_file):
         config_call_1 = get_config()
         clean_cached_config()
         config_call_2 = get_config()
-        assert config_call_1 != config_call_2
-        assert config_mock.call_count == 2
+
+        assert config_call_1 is not config_call_2
 
     def test_get_config_dirs(self):
         rucio_home = "test"

--- a/tests/rucio/common/test_config.py
+++ b/tests/rucio/common/test_config.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from unittest.mock import patch
 
 import pytest
 
-from rucio.common.config import _convert_to_boolean, convert_to_any_type, get_config_dirs
+from rucio.common.config import _convert_to_boolean, clean_cached_config, convert_to_any_type, get_config, get_config_dirs
 
 
 class TestConversion:
@@ -71,6 +72,19 @@ class TestConversion:
 
 
 class TestConfig:
+    def test_get_config_is_cached(self, temp_config_file):
+        config_call_1 = get_config()
+        config_call_2 = get_config()
+        assert config_call_1 is config_call_2
+
+    @patch('rucio.common.config.Config')
+    def test_clean_cached_config(self, config_mock):
+        config_call_1 = get_config()
+        clean_cached_config()
+        config_call_2 = get_config()
+        assert config_call_1 != config_call_2
+        assert config_mock.call_count == 2
+
     def test_get_config_dirs(self):
         rucio_home = "test"
         virtual_env = "test2"


### PR DESCRIPTION
#7076 (though it's not a mutable global variable in this case) and #7312

Follow-up to https://github.com/rucio/rucio/pull/7120