### PR TITLE
Fix incorrect path for mako script in MANIFEST.in

### DIFF
--- a/MANIFEST.in.rucio
+++ b/MANIFEST.in.rucio
@@ -8,7 +8,7 @@ include setup.py
 include setup.cfg
 include pyproject.toml
 include requirements/requirements.server.txt
-include lib/rucio/db/migrate_repo/script.py.mako
+include lib/rucio/db/sqla/migrate_repo/script.py.mako
 include etc/rse-accounts.cfg.template
 include etc/rucio.cfg.atlas.client.template
 include etc/rucio.cfg.template

--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -160,7 +160,7 @@ def config_get(
         use_cache: bool = True,
         expiration_time: int = 900,
         convert_type_fnc: 'Callable[[str], _T]' = lambda x: x,
-) -> Union[_T, _U]:
+rucio=None) -> Union[_T, _U]:
     """
     Return the string value for a given option in a section
 


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->

The path to the mako script in MANIFEST.in was incorrect:
- Current: lib/rucio/db/migrate_repo/script.py.mako
- Correct: lib/rucio/db/sqlalchemy/migrate_repo/script.py.mako