### PR TITLE
Clients: allow upload without configuring the account

### DIFF
--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -81,6 +81,16 @@ class UploadClient:
         self.tracing = tracing
         if not self.tracing:
             logger(logging.DEBUG, 'Tracing is turned off.')
+        if self.client.account is None:
+            self.logger(logging.DEBUG, 'No account specified, querying rucio.')
+            try:
+                acc = self.client.whoami()
+                if acc is None:
+                    raise InputValidationError('account not specified and rucio has no account with your identity')
+                self.client.account = acc['account']
+            except RucioException as e:
+                raise InputValidationError('account not specified and problem with rucio: %s' % e)
+            self.logger(logging.DEBUG, 'Discovered account as "%s"' % self.client.account)
         self.default_file_scope: Final[str] = 'user.' + self.client.account
         self.rses = {}
         self.rse_expressions = {}


### PR DESCRIPTION
Motivation:

Commit 00326935c8 updated the client so that it was no longer necessary for the client to specify the account; the support for this already existed in the server.

Unfortunately, this patch was incomplete: it is still required that the user configures the desired account when uploading data, even when the user's identity maps to a single identity.

Moreover, failure to configure the account leads to an obscure error message:

    can only concatenate str (not "NoneType") to str

This provides the user with no useful information on how to correct the problem.  Enabling verbose output leads to the client providing arguably incorrect information:

    This means the parameter you passed has a wrong type.

Modification:

The UploadClient class now discovers an account for the user's identity if no account was specified.  It does this by making a whoami query against the Rucio server, and using the supplied account.

If the server is unable to provide the account information for this user then the operation will fail with a clear error message that provides information on how to correct the situation.

Result:

It is now possible to upload data without the client configuring the desired account.  Under these circumstances, the default account for that user identity is used.

Closes: #7349

