### PR TITLE
Client: Update help menu for rucio distance list / remove and account

### DIFF
--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -200,7 +200,6 @@ class AccountClient(BaseClient):
         :param account: The account name.
         :param identity: The identity key name. For example x509 DN, or a username.
         :param authtype: The type of the authentication (x509, gss, userpass).
-        :param default: If True, the account should be used by default with the provided identity.
         """
 
         data = dumps({'identity': identity, 'authtype': authtype})

--- a/lib/rucio/client/commands/account.py
+++ b/lib/rucio/client/commands/account.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from argparse import SUPPRESS
 from typing import TYPE_CHECKING
 
@@ -60,20 +61,20 @@ class Account(CommandBase):
         parser.add_argument("--filters", dest="filters", action="store", help="Filter arguments in form `key=value,another_key=next_value`")
 
     def add_namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("--type", dest="accounttype", help="Account Type (USER, GROUP, SERVICE)", required=True)
+        parser.add_argument("--type", dest="account_type", help="Account Type", choices={"USER", "GROUP", "SERVICE"}, required=True)
         parser.add_argument("-a", "--account", dest="account", help="Account name", required=True)
-        parser.add_argument("--email", dest="accountemail", help="Add an email address associated with the account")
+        parser.add_argument("--email", dest="email", help="Add an email address associated with the account")
 
     def show_namespace(self, parser: "ArgumentParser") -> None:
         parser.add_argument("-a", "--account", dest="account", help="Account name", required=True)
 
     def update_namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-a", "--account", help="Account name", required=True)
-        parser.add_argument("--email", help="Account email")
-        parser.add_argument("--ban", type=bool, choices=(True, False), help='Ban the account, to disable it. Use --ban False to unban.', default=None)
+        parser.add_argument("-a", "--account", dest="account", help="Account name", required=True)
+        parser.add_argument("--email", dest="email", help="Account email")
+        parser.add_argument("--ban", dest="ban", type=bool, choices=(True, False), help='Ban the account, to disable it. Use --ban False to unban.', default=None)
 
     def remove_namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("-a", "--account", dest="acnt", action="store", help="Account name", required=True)
+        parser.add_argument("-a", "--account", dest="account", action="store", help="Account name", required=True)
 
     def _operations(self) -> dict[str, "OperationDict"]:
         return {
@@ -120,7 +121,7 @@ class Attribute(Account):
         return {}
 
     def namespace(self, subparser):
-        subparser.add_argument("-a", "--account", help="Account name")
+        subparser.add_argument("-a", "--account", dest="account", help="Account name")
         subparser.add_argument("--key", dest="key", action="store", help="Attribute key")
         subparser.add_argument("--value", dest="value", action="store", help="Attribute value")
 
@@ -153,7 +154,7 @@ class Limit(Account):
         parser.add_argument("-a", "--account", dest="account", help="Account name", required=True)
         parser.add_argument("--rses", "--rse-exp", dest='rse', action="store", help="RSE expression")
         parser.add_argument("--bytes", action="store", help='Value can be specified in bytes ("10000"), with a storage unit ("10GB"), or "infinity"')
-        parser.add_argument("--locality", nargs="?", default="local", choices=["local", "global"], help="Global or local limit scope")
+        parser.add_argument("--locality", nargs="?", default="local", choices={"local", "global"}, help="Global or local limit scope")
         parser.add_argument("--human", default=True, help=SUPPRESS)
 
     def _operations(self) -> dict[str, "OperationDict"]:
@@ -186,10 +187,10 @@ class Identity(Account):
 
     def namespace(self, parser: "ArgumentParser") -> None:
         parser.add_argument("--account", dest="account", action="store", help="Account name", required=True)
-        parser.add_argument("--type", dest="authtype", action="store", choices=["X509", "GSS", "USERPASS", "SSH", "SAML", "OIDC"], help="Authentication type")
-        parser.add_argument("--id", dest="identity", action="store", help="Identity as a DNs for X509 IDs.")
+        parser.add_argument("--type", dest="authtype", action="store", choices={"X509", "GSS", "USERPASS", "SSH", "SAML", "OIDC"}, help="Authentication type")
+        parser.add_argument("--id", dest="identity", action="store", help="Identity as a DNs for X509 IDs")
         parser.add_argument("--email", dest="email", action="store", help="Email address associated with the identity")
-        parser.add_argument("--password", dest="password", action="store", help="Password if authtype is USERPASS")
+        parser.add_argument("--password", dest="password", action="store", help="Password if type is USERPASS")
         parser.add_argument("--human", default=True, help=SUPPRESS)
 
     def _operations(self) -> dict[str, "OperationDict"]:

--- a/lib/rucio/client/commands/bin_legacy/rucio_admin.py
+++ b/lib/rucio/client/commands/bin_legacy/rucio_admin.py
@@ -71,7 +71,6 @@ def get_scope(did, client):
         scopes = client.list_scopes()
         scope, name = extract_scope(did, scopes)
         return scope, name
-    return None, did
 
 
 @exception_handler
@@ -82,7 +81,7 @@ def add_account(args, client, logger, console, spinner):
     Adds a new account. Specify metadata fields as arguments.
 
     """
-    client.add_account(account=args.account, type_=args.accounttype, email=args.accountemail)
+    client.add_account(account=args.account, type_=args.account_type, email=args.email)
     print('Added new account: %s' % args.account)
     return SUCCESS
 
@@ -95,8 +94,8 @@ def delete_account(args, client, logger, console, spinner):
     Delete account.
 
     """
-    client.delete_account(args.acnt)
-    print('Deleted account: %s' % args.acnt)
+    client.delete_account(args.account)
+    print('Deleted account: %s' % args.account)
     return SUCCESS
 
 
@@ -1524,8 +1523,8 @@ def get_parser():
                                                              '\n')
     add_account_parser.set_defaults(which='add_account')
     add_account_parser.add_argument('account', action='store', help='Account name')
-    add_account_parser.add_argument('--type', dest='accounttype', default='USER', help='Account Type (USER, GROUP, SERVICE)')
-    add_account_parser.add_argument('--email', dest='accountemail', action='store',
+    add_account_parser.add_argument('--type', dest='account_type', default='USER', help='Account Type (USER, GROUP, SERVICE)')
+    add_account_parser.add_argument('--email', dest='email', action='store',
                                     help='Email address associated with the account')
 
     # The disable_account command
@@ -1540,7 +1539,7 @@ def get_parser():
                                                                 '    Deleted account: jdoe-sister\n'
                                                                 '\n')
     delete_account_parser.set_defaults(which='delete_account')
-    delete_account_parser.add_argument('acnt', action='store', help='Account name')
+    delete_account_parser.add_argument('account', action='store', help='Account name')
 
     # The info_account command
     info_account_parser = account_subparser.add_parser('info',

--- a/lib/rucio/client/commands/rse.py
+++ b/lib/rucio/client/commands/rse.py
@@ -62,7 +62,7 @@ class RSE(CommandBase):
     def usage_example(self) -> list[str]:
         return [
             "$ rucio rse list # Show all current RSEs, can also access with",
-            "$ rucio rse list --rses 'deterministic=True' # Show all RSEs that match the RSE Expression 'deterministic=True'",
+            "$ rucio rse list --rses 'deterministic=True'  # Show all RSEs that match the RSE Expression 'deterministic=True'",
             "$ rucio rse remove --rse RemoveThisRSE  # Disable an RSE by name",
             "$ rucio rse add --rse CreateANewRSE  # add a new RSE named CreateANewRSE",
             "$ rucio rse update --rse rse123456 --setting deterministic --value False  # Make an RSE Non-Deterministic",
@@ -125,8 +125,8 @@ class Attribute(RSE):
     def usage_example(self) -> list[str]:
         return [
             "$ rucio rse attribute list --rse ThisRSE  # Show all the attributes for a given RSE",
-            "$ rucio rse attribute list --rse ThisRSE --key name # Show all the attribute 'name' for a given RSE",
-            "$ rucio rse attribute add --rse ThisRSE --key given-attribute --value updated # Set the attribute 'given-attribute' to 'updated' for an RSE",
+            "$ rucio rse attribute list --rse ThisRSE --key name  # Show all the attribute 'name' for a given RSE",
+            "$ rucio rse attribute add --rse ThisRSE --key given-attribute --value updated  # Set the attribute 'given-attribute' to 'updated' for an RSE",
         ]
 
     def add(self):
@@ -148,10 +148,15 @@ class Distance(RSE):
 
     def _operations(self) -> dict[str, "OperationDict"]:
         return {
-            "list": {"call": self.list_, "docs": "Show distances between RSEs"},
-            "add": {"call": self.add, "docs": "Add or update a distance between RSEs"},
-            "remove": {"call": self.remove, "docs": "Delete the distance between a pair of RSEs. The mandatory parameters are source and destination"},
-            "set": {"call": self.set_, "docs": "Update the distance between a pair of RSE that already have a distance between them"},
+            "list": {"call": self.list_, "docs": "Show distances between RSEs",
+                     "namespace": self.list_namespace},
+            "add": {"call": self.add, "docs": "Add a distance between RSEs", "namespace": self.add_namespace},
+            "remove": {"call": self.remove,
+                       "docs": "Delete the distance between a pair of RSEs",
+                       "namespace": self.remove_namespace},
+            "set": {"call": self.set_,
+                    "docs": "Update the distance between a pair of RSE that already have a distance between them",
+                    "namespace": self.set_namespace},
         }
 
     def usage_example(self) -> list[str]:
@@ -162,10 +167,19 @@ class Distance(RSE):
             "$ rucio rse distance set --source rse1 --destination rse2 --distance 20  # Update an existing distance",
         ]
 
-    def namespace(self, parser: "ArgumentParser") -> None:
-        parser.add_argument("--source", dest="source", action="store", help="Source RSE name")
-        parser.add_argument("--destination", dest="destination", action="store", help="Destination RSE name")
+    def list_namespace(self, parser: "ArgumentParser") -> None:
+        parser.add_argument("--source", dest="source", help="Source RSE name")
+        parser.add_argument("--destination", dest="destination", help="Destination RSE name")
+
+    def remove_namespace(self, parser: "ArgumentParser") -> None:
+        self.list_namespace(parser)
+
+    def add_namespace(self, parser: "ArgumentParser") -> None:
+        self.list_namespace(parser)
         parser.add_argument("--distance", dest="distance", type=int, help="Distance between RSEs")
+
+    def set_namespace(self, parser: "ArgumentParser") -> None:
+        self.add_namespace(parser)
 
     def list_(self):
         get_distance_rses(self.args, self.client, self.logger, self.console, self.spinner)
@@ -258,7 +272,7 @@ class QOS(RSE):
         return [
             "$ rucio rse qospolicy list --rse JDOE_DATADISK  # List QoS Policy for a given RSE",
             "$ rucio rse qospolicy add --rse JDOE_DATADISK --policy SLOW_BUT_CHEAP  # Add a SLOW_BUT_CHEAP policy to the JDOE_DATADISK RSE",
-            "$ rucio rse qospolicy remove --rse  JDOE_DATADISK --policy SLOW_BUT_CHEAP  # Remove the same policy",
+            "$ rucio rse qospolicy remove --rse JDOE_DATADISK --policy SLOW_BUT_CHEAP  # Remove the same policy",
         ]
 
     def add(self):


### PR DESCRIPTION
This fixes https://github.com/rucio/rucio/issues/7362.

Before this PR:

```
❯ rucio rse distance remove --help
usage: rucio rse distance remove [-h] [--source SOURCE] [--destination DESTINATION] [--distance DISTANCE]

optional arguments:
  -h, --help            show this help message and exit
  --source SOURCE       Source RSE name
  --destination DESTINATION
                        Destination RSE name
  --distance DISTANCE   Distance between RSEs
```

After this PR:
```
❯ rucio rse distance list --help
usage: rucio rse distance list [-h] [--source SOURCE] [--destination DESTINATION]

options:
  -h, --help            show this help message and exit
  --source SOURCE       Source RSE name
  --destination DESTINATION
                        Destination RSE name
```

Updated commands:

- `rucio rse distance list`
- `rucio rse distance remove`

It also has some minor updates to the `rucio account` command. Some very minor changes to the help text but mostly it's internal changes to unify the usage of argparse.
