### PR TITLE
pre-commit: update repos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     entry: tools/add_header
     language: system
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.3
+  rev: v0.9.3
   hooks:
     - id: ruff
       args: [ --fix ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v5.0.0
   hooks:
   - id: end-of-file-fixer
   - id: trailing-whitespace


### PR DESCRIPTION
Update `pre-commit` repos to latest version.

In particular the current https://github.com/pre-commit/pre-commit-hooks release (`v2.3.0`) is from Aug 5, 2019 and gave me a deprecation warning when running the hooks.

Adding https://pre-commit.ci/, as already pointed out in https://github.com/rucio/rucio/issues/7321, should take care of updating versions automatically via periodic PRs.