### PR TITLE
Client: New exception when client protocol missing, more detailed messages

### DIFF
--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -20,6 +20,8 @@
 
 """
 
+from typing import Optional
+
 from rucio.common.constraints import AUTHORIZED_VALUE_TYPES
 
 
@@ -93,11 +95,12 @@ class ClientParameterMismatch(RucioException):
 
 class ClientProtocolNotSupported(RucioException):
     """
-    RucioException
+    Client protocol not supported
     """
-    def __init__(self, *args):
+
+    def __init__(self, host: str, protocol: str, protocols_allowed: Optional[list[str]] = None, *args):
         super(ClientProtocolNotSupported, self).__init__(*args)
-        self._message = "Client protocol not supported."
+        self._message = f"Client protocol '{protocol}' not supported when connecting to host '{host}'.{' Allowed protocols: ' + ', '.join(protocols_allowed) if protocols_allowed else ''}"
         self.error_code = 6
 
 
@@ -1182,3 +1185,14 @@ class ConfigLoadingError(RucioException):
         super(ConfigLoadingError, self).__init__(*args, **kwargs)
         self._message = 'Could not load Rucio configuration file. Rucio tried loading the following configuration file:\n\t %s' % (config_file)
         self.error_code = 112
+
+
+class ClientProtocolNotFound(RucioException):
+    """
+    Missing protocol in client configuration (e.g. no http/https in url).
+    """
+
+    def __init__(self, host: str, protocols_allowed: Optional[list[str]] = None, *args):
+        super(ClientProtocolNotFound, self).__init__(*args)
+        self._message = f"Client protocol missing when connecting to host '{host}'.{' Allowed protocols: ' + ', '.join(protocols_allowed) if protocols_allowed else ''}"
+        self.error_code = 113

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from rucio.common.exception import CannotAuthenticate, ClientProtocolNotSupported, MissingClientParameter, RucioException
+from rucio.common.exception import CannotAuthenticate, ClientProtocolNotFound, ClientProtocolNotSupported, MissingClientParameter, RucioException
 from rucio.common.utils import execute
 from rucio.tests.common import remove_config
 from tests.mocks.mock_http_server import MockServer
@@ -88,13 +88,53 @@ class TestBaseClient:
         with pytest.raises(MissingClientParameter):
             BaseClient(account='root', ca_cert=self.cacert, auth_type='x509', creds=creds, vo=vo)
 
-    def testClientProtocolNotSupported(self, vo):
-        """ CLIENTS (BASECLIENT): try to pass an host with a not supported protocol."""
+    def testClientRucioProtocolNotSupported(self, vo):
+        """ CLIENTS (BASECLIENT): try to pass a rucio host with a not supported protocol."""
         creds = {'username': 'ddmlab', 'password': 'secret'}
         from rucio.client.baseclient import BaseClient
 
         with pytest.raises(ClientProtocolNotSupported):
-            BaseClient(rucio_host='localhost', auth_host='junk://localhost', account='root', auth_type='userpass', creds=creds, vo=vo)
+            BaseClient(rucio_host='junk://localhost', auth_host='http://localhost', account='root', auth_type='userpass', creds=creds, vo=vo)
+
+    def testClientAuthProtocolNotSupported(self, vo):
+        """ CLIENTS (BASECLIENT): try to pass an auth host with a not supported protocol."""
+        creds = {'username': 'ddmlab', 'password': 'secret'}
+        from rucio.client.baseclient import BaseClient
+
+        with pytest.raises(ClientProtocolNotSupported):
+            BaseClient(rucio_host='https://localhost', auth_host='junk://localhost', account='root', auth_type='userpass', creds=creds, vo=vo)
+
+    def testClientRucioAndAuthProtocolNotSupported(self, vo):
+        """ CLIENTS (BASECLIENT): try to pass both a rucio and auth host with a not supported protocol."""
+        creds = {'username': 'ddmlab', 'password': 'secret'}
+        from rucio.client.baseclient import BaseClient
+
+        with pytest.raises(ClientProtocolNotSupported):
+            BaseClient(rucio_host='junk://localhost', auth_host='junk://localhost', account='root', auth_type='userpass', creds=creds, vo=vo)
+
+    def testClientRucioProtocolNotFound(self, vo):
+        """ CLIENTS (BASECLIENT): try to pass a rucio host with a missing protocol."""
+        creds = {'username': 'ddmlab', 'password': 'secret'}
+        from rucio.client.baseclient import BaseClient
+
+        with pytest.raises(ClientProtocolNotFound):
+            BaseClient(rucio_host='localhost', auth_host='https://localhost', account='root', auth_type='userpass', creds=creds, vo=vo)
+
+    def testClientAuthProtocolNotFound(self, vo):
+        """ CLIENTS (BASECLIENT): try to pass an auth host with a not supported protocol."""
+        creds = {'username': 'ddmlab', 'password': 'secret'}
+        from rucio.client.baseclient import BaseClient
+
+        with pytest.raises(ClientProtocolNotFound):
+            BaseClient(rucio_host='http://localhost', auth_host='localhost', account='root', auth_type='userpass', creds=creds, vo=vo)
+
+    def testClientRucioAndAuthProtocolNotFound(self, vo):
+        """ CLIENTS (BASECLIENT): try to pass both a rucio and auth host with a missing protocol."""
+        creds = {'username': 'ddmlab', 'password': 'secret'}
+        from rucio.client.baseclient import BaseClient
+
+        with pytest.raises(ClientProtocolNotFound):
+            BaseClient(rucio_host='localhost', auth_host='localhost', account='root', auth_type='userpass', creds=creds, vo=vo)
 
     def testRetryOn502AlwaysFail(self, vo):
         """ CLIENTS (BASECLIENT): Ensure client retries on 502 error codes, but fails on repeated errors"""


### PR DESCRIPTION
This PR fixes https://github.com/rucio/rucio/issues/7365

Before this PR:

```
❯ rucio whoami
Traceback (most recent call last):
  File "/Users/lobis/git/rucio/venv-brew/bin/rucio", line 96, in <module>
    main()
    ~~~~^^
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/commands/command.py", line 251, in main
    client = get_client(args, logger)
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/commands/utils.py", line 199, in get_client
    client = Client(rucio_host=args.host, auth_host=args.auth_host, account=args.issuer, auth_type=auth_type, creds=creds, ca_cert=args.ca_certificate, timeout=args.timeout, user_agent=args.user_agent, vo=args.vo, logger=logger)
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/client.py", line 120, in __init__
    super(Client, self).__init__(**args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/baseclient.py", line 161, in __init__
    raise ClientProtocolNotSupported('\'%s\' not supported' % rucio_scheme)
rucio.common.exception.ClientProtocolNotSupported: Client protocol not supported.
Details: '' not supported
```

After this PR:

- Missing protocol:
```
❯ rucio whoami
Traceback (most recent call last):
  File "/Users/lobis/git/rucio/venv-brew/bin/rucio", line 96, in <module>
    main()
    ~~~~^^
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/commands/command.py", line 251, in main
    client = get_client(args, logger)
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/commands/utils.py", line 199, in get_client
    client = Client(rucio_host=args.host, auth_host=args.auth_host, account=args.issuer, auth_type=auth_type, creds=creds, ca_cert=args.ca_certificate, timeout=args.timeout, user_agent=args.user_agent, vo=args.vo, logger=logger)
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/client.py", line 120, in __init__
    super(Client, self).__init__(**args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/baseclient.py", line 169, in __init__
    raise ClientProtocolNotFound(host=self.auth_host, protocols_allowed=auth_scheme_allowed)
rucio.common.exception.ClientProtocolNotFound: Client protocol missing when connecting to host 'example.cern.ch'. Allowed protocols: http, https
```

- Bad protocol:
```
❯ rucio whoami
Traceback (most recent call last):
  File "/Users/lobis/git/rucio/venv-brew/bin/rucio", line 96, in <module>
    main()
    ~~~~^^
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/commands/command.py", line 251, in main
    client = get_client(args, logger)
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/commands/utils.py", line 199, in get_client
    client = Client(rucio_host=args.host, auth_host=args.auth_host, account=args.issuer, auth_type=auth_type, creds=creds, ca_cert=args.ca_certificate, timeout=args.timeout, user_agent=args.user_agent, vo=args.vo, logger=logger)
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/client.py", line 120, in __init__
    super(Client, self).__init__(**args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/lobis/git/rucio/venv-brew/lib/python3.13/site-packages/rucio/client/baseclient.py", line 171, in __init__
    raise ClientProtocolNotSupported(host=self.auth_host, protocol=auth_scheme, protocols_allowed=auth_scheme_allowed)
rucio.common.exception.ClientProtocolNotSupported: Client protocol 'bad' not supported when connecting to host 'bad://example.cern.ch'. Allowed protocols: http, https
```