### PR TITLE
rest: handle bulk traces #7368

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/traces.py
+++ b/lib/rucio/web/rest/flaskapi/v1/traces.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import calendar
 import datetime
 import json
 import uuid
@@ -51,11 +50,8 @@ class Trace(ErrorHandlingMethodView):
           trace(payload): A function to handle the processed payload.
         """
         # generate entry timestamp
-        payload["traceTimeentry"] = datetime.datetime.utcnow()
-        payload["traceTimeentryUnix"] = (
-            calendar.timegm(payload["traceTimeentry"].timetuple())
-            + payload["traceTimeentry"].microsecond / 1e6
-        )
+        payload["traceTimeentry"] = datetime.datetime.now(datetime.timezone.utc)
+        payload["traceTimeentryUnix"] = payload["traceTimeentry"].timestamp()
 
         # guess client IP
         payload["traceIp"] = request.headers.get(

--- a/lib/rucio/web/rest/flaskapi/v1/traces.py
+++ b/lib/rucio/web/rest/flaskapi/v1/traces.py
@@ -15,14 +15,15 @@
 
 import calendar
 import datetime
+import json
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from flask import Blueprint, Flask, request
 from werkzeug.datastructures import Headers
 
 from rucio.core.trace import trace
-from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, json_parameters, response_headers
+from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, response_headers
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -31,6 +32,39 @@ if TYPE_CHECKING:
 
 
 class Trace(ErrorHandlingMethodView):
+
+    def __handle_payload_item(self, payload: dict) -> None:
+        """
+        Handles and processes a single trace payload item by adding various trace information.
+
+        Args:
+          payload (dict): The payload dictionary to be processed.
+
+        Modifies:
+          payload (dict): Adds the following keys to the payload:
+            - 'traceTimeentry': The current UTC timestamp.
+            - 'traceTimeentryUnix': The Unix timestamp with microsecond precision.
+            - 'traceIp': The client's IP address, either from 'X-Forwarded-For' header or remote address.
+            - 'traceId': A unique identifier for the trace, generated as a UUID without hyphens.
+
+        Calls:
+          trace(payload): A function to handle the processed payload.
+        """
+        # generate entry timestamp
+        payload["traceTimeentry"] = datetime.datetime.utcnow()
+        payload["traceTimeentryUnix"] = (
+            calendar.timegm(payload["traceTimeentry"].timetuple())
+            + payload["traceTimeentry"].microsecond / 1e6
+        )
+
+        # guess client IP
+        payload["traceIp"] = request.headers.get(
+            "X-Forwarded-For", default=request.remote_addr
+        )
+
+        # generate unique ID
+        payload["traceId"] = str(uuid.uuid4()).replace("-", "").lower()
+        trace(payload=payload)
 
     def get_headers(self) -> "Optional[HeadersType]":
         headers = Headers()
@@ -57,8 +91,13 @@ class Trace(ErrorHandlingMethodView):
           content:
             application/json:
               schema:
-                description: The trace information.
+          oneOf:
+            - type: object
+              description: A single trace object.
+            - type: array
+              items:
                 type: object
+              description: A list of trace objects.
         responses:
           201:
             description: OK
@@ -66,21 +105,23 @@ class Trace(ErrorHandlingMethodView):
             description: Cannot decode json data.
         """
         headers = self.get_headers()
-        payload = json_parameters()
+        req_body: str = request.get_data(as_text=True)
+        payload: Union[list, dict, None] = json.loads(req_body) if req_body else None
 
-        # generate entry timestamp
-        payload['traceTimeentry'] = datetime.datetime.utcnow()
-        payload['traceTimeentryUnix'] = calendar.timegm(payload['traceTimeentry'].timetuple()) + payload['traceTimeentry'].microsecond / 1e6
+        if payload is None:
+            return (
+                "Invalid JSON data. Please provide a single trace as a JSON object or a list of trace objects.",
+                400,
+                headers,
+            )
 
-        # guess client IP
-        payload['traceIp'] = request.headers.get('X-Forwarded-For', default=request.remote_addr)
+        if isinstance(payload, list):
+            for item in payload:
+                self.__handle_payload_item(item)
+        else:
+            self.__handle_payload_item(payload)
 
-        # generate unique ID
-        payload['traceId'] = str(uuid.uuid4()).replace('-', '').lower()
-
-        trace(payload=payload)
-
-        return 'Created', 201, headers
+        return "Created", 201, headers
 
 
 def blueprint():

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -43,6 +43,44 @@ def test_submit_trace(rest_client):
     assert response.status_code == 201
 
 
+def test_bulk_submit_traces(rest_client):
+    """TRACE (REST): submit multiple traces via POST"""
+    payload = [
+        {
+            "uuid": str(uuid.uuid4()),  # str, because not JSON serializable
+            "string": "deadbeef",
+            "hex": 0xDEADBEEF,
+            "int": 3,
+            "float": 3.14,
+            "long": 314314314314314314,
+            "timestamp": time.time(),
+            "datetime_str": str(
+                datetime.datetime.utcnow()
+            ),  # str, because not JSON serializable
+            "boolean": True,
+        },
+        {
+            "uuid": str(uuid.uuid4()),  # str, because not JSON serializable
+            "string": "deadbeef",
+            "hex": 0xDEADBEEF,
+            "int": 3,
+            "float": 3.14,
+            "long": 314314314314314314,
+            "timestamp": time.time(),
+            "datetime_str": str(
+                datetime.datetime.utcnow()
+            ),  # str, because not JSON serializable
+            "boolean": True,
+        },
+    ]
+    response = rest_client.post(
+        "/traces/",
+        json=payload,
+        content_type=[("Content-Type", "application/octet-stream")],
+    )
+    assert response.status_code == 201
+
+
 def test_submit_trace_wrong_content_type(rest_client):
     """
     TRACE (REST): submit data with wrong Content-Type to check backwards-compatibility.


### PR DESCRIPTION
Fix #7368 

This PR enhances the POST /traces/ endpoint to accept a list of trace objects in the request body while maintaining backward compatibility with the existing single-trace format.

Enhancements to trace handling:

* [`lib/rucio/web/rest/flaskapi/v1/traces.py`](diffhunk://#diff-079a0ba14236814e622ee6688ffcbfc312582d32e3a4dde97a9a697f71df6626R36-R68): Introduced the `__handle_payload_item` method to process individual trace payload items, adding trace information such as timestamps, client IP, and a unique trace ID.

Support for bulk trace submissions:

* [`lib/rucio/web/rest/flaskapi/v1/traces.py`](diffhunk://#diff-079a0ba14236814e622ee6688ffcbfc312582d32e3a4dde97a9a697f71df6626L60-R124): Modified the `post` method to handle both single and multiple trace objects, validating the JSON data and processing each trace item accordingly.

Test suite updates:

* [`tests/test_trace.py`](diffhunk://#diff-6cc3dad51d58aecec1745e607a16e76b7c66a42c10ae778061bcc49c4ae817d1R46-R83): Added a new test `test_bulk_submit_traces` to verify the functionality of submitting multiple traces via a POST request.

Other changes:

* [`lib/rucio/web/rest/flaskapi/v1/traces.py`](diffhunk://#diff-079a0ba14236814e622ee6688ffcbfc312582d32e3a4dde97a9a697f71df6626R18-R26): Updated imports to include `Union` from `typing` and `json` for JSON handling.

**Open Question**
Should the Rucio client be updated to leverage this change?