### PR TITLE
Testing: remove policy restriction for `test_default_hash` #7334

### DIFF
--- a/tests/test_rse_lfn2path.py
+++ b/tests/test_rse_lfn2path.py
@@ -43,7 +43,6 @@ class TestDeterministicTranslation:
         )
         assert translator.path("foo", "bar") == "foo/4e/99/bar"
 
-    @pytest.mark.skipif(os.environ.get('POLICY') != 'atlas', reason='Test ATLAS hash convention')
     def test_default_hash(self):
         """LFN2PFN: Translate to path using default algorithm (Success)"""
         translator = RSEDeterministicTranslation(

--- a/tests/test_rse_lfn2path.py
+++ b/tests/test_rse_lfn2path.py
@@ -43,6 +43,7 @@ class TestDeterministicTranslation:
         )
         assert translator.path("foo", "bar") == "foo/4e/99/bar"
 
+    @pytest.mark.skipif(os.environ.get('POLICY') == 'belleii', reason='BelleII does not use hashed lfn2pfn')
     def test_default_hash(self):
         """LFN2PFN: Translate to path using default algorithm (Success)"""
         translator = RSEDeterministicTranslation(


### PR DESCRIPTION
The test_default_hash was being skipped unless the policy was ATLAS, but ATLAS does not have a specific lfn2pfn algorithm. The default hash algorithm should be tested universally.

Removed the @pytest.mark.skipif condition to ensure the test runs in all conditions.

Fixes : #7334 

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
