### PR TITLE
Client: Redirect does not regard main kwargs #7341

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -90,28 +90,32 @@ def map_legacy_command() -> Optional[list[str]]:
             "touch": ["did", "update", "--touch"],
             "add-lifetime-exception": ["lifetime-exception", "add"],
         }
-        try:
-            new_command = command_map[command]
-        except KeyError:
-            pass
+        new_command = command_map.get(command)
 
     return new_command
 
 
 if __name__ == "__main__":
-    commands = ("-h", "--help", "--version", "account", "config", "did", "replica", "rse", "rule", "scope", "subscription", "ping", "whoami", "test-server", "lifetime-exception", "upload", "download")
+    commands = ("account", "config", "did", "replica", "rse", "rule", "scope", "subscription", "ping", "whoami", "test-server", "lifetime-exception", "upload", "download")
+
+    parser = argparse.ArgumentParser(add_help=False)
+    # Check for legacy flag
+    parser.add_argument("--legacy", action="store_true")
+    # Check for commands in the new command list
+    parser.add_argument("-h", "--help", action="store_true")
+    parser.add_argument("--version", action="store_true")
+
+    args, _ = parser.parse_known_args()
+
     logger = setup_logger(module_name=__name__)
-    first_command = _get_first_command(sys.argv[1:])
 
-    is_legacy = '--legacy' in sys.argv
-
-    if (first_command in commands) and not is_legacy:
-        main()
-
-    elif is_legacy:
+    if args.legacy:
         make_warning(logger)
         sys.argv.pop(sys.argv.index('--legacy'))
         main_legacy()
+
+    elif (any(arg in commands for arg in sys.argv)) or args.help or args.version:
+        main()
 
     else:
         make_warning(logger)

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -21,6 +21,22 @@ from rucio.common.utils import generate_uuid
 from rucio.tests.common import account_name_generator, execute, file_generator, rse_name_generator, scope_name_generator
 
 
+def test_main_args():
+    specify_account = "rucio --account root --auth-strategy userpass whoami"
+    exitcode, out, err = execute(specify_account)
+
+    assert exitcode == 0
+    assert "This method is being deprecated" not in err
+    assert "root" in out
+
+    legacy_arg = "rucio --legacy --account root --auth-strategy userpass whoami"
+    exitcode, out, err = execute(legacy_arg)
+
+    assert exitcode == 0
+    assert "This method is being deprecated" in err
+    assert "root" in out
+
+
 def test_account(rucio_client):
     new_account = account_name_generator()
     command = f"rucio account add --type USER --account {new_account}"


### PR DESCRIPTION
Closes #7341 

Adds kwarg parsing in `bin/rucio` to check for the legacy flag, and instead of checking the first non `--` arg, checks for the presence of the new command groups. 