### PR TITLE
Client: refactor rich client `get_pager` to avoid hanging

### DIFF
--- a/lib/rucio/client/richclient.py
+++ b/lib/rucio/client/richclient.py
@@ -15,7 +15,7 @@
 import logging
 import pydoc
 import re
-import subprocess
+import shutil
 import sys
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
@@ -309,16 +309,9 @@ def get_pager() -> 'Callable[[str], None]':
     :returns: pager
     """
     default_pager = 'less'
-    try:
-        result = subprocess.run([default_pager], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        less_available = result.returncode == 0
-    except Exception:
-        less_available = False
+    # Attempt to use the default pager if available.
+    if shutil.which(default_pager) is not None:
+        return lambda text: pydoc.pipepager(text, f'{default_pager} -FRSXKM')
 
-    def less_pager_function(text: str) -> None:
-        """Use the 'less' pager with -FRSXKM options."""
-        pydoc.pipepager(text, f'{default_pager} -FRSXKM')
-
-    if less_available:
-        return less_pager_function
+    # Fall back to pydoc.pager if the default pager is not available.
     return pydoc.pager


### PR DESCRIPTION
Fixes https://github.com/rucio/rucio/issues/7410.

Without this timeout it hangs indefinitely in PyCharm.

I put a `0.1` second timeout which should be almost imperceptible (it will only be triggered when `less` is not found, instead of hanging indefinitely) and it should not change behaviour for the case where `less` is indeed in the system. `0.1` seconds should be plenty of time to find it in the system.