### PR TITLE
Protocols: Handle `exists(None)` in GFAL Fix #7398

### DIFF
--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -232,7 +232,7 @@ def str_to_date(string: str) -> Optional[datetime.datetime]:
 def val_to_space_sep_str(vallist: list[str]) -> str:
     """ Converts a list of values into a string of space separated values
 
-    :param vallist: the list of values to to convert into string
+    :param vallist: the list of values to convert into string
     :return: the string of space separated values or the value initially passed as parameter
     """
     try:
@@ -240,7 +240,7 @@ def val_to_space_sep_str(vallist: list[str]) -> str:
             return str(" ".join(vallist))
         else:
             return str(vallist)
-    except:
+    except Exception:
         return ''
 
 
@@ -1669,3 +1669,20 @@ def deep_merge_dict(source: dict, destination: dict) -> dict:
             destination[key] = value
 
     return destination
+
+
+def is_method_overridden(obj, base_cls, method_name):
+    """
+    Return True if `obj` (an instance of a subclass of `base_cls`) has overridden the given method_name from base_cls.
+    That is, `type(obj).<method_name>` is not the same function object as `base_cls.<method_name>`.
+
+    :param obj:         An instance of (a subclass of) base_cls.
+    :param base_cls:    The base class which may define the method.
+    :param method_name: Name of the method (str) to check.
+    :returns:           Boolean, True if the subclass provides a real override.
+    """
+    if not hasattr(obj, method_name):
+        return False
+    if getattr(type(obj), method_name, None) is getattr(base_cls, method_name, None):  # Caring for bound/unbound cases
+        return False
+    return True

--- a/lib/rucio/rse/protocols/bittorrent.py
+++ b/lib/rucio/rse/protocols/bittorrent.py
@@ -187,9 +187,6 @@ class Default(RSEProtocol):
     def delete(self, path):
         raise NotImplementedError
 
-    def exists(self, path):
-        raise NotImplementedError
-
     def put(self, source, target, source_dir, transfer_timeout=None):
         raise NotImplementedError
 

--- a/lib/rucio/rse/protocols/cache.py
+++ b/lib/rucio/rse/protocols/cache.py
@@ -49,17 +49,6 @@ class Default(protocol.RSEProtocol):
         """
         return ''.join([self.rse['scheme'], '://%s' % self.rse['hostname'], path])
 
-    def exists(self, pfn):
-        """ Checks if the requested file is known by the referred RSE.
-
-            :param pfn: Physical file name
-
-            :returns: True if the file exists, False if it doesn't
-
-            :raise  ServiceUnavailable
-        """
-        raise NotImplementedError
-
     def connect(self):
         """ Establishes the actual connection to the referred RSE.
 

--- a/lib/rucio/rse/protocols/dummy.py
+++ b/lib/rucio/rse/protocols/dummy.py
@@ -38,17 +38,6 @@ class Default(protocol.RSEProtocol):
         """
         return ''.join([self.rse['scheme'], '://%s' % self.rse['hostname'], path])
 
-    def exists(self, pfn):
-        """ Checks if the requested file is known by the referred RSE.
-
-            :param pfn: Physical file name
-
-            :returns: True if the file exists, False if it doesn't
-
-            :raise  ServiceUnavailable
-        """
-        raise NotImplementedError
-
     def connect(self):
         """ Establishes the actual connection to the referred RSE.
 

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -28,7 +28,7 @@ from rucio.rse.protocols import protocol
 
 try:
     import gfal2  # pylint: disable=import-error
-except:
+except Exception:
     if 'RUCIO_CLIENT_MODE' not in os.environ:
         if not config.config_has_section('database'):
             raise exception.MissingDependency('Missing dependency : gfal2')
@@ -344,7 +344,12 @@ class Default(protocol.RSEProtocol):
 
         :raises SourceNotFound: if the source file was not found on the referred storage.
         """
+
         self.logger(logging.DEBUG, 'checking if file exists {}'.format(path))
+
+        if path is None:
+            # Action not supported
+            raise exception.RSEOperationNotSupported()
 
         try:
             status = self.__gfal2_exist(path)
@@ -515,7 +520,6 @@ class Default(protocol.RSEProtocol):
         try:
             if ctx.stat(str(path)):
                 return 0
-            return -1
         except gfal2.GError as error:  # pylint: disable=no-member
             if error.code == errno.ENOENT or 'No such file' in str(error):  # pylint: disable=no-member
                 return -1

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -205,7 +205,6 @@ class RSEProtocol(ABC):
 
         return ret
 
-    @abstractmethod
     def exists(self, path):
         """
             Checks if the requested file is known by the referred RSE.

--- a/lib/rucio/rse/protocols/storm.py
+++ b/lib/rucio/rse/protocols/storm.py
@@ -68,17 +68,6 @@ class Default(protocol.RSEProtocol):
         """
         return ''.join([self.rse['scheme'], '://%s' % self.rse['hostname'], path])
 
-    def exists(self, pfn):
-        """ Checks if the requested file is known by the referred RSE.
-
-            :param pfn: Physical file name
-
-            :returns: True if the file exists, False if it doesn't
-
-            :raise  ServiceUnavailable
-        """
-        raise NotImplementedError
-
     def connect(self):
         """ Establishes the actual connection to the referred RSE.
 
@@ -139,7 +128,7 @@ class Default(protocol.RSEProtocol):
             name = pfn.split('/')[-1]
             if name not in target:
                 target = None
-        except:
+        except Exception:
             target = None
             pass
 
@@ -149,7 +138,7 @@ class Default(protocol.RSEProtocol):
             # requests preferable
             try:
                 rcode, etag_meta = requests_etag(pfn, 300)
-            except:
+            except Exception:
                 pass
             # fallback to davix
             if rcode != 207:


### PR DESCRIPTION
With the introduced changes, GFAL no longer tries to execute `exists(None)` as it was always leading to an exception. It now returns the exception `RSEOperationNotSupported` which will silently lead to the same prior behavior as it is caught by:

https://github.com/rucio/rucio/blob/5dcf2f958ee80ae335a88b95f83291b1e5b241eb/lib/rucio/rse/rsemanager.py#L274-L280

Moreover, I removed the `return -1` from

https://github.com/rucio/rucio/blob/5dcf2f958ee80ae335a88b95f83291b1e5b241eb/lib/rucio/rse/protocols/gfal.py#L514-L518

because judging from the underlying C function `gfal2_stat(..)`, it is effectively unreachable. Basically, the helper function translates the C GError into a Python exception of type `gfal2.GError` and so, instead of returning any negative integer, it raises the exception.

[Source:](https://github.com/cern-fts/gfal2-python/blob/69466f56110ec87886d1749d0a8d4529d153c30d/src/Gfal2Context.cpp#L156-L165)

```
Stat Gfal2Context::stat_c(const std::string & path)
{
    ScopedGILRelease unlock;
    GError* tmp_err = NULL;
    Stat st;
    const int ret = gfal2_stat(cont->get(), path.c_str(), &st._st, &tmp_err);
    if (ret < 0)
        GErrorWrapper::throwOnError(&tmp_err);
    return st;
}
```