### PR TITLE
Add context manager for database sessions, migrate gateway/identity, add validation to relevant APIs

### DIFF
--- a/lib/rucio/db/sqla/constants.py
+++ b/lib/rucio/db/sqla/constants.py
@@ -201,6 +201,6 @@ class TransferLimitDirection(Enum):
     DESTINATION = 'D'
 
 
-class DBSessionOperation(Enum):
+class DatabaseOperationType(Enum):
     READ = 'read'
     WRITE = 'write'

--- a/lib/rucio/db/sqla/constants.py
+++ b/lib/rucio/db/sqla/constants.py
@@ -199,3 +199,8 @@ class SubscriptionState(Enum):
 class TransferLimitDirection(Enum):
     SOURCE = 'S'
     DESTINATION = 'D'
+
+
+class DBSessionOperation(Enum):
+    READ = 'read'
+    WRITE = 'write'

--- a/lib/rucio/db/sqla/session.py
+++ b/lib/rucio/db/sqla/session.py
@@ -16,6 +16,7 @@ import copy
 import logging
 import os
 import sys
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from functools import update_wrapper
 from inspect import getfullargspec, isgeneratorfunction
@@ -24,6 +25,7 @@ from threading import Lock
 from time import sleep
 from typing import TYPE_CHECKING, Any, Union
 
+from db.sqla.constants import DBSessionOperation
 from sqlalchemy import MetaData, create_engine, event, text
 from sqlalchemy.exc import DatabaseError, DisconnectionError, OperationalError, SQLAlchemyError, TimeoutError
 from sqlalchemy.orm import DeclarativeBase, Session, scoped_session, sessionmaker
@@ -37,7 +39,7 @@ from rucio.common.utils import retrying
 EXTRA_MODULES = import_extras(['MySQLdb', 'pymysql'])
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
     from typing import Optional, ParamSpec, TypeVar
 
     from pymysql import Connection as MySQLConnection
@@ -502,3 +504,29 @@ def transactional_session(function: "Callable[P, R]") -> 'Callable':
         return result
 
     return _update_session_wrapper(new_funct, function)
+
+
+@retrying(retry_on_exception=retry_if_db_connection_error,
+          wait_fixed=500,
+          stop_max_attempt_number=2)
+@contextmanager
+def db_session(operation: DBSessionOperation) -> "Iterator[Session]":
+    session_scoped = get_session()
+    session = session_scoped()
+    session.begin()
+
+    try:
+        yield session
+        if operation is DBSessionOperation.WRITE:
+            session.commit()
+    except TimeoutError as error:
+        session.rollback()
+        raise DatabaseException(str(error))
+    except DatabaseError as error:
+        session.rollback()
+        raise DatabaseException(str(error))
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session_scoped.remove()

--- a/lib/rucio/gateway/identity.py
+++ b/lib/rucio/gateway/identity.py
@@ -21,25 +21,21 @@ from typing import TYPE_CHECKING, Optional
 from rucio.common import exception
 from rucio.common.types import InternalAccount
 from rucio.core import identity
-from rucio.db.sqla.constants import IdentityType
-from rucio.db.sqla.session import read_session, transactional_session
+from rucio.db.sqla.constants import DatabaseOperationType, IdentityType
+from rucio.db.sqla.session import db_session
 from rucio.gateway import permission
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from sqlalchemy import Row
-    from sqlalchemy.orm import Session
 
 
-@transactional_session
 def add_identity(
     identity_key: str,
     id_type: str,
     email: str,
     password: Optional[str] = None,
-    *,
-    session: "Session"
 ) -> None:
     """
     Creates a user identity.
@@ -48,19 +44,16 @@ def add_identity(
     :param id_type: The type of the authentication (x509, gss, userpass, ssh, saml)
     :param email: The Email address associated with the identity.
     :param password: If type==userpass, this sets the password.
-    :param session: The database session in use.
     """
-    return identity.add_identity(identity_key, IdentityType[id_type.upper()], email, password=password, session=session)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        return identity.add_identity(identity_key, IdentityType[id_type.upper()], email, password=password, session=session)
 
 
-@transactional_session
 def del_identity(
     identity_key: str,
     id_type: str,
     issuer: str,
     vo: str = 'def',
-    *,
-    session: "Session"
 ) -> None:
     """
     Deletes a user identity.
@@ -68,18 +61,18 @@ def del_identity(
     :param id_type: The type of the authentication (x509, gss, userpass, ssh, saml).
     :param issuer: The issuer account.
     :param vo: the VO of the issuer.
-    :param session: The database session in use.
     """
     converted_id_type = IdentityType[id_type.upper()]
-    kwargs = {'accounts': identity.list_accounts_for_identity(identity_key, converted_id_type, session=session)}
-    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='del_identity', kwargs=kwargs, session=session)
-    if not auth_result.allowed:
-        raise exception.AccessDenied('Account %s can not delete identity. %s' % (issuer, auth_result.message))
 
-    return identity.del_identity(identity_key, converted_id_type, session=session)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        kwargs = {'accounts': identity.list_accounts_for_identity(identity_key, converted_id_type, session=session)}
+        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='del_identity', kwargs=kwargs, session=session)
+        if not auth_result.allowed:
+            raise exception.AccessDenied('Account %s can not delete identity. %s' % (issuer, auth_result.message))
+
+        return identity.del_identity(identity_key, converted_id_type, session=session)
 
 
-@transactional_session
 def add_account_identity(
     identity_key: str,
     id_type: str,
@@ -89,8 +82,6 @@ def add_account_identity(
     default: bool = False,
     password: Optional[str] = None,
     vo: str = 'def',
-    *,
-    session: "Session"
 ) -> None:
     """
     Adds a membership association between identity and account.
@@ -103,40 +94,37 @@ def add_account_identity(
     :param default: If True, the account should be used by default with the provided identity.
     :param password: Password if id_type is userpass.
     :param vo: the VO to act on.
-    :param session: The database session in use.
     """
     kwargs = {'identity': identity_key, 'type': id_type, 'account': account}
-    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='add_account_identity', kwargs=kwargs, session=session)
-    if not auth_result.allowed:
-        raise exception.AccessDenied('Account %s can not add account identity. %s' % (issuer, auth_result.message))
 
-    internal_account = InternalAccount(account, vo=vo)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='add_account_identity', kwargs=kwargs, session=session)
+        if not auth_result.allowed:
+            raise exception.AccessDenied('Account %s can not add account identity. %s' % (issuer, auth_result.message))
 
-    return identity.add_account_identity(identity=identity_key, type_=IdentityType[id_type.upper()], default=default,
-                                         email=email, account=internal_account, password=password, session=session)
+        internal_account = InternalAccount(account, vo=vo)
+
+        return identity.add_account_identity(identity=identity_key, type_=IdentityType[id_type.upper()], default=default,
+                                             email=email, account=internal_account, password=password, session=session)
 
 
-@read_session
-def verify_identity(identity_key: str, id_type: str, password: Optional[str] = None, *, session: "Session") -> bool:
+def verify_identity(identity_key: str, id_type: str, password: Optional[str] = None) -> bool:
     """
     Verifies a user identity.
     :param identity_key: The identity key name. For example x509 DN, or a username.
     :param id_type: The type of the authentication (x509, gss, userpass, ssh, saml)
     :param password: If type==userpass, verifies the identity_key, .
-    :param session: The database session in use.
     """
-    return identity.verify_identity(identity_key, IdentityType[id_type.upper()], password=password, session=session)
+    with db_session(DatabaseOperationType.READ) as session:
+        return identity.verify_identity(identity_key, IdentityType[id_type.upper()], password=password, session=session)
 
 
-@transactional_session
 def del_account_identity(
     identity_key: str,
     id_type: str,
     account: str,
     issuer: str,
     vo: str = 'def',
-    *,
-    session: "Session"
 ) -> None:
     """
     Removes a membership association between identity and account.
@@ -146,62 +134,56 @@ def del_account_identity(
     :param account: The account name.
     :param issuer: The issuer account.
     :param vo: the VO to act on.
-    :param session: The database session in use.
     """
     kwargs = {'account': account}
-    auth_result = permission.has_permission(issuer=issuer, vo=vo, action='del_account_identity', kwargs=kwargs, session=session)
-    if not auth_result.allowed:
-        raise exception.AccessDenied('Account %s can not delete account identity. %s' % (issuer, auth_result.message))
 
-    internal_account = InternalAccount(account, vo=vo)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='del_account_identity', kwargs=kwargs, session=session)
+        if not auth_result.allowed:
+            raise exception.AccessDenied('Account %s can not delete account identity. %s' % (issuer, auth_result.message))
 
-    return identity.del_account_identity(identity_key, IdentityType[id_type.upper()], internal_account, session=session)
+        internal_account = InternalAccount(account, vo=vo)
+
+        return identity.del_account_identity(identity_key, IdentityType[id_type.upper()], internal_account, session=session)
 
 
-@read_session
-def list_identities(*, session: "Session", **kwargs) -> "Sequence[Row[tuple[str, IdentityType]]]":
+def list_identities(**kwargs) -> "Sequence[Row[tuple[str, IdentityType]]]":
     """
     Returns a list of all enabled identities.
 
-    :param session: The database session in use.
     returns: A list of all enabled identities.
     """
-    return identity.list_identities(session=session, **kwargs)
+    with db_session(DatabaseOperationType.READ) as session:
+        return identity.list_identities(session=session, **kwargs)
 
 
-@read_session
 def get_default_account(
     identity_key: str,
     id_type: str,
-    *,
-    session: "Session"
 ) -> str:
     """
     Returns the default account for this identity.
 
     :param identity_key: The identity key name. For example x509 DN, or a username.
     :param id_type: The type of the authentication (x509, gss, userpass, ssh, saml).
-    :param session: The database session in use.
     """
-    account = identity.get_default_account(identity_key, IdentityType[id_type.upper()], session=session)
+    with db_session(DatabaseOperationType.READ) as session:
+        account = identity.get_default_account(identity_key, IdentityType[id_type.upper()], session=session)
     return account.external
 
 
-@read_session
 def list_accounts_for_identity(
     identity_key: str,
     id_type: str,
-    *,
-    session: "Session"
 ) -> list[str]:
     """
     Returns a list of all accounts for an identity.
 
     :param identity: The identity key name. For example x509 DN, or a username.
     :param id_type: The type of the authentication (x509, gss, userpass, ssh, saml).
-    :param session: The database session in use.
 
     returns: A list of all accounts for the identity.
     """
-    accounts = identity.list_accounts_for_identity(identity_key, IdentityType[id_type.upper()], session=session)
+    with db_session(DatabaseOperationType.READ) as session:
+        accounts = identity.list_accounts_for_identity(identity_key, IdentityType[id_type.upper()], session=session)
     return [account.external for account in accounts]

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -687,7 +687,7 @@ class Identities(ErrorHandlingMethodView):
         vo = request.environ.get('vo')
 
         if not issuer or not vo:
-            return 'Issuer and VO must be set.', 400
+            return generate_http_error_flask(400, ValueError.__name__, 'Issuer and VO must be set.')
 
         try:
             add_account_identity(
@@ -800,7 +800,7 @@ class Identities(ErrorHandlingMethodView):
         vo = request.environ.get('vo')
 
         if not issuer or not vo:
-            return 'Issuer and VO must be set.', 400
+            return generate_http_error_flask(400, ValueError.__name__, 'Issuer and VO must be set.')
 
         try:
             del_account_identity(identity, authtype, account, issuer, vo=vo)

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -682,6 +682,13 @@ class Identities(ErrorHandlingMethodView):
         identity = param_get(parameters, 'identity')
         authtype = param_get(parameters, 'authtype')
         email = param_get(parameters, 'email')
+
+        issuer = request.environ.get('issuer')
+        vo = request.environ.get('vo')
+
+        if not issuer or not vo:
+            return 'Issuer and VO must be set.', 400
+
         try:
             add_account_identity(
                 identity_key=identity,
@@ -689,9 +696,9 @@ class Identities(ErrorHandlingMethodView):
                 account=account,
                 email=email,
                 password=param_get(parameters, 'password', default=None),
-                issuer=request.environ.get('issuer'),
+                issuer=issuer,
                 default=param_get(parameters, 'default', default=False),
-                vo=request.environ.get('vo'),
+                vo=vo,
             )
         except AccessDenied as error:
             return generate_http_error_flask(401, error)
@@ -788,8 +795,15 @@ class Identities(ErrorHandlingMethodView):
         parameters = json_parameters()
         identity = param_get(parameters, 'identity')
         authtype = param_get(parameters, 'authtype')
+
+        issuer = request.environ.get('issuer')
+        vo = request.environ.get('vo')
+
+        if not issuer or not vo:
+            return 'Issuer and VO must be set.', 400
+
         try:
-            del_account_identity(identity, authtype, account, request.environ.get('issuer'), vo=request.environ.get('vo'))
+            del_account_identity(identity, authtype, account, issuer, vo=vo)
         except AccessDenied as error:
             return generate_http_error_flask(401, error)
         except (AccountNotFound, IdentityError) as error:

--- a/lib/rucio/web/rest/flaskapi/v1/identities.py
+++ b/lib/rucio/web/rest/flaskapi/v1/identities.py
@@ -77,6 +77,12 @@ class UserPass(ErrorHandlingMethodView):
         if not username or not password or not email:
             return 'Username, Email and Password must be set.', 400
 
+        issuer = request.environ.get('issuer')
+        vo = request.environ.get('vo')
+
+        if not issuer or not vo:
+            return 'Issuer and VO must be set.', 400
+
         add_identity(username, 'userpass', email, password)
 
         add_account_identity(
@@ -85,8 +91,8 @@ class UserPass(ErrorHandlingMethodView):
             account=account,
             email=email,
             password=password,
-            issuer=request.environ.get('issuer'),
-            vo=request.environ.get('vo'),
+            issuer=issuer,
+            vo=vo,
         )
 
         return 'Created', 201
@@ -133,14 +139,20 @@ class X509(ErrorHandlingMethodView):
         if not dn or not email:
             return 'SSL_CLIENT_S_DN and email must be set.', 400
 
+        issuer = request.environ.get('issuer')
+        vo = request.environ.get('vo')
+
+        if not issuer or not vo:
+            return 'Issuer and VO must be set.', 400
+
         add_identity(dn, 'x509', email=email)
         add_account_identity(
             identity_key=dn,
             id_type='x509',
             account=account,
             email=email,
-            issuer=request.environ.get('issuer'),
-            vo=request.environ.get('vo'),
+            issuer=issuer,
+            vo=vo,
         )
 
         return 'Created', 201
@@ -187,14 +199,20 @@ class GSS(ErrorHandlingMethodView):
         if not gsscred or not email:
             return 'REMOTE_USER and email must be set.', 400
 
+        issuer = request.environ.get('issuer')
+        vo = request.environ.get('vo')
+
+        if not issuer or not vo:
+            return 'Issuer and VO must be set.', 400
+
         add_identity(gsscred, 'gss', email=email)
         add_account_identity(
             identity_key=gsscred,
             id_type='gss',
             account=account,
             email=email,
-            issuer=request.environ.get('issuer'),
-            vo=request.environ.get('vo'),
+            issuer=issuer,
+            vo=vo,
         )
 
         return 'Created', 201

--- a/lib/rucio/web/rest/flaskapi/v1/identities.py
+++ b/lib/rucio/web/rest/flaskapi/v1/identities.py
@@ -130,6 +130,9 @@ class X509(ErrorHandlingMethodView):
         dn = request.environ.get('SSL_CLIENT_S_DN')
         email = request.headers.get('X-Rucio-Email', default=None)
 
+        if not dn or not email:
+            return 'SSL_CLIENT_S_DN and email must be set.', 400
+
         add_identity(dn, 'x509', email=email)
         add_account_identity(
             identity_key=dn,

--- a/lib/rucio/web/rest/flaskapi/v1/identities.py
+++ b/lib/rucio/web/rest/flaskapi/v1/identities.py
@@ -74,8 +74,8 @@ class UserPass(ErrorHandlingMethodView):
         password = request.headers.get('X-Rucio-Password', default=None)
         email = request.headers.get('X-Rucio-Email', default=None)
 
-        if not username or not password:
-            return 'Username and Password must be set.', 400
+        if not username or not password or not email:
+            return 'Username, Email and Password must be set.', 400
 
         add_identity(username, 'userpass', email, password)
 

--- a/lib/rucio/web/rest/flaskapi/v1/identities.py
+++ b/lib/rucio/web/rest/flaskapi/v1/identities.py
@@ -16,7 +16,7 @@ from flask import Flask, jsonify, request
 
 from rucio.gateway.identity import add_account_identity, add_identity, list_accounts_for_identity
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
-from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, response_headers
+from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, generate_http_error_flask, response_headers
 
 
 class UserPass(ErrorHandlingMethodView):
@@ -75,13 +75,13 @@ class UserPass(ErrorHandlingMethodView):
         email = request.headers.get('X-Rucio-Email', default=None)
 
         if not username or not password or not email:
-            return 'Username, Email and Password must be set.', 400
+            return generate_http_error_flask(400, ValueError.__name__, 'Username, Email and Password must be set.')
 
         issuer = request.environ.get('issuer')
         vo = request.environ.get('vo')
 
         if not issuer or not vo:
-            return 'Issuer and VO must be set.', 400
+            return generate_http_error_flask(400, ValueError.__name__, 'Issuer and VO must be set.')
 
         add_identity(username, 'userpass', email, password)
 
@@ -137,13 +137,13 @@ class X509(ErrorHandlingMethodView):
         email = request.headers.get('X-Rucio-Email', default=None)
 
         if not dn or not email:
-            return 'SSL_CLIENT_S_DN and email must be set.', 400
+            return generate_http_error_flask(400, ValueError.__name__, 'SSL_CLIENT_S_DN and email must be set.')
 
         issuer = request.environ.get('issuer')
         vo = request.environ.get('vo')
 
         if not issuer or not vo:
-            return 'Issuer and VO must be set.', 400
+            return generate_http_error_flask(400, ValueError.__name__, 'Issuer and VO must be set.')
 
         add_identity(dn, 'x509', email=email)
         add_account_identity(
@@ -197,13 +197,13 @@ class GSS(ErrorHandlingMethodView):
         email = request.headers.get('X-Rucio-Email', default=None)
 
         if not gsscred or not email:
-            return 'REMOTE_USER and email must be set.', 400
+            return generate_http_error_flask(400, ValueError.__name__, 'REMOTE_USER and email must be set.')
 
         issuer = request.environ.get('issuer')
         vo = request.environ.get('vo')
 
         if not issuer or not vo:
-            return 'Issuer and VO must be set.', 400
+            return generate_http_error_flask(400, ValueError.__name__, 'Issuer and VO must be set.')
 
         add_identity(gsscred, 'gss', email=email)
         add_account_identity(

--- a/lib/rucio/web/rest/flaskapi/v1/identities.py
+++ b/lib/rucio/web/rest/flaskapi/v1/identities.py
@@ -184,6 +184,9 @@ class GSS(ErrorHandlingMethodView):
         gsscred = request.environ.get('REMOTE_USER')
         email = request.headers.get('X-Rucio-Email', default=None)
 
+        if not gsscred or not email:
+            return 'REMOTE_USER and email must be set.', 400
+
         add_identity(gsscred, 'gss', email=email)
         add_account_identity(
             identity_key=gsscred,


### PR DESCRIPTION
- 1fb4c82adc12a7ec728bb49108b46fe99d581808: fixes https://github.com/rucio/rucio/issues/7407. I created a single context manager to replace read and write operations, as they mostly followed the same logic - the main difference is that `read` only rolls back, and `write` can commit. Additionally, `read` always rolls back at the end, which was not the case with the decorator; this is because it's good practice to always commit/rollback a transaction, see https://stackoverflow.com/questions/309834/should-i-commit-or-rollback-a-read-transaction
- 0909b1e53660e2a767c91fdda3b68a432e65187e: this is the initial gateway migration. I plan to migrate the entire gateway layer first, and then move on to core. I find this a bit easier, because gateway functions are generally only called by the API, whereas core functions are a bit more widespread.
- The other commits add API validation to parameters that were not being validated, but whose `Optional` type was not previously causing issues with the static code analyzers due to the fact that the session decorators were hiding the annotations from the analyzers.


### Why is there no stream session equivalent in the context manager?
Stream session and read session are functionally equivalent, from the session's point of view. How the function's return is handled should be handled by the function, it doesn't depend on the session (i.e. the context manager's job is to manage the session, the function's job is to return the data as needed).