### PR TITLE
Clients : Handle Non-Existent Accounts in `rucio-admin account get-limits`

### DIFF
--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -256,6 +256,7 @@ class AccountClient(BaseClient):
         :param locality:       The scope of the account limit. 'local' or 'global'.
         """
 
+        self.get_account(account)
         if locality == 'local':
             return self.get_local_account_limit(account, rse_expression)
         elif locality == 'global':

--- a/lib/rucio/client/commands/bin_legacy/rucio_admin.py
+++ b/lib/rucio/client/commands/bin_legacy/rucio_admin.py
@@ -36,10 +36,7 @@ from rucio import version
 from rucio.client.commands.utils import exception_handler, get_client, setup_gfal2_logger, signal_handler
 from rucio.client.richclient import MAX_TRACEBACK_WIDTH, MIN_CONSOLE_WIDTH, CLITheme, generate_table, get_cli_config, get_pager, print_output, setup_rich_logger
 from rucio.common.constants import RseAttr
-from rucio.common.exception import (
-    ReplicaNotFound,
-    RSEOperationNotSupported,
-)
+from rucio.common.exception import AccountNotFound, ReplicaNotFound, RSEOperationNotSupported
 from rucio.common.extra import import_extras
 from rucio.common.utils import StoreAndDeprecateWarningAction, chunks, clean_pfns, construct_non_deterministic_pfn, extract_scope, get_bytes_value_from_string, parse_response, render_json, setup_logger, sizefmt
 from rucio.rse import rsemanager as rsemgr
@@ -238,11 +235,16 @@ def get_limits(args, client, logger, console, spinner):
     Grant an identity access to an account.
 
     """
-    locality = args.locality.lower()
-    limits = client.get_account_limits(account=args.account, rse_expression=args.rse, locality=locality)
-    for rse in limits:
-        print('Quota on %s for %s : %s' % (rse, args.account, sizefmt(limits[rse], True)))
-    return SUCCESS
+    try:
+        locality = args.locality.lower()
+        limits = client.get_account_limits(account=args.account, rse_expression=args.rse, locality=locality)
+        for rse in limits:
+            print('Quota on %s for %s : %s' % (rse, args.account, sizefmt(limits[rse], True)))
+        return SUCCESS
+
+    except AccountNotFound as e:
+        logger.error(f"Validation Error: {e}")
+        return FAILURE
 
 
 @exception_handler

--- a/tests/test_account_limits.py
+++ b/tests/test_account_limits.py
@@ -14,6 +14,7 @@
 
 import pytest
 
+from rucio.common.exception import AccountNotFound
 from rucio.core import account_limit
 
 
@@ -147,6 +148,14 @@ class TestAccountClient:
 
         assert limit == {rse1: 333}
         account_limit.delete_local_account_limit(account=account, rse_id=rse1_id)
+
+    def test_get_limits_nonexistent_account(self, rucio_client):
+        """ ACCOUNT_LIMIT (CLIENTS): Ensure get_limits fails for nonexistent accounts. """
+        nonexistent_account = "nonexistent_account_123"
+        with pytest.raises(AccountNotFound) as exc_info:
+            rucio_client.get_account_limits(account=nonexistent_account, rse_expression="", locality="local")
+
+        assert f"Account with ID '{nonexistent_account}' cannot be found" in str(exc_info.value)
 
     def test_set_local_account_limit(self, account, rucio_client, rse_factory):
         """ ACCOUNTLIMIT (CLIENTS): Set local account limit """


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Previously, `rucio-admin account get-limits` accepted nonexistent accounts and returned misleading responses. This fix adds a validation check to ensure that the account exists before retrieving limits in `accountclient`.
This PR also adds error handling and a validation test case for the same.
