### PR TITLE
clients: add validation for missing 'bytes' field in `add_replicas` 

### DIFF
--- a/lib/rucio/gateway/replica.py
+++ b/lib/rucio/gateway/replica.py
@@ -272,6 +272,11 @@ def add_replicas(rse, files, issuer, ignore_availability=False, vo='def', *, ses
 
     :returns: True is successful, False otherwise
     """
+    for file in files:
+        if "bytes" not in file:
+            raise exception.InvalidObject(
+                f"Missing required field: 'bytes'. The file '{file.get('name', 'unknown')}' must have a 'bytes' field specifying its size."
+            )
     for v_file in files:
         v_file.update({"type": "FILE"})  # Make sure DIDs are identified as files for checking
     validate_schema(name='dids', obj=files, vo=vo)

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -27,7 +27,7 @@ from werkzeug.datastructures import Headers, MultiDict
 
 from rucio.client.ruleclient import RuleClient
 from rucio.common.constants import RseAttr
-from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifierNotFound, InputValidationError, ReplicaIsLocked, ReplicaNotFound, RucioException, ScopeNotFound
+from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifierNotFound, InputValidationError, InvalidObject, ReplicaIsLocked, ReplicaNotFound, RucioException, ScopeNotFound
 from rucio.common.schema import get_schema_value
 from rucio.common.utils import clean_pfns, generate_uuid, parse_response
 from rucio.core.config import set as cconfig_set
@@ -802,6 +802,14 @@ def test_client_add_replica_scope_not_found(rse_factory, replica_client):
     rse, _ = rse_factory.make_mock_rse()
     files = [{'scope': 'nonexistingscope', 'name': did_name_generator('file'), 'bytes': 1, 'adler32': '0cc737eb'}]
     with pytest.raises(ScopeNotFound):
+        replica_client.add_replicas(rse=rse, files=files)
+
+
+def test_client_add_replica_missing_bytes_field(rse_factory, replica_client):
+    """ REPLICA (CLIENT): Add replica with missing 'bytes' field """
+    rse, _ = rse_factory.make_mock_rse()
+    files = [{'scope': 'testscope', 'name': did_name_generator('file'), 'adler32': '0cc737ed'}]
+    with pytest.raises(InvalidObject, match="Missing required field: 'bytes'"):
         replica_client.add_replicas(rse=rse, files=files)
 
 


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
fixes #7468 