### PR TITLE
Policies: full diff-based schema support #6842

### DIFF
--- a/lib/rucio/common/schema/generic.py
+++ b/lib/rucio/common/schema/generic.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jsonschema import ValidationError, validate
-
-from rucio.common.exception import InvalidObject
 
 ACCOUNT_LENGTH = 25
 
@@ -417,17 +414,3 @@ SCHEMAS = {'account': ACCOUNT,
            'cache_delete_replicas': CACHE_DELETE_REPLICAS,
            'account_attribute': ACCOUNT_ATTRIBUTE,
            'import': IMPORT}
-
-
-def validate_schema(name, obj):
-    """
-    Validate object against json schema
-
-    :param name: The json schema name.
-    :param obj: The object to validate.
-    """
-    try:
-        if obj:
-            validate(obj, SCHEMAS.get(name, {}))
-    except ValidationError as error:  # NOQA, pylint: disable=W0612
-        raise InvalidObject(f'Problem validating {name}: {error}')

--- a/lib/rucio/common/schema/generic_multi_vo.py
+++ b/lib/rucio/common/schema/generic_multi_vo.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jsonschema import ValidationError, validate
-
-from rucio.common.exception import InvalidObject
 
 ACCOUNT_LENGTH = 29
 
@@ -396,17 +393,3 @@ SCHEMAS = {'account': ACCOUNT,
            'account_attribute': ACCOUNT_ATTRIBUTE,
            'import': IMPORT,
            'vo': VO}
-
-
-def validate_schema(name, obj):
-    """
-    Validate object against json schema
-
-    :param name: The json schema name.
-    :param obj: The object to validate.
-    """
-    try:
-        if obj:
-            validate(obj, SCHEMAS.get(name, {}))
-    except ValidationError as error:  # NOQA, pylint: disable=W0612
-        raise InvalidObject(f'Problem validating {name}: {error}')

--- a/tests/mocks/schema_diff.py
+++ b/tests/mocks/schema_diff.py
@@ -20,3 +20,10 @@ SCOPE = {"description": "Scope name",
          "type": "string",
          "maxLength": SCOPE_LENGTH,
          "pattern": "^[a-zA-Z_\\-.0-9]+$"}
+
+ACCOUNT = {"description": "Account name",
+           "type": "string",
+           "maxLength": 1000,
+           "pattern": "^[a-z0-9-_]+$"}
+
+SCHEMAS = {'account': ACCOUNT}

--- a/tests/test_policy_package.py
+++ b/tests/test_policy_package.py
@@ -56,5 +56,11 @@ class TestPolicyPackage:
         # check that omitted value falls back to generic module
         assert rucio.common.schema.get_schema_value('NAME_LENGTH') == 250
 
+        # check that schemas defined in our module override generic
+        rucio.common.schema.validate_schema('account', 'this-account-name-is-too-long-for-the-generic-schema-but-should-validate-against-the-mock-one')
+
+        # check that schemas not defined in our module fall back to generic
+        rucio.common.schema.validate_schema('r_name', 'name_to_validate')
+
         # restore original schema module
         rucio.common.schema.schema_modules['def'] = old_module


### PR DESCRIPTION
This PR reworks the schema code so that proper diff-based schemas are possible. When a schema value is required, the code now walks the schema structure and substitutes included values dynamically. This means that it's possible to have a schema value in a policy package include a value from the generic fallback module, or vice versa. The policy package will always take priority.

I am open to suggestions regarding the syntax. I picked a string prefix that seems unlikely to conflict with anything but I'm happy to change it if people have better suggestions.

As part of this work, the `validate_schema` function has been moved out of the schema modules and into `__init__.py`. This means that the behaviour of the validation function itself can no longer be customised, but I don't think that should be a problem. I have also refactored the policy module loading a little so that single and multi VO cases now mostly share the same code path.

I will also submit an update to the policy package documentation to reflect this change.