### PR TITLE
Testing: Codecov, turn project coverage off

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 coverage:
   status:
+    project: off
     patch:
       default:
         paths:


### PR DESCRIPTION
We will revise this in the future,
but for now we should keep this off,
as it is not needed for any useful checks.
Patch coverage is the main feature we want to use, in order to check coverage in PRs.
