### PR TITLE
Core: Standardize account limits methods

### DIFF
--- a/lib/rucio/core/rse_selector.py
+++ b/lib/rucio/core/rse_selector.py
@@ -96,7 +96,7 @@ class RSESelector:
                 else:
                     # check local quota
                     local_quota_left = None
-                    quota_limit = get_local_account_limit(account=account, rse_id=rse['rse_id'], session=session)
+                    quota_limit = get_local_account_limit(account=account, rse_ids=rse['rse_id'], session=session)
                     if quota_limit is None:
                         local_quota_left = 0
                     else:

--- a/lib/rucio/core/rse_selector.py
+++ b/lib/rucio/core/rse_selector.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Optional
 
 from rucio.common.exception import InsufficientAccountLimit, InsufficientTargetRSEs, InvalidRuleWeight, RSEOverQuota
 from rucio.core.account import get_all_rse_usages_per_account, get_usage, has_account_attribute
-from rucio.core.account_limit import get_global_account_limits, get_local_account_limit
+from rucio.core.account_limit import get_global_account_limit, get_local_account_limit
 from rucio.core.rse import get_rse_limits, has_rse_attribute, list_rse_attributes
 from rucio.core.rse_counter import get_counter as get_rse_counter
 from rucio.core.rse_expression_parser import parse_expression
@@ -86,7 +86,7 @@ class RSESelector:
                 rse['space_left'] = float('inf')
                 rses_with_enough_quota.append(rse)
         else:
-            global_quota_limit = get_global_account_limits(account=account, session=session)
+            global_quota_limit = get_global_account_limit(account=account, session=session)
             all_rse_usages = {usage['rse_id']: usage['bytes'] for usage in get_all_rse_usages_per_account(account=account, session=session)}
             for rse in self.rses:
                 if rse['mock_rse']:

--- a/lib/rucio/gateway/account_limit.py
+++ b/lib/rucio/gateway/account_limit.py
@@ -83,55 +83,38 @@ def get_local_account_limit(
 
 
 @read_session
-def get_global_account_limits(
-    account: str,
-    vo: str = 'def',
-    *,
-    session: "Session"
-) -> dict[str, RSEResolvedGlobalAccountLimitDict]:
-    """
-    Lists the limitation names/values for the specified account name.
-
-    REST API: http://<host>:<port>/rucio/account/<account>/limits
-
-    :param account:     The account name.
-    :param vo:          The VO to act on.
-    :param session:     The database session in use.
-
-    :returns: The account limits.
-    """
-    if account:
-        internal_account = InternalAccount(account, vo=vo)
-    else:
-        internal_account = InternalAccount('*', vo=vo)
-
-    return account_limit_core.get_global_account_limits(account=internal_account, session=session)
-
-
-@read_session
 def get_global_account_limit(
-    account: str,
-    rse_expression: str,
-    vo: str = 'def',
-    *,
-    session: "Session"
-) -> dict[str, dict[str, RSEResolvedGlobalAccountLimitDict]]:
+        account: str,
+        rse_expression: Optional[str] = None,
+        vo: str = 'def',
+        *,
+        session: "Session"
+) -> Union[dict[str, RSEResolvedGlobalAccountLimitDict], dict[str, dict[str, RSEResolvedGlobalAccountLimitDict]]]:
     """
-    Lists the limitation names/values for the specified account name and rse expression.
+    Lists the global account limitation names/values for the specified account.
+    If an RSE expression is provided, fetches the limit for that expression.
+    Otherwise, fetches all global limits for the account.
 
     REST API: http://<host>:<port>/rucio/account/<account>/limits
 
     :param account:         The account name.
-    :param rse_expression:  The rse expression.
+    :param rse_expression:  The RSE expression (optional for fetching all limits).
     :param vo:              The VO to act on.
     :param session:         The database session in use.
 
-    :returns: The account limit.
+    :returns:
+        - If `rse_expression` is provided: `{rse_expression: {...}}`
+        - If `rse_expression` is not provided: `{...}` (dictionary of all limits).
     """
 
     internal_account = InternalAccount(account, vo=vo)
 
-    return {rse_expression: account_limit_core.get_global_account_limit(account=internal_account, rse_expression=rse_expression, session=session)}
+    if rse_expression:
+        return {rse_expression: account_limit_core.get_global_account_limit(
+            account=internal_account, rse_expression=rse_expression, session=session
+        )}
+
+    return account_limit_core.get_global_account_limit(account=internal_account, session=session)
 
 
 @transactional_session

--- a/lib/rucio/gateway/account_limit.py
+++ b/lib/rucio/gateway/account_limit.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import rucio.common.exception
 import rucio.gateway.permission
@@ -48,57 +48,38 @@ def get_rse_account_usage(
 
 
 @read_session
-def get_local_account_limits(
-    account: str,
-    vo: str = 'def',
-    *,
-    session: "Session"
-) -> dict[str, Any]:
-    """
-    Lists the limitation names/values for the specified account name.
-
-    REST API: http://<host>:<port>/rucio/account/<account>/limits
-
-    :param account:     The account name.
-    :param vo:          The VO to act on.
-    :param session:     The database session in use.
-
-    :returns: The account limits.
-    """
-
-    internal_account = InternalAccount(account, vo=vo)
-
-    rse_instead_id = {}
-    for elem in account_limit_core.get_local_account_limits(account=internal_account, session=session).items():
-        rse_instead_id[get_rse_name(rse_id=elem[0], session=session)] = elem[1]
-    return rse_instead_id
-
-
-@read_session
 def get_local_account_limit(
-    account: str,
-    rse: str,
-    vo: str = 'def',
-    *,
-    session: "Session"
+        account: str,
+        rse: Optional[str] = None,
+        vo: str = 'def',
+        *,
+        session: "Session"
 ) -> dict[str, Union[int, float, None]]:
     """
-    Lists the limitation names/values for the specified account name and rse name.
+    Lists the limitation names/values for the specified account name.
+    If an RSE is provided, it returns the limit for that specific RSE.
+    Otherwise, it returns all account limits.
 
     REST API: http://<host>:<port>/rucio/account/<account>/limits
 
-    :param account:     The account name.
-    :param rse:         The rse name.
-    :param vo:          The VO to act on.
-    :param session:     The database session in use.
+    :param account: The account name.
+    :param rse: The RSE name (optional).
+    :param vo: The VO to act on.
+    :param session: The database session in use.
 
-    :returns: The account limit.
+    :returns: A dictionary of account limits with RSE names as keys and limits as values.
     """
 
     internal_account = InternalAccount(account, vo=vo)
 
-    rse_id = get_rse_id(rse=rse, vo=vo, session=session)
-    return {rse: account_limit_core.get_local_account_limit(account=internal_account, rse_id=rse_id, session=session)}
+    if rse:
+        # Single RSE lookup
+        rse_id = get_rse_id(rse=rse, vo=vo, session=session)
+        return {rse: account_limit_core.get_local_account_limit(account=internal_account, rse_ids=rse_id, session=session)}
+    else:
+        # Fetch all RSE limits
+        limits = account_limit_core.get_local_account_limit(account=internal_account, rse_ids=None, session=session)
+        return {get_rse_name(rse_id=rse_id, session=session): limit for rse_id, limit in limits.items()}
 
 
 @read_session

--- a/lib/rucio/gateway/account_limit.py
+++ b/lib/rucio/gateway/account_limit.py
@@ -98,7 +98,7 @@ def get_global_account_limit(
     REST API: http://<host>:<port>/rucio/account/<account>/limits
 
     :param account:         The account name.
-    :param rse_expression:  The RSE expression (optional for fetching all limits).
+    :param rse_expression:  The RSE expression (optional; if not provided, all limits will be fetched).
     :param vo:              The VO to act on.
     :param session:         The database session in use.
 

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -21,7 +21,7 @@ from flask import Flask, Response, jsonify, redirect, request
 from rucio.common.exception import AccessDenied, AccountNotFound, CounterNotFound, Duplicate, IdentityError, InvalidObject, RSENotFound, RuleNotFound, ScopeNotFound
 from rucio.common.utils import APIEncoder, render_json
 from rucio.gateway.account import add_account, add_account_attribute, del_account, del_account_attribute, get_account_info, get_usage_history, list_account_attributes, list_accounts, list_identities, update_account
-from rucio.gateway.account_limit import get_global_account_limit, get_global_account_limits, get_global_account_usage, get_local_account_limit, get_local_account_limits, get_local_account_usage
+from rucio.gateway.account_limit import get_global_account_limit, get_global_account_limits, get_global_account_usage, get_local_account_limit, get_local_account_usage
 from rucio.gateway.identity import add_account_identity, del_account_identity
 from rucio.gateway.rule import list_replication_rules
 from rucio.gateway.scope import add_scope, get_scopes
@@ -561,10 +561,7 @@ class LocalAccountLimits(ErrorHandlingMethodView):
             description: Not Acceptable
         """
         try:
-            if rse:
-                limits = get_local_account_limit(account=account, rse=rse, vo=request.environ.get('vo'))
-            else:
-                limits = get_local_account_limits(account=account, vo=request.environ.get('vo'))
+            limits = get_local_account_limit(account=account, rse=rse, vo=request.environ.get('vo'))
         except RSENotFound as error:
             return generate_http_error_flask(404, error)
 

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -21,7 +21,7 @@ from flask import Flask, Response, jsonify, redirect, request
 from rucio.common.exception import AccessDenied, AccountNotFound, CounterNotFound, Duplicate, IdentityError, InvalidObject, RSENotFound, RuleNotFound, ScopeNotFound
 from rucio.common.utils import APIEncoder, render_json
 from rucio.gateway.account import add_account, add_account_attribute, del_account, del_account_attribute, get_account_info, get_usage_history, list_account_attributes, list_accounts, list_identities, update_account
-from rucio.gateway.account_limit import get_global_account_limit, get_global_account_limits, get_global_account_usage, get_local_account_limit, get_local_account_usage
+from rucio.gateway.account_limit import get_global_account_limit, get_global_account_usage, get_local_account_limit, get_local_account_usage
 from rucio.gateway.identity import add_account_identity, del_account_identity
 from rucio.gateway.rule import list_replication_rules
 from rucio.gateway.scope import add_scope, get_scopes
@@ -606,10 +606,7 @@ class GlobalAccountLimits(ErrorHandlingMethodView):
             description: Not Acceptable
         """
         try:
-            if rse_expression:
-                limits = get_global_account_limit(account=account, rse_expression=rse_expression, vo=request.environ.get('vo'))
-            else:
-                limits = get_global_account_limits(account=account, vo=request.environ.get('vo'))
+            limits = get_global_account_limit(account=account, rse_expression=rse_expression, vo=request.environ.get('vo'))
         except RSENotFound as error:
             return generate_http_error_flask(404, error)
 

--- a/tests/test_account_limits.py
+++ b/tests/test_account_limits.py
@@ -49,14 +49,14 @@ class TestCoreAccountLimits:
         rse1, rse1_id = rse_factory.make_mock_rse()
         limit = 10
         account_limit.set_global_account_limit(account, rse1, limit, session=db_session)
-        results = account_limit.get_global_account_limits(account=account, session=db_session)
+        results = account_limit.get_global_account_limit(account=account, session=db_session)
         assert len(results) == 1
         assert rse1 in results
         assert results[rse1]['resolved_rses'] == [rse1]
         assert results[rse1]['resolved_rse_ids'] == [rse1_id]
         assert results[rse1]['limit'] == limit
         account_limit.delete_global_account_limit(account, rse1, session=db_session)
-        results = account_limit.get_global_account_limits(account=account, session=db_session)
+        results = account_limit.get_global_account_limit(account=account, session=db_session)
         assert len(results) == 0
 
     def test_get_global_account_usage(self, account, rse_factory, db_session):

--- a/tests/test_account_limits.py
+++ b/tests/test_account_limits.py
@@ -79,19 +79,19 @@ class TestCoreAccountLimits:
         """ ACCOUNT_LIMIT (CORE): Set, get and delete local account limits """
         _, rse1_id = rse_factory.make_mock_rse()
         _, rse2_id = rse_factory.make_mock_rse()
-        _, rse3_id = rse_factory.make_mock_rse()
         limit1 = 100
         limit2 = 200
         account_limit.set_local_account_limit(account=account, rse_id=rse1_id, bytes_=limit1, session=db_session)
+        results = account_limit.get_local_account_limit(account=account, rse_ids=[rse1_id], session=db_session)
+        assert len(results) == 1
+        assert results[rse1_id] == limit1
         account_limit.set_local_account_limit(account=account, rse_id=rse2_id, bytes_=limit2, session=db_session)
-        account_limit.set_local_account_limit(account=account, rse_id=rse3_id, bytes_=limit2, session=db_session)
         results = account_limit.get_local_account_limit(account=account, rse_ids=[rse1_id, rse2_id],session=db_session)
         assert len(results) == 2
         assert results[rse1_id] == limit1
         assert results[rse2_id] == limit2
         account_limit.delete_local_account_limit(account=account, rse_id=rse1_id, session=db_session)
         account_limit.delete_local_account_limit(account=account, rse_id=rse2_id, session=db_session)
-        account_limit.delete_local_account_limit(account=account, rse_id=rse3_id, session=db_session)
         results = account_limit.get_local_account_limit(account=account,rse_ids=[rse1_id, rse2_id], session=db_session)
         assert len(results) == 0
 

--- a/tests/test_gateway_external_representation.py
+++ b/tests/test_gateway_external_representation.py
@@ -137,7 +137,7 @@ class TestGatewayExternalRepresentation:
         gateway_acc_lim.set_local_account_limit(account_name, rse1, 10000, issuer='root', vo=vo)
         gateway_acc_lim.set_global_account_limit(account_name, rse_expr, 20000, issuer='root', vo=vo)
 
-        out = gateway_acc_lim.get_local_account_limits(account_name, vo=vo)
+        out = gateway_acc_lim.get_local_account_limit(account_name,rse=None, vo=vo)
         assert rse1 in out
         assert rse1_id not in out
 

--- a/tests/test_gateway_external_representation.py
+++ b/tests/test_gateway_external_representation.py
@@ -145,7 +145,7 @@ class TestGatewayExternalRepresentation:
         assert rse1 in out
         assert rse1_id not in out
 
-        out = gateway_acc_lim.get_global_account_limits(account_name, vo=vo)
+        out = gateway_acc_lim.get_global_account_limit(account_name, vo=vo)
         assert rse_expr in out
         if vo2:
             assert 'vo={}&({})'.format(vo, rse_expr) not in out


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Fixes #7483 

#### **For Local Limits**  
The two methods, `get_local_account_limit` and `get_local_account_limits`, have been merged into one: `get_local_account_limit`, used in both core and gateway levels. Now, the `RSE` parameter works like this:  

- **Single RSE** (`str`) → Returns **one limit**.  
- **Multiple RSEs** (`list[str]`) → Returns **multiple limits**.  
- **No RSE (None)** → Returns **all limits**.  

Test cases have been added or updated to check if the function works correctly for single, multiple, and all RSEs.

#### **For Global Limits**
The two methods, `get_global_account_limit` and `get_global_account_limits`, have been merged into one:
`get_global_account_Limit`, used in both core and gateway levels.

- **Single RSE Expression** (`str`) with account -> returns the global limit for that specific expression in that account
- If **no RSE expression(`none`)** is provided, it returns all global account limits for the specified account (or for all accounts if no account is given).
