### PR TITLE
REST & API: Standardize error response using generate_http_error_flask

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -697,7 +697,7 @@ class TokenOIDC(ErrorHandlingMethodView):
             # response.set_cookie('rucio-auth-token-created-at', value=str(time.time()))
             return response
         else:
-            return '', 400, headers
+            return generate_http_error_flask(status_code=400, exc="BadRequest", exc_msg="", headers=headers)
 
 
 class RefreshOIDC(ErrorHandlingMethodView):
@@ -1444,7 +1444,7 @@ class SAML(ErrorHandlingMethodView):
         headers.set('Pragma', 'no-cache')
 
         if not EXTRA_MODULES['onelogin']:
-            return "SAML not configured on the server side.", 400, headers
+            return generate_http_error_flask(status_code=400, exc="ConfigurationError", exc_msg="SAML not configured on the server side.", headers=headers)
 
         saml_nameid = request.cookies.get('saml-nameid', default=None)
         vo = extract_vo(request.headers)

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -22,7 +22,7 @@ from flask import Blueprint, Flask, Response, redirect, render_template, request
 from werkzeug.datastructures import Headers
 
 from rucio.common.config import config_get
-from rucio.common.exception import AccessDenied, CannotAuthenticate, CannotAuthorize, IdentityError, IdentityNotFound
+from rucio.common.exception import AccessDenied, CannotAuthenticate, CannotAuthorize, ConfigurationError, IdentityError, IdentityNotFound, InvalidRequest
 from rucio.common.extra import import_extras
 from rucio.common.utils import date_to_str
 from rucio.core.authentication import strip_x509_proxy_attributes
@@ -697,7 +697,7 @@ class TokenOIDC(ErrorHandlingMethodView):
             # response.set_cookie('rucio-auth-token-created-at', value=str(time.time()))
             return response
         else:
-            return generate_http_error_flask(status_code=400, exc="BadRequest", exc_msg="", headers=headers)
+            return generate_http_error_flask(status_code=400, exc=InvalidRequest.__name__, exc_msg="", headers=headers)
 
 
 class RefreshOIDC(ErrorHandlingMethodView):
@@ -1444,7 +1444,7 @@ class SAML(ErrorHandlingMethodView):
         headers.set('Pragma', 'no-cache')
 
         if not EXTRA_MODULES['onelogin']:
-            return generate_http_error_flask(status_code=400, exc="ConfigurationError", exc_msg="SAML not configured on the server side.", headers=headers)
+            return generate_http_error_flask(status_code=400, exc=ConfigurationError.__name__, exc_msg="SAML not configured on the server side.", headers=headers)
 
         saml_nameid = request.cookies.get('saml-nameid', default=None)
         vo = extract_vo(request.headers)


### PR DESCRIPTION
Issue #7509, 
This PR addresses issue by standardizing error responses in the API to use `generate_http_error_flask`. This ensures consistency in error handling across the codebase.

I have replaced all instances I could find, but there might be additional cases that need to be addressed. I’m not entirely sure if I’ve caught everything. Please let me know, if there are any changes or additional instances that need to be changed!