### PR TITLE
Core: Identity LFN2PFN clean duplicated `/` in output path

### DIFF
--- a/lib/rucio/rse/translation.py
+++ b/lib/rucio/rse/translation.py
@@ -217,9 +217,13 @@ class RSEDeterministicTranslation(PolicyPackageAlgorithms):
         del rse
         del rse_attrs
         del protocol_attrs
+
         if scope.startswith('user') or scope.startswith('group'):
             scope = scope.replace('.', '/')
-        return '%s/%s' % (scope, name)
+        path = f'{scope}/{name}'
+        while '//' in path:
+            path = path.replace('//', '/')
+        return path
 
     @classmethod
     def _module_init_(cls) -> None:


### PR DESCRIPTION
Closes #7528 

Before this PR, if a did name starts with a `/` (e.g. `scope:/path/`), the resulting pfn will have a double `/` in the path part. 

When manually registering a replica, you would also need to provide this double `/` in the path, otherwise pfn would not match.

This change trims all double `/` into single `/`, so all pfn using the identity lfn2pfn are expected to have single `/` in the path part of the pfn.

I acknowledge that this is a breaking change and I am not fully aware of all unintended consequences.