### PR TITLE
Policy / Core: Update default DID name expression to support `/`

### DIFF
--- a/lib/rucio/common/schema/generic.py
+++ b/lib/rucio/common/schema/generic.py
@@ -56,7 +56,7 @@ NAME_LENGTH = 250
 NAME = {"description": "Data Identifier name",
         "type": "string",
         "maxLength": NAME_LENGTH,
-        "pattern": "^[A-Za-z0-9][A-Za-z0-9\\.\\-\\_]*$"}
+        "pattern": r"^[/A-Za-z0-9][/A-Za-z0-9\.\-_]*$"}
 
 R_NAME = {"description": "Data Identifier name",
           "type": "string",

--- a/lib/rucio/common/schema/generic_multi_vo.py
+++ b/lib/rucio/common/schema/generic_multi_vo.py
@@ -57,7 +57,7 @@ NAME_LENGTH = 250
 NAME = {"description": "Data Identifier name",
         "type": "string",
         "maxLength": NAME_LENGTH,
-        "pattern": "^[A-Za-z0-9][A-Za-z0-9\\.\\-\\_]*$"}
+        "pattern": r"^[/A-Za-z0-9][/A-Za-z0-9\.\-_]*$"}
 
 R_NAME = {"description": "Data Identifier name",
           "type": "string",


### PR DESCRIPTION
Update the regex to support `/` in name, including just the `/` as a did name.

This should only extend the set of valid did names, so it should (hopefully) have no effect on existing installations.

Since this is the default, it won't affect those users using a policy package.

Related to #7530 

Closes https://github.com/rucio/rucio/issues/7691

Also closes https://github.com/rucio/rucio/issues/7530