### PR TITLE
tests: skip x509 auth cert tests outside GitHub actions

### DIFF
--- a/lib/rucio/tests/common.py
+++ b/lib/rucio/tests/common.py
@@ -45,6 +45,8 @@ skip_multivo = pytest.mark.skipif('SUITE' in os.environ and os.environ['SUITE'] 
                                   reason="does not work for multiVO")
 skip_non_belleii = pytest.mark.skipif(not ('POLICY' in os.environ and os.environ['POLICY'] == 'belleii'),
                                       reason="specific belleii tests")
+skip_outside_gh_actions = pytest.mark.skipif(os.getenv("GITHUB_ACTIONS") != "true",
+                                             reason="Skipping tests outside GitHub Actions")
 
 
 def is_influxdb_available() -> bool:

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -18,7 +18,7 @@ import os
 import pytest
 
 from rucio.common.config import config_get, config_get_bool
-from rucio.tests.common import account_name_generator, execute, get_long_vo, rse_name_generator
+from rucio.tests.common import account_name_generator, execute, get_long_vo, rse_name_generator, skip_outside_gh_actions
 
 
 class TestCurlRucio:
@@ -54,6 +54,7 @@ class TestCurlRucio:
         print(out, )
         assert 'X-Rucio-Auth-Token' in out
 
+    @skip_outside_gh_actions
     def test_get_auth_x509(self):
         """AUTH (CURL): Test auth token retrieval with via x509"""
         cmd = 'curl -s -i --cacert %s -H "X-Rucio-Account: root" %s -cert %s --key %s -X GET %s/auth/x509' % (self.cacert, self.vo_header, self.usercert, self.userkey, self.auth_host)
@@ -86,6 +87,7 @@ class TestCurlRucio:
         print(out, )
         # assert 'X-Rucio-Auth-Token' in out
 
+    @skip_outside_gh_actions
     def test_get_auth_validate(self):
         """AUTH (CURL): Test if token is valid"""
         cmd = 'curl -s -i --cacert %s -H "X-Rucio-Account: root" %s --cert %s --key %s -X GET %s/auth/x509 | tr -d \'\r\' | grep X-Rucio-Auth-Token:' % (self.cacert, self.vo_header, self.usercert, self.userkey, self.auth_host)
@@ -98,6 +100,7 @@ class TestCurlRucio:
         print(out)
         assert 'datetime.datetime' in out
 
+    @skip_outside_gh_actions
     @pytest.mark.dirty
     def test_post_account(self):
         """ACCOUNT (CURL): add account"""
@@ -111,6 +114,7 @@ class TestCurlRucio:
         print(out)
         assert '201 Created'.lower() in out.lower()
 
+    @skip_outside_gh_actions
     def test_get_accounts_whoami(self):
         """ACCOUNT (CURL): Test whoami method"""
         cmd = 'curl -s -i --cacert %s -H "X-Rucio-Account: root" %s --cert %s --key %s -X GET %s/auth/x509 | tr -d \'\r\' | grep X-Rucio-Auth-Token:' % (self.cacert, self.vo_header, self.usercert, self.userkey, self.auth_host)
@@ -124,6 +128,7 @@ class TestCurlRucio:
         print(out)
         assert '303 See Other'.lower() in out.lower()
 
+    @skip_outside_gh_actions
     @pytest.mark.dirty
     def test_post_rse(self):
         """RSE (CURL): add RSE"""


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
- Marked x509-failed-tests with `pytest.mark.skipif` to skip tests outside CI (github actions) env for local runs.
- Github Actions has a [env variable](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables) `GITHUB_ACTIONS` which is always set to true while running as part of the workflow.

Fixes #7507 

![Screenshot 2025-03-20 at 14 55 01](https://github.com/user-attachments/assets/426d84c5-cbf9-4ada-b1b7-f70d17afdcac)