### PR TITLE
Update `setup.cfg` to address installation error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@
 
 [global]
 verbose = 1
-force-manifest = 1
 
 [metadata]
 description_file = README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ verbose         = 1
 force-manifest  = 1
 
 [metadata]
-description-file =
+description_file =
     README.md
 
 [egg_info]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,13 +3,13 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 [global]
-verbose         = 1
-force-manifest  = 1
+verbose = 1
+force-manifest = 1
 
 [metadata]
-description_file =
-    README.md
+description_file = README.md
 
 [egg_info]
 tag_build =
@@ -17,7 +17,7 @@ tag_date = 0
 tag_svn_revision = 0
 
 [pep8]
-max-line-length=256
+max-line-length = 256
 
 [flake8]
-max-line-length=256
+max-line-length = 256


### PR DESCRIPTION
I removed the key `force-manifest` as I think it's not actually used anywhere, but I'm not 100% sure.

Closes #7544 

Is there any reason why we can't just remove this file? I feel that `pyproject.toml` should be enough.