### PR TITLE
fix: InvalidConfigError when using setuptools >= 58

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ verbose         = 1
 force-manifest  = 1
 
 [metadata]
-description-file =
+description_file =
     README.md
 
 [egg_info]


### PR DESCRIPTION
This fixes an error when building the sdist using the setuptools released this morning.

```
setuptools.errors.InvalidConfigError: Invalid dash-separated key 'description-file' in 'metadata' (setup.cfg), please use the underscore name 'description_file' instead.
```