### PR TITLE
Policy / Core: Update default `SCOPE_NAME_REGEXP` to capture slashes in second group

### DIFF
--- a/lib/rucio/common/schema/generic.py
+++ b/lib/rucio/common/schema/generic.py
@@ -370,7 +370,7 @@ ACCOUNT_ATTRIBUTE = {"description": "Account attribute",
                      "type": "string",
                      "pattern": r'^[a-zA-Z0-9-_\\/\\.]{1,30}$'}
 
-SCOPE_NAME_REGEXP = '/(.*)/(.*)'
+SCOPE_NAME_REGEXP = r"/([^/]+)/(.*)"
 
 DISTANCE = {"description": "RSE distance",
             "type": "object",


### PR DESCRIPTION
This regex (`SCOPE_NAME_REGEXP`) should probably be removed in favour of a generic method, but for the time being this fixes some issues.

Related to #7530 