### PR TITLE
Client: Don't show depreciation warning if command is invalid

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -17,8 +17,9 @@ import argparse
 import sys
 from typing import TYPE_CHECKING, Optional
 
+from rucio.cli.bin_legacy.rucio import get_parser
 from rucio.cli.bin_legacy.rucio import main as main_legacy
-from rucio.cli.command import main
+from rucio.cli.command import get_help_menu, main
 from rucio.common.utils import setup_logger
 
 if TYPE_CHECKING:
@@ -118,16 +119,15 @@ if __name__ == "__main__":
         main()  # pylint: disable=E1120
 
     else:
-        make_warning(logger)
         try:
-            main_legacy()
+            get_parser().parse_args()
         # Make a custom warning - show the new help menu when invalid commands are called.
         except argparse.ArgumentError:
-            logger.error("Invalid argument(s) - %s " % sys.argv[1:])
-            command = map_legacy_command()
-            if command is not None:
-                sys.argv = ["rucio"] + command + ["-h"]
-            else:
-                sys.argv = ["rucio", "-h"]
+            org_arguments = sys.argv[1:]
+            logger.error("Invalid argument(s) - %s " % org_arguments)
 
-            main()  # pylint: disable=E1120
+            get_help_menu()
+            sys.exit(2)
+
+        make_warning(logger)
+        main_legacy()

--- a/lib/rucio/cli/command.py
+++ b/lib/rucio/cli/command.py
@@ -230,6 +230,11 @@ def main(
     ctx.call_on_close(_teardown)
 
 
+def get_help_menu() -> None:
+    with click.Context(main) as ctx:
+        click.echo(main.get_help(ctx))
+
+
 @click.pass_context
 def _teardown(ctx):
     time_elapsed = time.time() - ctx.obj.start_time

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -35,6 +35,12 @@ def test_main_args():
     assert "This method is being deprecated" in err
     assert "root" in out
 
+    non_existent_cmd = "rucio lfkdl --slkfdj 1"
+    exitcode, out, err = execute(non_existent_cmd)
+
+    assert exitcode == 2
+    assert "This method is being deprecated" not in err
+
 
 def test_help_menus():
     """Verify help menus"""


### PR DESCRIPTION
Closes #7480

Exit with exitcode 2 if the command is invalid, show the new help menu - do not show the depreciation warning 