### PR TITLE
Dependencies: add upper version limit of 1.2.2 to dopgile-cache in install_requires

### DIFF
--- a/setuputil.py
+++ b/setuputil.py
@@ -19,7 +19,7 @@ clients_requirements_table = {
     'install_requires': [
         'requests',
         'urllib3',
-        'dogpile-cache',
+        'dogpile-cache<=1.2.2',
         'packaging',
         'tabulate',
         'jsonschema',


### PR DESCRIPTION
fix #7571

This is a quick fix to have another rc. Long-term, we should look at how we do requirements management. Ideally, we should do this together with a move to `pyproject.toml`, as I think the current `setup.py` setup complicates things a bit.