### PR TITLE
Messaging: add username and password conn params if not use_ssl

### DIFF
--- a/lib/rucio/common/stomp_utils.py
+++ b/lib/rucio/common/stomp_utils.py
@@ -287,7 +287,7 @@ class StompConnectionManager:
         config = self._config
         params = {'wait': True, "heartbeats": self._config.heartbeats}
         self._logger(logging.WARNING, 'heartbeats: %s', self._config.heartbeats)
-        if config.use_ssl:
+        if not config.use_ssl:
             params.update(username=config.username, password=config.password)
 
         for conn in self._conns:


### PR DESCRIPTION
fix #7583

If use_ssl, each connection is appended the cert_file and key_file as part of the StompConnectionManager __init__, so there is no need to append them to the params here.