### PR TITLE
common: Rename `get_lfn2pfn_algorithm_default` to `get_lfn2pfn_algorithm` for naming consistency

### DIFF
--- a/lib/rucio/common/config.py
+++ b/lib/rucio/common/config.py
@@ -724,7 +724,7 @@ def get_config_dirs() -> list[str]:
     return configdirs
 
 
-def get_lfn2pfn_algorithm_default() -> str:
+def get_lfn2pfn_algorithm() -> str:
     """Returns the default algorithm name for LFN2PFN translation for this server."""
     default_lfn2pfn = "hash"
     try:

--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -28,7 +28,7 @@ from sqlalchemy.sql.expression import Executable, and_, delete, desc, false, fun
 from rucio.common import exception, types, utils
 from rucio.common.cache import MemcacheRegion
 from rucio.common.checksum import CHECKSUM_KEY, GLOBALLY_SUPPORTED_CHECKSUMS
-from rucio.common.config import get_lfn2pfn_algorithm_default
+from rucio.common.config import get_lfn2pfn_algorithm
 from rucio.common.constants import RSE_ALL_SUPPORTED_PROTOCOL_OPERATIONS, RSE_ATTRS_BOOL, RSE_ATTRS_STR, SUPPORTED_SIGN_URL_SERVICES_LITERAL, RseAttr
 from rucio.common.utils import Availability
 from rucio.core.rse_counter import add_counter, get_counter
@@ -1566,7 +1566,7 @@ def _format_get_rse_protocols(
     # Resolve LFN2PFN default algorithm as soon as possible.  This way, we can send back the actual
     # algorithm name in response to REST queries.
     if not lfn2pfn_algorithm:
-        lfn2pfn_algorithm = get_lfn2pfn_algorithm_default()
+        lfn2pfn_algorithm = get_lfn2pfn_algorithm()
 
     # Copy verify_checksum from the attributes, later: assume True if not specified
     if rse_attributes:

--- a/lib/rucio/rse/translation.py
+++ b/lib/rucio/rse/translation.py
@@ -236,7 +236,7 @@ class RSEDeterministicTranslation(PolicyPackageAlgorithms):
         if policy_module:
             importlib.import_module(policy_module)
 
-        cls._DEFAULT_LFN2PFN = config.get_lfn2pfn_algorithm_default()
+        cls._DEFAULT_LFN2PFN = config.get_lfn2pfn_algorithm()
 
     def path(
             self,


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Fix #7465 