### PR TITLE
Migrate gateway/scope and gateway/dirac to session context manager, minor refactors

### DIFF
--- a/lib/rucio/gateway/dirac.py
+++ b/lib/rucio/gateway/dirac.py
@@ -15,13 +15,14 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 from rucio.common.exception import AccessDenied
+from rucio.common.types import InternalScope
 from rucio.common.utils import extract_scope
 from rucio.core import dirac
 from rucio.core.rse import get_rse_id
+from rucio.core.scope import list_scopes
 from rucio.db.sqla.constants import DatabaseOperationType
 from rucio.db.sqla.session import db_session
 from rucio.gateway.permission import has_permission
-from rucio.gateway.scope import list_scopes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -49,7 +50,8 @@ def add_files(
     """
 
     with db_session(DatabaseOperationType.WRITE) as session:
-        scopes = list_scopes(vo=vo, session=session)
+        filter_ = {'scope': InternalScope(scope='*', vo=vo)}
+        scopes = [scope.external for scope in list_scopes(filter_=filter_, session=session)]
         dids = []
         rses = {}
         for lfn in lfns:

--- a/lib/rucio/gateway/scope.py
+++ b/lib/rucio/gateway/scope.py
@@ -14,8 +14,8 @@
 
 from typing import Any, Optional
 
-import rucio.common.exception
 import rucio.gateway.permission
+from rucio.common.exception import AccessDenied
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core import scope as core_scope
@@ -66,7 +66,7 @@ def add_scope(
     with db_session(DatabaseOperationType.WRITE) as session:
         auth_result = rucio.gateway.permission.has_permission(issuer=issuer, vo=vo, action='add_scope', kwargs=kwargs, session=session)
         if not auth_result.allowed:
-            raise rucio.common.exception.AccessDenied('Account %s can not add scope. %s' % (issuer, auth_result.message))
+            raise AccessDenied('Account %s can not add scope. %s' % (issuer, auth_result.message))
 
         internal_scope = InternalScope(scope, vo=vo)
         internal_account = InternalAccount(account, vo=vo)

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -217,7 +217,7 @@ class Scopes(ErrorHandlingMethodView):
             description: Not acceptable
         """
         try:
-            scopes = get_scopes(account, vo=request.environ.get('vo'))
+            scopes = get_scopes(account, vo=request.environ['vo'])
         except AccountNotFound as error:
             return generate_http_error_flask(404, error)
 
@@ -264,7 +264,7 @@ class Scopes(ErrorHandlingMethodView):
             description: Scope already exists.
         """
         try:
-            add_scope(scope, account, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+            add_scope(scope, account, issuer=request.environ['issuer'], vo=request.environ['vo'])
         except InvalidObject as error:
             return generate_http_error_flask(400, error)
         except AccessDenied as error:

--- a/lib/rucio/web/rest/flaskapi/v1/dirac.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dirac.py
@@ -80,8 +80,8 @@ class AddFiles(ErrorHandlingMethodView):
         ignore_availability = param_get(parameters, 'ignore_availability', default=False)
         parents_metadata = param_get(parameters, 'parents_metadata', default=None)
         try:
-            add_files(lfns=lfns, issuer=request.environ.get('issuer'), ignore_availability=ignore_availability,
-                      parents_metadata=parents_metadata, vo=request.environ.get('vo'))
+            add_files(lfns=lfns, issuer=request.environ['issuer'], ignore_availability=ignore_availability,
+                      parents_metadata=parents_metadata, vo=request.environ['vo'])
         except InvalidPath as error:
             return generate_http_error_flask(400, error)
         except AccessDenied as error:

--- a/lib/rucio/web/rest/flaskapi/v1/scopes.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scopes.py
@@ -46,7 +46,7 @@ class Scope(ErrorHandlingMethodView):
           406:
             description: Not acceptable
         """
-        return jsonify(list_scopes(vo=request.environ.get('vo')))
+        return jsonify(list_scopes(vo=request.environ['vo']))
 
     def post(self, account, scope):
         """
@@ -84,7 +84,7 @@ class Scope(ErrorHandlingMethodView):
             description: Scope already exists
         """
         try:
-            add_scope(scope, account, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
+            add_scope(scope, account, issuer=request.environ['issuer'], vo=request.environ['vo'])
         except Duplicate as error:
             return generate_http_error_flask(409, error)
         except AccountNotFound as error:
@@ -129,7 +129,7 @@ class AccountScopeList(ErrorHandlingMethodView):
             description: Not acceptable
         """
         try:
-            scopes = get_scopes(account, vo=request.environ.get('vo'))
+            scopes = get_scopes(account, vo=request.environ['vo'])
         except AccountNotFound as error:
             return generate_http_error_flask(404, error)
 


### PR DESCRIPTION
Part of:
- #7409
- #7605 

In addition, note this commit 270288946b4febda8ba0392ea39428b30b097b93 - this is the reason why I had to make a single PR for both scope and dirac. DIRAC used the gateway version of `list_scopes` instead of the core version, so I had to change it here, as we want to avoid having gateway functions calling other gateway functions (except for `has_permission`, which does not have an API route and is effectively a 'gateway utility' rather than a real gateway function)