### PR TITLE
Drop unneeded dataclasses requirement

### DIFF
--- a/setuputil.py
+++ b/setuputil.py
@@ -23,7 +23,6 @@ clients_requirements_table = {
         'packaging',
         'tabulate',
         'jsonschema',
-        'dataclasses',
         'rich',
         'typing_extensions'
     ],
@@ -68,7 +67,6 @@ server_requirements_table = {
         'packaging<=24.1',
         'tabulate<=0.9.0',
         'jsonschema<=4.23.0',
-        'dataclasses',  # no upper limit is set in .in or .txt req files
         'rich<=13.9.4',
         'typing_extensions<=4.12.2',
         'argcomplete<=3.5.3',


### PR DESCRIPTION
since rucio only supports Python>=3.9, and dataclasses are part of the standard library since 3.7 .

Fix https://github.com/rucio/rucio/issues/7266 .

This is particularly important for Galaxy, which requires rucio-clients as a dev dependency. When resolving our dependencies with uv, dataclasses 0.8 gets selected (due to https://github.com/astral-sh/uv/issues/7462 ), which is a version not installable on Python >=3.7, breaking installation, see https://github.com/galaxyproject/galaxy/pull/19998