### PR TITLE
Database: Fix for query instability with wildcard queries

### DIFF
--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -234,7 +234,7 @@ class DidColumnMeta(DidMetaPlugin):
         )
         stmt = stmt.with_hint(
             models.DataIdentifier,
-            'NO_EXPAND',
+            'USE_CONCAT INDEX_RS_ASC(DIDS)',
             'oracle'
         )
 


### PR DESCRIPTION
This forces the oracle database to do index range scans instead of full table/partition scans.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
