### PR TITLE
Change the style of client docstrings to numpy style 

### DIFF
--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -33,14 +33,24 @@ class AccountClient(BaseClient):
 
     def add_account(self, account: str, type_: str, email: str) -> bool:
         """
-        Sends the request to create a new account.
+        Parameters
+        ----------
+        account : str
+            The name of the account.
+        type_ : str
+            The account type.
+        email : str
+            The Email address associated with the account.
 
-        :param account: the name of the account.
-        :param type_: The account type
-        :param email: The Email address associated with the account.
+        Returns
+        -------
+        bool
+            True if account was created successfully else False.
 
-        :return: True if account was created successfully else False.
-        :raises Duplicate: if account already exists.
+        Raises
+        ------
+        Duplicate
+            If account already exists.
         """
 
         data = dumps({'type': type_, 'email': email})
@@ -55,11 +65,22 @@ class AccountClient(BaseClient):
 
     def delete_account(self, account: str) -> bool:
         """
-        Sends the request to disable an account.
+        Send the request to disable an account.
 
-        :param account: the name of the account.
-        :return: True is account was disabled successfully. False otherwise.
-        :raises AccountNotFound: if account doesn't exist.
+        Parameters
+        ----------
+        account : str
+            The name of the account.
+
+        Returns
+        -------
+        bool
+            True if account was disabled successfully. False otherwise.
+
+        Raises
+        ------
+        AccountNotFound
+            If account doesn't exist.
         """
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account])
@@ -74,11 +95,22 @@ class AccountClient(BaseClient):
 
     def get_account(self, account: str) -> Optional[dict[str, Any]]:
         """
-        Sends the request to get information about a given account.
+        Send the request to get information about a given account.
 
-        :param account: the name of the account.
-        :return: a list of attributes for the account. None if failure.
-        :raises AccountNotFound: if account doesn't exist.
+        Parameters
+        ----------
+        account : str
+            The name of the account.
+
+        Returns
+        -------
+        dict or None
+            A dictionary of attributes for the account. None if failure.
+
+        Raises
+        ------
+        AccountNotFound
+            If account doesn't exist.
         """
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account])
@@ -92,11 +124,27 @@ class AccountClient(BaseClient):
         raise exc_cls(exc_msg)
 
     def update_account(self, account: str, key: str, value: Any) -> bool:
-        """ Update a property of an account.
+        """
+        Update a property of an account.
 
-        :param account: Name of the account.
-        :param key: Account property like status.
-        :param value: Property value.
+        Parameters
+        ----------
+        account : str
+            Name of the account.
+        key : str
+            Account property like status.
+        value : Any
+            Property value.
+
+        Returns
+        -------
+        bool
+            True if successful.
+
+        Raises
+        ------
+        Exception
+            If update fails.
         """
         data = dumps({key: value})
         path = '/'.join([self.ACCOUNTS_BASEURL, account])
@@ -117,14 +165,26 @@ class AccountClient(BaseClient):
             filters: Optional[dict[str, Any]] = None
     ) -> "Iterator[dict[str, Any]]":
         """
-        Sends the request to list all rucio accounts.
+        Send the request to list all rucio accounts.
 
-        :param type: The account type
-        :param identity: The identity key name. For example x509 DN, or a username.
-        :param filters: A dictionary key:account attribute to use for the filtering
+        Parameters
+        ----------
+        account_type : str, optional
+            The account type.
+        identity : str, optional
+            The identity key name. For example x509 DN, or a username.
+        filters : dict, optional
+            A dictionary key:account attribute to use for the filtering.
 
-        :return: a list containing account info dictionary for all rucio accounts.
-        :raises AccountNotFound: if account doesn't exist.
+        Returns
+        -------
+        Iterator[dict]
+            An iterator of dictionaries containing account information.
+
+        Raises
+        ------
+        AccountNotFound
+            If account doesn't exist.
         """
         path = '/'.join([self.ACCOUNTS_BASEURL])
         url = build_url(choice(self.list_hosts), path=path)
@@ -148,10 +208,17 @@ class AccountClient(BaseClient):
 
     def whoami(self) -> Optional[dict[str, Any]]:
         """
-        Get information about account whose token is used
+        Get information about account whose token is used.
 
-        :return: a list of attributes for the account. None if failure.
-        :raises AccountNotFound: if account doesn't exist.
+        Returns
+        -------
+        dict or None
+            A dictionary of attributes for the account. None if failure.
+
+        Raises
+        ------
+        AccountNotFound
+            If account doesn't exist.
         """
         return self.get_account('whoami')
 
@@ -165,14 +232,28 @@ class AccountClient(BaseClient):
             password: Optional[str] = None
     ) -> bool:
         """
-        Adds a membership association between identity and account.
+        Add a membership association between identity and account.
 
-        :param account: The account name.
-        :param identity: The identity key name. For example x509 DN, or a username.
-        :param authtype: The type of the authentication (x509, gss, userpass).
-        :param default: If True, the account should be used by default with the provided identity.
-        :param email: The Email address associated with the identity.
-        :param password: Password if authtype is userpass.
+        Parameters
+        ----------
+        account : str
+            The account name.
+        identity : str
+            The identity key name. For example x509 DN, or a username.
+        authtype : str
+            The type of the authentication (x509, gss, userpass).
+        email : str
+            The Email address associated with the identity.
+        default : bool, optional
+            If True, the account should be used by default with the provided identity.
+        password : str, optional
+            Password if authtype is userpass.
+
+        Returns
+        -------
+        bool
+            True if successful.
+
         """
 
         data = dumps({'identity': identity, 'authtype': authtype, 'default': default, 'email': email, 'password': password})
@@ -197,9 +278,19 @@ class AccountClient(BaseClient):
         """
         Delete an identity's membership association with an account.
 
-        :param account: The account name.
-        :param identity: The identity key name. For example x509 DN, or a username.
-        :param authtype: The type of the authentication (x509, gss, userpass).
+        Parameters
+        ----------
+        account : str
+            The account name.
+        identity : str
+            The identity key name. For example x509 DN, or a username.
+        authtype : str
+            The type of the authentication (x509, gss, userpass).
+
+        Returns
+        -------
+        bool
+            True if successful.
         """
 
         data = dumps({'identity': identity, 'authtype': authtype})
@@ -219,7 +310,10 @@ class AccountClient(BaseClient):
         """
         List all identities on an account.
 
-        :param account: The account name.
+        Parameters
+        ----------
+        account : str
+            The account name.
         """
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'identities'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -235,7 +329,11 @@ class AccountClient(BaseClient):
         """
         List the associated rules of an account.
 
-        :param account: The account name.
+        Parameters
+        ----------
+        account : str
+            The account name.
+
         """
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'rules'])
@@ -251,9 +349,15 @@ class AccountClient(BaseClient):
         """
         Return the correct account limits for the given locality.
 
-        :param account:        The account name.
-        :param rse_expression: Valid RSE expression
-        :param locality:       The scope of the account limit. 'local' or 'global'.
+        Parameters
+        ----------
+        account : str
+            The account name.
+        rse_expression : str
+            Valid RSE expression.
+        locality : str
+            The scope of the account limit. 'local' or 'global'.
+
         """
 
         if locality == 'local':
@@ -268,8 +372,13 @@ class AccountClient(BaseClient):
         """
         List the account limit for the specific RSE expression.
 
-        :param account:        The account name.
-        :param rse_expression: The rse expression.
+        Parameters
+        ----------
+        account : str
+            The account name.
+        rse_expression : str
+            The rse expression.
+
         """
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'limits', 'global', quote_plus(rse_expression)])
@@ -284,7 +393,10 @@ class AccountClient(BaseClient):
         """
         List all RSE expression limits of this account.
 
-        :param account: The account name.
+        Parameters
+        ----------
+        account : str
+            The account name.
         """
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'limits', 'global'])
@@ -299,7 +411,10 @@ class AccountClient(BaseClient):
         """
         List the account rse limits of this account.
 
-        :param account: The account name.
+        Parameters
+        ----------
+        account : str
+            The account name.
         """
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'limits', 'local'])
@@ -314,8 +429,12 @@ class AccountClient(BaseClient):
         """
         List the account rse limits of this account for the specific rse.
 
-        :param account: The account name.
-        :param rse:     The rse name.
+        Parameters
+        ----------
+        account : str
+            The account name.
+        rse : str
+            The rse name.
         """
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'limits', 'local', rse])
@@ -330,8 +449,12 @@ class AccountClient(BaseClient):
         """
         List the account usage for one or all rses of this account.
 
-        :param account: The account name.
-        :param rse:     The rse name.
+        Parameters
+        ----------
+        account : str
+            The account name.
+        rse : str, optional
+            The rse name.
         """
         if rse:
             path = '/'.join([self.ACCOUNTS_BASEURL, account, 'usage', 'local', rse])
@@ -349,8 +472,12 @@ class AccountClient(BaseClient):
         """
         List the account usage for one or all RSE expressions of this account.
 
-        :param account:        The account name.
-        :param rse_expression: The rse expression.
+        Parameters
+        ----------
+        account : str
+            The account name.
+        rse_expression : str, optional
+            The rse expression.
         """
         if rse_expression:
             path = '/'.join([self.ACCOUNTS_BASEURL, account, 'usage', 'global', quote_plus(rse_expression)])
@@ -368,8 +495,12 @@ class AccountClient(BaseClient):
         """
         List the account usage history of this account on rse.
 
-        :param account: The account name.
-        :param rse:     The rse name.
+        Parameters
+        ----------
+        account : str
+            The account name.
+        rse : str
+            The rse name.
         """
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'usage/history', rse])
         url = build_url(choice(self.list_hosts), path=path)
@@ -384,7 +515,10 @@ class AccountClient(BaseClient):
         """
         List the attributes for an account.
 
-        :param account: The account name.
+        Parameters
+        ----------
+        account : str
+            The account name.
         """
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'attr/'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -397,11 +531,16 @@ class AccountClient(BaseClient):
 
     def add_account_attribute(self, account: str, key: str, value: Any) -> bool:
         """
-        Adds an attribute to an account.
+        Add an attribute to an account.
 
-        :param account: The account name.
-        :param key: The attribute key.
-        :param value: The attribute value.
+        Parameters
+        ----------
+        account : str
+            The account name.
+        key : str
+            The attribute key.
+        value : Any
+            The attribute value.
         """
 
         data = dumps({'key': key, 'value': value})
@@ -418,8 +557,12 @@ class AccountClient(BaseClient):
         """
         Delete an attribute for an account.
 
-        :param account: The account name.
-        :param key: The attribute key.
+        Parameters
+        ----------
+        account : str
+            The account name.
+        key : str
+            The attribute key.
         """
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'attr', key])

--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -33,18 +33,20 @@ class AccountClient(BaseClient):
 
     def add_account(self, account: str, type_: str, email: str) -> bool:
         """
+        Sends the request to create a new account.
+
         Parameters
         ----------
-        account : str
+        account :
             The name of the account.
-        type_ : str
+        type_ :
             The account type.
-        email : str
+        email :
             The Email address associated with the account.
 
         Returns
         -------
-        bool
+
             True if account was created successfully else False.
 
         Raises
@@ -69,12 +71,12 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The name of the account.
 
         Returns
         -------
-        bool
+
             True if account was disabled successfully. False otherwise.
 
         Raises
@@ -99,12 +101,12 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The name of the account.
 
         Returns
         -------
-        dict or None
+
             A dictionary of attributes for the account. None if failure.
 
         Raises
@@ -129,16 +131,16 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             Name of the account.
-        key : str
+        key :
             Account property like status.
-        value : Any
+        value :
             Property value.
 
         Returns
         -------
-        bool
+
             True if successful.
 
         Raises
@@ -169,16 +171,16 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account_type : str, optional
+        account_type :
             The account type.
-        identity : str, optional
+        identity :
             The identity key name. For example x509 DN, or a username.
-        filters : dict, optional
+        filters :
             A dictionary key:account attribute to use for the filtering.
 
         Returns
         -------
-        Iterator[dict]
+
             An iterator of dictionaries containing account information.
 
         Raises
@@ -212,7 +214,7 @@ class AccountClient(BaseClient):
 
         Returns
         -------
-        dict or None
+
             A dictionary of attributes for the account. None if failure.
 
         Raises
@@ -236,22 +238,22 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
-        identity : str
+        identity :
             The identity key name. For example x509 DN, or a username.
-        authtype : str
+        authtype :
             The type of the authentication (x509, gss, userpass).
-        email : str
+        email :
             The Email address associated with the identity.
-        default : bool, optional
+        default :
             If True, the account should be used by default with the provided identity.
-        password : str, optional
+        password :
             Password if authtype is userpass.
 
         Returns
         -------
-        bool
+
             True if successful.
 
         """
@@ -280,16 +282,16 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
-        identity : str
+        identity :
             The identity key name. For example x509 DN, or a username.
-        authtype : str
+        authtype :
             The type of the authentication (x509, gss, userpass).
 
         Returns
         -------
-        bool
+
             True if successful.
         """
 
@@ -312,7 +314,7 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
         """
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'identities'])
@@ -331,7 +333,7 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
 
         """
@@ -351,11 +353,11 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
-        rse_expression : str
+        rse_expression :
             Valid RSE expression.
-        locality : str
+        locality :
             The scope of the account limit. 'local' or 'global'.
 
         """
@@ -374,9 +376,9 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
-        rse_expression : str
+        rse_expression :
             The rse expression.
 
         """
@@ -395,7 +397,7 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
         """
 
@@ -413,7 +415,7 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
         """
 
@@ -431,9 +433,9 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
-        rse : str
+        rse :
             The rse name.
         """
 
@@ -451,9 +453,9 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
-        rse : str, optional
+        rse :
             The rse name.
         """
         if rse:
@@ -474,9 +476,9 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
-        rse_expression : str, optional
+        rse_expression :
             The rse expression.
         """
         if rse_expression:
@@ -497,9 +499,9 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
-        rse : str
+        rse :
             The rse name.
         """
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'usage/history', rse])
@@ -517,7 +519,7 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
         """
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'attr/'])
@@ -535,11 +537,11 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
-        key : str
+        key :
             The attribute key.
-        value : Any
+        value :
             The attribute value.
         """
 
@@ -559,9 +561,9 @@ class AccountClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The account name.
-        key : str
+        key :
             The attribute key.
         """
 

--- a/lib/rucio/client/accountlimitclient.py
+++ b/lib/rucio/client/accountlimitclient.py
@@ -38,11 +38,21 @@ class AccountLimitClient(BaseClient):
         """
         Sets an account limit for a given limit scope.
 
-        :param account: The name of the account.
-        :param rse:     The rse name.
-        :param bytes_:   An integer with the limit in bytes.
-        :param locality: The scope of the account limit. 'local' or 'global'.
-        :return:        True if quota was created successfully else False.
+        Parameters
+        ----------
+        account : str
+            The name of the account.
+        rse : str
+            The rse name.
+        bytes_ : int
+            The limit in bytes.
+        locality : {'local', 'global'}
+            The scope of the account limit.
+
+        Returns
+        -------
+        bool
+            True if quota was created successfully, False otherwise.
         """
 
         if locality == 'local':
@@ -62,10 +72,19 @@ class AccountLimitClient(BaseClient):
         """
         Deletes an account limit for a given limit scope.
 
-        :param account: The name of the account.
-        :param rse:     The rse name.
-        :param locality: The scope of the account limit. 'local' or 'global'.
-        :return:        True if quota was created successfully else False.
+        Parameters
+        ----------
+        account : str
+            The name of the account.
+        rse : str
+            The rse name.
+        locality : {'local', 'global'}
+            The scope of the account limit.
+
+        Returns
+        -------
+        bool
+            True if quota was deleted successfully, False otherwise.
         """
 
         if locality == 'local':
@@ -85,10 +104,19 @@ class AccountLimitClient(BaseClient):
         """
         Sends the request to set an account limit for an account.
 
-        :param account: The name of the account.
-        :param rse:     The rse name.
-        :param bytes_:   An integer with the limit in bytes.
-        :return:        True if quota was created successfully else False.
+        Parameters
+        ----------
+        account : str
+            The name of the account.
+        rse : str
+            The rse name.
+        bytes_ : int
+            The limit in bytes.
+
+        Returns
+        -------
+        bool
+            True if quota was created successfully, False otherwise.
         """
 
         data = dumps({'bytes': bytes_})
@@ -111,11 +139,22 @@ class AccountLimitClient(BaseClient):
         """
         Sends the request to remove an account limit.
 
-        :param account: The name of the account.
-        :param rse:     The rse name.
+        Parameters
+        ----------
+        account : str
+            The name of the account.
+        rse : str
+            The rse name.
 
-        :return: True if quota was removed successfully. False otherwise.
-        :raises AccountNotFound: if account doesn't exist.
+        Returns
+        -------
+        bool
+            True if quota was removed successfully, False otherwise.
+
+        Raises
+        ------
+        AccountNotFound
+            If account doesn't exist.
         """
 
         path = '/'.join([self.ACCOUNTLIMIT_BASEURL, 'local', account, rse])
@@ -138,10 +177,19 @@ class AccountLimitClient(BaseClient):
         """
         Sends the request to set a global account limit for an account.
 
-        :param account:        The name of the account.
-        :param rse_expression: The rse expression.
-        :param bytes_:          An integer with the limit in bytes.
-        :return:               True if quota was created successfully else False.
+        Parameters
+        ----------
+        account : str
+            The name of the account.
+        rse_expression : str
+            The rse expression.
+        bytes_ : int
+            The limit in bytes.
+
+        Returns
+        -------
+        bool
+            True if quota was created successfully, False otherwise.
         """
 
         data = dumps({'bytes': bytes_})
@@ -164,11 +212,22 @@ class AccountLimitClient(BaseClient):
         """
         Sends the request to remove a global account limit.
 
-        :param account:        The name of the account.
-        :param rse_expression: The rse expression.
+        Parameters
+        ----------
+        account : str
+            The name of the account.
+        rse_expression : str
+            The rse expression.
 
-        :return: True if quota was removed successfully. False otherwise.
-        :raises AccountNotFound: if account doesn't exist.
+        Returns
+        -------
+        bool
+            True if quota was removed successfully, False otherwise.
+
+        Raises
+        ------
+        AccountNotFound
+            If account doesn't exist.
         """
 
         path = '/'.join([self.ACCOUNTLIMIT_BASEURL, 'global', account, quote_plus(rse_expression)])

--- a/lib/rucio/client/accountlimitclient.py
+++ b/lib/rucio/client/accountlimitclient.py
@@ -40,18 +40,18 @@ class AccountLimitClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The name of the account.
-        rse : str
+        rse :
             The rse name.
-        bytes_ : int
+        bytes_ :
             The limit in bytes.
-        locality : {'local', 'global'}
+        locality :
             The scope of the account limit.
 
         Returns
         -------
-        bool
+
             True if quota was created successfully, False otherwise.
         """
 
@@ -74,16 +74,16 @@ class AccountLimitClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The name of the account.
-        rse : str
+        rse :
             The rse name.
-        locality : {'local', 'global'}
+        locality :
             The scope of the account limit.
 
         Returns
         -------
-        bool
+
             True if quota was deleted successfully, False otherwise.
         """
 
@@ -106,16 +106,16 @@ class AccountLimitClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The name of the account.
-        rse : str
+        rse :
             The rse name.
-        bytes_ : int
+        bytes_ :
             The limit in bytes.
 
         Returns
         -------
-        bool
+
             True if quota was created successfully, False otherwise.
         """
 
@@ -141,14 +141,14 @@ class AccountLimitClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The name of the account.
-        rse : str
+        rse :
             The rse name.
 
         Returns
         -------
-        bool
+
             True if quota was removed successfully, False otherwise.
 
         Raises
@@ -179,16 +179,16 @@ class AccountLimitClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The name of the account.
-        rse_expression : str
+        rse_expression :
             The rse expression.
-        bytes_ : int
+        bytes_ :
             The limit in bytes.
 
         Returns
         -------
-        bool
+
             True if quota was created successfully, False otherwise.
         """
 
@@ -214,14 +214,14 @@ class AccountLimitClient(BaseClient):
 
         Parameters
         ----------
-        account : str
+        account :
             The name of the account.
-        rse_expression : str
+        rse_expression :
             The rse expression.
 
         Returns
         -------
-        bool
+
             True if quota was removed successfully, False otherwise.
 
         Raises

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -98,25 +98,25 @@ class BaseClient:
 
         Parameters
         ----------
-        rucio_host : str, optional
+        rucio_host :
             The address of the rucio server, if None it is read from the config file.
-        auth_host : str, optional
+        auth_host :
             The address of the rucio authentication server, if None it is read from the config file.
-        account : str, optional
+        account :
             The account to authenticate to rucio.
-        ca_cert : str, optional
+        ca_cert :
             The path to the rucio server certificate.
-        auth_type : str, optional
+        auth_type :
             The type of authentication (e.g.: 'userpass', 'kerberos' ...)
-        creds : dict, optional
+        creds :
             Dictionary with credentials needed for authentication.
-        timeout : int, optional
+        timeout :
             Timeout for requests.
-        user_agent : str, optional
+        user_agent :
             Indicates the client.
-        vo : str, optional
+        vo :
             The VO to authenticate into.
-        logger : Logger, optional
+        logger :
             Logger object to use. If None, use the default LOG created by the module.
         """
 

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -95,15 +95,29 @@ class BaseClient:
                  logger: 'Logger' = LOG) -> None:
         """
         Constructor of the BaseClient.
-        :param rucio_host: The address of the rucio server, if None it is read from the config file.
-        :param auth_host: The address of the rucio authentication server, if None it is read from the config file.
-        :param account: The account to authenticate to rucio.
-        :param ca_cert: The path to the rucio server certificate.
-        :param auth_type: The type of authentication (e.g.: 'userpass', 'kerberos' ...)
-        :param creds: Dictionary with credentials needed for authentication.
-        :param user_agent: Indicates the client.
-        :param vo: The VO to authenticate into.
-        :param logger: Logger object to use. If None, use the default LOG created by the module
+
+        Parameters
+        ----------
+        rucio_host : str, optional
+            The address of the rucio server, if None it is read from the config file.
+        auth_host : str, optional
+            The address of the rucio authentication server, if None it is read from the config file.
+        account : str, optional
+            The account to authenticate to rucio.
+        ca_cert : str, optional
+            The path to the rucio server certificate.
+        auth_type : str, optional
+            The type of authentication (e.g.: 'userpass', 'kerberos' ...)
+        creds : dict, optional
+            Dictionary with credentials needed for authentication.
+        timeout : int, optional
+            Timeout for requests.
+        user_agent : str, optional
+            Indicates the client.
+        vo : str, optional
+            The VO to authenticate into.
+        logger : Logger, optional
+            Logger object to use. If None, use the default LOG created by the module.
         """
 
         self.logger = logger

--- a/lib/rucio/client/client.py
+++ b/lib/rucio/client/client.py
@@ -58,63 +58,71 @@ class Client(AccountClient,
              LifetimeClient):
 
     """
-        Main client class for accessing Rucio resources. Handles the authentication.
+    Main client class for accessing Rucio resources. Handles the authentication.
 
-        Note:
-            Used to access all client methods. Each entity client *can* be used to access methods, but using the main client class is recommended for ease of use.
+    Note:
+    ------
+        Used to access all client methods. Each entity client *can* be used to access methods, but using the main client class is recommended for ease of use.
 
-    For using general methods -
+
+    Example:
+    -------
+        from rucio.client import Client
+
+        client = Client()  # authenticate with config or environ settings
+        client.add_replication_rule(...)
+
+        client = Client(
+            rucio_host = "my_host",
+            auth_host = "my_auth_host",
+            account = "jdoe12345",
+            auth_type = "userpass",
+            creds = {
+                "username": "jdoe12345",
+                "password": "******",
+            }
+        ) # authenticate with kwargs
+        client.list_replicas(...)
 
 
-    ```
-    from rucio.client import Client
+        # For using the upload and download clients
 
-    client = Client()  # authenticate with config or environ settings
-    client.add_replication_rule(...)
+        from rucio.client import Client
+        from rucio.client.uploadclient import UploadClient
+        from rucio.client.downloadclient import DownloadClient
 
-    client = Client(
-        rucio_host = "my_host",
-        auth_host = "my_auth_host",
-        account = "jdoe12345",
-        auth_type = "userpass",
-        creds = {
-            "username": "jdoe12345",
-            "password": "******",
-        }
-    ) # authenticate with kwargs
-    client.list_replicas(...)
-    ```
+        client = Client(...) # Initialize a client using your preferred method
 
-    For using the upload and download clients -
+        upload_client = UploadClient(client) # Pass forward the initialized client
+        upload_client.upload(items=...)
 
-    ```
-    from rucio.client import Client
-    from rucio.client.uploadclient import UploadClient
-    from rucio.client.downloadclient import DownloadClient
-
-    client = Client(...) # Initialize a client using your preferred method
-
-    upload_client = UploadClient(client) # Pass forward the initialized client
-    upload_client.upload(items=...)
-
-    download_client = DownloadClient(client)
-    download_client.download_dids(items=...)
-    ```
-
+        download_client = DownloadClient(client)
+        download_client.download_dids(items=...)
     """
 
     def __init__(self, **args):
         """
         Constructor for the Rucio main client class.
 
-        :param rucio_host: the host of the rucio system.
-        :param auth_host: the host of the rucio authentication server.
-        :param account: the rucio account that should be used to interact with the rucio system.
-        :param ca_cert: the certificate to verify the server.
-        :param auth_type: the type of authentication to use (e.g. userpass, x509 ...)
-        :param creds: credentials needed for authentication.
-        :param timeout: Float describes the timeout of the request (in seconds).
-        :param vo: The vo that the client will interact with.
-        :param logger: Logger instance to use (optional)
+        Parameters
+        ----------
+        rucio_host : str
+            The host of the rucio system.
+        auth_host : str
+            The host of the rucio authentication server.
+        account : str
+            The rucio account that should be used to interact with the rucio system.
+        ca_cert : str
+            The certificate to verify the server.
+        auth_type : str
+            The type of authentication to use (e.g. userpass, x509 ...).
+        creds : dict
+            Credentials needed for authentication.
+        timeout : float
+            Describes the timeout of the request (in seconds).
+        vo : str
+            The vo that the client will interact with.
+        logger : logging.Logger, optional
+            Logger instance to use.
         """
         super(Client, self).__init__(**args)

--- a/lib/rucio/client/client.py
+++ b/lib/rucio/client/client.py
@@ -106,23 +106,23 @@ class Client(AccountClient,
 
         Parameters
         ----------
-        rucio_host : str
+        rucio_host :
             The host of the rucio system.
-        auth_host : str
+        auth_host :
             The host of the rucio authentication server.
-        account : str
+        account :
             The rucio account that should be used to interact with the rucio system.
-        ca_cert : str
+        ca_cert :
             The certificate to verify the server.
-        auth_type : str
+        auth_type :
             The type of authentication to use (e.g. userpass, x509 ...).
-        creds : dict
+        creds :
             Credentials needed for authentication.
-        timeout : float
+        timeout :
             Describes the timeout of the request (in seconds).
-        vo : str
+        vo :
             The vo that the client will interact with.
-        logger : logging.Logger, optional
+        logger :
             Logger instance to use.
         """
         super(Client, self).__init__(**args)

--- a/lib/rucio/client/configclient.py
+++ b/lib/rucio/client/configclient.py
@@ -37,9 +37,9 @@ class ConfigClient(BaseClient):
 
         Parameters
         ----------
-        section : str, optional
+        section :
             The name of the section.
-        option : str, optional
+        option :
             The option within the section.
         """
 
@@ -73,13 +73,13 @@ class ConfigClient(BaseClient):
 
         Parameters
         ----------
-        section : str
+        section :
             The name of the section.
-        option : str
+        option :
             The name of the option.
-        value : Any
+        value :
             The value to set on the config option.
-        use_body_for_params : bool, default=True
+        use_body_for_params :
             Send parameters in a json-encoded request body instead of url-encoded.
 
         Returns
@@ -126,14 +126,14 @@ class ConfigClient(BaseClient):
 
         Parameters
         ----------
-        section : str
+        section :
             The name of the section.
-        option : str
+        option :
             The name of the option.
 
         Returns
         -------
-        bool
+
             True if option was removed successfully.
         """
 

--- a/lib/rucio/client/configclient.py
+++ b/lib/rucio/client/configclient.py
@@ -35,9 +35,12 @@ class ConfigClient(BaseClient):
         """
         Sends the request to get the matching configuration.
 
-        :param section: the optional name of the section.
-        :param option: the optional option within the section.
-        :return: dictionary containing the configuration.
+        Parameters
+        ----------
+        section : str, optional
+            The name of the section.
+        option : str, optional
+            The option within the section.
         """
 
         if section is None and option is not None:
@@ -68,18 +71,30 @@ class ConfigClient(BaseClient):
         """
         Sends the request to create or set an option within a section. Missing sections will be created.
 
-        :param section: the name of the section.
-        :param option: the name of the option.
-        :param value: the value to set on the config option
-        :param use_body_for_params: send parameters in a json-encoded request body instead of url-encoded
-        TODO: remove this parameter
+        Parameters
+        ----------
+        section : str
+            The name of the section.
+        option : str
+            The name of the option.
+        value : Any
+            The value to set on the config option.
+        use_body_for_params : bool, default=True
+            Send parameters in a json-encoded request body instead of url-encoded.
+
+        Returns
+        -------
+        bool
+            True if option was set successfully.
+
+        Note:
+        ------
         The format of the /config endpoint was recently changed. We migrated from performing a PUT on
         "/config/<section>/<option>/<value>" to sending the parameters using a json-encoded body.
         This was done to fix multiple un-wanted side effects related to how the middleware treats
         values encoded in a path.
         For a smooth transition, we allow both cases for now, but we should migrate to only passing
         values via the request body.
-        :return: True if option was removed successfully. False otherwise.
         """
 
         if use_body_for_params:
@@ -107,11 +122,19 @@ class ConfigClient(BaseClient):
             option: str
     ) -> bool:
         """
-        Sends the request to remove an option from a section
+        Sends the request to remove an option from a section.
 
-        :param section: the name of the section.
-        :param option: the name of the option.
-        :return: True if option was removed successfully. False otherwise.
+        Parameters
+        ----------
+        section : str
+            The name of the section.
+        option : str
+            The name of the option.
+
+        Returns
+        -------
+        bool
+            True if option was removed successfully.
         """
 
         path = '/'.join([self.CONFIG_BASEURL, section, option])

--- a/lib/rucio/client/credentialclient.py
+++ b/lib/rucio/client/credentialclient.py
@@ -36,20 +36,20 @@ class CredentialClient(BaseClient):
 
         Parameters
         ----------
-        rse : str
+        rse :
             The name of the RSE the URL points to.
-        service : str
+        service :
             The service the URL points to (gcs, s3, swift)
-        operation : str
+        operation :
             The desired operation (read, write, delete)
-        url : str
+        url :
             The URL to sign
-        lifetime : int, optional
+        lifetime :
             The desired lifetime of the URL in seconds, by default 3600
 
         Returns
         -------
-        str
+
             The signed URL string
         """
         path = '/'.join([self.CREDENTIAL_BASEURL, 'signurl'])

--- a/lib/rucio/client/credentialclient.py
+++ b/lib/rucio/client/credentialclient.py
@@ -34,13 +34,23 @@ class CredentialClient(BaseClient):
         """
         Return a signed version of the given URL for the given operation.
 
-        :param rse: The name of the RSE the URL points to.
-        :param service: The service the URL points to (gcs, s3, swift)
-        :param operation: The desired operation (read, write, delete)
-        :param url: The URL to sign
-        :param lifetime: The desired lifetime of the URL in seconds
+        Parameters
+        ----------
+        rse : str
+            The name of the RSE the URL points to.
+        service : str
+            The service the URL points to (gcs, s3, swift)
+        operation : str
+            The desired operation (read, write, delete)
+        url : str
+            The URL to sign
+        lifetime : int, optional
+            The desired lifetime of the URL in seconds, by default 3600
 
-        :return: The signed URL string
+        Returns
+        -------
+        str
+            The signed URL string
         """
         path = '/'.join([self.CREDENTIAL_BASEURL, 'signurl'])
         params = {}

--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -45,14 +45,21 @@ class DIDClient(BaseClient):
         """
         List all data identifiers in a scope which match a given pattern.
 
-        :param scope: The scope name.
-        :param filters: A nested dictionary of key/value pairs like [{'key1': 'value1', 'key2.lte': 'value2'}, {'key3.gte, 'value3'}].
-                        Keypairs in the same dictionary are AND'ed together, dictionaries are OR'ed together. Keys should be suffixed
-                        like <key>.<operation>, e.g. key1 >= value1 is equivalent to {'key1.gte': value}, where <operation> belongs to one
-                        of the set {'lte', 'gte', 'gt', 'lt', 'ne' or ''}. Equivalence doesn't require an operator.
-        :param did_type: The type of the did: 'all'(container, dataset or file)|'collection'(dataset or container)|'dataset'|'container'|'file'
-        :param long: Long format option to display more information for each DID.
-        :param recursive: Recursively list DIDs content.
+        Parameters
+        ----------
+            scope : str
+                The scope name.
+            filters : list[dict[str, Any]]
+                A nested dictionary of key/value pairs like [{'key1': 'value1', 'key2.lte': 'value2'}, {'key3.gte, 'value3'}].
+                Keypairs in the same dictionary are AND'ed together, dictionaries are OR'ed together. Keys should be suffixed
+                like <key>.<operation>, e.g. key1 >= value1 is equivalent to {'key1.gte': value}, where <operation> belongs to one
+                of the set {'lte', 'gte', 'gt', 'lt', 'ne' or ''}. Equivalence doesn't require an operator.
+            did_type : str
+                The type of the did: 'all'(container, dataset or file)|'collection'(dataset or container)|'dataset'|'container'|'file'
+            long : bool
+                Long format option to display more information for each DID.
+            recursive : bool
+                Recursively list DIDs content.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), 'dids', 'search'])
 
@@ -103,15 +110,27 @@ class DIDClient(BaseClient):
         """
         Add data identifier for a dataset or container.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param did_type: The data identifier type (dataset|container).
-        :param statuses: Dictionary with statuses, e.g. {'monotonic':True}.
-        :param meta: Meta-data associated with the data identifier is represented using key/value pairs in a dictionary.
-        :param rules: Replication rules associated with the data identifier. A list of dictionaries, e.g., [{'copies': 2, 'rse_expression': 'TIERS1'}, ].
-        :param lifetime: DID's lifetime (in seconds).
-        :param dids: The content.
-        :param rse: The RSE name when registering replicas.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        did_type : Literal['DATASET', 'CONTAINER']
+            The data identifier type (dataset|container).
+        statuses : Mapping[str, Any], optional
+            Dictionary with statuses, e.g. {'monotonic':True}.
+        meta : Mapping[str, Any], optional
+            Meta-data associated with the data identifier is represented using key/value pairs in a dictionary.
+        rules : Sequence[Mapping[str, Any]], optional
+            Replication rules associated with the data identifier. A list of dictionaries,
+            e.g., [{'copies': 2, 'rse_expression': 'TIERS1'}, ].
+        lifetime : int, optional
+            DID's lifetime (in seconds).
+        dids : Sequence[Mapping[str, Any]], optional
+            The content.
+        rse : str, optional
+            The RSE name when registering replicas.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name)])
         url = build_url(choice(self.list_hosts), path=path)
@@ -163,14 +182,25 @@ class DIDClient(BaseClient):
         """
         Add data identifier for a dataset.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param statuses: Dictionary with statuses, e.g.g {'monotonic':True}.
-        :param meta: Meta-data associated with the data identifier is represented using key/value pairs in a dictionary.
-        :param rules: Replication rules associated with the data identifier. A list of dictionaries, e.g., [{'copies': 2, 'rse_expression': 'TIERS1'}, ].
-        :param lifetime: DID's lifetime (in seconds).
-        :param files: The content.
-        :param rse: The RSE name when registering replicas.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        statuses : Mapping[str, Any], optional
+            Dictionary with statuses, e.g. {'monotonic':True}.
+        meta : Mapping[str, Any], optional
+            Meta-data associated with the data identifier is represented using key/value pairs in a dictionary.
+        rules : Sequence[Mapping[str, Any]], optional
+            Replication rules associated with the data identifier. A list of dictionaries,
+            e.g., [{'copies': 2, 'rse_expression': 'TIERS1'}, ].
+        lifetime : int, optional
+            DID's lifetime (in seconds).
+        files : Sequence[Mapping[str, Any]], optional
+            The content.
+        rse : str, optional
+            The RSE name when registering replicas.
         """
         return self.add_did(scope=scope, name=name, did_type='DATASET',
                             statuses=statuses, meta=meta, rules=rules,
@@ -180,7 +210,10 @@ class DIDClient(BaseClient):
         """
         Bulk add datasets.
 
-        :param dsns: A list of datasets.
+        Parameters
+        ----------
+        dids : Sequence[Mapping[str, Any]]
+            A list of datasets.
         """
         return self.add_dids(dids=[dict(list(dsn.items()) + [('type', 'DATASET')]) for dsn in dsns])
 
@@ -209,7 +242,10 @@ class DIDClient(BaseClient):
         """
         Bulk add containers.
 
-        :param cnts: A list of containers.
+        Parameters
+        ----------
+        cnts : Sequence[Mapping[str, Any]]
+            A list of containers.
         """
         return self.add_dids(dids=[dict(list(cnt.items()) + [('type', 'CONTAINER')]) for cnt in cnts])
 
@@ -223,10 +259,16 @@ class DIDClient(BaseClient):
         """
         Attach data identifier.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param dids: The content.
-        :param rse: The RSE name when registering replicas.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        dids : Sequence[Mapping[str, Any]]
+            The content.
+        rse : str, optional
+            The RSE name when registering replicas.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'dids'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -247,11 +289,16 @@ class DIDClient(BaseClient):
             dids: Optional["Sequence[Mapping[str, Any]]"] = None
     ) -> bool:
         """
-        Detach data identifier
+        Detach data identifier.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param dids: The content.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        dids : Sequence[Mapping[str, Any]], optional
+            The content.
         """
 
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'dids'])
@@ -271,11 +318,14 @@ class DIDClient(BaseClient):
         """
         Add dids to dids.
 
-        :param attachments: The attachments.
-            attachments is: [attachment, attachment, ...]
-            attachment is: {'scope': scope, 'name': name, 'dids': dids}
+        Parameters
+        ----------
+        attachments : Sequence[dict[str, Union[str, Sequence[dict[str, Any]]]]]
+            The attachments.
+            An attachment contains: "scope", "name", "dids".
             dids is: [{'scope': scope, 'name': name}, ...]
-        :param ignore_duplicate: If True, ignore duplicate entries.
+        ignore_duplicate : bool, optional
+            If True, ignore duplicate entries.
         """
         path = '/'.join([self.DIDS_BASEURL, 'attachments'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -295,11 +345,14 @@ class DIDClient(BaseClient):
         """
         Add files to datasets.
 
-        :param attachments: The attachments.
-            attachments is: [attachment, attachment, ...]
-            attachment is: {'scope': scope, 'name': name, 'dids': dids}
+        Parameters
+        ----------
+        attachments : Sequence[dict[str, Union[str, Sequence[dict[str, Any]]]]]
+            The attachments.
+            An attachment contains: "scope", "name", "dids".
             dids is: [{'scope': scope, 'name': name}, ...]
-        :param ignore_duplicate: If True, ignore duplicate entries.
+        ignore_duplicate : bool, optional
+            If True, ignore duplicate entries.
         """
         return self.attach_dids_to_dids(attachments=attachments,
                                         ignore_duplicate=ignore_duplicate)
@@ -311,9 +364,11 @@ class DIDClient(BaseClient):
         """
         Add datasets_to_containers.
 
-        :param attachments: The attachments.
-            attachments is: [attachment, attachment, ...]
-            attachment is: {'scope': scope, 'name': name, 'dids': dids}
+        Parameters
+        ----------
+        attachments : Sequence[dict[str, Union[str, Sequence[dict[str, Any]]]]]
+            The attachments.
+            An attachment contains: "scope", "name", "dids".
             dids is: [{'scope': scope, 'name': name}, ...]
         """
         return self.attach_dids_to_dids(attachments=attachments)
@@ -325,9 +380,11 @@ class DIDClient(BaseClient):
         """
         Add containers_to_containers.
 
-        :param attachments: The attachments.
-            attachments is: [attachment, attachment, ...]
-            attachment is: {'scope': scope, 'name': name, 'dids': dids}
+        Parameters
+        ----------
+        attachments : Sequence[dict[str, Union[str, Sequence[dict[str, Any]]]]]
+            The attachments.
+            An attachment contains: "scope", "name", "dids".
             dids is: [{'scope': scope, 'name': name}, ...]
         """
         return self.attach_dids_to_dids(attachments=attachments)
@@ -342,10 +399,16 @@ class DIDClient(BaseClient):
         """
         Add files to datasets.
 
-        :param scope: The scope name.
-        :param name: The dataset name.
-        :param files: The content.
-        :param rse: The RSE name when registering replicas.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The dataset name.
+        files : Sequence[Mapping[str, Any]]
+            The content.
+        rse : str, optional
+            The RSE name when registering replicas.
         """
         return self.attach_dids(scope=scope, name=name, dids=files, rse=rse)
 
@@ -358,9 +421,14 @@ class DIDClient(BaseClient):
         """
         Add files to archive.
 
-        :param scope: The scope name.
-        :param name: The dataset name.
-        :param files: The content.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The dataset name.
+        files : Sequence[Mapping[str, Any]]
+            The content.
         """
         return self.attach_dids(scope=scope, name=name, dids=files)
 
@@ -373,9 +441,14 @@ class DIDClient(BaseClient):
         """
         Add datasets to container.
 
-        :param scope: The scope name.
-        :param name: The dataset name.
-        :param dsns: The content.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The dataset name.
+        dsns : Sequence[Mapping[str, Any]]
+            The content.
         """
         return self.attach_dids(scope=scope, name=name, dids=dsns)
 
@@ -388,9 +461,14 @@ class DIDClient(BaseClient):
         """
         Add containers to container.
 
-        :param scope: The scope name.
-        :param name: The dataset name.
-        :param cnts: The content.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The dataset name.
+        cnts : Sequence[Mapping[str, Any]]
+            The content.
         """
         return self.attach_dids(scope=scope, name=name, dids=cnts)
 
@@ -402,8 +480,12 @@ class DIDClient(BaseClient):
         """
         List data identifier contents.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
         """
 
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'dids'])
@@ -443,9 +525,14 @@ class DIDClient(BaseClient):
         """
         List data identifier file contents.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param long: A boolean to choose if GUID is returned or not.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        long : bool, optional
+            A boolean to choose if GUID is returned or not.
         """
 
         payload = {}
@@ -465,7 +552,10 @@ class DIDClient(BaseClient):
         """
         List data identifier file contents.
 
-        :param dids: The list of DIDs.
+        Parameters
+        ----------
+        dids : list[dict[str, Any]]
+            The list of DIDs.
         """
 
         data = {'dids': dids}
@@ -489,11 +579,17 @@ class DIDClient(BaseClient):
         """
         Retrieve a single data identifier.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param dynamic_depth: The DID type as string ('FILE'/'DATASET') at which to stop the dynamic
-        length/bytes calculation. If not set, the size will not be computed dynamically.
-        :param dynamic: (Deprecated) same as dynamic_depth = 'FILE'
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        dynamic_depth : str, optional
+            The DID type ('FILE'/'DATASET') at which to stop the dynamic
+            length/bytes calculation. If not set, the size will not be computed dynamically.
+        dynamic : bool, optional
+            Deprecated. Same as setting dynamic_depth='FILE'.
         """
 
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name)])
@@ -517,11 +613,16 @@ class DIDClient(BaseClient):
             plugin: str = 'DID_COLUMN'
     ) -> dict[str, Any]:
         """
-        Get data identifier metadata
+        Get data identifier metadata.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param plugin: Backend Metadata plugin the Rucio server should use to query data.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        plugin : str, default='DID_COLUMN'
+            Backend Metadata plugin the Rucio server should use to query data.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'meta'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -565,13 +666,20 @@ class DIDClient(BaseClient):
             recursive: bool = False
     ) -> bool:
         """
-        Set data identifier metadata
+        Set data identifier metadata.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param key: the key.
-        :param value: the value.
-        :param recursive: Option to propagate the metadata change to content.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        key : str
+            The metadata key.
+        value : Any
+            The metadata value.
+        recursive : bool, default=False
+            Option to propagate the metadata change to content.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'meta', key])
         url = build_url(choice(self.list_hosts), path=path)
@@ -593,10 +701,16 @@ class DIDClient(BaseClient):
         """
         Set data identifier metadata in bulk.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param meta: the metadata key-values.
-        :param recursive: Option to propagate the metadata change to content.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        meta : Mapping[str, Any]
+            The metadata key-value pairs.
+        recursive : bool, default=False
+            Option to propagate the metadata change to content.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'meta'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -616,8 +730,13 @@ class DIDClient(BaseClient):
         """
         Set metadata to a list of data identifiers.
 
-        :param dids: A list of dids including metadata, i.e. [{'scope': scope1, 'name': name1, 'meta': {key1: value1, key2: value2}] .
-        :param recursive: Option to propagate the metadata update to content.
+        Parameters
+        ----------
+        dids : Sequence[Mapping[str, Any]]
+            A list of dids including metadata, i.e.
+            [{'scope': scope1, 'name': name1, 'meta': {key1: value1, key2: value2}}, ...].
+        recursive : bool, default=False
+            Option to propagate the metadata update to content.
         """
         path = '/'.join([self.DIDS_BASEURL, 'bulkdidsmeta'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -636,11 +755,16 @@ class DIDClient(BaseClient):
             **kwargs
     ) -> bool:
         """
-        Set data identifier status
+        Set data identifier status.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param kwargs:  Keyword arguments of the form status_name=value.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        **kwargs
+            Keyword arguments of the form status_name=value.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'status'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -658,10 +782,14 @@ class DIDClient(BaseClient):
             name: str
     ) -> bool:
         """
-        close dataset/container
+        Close dataset/container.
 
-        :param scope: The scope name.
-        :param name: The dataset/container name.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The dataset/container name.
         """
         return self.set_status(scope=scope, name=name, open=False)
 
@@ -672,11 +800,16 @@ class DIDClient(BaseClient):
             key: str
     ) -> bool:
         """
-        Delete data identifier metadata
+        Delete data identifier metadata.
 
-        :param scope: The scope name.
-        :param name: The data identifier.
-        :param key: the key.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        key : str
+            The metadata key to be deleted.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'meta'])
         url = build_url(choice(self.list_hosts), path=path, params={'key': key})
@@ -717,8 +850,12 @@ class DIDClient(BaseClient):
         """
         List the associated rules a file is affected from..
 
-        :param scope: The scope name.
-        :param name:  The file name.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
         """
 
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'associated_rules'])
@@ -733,9 +870,16 @@ class DIDClient(BaseClient):
     def get_dataset_by_guid(self, guid: str) -> "Iterator[dict[str, Any]]":
         """
         Get the parent datasets for a given GUID.
-        :param guid: The GUID.
 
-        :returns: A did
+        Parameters
+        ----------
+        guid : str
+            The GUID.
+
+        Returns
+        -------
+        Iterator[dict[str, Any]]
+            A did
         """
 
         path = '/'.join([self.DIDS_BASEURL, guid, 'guid'])
@@ -756,9 +900,14 @@ class DIDClient(BaseClient):
         """
         List data identifiers in a scope.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param recursive: boolean, True or False.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
+        recursive : bool
+            ''
         """
 
         payload = {}
@@ -784,8 +933,12 @@ class DIDClient(BaseClient):
         """
         List parent dataset/containers of a did.
 
-        :param scope: The scope.
-        :param name:  The name.
+        Parameters
+        ----------
+        scope : str
+            The scope.
+        name : str
+            The name,
         """
 
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'parents'])
@@ -809,12 +962,18 @@ class DIDClient(BaseClient):
         """
         Create a sample from an input collection.
 
-        :param input_scope: The scope of the input DID.
-        :param input_name: The name of the input DID.
-        :param output_scope: The scope of the output dataset.
-        :param output_name: The name of the output dataset.
-        :param account: The account.
-        :param nbfiles: The number of files to register in the output dataset.
+        Parameters
+        ----------
+        input_scope : str
+            The scope of the input DID.
+        input_name : str
+            The name of the input DID.
+        output_scope : str
+            The scope of the output dataset.
+        output_name : str
+            The name of the output dataset.
+        nbfiles : int
+            The number of files to register in the output dataset.
         """
         path = '/'.join([self.DIDS_BASEURL, 'sample'])
         data = dumps({
@@ -836,7 +995,10 @@ class DIDClient(BaseClient):
         """
         Resurrect a list of dids.
 
-        :param dids:  A list of dids [{'scope': scope, 'name': name}, ...]
+        Parameters
+        ----------
+        dids: Sequence[Mapping[str, Any]]
+            A list of dids [{'scope': scope, 'name': name}, ...]
         """
         path = '/'.join([self.DIDS_BASEURL, 'resurrect'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -854,9 +1016,12 @@ class DIDClient(BaseClient):
     ) -> "Iterator[dict[str, Any]]":
         """
         List archive contents.
-
-        :param scope: The scope name.
-        :param name: The data identifier name.
+        Parameters
+        ----------
+        scope : str
+            The scope name.
+        name : str
+            The data identifier name.
         """
         path = '/'.join([self.ARCHIVES_BASEURL, quote_plus(scope), quote_plus(name), 'files'])
         url = build_url(choice(self.list_hosts), path=path)

--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -212,7 +212,7 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        dids :
+        dsns :
             A list of datasets.
         """
         return self.add_dids(dids=[dict(list(dsn.items()) + [('type', 'DATASET')]) for dsn in dsns])
@@ -930,7 +930,7 @@ class DIDClient(BaseClient):
         name :
             The data identifier name.
         recursive :
-            ''
+            boolean, True or False.
         """
 
         payload = {}

--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -47,18 +47,18 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-            scope : str
+            scope :
                 The scope name.
-            filters : list[dict[str, Any]]
+            filters :
                 A nested dictionary of key/value pairs like [{'key1': 'value1', 'key2.lte': 'value2'}, {'key3.gte, 'value3'}].
                 Keypairs in the same dictionary are AND'ed together, dictionaries are OR'ed together. Keys should be suffixed
                 like <key>.<operation>, e.g. key1 >= value1 is equivalent to {'key1.gte': value}, where <operation> belongs to one
                 of the set {'lte', 'gte', 'gt', 'lt', 'ne' or ''}. Equivalence doesn't require an operator.
-            did_type : str
+            did_type :
                 The type of the did: 'all'(container, dataset or file)|'collection'(dataset or container)|'dataset'|'container'|'file'
-            long : bool
+            long :
                 Long format option to display more information for each DID.
-            recursive : bool
+            recursive :
                 Recursively list DIDs content.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), 'dids', 'search'])
@@ -112,24 +112,24 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
-        did_type : Literal['DATASET', 'CONTAINER']
+        did_type :
             The data identifier type (dataset|container).
-        statuses : Mapping[str, Any], optional
+        statuses :
             Dictionary with statuses, e.g. {'monotonic':True}.
-        meta : Mapping[str, Any], optional
+        meta :
             Meta-data associated with the data identifier is represented using key/value pairs in a dictionary.
-        rules : Sequence[Mapping[str, Any]], optional
+        rules :
             Replication rules associated with the data identifier. A list of dictionaries,
             e.g., [{'copies': 2, 'rse_expression': 'TIERS1'}, ].
-        lifetime : int, optional
+        lifetime :
             DID's lifetime (in seconds).
-        dids : Sequence[Mapping[str, Any]], optional
+        dids :
             The content.
-        rse : str, optional
+        rse :
             The RSE name when registering replicas.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name)])
@@ -184,22 +184,22 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
-        statuses : Mapping[str, Any], optional
+        statuses :
             Dictionary with statuses, e.g. {'monotonic':True}.
-        meta : Mapping[str, Any], optional
+        meta :
             Meta-data associated with the data identifier is represented using key/value pairs in a dictionary.
-        rules : Sequence[Mapping[str, Any]], optional
+        rules :
             Replication rules associated with the data identifier. A list of dictionaries,
             e.g., [{'copies': 2, 'rse_expression': 'TIERS1'}, ].
-        lifetime : int, optional
+        lifetime :
             DID's lifetime (in seconds).
-        files : Sequence[Mapping[str, Any]], optional
+        files :
             The content.
-        rse : str, optional
+        rse :
             The RSE name when registering replicas.
         """
         return self.add_did(scope=scope, name=name, did_type='DATASET',
@@ -212,7 +212,7 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        dids : Sequence[Mapping[str, Any]]
+        dids :
             A list of datasets.
         """
         return self.add_dids(dids=[dict(list(dsn.items()) + [('type', 'DATASET')]) for dsn in dsns])
@@ -229,12 +229,21 @@ class DIDClient(BaseClient):
         """
         Add data identifier for a container.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
-        :param statuses: Dictionary with statuses, e.g.g {'monotonic':True}.
-        :param meta: Meta-data associated with the data identifier is represented using key/value pairs in a dictionary.
-        :param rules: Replication rules associated with the data identifier. A list of dictionaries, e.g., [{'copies': 2, 'rse_expression': 'TIERS1'}, ].
-        :param lifetime: DID's lifetime (in seconds).
+        Parameters
+        ----------
+        scope :
+            The scope name.
+        name :
+            The data identifier name.
+        statuses :
+            Dictionary with statuses, e.g. {'monotonic':True}.
+        meta :
+            Meta-data associated with the data identifier is represented using key/value pairs in a dictionary.
+        rules :
+            Replication rules associated with the data identifier. A list of dictionaries,
+            e.g., [{'copies': 2, 'rse_expression': 'TIERS1'}, ].
+        lifetime :
+            DID's lifetime (in seconds).
         """
         return self.add_did(scope=scope, name=name, did_type='CONTAINER', statuses=statuses, meta=meta, rules=rules, lifetime=lifetime)
 
@@ -244,7 +253,7 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        cnts : Sequence[Mapping[str, Any]]
+        cnts :
             A list of containers.
         """
         return self.add_dids(dids=[dict(list(cnt.items()) + [('type', 'CONTAINER')]) for cnt in cnts])
@@ -261,13 +270,13 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
-        dids : Sequence[Mapping[str, Any]]
+        dids :
             The content.
-        rse : str, optional
+        rse :
             The RSE name when registering replicas.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'dids'])
@@ -293,11 +302,11 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
-        dids : Sequence[Mapping[str, Any]], optional
+        dids :
             The content.
         """
 
@@ -320,11 +329,11 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        attachments : Sequence[dict[str, Union[str, Sequence[dict[str, Any]]]]]
+        attachments :
             The attachments.
             An attachment contains: "scope", "name", "dids".
             dids is: [{'scope': scope, 'name': name}, ...]
-        ignore_duplicate : bool, optional
+        ignore_duplicate :
             If True, ignore duplicate entries.
         """
         path = '/'.join([self.DIDS_BASEURL, 'attachments'])
@@ -347,11 +356,11 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        attachments : Sequence[dict[str, Union[str, Sequence[dict[str, Any]]]]]
+        attachments :
             The attachments.
             An attachment contains: "scope", "name", "dids".
             dids is: [{'scope': scope, 'name': name}, ...]
-        ignore_duplicate : bool, optional
+        ignore_duplicate :
             If True, ignore duplicate entries.
         """
         return self.attach_dids_to_dids(attachments=attachments,
@@ -366,7 +375,7 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        attachments : Sequence[dict[str, Union[str, Sequence[dict[str, Any]]]]]
+        attachments :
             The attachments.
             An attachment contains: "scope", "name", "dids".
             dids is: [{'scope': scope, 'name': name}, ...]
@@ -382,7 +391,7 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        attachments : Sequence[dict[str, Union[str, Sequence[dict[str, Any]]]]]
+        attachments :
             The attachments.
             An attachment contains: "scope", "name", "dids".
             dids is: [{'scope': scope, 'name': name}, ...]
@@ -401,13 +410,13 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The dataset name.
-        files : Sequence[Mapping[str, Any]]
+        files :
             The content.
-        rse : str, optional
+        rse :
             The RSE name when registering replicas.
         """
         return self.attach_dids(scope=scope, name=name, dids=files, rse=rse)
@@ -423,11 +432,11 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The dataset name.
-        files : Sequence[Mapping[str, Any]]
+        files :
             The content.
         """
         return self.attach_dids(scope=scope, name=name, dids=files)
@@ -443,11 +452,11 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The dataset name.
-        dsns : Sequence[Mapping[str, Any]]
+        dsns :
             The content.
         """
         return self.attach_dids(scope=scope, name=name, dids=dsns)
@@ -463,11 +472,11 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The dataset name.
-        cnts : Sequence[Mapping[str, Any]]
+        cnts :
             The content.
         """
         return self.attach_dids(scope=scope, name=name, dids=cnts)
@@ -482,9 +491,9 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
         """
 
@@ -504,8 +513,13 @@ class DIDClient(BaseClient):
         """
         List data identifier contents history.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
+        Parameters
+        ----------
+        scope :
+            The scope name.
+        name :
+            The data identifier name.
+
         """
 
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'dids', 'history'])
@@ -527,11 +541,11 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
-        long : bool, optional
+        long :
             A boolean to choose if GUID is returned or not.
         """
 
@@ -554,7 +568,7 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        dids : list[dict[str, Any]]
+        dids :
             The list of DIDs.
         """
 
@@ -581,14 +595,14 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
-        dynamic_depth : str, optional
+        dynamic_depth :
             The DID type ('FILE'/'DATASET') at which to stop the dynamic
             length/bytes calculation. If not set, the size will not be computed dynamically.
-        dynamic : bool, optional
+        dynamic :
             Deprecated. Same as setting dynamic_depth='FILE'.
         """
 
@@ -617,11 +631,11 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
-        plugin : str, default='DID_COLUMN'
+        plugin :
             Backend Metadata plugin the Rucio server should use to query data.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'meta'])
@@ -644,9 +658,14 @@ class DIDClient(BaseClient):
     ) -> "Iterator[dict[str, Any]]":
         """
         Bulk get data identifier metadata
-        :param dids:               A list of dids.
-        :param inherit:            A boolean. If set to true, the metadata of the parent are concatenated.
-        :param plugin:             The metadata plugin to query, 'ALL' for all available plugins
+        Parameters
+        ----------
+        dids :
+            A list of dids.
+        inherit :
+            A boolean. If set to true, the metadata of the parent are concatenated.
+        plugin :
+            The metadata plugin to query, 'ALL' for all available plugins
         """
         data = {'dids': dids, 'inherit': inherit, 'plugin': plugin}
         path = '/'.join([self.DIDS_BASEURL, 'bulkmeta'])
@@ -670,15 +689,15 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
-        key : str
+        key :
             The metadata key.
-        value : Any
+        value :
             The metadata value.
-        recursive : bool, default=False
+        recursive :
             Option to propagate the metadata change to content.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'meta', key])
@@ -703,13 +722,13 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
-        meta : Mapping[str, Any]
+        meta :
             The metadata key-value pairs.
-        recursive : bool, default=False
+        recursive :
             Option to propagate the metadata change to content.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'meta'])
@@ -732,10 +751,10 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        dids : Sequence[Mapping[str, Any]]
+        dids :
             A list of dids including metadata, i.e.
             [{'scope': scope1, 'name': name1, 'meta': {key1: value1, key2: value2}}, ...].
-        recursive : bool, default=False
+        recursive :
             Option to propagate the metadata update to content.
         """
         path = '/'.join([self.DIDS_BASEURL, 'bulkdidsmeta'])
@@ -759,9 +778,9 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
         **kwargs
             Keyword arguments of the form status_name=value.
@@ -786,9 +805,9 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The dataset/container name.
         """
         return self.set_status(scope=scope, name=name, open=False)
@@ -804,11 +823,11 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
-        key : str
+        key :
             The metadata key to be deleted.
         """
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'meta'])
@@ -829,8 +848,12 @@ class DIDClient(BaseClient):
         """
         List the associated rules of a data identifier.
 
-        :param scope: The scope name.
-        :param name: The data identifier name.
+        Parameters
+        ----------
+        scope :
+            The scope name.
+        name :
+            The data identifier name.
         """
 
         path = '/'.join([self.DIDS_BASEURL, quote_plus(scope), quote_plus(name), 'rules'])
@@ -852,9 +875,9 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
         """
 
@@ -873,12 +896,12 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        guid : str
+        guid :
             The GUID.
 
         Returns
         -------
-        Iterator[dict[str, Any]]
+
             A did
         """
 
@@ -902,11 +925,11 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
-        recursive : bool
+        recursive :
             ''
         """
 
@@ -935,9 +958,9 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope.
-        name : str
+        name :
             The name,
         """
 
@@ -964,15 +987,15 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        input_scope : str
+        input_scope :
             The scope of the input DID.
-        input_name : str
+        input_name :
             The name of the input DID.
-        output_scope : str
+        output_scope :
             The scope of the output dataset.
-        output_name : str
+        output_name :
             The name of the output dataset.
-        nbfiles : int
+        nbfiles :
             The number of files to register in the output dataset.
         """
         path = '/'.join([self.DIDS_BASEURL, 'sample'])
@@ -997,7 +1020,7 @@ class DIDClient(BaseClient):
 
         Parameters
         ----------
-        dids: Sequence[Mapping[str, Any]]
+        dids :
             A list of dids [{'scope': scope, 'name': name}, ...]
         """
         path = '/'.join([self.DIDS_BASEURL, 'resurrect'])
@@ -1018,9 +1041,9 @@ class DIDClient(BaseClient):
         List archive contents.
         Parameters
         ----------
-        scope : str
+        scope :
             The scope name.
-        name : str
+        name :
             The data identifier name.
         """
         path = '/'.join([self.ARCHIVES_BASEURL, quote_plus(scope), quote_plus(name), 'files'])

--- a/lib/rucio/client/diracclient.py
+++ b/lib/rucio/client/diracclient.py
@@ -46,11 +46,11 @@ class DiracClient(BaseClient):
 
         Parameters
         ----------
-        lfns : list
+        lfns :
             List of lfn (dictionary {'lfn': <lfn>, 'rse': <rse>, 'bytes': <bytes>, 'adler32': <adler32>, 'guid': <guid>, 'pfn': <pfn>}
-        ignore_availability : bool
+        ignore_availability :
             A boolean to ignore blocked sites.
-        parents_metadata : Mapping[str, Mapping[str, Any]]
+        parents_metadata :
             Metadata for selected hierarchy DIDs. (dictionary {'lpn': {key : value}}). Default=None
         """
         path = '/'.join([self.DIRAC_BASEURL, 'addfiles'])

--- a/lib/rucio/client/diracclient.py
+++ b/lib/rucio/client/diracclient.py
@@ -38,13 +38,20 @@ class DiracClient(BaseClient):
     ) -> Literal[True]:
         """
         Bulk add files :
-        - Create the file and replica.
-        - If doesn't exist create the dataset containing the file as well as a rule on the dataset on ANY sites.
-        - Create all the ascendants of the dataset if they do not exist
+            * Create the file and replica.
 
-        :param lfns: List of lfn (dictionary {'lfn': <lfn>, 'rse': <rse>, 'bytes': <bytes>, 'adler32': <adler32>, 'guid': <guid>, 'pfn': <pfn>}
-        :param ignore_availability: A boolean to ignore blocked sites.
-        :param parents_metadata: Metadata for selected hierarchy DIDs. (dictionary {'lpn': {key : value}}). Default=None
+            * If doesn't exist create the dataset containing the file as well as a rule on the dataset on ANY sites.
+
+            * Create all the ascendants of the dataset if they do not exist
+
+        Parameters
+        ----------
+        lfns : list
+            List of lfn (dictionary {'lfn': <lfn>, 'rse': <rse>, 'bytes': <bytes>, 'adler32': <adler32>, 'guid': <guid>, 'pfn': <pfn>}
+        ignore_availability : bool
+            A boolean to ignore blocked sites.
+        parents_metadata : Mapping[str, Mapping[str, Any]]
+            Metadata for selected hierarchy DIDs. (dictionary {'lpn': {key : value}}). Default=None
         """
         path = '/'.join([self.DIRAC_BASEURL, 'addfiles'])
         url = build_url(choice(self.list_hosts), path=path)

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -78,7 +78,7 @@ class BaseExtractionTool:
         program_name :
             the name of the archive extraction program, e.g., unzip
         useability_check_args :
-            the arguments of the extraction program to test if its installed, e.g., --version
+            the arguments of the extraction program to test if it's installed, e.g., --version
         extract_args :
             the arguments that will be passed to the program for extraction
         logger :

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -71,12 +71,19 @@ class BaseExtractionTool:
             logger: "LoggerFunction" = logging.log
     ):
         """
-        Initialises a extraction tool object
+        Initializes a extraction tool object
 
-        :param program_name: the name of the archive extraction program, e.g., unzip
-        :param useability_check_args: the arguments of the extraction program to test if its installed, e.g., --version
-        :param extract_args: the arguments that will be passed to the program for extraction
-        :param logger: optional decorated logging.log object that can be passed from the calling daemon or client.
+        Parameters
+        ----------
+        program_name: str
+            the name of the archive extraction program, e.g., unzip
+        useability_check_args: str
+            the arguments of the extraction program to test if its installed, e.g., --version
+        extract_args: str
+            the arguments that will be passed to the program for extraction
+        logger: LoggerFunction
+            optional decorated logging.log object that can be passed from the calling daemon or client.
+
         """
         self.program_name = program_name
         self.useability_check_args = useability_check_args
@@ -88,7 +95,10 @@ class BaseExtractionTool:
         """
         Checks if the extraction tool is installed and usable
 
-        :returns: True if it is usable otherwise False
+        Returns
+        -------
+        bool
+            True if it is usable otherwise False
         """
         if self.is_useable_result is not None:
             return self.is_useable_result
@@ -113,11 +123,20 @@ class BaseExtractionTool:
         """
         Calls the extraction program to extract a file from an archive
 
-        :param archive_file_path: path to the archive
-        :param file_to_extract: file name to extract from the archive
-        :param dest_dir_path: destination directory where the extracted file will be stored
+        Parameters
+        ----------
+        archive_file_path: str
+            path to the archive
+        file_to_extract: str
+            file name to extract from the archive
+        dest_dir_path: str
+            destination directory where the extracted file will be stored
 
-        :returns: True on success otherwise False
+        Returns
+        -------
+        bool
+            True on success otherwise False
+
         """
         if not self.is_useable():
             return False
@@ -148,11 +167,16 @@ class DownloadClient:
             check_pcache: bool = False
     ):
         """
-        Initialises the basic settings for an DownloadClient object
+        Initializes the basic settings for an DownloadClient object
 
-        :param client:           Optional: rucio.client.client.Client object. If None, a new object will be created.
-        :param external_traces:  Optional: reference to a list where traces can be added
-        :param logger:           Optional: logging.Logger object. If None, default logger will be used.
+        Parameters
+        ----------
+        client: Client
+            Optional: rucio.client.client.Client object. If None, a new object will be created.
+        logger: LoggerFunction
+            Optional: If None, default logger will be used.
+        external_traces: list
+            Optional: reference to a list where traces can be added
         """
         self.check_pcache = check_pcache
         if logger is None:
@@ -219,29 +243,63 @@ class DownloadClient:
         """
         Download items with a given PFN. This function can only download files, no datasets.
 
-        :param items: List of dictionaries. Each dictionary describing a file to download. Keys:
-            pfn                            - PFN string of this file
-            did                            - DID string of this file (e.g. 'scope:file.name'). Wildcards are not allowed
-            rse                            - rse name (e.g. 'CERN-PROD_DATADISK'). RSE Expressions are not allowed
-            base_dir                       - Optional: Base directory where the downloaded files will be stored. (Default: '.')
-            no_subdir                      - Optional: If true, files are written directly into base_dir. (Default: False)
-            adler32                        - Optional: The adler32 checmsum to compare the downloaded files adler32 checksum with
-            md5                            - Optional: The md5 checksum to compare the downloaded files md5 checksum with
-            transfer_timeout               - Optional: Timeout time for the download protocols. (Default: None)
-            check_local_with_filesize_only - Optional: If true, already downloaded files will not be validated by checksum.
-        :param num_threads: Suggestion of number of threads to use for the download. It will be lowered if it's too high.
-        :param trace_custom_fields: Custom key value pairs to send with the traces
-        :param traces_copy_out: reference to an external list, where the traces should be uploaded
-        :param deactivate_file_download_exceptions: Boolean, if file download exceptions shouldn't be raised
+        Parameters
+        ----------
+        items : list[dict]
+            List of dictionaries. Each dictionary describing a file to download. Dictionary keys:
+            * **pfn** : str
+                PFN string of this file
 
+            * **did** : str
+                DID string of this file (e.g. 'scope:file.name'). Wildcards are not allowed
 
-        :returns: a list of dictionaries with an entry for each file, containing the input options, the did, and the clientState
-                  clientState can be one of the following: ALREADY_DONE, DONE, FILE_NOT_FOUND, FAIL_VALIDATE, FAILED
+            * **rse** : str
+                rse name (e.g. 'CERN-PROD_DATADISK'). RSE Expressions are not allowed
 
-        :raises InputValidationError: if one of the input items is in the wrong format
-        :raises NoFilesDownloaded: if no files could be downloaded
-        :raises NotAllFilesDownloaded: if not all files could be downloaded
-        :raises RucioException: if something unexpected went wrong during the download
+            * **base_dir** : str, optional
+                Base directory where the downloaded files will be stored. Default: '.'
+
+            * **no_subdir** : bool, optional
+                If true, files are written directly into base_dir. Default: False
+
+            * **adler32** : str, optional
+                The adler32 checksum to compare the downloaded file's adler32 checksum with
+
+            * **md5** : str, optional
+                The md5 checksum to compare the downloaded file's md5 checksum with
+
+            * **transfer_timeout** : int, optional
+                Timeout time for the download protocols. Default: None
+
+            * **check_local_with_filesize_only** : bool, optional
+                If true, already downloaded files will not be validated by checksum. Default: False
+
+        num_threads : int
+            Suggestion of number of threads to use for the download. It will be lowered if it's too high.
+        trace_custom_fields : dict, optional
+            Custom key value pairs to send with the traces
+        traces_copy_out : list, optional
+            Reference to an external list, where the traces should be uploaded
+        deactivate_file_download_exceptions : bool, optional
+            If file download exceptions shouldn't be raised. Default: False
+
+        Returns
+        -------
+        list[dict]
+            A list of dictionaries with an entry for each file, containing the input options,
+            the did, and the clientState. clientState can be one of the following:
+            ALREADY_DONE, DONE, FILE_NOT_FOUND, FAIL_VALIDATE, FAILED
+
+        Raises
+        ------
+        InputValidationError
+            If one of the input items is in the wrong format
+        NoFilesDownloaded
+            If no files could be downloaded
+        NotAllFilesDownloaded
+            If not all files could be downloaded
+        RucioException
+            If something unexpected went wrong during the download
         """
         trace_custom_fields = trace_custom_fields or {}
         logger = self.logger
@@ -304,34 +362,80 @@ class DownloadClient:
         """
         Download items with given DIDs. This function can also download datasets and wildcarded DIDs.
 
-        :param items: List of dictionaries. Each dictionary describing an item to download. Keys:
-            did                            - DID string of this file (e.g. 'scope:file.name')
-            filters                        - Filter to select DIDs for download. Optional if DID is given
-            rse                            - Optional: rse name (e.g. 'CERN-PROD_DATADISK') or rse expression from where to download
-            impl                           - Optional: name of the protocol implementation to be used to download this item.
-            no_resolve_archives            - Optional: bool indicating whether archives should not be considered for download (Default: False)
-            resolve_archives               - Deprecated: Use no_resolve_archives instead
-            force_scheme                   - Optional: force a specific scheme to download this item. (Default: None)
-            base_dir                       - Optional: base directory where the downloaded files will be stored. (Default: '.')
-            no_subdir                      - Optional: If true, files are written directly into base_dir. (Default: False)
-            nrandom                        - Optional: if the DID addresses a dataset, nrandom files will be randomly chosen for download from the dataset
-            ignore_checksum                - Optional: If true, skips the checksum validation between the downloaded file and the rucio catalouge. (Default: False)
-            transfer_timeout               - Optional: Timeout time for the download protocols. (Default: None)
-            transfer_speed_timeout         - Optional: Minimum allowed transfer speed (in KBps). Ignored if transfer_timeout set. Otherwise, used to compute default timeout (Default: 500)
-            check_local_with_filesize_only - Optional: If true, already downloaded files will not be validated by checksum.
-        :param num_threads: Suggestion of number of threads to use for the download. It will be lowered if it's too high.
-        :param trace_custom_fields: Custom key value pairs to send with the traces.
-        :param traces_copy_out: reference to an external list, where the traces should be uploaded
-        :param deactivate_file_download_exceptions: Boolean, if file download exceptions shouldn't be raised
-        :param sort: Select best replica by replica sorting algorithm. Available algorithms:
-            ``geoip``       - based on src/dst IP topographical distance
+        Parameters
+        ----------
+        items : list[dict]
+            List of dictionaries. Each dictionary describing an item to download. Dictionary keys:
+            * **did** : str
+                DID string of this file (e.g. 'scope:file.name')
 
-        :returns: a list of dictionaries with an entry for each file, containing the input options, the did, and the clientState
+            * **filters** : dict, optional
+                Filter to select DIDs for download. Optional if DID is given
 
-        :raises InputValidationError: if one of the input items is in the wrong format
-        :raises NoFilesDownloaded: if no files could be downloaded
-        :raises NotAllFilesDownloaded: if not all files could be downloaded
-        :raises RucioException: if something unexpected went wrong during the download
+            * **rse** : str, optional
+                rse name (e.g. 'CERN-PROD_DATADISK') or rse expression from where to download
+
+            * **impl** : str, optional
+                name of the protocol implementation to be used to download this item
+
+            * **no_resolve_archives** : bool, optional
+                bool indicating whether archives should not be considered for download. Default: False
+
+            * **resolve_archives** : bool, optional
+                Deprecated: Use no_resolve_archives instead
+
+            * **force_scheme** : str or list[str], optional
+                force a specific scheme to download this item. Default: None
+
+            * **base_dir** : str, optional
+                base directory where the downloaded files will be stored. Default: '.'
+
+            * **no_subdir** : bool, optional
+                If true, files are written directly into base_dir. Default: False
+
+            * **nrandom** : int, optional
+                if the DID addresses a dataset, nrandom files will be randomly chosen for download from the dataset
+
+            * **ignore_checksum** : bool, optional
+                If true, skips the checksum validation between the downloaded file and the rucio catalouge. Default: False
+
+            * **transfer_timeout** : int, optional
+                Timeout time for the download protocols. Default: None
+
+            * **transfer_speed_timeout** : int, optional
+                Minimum allowed transfer speed (in KBps). Ignored if transfer_timeout set. Otherwise, used to compute default timeout. Default: 500
+
+            * **check_local_with_filesize_only** : bool, optional
+                If true, already downloaded files will not be validated by checksum. Default: False
+
+        num_threads : int
+            Suggestion of number of threads to use for the download. It will be lowered if it's too high.
+        trace_custom_fields : dict, optional
+            Custom key value pairs to send with the traces
+        traces_copy_out : list, optional
+            Reference to an external list, where the traces should be uploaded
+        deactivate_file_download_exceptions : bool, optional
+            If file download exceptions shouldn't be raised. Default: False
+        sort : str, optional
+            Select best replica by replica sorting algorithm. Available algorithms:
+            ``geoip`` - based on src/dst IP topographical distance
+
+        Returns
+        -------
+        list[dict]
+            A list of dictionaries with an entry for each file, containing the input options,
+            the did, and the clientState.
+
+        Raises
+        ------
+        InputValidationError
+            If one of the input items is in the wrong format
+        NoFilesDownloaded
+            If no files could be downloaded
+        NotAllFilesDownloaded
+            If not all files could be downloaded
+        RucioException
+            If something unexpected went wrong during the download
         """
         trace_custom_fields = trace_custom_fields or {}
         logger = self.logger
@@ -364,24 +468,51 @@ class DownloadClient:
         """
         Download items using a given metalink file.
 
-        :param item: dictionary describing an item to download. Keys:
-            base_dir                       - Optional: base directory where the downloaded files will be stored. (Default: '.')
-            no_subdir                      - Optional: If true, files are written directly into base_dir. (Default: False)
-            ignore_checksum                - Optional: If true, skips the checksum validation between the downloaded file and the rucio catalouge. (Default: False)
-            transfer_timeout               - Optional: Timeout time for the download protocols. (Default: None)
-            check_local_with_filesize_only - Optional: If true, already downloaded files will not be validated by checksum.
+        Parameters
+        ----------
+        item : dict
+            Dictionary describing an item to download. Dictionary keys:
+            * **base_dir** : str, optional
+            Base directory where the downloaded files will be stored. Default: '.'
 
-        :param num_threads: Suggestion of number of threads to use for the download. It will be lowered if it's too high.
-        :param trace_custom_fields: Custom key value pairs to send with the traces.
-        :param traces_copy_out: reference to an external list, where the traces should be uploaded
-        :param deactivate_file_download_exceptions: Boolean, if file download exceptions shouldn't be raised
+            * **no_subdir** : bool, optional
+            If true, files are written directly into base_dir. Default: False
 
-        :returns: a list of dictionaries with an entry for each file, containing the input options, the did, and the clientState
+            * **ignore_checksum** : bool, optional
+            If true, skips the checksum validation between the downloaded file and the rucio catalogue. Default: False
 
-        :raises InputValidationError: if one of the input items is in the wrong format
-        :raises NoFilesDownloaded: if no files could be downloaded
-        :raises NotAllFilesDownloaded: if not all files could be downloaded
-        :raises RucioException: if something unexpected went wrong during the download
+            * **transfer_timeout** : int, optional
+            Timeout time for the download protocols. Default: None
+
+            * **check_local_with_filesize_only** : bool, optional
+            If true, already downloaded files will not be validated by checksum. Default: False
+
+
+        num_threads : int
+            Suggestion of number of threads to use for the download. It will be lowered if it's too high.
+        trace_custom_fields : dict, optional
+            Custom key value pairs to send with the traces
+        traces_copy_out : list, optional
+            Reference to an external list, where the traces should be uploaded
+        deactivate_file_download_exceptions : bool, optional
+            If file download exceptions shouldn't be raised. Default: False
+
+        Returns
+        -------
+        list[dict]
+            A list of dictionaries with an entry for each file, containing the input options,
+            the did, and the clientState.
+
+        Raises
+        ------
+        InputValidationError
+            If one of the input items is in the wrong format
+        NoFilesDownloaded
+            If no files could be downloaded
+        NotAllFilesDownloaded
+            If not all files could be downloaded
+        RucioException
+            If something unexpected went wrong during the download
         """
         trace_custom_fields = trace_custom_fields or {}
         logger = self.logger
@@ -419,12 +550,21 @@ class DownloadClient:
         Starts an appropriate number of threads to download items from the input list.
         (This function is meant to be used as class internal only)
 
-        :param input_items: list containing the input items to download
-        :param num_threads: suggestion of how many threads should be started
-        :param trace_custom_fields: Custom key value pairs to send with the traces
-        :param traces_copy_out: reference to an external list, where the traces should be uploaded
+        Parameters
+        ----------
+        input_items : list[dict]
+            List containing the input items to download
+        num_threads : int
+            Suggestion of how many threads should be started
+        trace_custom_fields : dict, optional
+            Custom key value pairs to send with the traces
+        traces_copy_out : list, optional
+            Reference to an external list, where the traces should be uploaded
 
-        :returns: list with output items as dictionaries
+        Returns
+        -------
+        list[dict]
+            List with output items as dictionaries
         """
         trace_custom_fields = trace_custom_fields or {}
         logger = self.logger
@@ -516,8 +656,16 @@ class DownloadClient:
     def _compute_actual_transfer_timeout(item: dict[str, Any]) -> int:
         """
         Merge the two options related to timeout into the value which will be used for protocol download.
-        :param item: dictionary that describes the item to download
-        :return: timeout in seconds
+
+        Parameters
+        ----------
+        item: dict
+            Dictionary that describes the item to download
+
+        Returns
+        -------
+        int
+            Timeout in seconds
         """
         default_transfer_timeout = 360
         default_transfer_speed_timeout = 500  # KBps
@@ -553,12 +701,21 @@ class DownloadClient:
         Downloads the given item and sends traces for success/failure.
         (This function is meant to be used as class internal only)
 
-        :param item: dictionary that describes the item to download
-        :param trace: dictionary representing a pattern of trace that will be send
-        :param traces_copy_out: reference to an external list, where the traces should be uploaded
-        :param log_prefix: string that will be put at the beginning of every log message
+        Parameters
+        -----------
+        item: dict
+            Dictionary describing the item to download
+        trace: dict
+            Dictionary representing a pattern of trace that will be send
+        traces_copy_out: list
+            Reference to an external list, where the traces should be uploaded
+        log_prefix: str
+            String that will be put at the beginning of every log message
 
-        :returns: dictionary with all attributes from the input item and a clientState attribute
+        Returns
+        -------
+        dict
+            Dictionary with all attributes from the input item and a clientState attribute
         """
         logger = self.logger
         pcache = Pcache() if self.check_pcache and len(item.get('archive_items', [])) == 0 else None
@@ -820,27 +977,58 @@ class DownloadClient:
         It only can download files that are available via https/davs.
         Aria2c needs to be installed and X509_USER_PROXY needs to be set!
 
-        :param items: List of dictionaries. Each dictionary describing an item to download. Keys:
-            did                            - DID string of this file (e.g. 'scope:file.name'). Wildcards are not allowed
-            rse                            - Optional: rse name (e.g. 'CERN-PROD_DATADISK') or rse expression from where to download
-            base_dir                       - Optional: base directory where the downloaded files will be stored. (Default: '.')
-            no_subdir                      - Optional: If true, files are written directly into base_dir. (Default: False)
-            nrandom                        - Optional: if the DID addresses a dataset, nrandom files will be randomly chosen for download from the dataset
-            ignore_checksum                - Optional: If true, skips the checksum validation between the downloaded file and the rucio catalouge. (Default: False)
-            check_local_with_filesize_only - Optional: If true, already downloaded files will not be validated by checksum.
+        Parameters
+        ----------
+        items: list[dict]
+            List of dictionaries. Each dictionary describing an item to download. Dictionary keys:
+            * **did** : str
+                DID string of this file (e.g. 'scope:file.name'). Wildcards are not allowed
 
-        :param trace_custom_fields: Custom key value pairs to send with the traces
-        :param filters: dictionary containing filter options
-        :param deactivate_file_download_exceptions: Boolean, if file download exceptions shouldn't be raised
-        :param sort: Select best replica by replica sorting algorithm. Available algorithms:
-            ``geoip``       - based on src/dst IP topographical distance
+            * **rse** : str, optional
+                rse name (e.g. 'CERN-PROD_DATADISK') or rse expression from where to download
 
-        :returns: a list of dictionaries with an entry for each file, containing the input options, the did, and the clientState
+            * **base_dir** : str, optional
+                base directory where the downloaded files will be stored. (Default: '.')
 
-        :raises InputValidationError: if one of the input items is in the wrong format
-        :raises NoFilesDownloaded: if no files could be downloaded
-        :raises NotAllFilesDownloaded: if not all files could be downloaded
-        :raises RucioException: if something went wrong during the download (e.g. aria2c could not be started)
+            * **no_subdir** : bool, optional
+                If true, files are written directly into base_dir. (Default: False)
+
+            * **nrandom** : int, optional
+                if the DID addresses a dataset, nrandom files will be randomly chosen for download from the dataset
+
+            * **ignore_checksum** : bool, optional
+                If true, skips the checksum validation between the downloaded file and the rucio catalogue. (Default: False)
+
+            * **check_local_with_filesize_only** : bool, optional
+                If true, already downloaded files will not be validated by checksum. (Default: False)
+
+        trace_custom_fields : dict, optional
+            Custom key value pairs to send with the traces
+        filters : dict, optional
+            Filter to select DIDs for download
+        deactivate_file_download_exceptions : bool, optional
+            If file download exceptions shouldn't be raised. Default: False
+        sort : str, optional
+            Select best replica by replica sorting algorithm. Available algorithms:
+            * **geoip** - based on src/dst IP topographical distance
+
+        Returns
+        -------
+        list[dict]
+            A list of dictionaries with an entry for each file, containing the input options,
+            the did, and the clientState.
+
+
+        Raises
+        ------
+        InputValidationError
+            If one of the input items is in the wrong format
+        NoFilesDownloaded
+            If no files could be downloaded
+        NotAllFilesDownloaded
+            If not all files could be downloaded
+        RucioException
+            If something unexpected went wrong during the download (e.g. aria2c could not be started)
         """
         trace_custom_fields = trace_custom_fields or {}
         filters = filters or {}
@@ -880,11 +1068,20 @@ class DownloadClient:
         the RPC proxy instance.
         (This function is meant to be used as class internal only)
 
-        :param rpc_secret: the secret for the RPC proxy
+        Parameters
+        ----------
+        rpc_secret : str
+            The secret for the RPC proxy
 
-        :returns: a tuple with the process and the rpc proxy objects
+        Returns
+        -------
+        tuple
+            A tuple with the process and the rpc proxy objects
 
-        :raises RucioException: if the process or the proxy could not be created
+        Raises
+        ------
+        RucioException
+            If the process or the proxy could not be created
         """
         logger = self.logger
         from xmlrpc.client import ServerProxy as RPCServerProxy
@@ -956,12 +1153,22 @@ class DownloadClient:
         as RPC background process first and a RPC proxy is needed.
         (This function is meant to be used as class internal only)
 
-        :param items: list of dictionaries containing one dict for each file to download
-        :param aria_rcp: RPCProxy to the aria2c process
-        :param rpc_auth: the rpc authentication token
-        :param trace_custom_fields: Custom key value pairs to send with the traces
+        Parameters
+        ----------
+        items: list[dict]
+            List of dictionaries. Each dictionary describing an item to download
+        aria_rpc: RPCProxy
+            RPC proxy to the aria2c process
+        rpc_auth: str
+            The rpc authentication token
+        trace_custom_fields: dict, optional
+            Custom key value pairs to send with the traces
 
-        :returns: a list of dictionaries with an entry for each file, containing the input options, the did, and the clientState
+        Returns
+        -------
+        list[dict]
+            A list of dictionaries with an entry for each file, containing the input options,
+            the did, and the clientState.
         """
         trace_custom_fields = trace_custom_fields or {}
         logger = self.logger
@@ -1111,7 +1318,10 @@ class DownloadClient:
     def _resolve_one_item_dids(self, item: dict[str, Any]) -> "Iterator[dict[str, Any]]":
         """
         Resolve scopes or wildcard DIDs to lists of full did names:
-        :param item: One input item
+        Parameters
+        ----------
+        item: dict
+            One input item
         """
         dids = item.get('did')
         filters = item.get('filters', {})
@@ -1150,21 +1360,31 @@ class DownloadClient:
         This function takes the input items given to download_dids etc.
         and resolves the sources.
 
-        - It first performs a list_dids call to dereference any wildcards and
+        1. It first performs a list_dids call to dereference any wildcards and
         retrieve DID stats (size, length, type).
-        - Next, input items are grouped together by common list_replicas options.
+
+        2. Next, input items are grouped together by common list_replicas options.
         For each group, a single list_replicas call is performed.
-        - The resolved File DIDs with sources are finally mapped back to initial
+
+        3. The resolved File DIDs with sources are finally mapped back to initial
         input items to be able to correctly retrieve download options
         (timeout, destination directories, etc)
 
-        :param input_items: List of dictionaries. Each dictionary describing an input item
+        Parameters
+        ----------
+        input_items: list[dict]
+            List of dictionaries. Each dictionary describing an input item
 
-        :returns: a tuple:
-        - a dictionary that maps the dereferenced(w/o wildcards) input DIDs to a list of input items
-        - and a list with a dictionary for each file DID which has to be downloaded
+        Returns:
+        -------
+        tuple[dict[str, Any], list[dict[str, Any]]]
+            * a dictionary that maps the dereferenced(w/o wildcards) input DIDs to a list of input items
+            * and a list with a dictionary for each file DID which has to be downloaded
 
-        :raises InputValidationError: if one of the input items is in the wrong format
+        Raises
+        ------
+        InputValidationError
+            If one of the input items is in the wrong format
         """
         logger = self.logger
 
@@ -1372,12 +1592,22 @@ class DownloadClient:
         Optimises the amount of files to download
         (This function is meant to be used as class internal only)
 
-        :param did_to_input_items: dictionary that maps resolved input DIDs to input items
-        :param file_items: list of dictionaries. Each dictionary describes a File DID to download
+        Parameters
+        ----------
+        did_to_input_items: dict
+            dictionary that maps resolved input DIDs to input items
+        file_items: list[dict]
+            list of dictionaries. Each dictionary describes a File DID to download
 
-        :returns: list of dictionaries. Each dictionary describes an element to download
+        Returns
+        -------
+        list[dict]
+            list of dictionaries. Each dictionary describes an element to download
 
-        :raises InputValidationError: if the given input is not valid or incomplete
+        Raises
+        ------
+        InputValidationError
+            If the given input is not valid or incomplete
         """
         logger = self.logger
 
@@ -1599,11 +1829,20 @@ class DownloadClient:
         Splits a given DID string (e.g. 'scope1:name.file') into its scope and name part
         (This function is meant to be used as class internal only)
 
-        :param did_str: the DID string that will be split
+        Parameters
+        ----------
+        did_str: str
+            the DID string that will be split
 
-        :returns: the scope- and name part of the given DID
+        Returns
+        -------
+        tuple[str, str]
+            the scope- and name part of the given DID
 
-        :raises InputValidationError: if the given DID string is not valid
+        Raises
+        ------
+        InputValidationError
+            If the given DID string is not valid
         """
         did = did_str.split(':')
         if len(did) == 2:
@@ -1638,11 +1877,19 @@ class DownloadClient:
         destination directory if it's not existent.
         (This function is meant to be used as class internal only)
 
-        :param base_dir: base directory part
-        :param dest_dir_name: name of the destination directory
-        :param no_subdir: if no subdirectory should be created
+        Parameters
+        ----------
+        base_dir: str
+            base directory part
+        dest_dir_name: str
+            name of the destination directory
+        no_subdir: bool
+            if no subdirectory should be created
 
-        :returns: the absolute path of the destination directory
+        Returns
+        -------
+        str
+            the absolute path of the destination directory
         """
         # append dest_dir_name, if subdir should be used
         if dest_dir_name.startswith('/'):
@@ -1663,13 +1910,22 @@ class DownloadClient:
         Checks if all files were successfully downloaded
         (This function is meant to be used as class internal only)
 
-        :param output_items: list of dictionaries describing the downloaded files
-        :param deactivate_file_download_exceptions: Boolean, if file download exceptions shouldn't be raised
+        Parameters
+        ----------
+        output_items: list[dict]
+            list of dictionaries describing the downloaded files
+        deactivate_file_download_exceptions: bool
+            Boolean, if file download exceptions shouldn't be raised
 
-        :returns: output_items list
+        Returns
+        -------
+        list[dict[str, Any]]
+            output_items list
 
-        :raises NoFilesDownloaded:
-        :raises NotAllFilesDownloaded:
+        Raises
+        ------
+        NoFilesDownloaded
+        NotAllFilesDownloaded
         """
         success_states = [FileDownloadState.ALREADY_DONE, FileDownloadState.DONE, FileDownloadState.FOUND_IN_PCACHE]
         num_successful = 0
@@ -1692,19 +1948,28 @@ class DownloadClient:
         """
         Checks if sending trace is allowed and send the trace.
 
-        :param trace: the trace
+        Parameters
+        ----------
+        trace: dict
+            the trace to send
         """
         if self.tracing:
             send_trace(trace, self.client.trace_host, self.client.user_agent)
 
     def preferred_impl(self, sources: list[dict[str, Any]]) -> Optional[str]:
         """
-            Finds the optimum protocol impl preferred by the client and
-            supported by the remote RSE.
+        Finds the optimum protocol impl preferred by the client and
+        supported by the remote RSE.
 
-            :param sources: List of sources for a given DID
+        Parameters
+        ----------
+        sources: list[dict[str, Any]]
+            List of sources for a given DID
 
-            :raises RucioException(msg): general exception with msg for more details.
+        Raises
+        -------
+        RucioException
+            General exception with msg for more details
         """
 
         preferred_protocols = []

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -75,13 +75,13 @@ class BaseExtractionTool:
 
         Parameters
         ----------
-        program_name: str
+        program_name :
             the name of the archive extraction program, e.g., unzip
-        useability_check_args: str
+        useability_check_args :
             the arguments of the extraction program to test if its installed, e.g., --version
-        extract_args: str
+        extract_args :
             the arguments that will be passed to the program for extraction
-        logger: LoggerFunction
+        logger :
             optional decorated logging.log object that can be passed from the calling daemon or client.
 
         """
@@ -97,7 +97,6 @@ class BaseExtractionTool:
 
         Returns
         -------
-        bool
             True if it is usable otherwise False
         """
         if self.is_useable_result is not None:
@@ -125,16 +124,15 @@ class BaseExtractionTool:
 
         Parameters
         ----------
-        archive_file_path: str
+        archive_file_path :
             path to the archive
-        file_to_extract: str
+        file_to_extract :
             file name to extract from the archive
-        dest_dir_path: str
+        dest_dir_pat :
             destination directory where the extracted file will be stored
 
         Returns
         -------
-        bool
             True on success otherwise False
 
         """
@@ -171,11 +169,11 @@ class DownloadClient:
 
         Parameters
         ----------
-        client: Client
+        client :
             Optional: rucio.client.client.Client object. If None, a new object will be created.
-        logger: LoggerFunction
+        logger :
             Optional: If None, default logger will be used.
-        external_traces: list
+        external_traces :
             Optional: reference to a list where traces can be added
         """
         self.check_pcache = check_pcache
@@ -1920,7 +1918,7 @@ class DownloadClient:
         ----------
         output_items:
             list of dictionaries describing the downloaded files
-        deactivate_file_download_exceptions: bool
+        deactivate_file_download_exceptions :
             Boolean, if file download exceptions shouldn't be raised
 
         Returns

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -664,7 +664,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        item:
+        item :
             Dictionary that describes the item to download
 
         Returns
@@ -1160,13 +1160,13 @@ class DownloadClient:
 
         Parameters
         ----------
-        items:
+        items :
             List of dictionaries. Each dictionary describing an item to download
-        aria_rpc:
+        aria_rpc :
             RPC proxy to the aria2c process
-        rpc_auth:
+        rpc_auth :
             The rpc authentication token
-        trace_custom_fields:
+        trace_custom_fields :
             Custom key value pairs to send with the traces
 
         Returns
@@ -1323,9 +1323,10 @@ class DownloadClient:
     def _resolve_one_item_dids(self, item: dict[str, Any]) -> "Iterator[dict[str, Any]]":
         """
         Resolve scopes or wildcard DIDs to lists of full did names:
+        
         Parameters
         ----------
-        item:
+        item :
             One input item
         """
         dids = item.get('did')
@@ -1377,7 +1378,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        input_items:
+        input_items :
             List of dictionaries. Each dictionary describing an input item
 
         Returns:
@@ -1598,9 +1599,9 @@ class DownloadClient:
 
         Parameters
         ----------
-        did_to_input_items:
+        did_to_input_items :
             dictionary that maps resolved input DIDs to input items
-        file_items:
+        file_items :
             list of dictionaries. Each dictionary describes a File DID to download
 
         Returns
@@ -1835,7 +1836,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        did_str:
+        did_str :
             the DID string that will be split
 
         Returns
@@ -1883,11 +1884,11 @@ class DownloadClient:
 
         Parameters
         ----------
-        base_dir:
+        base_dir :
             base directory part
-        dest_dir_name:
+        dest_dir_name :
             name of the destination directory
-        no_subdir:
+        no_subdir :
             if no subdirectory should be created
 
         Returns
@@ -1916,7 +1917,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        output_items:
+        output_items :
             list of dictionaries describing the downloaded files
         deactivate_file_download_exceptions :
             Boolean, if file download exceptions shouldn't be raised
@@ -1954,7 +1955,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        trace:
+        trace :
             the trace to send
         """
         if self.tracing:
@@ -1967,7 +1968,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        sources:
+        sources :
             List of sources for a given DID
 
         Raises

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -245,7 +245,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        items : list[dict]
+        items :
             List of dictionaries. Each dictionary describing a file to download. Dictionary keys:
             * **pfn** : str
                 PFN string of this file
@@ -274,18 +274,18 @@ class DownloadClient:
             * **check_local_with_filesize_only** : bool, optional
                 If true, already downloaded files will not be validated by checksum. Default: False
 
-        num_threads : int
+        num_threads :
             Suggestion of number of threads to use for the download. It will be lowered if it's too high.
-        trace_custom_fields : dict, optional
+        trace_custom_fields :
             Custom key value pairs to send with the traces
-        traces_copy_out : list, optional
+        traces_copy_out :
             Reference to an external list, where the traces should be uploaded
-        deactivate_file_download_exceptions : bool, optional
+        deactivate_file_download_exceptions :
             If file download exceptions shouldn't be raised. Default: False
 
         Returns
         -------
-        list[dict]
+
             A list of dictionaries with an entry for each file, containing the input options,
             the did, and the clientState. clientState can be one of the following:
             ALREADY_DONE, DONE, FILE_NOT_FOUND, FAIL_VALIDATE, FAILED
@@ -364,7 +364,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        items : list[dict]
+        items :
             List of dictionaries. Each dictionary describing an item to download. Dictionary keys:
             * **did** : str
                 DID string of this file (e.g. 'scope:file.name')
@@ -408,21 +408,21 @@ class DownloadClient:
             * **check_local_with_filesize_only** : bool, optional
                 If true, already downloaded files will not be validated by checksum. Default: False
 
-        num_threads : int
+        num_threads :
             Suggestion of number of threads to use for the download. It will be lowered if it's too high.
-        trace_custom_fields : dict, optional
+        trace_custom_fields :
             Custom key value pairs to send with the traces
-        traces_copy_out : list, optional
+        traces_copy_out :
             Reference to an external list, where the traces should be uploaded
-        deactivate_file_download_exceptions : bool, optional
+        deactivate_file_download_exceptions :
             If file download exceptions shouldn't be raised. Default: False
-        sort : str, optional
+        sort :
             Select best replica by replica sorting algorithm. Available algorithms:
             ``geoip`` - based on src/dst IP topographical distance
 
         Returns
         -------
-        list[dict]
+
             A list of dictionaries with an entry for each file, containing the input options,
             the did, and the clientState.
 
@@ -470,7 +470,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        item : dict
+        item :
             Dictionary describing an item to download. Dictionary keys:
             * **base_dir** : str, optional
             Base directory where the downloaded files will be stored. Default: '.'
@@ -488,18 +488,18 @@ class DownloadClient:
             If true, already downloaded files will not be validated by checksum. Default: False
 
 
-        num_threads : int
+        num_threads :
             Suggestion of number of threads to use for the download. It will be lowered if it's too high.
-        trace_custom_fields : dict, optional
+        trace_custom_fields :
             Custom key value pairs to send with the traces
-        traces_copy_out : list, optional
+        traces_copy_out :
             Reference to an external list, where the traces should be uploaded
-        deactivate_file_download_exceptions : bool, optional
+        deactivate_file_download_exceptions :
             If file download exceptions shouldn't be raised. Default: False
 
         Returns
         -------
-        list[dict]
+
             A list of dictionaries with an entry for each file, containing the input options,
             the did, and the clientState.
 
@@ -552,18 +552,18 @@ class DownloadClient:
 
         Parameters
         ----------
-        input_items : list[dict]
+        input_items :
             List containing the input items to download
-        num_threads : int
+        num_threads :
             Suggestion of how many threads should be started
-        trace_custom_fields : dict, optional
+        trace_custom_fields :
             Custom key value pairs to send with the traces
-        traces_copy_out : list, optional
+        traces_copy_out :
             Reference to an external list, where the traces should be uploaded
 
         Returns
         -------
-        list[dict]
+
             List with output items as dictionaries
         """
         trace_custom_fields = trace_custom_fields or {}
@@ -623,11 +623,18 @@ class DownloadClient:
         downloads them and stores the output in the output queue.
         (This function is meant to be used as class internal only)
 
-        :param input_queue: queue containing the input items to download
-        :param output_queue: queue where the output items will be stored
-        :param trace_custom_fields: Custom key value pairs to send with the traces
-        :param traces_copy_out: reference to an external list, where the traces should be uploaded
-        :param log_prefix: string that will be put at the beginning of every log message
+        Parameters
+        ----------
+        input_queue :
+            Queue containing the input items to download
+        output_queue :
+            Queue where the output items will be stored
+        trace_custom_fields :
+            Custom key value pairs to send with the traces
+        traces_copy_out :
+            Reference to an external list, where the traces should be uploaded
+        log_prefix :
+            String that will be put at the beginning of every log message
         """
         logger = self.logger
 
@@ -659,12 +666,12 @@ class DownloadClient:
 
         Parameters
         ----------
-        item: dict
+        item:
             Dictionary that describes the item to download
 
         Returns
         -------
-        int
+
             Timeout in seconds
         """
         default_transfer_timeout = 360
@@ -703,18 +710,18 @@ class DownloadClient:
 
         Parameters
         -----------
-        item: dict
+        item :
             Dictionary describing the item to download
-        trace: dict
+        trace :
             Dictionary representing a pattern of trace that will be send
-        traces_copy_out: list
+        traces_copy_out :
             Reference to an external list, where the traces should be uploaded
-        log_prefix: str
+        log_prefix :
             String that will be put at the beginning of every log message
 
         Returns
         -------
-        dict
+
             Dictionary with all attributes from the input item and a clientState attribute
         """
         logger = self.logger
@@ -979,7 +986,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        items: list[dict]
+        items :
             List of dictionaries. Each dictionary describing an item to download. Dictionary keys:
             * **did** : str
                 DID string of this file (e.g. 'scope:file.name'). Wildcards are not allowed
@@ -1002,19 +1009,19 @@ class DownloadClient:
             * **check_local_with_filesize_only** : bool, optional
                 If true, already downloaded files will not be validated by checksum. (Default: False)
 
-        trace_custom_fields : dict, optional
+        trace_custom_fields :
             Custom key value pairs to send with the traces
-        filters : dict, optional
+        filters :
             Filter to select DIDs for download
-        deactivate_file_download_exceptions : bool, optional
+        deactivate_file_download_exceptions :
             If file download exceptions shouldn't be raised. Default: False
-        sort : str, optional
+        sort :
             Select best replica by replica sorting algorithm. Available algorithms:
             * **geoip** - based on src/dst IP topographical distance
 
         Returns
         -------
-        list[dict]
+
             A list of dictionaries with an entry for each file, containing the input options,
             the did, and the clientState.
 
@@ -1070,12 +1077,12 @@ class DownloadClient:
 
         Parameters
         ----------
-        rpc_secret : str
+        rpc_secret :
             The secret for the RPC proxy
 
         Returns
         -------
-        tuple
+
             A tuple with the process and the rpc proxy objects
 
         Raises
@@ -1155,18 +1162,18 @@ class DownloadClient:
 
         Parameters
         ----------
-        items: list[dict]
+        items:
             List of dictionaries. Each dictionary describing an item to download
-        aria_rpc: RPCProxy
+        aria_rpc:
             RPC proxy to the aria2c process
-        rpc_auth: str
+        rpc_auth:
             The rpc authentication token
-        trace_custom_fields: dict, optional
+        trace_custom_fields:
             Custom key value pairs to send with the traces
 
         Returns
         -------
-        list[dict]
+
             A list of dictionaries with an entry for each file, containing the input options,
             the did, and the clientState.
         """
@@ -1320,7 +1327,7 @@ class DownloadClient:
         Resolve scopes or wildcard DIDs to lists of full did names:
         Parameters
         ----------
-        item: dict
+        item:
             One input item
         """
         dids = item.get('did')
@@ -1372,12 +1379,11 @@ class DownloadClient:
 
         Parameters
         ----------
-        input_items: list[dict]
+        input_items:
             List of dictionaries. Each dictionary describing an input item
 
         Returns:
         -------
-        tuple[dict[str, Any], list[dict[str, Any]]]
             * a dictionary that maps the dereferenced(w/o wildcards) input DIDs to a list of input items
             * and a list with a dictionary for each file DID which has to be downloaded
 
@@ -1594,14 +1600,14 @@ class DownloadClient:
 
         Parameters
         ----------
-        did_to_input_items: dict
+        did_to_input_items:
             dictionary that maps resolved input DIDs to input items
-        file_items: list[dict]
+        file_items:
             list of dictionaries. Each dictionary describes a File DID to download
 
         Returns
         -------
-        list[dict]
+
             list of dictionaries. Each dictionary describes an element to download
 
         Raises
@@ -1831,12 +1837,12 @@ class DownloadClient:
 
         Parameters
         ----------
-        did_str: str
+        did_str:
             the DID string that will be split
 
         Returns
         -------
-        tuple[str, str]
+
             the scope- and name part of the given DID
 
         Raises
@@ -1879,16 +1885,16 @@ class DownloadClient:
 
         Parameters
         ----------
-        base_dir: str
+        base_dir:
             base directory part
-        dest_dir_name: str
+        dest_dir_name:
             name of the destination directory
-        no_subdir: bool
+        no_subdir:
             if no subdirectory should be created
 
         Returns
         -------
-        str
+
             the absolute path of the destination directory
         """
         # append dest_dir_name, if subdir should be used
@@ -1912,14 +1918,14 @@ class DownloadClient:
 
         Parameters
         ----------
-        output_items: list[dict]
+        output_items:
             list of dictionaries describing the downloaded files
         deactivate_file_download_exceptions: bool
             Boolean, if file download exceptions shouldn't be raised
 
         Returns
         -------
-        list[dict[str, Any]]
+
             output_items list
 
         Raises
@@ -1950,7 +1956,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        trace: dict
+        trace:
             the trace to send
         """
         if self.tracing:
@@ -1963,7 +1969,7 @@ class DownloadClient:
 
         Parameters
         ----------
-        sources: list[dict[str, Any]]
+        sources:
             List of sources for a given DID
 
         Raises

--- a/lib/rucio/client/exportclient.py
+++ b/lib/rucio/client/exportclient.py
@@ -30,12 +30,12 @@ class ExportClient(BaseClient):
         Export RSE data (RSE, settings, attributes and distance).
         Parameters
         ----------
-        distance : bool
+        distance :
             To include the distance. Default is True.
 
         Returns
         -------
-        dict
+
             A dict containing data
         """
         payload = {'distance': distance}

--- a/lib/rucio/client/exportclient.py
+++ b/lib/rucio/client/exportclient.py
@@ -28,9 +28,15 @@ class ExportClient(BaseClient):
     def export_data(self, distance: bool = True) -> dict[str, Any]:
         """
         Export RSE data (RSE, settings, attributes and distance).
-        :param distance: To include the distance.
+        Parameters
+        ----------
+        distance : bool
+            To include the distance. Default is True.
 
-        :returns: A dict containing data
+        Returns
+        -------
+        dict
+            A dict containing data
         """
         payload = {'distance': distance}
         path = '/'.join([self.EXPORT_BASEURL])

--- a/lib/rucio/client/fileclient.py
+++ b/lib/rucio/client/fileclient.py
@@ -33,14 +33,14 @@ class FileClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope of the file.
-        lfn : str
+        lfn :
             The LFN
 
         Returns
         -------
-        list[dict[str, Any]]
+
             List of replicas.
         """
         path = '/'.join([self.BASEURL, quote_plus(scope), quote_plus(lfn), 'rses'])

--- a/lib/rucio/client/fileclient.py
+++ b/lib/rucio/client/fileclient.py
@@ -31,10 +31,17 @@ class FileClient(BaseClient):
         """
         List file replicas.
 
-        :param scope: the scope.
-        :param lfn: the lfn.
+        Parameters
+        ----------
+        scope : str
+            The scope of the file.
+        lfn : str
+            The LFN
 
-        :return: List of replicas.
+        Returns
+        -------
+        list[dict[str, Any]]
+            List of replicas.
         """
         path = '/'.join([self.BASEURL, quote_plus(scope), quote_plus(lfn), 'rses'])
         url = build_url(choice(self.list_hosts), path=path)

--- a/lib/rucio/client/importclient.py
+++ b/lib/rucio/client/importclient.py
@@ -29,7 +29,10 @@ class ImportClient(BaseClient):
         """
         Imports data into Rucio.
 
-        :param data: a dict containing data to be imported into Rucio.
+        Parameters
+        ----------
+        data: dict
+            A dict containing data to be imported into Rucio.
         """
         path = '/'.join([self.IMPORT_BASEURL])
         url = build_url(choice(self.list_hosts), path=path)

--- a/lib/rucio/client/importclient.py
+++ b/lib/rucio/client/importclient.py
@@ -31,7 +31,7 @@ class ImportClient(BaseClient):
 
         Parameters
         ----------
-        data: dict
+        data :
             A dict containing data to be imported into Rucio.
         """
         path = '/'.join([self.IMPORT_BASEURL])

--- a/lib/rucio/client/lifetimeclient.py
+++ b/lib/rucio/client/lifetimeclient.py
@@ -47,9 +47,9 @@ class LifetimeClient(BaseClient):
 
         Parameters
         ----------
-        exception_id : str, optional
+        exception_id :
             The unique identifier of a specific exception. If provided, returns only that exception.
-        states : list[LifetimeExceptionsState], optional
+        states :
             Filter exceptions by their states. Possible values are:
             * `A` (APPROVED): Exception was approved
             * `R` (REJECTED): Exception was rejected
@@ -57,7 +57,7 @@ class LifetimeClient(BaseClient):
 
         Returns
         -------
-        Iterator[dict[str, Any]]
+
             An iterator of dictionaries containing the exception details:
             * `id`: The unique identifier of the exception
             * `scope`: The scope of the data identifier
@@ -106,23 +106,23 @@ class LifetimeClient(BaseClient):
 
         Parameters
         ----------
-        dids : list[dict[str, Any]]
+        dids :
             List of dictionaries containing the data identifiers to be excepted.
             Each dictionary must contain:
             * **scope** : The scope of the data identifier
             * **name** : The name of the data identifier
-        account : str
+        account :
             The account requesting the exception
-        pattern : str
+        pattern :
             Associated pattern for the exception request
-        comments : str
+        comments :
             Justification for why the exception is needed (e.g. "Needed for my XYZ analysis..")
-        expires_at : datetime
+        expires_at :
             When the exception should expire (datetime object)
 
         Returns
         -------
-        dict[str, Any]
+
             A dictionary containing:
             * **exceptions** : Dictionary mapping exception IDs to lists of DIDs that were successfully added
             * **unknown** : List of DIDs that could not be found

--- a/lib/rucio/client/lifetimeclient.py
+++ b/lib/rucio/client/lifetimeclient.py
@@ -45,26 +45,32 @@ class LifetimeClient(BaseClient):
         (files, datasets, containers, or archives) that need to be kept longer than usual. These exceptions
         can be filtered by their ID or approval state (this feature is not available yet).
 
-        :param exception_id: The unique identifier of a specific exception. If provided, returns only that exception.
-        :param states: Filter exceptions by their states. Possible values are:
-                      - `A` (APPROVED): Exception was approved
-                      - `R` (REJECTED): Exception was rejected
-                      - `W` (WAITING): Exception is waiting for approval by an admin (or other authorized account)
+        Parameters
+        ----------
+        exception_id : str, optional
+            The unique identifier of a specific exception. If provided, returns only that exception.
+        states : list[LifetimeExceptionsState], optional
+            Filter exceptions by their states. Possible values are:
+            * `A` (APPROVED): Exception was approved
+            * `R` (REJECTED): Exception was rejected
+            * `W` (WAITING): Exception is waiting for approval by an admin (or other authorized account)
 
-        :returns:
+        Returns
+        -------
+        Iterator[dict[str, Any]]
             An iterator of dictionaries containing the exception details:
-             - `id`: The unique identifier of the exception
-             - `scope`: The scope of the data identifier
-             - `name`: The name of the data identifier
-             - `did_type`: Type of the data identifier:
-                    `F` (file), `D` (dataset), `C` (container), `A` (archive),
-                    `X` (deleted file), `Y` (deleted dataset), `Z` (deleted container)
-             - `account`: The account that requested the exception
-             - `pattern`: Pattern used for matching data identifiers
-             - `comments`: User provided comments explaining the exception
-             - `state`: Current state of the exception
-             - `created_at`: When the exception was created (returned as timestamp string)
-             - `expires_at`: When the exception expires (returned as timestamp string)
+            * `id`: The unique identifier of the exception
+            * `scope`: The scope of the data identifier
+            * `name`: The name of the data identifier
+            * `did_type`: Type of the data identifier:
+                `F` (file), `D` (dataset), `C` (container), `A` (archive),
+                `X` (deleted file), `Y` (deleted dataset), `Z` (deleted container)
+            * `account`: The account that requested the exception
+            * `pattern`: Pattern used for matching data identifiers
+            * `comments`: User provided comments explaining the exception
+            * `state`: Current state of the exception
+            * `created_at`: When the exception was created (returned as timestamp string)
+            * `expires_at`: When the exception expires (returned as timestamp string)
         """
 
         path = self.LIFETIME_BASEURL + '/'
@@ -98,19 +104,30 @@ class LifetimeClient(BaseClient):
         maximum extension periods. The request includes details about which DIDs should have extended
         lifetimes, who is requesting it, and why it's needed.
 
-        :param dids: List of dictionaries containing the data identifiers to be excepted.
-                    Each dictionary must contain:
-                    - `scope`: The scope of the data identifier
-                    - `name`: The name of the data identifier
-        :param account: The account requesting the exception
-        :param pattern: Associated pattern for the exception request
-        :param comments: Justification for why the exception is needed (e.g. "Needed for my XYZ analysis..")
-        :param expires_at: When the exception should expire (datetime object)
+        Parameters
+        ----------
+        dids : list[dict[str, Any]]
+            List of dictionaries containing the data identifiers to be excepted.
+            Each dictionary must contain:
+            * **scope** : The scope of the data identifier
+            * **name** : The name of the data identifier
+        account : str
+            The account requesting the exception
+        pattern : str
+            Associated pattern for the exception request
+        comments : str
+            Justification for why the exception is needed (e.g. "Needed for my XYZ analysis..")
+        expires_at : datetime
+            When the exception should expire (datetime object)
 
-        :returns: A dictionary containing:
-                 - `exceptions`: Dictionary mapping exception IDs to lists of DIDs that were successfully added
-                 - `unknown`: List of DIDs that could not be found
-                 - `not_affected`: List of DIDs that did not qualify for an exception
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary containing:
+            * **exceptions** : Dictionary mapping exception IDs to lists of DIDs that were successfully added
+            * **unknown** : List of DIDs that could not be found
+            * **not_affected** : List of DIDs that did not qualify for an exception
+
         """
 
         path = self.LIFETIME_BASEURL + '/'

--- a/lib/rucio/client/lockclient.py
+++ b/lib/rucio/client/lockclient.py
@@ -40,9 +40,9 @@ class LockClient(BaseClient):
 
         Parameters
         ----------
-        scope : str
+        scope :
             The scope of the did of the locks to list.
-        name : str
+        name :
             The name of the did of the locks to list.
 
         """
@@ -69,14 +69,14 @@ class LockClient(BaseClient):
 
         Parameters
         ----------
-        dids : list
+        dids :
             list of dictionaries {"scope":..., "name":..., "type":...}
             type can be either "dataset" or "container"
             type is optional, but if specified, improves the query performance
 
         Returns
         -------
-        list
+
             list of dictionaries with lock info
         """
 

--- a/lib/rucio/client/lockclient.py
+++ b/lib/rucio/client/lockclient.py
@@ -106,7 +106,7 @@ class LockClient(BaseClient):
 
         Parameters
         ----------
-        rse: str
+        rse :
             The rse of the locks to list
         """
 

--- a/lib/rucio/client/lockclient.py
+++ b/lib/rucio/client/lockclient.py
@@ -38,8 +38,13 @@ class LockClient(BaseClient):
         """
         Get a dataset locks of the specified dataset.
 
-        :param scope: the scope of the did of the locks to list.
-        :param name: the name of the did of the locks to list.
+        Parameters
+        ----------
+        scope : str
+            The scope of the did of the locks to list.
+        name : str
+            The name of the did of the locks to list.
+
         """
 
         path = '/'.join([self.LOCKS_BASEURL, quote_plus(scope), quote_plus(name)])
@@ -62,10 +67,17 @@ class LockClient(BaseClient):
         """
         Get list of locks for for all the files found, recursively, in the listed datasets or containers.
 
-        :param dids: list of dictionaries {"scope":..., "name":..., "type":...}
-                     type can be either "dataset" or "container"
-                     type is optional, but if specified, improves the query performance
-        :returns:    list of dictionaries with lock info
+        Parameters
+        ----------
+        dids : list
+            list of dictionaries {"scope":..., "name":..., "type":...}
+            type can be either "dataset" or "container"
+            type is optional, but if specified, improves the query performance
+
+        Returns
+        -------
+        list
+            list of dictionaries with lock info
         """
 
         # convert did list to list of dictionaries
@@ -92,7 +104,10 @@ class LockClient(BaseClient):
         """
         Get all dataset locks of the specified rse.
 
-        :param rse: the rse of the locks to list.
+        Parameters
+        ----------
+        rse: str
+            The rse of the locks to list
         """
 
         path = '/'.join([self.LOCKS_BASEURL, rse])

--- a/lib/rucio/client/metaconventionsclient.py
+++ b/lib/rucio/client/metaconventionsclient.py
@@ -37,19 +37,18 @@ class MetaConventionClient(BaseClient):
 
         Parameters
         ----------
-        key: str
+        key :
             The name for the new key.
 
-        key_type: str
+        key_type :
             The type of the key: all(container, dataset, file), collection(dataset or container), file, derived(compute from file for collection).
-        value_type: Optional[str]
+        value_type :
             The type of the value, if defined.
-        value_regexp: Optional[str]
+        value_regexp :
             The regular expression that values should match, if defined.
 
         Returns
         -------
-        bool
             True if key was created successfully.
 
         Raises
@@ -78,7 +77,6 @@ class MetaConventionClient(BaseClient):
 
         Returns
         -------
-        list[str]
             A list containing the names of all keys.
         """
         path = self.META_BASEURL + '/'
@@ -97,7 +95,6 @@ class MetaConventionClient(BaseClient):
 
         Returns
         -------
-        list[str]
             A list containing the names of all values for a key
         """
         path = '/'.join([self.META_BASEURL, quote_plus(key)]) + '/'
@@ -116,14 +113,13 @@ class MetaConventionClient(BaseClient):
 
         Parameters
         ----------
-        key: str
+        key :
             The name for key.
-        value: str
+        value :
             The value to be added.
 
         Returns
         -------
-        bool
             True if value was created successfully.
 
         Raises
@@ -148,9 +144,9 @@ class MetaConventionClient(BaseClient):
 
         Parameters
         ---------
-        key: str
+        key :
             The name for the key
-        value: str
+        value :
             The value
         """
         pass
@@ -161,7 +157,7 @@ class MetaConventionClient(BaseClient):
 
         Parameters
         ----------
-        key: str
+        key :
             The name for the key.
         """
         pass
@@ -172,11 +168,11 @@ class MetaConventionClient(BaseClient):
 
         Parameters
         ----------
-        key: str
+        key :
             The name for the key.
-        type_: Optional[str]
+        type_ :
             The type of the value, if defined.
-        regexp: Optional[str]
+        regexp :
             The regular expression that values should match, if defined.
         """
         pass

--- a/lib/rucio/client/metaconventionsclient.py
+++ b/lib/rucio/client/metaconventionsclient.py
@@ -35,13 +35,27 @@ class MetaConventionClient(BaseClient):
         """
         Sends the request to add an allowed key for DID metadata (update the DID Metadata Conventions table with a new key).
 
-        :param key: the name for the new key.
-        :param key_type: the type of the key: all(container, dataset, file), collection(dataset or container), file, derived(compute from file for collection).
-        :param value_type: the type of the value, if defined.
-        :param value_regexp: the regular expression that values should match, if defined.
+        Parameters
+        ----------
+        key: str
+            The name for the new key.
 
-        :return: True if key was created successfully.
-        :raises Duplicate: if key already exists.
+        key_type: str
+            The type of the key: all(container, dataset, file), collection(dataset or container), file, derived(compute from file for collection).
+        value_type: Optional[str]
+            The type of the value, if defined.
+        value_regexp: Optional[str]
+            The regular expression that values should match, if defined.
+
+        Returns
+        -------
+        bool
+            True if key was created successfully.
+
+        Raises
+        -------
+        Duplicate
+            If key already exists..
         """
 
         path = '/'.join([self.META_BASEURL, quote_plus(key)])
@@ -62,7 +76,10 @@ class MetaConventionClient(BaseClient):
         """
         Sends the request to list all keys for DID Metadata Conventions.
 
-        :return: a list containing the names of all keys.
+        Returns
+        -------
+        list[str]
+            A list containing the names of all keys.
         """
         path = self.META_BASEURL + '/'
         url = build_url(choice(self.list_hosts), path=path)
@@ -77,9 +94,11 @@ class MetaConventionClient(BaseClient):
     def list_values(self, key: str) -> Optional[list[str]]:
         """
         Sends the request to lists all allowed values for a DID key (all values for a key in DID Metadata Conventions).
-.
 
-        :return: a list containing the names of all values for a key.
+        Returns
+        -------
+        list[str]
+            A list containing the names of all values for a key
         """
         path = '/'.join([self.META_BASEURL, quote_plus(key)]) + '/'
         url = build_url(choice(self.list_hosts), path=path)
@@ -95,11 +114,22 @@ class MetaConventionClient(BaseClient):
         """
         Sends the request to add a value for a key in DID Metadata Convention.
 
-        :param key: the name for key.
-        :param value: the value.
+        Parameters
+        ----------
+        key: str
+            The name for key.
+        value: str
+            The value to be added.
 
-        :return: True if value was created successfully.
-        :raises Duplicate: if valid already exists.
+        Returns
+        -------
+        bool
+            True if value was created successfully.
+
+        Raises
+        -------
+        Duplicate
+            If value already exists.
         """
 
         path = '/'.join([self.META_BASEURL, quote_plus(key)]) + '/'
@@ -116,8 +146,12 @@ class MetaConventionClient(BaseClient):
         """
         Delete a key in the DID Metadata Conventions table.
 
-        :param key: the name for key.
-        :param value: the value.
+        Parameters
+        ---------
+        key: str
+            The name for the key
+        value: str
+            The value
         """
         pass
 
@@ -125,7 +159,10 @@ class MetaConventionClient(BaseClient):
         """
         Delete an allowed key.
 
-        :param key: the name for key.
+        Parameters
+        ----------
+        key: str
+            The name for the key.
         """
         pass
 
@@ -133,8 +170,13 @@ class MetaConventionClient(BaseClient):
         """
         Update a key.
 
-        :param key: the name for key.
-        :param type_: the type of the value, if defined.
-        :param regexp: the regular expression that values should match, if defined.
+        Parameters
+        ----------
+        key: str
+            The name for the key.
+        type_: Optional[str]
+            The type of the value, if defined.
+        regexp: Optional[str]
+            The regular expression that values should match, if defined.
         """
         pass

--- a/lib/rucio/client/pingclient.py
+++ b/lib/rucio/client/pingclient.py
@@ -28,7 +28,10 @@ class PingClient(BaseClient):
         """
         Sends a ping request to the rucio server.
 
-        :return: Dictonnary with server information
+        Returns
+        --------
+        dict
+            Dictionary with server information
         """
 
         headers = None

--- a/lib/rucio/client/pingclient.py
+++ b/lib/rucio/client/pingclient.py
@@ -30,7 +30,6 @@ class PingClient(BaseClient):
 
         Returns
         --------
-        dict
             Dictionary with server information
         """
 

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -33,9 +33,14 @@ class ReplicaClient(BaseClient):
         """
         Add quaratined replicas for RSE.
 
-        :param replicas: List of replica infos: {'scope': <scope> (optional), 'name': <name> (optional), 'path':<path> (required)}.
-        :param rse: RSE name.
-        :param rse_id: RSE id. Either RSE name or RSE id must be specified, but not both
+        Parameters
+        ----------
+        replicas : list
+            List of replica infos: {'scope': <scope> (optional), 'name': <name> (optional), 'path':<path> (required)}.
+        rse : str, optional
+            RSE name.
+        rse_id : str, optional
+            RSE id. Either RSE name or RSE id must be specified, but not both.
         """
 
         if (rse is None) == (rse_id is None):
@@ -54,10 +59,19 @@ class ReplicaClient(BaseClient):
         """
         Declare a list of bad replicas.
 
-        :param replicas: Either a list of PFNs (string) or a list of dicts {'scope': <scope>, 'name': <name>, 'rse_id': <rse_id> or 'rse': <rse_name>}
-        :param reason: The reason of the loss.
-        :param force: boolean, tell the serrver to ignore existing replica status in the bad_replicas table. Default: False
-        :returns: Dictionary {"rse_name": ["did: error",...]} - list of strings for DIDs failed to declare, by RSE
+        Parameters
+        ----------
+        replicas : list
+            Either a list of PFNs (string) or a list of dicts {'scope': <scope>, 'name': <name>, 'rse_id': <rse_id> or 'rse': <rse_name>}
+        reason : str
+            The reason of the loss.
+        force : bool, optional
+            Tell the server to ignore existing replica status in the bad_replicas table. Default: False
+
+        Returns
+        -------
+        dict
+            Dictionary of the form {"rse_name": ["did: error",...]} - list of strings for DIDs failed to declare, by RSE
         """
 
         out = {}    # {rse: ["did: error text",...]}
@@ -79,9 +93,14 @@ class ReplicaClient(BaseClient):
         """
         Declare a list of bad replicas.
 
-        :param rse: The RSE where the bad replicas reside
-        :param dids: The DIDs of the bad replicas
-        :param reason: The reason of the loss.
+        Parameters
+        ----------
+        rse : str
+            The RSE where the bad replicas reside.
+        dids : list
+            The DIDs of the bad replicas.
+        reason : str
+            The reason of the loss.
         """
         data = {'reason': reason, 'rse': rse, 'dids': dids}
         url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, 'bad/dids']))
@@ -96,8 +115,13 @@ class ReplicaClient(BaseClient):
         """
         Declare a list of bad replicas.
 
-        :param pfns: The list of PFNs.
-        :param reason: The reason of the loss.
+        Parameters
+        ----------
+        pfns: list
+            The list of PFNs.
+        reason: str
+            The reason of the loss.
+
         """
         data = {'reason': reason, 'pfns': pfns}
         url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, 'suspicious']))
@@ -110,11 +134,14 @@ class ReplicaClient(BaseClient):
 
     def get_did_from_pfns(self, pfns, rse=None):
         """
-        Get the DIDs associated to a PFN on one given RSE
+        Get the DIDs associated to a PFN on one given RSE.
 
-        :param pfns: The list of PFNs.
-        :param rse: The RSE name.
-        :returns: A list of dictionaries {pfn: {'scope': scope, 'name': name}}
+        Parameters
+        ----------
+        pfns : list
+            The list of PFNs.
+        rse : str
+            The RSE name.
         """
         data = {'rse': rse, 'pfns': pfns}
         url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, 'dids']))
@@ -134,24 +161,44 @@ class ReplicaClient(BaseClient):
         """
         List file replicas for a list of data identifiers (DIDs).
 
-        :param dids: The list of data identifiers (DIDs) like :
+        Parameters
+        ----------
+        dids: list
+            The list of data identifiers (DIDs) like :
             [{'scope': <scope1>, 'name': <name1>}, {'scope': <scope2>, 'name': <name2>}, ...]
-        :param schemes: A list of schemes to filter the replicas. (e.g. file, http, ...)
-        :param ignore_availability: Also include replicas from blocked RSEs into the list
-        :param metalink: ``False`` (default) retrieves as JSON,
-                         ``True`` retrieves as metalink4+xml.
-        :param rse_expression: The RSE expression to restrict replicas on a set of RSEs.
-        :param client_location: Client location dictionary for PFN modification {'ip', 'fqdn', 'site', 'latitude', 'longitude'}
-        :param sort: Sort the replicas: ``geoip`` - based on src/dst IP topographical distance
-        :param domain: Define the domain. None is fallback to 'wan', otherwise 'wan, 'lan', or 'all'
-        :param signature_lifetime: If supported, in seconds, restrict the lifetime of the signed PFN.
-        :param nrandom: pick N random replicas. If the initial number of replicas is smaller than N, returns all replicas.
-        :param resolve_archives: When set to True, find archives which contain the replicas.
-        :param resolve_parents: When set to True, find all parent datasets which contain the replicas.
-        :param updated_after: epoch timestamp or datetime object (UTC time), only return replicas updated after this time
+        schemes: list
+            A list of schemes to filter the replicas. (e.g. file, http, ...)
+        ignore_availability: bool
+            Also include replicas from blocked RSEs into the list
+        all_states: bool
+            Include all states of the replicas. Default: False
+        metalink: bool
+            ``False`` (default) retrieves as JSON,
+            ``True`` retrieves as metalink4+xml.
+        rse_expression: str
+            The RSE expression to restrict replicas on a set of RSEs.
+        client_location: dict
+            Client location dictionary for PFN modification {'ip', 'fqdn', 'site', 'latitude', 'longitude'}
+        sort: str
+            Sort the replicas: ``geoip`` - based on src/dst IP topographical distance
+        domain: str
+            Define the domain. None is fallback to 'wan', otherwise 'wan, 'lan', or 'all'
+        signature_lifetime: int
+            If supported, in seconds, restrict the lifetime of the signed PFN.
+        nrandom: int
+            pick N random replicas. If the initial number of replicas is smaller than N, returns all replicas.
+        resolve_archives: bool
+            When set to True, find archives which contain the replicas.
+        resolve_parents: bool
+            When set to True, find all parent datasets which contain the replicas.
+        updated_after: datetime
+            epoch timestamp or datetime object (UTC time), only return replicas updated after this time
 
-        :returns: A list of dictionaries with replica information.
 
+        Returns
+        -------
+        list
+            A list of dictionaries with replica information.
         """
         data = {'dids': dids,
                 'domain': domain}
@@ -208,11 +255,16 @@ class ReplicaClient(BaseClient):
         """
         List file replicas tagged as suspicious.
 
-        :param rse_expression: The RSE expression to restrict replicas on a set of RSEs.
-        :param younger_than: Datetime object to select the replicas which were declared since younger_than date. Default value = 10 days ago.
-        :param nattempts: The minimum number of replica appearances in the bad_replica DB table from younger_than date. Default value = 0.
-        :param state: State of the replica, either 'BAD' or 'SUSPICIOUS'. No value returns replicas with either state.
-
+        Parameters
+        ----------
+        rse_expression:
+            The RSE expression to restrict replicas on a set of RSEs.
+        younger_than:
+            Datetime object to select the replicas which were declared since younger_than date. Default value = 10 days ago.
+        nattempts:
+            The minimum number of replica appearances in the bad_replica DB table from younger_than date. Default value = 0.
+        state:
+            State of the replica, either 'BAD' or 'SUSPICIOUS'. No value returns replicas with either state.
         """
         params = {}
         if rse_expression:
@@ -246,17 +298,29 @@ class ReplicaClient(BaseClient):
         """
         Add file replicas to a RSE.
 
-        :param rse: the RSE name.
-        :param scope: The scope of the file.
-        :param name: The name of the file.
-        :param bytes_: The size in bytes.
-        :param adler32: adler32 checksum.
-        :param pfn: PFN of the file for non deterministic RSE.
-        :param md5: md5 checksum.
-        :param meta: Metadata attributes.
+        Parameters
+        ----------
+        rse : str
+            The RSE name.
+        scope : str
+            The scope of the file.
+        name : str
+            The name of the file.
+        bytes_ : int
+            The size in bytes.
+        adler32 : str
+            adler32 checksum.
+        pfn : str, optional
+            PFN of the file for non deterministic RSE.
+        md5 : str, optional
+            md5 checksum.
+        meta : dict, optional
+            Metadata attributes.
 
-        :return: True if files were created successfully.
-
+        Returns
+        -------
+        bool
+            True if files were created successfully.
         """
         meta = meta or {}
         dict_ = {'scope': scope, 'name': name, 'bytes': bytes_, 'meta': meta, 'adler32': adler32}
@@ -270,13 +334,19 @@ class ReplicaClient(BaseClient):
         """
         Bulk add file replicas to a RSE.
 
-        :param rse: the RSE name.
-        :param files: The list of files. This is a list of DIDs like :
+        Parameters
+        ----------
+        rse:
+            the RSE name
+        files:
+            The list of files. This is a list of DIDs like :
             [{'scope': <scope1>, 'name': <name1>}, {'scope': <scope2>, 'name': <name2>}, ...]
-        :param ignore_availability: Ignore the RSE blocklsit.
+        ignore_availability:
+            Ignore the RSE blocklist
 
-        :return: True if files were created successfully.
-
+        Returns
+        -------
+        True if files were created successfully.
         """
         url = build_url(choice(self.list_hosts), path=self.REPLICAS_BASEURL)
         data = {'rse': rse, 'files': files, 'ignore_availability': ignore_availability}
@@ -289,14 +359,19 @@ class ReplicaClient(BaseClient):
     def delete_replicas(self, rse, files, ignore_availability=True):
         """
         Bulk delete file replicas from a RSE.
-
-        :param rse: the RSE name.
-        :param files: The list of files. This is a list of DIDs like :
+        Parameters
+        ----------
+        rse:
+            the RSE name
+        files:
+            The list of files. This is a list of DIDs like :
             [{'scope': <scope1>, 'name': <name1>}, {'scope': <scope2>, 'name': <name2>}, ...]
-        :param ignore_availability: Ignore the RSE blocklist.
+        ignore_availability:
+            Ignore the RSE blocklist
 
-        :return: True if files have been deleted successfully.
-
+        Returns
+        -------
+        True if files have been deleted successfully.
         """
         url = build_url(choice(self.list_hosts), path=self.REPLICAS_BASEURL)
         data = {'rse': rse, 'files': files, 'ignore_availability': ignore_availability}
@@ -307,21 +382,29 @@ class ReplicaClient(BaseClient):
         raise exc_cls(exc_msg)
 
     def update_replicas_states(self, rse, files):
+
         """
+
         Bulk update the file replicas states from a RSE.
 
-        :param rse: the RSE name.
-        :param files: The list of files. This is a list of DIDs like :
+                Parameters
+        ----------
+        rse : str
+            The RSE name.
+        files : list
+            The list of files. This is a list of DIDs like :
             [{'scope': <scope1>, 'name': <name1>, 'state': <state1>}, {'scope': <scope2>, 'name': <name2>, 'state': <state2>}, ...],
-            where a state value can be either of:
-              'A' (AVAILABLE)
-              'U' (UNAVAILABLE)
-              'C' (COPYING)
-              'B' (BEING_DELETED)
-              'D' (BAD)
-              'T' (TEMPORARY_UNAVAILABLE)
-        :return: True if replica states have been updated successfully, otherwise an exception is raised.
+            Where a state value can be any of:
+                * 'A' (AVAILABLE)
+                * 'U' (UNAVAILABLE)
+                * 'C' (COPYING)
+                * 'B' (BEING_DELETED)
+                * 'D' (BAD)
+                * 'T' (TEMPORARY_UNAVAILABLE)
 
+        Returns
+        -------
+        True if replica states have been updated successfully, otherwise an exception is raised.
         """
         url = build_url(choice(self.list_hosts), path=self.REPLICAS_BASEURL)
         data = {'rse': rse, 'files': files}
@@ -335,12 +418,18 @@ class ReplicaClient(BaseClient):
         """
         List dataset replicas for a did (scope:name).
 
-        :param scope: The scope of the dataset.
-        :param name: The name of the dataset.
-        :param deep: Lookup at the file level.
+        Parameters
+        ----------
+        scope:
+            The scope of the dataset.
+        name:
+            The name of the dataset.
+        deep:
+            Lookup at the file level.
 
-        :returns: A list of dict dataset replicas.
-
+        Returns
+        -------
+        A list of dict dataset replicas
         """
         payload = {}
         if deep:
@@ -359,9 +448,14 @@ class ReplicaClient(BaseClient):
         """
         List dataset replicas for a did (scope:name).
 
-        :param dids: The list of DIDs of the datasets.
+        Parameters
+        ----------
+        dids:
+            The list of DIDs of the datasets
 
-        :returns: A list of dict dataset replicas.
+        Returns
+        -------
+        A list of dict dataset replicas
         """
         payload = {'dids': list(dids)}
         url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, 'datasets_bulk']))
@@ -378,11 +472,19 @@ class ReplicaClient(BaseClient):
 
         NOTICE: This is an RnD function and might change or go away at any time.
 
-        :param scope: The scope of the dataset.
-        :param name: The name of the dataset.
-        :param deep: Lookup at the file level.
+        Parameters
+        ----------
+        scope:
+            The scope of the dataset.
+        name:
+            The name of the dataset.
+        deep:
+            Lookup at the file level.
 
-        :returns: If VP exists a list of dicts of sites
+        Returns
+        -------
+        If VP exists a list of dicts of sites
+
         """
         payload = {}
         if deep:
@@ -401,12 +503,17 @@ class ReplicaClient(BaseClient):
         """
         List datasets at a RSE.
 
-        :param rse: the rse name.
-        :param filters: dictionary of attributes by which the results should be filtered.
-        :param limit: limit number.
-
-        :returns: A list of dict dataset replicas.
-
+        Parameters
+        ----------
+        rse:
+            The RSE name.
+        filters:
+            dictionary of attributes by which the results should be filtered.
+        limit:
+            limit number.
+        Returns
+        -------
+        A list of dict dataset replicas
         """
         url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, 'rse', rse]))
         r = self._send_request(url, type_='GET')
@@ -420,13 +527,20 @@ class ReplicaClient(BaseClient):
         """
         Declare a list of bad replicas.
 
-        :param pfns: The list of PFNs.
-        :param reason: The reason of the loss.
-        :param state: The state of the replica. Either BAD, SUSPICIOUS, TEMPORARY_UNAVAILABLE
-        :param expires_at: Specify a timeout for the TEMPORARY_UNAVAILABLE replicas. None for BAD files.
+        Parameters
+        ----------
+        pfns:
+            The list of PFNs.
+        reason:
+            The reason of the loss.
+        state:
+            The state of the replica. Either BAD, SUSPICIOUS, TEMPORARY_UNAVAILABLE
+        expires_at:
+            Specify a timeout for the TEMPORARY_UNAVAILABLE replicas. None for BAD files.
 
-        :return: True if PFNs were created successfully.
-
+        Returns
+        -------
+        True if PFNs were created successfully.
         """
         data = {'reason': reason, 'pfns': pfns, 'state': state, 'expires_at': expires_at}
         url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, 'bad/pfns']))
@@ -441,7 +555,10 @@ class ReplicaClient(BaseClient):
         """
         Set a tombstone on a list of replicas.
 
-        :param replicas: list of replicas.
+        Parameters
+        ----------
+        replicas:
+            list of replicas.
         """
         url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, 'tombstone']))
         data = {'replicas': replicas}

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -35,11 +35,11 @@ class ReplicaClient(BaseClient):
 
         Parameters
         ----------
-        replicas : list
+        replicas :
             List of replica infos: {'scope': <scope> (optional), 'name': <name> (optional), 'path':<path> (required)}.
-        rse : str, optional
+        rse :
             RSE name.
-        rse_id : str, optional
+        rse_id :
             RSE id. Either RSE name or RSE id must be specified, but not both.
         """
 
@@ -61,16 +61,16 @@ class ReplicaClient(BaseClient):
 
         Parameters
         ----------
-        replicas : list
+        replicas :
             Either a list of PFNs (string) or a list of dicts {'scope': <scope>, 'name': <name>, 'rse_id': <rse_id> or 'rse': <rse_name>}
-        reason : str
+        reason :
             The reason of the loss.
-        force : bool, optional
+        force :
             Tell the server to ignore existing replica status in the bad_replicas table. Default: False
 
         Returns
         -------
-        dict
+
             Dictionary of the form {"rse_name": ["did: error",...]} - list of strings for DIDs failed to declare, by RSE
         """
 
@@ -95,11 +95,11 @@ class ReplicaClient(BaseClient):
 
         Parameters
         ----------
-        rse : str
+        rse :
             The RSE where the bad replicas reside.
-        dids : list
+        dids :
             The DIDs of the bad replicas.
-        reason : str
+        reason :
             The reason of the loss.
         """
         data = {'reason': reason, 'rse': rse, 'dids': dids}
@@ -117,9 +117,9 @@ class ReplicaClient(BaseClient):
 
         Parameters
         ----------
-        pfns: list
+        pfns:
             The list of PFNs.
-        reason: str
+        reason:
             The reason of the loss.
 
         """
@@ -138,9 +138,9 @@ class ReplicaClient(BaseClient):
 
         Parameters
         ----------
-        pfns : list
+        pfns :
             The list of PFNs.
-        rse : str
+        rse :
             The RSE name.
         """
         data = {'rse': rse, 'pfns': pfns}
@@ -163,41 +163,41 @@ class ReplicaClient(BaseClient):
 
         Parameters
         ----------
-        dids: list
+        dids:
             The list of data identifiers (DIDs) like :
             [{'scope': <scope1>, 'name': <name1>}, {'scope': <scope2>, 'name': <name2>}, ...]
-        schemes: list
+        schemes:
             A list of schemes to filter the replicas. (e.g. file, http, ...)
-        ignore_availability: bool
+        ignore_availability:
             Also include replicas from blocked RSEs into the list
-        all_states: bool
+        all_states:
             Include all states of the replicas. Default: False
-        metalink: bool
+        metalink:
             ``False`` (default) retrieves as JSON,
             ``True`` retrieves as metalink4+xml.
-        rse_expression: str
+        rse_expression:
             The RSE expression to restrict replicas on a set of RSEs.
-        client_location: dict
+        client_location:
             Client location dictionary for PFN modification {'ip', 'fqdn', 'site', 'latitude', 'longitude'}
-        sort: str
+        sort:
             Sort the replicas: ``geoip`` - based on src/dst IP topographical distance
-        domain: str
+        domain:
             Define the domain. None is fallback to 'wan', otherwise 'wan, 'lan', or 'all'
-        signature_lifetime: int
+        signature_lifetime:
             If supported, in seconds, restrict the lifetime of the signed PFN.
-        nrandom: int
+        nrandom:
             pick N random replicas. If the initial number of replicas is smaller than N, returns all replicas.
-        resolve_archives: bool
+        resolve_archives:
             When set to True, find archives which contain the replicas.
-        resolve_parents: bool
+        resolve_parents:
             When set to True, find all parent datasets which contain the replicas.
-        updated_after: datetime
+        updated_after:
             epoch timestamp or datetime object (UTC time), only return replicas updated after this time
 
 
         Returns
         -------
-        list
+
             A list of dictionaries with replica information.
         """
         data = {'dids': dids,
@@ -300,26 +300,26 @@ class ReplicaClient(BaseClient):
 
         Parameters
         ----------
-        rse : str
+        rse :
             The RSE name.
-        scope : str
+        scope :
             The scope of the file.
-        name : str
+        name :
             The name of the file.
-        bytes_ : int
+        bytes_ :
             The size in bytes.
-        adler32 : str
+        adler32 :
             adler32 checksum.
-        pfn : str, optional
+        pfn :
             PFN of the file for non deterministic RSE.
-        md5 : str, optional
+        md5 :
             md5 checksum.
-        meta : dict, optional
+        meta :
             Metadata attributes.
 
         Returns
         -------
-        bool
+
             True if files were created successfully.
         """
         meta = meta or {}
@@ -387,11 +387,11 @@ class ReplicaClient(BaseClient):
 
         Bulk update the file replicas states from a RSE.
 
-                Parameters
+        Parameters
         ----------
-        rse : str
+        rse :
             The RSE name.
-        files : list
+        files :
             The list of files. This is a list of DIDs like :
             [{'scope': <scope1>, 'name': <name1>, 'state': <state1>}, {'scope': <scope2>, 'name': <name2>, 'state': <state2>}, ...],
             Where a state value can be any of:

--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -36,7 +36,9 @@ class RequestClient(BaseClient):
     ) -> 'Iterator[dict[str, Any]]':
         """Return latest request details
 
-        :return: request information
+        Returns
+        -------
+        request information
         """
         path = '/'.join([self.REQUEST_BASEURL, 'list']) + '?' + '&'.join(['src_rse={}'.format(src_rse), 'dst_rse={}'.format(
             dst_rse), 'request_states={}'.format(request_states)])
@@ -59,7 +61,9 @@ class RequestClient(BaseClient):
     ) -> 'Iterator[dict[str, Any]]':
         """Return historical request details
 
-        :return: request information
+        Returns
+        -------
+        request information
         """
         path = '/'.join([self.REQUEST_BASEURL, 'history', 'list']) + '?' + '&'.join(['src_rse={}'.format(src_rse), 'dst_rse={}'.format(
             dst_rse), 'request_states={}'.format(request_states), 'offset={}'.format(offset), 'limit={}'.format(limit)])
@@ -79,12 +83,22 @@ class RequestClient(BaseClient):
             scope: Optional[str] = None
     ) -> 'Iterator[dict[str, Any]]':
         """Return latest request details for a DID
+        Parameters
+        ----------
+        name:
+            DID
+        rse:
+            Destination RSE name
+        scope:
+            rucio scope, defaults to None
 
-        :param name: DID
-        :param rse: Destination RSE name
-        :param scope: rucio scope, defaults to None
-        :raises exc_cls: from BaseClient._get_exception
-        :return: request information
+        Raises
+        -------
+        exc_cls: from BaseClient._get_exception
+
+        Returns
+        -------
+        request information
         """
 
         if scope is not None:
@@ -104,13 +118,25 @@ class RequestClient(BaseClient):
             rse: str,
             scope: Optional[str] = None
     ) -> 'Iterator[dict[str, Any]]':
-        """Return latest request details for a DID
+        """
+        Return latest request details for a DID
 
-        :param name: DID
-        :param rse: Destination RSE name
-        :param scope: rucio scope, defaults to None
-        :raises exc_cls: from BaseClient._get_exception
-        :return: request information
+        Parameters
+        ----------
+        name:
+            DID
+        rse:
+            Destination RSE name
+        scope:
+            rucio scope, defaults to None
+
+        Raises
+        -------
+        exc_cls: from BaseClient._get_exception
+
+        Returns
+        -------
+        request information
         """
 
         if scope is not None:

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -36,11 +36,19 @@ class RSEClient(BaseClient):
         """
         Returns details about the referred RSE.
 
-        :param rse: Name of the referred RSE
+        Parameters
+        ----------
+        rse:
+            Name of the referred RSE
 
-        :returns: A dict containing all attributes of the referred RSE
+        Returns
+        --------
+        A dict containing all attributes of the referred RSE.
 
-        :raises RSENotFound: if the referred RSE was not found in the database
+        Raises
+        -------
+        RSENotFound:
+            if the referred RSE was not found in the database.
         """
         path = '/'.join([self.RSE_BASEURL, rse])
         url = build_url(choice(self.list_hosts), path=path)
@@ -54,27 +62,51 @@ class RSEClient(BaseClient):
             raise exc_cls(exc_msg)
 
     def add_rse(self, rse: str, **kwargs) -> Literal[True]:
+
         """
         Sends the request to create a new RSE.
 
-        :param rse: the name of the rse.
-        :param deterministic: Boolean to know if the pfn is generated deterministically.
-        :param volatile: Boolean for RSE cache.
-        :param city: City for the RSE.
-        :param region_code: The region code for the RSE.
-        :param country_name: The country.
-        :param continent: The continent.
-        :param time_zone: Timezone.
-        :param staging_area: Staging area.
-        :param ISP: Internet service provider.
-        :param rse_type: RSE type.
-        :param latitude: Latitude coordinate of RSE.
-        :param longitude: Longitude coordinate of RSE.
-        :param ASN: Access service network.
-        :param availability: Availability.
+        Parameters
+        ----------
+        rse
+            The name of the RSE.
+        deterministic
+            Boolean to know if the pfn is generated deterministically.
+        volatile
+            Boolean for RSE cache.
+        city
+            City for the RSE.
+        region_code
+            The region code for the RSE.
+        country_name
+            The country.
+        continent
+            The continent.
+        time_zone
+            Timezone.
+        staging_area
+            Staging area.
+        ISP
+            Internet service provider.
+        rse_type
+            RSE type.
+        latitude
+            Latitude coordinate of RSE.
+        longitude
+            Longitude coordinate of RSE.
+        ASN
+            Access service network.
+        availability
+            Availability.
 
-        :return: True if location was created successfully else False.
-        :raises Duplicate: if rse already exists.
+        Returns
+        -------
+            True if RSE was created successfully else False
+
+        Raises
+        ------
+        Duplicate
+            If RSE already exists.
         """
         path = 'rses/' + rse
         url = build_url(choice(self.list_hosts), path=path)
@@ -88,8 +120,12 @@ class RSEClient(BaseClient):
         """
         Update RSE properties like availability or name.
 
-        :param rse: the name of the new rse.
-        :param  parameters: A dictionary with property (name, read, write, delete as keys).
+        Parameters
+        ----------
+        rse:
+            The name of the RSE.
+        parameters:
+            A dictionary with property (name, read, write, delete as keys).
         """
         path = 'rses/' + rse
         url = build_url(choice(self.list_hosts), path=path)
@@ -103,8 +139,14 @@ class RSEClient(BaseClient):
         """
         Sends the request to delete a rse.
 
-        :param rse: the name of the rse.
-        :return: True if location was created successfully else False.
+        Parameters
+        ----------
+        rse
+            The name of the RSE.
+
+        Returns
+        -------
+        True if RSE was deleted successfully else False.
         """
         path = 'rses/' + rse
         url = build_url(choice(self.list_hosts), path=path)
@@ -119,8 +161,13 @@ class RSEClient(BaseClient):
         """
         Sends the request to list all rucio locations(RSEs).
 
-        :rse_expression: RSE Expression to use as filter.
-        :return:         a list containing the names of all rucio locations.
+        Parameters
+        ----------
+        rse_expression
+            RSE expression to use as filter.
+        Returns
+        -------
+        A list containing the names of all rucio locations.
         """
         if rse_expression:
             path = ['rses', "?expression=" + quote(rse_expression)]
@@ -144,12 +191,23 @@ class RSEClient(BaseClient):
         """
         Sends the request to add a RSE attribute.
 
-        :param rse: the name of the rse.
-        :param key: the attribute key.
-        :param value: the attribute value.
+        Parameters
+        ----------
+        rse:
+            The name of the RSE.
+        key:
+            The attribute key.
+        value:
+            The attribute value.
 
-        :return: True if RSE attribute was created successfully else False.
-        :raises Duplicate: if RSE attribute already exists.
+        Returns
+        -------
+        True if RSE attribute was created successfully else False.
+
+        Raises
+        -------
+        Duplicate
+            If RSE attribute already exists.
         """
         path = '/'.join([self.RSE_BASEURL, rse, 'attr', key])
         url = build_url(choice(self.list_hosts), path=path)
@@ -166,10 +224,16 @@ class RSEClient(BaseClient):
         """
         Sends the request to delete a RSE attribute.
 
-        :param rse: the RSE name.
-        :param key: the attribute key.
+        Parameters
+        ----------
+        rse
+            The RSE name.
+        key
+            The attribute key.
 
-        :return: True if RSE attribute was deleted successfully else False.
+        Returns
+        -------
+        True if RSE attribute was deleted successfully else False.
         """
         path = '/'.join([self.RSE_BASEURL, rse, 'attr', key])
         url = build_url(choice(self.list_hosts), path=path)
@@ -185,9 +249,14 @@ class RSEClient(BaseClient):
         """
         Sends the request to get RSE attributes.
 
-        :param rse: The RSE name.
+        Parameters
+        ----------
+        rse
+            The RSE name.
 
-        :return: A ``dict`` with the RSE attribute name/value pairs.
+        Returns
+        -------
+        A dict with the RSE attribute name/value pairs.
         """
         path = '/'.join([self.RSE_BASEURL, rse, 'attr/'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -203,26 +272,36 @@ class RSEClient(BaseClient):
         """
         Sends the request to create a new protocol for the given RSE.
 
-        :param rse: the name of the  rse.
-        :param scheme: identifier of this protocol
-        :param params: Attributes of the protocol. Supported are:
-            hostname:       hostname for this protocol (default = localhost)
-            port:           port for this protocol (default = 0)
-            prefix:         string used as a prfeix for this protocol when generating the PFN (default = None)
-            impl:           qualified name of the implementation class for this protocol (mandatory)
-            read:           integer representing the priority of this procotol for read operations (default = -1)
-            write:          integer representing the priority of this procotol for write operations (default = -1)
-            delete:         integer representing the priority of this procotol for delete operations (default = -1)
-            extended_attributes:  miscellaneous protocol specific information e.g. spacetoken for SRM (default = None)
+        Parameters
+        ----------
+        rse : str
+            The name of the RSE.
+        params : dict[str, Any]
+            Attributes of the protocol. Supported are:
+            - scheme: identifier of this protocol
+            - hostname: hostname for this protocol (default = localhost)
+            - port: port for this protocol (default = 0)
+            - prefix: string used as a prefix for this protocol when generating the PFN (default = None)
+            - impl: qualified name of the implementation class for this protocol (mandatory)
+            - read: integer representing the priority of this protocol for read operations (default = -1)
+            - write: integer representing the priority of this protocol for write operations (default = -1)
+            - delete: integer representing the priority of this protocol for delete operations (default = -1)
+            - extended_attributes: miscellaneous protocol specific information e.g. spacetoken for SRM (default = None)
 
-        :return: True if protocol was created successfully else False.
+        Returns
+        -------
+            True if protocol was created successfully.
 
-        :raises Duplicate: if protocol with same hostname, port and protocol identifier
-                            already exists for the given RSE.
-        :raises RSENotFound: if the RSE doesn't exist.
-        :raises KeyNotFound: if params is missing manadtory attributes to create the
-                             protocol.
-        :raises AccessDenied: if not authorized.
+        Raises
+        ------
+        Duplicate
+            If protocol with same hostname, port and protocol identifier already exists for the given RSE.
+        RSENotFound
+            If the RSE doesn't exist.
+        KeyNotFound
+            If params is missing mandatory attributes to create the protocol.
+        AccessDenied
+            If not authorized.
         """
         scheme = params['scheme']
         path = '/'.join([self.RSE_BASEURL, rse, 'protocols', scheme])
@@ -243,22 +322,35 @@ class RSEClient(BaseClient):
             scheme: Optional['SUPPORTED_PROTOCOLS_LITERAL'] = None
     ) -> Any:
         """
-        Returns protocol information. Parameter combinations are:
-        (operation OR default) XOR protocol.
+        Returns protocol information.
+        Parameter combinations are: (operation OR default) XOR protocol.
 
-        :param rse: the RSE name.
-        :param protocol_domain: The scope of the protocol. Supported are 'LAN', 'WAN', and 'ALL' (as default).
-        :param operation: The name of the requested operation (read, write, or delete).
-                          If None, all operations are queried.
-        :param default: Indicates if only the default operations should be returned.
-        :param scheme: The identifier of the requested protocol.
+        Parameters
+        ----------
+        rse : str
+            The RSE name.
+        protocol_domain : RSE_SUPPORTED_PROTOCOL_DOMAINS_LITERAL, optional
+            The scope of the protocol. Supported are 'LAN', 'WAN', and 'ALL', by default 'ALL'.
+        operation : RSE_ALL_SUPPORTED_PROTOCOL_OPERATIONS_LITERAL, optional
+            The name of the requested operation (read, write, or delete).
+            If None, all operations are queried, by default None.
+        default : bool, optional
+            Indicates if only the default operations should be returned, by default False.
+        scheme : SUPPORTED_PROTOCOLS_LITERAL, optional
+            The identifier of the requested protocol, by default None.
 
-        :returns: A dict with details about each matching protocol.
+        Returns
+        -------
+            A dict with details about each matching protocol.
 
-        :raises RSENotFound: if the RSE doesn't exist.
-        :raises RSEProtocolNotSupported: if no matching protocol entry could be found.
-        :raises RSEOperationNotSupported: if no matching protocol entry for the requested
-                                          operation could be found.
+        Raises
+        ------
+        RSENotFound
+            If the RSE doesn't exist.
+        RSEProtocolNotSupported
+            If no matching protocol entry could be found.
+        RSEOperationNotSupported
+            If no matching protocol entry for the requested operation could be found.
         """
 
         path = None
@@ -294,18 +386,33 @@ class RSEClient(BaseClient):
         Returns PFNs that should be used at a RSE, corresponding to requested LFNs.
         The PFNs are generated for the RSE *regardless* of whether a replica exists for the LFN.
 
-        :param rse: the RSE name
-        :param lfns: A list of LFN strings to translate to PFNs.
-        :param protocol_domain: The scope of the protocol. Supported are 'LAN', 'WAN', and 'ALL' (as default).
-        :param operation: The name of the requested operation (read, write, or delete).
-                          If None, all operations are queried.
-        :param scheme: The identifier of the requested protocol (gsiftp, https, davs, etc).
+        Parameters
+        ----------
+        rse :
+            The RSE name.
+        lfns :
+            A list of LFN strings to translate to PFNs.
+        protocol_domain :
+            The scope of the protocol.
+        operation :
+            The name of the requested operation (read, write, or delete).
+            If None, all operations are queried, by default None.
+        scheme :
+            The identifier of the requested protocol (gsiftp, https, davs, etc), by default None.
 
-        :returns: A dictionary of LFN / PFN pairs.
-        :raises RSENotFound: if the RSE doesn't exist.
-        :raises RSEProtocolNotSupported: if no matching protocol entry could be found.
-        :raises RSEOperationNotSupported: if no matching protocol entry for the requested
-                                          operation could be found.
+        Returns
+        -------
+        dict[str, str]
+            A dictionary of LFN / PFN pairs.
+
+        Raises
+        ------
+        RSENotFound
+            If the RSE doesn't exist.
+        RSEProtocolNotSupported
+            If no matching protocol entry could be found.
+        RSEOperationNotSupported
+            If no matching protocol entry for the requested operation could be found.
         """
         path = '/'.join([self.RSE_BASEURL, rse, 'lfns2pfns'])
         params = []
@@ -339,16 +446,29 @@ class RSEClient(BaseClient):
         Deletes matching protocols from RSE. Protocols using the same identifier can be
         distinguished by hostname and port.
 
-        :param rse: the RSE name.
-        :param scheme: identifier of the protocol.
-        :param hostname: hostname of the protocol.
-        :param port: port of the protocol.
+        Parameters
+        ----------
+        rse :
+            The RSE name.
+        scheme :
+            The identifier of the protocol.
+        hostname :
+            The hostname of the protocol.
+        port :
+            The port of the protocol.
 
-        :returns: True if success.
+        Returns
+        -------
+        True if success.
 
-        :raises RSEProtocolNotSupported: if no matching protocol entry could be found.
-        :raises RSENotFound: if the RSE doesn't exist.
-        :raises AccessDenied: if not authorized.
+        Raises
+        -------
+        RSEProtocolNotSupported
+            If no matching protocol entry could be found.
+        RSENotFound
+            If the RSE doesn't exist.
+        AccessDenied
+            If not authorized.
         """
         path = [self.RSE_BASEURL, rse, 'protocols', scheme]
         if hostname:
@@ -376,19 +496,32 @@ class RSEClient(BaseClient):
         Updates matching protocols from RSE. Protocol using the same identifier can be
         distinguished by hostname and port.
 
-        :param rse: the RSE name.
-        :param scheme: identifier of the protocol.
-        :param data: A dict providing the new values of the protocol attributes.
-                     Keys must match column names in database.
-        :param hostname: hostname of the protocol.
-        :param port: port of the protocol.
+        Parameters
+        ----------
+        rse:
+            The RSE name.
+        scheme:
+            The identifier of the protocol.
+        data:
+            A dict providing the new values of the protocol attributes. Keys must match column names in database.
+        hostname:
+            The hostname of the protocol.
+        port:
+            The port of the protocol.
+        Returns
+        -------
+        True if success.
 
-        :returns: True if success.
-
-        :raises RSEProtocolNotSupported: if no matching protocol entry could be found.
-        :raises RSENotFound: if the RSE doesn't exist.
-        :raises KeyNotFound: if invalid data was provided for update.
-        :raises AccessDenied: if not authorized.
+        Raises
+        -------
+        RSEProtocolNotSupported
+            If no matching protocol entry could be found.
+        RSENotFound
+            If the RSE doesn't exist.
+        KeyNotFound
+            If invalid data was provided for update.
+        AccessDenied
+            If not authorized.
         """
         path = [self.RSE_BASEURL, rse, 'protocols', scheme]
         if hostname:
@@ -416,18 +549,34 @@ class RSEClient(BaseClient):
         """
         Swaps the priorities of the provided operation.
 
-        :param rse: the RSE name.
-        :param domain: the domain in which priorities should be swapped i.e. wan or lan.
-        :param operation: the operation that should be swapped i.e. read, write, or delete.
-        :param scheme_a: the scheme of one of the two protocols to be swapped, e.g. srm.
-        :param scheme_b: the scheme of the other of the two protocols to be swapped, e.g. http.
+        Parameters
+        ----------
+        rse : str
+            The RSE name.
+        domain :
+            The domain in which priorities should be swapped (e.g., 'wan' or 'lan').
+        operation :
+            The operation for which priorities should be swapped (e.g., 'read', 'write', or 'delete').
+        scheme_a :
+            The scheme of one of the two protocols to be swapped (e.g., 'srm').
+        scheme_b :
+            The scheme of the other protocol to be swapped (e.g., 'http').
 
-        :returns: True if success.
+        Returns
+        -------
+        bool
+            True if successful.
 
-        :raises RSEProtocolNotSupported: if no matching protocol entry could be found.
-        :raises RSENotFound: if the RSE doesn't exist.
-        :raises KeyNotFound: if invalid data was provided for update.
-        :raises AccessDenied: if not authorized.
+        Raises
+        ------
+        RSEProtocolNotSupported
+            If no matching protocol entry could be found.
+        RSENotFound
+            If the RSE doesn't exist.
+        KeyNotFound
+            If invalid data was provided for update.
+        AccessDenied
+            If not authorized.
         """
 
         protocols = self.get_protocols(rse, domain, operation, False, scheme_a)['protocols']
@@ -445,14 +594,23 @@ class RSEClient(BaseClient):
 
     def add_qos_policy(self, rse: str, qos_policy: str) -> Literal[True]:
         """
-        Add a QoS policy from an RSE.
+        Add a QoS policy to an RSE.
 
-        :param rse_id: The id of the RSE.
-        :param qos_policy: The QoS policy to add.
-        :param session: The database session in use.
+        Parameters
+        ----------
+        rse
+            The name of the RSE.
+        qos_policy
+            The QoS policy to add.
 
-        :raises Duplicate: If the QoS policy already exists.
-        :returns: True if successful, except otherwise.
+        Returns
+        -------
+        True if successful.
+
+        Raises
+        ------
+        Duplicate
+            If the QoS policy already exists.
         """
 
         path = [self.RSE_BASEURL, rse, 'qos_policy', qos_policy]
@@ -469,11 +627,25 @@ class RSEClient(BaseClient):
         """
         Delete a QoS policy from an RSE.
 
-        :param rse_id: The id of the RSE.
-        :param qos_policy: The QoS policy to delete.
-        :param session: The database session in use.
+        Parameters
+        ----------
+        rse
+            The name of the RSE.
+        qos_policy
+            The QoS policy to delete.
+        session:
+            The database session in use.
 
-        :returns: True if successful, silent failure if QoS policy does not exist.
+        Returns
+        -------
+        True if successful.
+
+        Raises
+        ------
+        RSENotFound
+            If the RSE doesn't exist.
+        QoSPolicyNotFound
+            If the QoS policy doesn't exist.
         """
 
         path = [self.RSE_BASEURL, rse, 'qos_policy', qos_policy]
@@ -517,13 +689,22 @@ class RSEClient(BaseClient):
         """
         Set RSE usage information.
 
-        :param rse: the RSE name.
-        :param source: the information source, e.g. srm.
-        :param used: the used space in bytes.
-        :param free: the free in bytes.
-        :param files: the number of files
+        Parameters
+        ----------
+        rse:
+            The RSE name.
+        source:
+            The information source, e.g. srm.
+        used:
+            The used space in bytes.
+        free:
+            The free space in bytes.
+        files:
+            The number of files.
 
-        :returns: True if successful
+        Returns
+        -------
+        True if successful.
         """
         path = [self.RSE_BASEURL, rse, 'usage']
         path = '/'.join(path)
@@ -544,10 +725,16 @@ class RSEClient(BaseClient):
         """
         Get RSE usage information.
 
-        :param rse: the RSE name.
-        :param filters: dictionary of attributes by which the results should be filtered
+        Parameters
+        ----------
+        rse:
+            The RSE name.
+        filters:
+            dictionary of attributes by which the results should be filtered
 
-        :returns: True if successful, otherwise false.
+        Returns
+        -------
+        True if successful, otherwise false.
         """
         path = [self.RSE_BASEURL, rse, 'usage']
         path = '/'.join(path)
@@ -567,10 +754,16 @@ class RSEClient(BaseClient):
         """
         List RSE usage history information.
 
-        :param rse: The RSE name.
-        :param filters: dictionary of attributes by which the results should be filtered.
+        Parameters
+        ----------
+        rse:
+            The RSE name.
+        filters:
+            dictionary of attributes by which the results should be filtered
 
-        :returns:  list of dictionaries.
+        Returns
+        -------
+        list of dictionaries
         """
         path = [self.RSE_BASEURL, rse, 'usage', 'history']
         path = '/'.join(path)
@@ -593,11 +786,18 @@ class RSEClient(BaseClient):
         """
         Set RSE limit information.
 
-        :param rse: The RSE name.
-        :param name: The name of the limit.
-        :param value: The feature value.
+        Parameters
+        ----------
+        rse:
+            The RSE name.
+        name:
+            The name of the limit.
+        value:
+            The feature value.
 
-        :returns: True if successful
+        Returns
+        -------
+        True if successful.
         """
         path = [self.RSE_BASEURL, rse, 'limits']
         path = '/'.join(path)
@@ -617,9 +817,14 @@ class RSEClient(BaseClient):
         """
         Get RSE limits.
 
-        :param rse: The RSE name.
+        Parameters
+        ----------
+        rse:
+            The RSE name.
 
-        :returns: An iterator of RSE limits as dicts with 'name' and 'value' as keys.
+        Returns
+        -------
+        An iterator of RSE limits as dicts with 'name' and 'value' as keys.
         """
         path = [self.RSE_BASEURL, rse, 'limits']
         path = '/'.join(path)
@@ -636,10 +841,16 @@ class RSEClient(BaseClient):
         """
         Delete RSE limit information.
 
-        :param rse: The RSE name.
-        :param name: The name of the limit.
+        Parameters
+        ----------
+        rse:
+            The RSE name.
+        name:
+            The name of the limit.
 
-        :returns: True if successful
+        Returns
+        -------
+        True if successful.
         """
         path = [self.RSE_BASEURL, rse, 'limits']
         path = '/'.join(path)
@@ -686,9 +897,14 @@ class RSEClient(BaseClient):
         """
         Update distances with the given RSE ids.
 
-        :param source: The source.
-        :param destination: The destination.
-        :param parameters: A dictionary with property.
+        Parameters
+        ----------
+        source: str
+            The source RSE.
+        destination: str
+            The destination RSE.
+        parameters: dict[str, int]
+            A dictionary with property
         """
         path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)
@@ -709,10 +925,18 @@ class RSEClient(BaseClient):
         """
         Get distances between rses.
 
-        :param source: The source RSE.
-        :param destination: The destination RSE.
+        Param
+        ----------
+        source: str
+            The source RSE.
+        destination: str
 
-        :returns distance: List of dictionaries.
+            The destination RSE.
+
+        Returns
+        -------
+        list[dict[str, Union[str, int]]]
+            A list of dictionaries with the distance information.
         """
         path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)
@@ -731,8 +955,12 @@ class RSEClient(BaseClient):
         """
         Delete distances with the given RSE ids.
 
-        :param source: The source.
-        :param destination: The destination.
+        Parameters
+        ----------
+        source: str
+            The source
+        destination: str
+            The destination
         """
         path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -274,9 +274,9 @@ class RSEClient(BaseClient):
 
         Parameters
         ----------
-        rse : str
+        rse :
             The name of the RSE.
-        params : dict[str, Any]
+        params :
             Attributes of the protocol. Supported are:
             - scheme: identifier of this protocol
             - hostname: hostname for this protocol (default = localhost)
@@ -327,16 +327,16 @@ class RSEClient(BaseClient):
 
         Parameters
         ----------
-        rse : str
+        rse :
             The RSE name.
-        protocol_domain : RSE_SUPPORTED_PROTOCOL_DOMAINS_LITERAL, optional
+        protocol_domain :
             The scope of the protocol. Supported are 'LAN', 'WAN', and 'ALL', by default 'ALL'.
-        operation : RSE_ALL_SUPPORTED_PROTOCOL_OPERATIONS_LITERAL, optional
+        operation :
             The name of the requested operation (read, write, or delete).
             If None, all operations are queried, by default None.
-        default : bool, optional
+        default :
             Indicates if only the default operations should be returned, by default False.
-        scheme : SUPPORTED_PROTOCOLS_LITERAL, optional
+        scheme :
             The identifier of the requested protocol, by default None.
 
         Returns
@@ -402,7 +402,6 @@ class RSEClient(BaseClient):
 
         Returns
         -------
-        dict[str, str]
             A dictionary of LFN / PFN pairs.
 
         Raises
@@ -551,7 +550,7 @@ class RSEClient(BaseClient):
 
         Parameters
         ----------
-        rse : str
+        rse :
             The RSE name.
         domain :
             The domain in which priorities should be swapped (e.g., 'wan' or 'lan').
@@ -564,7 +563,6 @@ class RSEClient(BaseClient):
 
         Returns
         -------
-        bool
             True if successful.
 
         Raises
@@ -899,11 +897,11 @@ class RSEClient(BaseClient):
 
         Parameters
         ----------
-        source: str
+        source :
             The source RSE.
-        destination: str
+        destination :
             The destination RSE.
-        parameters: dict[str, int]
+        parameters :
             A dictionary with property
         """
         path = [self.RSE_BASEURL, source, 'distances', destination]
@@ -927,15 +925,14 @@ class RSEClient(BaseClient):
 
         Param
         ----------
-        source: str
+        source :
             The source RSE.
-        destination: str
+        destination :
 
             The destination RSE.
 
         Returns
         -------
-        list[dict[str, Union[str, int]]]
             A list of dictionaries with the distance information.
         """
         path = [self.RSE_BASEURL, source, 'distances', destination]
@@ -957,9 +954,9 @@ class RSEClient(BaseClient):
 
         Parameters
         ----------
-        source: str
+        source :
             The source
-        destination: str
+        destination :
             The destination
         """
         path = [self.RSE_BASEURL, source, 'distances', destination]

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -54,27 +54,52 @@ class RuleClient(BaseClient):
         weight: Optional[int] = None,
     ) -> Any:
         """
-        :param dids:                       The data identifier set.
-        :param copies:                     The number of replicas.
-        :param rse_expression:             Boolean string expression to give the list of RSEs.
-        :param priority:                   Priority of the transfers.
-        :param lifetime:                   The lifetime of the replication rules (in seconds).
-        :param grouping:                   ALL -  All files will be replicated to the same RSE.
-                                           DATASET - All files in the same dataset will be replicated to the same RSE.
-                                           NONE - Files will be completely spread over all allowed RSEs without any grouping considerations at all.
-        :param notify:                     Notification setting for the rule (Y, N, C).
-        :param source_replica_expression:  RSE Expression for RSEs to be considered for source replicas.
-        :param activity:                   Transfer Activity to be passed to FTS.
-        :param account:                    The account owning the rule.
-        :param meta:                       Metadata, as dictionary.
-        :param ignore_availability:        Option to ignore the availability of RSEs.
-        :param purge_replicas:             When the rule gets deleted purge the associated replicas immediately.
-        :param ask_approval:               Ask for approval of this replication rule.
-        :param asynchronous:               Create rule asynchronously by judge-injector.
-        :param locked:                     If the rule is locked, it cannot be deleted.
-        :param delay_injection:
-        :param comment:                    Comment about the rule.
-        :param weight:                     If the weighting option of the replication rule is used, the choice of RSEs takes their weight into account.
+        Add a replication rule.
+
+        Parameters
+        ----------
+        dids : sequence of dictionaries
+            The data identifier set.
+        copies : int
+            The number of replicas.
+        rse_expression : str
+            Boolean string expression to give the list of RSEs.
+        priority : optional
+            Priority of the transfers. Default is 3.
+        lifetime : optional
+            The lifetime of the replication rules (in seconds).
+        grouping : optional
+            ALL - All files will be replicated to the same RSE.
+            DATASET - All files in the same dataset will be replicated to the same RSE.
+            NONE - Files will be completely spread over all allowed RSEs without any grouping considerations at all.
+            Default is 'DATASET'.
+        notify : optional
+            Notification setting for the rule (Y, N, C). Default is 'N'.
+        source_replica_expression : optional
+            RSE Expression for RSEs to be considered for source replicas.
+        activity : optional
+            Transfer Activity to be passed to FTS.
+        account : optional
+            The account owning the rule.
+        meta : optional
+            Metadata, as dictionary.
+        ignore_availability : optional
+            Option to ignore the availability of RSEs. Default is False.
+        purge_replicas : optional
+            When the rule gets deleted purge the associated replicas immediately. Default is False.
+        ask_approval : optional
+            Ask for approval of this replication rule. Default is False.
+        asynchronous : optional
+            Create rule asynchronously by judge-injector. Default is False.
+        locked : optional
+            If the rule is locked, it cannot be deleted. Default is False.
+        delay_injection : optional
+            Delay the rule injection.
+        comment : optional
+            Comment about the rule.
+        weight : optional
+            If the weighting option of the replication rule is used, the choice of RSEs takes their weight into account.
+
         """
         path = self.RULE_BASEURL + '/'
         url = build_url(choice(self.list_hosts), path=path)
@@ -97,9 +122,17 @@ class RuleClient(BaseClient):
         """
         Deletes a replication rule and all associated locks.
 
-        :param rule_id:         The id of the rule to be deleted
-        :param purge_replicas:  Immediately delete the replicas.
-        :raises:                RuleNotFound, AccessDenied
+        Parameters
+        ----------
+        rule_id : str
+            The id of the rule to be deleted.
+        purge_replicas : bool, optional
+            Immediate delete the replicas
+
+        Raises
+        -------
+        RuleNotFound
+        AccessDenied
         """
 
         path = self.RULE_BASEURL + '/' + rule_id
@@ -118,8 +151,14 @@ class RuleClient(BaseClient):
         """
         Get a replication rule.
 
-        :param rule_id:  The id of the rule to be retrieved.
-        :raises:         RuleNotFound
+        Parameters
+        ----------
+        rule_id : str
+            The id of the rule to be retrieved.
+
+        Raises
+        -------
+        RuleNotFound
         """
         path = self.RULE_BASEURL + '/' + rule_id
         url = build_url(choice(self.list_hosts), path=path)
@@ -132,9 +171,16 @@ class RuleClient(BaseClient):
 
     def update_replication_rule(self, rule_id: str, options: dict[str, Any]) -> Literal[True]:
         """
-        :param rule_id:   The id of the rule to be retrieved.
-        :param options:   Options dictionary.
-        :raises:          RuleNotFound
+        Parameters
+        ----------
+        rule_id :
+            The id of the rule to be retrieved.
+        options :
+            Options dictionary.
+
+        Raises
+        -------
+        RuleNotFound
         """
         path = self.RULE_BASEURL + '/' + rule_id
         url = build_url(choice(self.list_hosts), path=path)
@@ -152,10 +198,19 @@ class RuleClient(BaseClient):
         exclude_expression: Optional[str] = None
     ) -> Any:
         """
-        :param rule_id:             Rule to be reduced.
-        :param copies:              Number of copies of the new rule.
-        :param exclude_expression:  RSE Expression of RSEs to exclude.
-        :raises:                    RuleReplaceFailed, RuleNotFound
+        Parameters
+        ----------
+        rule_id :
+            The id of the rule to be reduced.
+        copies :
+            Number of copies of the new rule.
+        exclude_expression :
+            RSE Expression of RSEs to exclude.
+
+        Raises
+        -------
+        RuleNotFound
+        RuleReplaceFailed
         """
 
         path = self.RULE_BASEURL + '/' + rule_id + '/reduce'
@@ -176,10 +231,18 @@ class RuleClient(BaseClient):
         """
         Move a replication rule to another RSE and, once done, delete the original one.
 
-        :param rule_id:                    Rule to be moved.
-        :param rse_expression:             RSE expression of the new rule.
-        :param override:                   Configurations to update for the new rule.
-        :raises:                           RuleNotFound, RuleReplaceFailed
+        Parameters
+        ----------
+        rule_id :
+            Rule to be moved.
+        rse_expression :
+            RSE expression of the new rule.
+        override :
+            Configurations to update for the new rule.
+        Raises
+        -------
+        RuleNotFound
+        RuleReplaceFailed
         """
 
         path = self.RULE_BASEURL + '/' + rule_id + '/move'
@@ -197,8 +260,14 @@ class RuleClient(BaseClient):
 
     def approve_replication_rule(self, rule_id: str) -> Literal[True]:
         """
-        :param rule_id:             Rule to be approved.
-        :raises:                    RuleNotFound
+        Parameters
+        ----------
+        rule_id :
+            Rule to be approved.
+
+        Raises
+        -------
+        RuleNotFound
         """
 
         path = self.RULE_BASEURL + '/' + rule_id
@@ -212,9 +281,17 @@ class RuleClient(BaseClient):
 
     def deny_replication_rule(self, rule_id: str, reason: Optional[str] = None) -> Literal[True]:
         """
-        :param rule_id:             Rule to be denied.
-        :param reason:              Reason for denying the rule.
-        :raises:                    RuleNotFound
+        Parameters
+        ----------
+        rule_id :
+            Rule to be denied.
+        reason :
+            Reason for denying the rule.
+
+        Raises
+        -------
+        RuleNotFound
+
         """
 
         path = self.RULE_BASEURL + '/' + rule_id
@@ -235,8 +312,12 @@ class RuleClient(BaseClient):
         """
         List the rule history of a DID.
 
-        :param scope: The scope of the DID.
-        :param name: The name of the DID.
+        Parameters
+        ----------
+        scope :
+            The scope of the DID.
+        name :
+            The name of the DID.
         """
         path = '/'.join([self.RULE_BASEURL, quote_plus(scope), quote_plus(name), 'history'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -250,8 +331,13 @@ class RuleClient(BaseClient):
         """
         Examine a replication rule for errors during transfer.
 
-        :param rule_id:             Rule to be denied.
-        :raises:                    RuleNotFound
+        Parameters
+        ----------
+        rule_id :
+            The rule to be denied
+        Raises
+        -------
+        RuleNotFound
         """
         path = self.RULE_BASEURL + '/' + rule_id + '/analysis'
         url = build_url(choice(self.list_hosts), path=path)
@@ -265,8 +351,13 @@ class RuleClient(BaseClient):
         """
         List details of all replica locks for a rule.
 
-        :param rule_id:             Rule to be denied.
-        :raises:                    RuleNotFound
+        Parameters
+        ----------
+        rule_id :
+            The rule to be denied
+        Raises
+        -------
+        RuleNotFound
         """
         path = self.RULE_BASEURL + '/' + rule_id + '/locks'
         url = build_url(choice(self.list_hosts), path=path)
@@ -279,9 +370,14 @@ class RuleClient(BaseClient):
     def list_replication_rules(self, filters: Optional[dict[str, Any]] = None) -> "Iterator[dict[str, Any]]":
         """
         List all replication rules which match a filter
-        :param filters: dictionary of attributes by which the rules should be filtered
+        Parameters
+        ----------
+        filers:
+            dictionary of attributes by which the rules should be filtered
 
-        :returns: True if successful, otherwise false.
+        Returns
+        -------
+        True if successful, otherwise false.
         """
         filters = filters or {}
         path = self.RULE_BASEURL + '/'

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -58,46 +58,46 @@ class RuleClient(BaseClient):
 
         Parameters
         ----------
-        dids : sequence of dictionaries
+        dids :
             The data identifier set.
-        copies : int
+        copies :
             The number of replicas.
-        rse_expression : str
+        rse_expression :
             Boolean string expression to give the list of RSEs.
-        priority : optional
+        priority :
             Priority of the transfers. Default is 3.
-        lifetime : optional
+        lifetime :
             The lifetime of the replication rules (in seconds).
-        grouping : optional
+        grouping :
             ALL - All files will be replicated to the same RSE.
             DATASET - All files in the same dataset will be replicated to the same RSE.
             NONE - Files will be completely spread over all allowed RSEs without any grouping considerations at all.
             Default is 'DATASET'.
-        notify : optional
+        notify :
             Notification setting for the rule (Y, N, C). Default is 'N'.
-        source_replica_expression : optional
+        source_replica_expression :
             RSE Expression for RSEs to be considered for source replicas.
-        activity : optional
+        activity :
             Transfer Activity to be passed to FTS.
-        account : optional
+        account :
             The account owning the rule.
-        meta : optional
+        meta :
             Metadata, as dictionary.
-        ignore_availability : optional
+        ignore_availability :
             Option to ignore the availability of RSEs. Default is False.
-        purge_replicas : optional
+        purge_replicas :
             When the rule gets deleted purge the associated replicas immediately. Default is False.
-        ask_approval : optional
+        ask_approval :
             Ask for approval of this replication rule. Default is False.
-        asynchronous : optional
+        asynchronous :
             Create rule asynchronously by judge-injector. Default is False.
-        locked : optional
+        locked :
             If the rule is locked, it cannot be deleted. Default is False.
-        delay_injection : optional
+        delay_injection :
             Delay the rule injection.
-        comment : optional
+        comment :
             Comment about the rule.
-        weight : optional
+        weight :
             If the weighting option of the replication rule is used, the choice of RSEs takes their weight into account.
 
         """
@@ -124,9 +124,9 @@ class RuleClient(BaseClient):
 
         Parameters
         ----------
-        rule_id : str
+        rule_id :
             The id of the rule to be deleted.
-        purge_replicas : bool, optional
+        purge_replicas :
             Immediate delete the replicas
 
         Raises
@@ -153,7 +153,7 @@ class RuleClient(BaseClient):
 
         Parameters
         ----------
-        rule_id : str
+        rule_id :
             The id of the rule to be retrieved.
 
         Raises

--- a/lib/rucio/client/scopeclient.py
+++ b/lib/rucio/client/scopeclient.py
@@ -35,11 +35,23 @@ class ScopeClient(BaseClient):
         """
         Sends the request to add a new scope.
 
-        :param account: the name of the account to add the scope to.
-        :param scope: the name of the new scope.
-        :return: True if scope was created successfully.
-        :raises Duplicate: if scope already exists.
-        :raises AccountNotFound: if account doesn't exist.
+        Parameters
+        ----------
+        account :
+            The name of the account to add the scope to.
+        scope :
+            The name of the new scope.
+
+        Returns
+        -------
+            True if scope was created successfully.
+
+        Raises
+        ------
+        Duplicate
+            If scope already exists.
+        AccountNotFound
+            If account doesn't exist.
         """
 
         path = '/'.join([self.SCOPE_BASEURL, account, 'scopes', quote_plus(scope)])
@@ -55,7 +67,9 @@ class ScopeClient(BaseClient):
         """
         Sends the request to list all scopes.
 
-        :return: a list containing the names of all scopes.
+        Returns
+        -------
+        A list containing the names of all scopes.
         """
 
         path = '/'.join(['scopes/'])
@@ -72,10 +86,21 @@ class ScopeClient(BaseClient):
         """
         Sends the request to list all scopes for a rucio account.
 
-        :param account: the rucio account to list scopes for.
-        :return: a list containing the names of all scopes for a rucio account.
-        :raises AccountNotFound: if account doesn't exist.
-        :raises ScopeNotFound: if no scopes exist for account.
+        Parameters
+        ----------
+        account :
+            The rucio account to list scopes for.
+
+        Returns
+        -------
+            A list containing the names of all scopes for a rucio account.
+
+        Raises
+        ------
+        AccountNotFound
+            If account doesn't exist.
+        ScopeNotFound
+            If no scopes exist for account.
         """
 
         path = '/'.join([self.SCOPE_BASEURL, account, 'scopes/'])

--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -47,16 +47,25 @@ class SubscriptionClient(BaseClient):
 
         Parameters
         ----------
-        name : Name of the subscription
-        account : Account identifier
-        filter_ : Dictionary of attributes by which the input data should be filtered
+        name :
+            Name of the subscription
+        account :
+            Account identifier
+        filter_ :
+            Dictionary of attributes by which the input data should be filtered
             Example: `{'dsn': 'data11_hi*.express_express.*,data11_hi*physics_MinBiasOverlay*', 'account': 'tzero'}`
-        replication_rules : Replication rules to be set. Dictionary with keys copies, rse_expression, weight, rse_expression
-        comments : Comments for the subscription
-        lifetime : Subscription's lifetime (days); False if subscription has no lifetime
-        retroactive : Flag to know if the subscription should be applied on previous data
-        dry_run : Just print the subscriptions actions without actually executing them (Useful if retroactive flag is set)
-        priority : The priority of the subscription (3 by default)
+        replication_rules :
+            Replication rules to be set. Dictionary with keys copies, rse_expression, weight, rse_expression
+        comments :
+            Comments for the subscription
+        lifetime :
+            Subscription's lifetime (days); False if subscription has no lifetime
+        retroactive :
+            Flag to know if the subscription should be applied on previous data
+        dry_run :
+            Just print the subscriptions actions without actually executing them (Useful if retroactive flag is set)
+        priority :
+            The priority of the subscription (3 by default)
 
         """
         path = self.SUB_BASEURL + '/' + account + '/' + name

--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -45,16 +45,19 @@ class SubscriptionClient(BaseClient):
         """
         Adds a new subscription which will be verified against every new added file and dataset
 
-        :param name: Name of the subscription
-        :param account: Account identifier
-        :param filter_: Dictionary of attributes by which the input data should be filtered
-                       **Example**: ``{'dsn': 'data11_hi*.express_express.*,data11_hi*physics_MinBiasOverlay*', 'account': 'tzero'}``
-        :param replication_rules: Replication rules to be set : Dictionary with keys copies, rse_expression, weight, rse_expression
-        :param comments: Comments for the subscription
-        :param lifetime: Subscription's lifetime (days); False if subscription has no lifetime
-        :param retroactive: Flag to know if the subscription should be applied on previous data
-        :param dry_run: Just print the subscriptions actions without actually executing them (Useful if retroactive flag is set)
-        :param priority: The priority of the subscription (3 by default)
+        Parameters
+        ----------
+        name : Name of the subscription
+        account : Account identifier
+        filter_ : Dictionary of attributes by which the input data should be filtered
+            Example: `{'dsn': 'data11_hi*.express_express.*,data11_hi*physics_MinBiasOverlay*', 'account': 'tzero'}`
+        replication_rules : Replication rules to be set. Dictionary with keys copies, rse_expression, weight, rse_expression
+        comments : Comments for the subscription
+        lifetime : Subscription's lifetime (days); False if subscription has no lifetime
+        retroactive : Flag to know if the subscription should be applied on previous data
+        dry_run : Just print the subscriptions actions without actually executing them (Useful if retroactive flag is set)
+        priority : The priority of the subscription (3 by default)
+
         """
         path = self.SUB_BASEURL + '/' + account + '/' + name
         url = build_url(choice(self.list_hosts), path=path)
@@ -82,10 +85,21 @@ class SubscriptionClient(BaseClient):
         Returns a dictionary with the subscription information :
         Examples: ``{'status': 'INACTIVE/ACTIVE/BROKEN', 'last_modified_date': ...}``
 
-        :param name: Name of the subscription
-        :param account: Account identifier
-        :returns: Dictionary containing subscription parameter
-        :raises: exception.NotFound if subscription is not found
+        Parameters
+        ----------
+        name :
+            Name of the subscription
+        account :
+            Account identifier
+
+        Returns
+        -------
+        Dictionary with the subscription information
+
+        Raises
+        -------
+        NotFound
+            If subscription is not found
         """
         path = self.SUB_BASEURL
         if account:
@@ -120,17 +134,23 @@ class SubscriptionClient(BaseClient):
         """
         Updates a subscription
 
-        :param name: Name of the subscription
-        :param account: Account identifier
-        :param filter_: Dictionary of attributes by which the input data should be filtered
-                       **Example**: ``{'dsn': 'data11_hi*.express_express.*,data11_hi*physics_MinBiasOverlay*', 'account': 'tzero'}``
-        :param replication_rules: Replication rules to be set : Dictionary with keys copies, rse_expression, weight, rse_expression
-        :param comments: Comments for the subscription
-        :param lifetime: Subscription's lifetime (days); False if subscription has no lifetime
-        :param retroactive: Flag to know if the subscription should be applied on previous data
-        :param dry_run: Just print the subscriptions actions without actually executing them (Useful if retroactive flag is set)
-        :param priority: The priority of the subscription
-        :raises: exception.NotFound if subscription is not found
+        Parameters
+        ----------
+        name : Name of the subscription
+        account : Account identifier
+        filter_ : Dictionary of attributes by which the input data should be filtered
+            Example: `{'dsn': 'data11_hi*.express_express.*,data11_hi*physics_MinBiasOverlay*', 'account': 'tzero'}`
+        replication_rules : Replication rules to be set. Dictionary with keys copies, rse_expression, weight, rse_expression
+        comments : Comments for the subscription
+        lifetime : Subscription's lifetime (days); False if subscription has no lifetime
+        retroactive : Flag to know if the subscription should be applied on previous data
+        dry_run : Just print the subscriptions actions without actually executing them (Useful if retroactive flag is set)
+        priority : The priority of the subscription
+
+        Raises
+        ------
+        NotFound
+            If subscription is not found
         """
         if not account:
             account = self.account
@@ -159,8 +179,12 @@ class SubscriptionClient(BaseClient):
         """
         List the associated rules of a subscription.
 
-        :param account: Account of the subscription.
-        :param name:    Name of the subscription.
+        Parameters
+        ----------
+        account :
+            Account of the subscription.
+        name :
+            Name of the subscription.
         """
 
         path = '/'.join([self.SUB_BASEURL, account, name, 'rules'])

--- a/lib/rucio/client/touchclient.py
+++ b/lib/rucio/client/touchclient.py
@@ -40,13 +40,22 @@ class TouchClient(BaseClient):
         """
         Sends a touch trace for a given file or dataset.
 
-        :param scope: the scope of the file/dataset to update.
-        :param name: the name of file/dataset to update.
-        :param rse: optional parameter if a specific replica should be touched.
-        :raises DataIdentifierNotFound: if given dids does not exist.
-        :raises RSENotFound: if rse is not None and given rse does not exist.
-        :raises UnsupportedDIDType: if type of the given DID is not FILE or DATASET.
-        :raises RucioException: if trace could not be sent successfully.
+        Parameters
+        ----------
+        scope : The scope of the file/dataset to update.
+        name : The name of file/dataset to update.
+        rse : Optional parameter if a specific replica should be touched.
+
+        Raises
+        ------
+        DataIdentifierNotFound
+            If given dids does not exist.
+        RSENotFound
+            If rse is not None and given rse does not exist.
+        UnsupportedDIDType
+            If type of the given DID is not FILE or DATASET.
+        RucioException
+            If trace could not be sent successfully.
         """
 
         trace = {}


### PR DESCRIPTION
Related to PR #7654 

Proposes all existing client docustrings are written in "numpy" style to avoid large blocks of unstructured text in arguments that are a dictionary with specific fields

Tries to make very few editorial changes. 

Should be followed up with a PR in the documentation repo changing the style of docstring in the `mkdoc.yaml` file