### PR TITLE
Feature 7687 wlcg token discovery

### DIFF
--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -911,7 +911,6 @@ class BaseClient:
                     raise CannotAuthenticate('x509 authentication failed for account=%s with identity=%s' % (self.account,
                                                                                                              self.creds))
             elif self.auth_type == 'oidc':
-                
                 if not self.__get_token_oidc():
                     raise CannotAuthenticate('OIDC authentication failed for account=%s' % self.account)
 

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -951,7 +951,7 @@ class BaseClient:
                 self.headers['X-Rucio-Auth-Token'] = self.auth_token
                 return True
 
-        if not os.path.exists(self.token_file):
+        if not path.exists(self.token_file):
             return False
 
         try:

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -951,7 +951,7 @@ class BaseClient:
                 self.headers['X-Rucio-Auth-Token'] = self.auth_token
                 return True
 
-        if not path.exists(self.token_file):
+        if not os.path.exists(self.token_file):
             return False
 
         try:

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1708,7 +1708,7 @@ def get_transfer_schemas() -> dict[str, list[str]]:
     return scheme_map
 
 
-def wlcg_token_discovery(user_id=None):
+def wlcg_token_discovery() -> Optional[str]:
     """
     Discovers a WLCG bearer token from the environment, following the specified precedence.
     Specs: https://zenodo.org/records/3937438

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -1713,12 +1713,9 @@ def wlcg_token_discovery(user_id=None):
     Discovers a WLCG bearer token from the environment, following the specified precedence.
     Specs: https://zenodo.org/records/3937438
 
-    :param user_id: (Optional) The user ID. If None, uses the effective user ID.
     :returns: The discovered token (string), or None if no valid token is found.
     """
-    if user_id is None:
-        user_id = os.geteuid()
-
+    user_id = os.geteuid()
     token = None
 
     # 1. Check BEARER_TOKEN environment variable


### PR DESCRIPTION
Add wlcg_token_discovery specs.
https://zenodo.org/records/3937438

it is invoked for auth_type oidc,
-  invoke wlcg_token_discovery if auth_type oidc
- if found it will send that to do validate_jwt and if ok stored and ok auth . 
- if no token from above  then go on with regular flow (ie. look for rucio token file  and so on (which includes oidc flow))

closes #7687 