### PR TITLE
Docker & Kubernetes: Make `docker_compose.yml` compatible with Podman; Fix rucio#7715 

### DIFF
--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -1,10 +1,11 @@
-name: rucio
+name: dev
 
 services:
   # ------------------------------------------------------------------
   # Main Rucio dev containers
   # ------------------------------------------------------------------
   rucioclient:
+    container_name: dev-rucioclient-1
     image: "docker.io/${DOCKER_REPO:-rucio}/rucio-dev${RUCIO_TAG:+:release-${RUCIO_TAG}}"
     platform: linux/amd64
     entrypoint: ["/rucio_source/etc/docker/dev/rucio/entrypoint.sh"]
@@ -65,6 +66,7 @@ services:
   # Database, MQ, metrics, and other external services
   # ------------------------------------------------------------------
   ruciodb:
+    container_name: dev-ruciodb-1
     image: docker.io/postgres:14
     environment:
       - POSTGRES_USER=rucio
@@ -73,9 +75,11 @@ services:
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
 
   graphite:
+    container_name: dev-graphite-1
     image: docker.io/graphiteapp/graphite-statsd
 
   influxdb:
+    container_name: dev-influxdb-1
     image: docker.io/influxdb:latest
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup
@@ -86,21 +90,24 @@ services:
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mytoken
 
   elasticsearch:
+    container_name: dev-elasticsearch-1
     image: docker.io/elasticsearch:7.8.0
     environment:
       - discovery.type=single-node
 
   activemq:
+    container_name: dev-activemq-1
     image: docker.io/apache/activemq-classic:5.18.7
     platform: linux/amd64
     volumes:
       - ./activemq/users.properties:/opt/apache-activemq/conf/users.properties
     environment:
-      # web portal acccess, helpful for debugging
+      # web portal access, helpful for debugging
       ACTIVEMQ_WEB_USER: activemq
       ACTIVEMQ_WEB_PASSWORD: supersecret
 
   postgres14:
+    container_name: dev-postgres14-1
     image: docker.io/postgres:14
     profiles:
       - postgres14
@@ -111,6 +118,7 @@ services:
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
 
   mysql8:
+    container_name: dev-mysql8-1
     image: docker.io/mysql:8.3
     profiles:
       - mysql8
@@ -125,6 +133,7 @@ services:
       - "--character-set-server=latin1"
 
   oracle:
+    container_name: dev-oracle-1
     image: docker.io/gvenzl/oracle-xe:18.4.0
     platform: linux/amd64
     profiles:
@@ -163,6 +172,7 @@ services:
         hard: 10240
 
   ftsdb:
+    container_name: dev-ftsdb-1
     image: docker.io/mysql:8.3
     profiles:
       - storage
@@ -174,6 +184,7 @@ services:
       - MYSQL_DATABASE=fts
 
   xrd1:
+    container_name: dev-xrd1-1
     image: "docker.io/${DOCKER_REPO:-rucio}/test-xrootd:${RUCIO_TAG:-latest}"
     platform: linux/amd64
     profiles:
@@ -191,6 +202,7 @@ services:
         hard: 10240
 
   xrd2:
+    container_name: dev-xrd2-1
     image: "docker.io/${DOCKER_REPO:-rucio}/test-xrootd:${RUCIO_TAG:-latest}"
     platform: linux/amd64
     profiles:
@@ -208,6 +220,7 @@ services:
         hard: 10240
 
   xrd3:
+    container_name: dev-xrd3-1
     image: "docker.io/${DOCKER_REPO:-rucio}/test-xrootd:${RUCIO_TAG:-latest}"
     platform: linux/amd64
     profiles:
@@ -225,6 +238,7 @@ services:
         hard: 10240
 
   xrd4:
+    container_name: dev-xrd4-1
     image: "docker.io/${DOCKER_REPO:-rucio}/test-xrootd:${RUCIO_TAG:-latest}"
     platform: linux/amd64
     profiles:
@@ -242,6 +256,7 @@ services:
         hard: 10240
 
   xrd5:
+    container_name: dev-xrd5-1
     image: "docker.io/${DOCKER_REPO:-rucio}/test-xrootd:${RUCIO_TAG:-latest}"
     platform: linux/amd64
     profiles:
@@ -266,6 +281,7 @@ services:
         hard: 10240
 
   web1:
+    container_name: dev-web1-1
     image: "docker.io/${DOCKER_REPO:-rucio}/test-webdav:latest"
     platform: linux/amd64
     environment:
@@ -285,6 +301,7 @@ services:
   # Other services
   # ------------------------------------------------------------------
   minio:
+    container_name: dev-minio-1
     image: docker.io/minio/minio
     profiles:
       - storage
@@ -297,6 +314,7 @@ services:
     command: ["server", "/data"]
 
   ssh1:
+    container_name: dev-ssh1-1
     image: "docker.io/${DOCKER_REPO:-rucio}/test-ssh:${RUCIO_TAG:-latest}"
     platform: linux/amd64
     profiles:
@@ -308,6 +326,7 @@ services:
   # External metadata services
   # ------------------------------------------------------------------
   mongo:
+    container_name: dev-mongo-1
     image: docker.io/mongo:5.0
     profiles:
       - externalmetadata
@@ -316,11 +335,13 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: mongo-meta
 
   mongo-noauth:
+    container_name: dev-mongo-noauth-1
     image: docker.io/mongo:5.0
     profiles:
       - externalmetadata
 
   postgres:
+    container_name: dev-postgres-1
     image: docker.io/postgres:14
     profiles:
       - externalmetadata
@@ -331,6 +352,7 @@ services:
     command: ["-p", "5433"]
 
   elasticsearch_meta:
+    container_name: dev-elasticsearch_meta-1
     image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
     platform: linux/amd64
     profiles:
@@ -348,6 +370,7 @@ services:
   # Monitoring stack
   # ------------------------------------------------------------------
   logstash:
+    container_name: dev-logstash-1
     image: docker.elastic.co/logstash/logstash-oss:7.3.2
     platform: linux/amd64
     profiles:
@@ -357,11 +380,13 @@ services:
       - ./pipeline.conf:/usr/share/logstash/pipeline/pipeline.conf:Z
 
   kibana:
+    container_name: dev-kibana-1
     image: docker.io/kibana:7.4.0
     profiles:
       - monitoring
 
   grafana:
+    container_name: dev-grafana-1
     image: docker.io/grafana/grafana:latest
     profiles:
       - monitoring
@@ -370,6 +395,7 @@ services:
   # IAM / Keycloak for auth
   # ------------------------------------------------------------------
   iam-db:
+    container_name: dev-iam-db-1
     image: mariadb:10.11
     profiles:
       - iam
@@ -386,6 +412,7 @@ services:
       - ./iam/indigoiam_db.sql:/docker-entrypoint-initdb.d/03_indigoiam.sql:ro
 
   indigoiam:
+    container_name: dev-indigoiam-1
     image: nginx
     profiles:
       - iam
@@ -404,6 +431,7 @@ services:
       - indigoiam-login-service
 
   indigoiam-login-service:
+    container_name: dev-indigoiam-login-service-1
     image: indigoiam/iam-login-service:v1.8.2p2
     platform: linux/amd64
     profiles:
@@ -440,6 +468,7 @@ services:
         condition: service_healthy
 
   keycloak:
+    container_name: dev-keycloak-1
     image: quay.io/keycloak/keycloak:23.0.1
     command: start-dev --features=token-exchange,admin-fine-grained-authz,dynamic-scopes --db mariadb --db-url-host iam-db --db-username keycloak --db-password secret --https-certificate-file=/cert.pem --https-certificate-key-file=/key.pem
     profiles:

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   # ------------------------------------------------------------------
   rucioclient:
     container_name: dev-rucioclient-1
-    image: "docker.io/${DOCKER_REPO:-rucio}/rucio-dev${RUCIO_TAG:+:release-${RUCIO_TAG}}"
+    image: "docker.io/${DOCKER_REPO:-rucio}/rucio-dev:${RUCIO_DEV_PREFIX:-}${RUCIO_TAG:-latest}"
     platform: linux/amd64
     entrypoint: ["/rucio_source/etc/docker/dev/rucio/entrypoint.sh"]
     command: ["sleep", "infinity"]
@@ -36,7 +36,7 @@ services:
 
   rucio:
     container_name: dev-rucio-1
-    image: "docker.io/${DOCKER_REPO:-rucio}/rucio-dev${RUCIO_TAG:+:release-${RUCIO_TAG}}"
+    image: "docker.io/${DOCKER_REPO:-rucio}/rucio-dev:${RUCIO_DEV_PREFIX:-}${RUCIO_TAG:-latest}"
     platform: linux/amd64
     entrypoint: ["/rucio_source/etc/docker/dev/rucio/entrypoint.sh"]
     command: ["httpd","-D","FOREGROUND"]

--- a/tools/bootstrap_dev.sh
+++ b/tools/bootstrap_dev.sh
@@ -49,10 +49,10 @@
 #   (You can also use the short forms: -r <TAG>, -l, -m, -p <NAME>)
 #
 # Examples:
-#   1) Check out a specific release (36.5.0) and start the dev environment including the "storage" profile:
-#        ./tools/bootstrap_dev.sh --release 36.5.0 --profile storage
+#   1) Check out a specific release (37.4.0) and start the dev environment including the "storage" profile:
+#        ./tools/bootstrap_dev.sh --release 37.4.0 --profile storage
 #     or the short form:
-#        ./tools/bootstrap_dev.sh -r 36.5.0 -p storage
+#        ./tools/bootstrap_dev.sh -r 37.4.0 -p storage
 #
 #   2) Check out master and run the dev environment including the "storage" and "monitoring" profiles:
 #        ./tools/bootstrap_dev.sh --master --profile storage --profile monitoring
@@ -92,7 +92,7 @@ function usage() {
 Usage: $0 [options]
 
 Checkout options (mutually exclusive):
-  -r, --release <TAG>   Force local '$DEMO_BRANCH' branch to the upstream release tag <TAG>, e.g. 36.5.0.
+  -r, --release <TAG>   Force local '$DEMO_BRANCH' branch to the upstream release tag <TAG>, e.g. 37.4.0.
   -l, --latest          Force local '$DEMO_BRANCH' to the semver release that matches the Docker Hub 'latest' digest.
   -m, --master          Force local '$DEMO_BRANCH' to the upstream master branch.
 
@@ -115,7 +115,7 @@ Notes:
      Rucio repository. If it's absent or incorrect, the script will fix it automatically.
 
 Examples:
-  $0 --release 36.5.0 --profile storage
+  $0 --release 37.4.0 --profile storage
   $0 --master --profile storage --profile monitoring
   $0 --latest --profile storage
   $0 --master
@@ -345,7 +345,7 @@ while [[ $# -gt 0 ]]; do
       fi
       # Ensure $2 is valid
       if [[ -z "${2:-}" || "${2:0:1}" == "-" ]]; then
-        echo "ERROR: Option '$1' requires a release tag (e.g. '36.5.0')."
+        echo "ERROR: Option '$1' requires a release tag (e.g. '37.4.0')."
         exit 1
       fi
       SPECIFIED_RELEASE="$2"
@@ -599,14 +599,23 @@ Rucio dev environment started.
 
 -------------------------------------------------------------------
  IMPORTANT:
-   1) You can also manually spin up the dev environment using Docker Compose directly. For example:
-      docker-compose --project-name dev --file etc/docker/dev/docker-compose.yml up -d
+   1) You can also manually spin up the \`latest\` dev environment using Docker Compose directly.
+      Example using docker:
+        docker-compose --file path_to/etc/docker/dev/docker-compose.yml up
+      ..or using podman:
+        podman-compose --file path_to/etc/docker/dev/docker-compose.yml up -d
 
-   2) Additionally, you can specify custom parameters, such as a Docker repository, a specific Rucio release tag, or extra profiles. For example:
-      DOCKER_REPO=my_repo RUCIO_TAG=36.5.0 docker-compose --project-name dev --file etc/docker/dev/docker-compose.yml --profile storage --profile monitoring up -d
+   2) Additionally, you can specify custom parameters, such as a Docker repository, a specific Rucio
+      release tag (in such cases, RUCIO_DEV_PREFIX=release- is required), or extra profiles.
+      Example using docker:
+        DOCKER_REPO=my_repo RUCIO_TAG=37.4.0 RUCIO_DEV_PREFIX=release- docker-compose --project-name dev --file path_to/etc/docker/dev/docker-compose.yml --profile storage --profile monitoring up
+      ..or using podman:
+        RUCIO_TAG=37.4.0 RUCIO_DEV_PREFIX=release- podman-compose --file path_to/etc/docker/dev/docker-compose.yml --profile storage up -d
 
    3) Switching local branches while containers are running:
-      If you change or check out a different branch locally, the bind-mounted code inside the container will be replaced on-the-fly. This can cause unpredictable
-      behavior or partial/inconsistent code loading. For best results, tear down the containers before switching branches, then start them again on the new branch.
+      If you change or check out a different branch locally, the bind-mounted code inside
+      the container will be replaced on-the-fly. This can cause unpredictable behavior or
+      partial/inconsistent code loading. For best results, tear down the containers before
+      switching branches, then start them again on the new branch.
 -------------------------------------------------------------------
 EOF

--- a/tools/bootstrap_dev.sh
+++ b/tools/bootstrap_dev.sh
@@ -442,6 +442,9 @@ ensure_upstream_exists
 # We'll pass this to Docker Compose as RUCIO_TAG. If empty, that means :latest.
 RUCIO_TAG=""
 
+# By default, no prefix for rucio-dev images
+RUCIO_DEV_PREFIX=""
+
 # If user specified any destructive checkout option
 if [[ "$USE_MASTER" == "true" || "$USE_LATEST" == "true" || -n "$SPECIFIED_RELEASE" ]]; then
 
@@ -465,7 +468,7 @@ if [[ "$USE_MASTER" == "true" || "$USE_LATEST" == "true" || -n "$SPECIFIED_RELEA
   if [[ "$USE_MASTER" == "true" ]]; then
     echo ">>> Force-reset local '$DEMO_BRANCH' to '$UPSTREAM_REMOTE/master'."
     git checkout -B "$DEMO_BRANCH" "$UPSTREAM_REMOTE/master"
-    # RUCIO_TAG stays empty => "docker.io/.../rucio-dev:latest" (which shall be updated later to master state)
+    # RUCIO_TAG and RUCIO_DEV_PREFIX stay empty => "docker.io/.../rucio-dev:latest"
 
   # --release
   elif [[ -n "$SPECIFIED_RELEASE" ]]; then
@@ -473,6 +476,9 @@ if [[ "$USE_MASTER" == "true" || "$USE_LATEST" == "true" || -n "$SPECIFIED_RELEA
     ensure_tag_fetched "$SPECIFIED_RELEASE"
     git checkout -B "$DEMO_BRANCH" "refs/tags/$SPECIFIED_RELEASE"
     RUCIO_TAG="$SPECIFIED_RELEASE"
+
+    # For rucio-dev images that use "release-<tag>" style
+    RUCIO_DEV_PREFIX="release-"
 
   # --latest
   elif [[ "$USE_LATEST" == "true" ]]; then
@@ -521,10 +527,11 @@ fi
 #       (First tear down any existing environment to ensure a clean start)
 # ---------------------------------------------------------------------------
 
-echo ">>> Using Docker images with RUCIO_TAG=\"$RUCIO_TAG\""
+echo ">>> Using Docker images with RUCIO_TAG=\"$RUCIO_TAG\" and RUCIO_DEV_PREFIX=\"$RUCIO_DEV_PREFIX\""
 
 # Make sure Docker Compose sees the RUCIO_TAG environment variable
 export RUCIO_TAG="$RUCIO_TAG"
+export RUCIO_DEV_PREFIX="$RUCIO_DEV_PREFIX"
 
 cd "$RUCIO_REPO_ROOT/etc/docker/dev"
 


### PR DESCRIPTION
As described in #7715, this PR makes `docker_compose.yml` compatible with Podman. It also switches to fixed project/container names to avoid possible errors when deploying those under a custom `--project-name`, and updates the examples in `bootstrap_dev.sh`.