### PR TITLE
Client: Unify `rucio-admin scope list` and `rucio list-scopes`

### DIFF
--- a/lib/rucio/cli/bin_legacy/rucio.py
+++ b/lib/rucio/cli/bin_legacy/rucio.py
@@ -542,15 +542,17 @@ def list_scopes(args, client, logger, console, spinner):
 
     List scopes.
     """
-    # For the moment..
-
     if cli_config == 'rich':
         spinner.update(status='Fetching scopes')
         spinner.start()
 
-    scopes = client.list_scopes()
+    if args.account:
+        scopes = client.list_scopes_for_account(args.account)
+    else:
+        scopes = client.list_scopes()
     if cli_config == 'rich':
-        table = generate_table([[scope] for scope in sorted(scopes)], headers=['SCOPE'], col_alignments=['left'])
+        scopes = [[scope] for scope in sorted(scopes) if 'mock' not in scope]
+        table = generate_table(scopes, headers=['SCOPE'], col_alignments=['left'])
         spinner.stop()
         print_output(table, console=console, no_pager=args.no_pager)
     else:
@@ -2499,6 +2501,7 @@ You can filter by key/value, e.g.::
     ''')
 
     scope_list_parser.set_defaults(function=list_scopes)
+    scope_list_parser.add_argument('--account', help='Filter scopes by account')
 
     # The close command
     close_parser = subparsers.add_parser('close', help='Close a dataset or container.')

--- a/lib/rucio/cli/bin_legacy/rucio_admin.py
+++ b/lib/rucio/cli/bin_legacy/rucio_admin.py
@@ -779,8 +779,7 @@ def list_scopes(args, client, logger, console, spinner):
         print_output(table, console=console, no_pager=args.no_pager)
     else:
         for scope in scopes:
-            if 'mock' not in scope:
-                print(scope)
+            print(scope)
     return SUCCESS
 
 

--- a/tests/test_bin_rucio.py
+++ b/tests/test_bin_rucio.py
@@ -134,19 +134,30 @@ def test_attributes(random_account):
 @pytest.mark.dirty(reason="Creates a new scope on vo=def")
 def test_scope(random_account):
     """CLIENT(ADMIN): Add/list/delete/list scope"""
-    tmp_scp = scope_name_generator().replace("mock", "test")
+    tmp_scp = scope_name_generator()
     cmd = f'rucio-admin scope add --account {random_account} --scope {tmp_scp}'
     exitcode, out, _ = execute(cmd)
     assert exitcode == 0
     assert f'Added new scope to {random_account}: {tmp_scp}' in out
 
-    cmd = 'rucio list-scopes'
+    cmd = f'rucio-admin scope list --account {random_account}'
     exitcode, out, _ = execute(cmd)
     assert exitcode == 0
     assert tmp_scp in out
 
-    cmd = f'rucio-admin scope list --account {random_account}'
-    exitcode, out, _ = execute(cmd)
+    cmd = 'rucio-admin scope list'
+    exitcode, out, err = execute(cmd)
+    assert exitcode == 0
+    assert tmp_scp in out
+
+    # Client should do the same
+    cmd = 'rucio list-scopes'
+    exitcode, out, err = execute(cmd)
+    assert exitcode == 0
+    assert tmp_scp in out
+
+    cmd = f'rucio list-scopes --account {random_account}'
+    exitcode, out, err = execute(cmd)
     assert exitcode == 0
     assert tmp_scp in out
 


### PR DESCRIPTION
Closes #7316 

* `rucio list-scopes` now accepts an 'account' argument 
* `rucio-admin scope list` now can print out 'mock' scopes. 