### PR TITLE
Encode requests url's in `rucio.js` 

### DIFF
--- a/lib/rucio/web/ui/static/rucio.js
+++ b/lib/rucio/web/ui/static/rucio.js
@@ -414,7 +414,7 @@ RucioClient.prototype.list_account_rules = function(options) {
 /* list all dids for a scope */
 RucioClient.prototype.scope_list = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope);
     if ('name' in options || 'recursive' in options) {
         url += '?name=' + options.name;
     };
@@ -458,7 +458,7 @@ RucioClient.prototype.list_subscriptions = function(options) {
 /* list all subscriptions for an account */
 RucioClient.prototype.list_replication_rules = function(options) {
     check_token();
-    var url = this.url + '/subscriptions/' + options.account + '/' + options.name + '/Rules';
+    var url = this.url + '/subscriptions/' + options.account + '/' + encodeURIComponent(options.name) + '/Rules';
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -477,7 +477,7 @@ RucioClient.prototype.list_replication_rules = function(options) {
 /* list all subscriptions for an account */
 RucioClient.prototype.list_subscription_rules_state = function(options) {
     check_token();
-    var url = this.url + '/subscriptions/' + options.account + '/' + options.name + '/Rules/States';
+    var url = this.url + '/subscriptions/' + options.account + '/' + encodeURIComponent(options.name) + '/Rules/States';
     if (options.async == null ) { options.async = true; }
     jQuery.ajax({url: url,
                  crossDomain: true,
@@ -537,7 +537,7 @@ RucioClient.prototype.create_rule = function(options) {
 /* list replication rules */
 RucioClient.prototype.list_replication_rules = function(options) {
     check_token();
-    var url = this.url + '/subscriptions/' + options.account + '/' + options.name + '/Rules?state=' + options.state;
+    var url = this.url + '/subscriptions/' + options.account + '/' + encodeURIComponent(options.name) + '/Rules?state=' + options.state;
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -764,7 +764,7 @@ RucioClient.prototype.show_metadata = function(options) {
 /* show DID metadata */
 RucioClient.prototype.did_get_metadata = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name + '/meta';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/meta';
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
                  crossDomain: true,
@@ -785,7 +785,7 @@ RucioClient.prototype.did_get_metadata = function(options) {
 /* show generic DID metadata */
 RucioClient.prototype.did_get_generic_metadata = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name + '/did_meta';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/did_meta';
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
                  crossDomain: true,
@@ -806,7 +806,7 @@ RucioClient.prototype.did_get_generic_metadata = function(options) {
 /* show DID files */
 RucioClient.prototype.did_get_files = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name + '/files';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/files';
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -825,7 +825,7 @@ RucioClient.prototype.did_get_files = function(options) {
 /* List DID parents */
 RucioClient.prototype.list_parent_dids = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name + '/parents';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/parents';
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -844,7 +844,7 @@ RucioClient.prototype.list_parent_dids = function(options) {
 /* returns the DID contents */
 RucioClient.prototype.list_contents = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name + '/dids';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/dids';
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -901,7 +901,7 @@ RucioClient.prototype.list_replicas = function(options) {
 /* list all rules of a DID */
 RucioClient.prototype.did_get_rules = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name + '/rules';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/rules';
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -1044,7 +1044,7 @@ RucioClient.prototype.get_account_usage = function(options) {
 /* get request by did */
 RucioClient.prototype.get_request_by_did = function(options) {
     check_token();
-    var url = this.url + '/requests/' + options.scope + '/' + options.name + '/' + options.rse;
+    var url = this.url + '/requests/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/' + options.rse;
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -1083,7 +1083,7 @@ RucioClient.prototype.get_subscription_by_id = function(options) {
 
 /* Update an existing subscription */
 RucioClient.prototype.update_subscription = function(options) {
-    var url = this.url + '/subscriptions/' + options.account + '/' + options.name;
+    var url = this.url + '/subscriptions/' + options.account + '/' + encodeURIComponent(options.name);
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -1103,7 +1103,7 @@ RucioClient.prototype.update_subscription = function(options) {
 
 /* Create a subscription */
 RucioClient.prototype.create_subscription = function(options) {
-    var url = this.url + '/subscriptions/' + options.account + '/' + options.name;
+    var url = this.url + '/subscriptions/' + options.account + '/' + encodeURIComponent(options.name);
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -1345,7 +1345,7 @@ RucioClient.prototype.list_heartbeats = function(options) {
 /* retrieve a single data identifier */
 RucioClient.prototype.get_did = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name;
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name);
     if (options.dynamic) { url += '?dynamic=' + options.dynamic; }
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
@@ -1414,7 +1414,7 @@ RucioClient.prototype.create_did_sample = function(options) {
 /* Set metadata for a DID */
 RucioClient.prototype.set_metadata = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name + '/meta/' + options.key;
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/meta/' + options.key;
     jQuery.ajax({url: url,
                  crossDomain: true,
                  type: 'POST',
@@ -1435,7 +1435,7 @@ RucioClient.prototype.set_metadata = function(options) {
 /* Set DID status */
 RucioClient.prototype.set_status = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name + '/status';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/status';
     if (options.async == null ) { options.async = true; }
     jQuery.ajax({url: url,
                  crossDomain: true,
@@ -1499,7 +1499,7 @@ RucioClient.prototype.list_account_attributes = function(options) {
 /* list dataset replicas */
 RucioClient.prototype.list_dataset_replicas = function(options) {
     check_token();
-    var url = this.url + '/replicas/' + options.scope + '/' + options.name + '/datasets';
+    var url = this.url + '/replicas/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/datasets';
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -1539,7 +1539,7 @@ RucioClient.prototype.set_account_limit = function(options) {
 /* add data identifier */
 RucioClient.prototype.add_did = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name;
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name);
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
                  async: options.async,
@@ -1562,7 +1562,7 @@ RucioClient.prototype.add_did = function(options) {
 /* attach dids */
 RucioClient.prototype.attach_dids = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name + '/dids';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/dids';
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
                  async: options.async,
@@ -1585,7 +1585,7 @@ RucioClient.prototype.attach_dids = function(options) {
 /* detach dids */
 RucioClient.prototype.detach_dids = function(options) {
     check_token();
-    var url = this.url + '/dids/' + options.scope + '/' + options.name + '/dids';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/dids';
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
         async: options.async,

--- a/lib/rucio/web/ui/static/rucio.js
+++ b/lib/rucio/web/ui/static/rucio.js
@@ -785,7 +785,7 @@ RucioClient.prototype.did_get_metadata = function(options) {
 /* show generic DID metadata */
 RucioClient.prototype.did_get_generic_metadata = function(options) {
     check_token();
-    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/did_meta';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/did_meta';
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
                  crossDomain: true,
@@ -806,7 +806,7 @@ RucioClient.prototype.did_get_generic_metadata = function(options) {
 /* show DID files */
 RucioClient.prototype.did_get_files = function(options) {
     check_token();
-    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/files';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/files';
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -825,7 +825,7 @@ RucioClient.prototype.did_get_files = function(options) {
 /* List DID parents */
 RucioClient.prototype.list_parent_dids = function(options) {
     check_token();
-    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/parents';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/parents';
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -844,7 +844,7 @@ RucioClient.prototype.list_parent_dids = function(options) {
 /* returns the DID contents */
 RucioClient.prototype.list_contents = function(options) {
     check_token();
-    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/dids';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/dids';
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -901,7 +901,7 @@ RucioClient.prototype.list_replicas = function(options) {
 /* list all rules of a DID */
 RucioClient.prototype.did_get_rules = function(options) {
     check_token();
-    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/rules';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/rules';
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -1044,7 +1044,7 @@ RucioClient.prototype.get_account_usage = function(options) {
 /* get request by did */
 RucioClient.prototype.get_request_by_did = function(options) {
     check_token();
-    var url = this.url + '/requests/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/' + options.rse;
+    var url = this.url + '/requests/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/' + options.rse;
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -1345,7 +1345,7 @@ RucioClient.prototype.list_heartbeats = function(options) {
 /* retrieve a single data identifier */
 RucioClient.prototype.get_did = function(options) {
     check_token();
-    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name);
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name);
     if (options.dynamic) { url += '?dynamic=' + options.dynamic; }
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
@@ -1414,7 +1414,7 @@ RucioClient.prototype.create_did_sample = function(options) {
 /* Set metadata for a DID */
 RucioClient.prototype.set_metadata = function(options) {
     check_token();
-    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/meta/' + options.key;
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/meta/' + options.key;
     jQuery.ajax({url: url,
                  crossDomain: true,
                  type: 'POST',
@@ -1435,7 +1435,7 @@ RucioClient.prototype.set_metadata = function(options) {
 /* Set DID status */
 RucioClient.prototype.set_status = function(options) {
     check_token();
-    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/status';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/status';
     if (options.async == null ) { options.async = true; }
     jQuery.ajax({url: url,
                  crossDomain: true,
@@ -1499,7 +1499,7 @@ RucioClient.prototype.list_account_attributes = function(options) {
 /* list dataset replicas */
 RucioClient.prototype.list_dataset_replicas = function(options) {
     check_token();
-    var url = this.url + '/replicas/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/datasets';
+    var url = this.url + '/replicas/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/datasets';
     jQuery.ajax({url: url,
                  crossDomain: true,
                  headers: this.headers,
@@ -1539,7 +1539,7 @@ RucioClient.prototype.set_account_limit = function(options) {
 /* add data identifier */
 RucioClient.prototype.add_did = function(options) {
     check_token();
-    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name);
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name);
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
                  async: options.async,
@@ -1562,7 +1562,7 @@ RucioClient.prototype.add_did = function(options) {
 /* attach dids */
 RucioClient.prototype.attach_dids = function(options) {
     check_token();
-    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/dids';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/dids';
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
                  async: options.async,
@@ -1585,7 +1585,7 @@ RucioClient.prototype.attach_dids = function(options) {
 /* detach dids */
 RucioClient.prototype.detach_dids = function(options) {
     check_token();
-    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + encodeURIComponent(options.name) + '/dids';
+    var url = this.url + '/dids/' + encodeURIComponent(options.scope) + '/' + encodeURIComponent(options.name) + '/dids';
     if (options.async == null) { options.async = true; }
     jQuery.ajax({url: url,
         async: options.async,


### PR DESCRIPTION
Fix #7724 

This pull request improves the handling of URLs in the `RucioClient` JavaScript module by ensuring proper encoding of dynamic URL components (`scope` and `name`) using `encodeURIComponent`. 

### URL Encoding Improvements:

* Updated all API calls in `RucioClient` to use `encodeURIComponent` for `scope` and `name` parameters, ensuring proper encoding of special characters. This change affects multiple methods, including:
  - `scope_list`
  - `list_subscriptions`
  - `list_replication_rules`
  - `did_get_metadata`, `did_get_generic_metadata`, `did_get_files`, and `list_parent_dids` [[1]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L767-R767) [[2]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L788-R788) [[3]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L809-R809) [[4]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L828-R828)
  - `list_contents`, `did_get_rules`, and `get_request_by_did` [[1]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L847-R847) [[2]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L904-R904) [[3]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L1047-R1047)
  - `update_subscription` and `create_subscription` [[1]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L1086-R1086) [[2]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L1106-R1106)
  - `get_did`, `set_metadata`, and `set_status` [[1]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L1348-R1348) [[2]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L1417-R1417) [[3]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L1438-R1438)
  - `list_dataset_replicas`, `add_did`, `attach_dids`, and `detach_dids` [[1]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L1502-R1502) [[2]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L1542-R1542) [[3]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L1565-R1565) [[4]](diffhunk://#diff-57eb2a50b4fca5d9bb30f87eccebff890e8ebaa52c3721fd1a520246a105f183L1588-R1588) 
