### PR TITLE
Conveyor: Remove ftshosts configuration from multiple Rucio configuration templates

### DIFF
--- a/etc/docker/test/extra/rucio_autotests_common.cfg
+++ b/etc/docker/test/extra/rucio_autotests_common.cfg
@@ -43,7 +43,6 @@ user_scope = travis
 [conveyor]
 scheme = srm,root,davs,gsiftp,http,https,mock,file,magnet
 transfertool = fts3
-ftshosts = https://fts:8446
 cacert = /opt/rucio/etc/rucio_ca.pem
 usercert = /opt/rucio/etc/ruciouser.pem
 

--- a/etc/docker/test/extra/rucio_default.cfg
+++ b/etc/docker/test/extra/rucio_default.cfg
@@ -55,7 +55,6 @@ scheme = https,davs,gsiftp,root,srm,mock,file,magnet
 #hostcert = /etc/grid-security/hostcert.pem
 #hostkey = /etc/grid-security/hostkey.pem
 transfertool = fts3
-ftshosts = https://fts:8446
 cacert = /etc/grid-security/certificates/5fca1cb1.0
 usercert = /opt/rucio/etc/usercertkey.pem
 

--- a/etc/rucio.cfg.template
+++ b/etc/rucio.cfg.template
@@ -116,7 +116,6 @@ metrics_port = 8080
 [conveyor]
 scheme = srm,gsiftp,root,http,https
 transfertool = fts3
-ftshosts = https://fts3-pilot.cern.ch:8446, https://fts3-pilot.cern.ch:8446
 cacert = /opt/rucio/etc/web/ca.crt
 usercert = /opt/rucio/tools/x509up
 

--- a/etc/rucio_multi_vo.cfg.template
+++ b/etc/rucio_multi_vo.cfg.template
@@ -97,7 +97,6 @@ metrics_port = 8080
 [conveyor]
 scheme = srm,gsiftp,root,http,https
 transfertool = fts3
-ftshosts = https://fts3-pilot.cern.ch:8446, https://fts3-pilot.cern.ch:8446
 cacert = /opt/rucio/etc/web/ca.crt
 usercert = /opt/rucio/tools/x509up
 


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
I went through the code and noticed that the conveyor daemons (like the submitter, poller, receiver, etc.) no longer use the ftshosts setting. Instead, they get the FTS server information from the RSE attributes (through `RseAttr.FTS`). The FTS3Transfertool class uses the `_pick_fts_servers` method to do this. Since the ftshosts config was still present in some files but wasn’t being used anymore, I cleaned those up and removed them in this PR.

Fixes #7696 
