### PR TITLE
Include transfer limit functions in the python client

### DIFF
--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Optional
+from json import dumps
+from typing import TYPE_CHECKING, Any, Literal, Optional
 from urllib.parse import quote_plus
 
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
 from rucio.common.utils import build_url
+from rucio.db.sqla.constants import TransferLimitDirection
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -123,3 +125,82 @@ class RequestClient(BaseClient):
         else:
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
+
+    def list_transfer_limits(
+            self
+    ) -> 'Iterator[dict[str, Any]]':
+        """Returns all the transfer limits
+
+        :returns: transfer limits
+        """
+        path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
+        url = build_url(choice(self.list_hosts), path=path)
+        r = self._send_request(url, type_='GET')
+
+        if r.status_code == codes.ok:
+            return self._load_json_data(r)
+        else:
+            exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+            raise exc_cls(exc_msg)
+
+    def set_transfer_limit(
+            self,
+            rse_expression: str,
+            activity: Optional[str] = None,
+            direction: TransferLimitDirection = TransferLimitDirection.DESTINATION,
+            max_transfers: Optional[int] = None,
+            volume: Optional[int] = None,
+            deadline: Optional[int] = None,
+            strategy: Optional[str] = None,
+            transfers: Optional[int] = None,
+            waitings: Optional[int] = None,
+    ) -> Literal[True]:
+        """Set the transfer limit for a given RSE
+
+        :param rse_expression: RSE expression string.
+        :param activity: The activity.
+        :param direction: The direction in which this limit applies (source/destination)
+        :param max_transfers: Maximum transfers.
+        :param volume: Maximum transfer volume in bytes.
+        :param deadline: Maximum waiting time in hours until a datasets gets released.
+        :param strategy: defines how to handle datasets: `fifo` (each file released separately) or `grouped_fifo` (wait for the entire dataset to fit)
+        :param transfers: Current number of active transfers
+        :param waitings: Current number of waiting transfers
+        
+        :returns: True if the transfer limit was deleted
+        """
+        path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
+        url = build_url(choice(self.list_hosts), path=path)
+        data = dumps({'rse_expression': rse_expression, 'activity': activity, 'direction': direction.value,
+                'max_transfers': max_transfers, 'volume': volume, 'deadline': deadline, 'strategy': strategy,
+                'transfers': transfers, 'waitings': waitings})
+        r = self._send_request(url, type_='PUT', data=data)
+
+        if r.status_code == codes.created:
+            return True
+        exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+        raise exc_cls(exc_msg)
+
+    def delete_transfer_limit(
+            self,
+            rse_expression: str,
+            activity: Optional[str] = None,
+            direction: TransferLimitDirection = TransferLimitDirection.DESTINATION
+    ) -> Literal[True]:
+        """Delete the transfer limit for a given RSE
+
+        :param rse_expression: RSE expression string.
+        :param activity: The activity.
+        :param direction: The direction in which this limit applies (source/destination)
+
+        :returns: True if the transfer limit was deleted
+        """
+        path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
+        url = build_url(choice(self.list_hosts), path=path)
+        data = dumps({'rse_expression': rse_expression, 'activity': activity, 'direction': direction.value})
+        r = self._send_request(url, type_='DEL', data=data)
+
+        if r.status_code == codes.ok:
+            return True
+        exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+        raise exc_cls(exc_msg)

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -121,7 +121,10 @@ def has_permission(issuer: "InternalAccount", action: str, kwargs: dict[str, Any
             'del_identity': perm_del_identity,
             'remove_did_from_followed': perm_remove_did_from_followed,
             'remove_dids_from_followed': perm_remove_dids_from_followed,
-            'export': perm_export}
+            'export': perm_export,
+            'list_transfer_limits': perm_list_transfer_limits,
+            'set_transfer_limit': perm_set_transfer_limit,
+            'delete_transfer_limit': perm_delete_transfer_limit}
 
     return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs, session=session)
 
@@ -1122,3 +1125,36 @@ def perm_export(issuer: "InternalAccount", kwargs: dict[str, Any], *, session: "
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer)
+
+def perm_list_transfer_limits(issuer: "InternalAccount", kwargs: dict[str, Any], *, session: "Optional[Session]" = None) -> bool:
+    """
+    Checks if an account can list transfer limits.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
+    :returns: True if account is allowed, otherwise False
+    """
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+
+def perm_set_transfer_limit(issuer: "InternalAccount", kwargs: dict[str, Any], *, session: "Optional[Session]" = None) -> bool:
+    """
+    Checks if an account can set transfer limits.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
+    :returns: True if account is allowed, otherwise False
+    """
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+
+def perm_delete_transfer_limit(issuer: "InternalAccount", kwargs: dict[str, Any], *, session: "Optional[Session]" = None) -> bool:
+    """
+    Checks if an account can delete transfer limits.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
+    :returns: True if account is allowed, otherwise False
+    """
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)

--- a/lib/rucio/gateway/request.py
+++ b/lib/rucio/gateway/request.py
@@ -23,7 +23,8 @@ from rucio.common.types import InternalAccount, InternalScope, RequestGatewayDic
 from rucio.common.utils import gateway_update_return_dict
 from rucio.core import request
 from rucio.core.rse import get_rse_id
-from rucio.db.sqla.session import read_session, stream_session, transactional_session
+from rucio.db.sqla.constants import DatabaseOperationType, TransferLimitDirection
+from rucio.db.sqla.session import db_session, read_session, stream_session, transactional_session
 from rucio.gateway import permission
 
 if TYPE_CHECKING:
@@ -328,3 +329,97 @@ def get_request_metrics(
         raise exception.AccessDenied(f'{issuer} cannot get request statistics. {auth_result.message}')
 
     return request.get_request_metrics(dest_rse_id=dst_rse_id, src_rse_id=src_rse_id, activity=activity, group_by_rse_attribute=group_by_rse_attribute, session=session)
+
+def list_transfer_limits(
+    issuer: str,
+    vo: str = 'def'
+) -> "Iterator[dict[str, Any]]":
+    """
+    List all the transfer limits.
+
+    :param issuer: Issuing account as a string.
+    :param session: The database session in use.
+
+    :returns: The list of transfer limits
+    """
+    with db_session(DatabaseOperationType.READ) as session:
+        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='list_transfer_limits', kwargs={}, session=session)
+        if not auth_result.allowed:
+            raise exception.AccessDenied(f'{issuer} cannot list transfer limits. {auth_result.message}')
+
+        return request.list_transfer_limits(session=session)
+
+def set_transfer_limit(
+    issuer: str,
+    rse_expression: str,
+    activity: Optional[str] = None,
+    direction: TransferLimitDirection = TransferLimitDirection.DESTINATION,
+    max_transfers: Optional[int] = None,
+    volume: Optional[int] = None,
+    deadline: Optional[int] = None,
+    strategy: Optional[str] = None,
+    transfers: Optional[int] = None,
+    waitings: Optional[int] = None,
+    vo: str = 'def'
+) -> None:
+    """
+    Create or update a transfer limit
+
+    :param issuer: Issuing account as a string.
+    :param vo: The VO to act on.
+    :param rse_expression: RSE expression for which the transfer limit applies.
+    :param activity: The activity for which the transfer limit applies.
+    :param direction: The direction in which this limit applies (source/destination)
+    :param max_transfers: Maximum transfers.
+    :param volume: Maximum transfer volume in bytes.
+    :param deadline: Maximum waiting time in hours until a datasets gets released.
+    :param strategy: defines how to handle datasets: `fifo` (each file released separately) or `grouped_fifo` (wait for the entire dataset to fit)
+    :param transfers: Current number of active transfers
+    :param waitings: Current number of waiting transfers
+    :param session: The database session in use.
+
+    :returns: None
+    """
+    with db_session(DatabaseOperationType.WRITE) as session:
+        kwargs = {'rse_expression': rse_expression, 'activity': activity, 'max_transfers': max_transfers}
+        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='set_transfer_limit', kwargs=kwargs, session=session)
+        if not auth_result.allowed:
+            raise exception.AccessDenied(f'{issuer} cannot set transfer limits. {auth_result.message}')
+
+        request.set_transfer_limit(rse_expression=rse_expression,
+                                activity=activity,
+                                direction=direction,
+                                max_transfers=max_transfers,
+                                volume=volume,
+                                deadline=deadline,
+                                strategy=strategy,
+                                transfers=transfers,
+                                waitings=waitings)
+
+def delete_transfer_limit(
+    issuer: str,
+    rse_expression: str,
+    activity: Optional[str] = None,
+    direction: TransferLimitDirection = TransferLimitDirection.DESTINATION,
+    vo: str = 'def'
+) -> None:
+    """
+    Delete a transfer limit
+
+    :param issuer: Issuing account as a string.
+    :param vo: The VO to act on.
+    :param rse_expression: RSE expression for which the transfer limit applies.
+    :param activity: The activity for which the transfer limit applies.
+    :param direction: The direction in which this limit applies (source/destination)
+    :param session: The database session in use.
+    """
+    with db_session(DatabaseOperationType.WRITE) as session:
+        kwargs = {'rse_expression': rse_expression, 'activity': activity}
+        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='delete_transfer_limit', kwargs=kwargs, session=session)
+        if not auth_result.allowed:
+            raise exception.AccessDenied(f'{issuer} cannot delete transfer limits. {auth_result.message}')
+
+        request.delete_transfer_limit(rse_expression=rse_expression,
+                                    activity=activity,
+                                    direction=direction,
+                                    session=session)

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -13,18 +13,18 @@
 # limitations under the License.
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import flask
 from flask import Flask, Response
 
-from rucio.common.exception import RequestNotFound
+from rucio.common.exception import AccessDenied, RequestNotFound
 from rucio.common.utils import APIEncoder, render_json
 from rucio.core.rse import get_rses_with_attribute_value
-from rucio.db.sqla.constants import RequestState
+from rucio.db.sqla.constants import RequestState, TransferLimitDirection
 from rucio.gateway import request
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
-from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, generate_http_error_flask, parse_scope_name, response_headers, try_stream
+from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, generate_http_error_flask, json_parameters, param_get, parse_scope_name, response_headers, try_stream
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -972,6 +972,187 @@ class RequestMetricsGet(ErrorHandlingMethodView):
                 yield render_json(**result) + '\n'
         return try_stream(generate())
 
+class TransferLimits(ErrorHandlingMethodView):
+    """ REST API to get, set or delete transfer limits. """
+
+    @check_accept_header_wrapper_flask(['application/x-json-stream'])
+    def get(self) -> flask.Response:
+        """
+        ---
+        summary: Get Transfer Limits
+        description: Get all the transfer limits.
+        tags:
+          - Requests
+        responses:
+          200:
+            description: OK
+            content:
+              application/x-json-stream:
+                schema:
+                  description: All the transfer limits
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        description: The transfer limit id.
+                        type: string
+                      rse_expression:
+                        description: The RSE expression for which the limit applies.
+                        type: string
+                      direction:
+                        description: The direction in which this limit applies (source/destination)
+                        type: string
+                      max_transfers:
+                        description: Maximum number of transfers allowed.
+                        type: integer
+                      volume:
+                        description: Maximum transfer volume in bytes.
+                        type: integer
+                      deadline:
+                        description: Maximum waiting time in hours until a datasets gets released.
+                        type: integer
+                      strategy:
+                        description: defines how to handle datasets: `fifo` (each file released separately) or `grouped_fifo` (wait for the entire dataset to fit)
+                        type: string
+                      transfers:
+                        description: Current number of active transfers
+                        type: integer
+                      waitings:
+                        description: Current number of waiting transfers
+                        type: integer
+                      updated_at:
+                        description: Datetime of the last update.
+                        type: string
+                      created_at:
+                        description: Datetime of the creation of the transfer limit.
+                        type: string
+          401:
+            description: Invalid Auth Token
+        """
+        transfer_limits = request.list_transfer_limits(issuer=flask.request.environ['issuer'], vo=flask.request.environ['vo'])
+        def generate() -> "Iterator[str]":
+                for limit in transfer_limits:
+                    yield json.dumps(limit, cls=APIEncoder) + '\n'
+        return try_stream(generate())
+
+    def put(self) -> Union[flask.Response, tuple[str, int]]:
+        """
+        ---
+        summary: Set Transfer Limit
+        description: Create or update a transfer limit for a specific RSE expression and activity.
+        tags:
+          - Requests
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - rse_expression
+                  - max_transfers
+                properties:
+                  rse_expression:
+                    type: string
+                    description: The RSE expression for which the transfer limit is being set.
+                  activity:
+                    type: string
+                    description: The activity to which the transfer limit applies.
+                  max_transfers:
+                    type: integer
+                    description: The maximum number of transfers allowed.
+                  direction:
+                    type: string
+                    description: The direction of the transfer limit (source or destination).
+                    enum: ["SOURCE", "DESTINATION"]
+                    default: "DESTINATION"
+                  volume:
+                    type: integer
+                    description: The maximum transfer volume in bytes.
+                  deadline:
+                    type: integer
+                    description: The maximum waiting time in hours until a dataset is released.
+                  strategy:
+                    type: string
+                    description: The strategy for handling datasets (e.g., `fifo` or `grouped_fifo`).
+                  transfers:
+                    type: integer
+                    description: The current number of active transfers.
+                  waitings:
+                    type: integer
+                    description: The current number of waiting transfers.
+        responses:
+          201:
+            description: Transfer limit set successfully.
+          400:
+            description: Invalid input data.
+          401:
+            description: Invalid Auth Token.
+          500:
+            description: Internal server error.
+        """
+        parameters = json_parameters()
+        rse_expression = param_get(parameters, 'rse_expression')
+        max_transfers = param_get(parameters, 'max_transfers')
+
+        try:
+          request.set_transfer_limit(
+            rse_expression=rse_expression,
+            max_transfers=max_transfers,
+            activity=param_get(parameters, 'activity', default=None),
+            direction=param_get(parameters, 'direction', default=TransferLimitDirection.DESTINATION),
+            volume=param_get(parameters, 'volume', default=None),
+            deadline=param_get(parameters, 'deadline', default=None),
+            strategy=param_get(parameters, 'strategy', default=None),
+            transfers=param_get(parameters, 'transfers', default=None),
+            waitings=param_get(parameters, 'waitings', default=None),
+            issuer=flask.request.environ['issuer'],
+            vo=flask.request.environ['vo']
+          )
+        except AccessDenied as error:
+          return generate_http_error_flask(401, error)
+
+        return '', 201
+
+    def delete(self) -> Union[flask.Response, tuple[str, int]]:
+        """
+        ---
+        summary: Delete Transfer Limit
+        description: Delete a transfer limit for an RSE expression.
+        tags:
+          - Requests
+        parameters:
+          - name: rse_expression
+            in: query
+            description: The RSE expression to delete the limit for.
+            required: true
+            schema:
+              type: string
+        responses:
+          200:
+            description: Transfer limit deleted successfully.
+          400:
+            description: Invalid input data.
+          401:
+            description: Invalid Auth Token.
+          500:
+            description: Internal server error.
+        """
+        parameters = json_parameters()
+        rse_expression = param_get(parameters, 'rse_expression')
+
+        try:
+          request.delete_transfer_limit(
+            rse_expression=rse_expression,
+            activity=param_get(parameters, 'activity', default=None),
+            direction=param_get(parameters, 'direction', default=TransferLimitDirection.DESTINATION),
+            issuer=flask.request.environ['issuer'],
+            vo=flask.request.environ['vo']
+          )
+        except AccessDenied as error:
+          return generate_http_error_flask(401, error)
+
+        return '', 200
 
 def blueprint():
     bp = AuthenticatedBlueprint('requests', __name__, url_prefix='/requests')
@@ -986,6 +1167,8 @@ def blueprint():
     bp.add_url_rule('/history/list', view_func=request_history_list_view, methods=['get', ])
     request_metrics_view = RequestMetricsGet.as_view('request_metrics_get')
     bp.add_url_rule('/metrics', view_func=request_metrics_view, methods=['get', ])
+    transfer_limits_view = TransferLimits.as_view('transfer_limits_get')
+    bp.add_url_rule('/transfer_limits', view_func=transfer_limits_view, methods=['get', 'put', 'delete'])
 
     bp.after_request(response_headers)
     return bp


### PR DESCRIPTION
Fixes #7661 

Works as expected:
```
>>> from rucio.client import Client
>>> client = Client()
>>> print(list(client.list_transfer_limits()))
[]
>>> print(client.set_transfer_limit(rse_expression="MOCK", max_transfers=21))
True
>>> print(list(client.list_transfer_limits()))
[{'activity': 'all_activities', 'rse_expression': 'MOCK', 'direction': 'DESTINATION', 'volume': 0, 'strategy': 'fifo', 'waitings': None, 'updated_at': datetime.datetime(2025, 5, 19, 12, 18, 7), 'id': 'aa3ff0b01ed14ed38b731a25b6f8d4e4', 'max_transfers': 21, 'deadline': 1, 'transfers': None, 'created_at': datetime.datetime(2025, 5, 19, 12, 18, 7)}]
>>> print(client.delete_transfer_limit(rse_expression="MOCK"))
True
>>> print(list(client.list_transfer_limits()))
[]
>>> 
```