### PR TITLE
Client: Remove core dependancy from the client

### DIFF
--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -20,7 +20,6 @@ from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
 from rucio.common.utils import build_url
-from rucio.db.sqla.constants import TransferLimitDirection
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -173,7 +172,6 @@ class RequestClient(BaseClient):
             self,
             rse_expression: str,
             activity: Optional[str] = None,
-            direction: TransferLimitDirection = TransferLimitDirection.DESTINATION,
             max_transfers: Optional[int] = None,
             volume: Optional[int] = None,
             deadline: Optional[int] = None,
@@ -185,7 +183,6 @@ class RequestClient(BaseClient):
 
         :param rse_expression: RSE expression string.
         :param activity: The activity.
-        :param direction: The direction in which this limit applies (source/destination)
         :param max_transfers: Maximum transfers.
         :param volume: Maximum transfer volume in bytes.
         :param deadline: Maximum waiting time in hours until a datasets gets released.
@@ -197,9 +194,9 @@ class RequestClient(BaseClient):
         """
         path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
         url = build_url(choice(self.list_hosts), path=path)
-        data = dumps({'rse_expression': rse_expression, 'activity': activity, 'direction': direction.value,
-                'max_transfers': max_transfers, 'volume': volume, 'deadline': deadline, 'strategy': strategy,
-                'transfers': transfers, 'waitings': waitings})
+        data = dumps({'rse_expression': rse_expression, 'activity': activity,
+                'max_transfers': max_transfers, 'volume': volume, 'deadline': deadline,
+                'strategy': strategy,'transfers': transfers, 'waitings': waitings})
         r = self._send_request(url, type_='PUT', data=data)
 
         if r.status_code == codes.created:
@@ -210,20 +207,18 @@ class RequestClient(BaseClient):
     def delete_transfer_limit(
             self,
             rse_expression: str,
-            activity: Optional[str] = None,
-            direction: TransferLimitDirection = TransferLimitDirection.DESTINATION
+            activity: Optional[str] = None
     ) -> Literal[True]:
         """Delete the transfer limit for a given RSE
 
         :param rse_expression: RSE expression string.
         :param activity: The activity.
-        :param direction: The direction in which this limit applies (source/destination)
 
         :returns: True if the transfer limit was deleted
         """
         path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
         url = build_url(choice(self.list_hosts), path=path)
-        data = dumps({'rse_expression': rse_expression, 'activity': activity, 'direction': direction.value})
+        data = dumps({'rse_expression': rse_expression, 'activity': activity})
         r = self._send_request(url, type_='DEL', data=data)
 
         if r.status_code == codes.ok:


### PR DESCRIPTION
Fixes #7746 

In particular, removing `(rucio.db.sqla.constants.TransferLimitDirection)` from the `requestclient.py`. This removes the ability to set the transfer limit direction via the client. Other abilities are preserved, e.g. [1]. As an alternative, we could hard code the type annotation as well (`direction: Union['D', 'S'] = 'D'`), but this is simply not maintainable long-term.


@dchristidis @bari12 FYI

[1]
```
>>> from rucio.client import Client
>>> client = Client()
>>> print(list(client.list_transfer_limits()))
[]
>>> print(client.set_transfer_limit(rse_expression="MOCK", max_transfers=21))
True
>>> print(list(client.list_transfer_limits()))
[{'activity': 'all_activities', 'rse_expression': 'MOCK', 'direction': 'DESTINATION', 'volume': 0, 'strategy': 'fifo', 'waitings': None, 'updated_at': datetime.datetime(2025, 5, 27, 8, 54), 'id': 'a655c177d7b245089075247360d96237', 'max_transfers': 21, 'deadline': 1, 'transfers': None, 'created_at': datetime.datetime(2025, 5, 27, 8, 54)}]
>>> print(client.delete_transfer_limit(rse_expression="MOCK"))
True
>>> print(list(client.list_transfer_limits()))
[]
```

