### PR TITLE
Rewrite of TestBinRucio using pytest fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,7 +312,7 @@ def random_account(vo: str) -> "Iterator[InternalAccount]":
 
 
 @pytest.fixture
-def random_account_factory(vo: str):
+def random_account_factory(vo: str) -> "Iterator[InternalAccount]":
     import random
     import string
 
@@ -325,7 +325,7 @@ def random_account_factory(vo: str):
 
     made_accounts = []
 
-    def make_account():
+    def make_account() -> InternalAccount:
         account = InternalAccount(''.join(random.choice(string.ascii_lowercase) for _ in range(10)), vo=vo)
         made_accounts.append(account)
         if os.environ.get('SUITE') == 'client':

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -756,7 +756,6 @@ def test_download_traceless(rucio_client):
     assert client.tracing is True
 
 
-# Adapted from tests/test_bin_rucio download tests
 @pytest.mark.noparallel(reason='fails when run in parallel')
 def test_download_no_subdir(download_client, did_factory, rse_factory):
     """CLIENT(USER): Rucio download files with the 'no_subdir' argument, ensure the scope dir is not created, and check that files already found locally are not replaced"""

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -454,7 +454,6 @@ def test_upload_registration_fail(rse, scope, upload_client_registration_fail, f
         upload_client_registration_fail.upload(items=[item])
 
 
-# The following tests are adapted from tests in tests/test_bin_rucio
 @pytest.mark.skipif('SUITE' in os.environ and os.environ['SUITE'] == 'client', reason="Requires DB access")
 def test_upload_file_register_after_upload(rse, scope, upload_client, rucio_client, file_factory, vo):
     """CLIENT(USER): Rucio upload files with registration after upload"""


### PR DESCRIPTION
Closes #7641 

List of changes:
* Isolate tests instead of using a class setup stage
* Remove calls to cli used for setup (e.g. rucio upload, rucio add did)
* Use tempfile were possible
* Check functionality with a py client call instead of trusting output
* Remove format strings and extra print statements where possible
* Split up tests testing multiple things