### PR TITLE
Documentation: quote all single-line descriptions Fix #7754

### DIFF
--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1323,7 +1323,7 @@ class DownloadClient:
     def _resolve_one_item_dids(self, item: dict[str, Any]) -> "Iterator[dict[str, Any]]":
         """
         Resolve scopes or wildcard DIDs to lists of full did names:
-        
+
         Parameters
         ----------
         item :

--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -192,14 +192,15 @@ class RequestClient(BaseClient):
         :param strategy: defines how to handle datasets: `fifo` (each file released separately) or `grouped_fifo` (wait for the entire dataset to fit)
         :param transfers: Current number of active transfers
         :param waitings: Current number of waiting transfers
-        
+
         :returns: True if the transfer limit was deleted
         """
         path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
         url = build_url(choice(self.list_hosts), path=path)
-        data = dumps({'rse_expression': rse_expression, 'activity': activity, 'direction': direction.value,
-                'max_transfers': max_transfers, 'volume': volume, 'deadline': deadline, 'strategy': strategy,
-                'transfers': transfers, 'waitings': waitings})
+        data = dumps({'rse_expression': rse_expression, 'activity': activity,
+                      'direction': direction.value, 'max_transfers': max_transfers,
+                      'volume': volume, 'deadline': deadline, 'strategy': strategy,
+                      'transfers': transfers, 'waitings': waitings})
         r = self._send_request(url, type_='PUT', data=data)
 
         if r.status_code == codes.created:

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -1126,6 +1126,7 @@ def perm_export(issuer: "InternalAccount", kwargs: dict[str, Any], *, session: "
     """
     return _is_root(issuer)
 
+
 def perm_list_transfer_limits(issuer: "InternalAccount", kwargs: dict[str, Any], *, session: "Optional[Session]" = None) -> bool:
     """
     Checks if an account can list transfer limits.
@@ -1137,6 +1138,7 @@ def perm_list_transfer_limits(issuer: "InternalAccount", kwargs: dict[str, Any],
     """
     return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
 
+
 def perm_set_transfer_limit(issuer: "InternalAccount", kwargs: dict[str, Any], *, session: "Optional[Session]" = None) -> bool:
     """
     Checks if an account can set transfer limits.
@@ -1147,6 +1149,7 @@ def perm_set_transfer_limit(issuer: "InternalAccount", kwargs: dict[str, Any], *
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+
 
 def perm_delete_transfer_limit(issuer: "InternalAccount", kwargs: dict[str, Any], *, session: "Optional[Session]" = None) -> bool:
     """

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -402,7 +402,7 @@ def __declare_bad_file_replicas(
                     if f"{pfn} Unknown replica" not in unknown_replicas:
                         unknown_replicas.append('%s %s' % (pfn, 'Unknown replica'))
             elif scope or name:
-                unknown_replicas.append(f"{(scope,name)} Unknown replica")
+                unknown_replicas.append(f"{(scope, name)} Unknown replica")
 
     if status == BadFilesStatus.BAD:
         # For BAD file, we modify the replica state, not for suspicious

--- a/lib/rucio/gateway/request.py
+++ b/lib/rucio/gateway/request.py
@@ -364,14 +364,14 @@ def set_transfer_limit(
             raise exception.AccessDenied(f'{issuer} cannot set transfer limits. {auth_result.message}')
 
         request.set_transfer_limit(rse_expression=rse_expression,
-                                activity=activity,
-                                direction=direction,
-                                max_transfers=max_transfers,
-                                volume=volume,
-                                deadline=deadline,
-                                strategy=strategy,
-                                transfers=transfers,
-                                waitings=waitings)
+                                   activity=activity,
+                                   direction=direction,
+                                   max_transfers=max_transfers,
+                                   volume=volume,
+                                   deadline=deadline,
+                                   strategy=strategy,
+                                   transfers=transfers,
+                                   waitings=waitings)
 
 
 def delete_transfer_limit(
@@ -398,6 +398,6 @@ def delete_transfer_limit(
             raise exception.AccessDenied(f'{issuer} cannot delete transfer limits. {auth_result.message}')
 
         request.delete_transfer_limit(rse_expression=rse_expression,
-                                    activity=activity,
-                                    direction=direction,
-                                    session=session)
+                                      activity=activity,
+                                      direction=direction,
+                                      session=session)

--- a/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
@@ -35,13 +35,13 @@ class LocalAccountLimit(ErrorHandlingMethodView):
         parameters:
         - name: account
           in: path
-          description: The account for the accountlimit.
+          description: "The account for the accountlimit."
           schema:
             type: string
           style: simple
         - name: rse
           in: path
-          description: The rse for the accountlimit.
+          description: "The rse for the accountlimit."
           schema:
             type: string
           style: simple
@@ -54,20 +54,20 @@ class LocalAccountLimit(ErrorHandlingMethodView):
                 - bytes
                 properties:
                   bytes:
-                    description: The new limit in bytes.
+                    description: "The new limit in bytes."
                     type: integer
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No RSE or account found for the given id.
+            description: "No RSE or account found for the given id."
         """
         parameters = json_parameters()
         bytes_param = param_get(parameters, 'bytes')
@@ -89,23 +89,23 @@ class LocalAccountLimit(ErrorHandlingMethodView):
         parameters:
         - name: account
           in: path
-          description: The account for the accountlimit.
+          description: "The account for the accountlimit."
           schema:
             type: string
           style: simple
         - name: rse
           in: path
-          description: The rse for the accountlimit.
+          description: "The rse for the accountlimit."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No RSE or account found for the given id.
+            description: "No RSE or account found for the given id."
         """
         try:
             delete_local_account_limit(account=account, rse=rse, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
@@ -127,13 +127,13 @@ class GlobalAccountLimit(ErrorHandlingMethodView):
         parameters:
         - name: account
           in: path
-          description: The account for the accountlimit.
+          description: "The account for the accountlimit."
           schema:
             type: string
           style: simple
         - name: rse_expression
           in: path
-          description: The rse expression for the accountlimit.
+          description: "The rse expression for the accountlimit."
           schema:
             type: string
           style: simple
@@ -146,20 +146,20 @@ class GlobalAccountLimit(ErrorHandlingMethodView):
                 - bytes
                 properties:
                   bytes:
-                    description: The new limit in bytes.
+                    description: "The new limit in bytes."
                     type: integer
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No RSE or account found for the given id.
+            description: "No RSE or account found for the given id."
         """
         parameters = json_parameters()
         bytes_param = param_get(parameters, 'bytes')
@@ -187,23 +187,23 @@ class GlobalAccountLimit(ErrorHandlingMethodView):
         parameters:
         - name: account
           in: path
-          description: The account for the accountlimit.
+          description: "The account for the accountlimit."
           schema:
             type: string
           style: simple
         - name: rse_expression
           in: path
-          description: The rse expression for the accountlimit.
+          description: "The rse expression for the accountlimit."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No RSE or account found for the given id.
+            description: "No RSE or account found for the given id."
         """
         try:
             delete_global_account_limit(account=account, rse_expression=rse_expression, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -41,39 +41,39 @@ class Attributes(ErrorHandlingMethodView):
         """
         ---
         summary: List attributes
-        description: List all attributes for an account.
+        description: "List all attributes for an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: array
                   items:
                     type: object
-                    description: An account attribute.
+                    description: "An account attribute."
                     properties:
                       key:
-                        description: The key of the account attribute.
+                        description: "The key of the account attribute."
                         type: string
                       value:
-                        description: The value of the account attribute.
+                        description: "The value of the account attribute."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No account found for the given id.
+            description: "No account found for the given id."
           406:
-            description: Not acceptable.
+            description: "Not acceptable."
         """
         try:
             attribs = list_account_attributes(account, vo=request.environ.get('vo'))
@@ -86,19 +86,19 @@ class Attributes(ErrorHandlingMethodView):
         """
         ---
         summary: Create attribute
-        description: Create an attribute to an account.
+        description: "Create an attribute to an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         - name: key
           in: path
-          description: The key of the account attribute.
+          description: "The key of the account attribute."
           schema:
             type: string
           style: simple
@@ -111,25 +111,25 @@ class Attributes(ErrorHandlingMethodView):
                 - value
                 properties:
                   key:
-                    description: The key of the attribute. This would override the key defined in path.
+                    description: "The key of the attribute. This would override the key defined in path."
                     type: string
                   value:
-                    description: The value of the attribute.
+                    description: "The value of the attribute."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No account found for the given id.
+            description: "No account found for the given id."
           409:
-            description: Attribute already exists
+            description: "Attribute already exists"
         """
         parameters = json_parameters()
         value = param_get(parameters, 'value')
@@ -148,29 +148,29 @@ class Attributes(ErrorHandlingMethodView):
         """
         ---
         summary: Delete attribute
-        description: Delete an attribute of an account.
+        description: "Delete an attribute of an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         - name: key
           in: path
-          description: The key of the account attribute to remove.
+          description: "The key of the account attribute to remove."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No account found for the given id.
+            description: "No account found for the given id."
         """
         try:
             del_account_attribute(account=account, key=key, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
@@ -188,33 +188,33 @@ class Scopes(ErrorHandlingMethodView):
         """
         ---
         summary: List scopes
-        description: List all scopse for an account.
+        description: "List all scopse for an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: All scopes for the account.
+                  description: "All scopes for the account."
                   type: array
                   items:
-                    description: A scope
+                    description: "A scope"
                     type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No account or scope found for the given id.
+            description: "No account or scope found for the given id."
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scopes = get_scopes(account, vo=request.environ['vo'])
@@ -230,38 +230,38 @@ class Scopes(ErrorHandlingMethodView):
         """
         ---
         summary: Create scope
-        description: Creates a scopse with the given name for an account.
+        description: "Creates a scopse with the given name for an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         - name: scope
           in: path
-          description: The scope name.
+          description: "The scope name."
           schema:
             type: string
           style: simple
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           400:
-            description: Not acceptable
+            description: "Not acceptable"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No account found.
+            description: "No account found."
           409:
-            description: Scope already exists.
+            description: "Scope already exists."
         """
         try:
             add_scope(scope, account, issuer=request.environ['issuer'], vo=request.environ['vo'])
@@ -285,48 +285,48 @@ class AccountParameter(ErrorHandlingMethodView):
         """
         ---
         summary: List account parameters
-        description: Lists all parameters for an account.
+        description: "Lists all parameters for an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: object
                   properties:
                     account:
-                      description: The account identifier.
+                      description: "The account identifier."
                       type: string
                     account_type:
-                      description: The account type.
+                      description: "The account type."
                       type: string
                     status:
-                      description: The account status.
+                      description: "The account status."
                       type: string
                     email:
-                      description: The email for the account.
+                      description: "The email for the account."
                       type: string
                     suspended_at:
-                      description: Datetime if the account was suspended.
+                      description: "Datetime if the account was suspended."
                       type: string
                     deleted_at:
-                      description: Datetime if the account was deleted.
+                      description: "Datetime if the account was deleted."
                       type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No account found.
+            description: "No account found."
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         if account == 'whoami':
             # Redirect to the account uri
@@ -354,13 +354,13 @@ class AccountParameter(ErrorHandlingMethodView):
         """
         ---
         summary: Update
-        description: Update a parameter for an account.
+        description: "Update a parameter for an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
@@ -368,17 +368,17 @@ class AccountParameter(ErrorHandlingMethodView):
           content:
             'application/json':
               schema:
-                description: Json object with key-value pairs corresponding to the new values of the parameters.
+                description: "Json object with key-value pairs corresponding to the new values of the parameters."
                 type: object
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No account found.
+            description: "No account found."
           400:
-            description: Unknown status
+            description: "Unknown status"
         """
         parameters = json_parameters()
         for key, value in parameters.items():
@@ -397,13 +397,13 @@ class AccountParameter(ErrorHandlingMethodView):
         """
         ---
         summary: Create
-        description: Create an account.
+        description: "Create an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
@@ -417,26 +417,26 @@ class AccountParameter(ErrorHandlingMethodView):
                   - email
                 properties:
                   type:
-                    description: The account type.
+                    description: "The account type."
                     type: string
                     enum: ["USER", "GROUP", "SERVICE"]
                   email:
-                    description: The email for the account.
+                    description: "The email for the account."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           409:
-            description: Account already exists
+            description: "Account already exists"
           400:
-            description: Unknown status
+            description: "Unknown status"
         """
         parameters = json_parameters()
         type_param = param_get(parameters, 'type')
@@ -456,23 +456,23 @@ class AccountParameter(ErrorHandlingMethodView):
         """
         ---
         summary: Delete
-        description: Delete an account.
+        description: "Delete an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         responses:
           201:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Account not found
+            description: "Account not found"
         """
         try:
             del_account(account, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
@@ -490,12 +490,12 @@ class Account(ErrorHandlingMethodView):
         """
         ---
         summary: List
-        description: List all accounts.
+        description: "List all accounts."
         tags:
           - Account
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
@@ -504,16 +504,16 @@ class Account(ErrorHandlingMethodView):
                     type: object
                     properties:
                       account:
-                        description: The account identifier.
+                        description: "The account identifier."
                         type: string
                       type:
-                        description: The type.
+                        description: "The type."
                         type: string
                       email:
-                        description: The email.
+                        description: "The email."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
         """
 
         def generate(_filter: dict[str, Any], vo: str) -> "Iterator[str]":
@@ -529,36 +529,36 @@ class LocalAccountLimits(ErrorHandlingMethodView):
         """
         ---
         summary: Get local limit
-        description: Get the current local limits for an account on a specific RSE.
+        description: "Get the current local limits for an account on a specific RSE."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         - name: rse
           in: path
-          description: The rse identifier.
+          description: "The rse identifier."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: Json object with rse identifiers as keys and account limits in bytes as values.
+                  description: "Json object with rse identifiers as keys and account limits in bytes as values."
                   type: object
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found
+            description: "RSE not found"
           406:
-            description: Not Acceptable
+            description: "Not Acceptable"
         """
         try:
             limits = get_local_account_limit(account=account, rse=rse, vo=request.environ.get('vo'))
@@ -574,36 +574,36 @@ class GlobalAccountLimits(ErrorHandlingMethodView):
         """
         ---
         summary: Get global limit
-        description: Get the current global limits for an account on a specific RSE expression.
+        description: "Get the current global limits for an account on a specific RSE expression."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         - name: rse_expression
           in: path
-          description: The rse identifier.
+          description: "The rse identifier."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: Json object with rse expression as keys and limits in bytes as values.
+                  description: "Json object with rse expression as keys and limits in bytes as values."
                   type: object
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found
+            description: "RSE not found"
           406:
-            description: Not Acceptable
+            description: "Not Acceptable"
         """
         try:
             limits = get_global_account_limit(account=account, rse_expression=rse_expression, vo=request.environ.get('vo'))
@@ -618,13 +618,13 @@ class Identities(ErrorHandlingMethodView):
         """
         ---
         summary: Create identity
-        description: Grant an account identity access to an account.
+        description: "Grant an account identity access to an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
@@ -639,38 +639,38 @@ class Identities(ErrorHandlingMethodView):
                   - email
                 properties:
                   identity:
-                    description: The identity.
+                    description: "The identity."
                     type: string
                   authtype:
-                    description: The authtype.
+                    description: "The authtype."
                     type: string
                   email:
-                    description: The email.
+                    description: "The email."
                     type: string
                   password:
-                    description: The password.
+                    description: "The password."
                     type: string
                     default: none
                   default:
-                    description: Should this be the default account?
+                    description: "Should this be the default account?"
                     type: string
                     default: false
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Account not found
+            description: "Account not found"
           409:
-            description: Already exists
+            description: "Already exists"
           400:
-            description: Parameter missing
+            description: "Parameter missing"
         """
         parameters = json_parameters()
         identity = param_get(parameters, 'identity')
@@ -710,19 +710,19 @@ class Identities(ErrorHandlingMethodView):
         """
         ---
         summary: List identities
-        description: Lists all identities for an account.
+        description: "Lists all identities for an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
@@ -734,11 +734,11 @@ class Identities(ErrorHandlingMethodView):
                     items:
                       type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Account not found
+            description: "Account not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             def generate(vo: str) -> "Iterator[str]":
@@ -753,13 +753,13 @@ class Identities(ErrorHandlingMethodView):
         """
         ---
         summary: Delete identity
-        description: Delete an account identity.
+        description: "Delete an account identity."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
@@ -773,18 +773,18 @@ class Identities(ErrorHandlingMethodView):
                   - authtype
                 properties:
                   identity:
-                    description: The identity.
+                    description: "The identity."
                     type: string
                   authtype:
-                    description: The authtype.
+                    description: "The authtype."
                     type: string
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Account or identity not found
+            description: "Account or identity not found"
         """
         parameters = json_parameters()
         identity = param_get(parameters, 'identity')
@@ -813,19 +813,19 @@ class Rules(ErrorHandlingMethodView):
         """
         ---
         summary: List rules
-        description: Lists all rules for an account.
+        description: "Lists all rules for an account."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
@@ -833,11 +833,11 @@ class Rules(ErrorHandlingMethodView):
                   items:
                     type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Account or rule not found
+            description: "Account or rule not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         filters = {'account': account}
         filters.update(request.args)
@@ -858,25 +858,25 @@ class UsageHistory(ErrorHandlingMethodView):
         """
         ---
         summary: Get account usage history
-        description: Returns the account usage history.
+        description: "Returns the account usage history."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         - name: rse
           in: path
-          description: The rse identifier.
+          description: "The rse identifier."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
@@ -885,20 +885,20 @@ class UsageHistory(ErrorHandlingMethodView):
                     type: object
                     properties:
                       bytes:
-                        description: The number of bytes used.
+                        description: "The number of bytes used."
                         type: integer
                       files:
-                        description: The files.
+                        description: "The files."
                         type: string
                       updated_at:
-                        description: When the data was provided.
+                        description: "When the data was provided."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Account not found
+            description: "Account not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             usage = get_usage_history(account=account, rse=rse, issuer=request.environ.get('issuer'), vo=request.environ.get('vo'))
@@ -922,25 +922,25 @@ class LocalUsage(ErrorHandlingMethodView):
         """
         ---
         summary: Get local account usage
-        description: Returns the local account usage.
+        description: "Returns the local account usage."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         - name: rse
           in: path
-          description: The rse identifier.
+          description: "The rse identifier."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
@@ -949,23 +949,23 @@ class LocalUsage(ErrorHandlingMethodView):
                     type: object
                     properties:
                       rse_id:
-                        description: The rse id.
+                        description: "The rse id."
                         type: string
                       bytes:
-                        description: The number of bytes used.
+                        description: "The number of bytes used."
                         type: integer
                       bytes_limit:
-                        description: The maximum number of bytes.
+                        description: "The maximum number of bytes."
                         type: integer
                       bytes_remaining:
-                        description: The remaining number of bytes.
+                        description: "The remaining number of bytes."
                         type: integer
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Account or rse not found
+            description: "Account or rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             def generate(issuer: str, vo: str) -> "Iterator[str]":
@@ -986,25 +986,25 @@ class GlobalUsage(ErrorHandlingMethodView):
         """
         ---
         summary: Get local account usage
-        description: Returns the local account usage.
+        description: "Returns the local account usage."
         tags:
           - Account
         parameters:
         - name: account
           in: path
-          description: The account identifier.
+          description: "The account identifier."
           schema:
             type: string
           style: simple
         - name: rse_expression
           in: path
-          description: The rse expression.
+          description: "The rse expression."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
@@ -1013,23 +1013,23 @@ class GlobalUsage(ErrorHandlingMethodView):
                     type: object
                     properties:
                       rse_expression:
-                        description: The rse expression.
+                        description: "The rse expression."
                         type: string
                       bytes:
-                        description: The number of bytes used.
+                        description: "The number of bytes used."
                         type: integer
                       bytes_limit:
-                        description: The maximum number of bytes.
+                        description: "The maximum number of bytes."
                         type: integer
                       bytes_remaining:
-                        description: The remaining number of bytes.
+                        description: "The remaining number of bytes."
                         type: integer
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Account or rse not found
+            description: "Account or rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             def generate(vo: str, issuer: str) -> "Iterator[str]":

--- a/lib/rucio/web/rest/flaskapi/v1/archives.py
+++ b/lib/rucio/web/rest/flaskapi/v1/archives.py
@@ -33,19 +33,19 @@ class Archive(ErrorHandlingMethodView):
         """
         ---
         summary: List
-        description: List archive contents.
+        description: "List archive contents."
         tags:
           - Archive
         parameters:
         - name: scope_name
           in: path
-          description: The data identifier of the scope.
+          description: "The data identifier of the scope."
           schema:
             type: string
           style: simple
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
@@ -54,24 +54,24 @@ class Archive(ErrorHandlingMethodView):
                     type: object
                     properties:
                       scope:
-                        description: The scope of the did.
+                        description: "The scope of the did."
                         type: string
                       name:
-                        description: The name of the did.
+                        description: "The name of the did."
                         type: string
                       bytes:
-                        description: The number of bytes.
+                        description: "The number of bytes."
                         type: integer
                       adler32:
-                        description: The adler32 checksum.
+                        description: "The adler32 checksum."
                         type: string
                       md5:
-                        description: The md5 checksum.
+                        description: "The md5 checksum."
                         type: string
           400:
-            description: Invalid value
+            description: "Invalid value"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ.get('vo'))

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -71,12 +71,12 @@ class UserPass(ErrorHandlingMethodView):
         """
         ---
         summary: UserPass Allow cross-site scripting
-        description: UserPass Allow cross-site scripting. Explicit for Authentication.
+        description: "UserPass Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -97,7 +97,7 @@ class UserPass(ErrorHandlingMethodView):
                   type: string
                   enum: ['X-Rucio-Auth-Token']
           404:
-            description: Not found
+            description: "Not found"
         """
 
         return '', 200, self.get_headers()
@@ -107,41 +107,41 @@ class UserPass(ErrorHandlingMethodView):
         """
         ---
         summary: UserPass
-        description: Authenticate a Rucio account temporarily via username and password.
+        description: "Authenticate a Rucio account temporarily via username and password."
         tags:
           - Auth
         parameters:
         - name: X-Rucio-Account
           in: header
-          description: Account identifier as a string.
+          description: "Account identifier as a string."
           schema:
             type: string
           required: true
         - name: X-Rucio-Username
           in: header
-          description: Username as a string.
+          description: "Username as a string."
           schema:
             type: string
           required: true
         - name: X-Rucio-Password
           in: header
-          description: password as a text-plain string.
+          description: "password as a text-plain string."
           schema:
             type: string
           required: true
         - name: X-Rucio-AppID
           in: header
-          description: Application identifier as a string.
+          description: "Application identifier as a string."
           schema:
             type: string
         - name: X-Forwarded-For
           in: header
-          description: The forward ip address.
+          description: "The forward ip address."
           schema:
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -167,17 +167,17 @@ class UserPass(ErrorHandlingMethodView):
               X-Rucio-Auth-Account:
                 schema:
                   type: string
-                description: The rucio account used for authentication
+                description: "The rucio account used for authentication"
           206:
-            description: Partial content containing X-Rucio-Auth-Accounts header
+            description: "Partial content containing X-Rucio-Auth-Accounts header"
             headers:
               X-Rucio-Auth-Accounts:
                 schema:
                   type: string
-                description: The rucio accounts corresponding to the provided identity as a csv string
+                description: "The rucio accounts corresponding to the provided identity as a csv string"
 
           401:
-            description: Cannot authenticate
+            description: "Cannot authenticate"
         """
         headers = self.get_headers()
 
@@ -247,12 +247,12 @@ class OIDC(ErrorHandlingMethodView):
         """
         ---
         summary: OIDC Allow cross-site scripting
-        description: OIDC Allow cross-site scripting. Explicit for Authentication.
+        description: "OIDC Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -269,7 +269,7 @@ class OIDC(ErrorHandlingMethodView):
                   type: string
                   enum: ['true']
           404:
-            description: Not found
+            description: "Not found"
         """
 
         return '', 200, self.get_headers()
@@ -279,13 +279,13 @@ class OIDC(ErrorHandlingMethodView):
         """
         ---
         summary: OIDC
-        description: Authenticate a Rucio account via OIDC.
+        description: "Authenticate a Rucio account via OIDC."
         tags:
           - Auth
         parameters:
         - name: HTTP_X_RUCIO_ACCOUNT
           in: header
-          description: Account identifier as a string.
+          description: "Account identifier as a string."
           schema:
             type: string
         - name: HTTP_X_RUCIO_CLIENT_AUTHORIZE_SCOPE
@@ -318,14 +318,14 @@ class OIDC(ErrorHandlingMethodView):
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               X-Rucio-OIDC-Auth-URL:
-                description: User & Rucio OIDC Client specific Authorization URL
+                description: "User & Rucio OIDC Client specific Authorization URL"
                 schema:
                   type: string
           401:
-            description: Cannot authenticate
+            description: "Cannot authenticate"
         """
         headers = self.get_headers()
 
@@ -394,12 +394,12 @@ class RedirectOIDC(ErrorHandlingMethodView):
         """
         ---
         summary: RedirectOIDC Allow cross-site scripting
-        description: RedirectOIDC Allow cross-site scripting. Explicit for Authentication.
+        description: "RedirectOIDC Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -416,7 +416,7 @@ class RedirectOIDC(ErrorHandlingMethodView):
                   type: string
                   enum: ['true']
           404:
-            description: Not found
+            description: "Not found"
         """
         return '', 200, self.get_headers()
 
@@ -425,7 +425,7 @@ class RedirectOIDC(ErrorHandlingMethodView):
         """
         ---
         summary: RedirectOIDC
-        description: Authenticate a Rucio account via RedirectOIDC.
+        description: "Authenticate a Rucio account via RedirectOIDC."
         tags:
           - Auth
         parameters:
@@ -435,10 +435,10 @@ class RedirectOIDC(ErrorHandlingMethodView):
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               X-Rucio-Auth-Token:
-                description: The authentication token
+                description: "The authentication token"
                 schema:
                   type: string
               Content-Type:
@@ -446,9 +446,9 @@ class RedirectOIDC(ErrorHandlingMethodView):
                   type: string
                   enum: ['application/octet-stream']
           303:
-            description: Redirect
+            description: "Redirect"
           401:
-            description: Cannot authenticate
+            description: "Cannot authenticate"
         """
         headers = self.get_headers()
 
@@ -509,12 +509,12 @@ class CodeOIDC(ErrorHandlingMethodView):
         """
         ---
         summary: CodeOIDC Allow cross-site scripting
-        description: CodeOIDC Allow cross-site scripting. Explicit for Authentication.
+        description: "CodeOIDC Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -531,7 +531,7 @@ class CodeOIDC(ErrorHandlingMethodView):
                   type: string
                   enum: ['true']
           404:
-            description: Not found
+            description: "Not found"
         """
         return '', 200, self.get_headers()
 
@@ -540,7 +540,7 @@ class CodeOIDC(ErrorHandlingMethodView):
         """
         ---
         summary: CodeOIDC
-        description: Authenticate a Rucio account via CodeOIDC.
+        description: "Authenticate a Rucio account via CodeOIDC."
         tags:
           - Auth
         parameters:
@@ -550,9 +550,9 @@ class CodeOIDC(ErrorHandlingMethodView):
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
           400:
-            description: Invalid request
+            description: "Invalid request"
         """
         headers = self.get_headers()
 
@@ -606,12 +606,12 @@ class TokenOIDC(ErrorHandlingMethodView):
         """
         ---
         summary: TokenOIDC Allow cross-site scripting
-        description: TokenOIDC Allow cross-site scripting. Explicit for Authentication.
+        description: "TokenOIDC Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -628,7 +628,7 @@ class TokenOIDC(ErrorHandlingMethodView):
                   type: string
                   enum: ['true']
           404:
-            description: Not found
+            description: "Not found"
         """
         return '', 200, self.get_headers()
 
@@ -637,7 +637,7 @@ class TokenOIDC(ErrorHandlingMethodView):
         """
         ---
         summary: TokenOIDC
-        description: Authenticate a Rucio account via TokenOIDC.
+        description: "Authenticate a Rucio account via TokenOIDC."
         tags:
           - Auth
         parameters:
@@ -647,18 +647,18 @@ class TokenOIDC(ErrorHandlingMethodView):
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               X-Rucio-Auth-Token:
-                description: The authentication token
+                description: "The authentication token"
                 schema:
                   type: string
               X-Rucio-Auth-Token-Expires:
-                description: The time when the token expires
+                description: "The time when the token expires"
                 schema:
                   type: string
           401:
-            description: Cannot authenticate
+            description: "Cannot authenticate"
         """
         headers = self.get_headers()
 
@@ -721,12 +721,12 @@ class RefreshOIDC(ErrorHandlingMethodView):
         """
         ---
         summary: RefreshOIDC Allow cross-site scripting
-        description: RefreshOIDC Allow cross-site scripting. Explicit for Authentication.
+        description: "RefreshOIDC Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -747,7 +747,7 @@ class RefreshOIDC(ErrorHandlingMethodView):
                   type: string
                   enum: ['X-Rucio-Auth-Token']
           404:
-            description: Not found
+            description: "Not found"
         """
         return '', 200, self.get_headers()
 
@@ -756,7 +756,7 @@ class RefreshOIDC(ErrorHandlingMethodView):
         """
         ---
         summary: RefreshOIDC
-        description: Authenticate a Rucio account via RefreshOIDC.
+        description: "Authenticate a Rucio account via RefreshOIDC."
         tags:
           - Auth
         parameters:
@@ -772,18 +772,18 @@ class RefreshOIDC(ErrorHandlingMethodView):
           required: true
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               X-Rucio-Auth-Token:
-                description: The authentication token
+                description: "The authentication token"
                 schema:
                   type: string
               X-Rucio-Auth-Token-Expires:
-                description: The time when the token expires
+                description: "The time when the token expires"
                 schema:
                   type: string
           401:
-            description: Cannot authenticate
+            description: "Cannot authenticate"
         """
         headers = self.get_headers()
 
@@ -830,12 +830,12 @@ class GSS(ErrorHandlingMethodView):
         """
         ---
         summary: GSS Allow cross-site scripting
-        description: GSS Allow cross-site scripting. Explicit for Authentication.
+        description: "GSS Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -856,7 +856,7 @@ class GSS(ErrorHandlingMethodView):
                   type: string
                   enum: ['X-Rucio-Auth-Token']
           404:
-            description: Not found
+            description: "Not found"
         """
         return '', 200, self.get_headers()
 
@@ -865,7 +865,7 @@ class GSS(ErrorHandlingMethodView):
         """
         ---
         summary: GSS
-        description: Authenticate a Rucio account via GSS.
+        description: "Authenticate a Rucio account via GSS."
         tags:
           - Auth
         parameters:
@@ -889,18 +889,18 @@ class GSS(ErrorHandlingMethodView):
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               X-Rucio-Auth-Token:
-                description: The authentication token
+                description: "The authentication token"
                 schema:
                   type: string
               X-Rucio-Auth-Token-Expires:
-                description: The time when the token expires
+                description: "The time when the token expires"
                 schema:
                   type: string
           401:
-            description: Cannot authenticate
+            description: "Cannot authenticate"
         """
 
         headers = self.get_headers()
@@ -960,12 +960,12 @@ class x509(ErrorHandlingMethodView):  # noqa: N801
         """
         ---
         summary: x509 Allow cross-site scripting
-        description: x509 Allow cross-site scripting. Explicit for Authentication.
+        description: "x509 Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -986,7 +986,7 @@ class x509(ErrorHandlingMethodView):  # noqa: N801
                   type: string
                   enum: ['X-Rucio-Auth-Token']
           404:
-            description: Not found
+            description: "Not found"
         """
         return '', 200, self.get_headers()
 
@@ -995,7 +995,7 @@ class x509(ErrorHandlingMethodView):  # noqa: N801
         """
         ---
         summary: x509
-        description: Authenticate a Rucio account via x509.
+        description: "Authenticate a Rucio account via x509."
         tags:
           - Auth
         parameters:
@@ -1016,32 +1016,32 @@ class x509(ErrorHandlingMethodView):  # noqa: N801
           in: header
           schema:
             type: boolean
-          description: If set to true, a HTTP 206 response will be returned if the identity is associated with multiple accounts.
+          description: "If set to true, a HTTP 206 response will be returned if the identity is associated with multiple accounts."
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               X-Rucio-Auth-Token:
-                description: The authentication token
+                description: "The authentication token"
                 schema:
                   type: string
               X-Rucio-Auth-Token-Expires:
-                description: The time when the token expires
+                description: "The time when the token expires"
                 schema:
                   type: string
               X-Rucio-Auth-Account:
-                description: The rucio account corresponding to the provided identity
+                description: "The rucio account corresponding to the provided identity"
                 schema:
                   type: string
           206:
-            description: Partial content containing X-Rucio-Auth-Accounts header
+            description: "Partial content containing X-Rucio-Auth-Accounts header"
             headers:
               X-Rucio-Auth-Accounts:
                 schema:
                   type: string
-                description: The rucio accounts corresponding to the provided identity as a csv string
+                description: "The rucio accounts corresponding to the provided identity as a csv string"
           401:
-            description: Cannot authenticate
+            description: "Cannot authenticate"
         """
         headers = self.get_headers()
         headers['Content-Type'] = 'application/octet-stream'
@@ -1130,12 +1130,12 @@ class SSH(ErrorHandlingMethodView):
         """
         ---
         summary: SSH Allow cross-site scripting
-        description: SSH Allow cross-site scripting. Explicit for Authentication.
+        description: "SSH Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -1156,7 +1156,7 @@ class SSH(ErrorHandlingMethodView):
                   type: string
                   enum: ['X-Rucio-Auth-Token']
           404:
-            description: Not found
+            description: "Not found"
         """
         return '', 200, self.get_headers()
 
@@ -1165,7 +1165,7 @@ class SSH(ErrorHandlingMethodView):
         """
         ---
         summary: SSH
-        description: Authenticate a Rucio account via SSH.
+        description: "Authenticate a Rucio account via SSH."
         tags:
           - Auth
         parameters:
@@ -1189,18 +1189,18 @@ class SSH(ErrorHandlingMethodView):
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               X-Rucio-Auth-Token:
-                description: The authentication token
+                description: "The authentication token"
                 schema:
                   type: string
               X-Rucio-Auth-Token-Expires:
-                description: The time when the token expires
+                description: "The time when the token expires"
                 schema:
                   type: string
           401:
-            description: Cannot authenticate
+            description: "Cannot authenticate"
         """
         headers = self.get_headers()
 
@@ -1259,12 +1259,12 @@ class SSHChallengeToken(ErrorHandlingMethodView):
         """
         ---
         summary: SSHChallengeToken Allow cross-site scripting
-        description: SSHChallengeToken Allow cross-site scripting. Explicit for Authentication.
+        description: "SSHChallengeToken Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -1285,7 +1285,7 @@ class SSHChallengeToken(ErrorHandlingMethodView):
                   type: string
                   enum: ['X-Rucio-Auth-Token']
           404:
-            description: Not found
+            description: "Not found"
         """
         return '', 200, self.get_headers()
 
@@ -1294,7 +1294,7 @@ class SSHChallengeToken(ErrorHandlingMethodView):
         """
         ---
         summary: SSHChallengeToken
-        description: Authenticate a Rucio account via SSHChallengeToken.
+        description: "Authenticate a Rucio account via SSHChallengeToken."
         tags:
           - Auth
         parameters:
@@ -1313,18 +1313,18 @@ class SSHChallengeToken(ErrorHandlingMethodView):
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               X-Rucio-SSH-Challenge-Token:
-                description: The authentication token
+                description: "The authentication token"
                 schema:
                   type: string
               X-Rucio-SSH-Challenge-Token-Expires:
-                description: The time when the token expires
+                description: "The time when the token expires"
                 schema:
                   type: string
           401:
-            description: Cannot authenticate
+            description: "Cannot authenticate"
         """
         headers = self.get_headers()
 
@@ -1374,12 +1374,12 @@ class SAML(ErrorHandlingMethodView):
         """
         ---
         summary: SAML Allow cross-site scripting
-        description: SAML Allow cross-site scripting. Explicit for Authentication.
+        description: "SAML Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -1400,7 +1400,7 @@ class SAML(ErrorHandlingMethodView):
                   type: string
                   enum: ['X-Rucio-Auth-Token']
           404:
-            description: Not found
+            description: "Not found"
         """
         return '', 200, self.get_headers()
 
@@ -1409,7 +1409,7 @@ class SAML(ErrorHandlingMethodView):
         """
         ---
         summary: SAML
-        description: Authenticate a Rucio account via SAML.
+        description: "Authenticate a Rucio account via SAML."
         tags:
           - Auth
         parameters:
@@ -1428,22 +1428,22 @@ class SAML(ErrorHandlingMethodView):
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               X-Rucio-Auth-Token:
-                description: The authentication token
+                description: "The authentication token"
                 schema:
                   type: string
               X-Rucio-Auth-Token-Expires:
-                description: The time when the token expires
+                description: "The time when the token expires"
                 schema:
                   type: string
               X-Rucio-SAML-Auth-URL:
-                description: The time when the token expires
+                description: "The time when the token expires"
                 schema:
                   type: string
           401:
-            description: Cannot authenticate
+            description: "Cannot authenticate"
         """
         headers = self.get_headers()
 
@@ -1500,14 +1500,14 @@ class SAML(ErrorHandlingMethodView):
         """
         ---
         summary: Post a SAML request
-        description: Post a SAML request
+        description: "Post a SAML request"
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
         """
         if not EXTRA_MODULES['onelogin']:
             return "SAML not configured on the server side.", 200, [('X-Rucio-Auth-Token', '')]
@@ -1544,12 +1544,12 @@ class Validate(ErrorHandlingMethodView):
         """
         ---
         summary: Validate Allow cross-site scripting
-        description: Validate Allow cross-site scripting. Explicit for Authentication.
+        description: "Validate Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Auth
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
@@ -1570,7 +1570,7 @@ class Validate(ErrorHandlingMethodView):
                   type: string
                   enum: ['X-Rucio-Auth-Token']
           404:
-            description: Not found
+            description: "Not found"
         """
         return '', 200, self.get_headers()
 
@@ -1579,7 +1579,7 @@ class Validate(ErrorHandlingMethodView):
         """
         ---
         summary: Validate
-        description: Validate a Rucio auth token.
+        description: "Validate a Rucio auth token."
         tags:
           - Auth
         parameters:
@@ -1590,9 +1590,9 @@ class Validate(ErrorHandlingMethodView):
           required: true
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Cannot authenticate
+            description: "Cannot authenticate"
         """
 
         headers = self.get_headers()

--- a/lib/rucio/web/rest/flaskapi/v1/config.py
+++ b/lib/rucio/web/rest/flaskapi/v1/config.py
@@ -29,21 +29,21 @@ class Config(ErrorHandlingMethodView):
         """
         ---
         summary: List
-        description: List the full configuration.
+        description: "List the full configuration."
         tags:
           - Config
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: A dict with the sections as keys and a dict with the configuration as value.
+                  description: "A dict with the sections as keys and a dict with the configuration as value."
                   type: object
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         res = {}
         for section in config.sections(issuer=request.environ['issuer'], vo=request.environ['vo']):
@@ -57,7 +57,7 @@ class Config(ErrorHandlingMethodView):
         """
         ---
         summary: Create
-        description: Create or set the configuration option in the requested section.
+        description: "Create or set the configuration option in the requested section."
         tags:
           - Config
         requestBody:
@@ -68,18 +68,18 @@ class Config(ErrorHandlingMethodView):
                 type: object
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           400:
-            description: The input data was incomplete or invalid
+            description: "The input data was incomplete or invalid"
           500:
-            description: Configuration error
+            description: "Configuration error"
         """
         parameters = json_parameters()
         for section, section_config in parameters.items():
@@ -106,7 +106,7 @@ class Section(ErrorHandlingMethodView):
         parameters:
         - name: section
           in: path
-          description: The section to return.
+          description: "The section to return."
           schema:
             type: string
           style: simple
@@ -119,22 +119,22 @@ class Section(ErrorHandlingMethodView):
                 - bytes
                 properties:
                   bytes:
-                    description: The new limit in bytes.
+                    description: "The new limit in bytes."
                     type: integer
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: Dictionary of section options.
+                  description: "Dictionary of section options."
                   type: object
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Config not found
+            description: "Config not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         res = {}
         for item in config.items(section, issuer=request.environ['issuer'], vo=request.environ['vo']):
@@ -158,36 +158,36 @@ class OptionGetDel(ErrorHandlingMethodView):
         """
         ---
         summary: Get option
-        description: Returns the value of an option
+        description: "Returns the value of an option"
         tags:
           - Config
         parameters:
         - name: section
           in: path
-          description: The section.
+          description: "The section."
           schema:
             type: string
           style: simple
         - name: option
           in: path
-          description: The option of the section.
+          description: "The option of the section."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The value of the option
+                  description: "The value of the option"
                   type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Config not found
+            description: "Config not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             result = config.get(section=section, option=option, issuer=request.environ['issuer'], vo=request.environ['vo'])
@@ -201,27 +201,27 @@ class OptionGetDel(ErrorHandlingMethodView):
         """
         ---
         summary: Delete option
-        description: Delete an option of a section.
+        description: "Delete an option of a section."
         tags:
           - Config
         parameters:
         - name: section
           in: path
-          description: The section.
+          description: "The section."
           schema:
             type: string
           style: simple
         - name: option
           in: path
-          description: The option of the section.
+          description: "The option of the section."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
         """
         config.remove_option(section=section, option=option, issuer=request.environ['issuer'], vo=request.environ['vo'])
         return '', 200
@@ -234,40 +234,40 @@ class OptionSet(ErrorHandlingMethodView):
         """
         ---
         summary: Create value
-        description: Create or set the value of an option.
+        description: "Create or set the value of an option."
         tags:
           - Config
         parameters:
         - name: section
           in: path
-          description: The section.
+          description: "The section."
           schema:
             type: string
           style: simple
         - name: option
           in: path
-          description: The option of the section.
+          description: "The option of the section."
           schema:
             type: string
           style: simple
         - name: value
           in: path
-          description: The value to set.
+          description: "The value to set."
           schema:
             type: string
           style: simple
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           500:
-            description: Value could not be set
+            description: "Value could not be set"
             content:
               application/json:
                 schema:

--- a/lib/rucio/web/rest/flaskapi/v1/credentials.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credentials.py
@@ -47,38 +47,38 @@ class SignURL(ErrorHandlingMethodView):
         """
         ---
         summary: Cross-Site Scripting
-        description: Allow cross-site scripting. Explicit for Authentication.
+        description: "Allow cross-site scripting. Explicit for Authentication."
         tags:
           - Credentials
         responses:
           200:
-            description: OK
+            description: "OK"
             headers:
               Access-Control-Allow-Origin:
                 schema:
                   type: string
-                description: The http origin.
+                description: "The http origin."
               Access-Control-Allow-Headers:
                 schema:
                   type: string
-                description: The http access control request headers.
+                description: "The http access control request headers."
               Access-Control-Allow-Methods:
                 schema:
                   type: string
                   enum: ['*']
-                description: The allowed methods.
+                description: "The allowed methods."
               Access-Control-Allow-Credentials:
                 schema:
                   type: string
                   enum: ['true']
-                description: If credentials are allowed.
+                description: "If credentials are allowed."
               Access-Control-Expose-Headers:
                 schema:
                   type: string
                   enum: ['X-Rucio-Auth-Token']
-                description: The exposed access control header.
+                description: "The exposed access control header."
           404:
-            description: Not found
+            description: "Not found"
         """
         return '', 200, self.get_headers()
 
@@ -87,37 +87,37 @@ class SignURL(ErrorHandlingMethodView):
         """
         ---
         summary: Sign URL
-        description: Sign a url for a limited lifetime for a particular srevice.
+        description: "Sign a url for a limited lifetime for a particular srevice."
         tags:
           - Credentials
         parameters:
         - name: rse
           in: query
-          description: The RSE to authenticate against.
+          description: "The RSE to authenticate against."
           schema:
             type: string
           required: true
         - name: lifetime
           in: query
-          description: The lifetime, default 600s.
+          description: "The lifetime, default 600s."
           schema:
             type: string
           required: false
         - name: svc
           in: query
-          description: The service, default gcs.
+          description: "The service, default gcs."
           schema:
             type: string
           required: false
         - name: op
           in: query
-          description: The operation.
+          description: "The operation."
           schema:
             type: string
           required: false
         - name: url
           in: query
-          description: The Url of the authentication.
+          description: "The Url of the authentication."
           schema:
             type: string
           required: true
@@ -128,37 +128,37 @@ class SignURL(ErrorHandlingMethodView):
                 type: object
                 properties:
                   X-Rucio-Account:
-                    description: Account identifier.
+                    description: "Account identifier."
                     type: string
                   X-Rucio-VO:
-                    description: VO name (Multi-VO only).
+                    description: "VO name (Multi-VO only)."
                     type: string
                   X-Rucio-AppID:
-                    description: Application identifier.
+                    description: "Application identifier."
                     type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: array
                   items:
                     type: object
-                    description: An account attribute.
+                    description: "An account attribute."
                     properties:
                       key:
-                        description: The key of the account attribute.
+                        description: "The key of the account attribute."
                         type: string
                       value:
-                        description: The value of the account attribute.
+                        description: "The value of the account attribute."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           400:
-            description: bad request, no rse or url found.
+            description: "Bad request, no rse or url found."
           406:
-            description: Not acceptable.
+            description: "Not acceptable."
         """
         headers = self.get_headers()
         vo = extract_vo(request.headers)

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -81,63 +81,63 @@ class Scope(ErrorHandlingMethodView):
         """
         ---
         summary: Get Data Identifier
-        description: Return all data identifiers in the given scope.
+        description: "Return all data identifiers in the given scope."
         tags:
           - Data Identifiers
         parameters:
         - name: scope
           in: path
-          description: The scope.
+          description: "The scope."
           required: true
           schema:
             type: string
           style: simple
         - name: name
           in: query
-          description: The name of the data identifier (did).
+          description: "The name of the data identifier (did)."
           required: false
           schema:
             type: string
         - name: recursive
           in: query
-          description: If true, retrieves child identifiers recursively for non-file types.
+          description: "If true, retrieves child identifiers recursively for non-file types."
           required: false
           schema:
             type: boolean
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: Line-separated dictionary of dids.
+                  description: "Line-separated dictionary of dids."
                   type: array
                   items:
                     type: object
-                    description: Data identifier
+                    description: "Data identifier"
                     properties:
                       scope:
                         type: string
-                        description: The scope of the did.
+                        description: "The scope of the did."
                       name:
                         type: string
-                        description: The name of the did.
+                        description: "The name of the did."
                       type:
                         type: string
-                        description: The type of the did.
+                        description: "The type of the did."
                         enum: ['F', 'D', 'C', 'A', 'X', 'Y', 'Z']
                       parent:
                         type: string
-                        description: The parent of the did.
+                        description: "The parent of the did."
                       level:
                         type: integer
-                        description: The level of the did.
+                        description: "The level of the did."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No Dids found
+            description: "No Dids found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             def generate(name, recursive, vo):
@@ -164,98 +164,98 @@ class Search(ErrorHandlingMethodView):
         """
         ---
         summary: List Data identifier
-        description: List all data identifiers in a scope which match a given metadata.
+        description: "List all data identifiers in a scope which match a given metadata."
         tags:
           - Data Identifiers
         parameters:
         - name: scope
           in: path
-          description: The scope of the data identifiers.
+          description: "The scope of the data identifiers."
           schema:
             type: string
           style: simple
         - name: type
           in: query
-          description: The did type to search for.
+          description: "The did type to search for."
           schema:
             type: string
             enum: ['all', 'collection', 'container', 'dataset', 'file']
             default: 'collection'
         - name: limit
           in: query
-          description: The maximum number od dids returned.
+          description: "The maximum number od dids returned."
           schema:
             type: integer
         - name: long
           in: query
-          description: Provides a longer output, otherwise just prints names.
+          description: "Provides a longer output, otherwise just prints names."
           schema:
             type: boolean
             default: false
         - name: recursive
           in: query
-          description: Recursively list chilred.
+          description: "Recursively list chilred."
           schema:
             type: boolean
         - name: created_before
           in: query
-          description: Date string in RFC-1123 format where the creation date was earlier.
+          description: "Date string in RFC-1123 format where the creation date was earlier."
           schema:
             type: string
         - name: created_after
           in: query
-          description: Date string in RFC-1123 format where the creation date was later.
+          description: "Date string in RFC-1123 format where the creation date was later."
           schema:
             type: string
         - name: length
           in: query
-          description:  Exact number of attached DIDs.
+          description: "Exact number of attached DIDs."
           schema:
             type: integer
         - name: length.gt
           in: query
-          description: Number of attached DIDs greater than.
+          description: "Number of attached DIDs greater than."
           schema:
             type: integer
         - name: length.lt
           in: query
-          description: Number of attached DIDs less than.
+          description: "Number of attached DIDs less than."
           schema:
             type: integer
         - name: length.gte
           in: query
-          description: Number of attached DIDs greater than or equal to
+          description: "Number of attached DIDs greater than or equal to"
           schema:
             type: integer
         - name: length.lte
           in: query
-          description: Number of attached DIDs less than or equal to.
+          description: "Number of attached DIDs less than or equal to."
           schema:
             type: integer
         - name: name
           in: query
-          description: Name or pattern of a did.
+          description: "Name or pattern of a did."
           schema:
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: Line separated name of DIDs or dictionaries of DIDs for long option.
+                  description: "Line separated name of DIDs or dictionaries of DIDs for long option."
                   type: array
                   items:
                     type: object
-                    description: the name of a DID or a dictionarie of a DID for long option.
+                    description: "The name of a DID or a dictionarie of a DID for long option."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Invalid key in filter.
+            description: "Invalid key in filter."
           406:
-            description: Not acceptable
+            description: "Not acceptable"
           409:
-            description: Wrong did type
+            description: "Wrong did type"
         """
         filters = request.args.get('filters', default=None)
         if filters is not None:
@@ -290,7 +290,7 @@ class BulkDIDS(ErrorHandlingMethodView):
         """
         ---
         summary: Add Dids bulk
-        description: Add new Dids in bulk.
+        description: "Add new Dids in bulk."
         tags:
           - Data Identifiers
         requestBody:
@@ -299,7 +299,7 @@ class BulkDIDS(ErrorHandlingMethodView):
               schema:
                 type: array
                 items:
-                  description: One did to add.
+                  description: "One did to add."
                   type: object
                   required:
                     - scope
@@ -307,35 +307,35 @@ class BulkDIDS(ErrorHandlingMethodView):
                     - type
                   properties:
                     scope:
-                      description: The did scope.
+                      description: "The did scope."
                       type: string
                     name:
-                      description: The did name.
+                      description: "The did name."
                       type: string
                     type:
-                      description: The type of the did.
+                      description: "The type of the did."
                       type: string
                       enum: ["F", "D", "C", "A", "X", "Y", "Z"]
                     account:
-                      description: The account associated with the did.
+                      description: "The account associated with the did."
                       type: string
                     statuses:
-                      description: The monotonic status
+                      description: "The monotonic status"
                       type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
           409:
-            description: Did already exists
+            description: "Did already exists"
         """
         dids = json_list()
         try:
@@ -355,7 +355,7 @@ class Attachments(ErrorHandlingMethodView):
         """
         ---
         summary: Attach did to did
-        description: Attaches a did to another did
+        description: "Attaches a did to another did"
         tags:
           - Data Identifiers
         requestBody:
@@ -371,40 +371,40 @@ class Attachments(ErrorHandlingMethodView):
                       - dids
                     properties:
                       scope:
-                        description: The scope of the did.
+                        description: "The scope of the did."
                         type: string
                       name:
-                        description: The name of the did.
+                        description: "The name of the did."
                         type: string
                       dids:
-                        description: The dids associated to the did.
+                        description: "The dids associated to the did."
                         type: array
                         items:
                           type: object
-                          description: A did.
+                          description: "A did."
                           required:
                             - scope
                             - name
                           properties:
                             scope:
-                              description: The scope of the did.
+                              description: "The scope of the did."
                               type: string
                             name:
-                              description: The name of the did.
+                              description: "The name of the did."
                               type: string
                       rse_id:
-                        description: The rse id of the did.
+                        description: "The rse id of the did."
                         type: string
                   - type: object
                     required:
                       - attachments
                     properties:
                       ignore_duplicates:
-                        description: If duplicates should be ignored.
+                        description: "If duplicates should be ignored."
                         type: boolean
                         default: false
                       attachments:
-                        description: An array containing all dids. Duplicates are not ignored.
+                        description: "An array containing all dids. Duplicates are not ignored."
                         type: array
                         required:
                           - scope
@@ -412,44 +412,44 @@ class Attachments(ErrorHandlingMethodView):
                           - dids
                         properties:
                           scope:
-                            description: The scope of the did.
+                            description: "The scope of the did."
                             type: string
                           name:
-                            description: The name of the did.
+                            description: "The name of the did."
                             type: string
                           dids:
-                            description: The dids associated to the did.
+                            description: "The dids associated to the did."
                             type: array
                             items:
                               type: object
-                              description: A did.
+                              description: "A did."
                               required:
                                 - scope
                                 - name
                               properties:
                                 scope:
-                                  description: The scope of the did.
+                                  description: "The scope of the did."
                                   type: string
                                 name:
-                                  description: The name of the did.
+                                  description: "The name of the did."
                                   type: string
                           rse_id:
-                            description: The rse id of the did.
+                            description: "The rse id of the did."
                             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parse((dict, list))
         if isinstance(parameters, list):
@@ -482,99 +482,99 @@ class DIDs(ErrorHandlingMethodView):
         """
         ---
         summary: Get did
-        description: Get a single data identifier.
+        description: "Get a single data identifier."
         tags:
           - Data identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
         - name: dynamic_depth
           in: query
-          description: The DID type at which to stop the dynamic length/size estimation
+          description: "The DID type at which to stop the dynamic length/size estimation"
           schema:
             type: string
             enum: ["FILE", "DATASET"]
         - name: dynamic
           in: query
-          description: Same as dynamic_depth = "FILE"
+          description: "Same as dynamic_depth = 'FILE'"
           deprecated: true
           schema:
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   oneOf:
-                  - description: A single file did.
+                  - description: "A single file did."
                     type: object
                     properties:
                       scope:
-                        description: The scope of the did.
+                        description: "The scope of the did."
                         type: string
                       name:
-                        description: The name of the did.
+                        description: "The name of the did."
                         type: string
                       type:
-                        description: The type of the string.
+                        description: "The type of the string."
                         type: string
                       account:
-                        description: The associated account.
+                        description: "The associated account."
                         type: string
                       bytes:
-                        description: The size in bytes.
+                        description: "The size in bytes."
                         type: integer
                       length:
-                        description: The number of files. Corresponses to 1.
+                        description: "The number of files. Corresponses to 1."
                         type: integer
                         enum: [1]
                       md5:
-                        description: md5 checksum.
+                        description: "md5 checksum."
                         type: string
                       adler32:
-                        description: adler32 checksum.
+                        description: "adler32 checksum."
                         type: string
-                  - description: A single file did.
+                  - description: "A single file did."
                     type: object
                     properties:
                       scope:
-                        description: The scope of the did.
+                        description: "The scope of the did."
                         type: string
                       name:
-                        description: The name of the did.
+                        description: "The name of the did."
                         type: string
                       type:
-                        description: The type of the string.
+                        description: "The type of the string."
                         type: string
                       account:
-                        description: The associated account.
+                        description: "The associated account."
                         type: string
                       open:
-                        description: If the did is write open.
+                        description: "If the did is write open."
                         type: boolean
                       monotonic:
-                        description: If the did is monotonic.
+                        description: "If the did is monotonic."
                         type: boolean
                       expired_at:
-                        description: When the did expired.
+                        description: "When the did expired."
                         type: string
                       length:
-                        description: The number of associated dids.
+                        description: "The number of associated dids."
                         type: number
                       bytes:
-                        description: The size in bytes.
+                        description: "The size in bytes."
                         type: number
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Scope not found
+            description: "Scope not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -600,13 +600,13 @@ class DIDs(ErrorHandlingMethodView):
         """
         ---
         summary: Create did
-        description: Create a new data identifier.
+        description: "Create a new data identifier."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
@@ -619,53 +619,53 @@ class DIDs(ErrorHandlingMethodView):
                 - type
                 properties:
                   type:
-                    description: The type of the did.
+                    description: "The type of the did."
                     type: string
                   statuses:
-                    description: The statuses of the did.
+                    description: "The statuses of the did."
                     type: string
                   meta:
-                    description: The meta of the did.
+                    description: "The meta of the did."
                     type: string
                   rules:
-                    description: The rules associated with the did.
+                    description: "The rules associated with the did."
                     type: array
                     items:
                       type: object
-                      description: A rule.
+                      description: "A rule."
                   lifetime:
-                    description: The lifetime of the did.
+                    description: "The lifetime of the did."
                     type: string
                   dids:
-                    description: The dids associated with the did.
+                    description: "The dids associated with the did."
                     type: array
                     items:
                       type: object
-                      description: The did associated with a did.
+                      description: "The did associated with a did."
                       properties:
                         scope:
-                          description: The scope of the did.
+                          description: "The scope of the did."
                           type: string
                         name:
-                          description: The name of the did.
+                          description: "The name of the did."
                           type: string
                   rse:
-                    description: The rse associated with the did.
+                    description: "The rse associated with the did."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did or scope not found
+            description: "Did or scope not found"
           409:
-            description: Did already exists
+            description: "Did already exists"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -713,13 +713,13 @@ class DIDs(ErrorHandlingMethodView):
         """
         ---
         summary: Update did
-        description: Update a did.
+        description: "Update a did."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
@@ -730,17 +730,17 @@ class DIDs(ErrorHandlingMethodView):
                 type: object
                 properties:
                   open:
-                    description: The open status
+                    description: "The open status"
                     type: boolean
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           409:
-            description: Wrong status
+            description: "Wrong status"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -768,23 +768,23 @@ class Attachment(ErrorHandlingMethodView):
         """
         ---
         summary: Get did
-        description: Returns the contents of a data identifier.
+        description: "Returns the contents of a data identifier."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: Did found
+            description: "Did found"
             content:
               application/x-json-stream:
                 schema:
-                  description: The contents of a did. Items are line separated.
+                  description: "The contents of a did. Items are line separated."
                   type: array
                   items:
                     type: object
@@ -797,29 +797,29 @@ class Attachment(ErrorHandlingMethodView):
                       - md5
                     properties:
                       scope:
-                        description: The scope of the did.
+                        description: "The scope of the did."
                         type: string
                       name:
-                        description: The name of the did.
+                        description: "The name of the did."
                         type: string
                       type:
-                        description: The type of the did.
+                        description: "The type of the did."
                         type: string
                       bytes:
-                        description: The size of the did.
+                        description: "The size of the did."
                         type: number
                       adler32:
-                        description: The adler32 checksum of the did.
+                        description: "The adler32 checksum of the did."
                         type: string
                       md5:
-                        description: The md5 checksum of the did.
+                        description: "The md5 checksum of the did."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Scope not found
+            description: "Scope not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -838,13 +838,13 @@ class Attachment(ErrorHandlingMethodView):
         """
         ---
         summary: Add dids to did
-        description: Append data identifiers to data identifiers.
+        description: "Append data identifiers to data identifiers."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
@@ -857,40 +857,40 @@ class Attachment(ErrorHandlingMethodView):
                 - dids
                 properties:
                   rse:
-                    description: The name of the rse.
+                    description: "The name of the rse."
                     type: string
                   account:
-                    description: The account which attaches the dids.
+                    description: "The account which attaches the dids."
                     type: string
                   dids:
-                    description: The dids to attach.
+                    description: "The dids to attach."
                     type: object
                     properties:
                       account:
-                        description: The account attaching the did.
+                        description: "The account attaching the did."
                         type: string
                       scope:
-                        description: The scope of the did.
+                        description: "The scope of the did."
                         type: string
                       name:
-                        description: The name of the did.
+                        description: "The name of the did."
                         type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
           409:
-            description: Already attached
+            description: "Already attached"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -916,13 +916,13 @@ class Attachment(ErrorHandlingMethodView):
         """
         ---
         summary: Detach dids from did
-        description: Detach data identifiers from data identifiers.
+        description: "Detach data identifiers from data identifiers."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
@@ -935,24 +935,24 @@ class Attachment(ErrorHandlingMethodView):
                 - dids
                 properties:
                   dids:
-                    description: The dids to detach.
+                    description: "The dids to detach."
                     type: array
                     items:
                       type: object
                       properties:
                         scope:
-                          description: The scope of the did.
+                          description: "The scope of the did."
                           type: string
                         name:
-                          description: The name of the did.
+                          description: "The name of the did."
                           type: string
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -981,61 +981,61 @@ class AttachmentHistory(ErrorHandlingMethodView):
         """
         ---
         summary: Get history
-        description: Returns the content history of a data identifier.
+        description: "Returns the content history of a data identifier."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: Did found
+            description: "Did found"
             content:
               application/x-json-stream:
                 schema:
-                  description: The dids with their information and history. Elements are separated by new line characters.
+                  description: "The dids with their information and history. Elements are separated by new line characters."
                   type: array
                   items:
                     type: object
-                    description: A single did with history data.
+                    description: "A single did with history data."
                     properties:
                       scope:
-                        description: The scope of the did.
+                        description: "The scope of the did."
                         type: string
                       name:
-                        description: The name of the did.
+                        description: "The name of the did."
                         type: string
                       type:
-                        description: The type of the did.
+                        description: "The type of the did."
                         type: string
                       bytes:
-                        description: The size of the did in bytes.
+                        description: "The size of the did in bytes."
                         type: integer
                       adler32:
-                        description: The abler32 sha checksum.
+                        description: "The abler32 sha checksum."
                         type: string
                       md5:
-                        description: The md5 checksum.
+                        description: "The md5 checksum."
                         type: string
                       deleted_at:
-                        description: The deleted_at date time.
+                        description: "The deleted_at date time."
                         type: string
                       created_at:
-                        description: The created_at date time.
+                        description: "The created_at date time."
                         type: string
                       updated_at:
-                        description: The last time the did was updated.
+                        description: "The last time the did was updated."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -1058,84 +1058,84 @@ class Files(ErrorHandlingMethodView):
         """
         ---
         summary: Get replicas
-        description: List all replicas for a did.
+        description: "List all replicas for a did."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
         - name: long
           in: query
-          description: Flag to trigger long output.
+          description: "Flag to trigger long output."
           schema:
             type: object
           required: false
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
                   oneOf:
-                    - description: All replica information if `long` is defined.
+                    - description: "All replica information if `long` is defined."
                       type: array
                       items:
                         type: object
                         properties:
                           scope:
-                            description: The scope of the did.
+                            description: "The scope of the did."
                             type: string
                           name:
-                            description: The name of the did.
+                            description: "The name of the did."
                             type: string
                           bytes:
-                            description: The size of the did in bytes.
+                            description: "The size of the did in bytes."
                             type: integer
                           guid:
-                            description: The guid of the did.
+                            description: "The guid of the did."
                             type: string
                           events:
-                            description: The number of events of the did.
+                            description: "The number of events of the did."
                             type: integer
                           adler32:
-                            description: The adler32 checksum.
+                            description: "The adler32 checksum."
                             type: string
                           lumiblocknr:
-                            description: The lumi block nr. Only available if `long` is defined in the query.
+                            description: "The lumi block nr. Only available if `long` is defined in the query."
                             type: integer
-                    - description: All replica information.
+                    - description: "All replica information."
                       type: array
                       items:
                         type: object
                         properties:
                           scope:
-                            description: The scope of the did.
+                            description: "The scope of the did."
                             type: string
                           name:
-                            description: The name of the did.
+                            description: "The name of the did."
                             type: string
                           bytes:
-                            description: The size of the did in bytes.
+                            description: "The size of the did in bytes."
                             type: integer
                           guid:
-                            description: The guid of the did.
+                            description: "The guid of the did."
                             type: string
                           events:
-                            description: The number of events of the did.
+                            description: "The number of events of the did."
                             type: integer
                           adler32:
-                            description: The adler32 checksum.
+                            description: "The adler32 checksum."
                             type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         long = 'long' in request.args
 
@@ -1160,7 +1160,7 @@ class BulkFiles(ErrorHandlingMethodView):
         """
         ---
         summary: List files bulk
-        description: List files in multiple dids
+        description: "List files in multiple dids"
         tags:
           - Data Identifiers
         requestBody:
@@ -1169,56 +1169,56 @@ class BulkFiles(ErrorHandlingMethodView):
               schema:
                 type: array
                 items:
-                  description: One did to list files.
+                  description: "One did to list files."
                   type: object
                   required:
                     - scope
                     - name
                   properties:
                     scope:
-                      description: The did scope.
+                      description: "The did scope."
                       type: string
                     name:
-                      description: The did name.
+                      description: "The did name."
                       type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: All collections file content.
+                  description: "All collections file content."
                   type: array
                   items:
-                    description: Collections file content.
+                    description: "Collections file content."
                     type: object
                     properties:
                       parent_scope:
-                        description: The scope of the parent did.
+                        description: "The scope of the parent did."
                         type: string
                       parent_name:
-                        description: The name of the parent did.
+                        description: "The name of the parent did."
                         type: string
                       scope:
-                        description: The scope of the did.
+                        description: "The scope of the did."
                         type: string
                       name:
-                        description: The name of the did.
+                        description: "The name of the did."
                         type: string
                       bytes:
-                        description: The size of the did in bytes.
+                        description: "The size of the did in bytes."
                         type: integer
                       guid:
-                        description: The guid of the did.
+                        description: "The guid of the did."
                         type: string
                       events:
-                        description: The number of events of the did.
+                        description: "The number of events of the did."
                         type: integer
                       adler32:
-                        description: The adler32 checksum.
+                        description: "The adler32 checksum."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
         """
         parameters = json_parameters(parse_response)
         dids = param_get(parameters, 'dids', default=[])
@@ -1240,43 +1240,43 @@ class Parents(ErrorHandlingMethodView):
         """
         ---
         summary: Get Parents
-        description: Lists all parents of the did.
+        description: "Lists all parents of the did."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: The parents of the did.
+                  description: "The parents of the did."
                   type: array
                   items:
                     type: object
-                    description: A parent of the did.
+                    description: "A parent of the did."
                     properties:
                       scope:
-                        description: The scope of the did.
+                        description: "The scope of the did."
                         type: string
                       name:
-                        description: The name of the did.
+                        description: "The name of the did."
                         type: string
                       type:
-                        description: The type of the did.
+                        description: "The type of the did."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -1299,38 +1299,38 @@ class Meta(ErrorHandlingMethodView):
         """
         ---
         summary: Get metadata
-        description: Get the metadata of a did.
+        description: "Get the metadata of a did."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
         - name: plugin
           in: query
-          description: The plugin to use.
+          description: "The plugin to use."
           schema:
             type: string
             default: DID_COLUMN
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: A data identifier with all attributes.
+                  description: "A data identifier with all attributes."
                   type: object
           400:
-            description: Bad Request - Invalid metadata plugin specified
+            description: "Bad Request - Invalid metadata plugin specified"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -1350,13 +1350,13 @@ class Meta(ErrorHandlingMethodView):
         """
         ---
         summary: Add metadata
-        description: Add metadata to a did.
+        description: "Add metadata to a did."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
@@ -1369,26 +1369,26 @@ class Meta(ErrorHandlingMethodView):
                 - meta
                 properties:
                   meta:
-                    description: The metadata to add. A dictionary containing the metadata name as key and the value as value.
+                    description: "The metadata to add. A dictionary containing the metadata name as key and the value as value."
                     type: object
                   recursive:
-                    description: Flag if the metadata should be applied recirsively to children.
+                    description: "Flag if the metadata should be applied recirsively to children."
                     type: boolean
                     default: false
         responses:
           201:
-            description: Created
+            description: "Created"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -1420,34 +1420,34 @@ class Meta(ErrorHandlingMethodView):
         """
         ---
         summary: Delete metadata
-        description: Deletes the specified metadata from the did.
+        description: "Deletes the specified metadata from the did."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
         - name: key
           in: query
-          description: The key to delete.
+          description: "The key to delete."
           schema:
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
           400:
-            description: scope_name could not be parsed.
+            description: "scope_name could not be parsed."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did or key not found
+            description: "Did or key not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
           409:
-            description: Feature is not in current database.
+            description: "Feature is not in current database."
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -1474,19 +1474,19 @@ class SingleMeta(ErrorHandlingMethodView):
         """
         ---
         summary: Add metadata
-        description: Add metadata to a did.
+        description: "Add metadata to a did."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
         - name: key
           in: path
-          description: The key for the metadata.
+          description: "The key for the metadata."
           schema:
             type: string
           style: simple
@@ -1499,26 +1499,26 @@ class SingleMeta(ErrorHandlingMethodView):
                 - value
                 properties:
                   value:
-                    description: The value to set.
+                    description: "The value to set."
                     type: object
         responses:
           201:
-            description: Created
+            description: "Created"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
           409:
-            description: Metadata already exists
+            description: "Metadata already exists"
           400:
-            description: Invalid key or value
+            description: "Invalid key or value"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -1554,7 +1554,7 @@ class BulkDIDsMeta(ErrorHandlingMethodView):
         """
         ---
         summary: Add metadata bulk
-        description: Adds metadata in a bulk.
+        description: "Adds metadata in a bulk."
         tags:
           - Data Identifiers
         requestBody:
@@ -1566,37 +1566,37 @@ class BulkDIDsMeta(ErrorHandlingMethodView):
                 - dids
                 properties:
                   dids:
-                    description: A list with all the dids and the metadata.
+                    description: "A list with all the dids and the metadata."
                     type: array
                     items:
-                      description: The did and associated metadata.
+                      description: "The did and associated metadata."
                       type: object
                       properties:
                         scope:
-                          description: The scope of the did.
+                          description: "The scope of the did."
                           type: string
                         name:
-                          description: The name of the did.
+                          description: "The name of the did."
                           type: string
                         meta:
-                          description: The metadata to add. A dictionary with the meta key as key and the value as value.
+                          description: "The metadata to add. A dictionary with the meta key as key and the value as value."
                           type: object
         responses:
           200:
-            description: Created
+            description: "Created"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
           409:
-            description: Unsupported Operation
+            description: "Unsupported Operation"
         """
         parameters = json_parameters()
         dids = param_get(parameters, 'dids')
@@ -1620,33 +1620,33 @@ class Rules(ErrorHandlingMethodView):
         """
         ---
         summary: Get rules
-        description: Lists all rules of a given did.
+        description: "Lists all rules of a given did."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: The rules associated with a did.
+            description: "The rules associated with a did."
             content:
               application/x-json-stream:
                 schema:
-                  description: The rules associated with a did.
+                  description: "The rules associated with a did."
                   type: array
                   items:
-                    description: A rule.
+                    description: "A rule."
                     type: object
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did or rule not found
+            description: "Did or rule not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -1672,7 +1672,7 @@ class BulkMeta(ErrorHandlingMethodView):
         """
         ---
         summary: Get metadata bulk
-        description: List all metadata of a list of data identifiers.
+        description: "List all metadata of a list of data identifiers."
         tags:
           - Data Identifiers
         requestBody:
@@ -1684,45 +1684,45 @@ class BulkMeta(ErrorHandlingMethodView):
                 - dids
                 properties:
                   dids:
-                    description: The dids.
+                    description: "The dids."
                     type: array
                     items:
-                      description: A did.
+                      description: "A did."
                       type: object
                       properties:
                         name:
-                          description: The name of the did.
+                          description: "The name of the did."
                           type: string
                         scope:
-                          description: The scope of the did.
+                          description: "The scope of the did."
                           type: string
                   inherit:
-                    description: Concatenated the metadata of the parent if set to true.
+                    description: "Concatenated the metadata of the parent if set to true."
                     type: boolean
                     default: false
                   plugin:
-                    description: The did meta plugin to query or "ALL" for all available plugins
+                    description: "The did meta plugin to query or 'ALL' for all available plugins"
                     type: string
                     default: "JSON"
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: A list of metadata identifiers for the dids. Separated by new lines.
+                  description: "A list of metadata identifiers for the dids. Separated by new lines."
                   type: array
                   items:
-                    description: The metadata for one did.
+                    description: "The metadata for one did."
                     type: object
           400:
-            description: Cannot decode json parameter list
+            description: "Cannot decode json parameter list"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters()
         dids = param_get(parameters, 'dids')
@@ -1748,55 +1748,55 @@ class AssociatedRules(ErrorHandlingMethodView):
         """
         ---
         summary: Get associated rules
-        description: Gets all associated rules for a file.
+        description: "Gets all associated rules for a file."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: All associated rules for a file. Items are separated by new line character.
+                  description: "All associated rules for a file. Items are separated by new line character."
                   type: array
                   items:
-                    description: A replication rule associated with the file. Has more fields than listed here.
+                    description: "A replication rule associated with the file. Has more fields than listed here."
                     type: object
                     properties:
                       id:
-                        description: The id of the rule.
+                        description: "The id of the rule."
                         type: string
                       subscription_id:
-                        description: The subscription id of the rule.
+                        description: "The subscription id of the rule."
                         type: string
                       account:
-                        description: The account associated with the rule.
+                        description: "The account associated with the rule."
                         type: string
                       scope:
-                        description: The scope associated with the rule.
+                        description: "The scope associated with the rule."
                         type: string
                       name:
-                        description: The name of the rule.
+                        description: "The name of the rule."
                         type: string
                       state:
-                        description: The state of the rule.
+                        description: "The state of the rule."
                         type: string
                       rse_expression:
-                        description: The rse expression of the rule.
+                        description: "The rse expression of the rule."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -1819,40 +1819,40 @@ class GUIDLookup(ErrorHandlingMethodView):
         """
         ---
         summary: Get dataset
-        description: Returns the dataset associated with a GUID.
+        description: "Returns the dataset associated with a GUID."
         tags:
           - Data Identifiers
         parameters:
         - name: guid
           in: path
-          description: The GUID to query buy.
+          description: "The GUID to query buy."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of all datasets associated with the guid. Items are separated by new line character.
+                  description: "A list of all datasets associated with the guid. Items are separated by new line character."
                   type: array
                   items:
-                    description: A dataset associated with a guid.
+                    description: "A dataset associated with a guid."
                     type: object
                     properties:
                       scope:
-                        description: The scope of the dataset.
+                        description: "The scope of the dataset."
                         type: string
                       name:
-                        description: The name of the dataset.
+                        description: "The name of the dataset."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             def generate(vo):
@@ -1870,56 +1870,56 @@ class SampleLegacy(ErrorHandlingMethodView):
         """
         ---
         summary: Create sample
-        description: Creates a sample from an input collection.
+        description: "Creates a sample from an input collection."
         tags:
           - Data Identifiers
         parameters:
         - name: input_scope
           in: path
-          description: The input scope.
+          description: "The input scope."
           schema:
             type: string
           style: simple
         - name: input_name
           in: path
-          description: The input name.
+          description: "The input name."
           schema:
             type: string
           style: simple
         - name: output_scope
           in: path
-          description: The output scope.
+          description: "The output scope."
           schema:
             type: string
           style: simple
         - name: output_name
           in: path
-          description: The output name.
+          description: "The output name."
           schema:
             type: string
           style: simple
         - name: nbfiles
           in: path
-          description: The number of files to register in the output dataset.
+          description: "The number of files to register in the output dataset."
           schema:
             type: string
           style: simple
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
           409:
-            description: Duplication
+            description: "Duplication"
         """
         try:
             create_did_sample(
@@ -1947,11 +1947,11 @@ class Sample(ErrorHandlingMethodView):
         """
         ---
         summary: Create sample
-        description: Creates a sample from an input collection.
+        description: "Creates a sample from an input collection."
         tags:
           - Data Identifiers
         requestBody:
-          description: Parameters (source and destination) for the files in the sample to be created
+          description: "Parameters (source and destination) for the files in the sample to be created"
           content:
             'application/json':
               schema:
@@ -1964,36 +1964,36 @@ class Sample(ErrorHandlingMethodView):
                 - nbfiles
                 properties:
                   input_scope:
-                    description: The input scope.
+                    description: "The input scope."
                     type: string
                   input_name:
-                    description: The input name.
+                    description: "The input name."
                     type: string
                   output_scope:
-                    description: The output scope.
+                    description: "The output scope."
                     type: string
                   output_name:
-                    description: The output name.
+                    description: "The output name."
                     type: string
                   nbfiles:
-                    description: The number of files to register in the output dataset.
+                    description: "The number of files to register in the output dataset."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
           409:
-            description: Duplication
+            description: "Duplication"
         """
         parameters = json_parameters()
         try:
@@ -2023,41 +2023,41 @@ class NewDIDs(ErrorHandlingMethodView):
         """
         ---
         summary: Get recent identifiers
-        description: Returns a list of recent identifiers.
+        description: "Returns a list of recent identifiers."
         tags:
           - Data Identifiers
         parameters:
         - name: type
           in: query
-          description: The type of the did.
+          description: "The type of the did."
           schema:
             type: string
           required: false
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of the recent dids. Items are separated by new line characters.
+                  description: "A list of the recent dids. Items are separated by new line characters."
                   type: array
                   items:
-                    description: A did.
+                    description: "A did."
                     type: object
                     properties:
                       scope:
-                        description: The scope of the did.
+                        description: "The scope of the did."
                         type: string
                       name:
-                        description: The name of the did.
+                        description: "The name of the did."
                         type: string
                       did_type:
-                        description: The type of the did.
+                        description: "The type of the did."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         def generate(_type, vo):
             for did in list_new_dids(did_type=_type, vo=vo):
@@ -2074,41 +2074,41 @@ class Resurrect(ErrorHandlingMethodView):
         """
         ---
         summary: Resurrect dids
-        description: Resurrect all given dids.
+        description: "Resurrect all given dids."
         tags:
           - Data Identifiers
         requestBody:
           content:
             'application/json':
               schema:
-                description: List of did to resurrect.
+                description: "List of did to resurrect."
                 type: array
                 items:
-                  description: A did to resurrect.
+                  description: "A did to resurrect."
                   type: object
                   properties:
                     scope:
-                      description: The scope of the did.
+                      description: "The scope of the did."
                       type: string
                     name:
-                      description: The name of the did
+                      description: "The name of the did"
                       type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           409:
-            description: Conflict
+            description: "Conflict"
           500:
-            description: Internal error
+            description: "Internal error"
         """
         dids = json_list()
 
@@ -2130,39 +2130,39 @@ class Follow(ErrorHandlingMethodView):
         """
         ---
         summary: Get followers
-        description: Get all followers for a specific did.
+        description: "Get all followers for a specific did."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: A list of all followers of a did.
+                  description: "A list of all followers of a did."
                   type: array
                   items:
-                    description: A follower of a did.
+                    description: "A follower of a did."
                     type: object
                     properties:
                       user:
-                        description: The user which follows the did.
+                        description: "The user which follows the did."
                         type: string
           400:
-            description: Value error
+            description: "Value error"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -2181,13 +2181,13 @@ class Follow(ErrorHandlingMethodView):
         """
         ---
         summary: Post follow
-        description: Mark the input DID as being followed by the given account.
+        description: "Mark the input DID as being followed by the given account."
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
@@ -2200,19 +2200,19 @@ class Follow(ErrorHandlingMethodView):
                 - account
                 properties:
                   account:
-                    description: The account to follow the did.
+                    description: "The account to follow the did."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
           400:
-            description: Scope or name could not be interpreted
+            description: "Scope or name could not be interpreted"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           500:
-            description: Internal error
+            description: "Internal error"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -2233,13 +2233,13 @@ class Follow(ErrorHandlingMethodView):
         """
         ---
         summary: Delete follow
-        description: Mark the input DID as not followed
+        description: "Mark the input DID as not followed"
         tags:
           - Data Identifiers
         parameters:
         - name: scope_name
           in: path
-          description: The scope and the name of the did.
+          description: "The scope and the name of the did."
           schema:
             type: string
           style: simple
@@ -2252,17 +2252,17 @@ class Follow(ErrorHandlingMethodView):
                 - account
                 properties:
                   account:
-                    description: The account to unfollow the did.
+                    description: "The account to unfollow the did."
                     type: string
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           500:
-            description: Internal error
+            description: "Internal error"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])

--- a/lib/rucio/web/rest/flaskapi/v1/dirac.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dirac.py
@@ -49,31 +49,31 @@ class AddFiles(ErrorHandlingMethodView):
                     items:
                       type: object
                   ignore_availability:
-                    description: If the availability should be ignored.
+                    description: "If the availability should be ignored."
                     type: boolean
                   parents_metadata:
                     description: "Metadata for selected hierarchy DIDs."
                     type: object
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           400:
-            description: Cannot decode json parameter list.
+            description: "Cannot decode json parameter list."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: DID not found
+            description: "DID not found"
           405:
-            description: Unsupported Operation
+            description: "Unsupported Operation"
           409:
-            description: Duplicate
+            description: "Duplicate"
           503:
-            description: Temporary error.
+            description: "Temporary error."
         """
         parameters = json_parameters(parse_response)
         lfns = param_get(parameters, 'lfns')

--- a/lib/rucio/web/rest/flaskapi/v1/export.py
+++ b/lib/rucio/web/rest/flaskapi/v1/export.py
@@ -28,28 +28,28 @@ class Export(ErrorHandlingMethodView):
         """
         ---
         summary: Export data
-        description: Export data from rucio.
+        description: "Export data from rucio."
         tags:
           - Export
         parameters:
         - name: distance
           in: query
-          description: Should the distance be enabled?
+          description: "Should the distance be enabled?"
           schema:
             type: boolean
           required: false
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: object
-                  description: Dictionary with rucio data.
+                  description: "Dictionary with rucio data."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         distance = request.args.get('distance', default='True') == 'True'
         return Response(render_json(**export_data(issuer=request.environ['issuer'], distance=distance, vo=request.environ['vo'])), content_type='application/json')

--- a/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
+++ b/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
@@ -31,23 +31,23 @@ class Heartbeat(ErrorHandlingMethodView):
         """
         ---
         summary: List
-        description: List all heartbeats.
+        description: "List all heartbeats."
         tags:
           - Heartbeat
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: array
                   items:
                     type: object
-                    description: List of tuples [('Executable', 'Hostname', ...), ...]
+                    description: "List of tuples [('Executable', 'Hostname', ...), ...]"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         return Response(json.dumps(list_heartbeats(issuer=request.environ['issuer'], vo=request.environ['vo']), cls=APIEncoder), content_type='application/json')
 
@@ -66,29 +66,29 @@ class Heartbeat(ErrorHandlingMethodView):
                 - bytes
                 properties:
                   executable:
-                    description: Name of the executable.
+                    description: "Name of the executable."
                     type: string
                   hostname:
-                    description: Name of the host.
+                    description: "Name of the host."
                     type: string
                   pid:
-                    description: UNIX Process ID as a number, e.g., 1234.
+                    description: "UNIX Process ID as a number, e.g., 1234."
                     type: integer
                   older_than:
-                    description: Ignore specified heartbeats older than specified nr of seconds.
+                    description: "Ignore specified heartbeats older than specified nr of seconds."
                     type: integer
                   payload:
-                    description: Payload identifier which can be further used to identify the work a certain thread is executing.
+                    description: "Payload identifier which can be further used to identify the work a certain thread is executing."
                     type: string
         responses:
           200:
-            description: OK
+            description: "OK"
           400:
-            description: Cannot decode json parameter list.
+            description: "Cannot decode json parameter list."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Key not found.
+            description: "Key not found."
         """
         parameters = json_parameters()
         try:

--- a/lib/rucio/web/rest/flaskapi/v1/identities.py
+++ b/lib/rucio/web/rest/flaskapi/v1/identities.py
@@ -26,49 +26,49 @@ class UserPass(ErrorHandlingMethodView):
         """
         ---
         summary: Create UserPass identity
-        description: Creates a new UserPass identity and maps it to an account.
+        description: "Creates a new UserPass identity and maps it to an account."
         tags:
           - Identity
         parameters:
         - name: account
           in: path
-          description: The account for the identity.
+          description: "The account for the identity."
           schema:
             type: string
           style: simple
         - name: X-Rucio-Username
           in: query
-          description: Username for the identity.
+          description: "Username for the identity."
           schema:
             type: string
           style: simple
           required: true
         - name: X-Rucio-Password
           in: query
-          description: The password for the identity.
+          description: "The password for the identity."
           schema:
             type: string
           style: simple
           required: true
         - name: X-Rucio-Email
           in: query
-          description: The email for the identity.
+          description: "The email for the identity."
           schema:
             type: string
           style: simple
           required: false
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           400:
-            description: Missing username or password.
+            description: "Missing username or password."
         """
         username = request.headers.get('X-Rucio-Username', default=None)
         password = request.headers.get('X-Rucio-Password', default=None)
@@ -105,33 +105,33 @@ class X509(ErrorHandlingMethodView):
         """
         ---
         summary: Create X509 identity
-        description: Creates a new X509 identity and maps it to an account.
+        description: "Creates a new X509 identity and maps it to an account."
         tags:
           - Identity
         parameters:
         - name: account
           in: path
-          description: The account for the identity.
+          description: "The account for the identity."
           schema:
             type: string
           style: simple
         - name: X-Rucio-Email
           in: query
-          description: The email for the identity.
+          description: "The email for the identity."
           schema:
             type: string
           style: simple
           required: false
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
         """
         dn = request.environ.get('SSL_CLIENT_S_DN')
         email = request.headers.get('X-Rucio-Email', default=None)
@@ -165,33 +165,33 @@ class GSS(ErrorHandlingMethodView):
         """
         ---
         summary: Create GSS identity
-        description: Creates a new GSS identity and maps it to an account.
+        description: "Creates a new GSS identity and maps it to an account."
         tags:
           - Identity
         parameters:
         - name: account
           in: path
-          description: The account for the identity.
+          description: "The account for the identity."
           schema:
             type: string
           style: simple
         - name: X-Rucio-Email
           in: query
-          description: The email for the identity.
+          description: "The email for the identity."
           schema:
             type: string
           style: simple
           required: false
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
         """
         gsscred = request.environ.get('REMOTE_USER')
         email = request.headers.get('X-Rucio-Email', default=None)
@@ -226,37 +226,37 @@ class Accounts(ErrorHandlingMethodView):
         """
         ---
         summary: List
-        description: List all identities mapped to an account.
+        description: "List all identities mapped to an account."
         tags:
           - Identity
         parameters:
         - name: identity_key
           in: path
-          description: Identity string.
+          description: "Identity string."
           schema:
             type: string
           style: simple
         - name: type
           in: path
-          description: Identity type.
+          description: "Identity type."
           schema:
             type: string
           style: simple
           required: false
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: array
                   items:
                     type: object
-                    description: Account for the identity.
+                    description: "Account for the identity."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           401:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         accounts = list_accounts_for_identity(identity_key, type_)
         return jsonify(accounts)

--- a/lib/rucio/web/rest/flaskapi/v1/import.py
+++ b/lib/rucio/web/rest/flaskapi/v1/import.py
@@ -27,7 +27,7 @@ class Import(ErrorHandlingMethodView):
         """
         ---
         summary: Import data
-        description: Import data into rucio
+        description: "Import data into rucio"
         tags:
             - Import
         requestBody:
@@ -37,75 +37,75 @@ class Import(ErrorHandlingMethodView):
                 type: object
                 properties:
                   rses:
-                    description: Rse data with rse name as key.
+                    description: "Rse data with rse name as key."
                     type: object
                     additionalProperties:
                       x-additionalPropertiesName: rse name
                       type: object
                       properties:
                         rse_type:
-                          description: The type of an rse.
+                          description: "The type of an rse."
                           type: string
                           enum: ['DISK', 'TAPE']
                   distances:
-                    description: Distances data with src rse name as key.
+                    description: "Distances data with src rse name as key."
                     type: object
                     additionalProperties:
                       x-additionalPropertiesName: src rse
-                      description: Distances with dest rse as key.
+                      description: "Distances with dest rse as key."
                       type: object
                       additionalProperties:
                         x-additionalPropertiesName: dest rse
-                        description: Distance for two rses.
+                        description: "Distance for two rses."
                         type: object
                         properties:
                           distance:
-                            description: The distance between the rses.
+                            description: "The distance between the rses."
                             type: integer
                           ranking:
                             deprecated: true
-                            description: Same as distance
+                            description: "Same as distance"
                             type: integer
                   accounts:
-                    description: Account data.
+                    description: "Account data."
                     type: array
                     items:
-                      description: An account.
+                      description: "An account."
                       type: object
                       properties:
                         account:
-                          description: The account identifier.
+                          description: "The account identifier."
                           type: string
                         email:
-                          description: The email of an account.
+                          description: "The email of an account."
                           type: string
                         identities:
-                          description: The identities associated with an account. Deletes old identities and adds the newly defined ones.
+                          description: "The identities associated with an account. Deletes old identities and adds the newly defined ones."
                           type: array
                           items:
-                            description: One identity associated with an account.
+                            description: "One identity associated with an account."
                             type: object
                             properties:
                               type:
-                                description: The type of the identity.
+                                description: "The type of the identity."
                                 type: string
                                 enum: ['X509', 'GSS', 'USERPASS', 'SSH', 'SAML', 'OIDC']
                               identity:
-                                description: Identifier of the identity.
+                                description: "Identifier of the identity."
                                 type: string
                               password:
-                                description: The password if the type is USERPASS.
+                                description: "The password if the type is USERPASS."
                                 type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
         """
         data = json_parameters(parse_response)
         import_data(data=data, issuer=request.environ['issuer'], vo=request.environ['vo'])

--- a/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
@@ -31,59 +31,59 @@ class LifetimeException(ErrorHandlingMethodView):
         """
         ---
         summary: List Exceptions
-        description: Retrieves all exceptions.
+        description: "Retrieves all exceptions."
         tags:
             - Lifetime Exceptions
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: One exception per line.
+                  description: "One exception per line."
                   type: array
                   items:
-                    description: A lifetime exception
+                    description: "A lifetime exception"
                     type: object
                     properties:
                       id:
-                        description: The id of the lifetime exception.
+                        description: "The id of the lifetime exception."
                         type: string
                       scope:
-                        description: The scope associated with the lifetime exception.
+                        description: "The scope associated with the lifetime exception."
                         type: string
                       name:
-                        description: The name of the lifetime exception.
+                        description: "The name of the lifetime exception."
                         type: string
                       did_type:
-                        description: The type of the did.
+                        description: "The type of the did."
                         type: string
                         enum: ['F', 'D', 'C', 'A', 'X', 'Y', 'Z']
                       account:
-                        description: The account associated with the lifetime exception.
+                        description: "The account associated with the lifetime exception."
                         type: string
                       pattern:
-                        description: The pattern of the lifetime exception.
+                        description: "The pattern of the lifetime exception."
                         type: string
                       comments:
-                        description: The comments of the lifetime exception.
+                        description: "The comments of the lifetime exception."
                         type: string
                       state:
-                        description: The state of the lifetime exception.
+                        description: "The state of the lifetime exception."
                         type: string
                         enum: ['A', 'R', 'W']
                       created_at:
-                        description: The datetime the lifetime exception was created.
+                        description: "The datetime the lifetime exception was created."
                         type: string
                       expires_at:
-                        description: The datetime the lifetime exception expires.
+                        description: "The datetime the lifetime exception expires."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Lifetime exception not found
+            description: "Lifetime exception not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             def generate(vo):
@@ -98,7 +98,7 @@ class LifetimeException(ErrorHandlingMethodView):
         """
         ---
         summary: Create Exception
-        description: Creates a Lifetime Exception.
+        description: "Creates a Lifetime Exception."
         tags:
             - Lifetime Exceptions
         requestBody:
@@ -108,38 +108,38 @@ class LifetimeException(ErrorHandlingMethodView):
                 type: object
                 properties:
                   dids:
-                    description: List of dids associated with the lifetime exception.
+                    description: "List of dids associated with the lifetime exception."
                     type: array
                     items:
-                      description: A did
+                      description: "A did"
                       type: object
                       properties:
                         name:
-                          description: The name of the did.
+                          description: "The name of the did."
                           type: string
                   pattern:
-                    description: The pattern of the lifetime exception.
+                    description: "The pattern of the lifetime exception."
                     type: string
                   comments:
-                    description: The comment for the lifetime exception.
+                    description: "The comment for the lifetime exception."
                     type: string
                   expires_at:
-                    description: The expiration date for the lifetime exception.
+                    description: "The expiration date for the lifetime exception."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The exception id.
+                  description: "The exception id."
                   type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           400:
-            description: Cannot decode json parameter list.
+            description: "Cannot decode json parameter list."
           409:
-            description: Lifetime exception already exists.
+            description: "Lifetime exception already exists."
         """
         parameters = json_parameters()
         try:
@@ -169,66 +169,66 @@ class LifetimeExceptionId(ErrorHandlingMethodView):
         """
         ---
         summary: Get Exception
-        description: Get a single Lifetime Exception.
+        description: "Get a single Lifetime Exception."
         tags:
             - Lifetime Exceptions
         parameters:
         - name: exception_id
           in: path
-          description: The id of the lifetime exception.
+          description: "The id of the lifetime exception."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: List of lifetime exceptions associated with the id.
+                  description: "List of lifetime exceptions associated with the id."
                   type: array
                   items:
-                    description: A lifetime exception
+                    description: "A lifetime exception"
                     type: object
                     properties:
                       id:
-                        description: The id of the lifetime exception.
+                        description: "The id of the lifetime exception."
                         type: string
                       scope:
-                        description: The scope associated with the lifetime exception.
+                        description: "The scope associated with the lifetime exception."
                         type: string
                       name:
-                        description: The name of the lifetime exception.
+                        description: "The name of the lifetime exception."
                         type: string
                       did_type:
-                        description: The type of the did.
+                        description: "The type of the did."
                         type: string
                         enum: ['F', 'D', 'C', 'A', 'X', 'Y', 'Z']
                       account:
-                        description: The account associated with the lifetime exception.
+                        description: "The account associated with the lifetime exception."
                         type: string
                       pattern:
-                        description: The pattern of the lifetime exception.
+                        description: "The pattern of the lifetime exception."
                         type: string
                       comments:
-                        description: The comments of the lifetime exception.
+                        description: "The comments of the lifetime exception."
                         type: string
                       state:
-                        description: The state of the lifetime exception.
+                        description: "The state of the lifetime exception."
                         type: string
                         enum: ['A', 'R', 'W']
                       created_at:
-                        description: The datetime the lifetime exception was created.
+                        description: "The datetime the lifetime exception was created."
                         type: string
                       expires_at:
-                        description: The datetime the lifetime exception expires.
+                        description: "The datetime the lifetime exception expires."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Lifetime exception not found
+            description: "Lifetime exception not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             def generate(vo):
@@ -243,13 +243,13 @@ class LifetimeExceptionId(ErrorHandlingMethodView):
         """
         ---
         summary: Approve/Reject exception
-        description: Approve/Reject a Lifetime Exception.
+        description: "Approve/Reject a Lifetime Exception."
         tags:
             - Lifetime Exceptions
         parameters:
         - name: exception_id
           in: path
-          description: The id of the Lifetime Exception.
+          description: "The id of the Lifetime Exception."
           schema:
             type: string
           style: simple
@@ -260,23 +260,23 @@ class LifetimeExceptionId(ErrorHandlingMethodView):
                 type: object
                 properties:
                   state:
-                    description: The new state for the Lifetime Exception.
+                    description: "The new state for the Lifetime Exception."
                     type: string
                     enum: ['A', 'R']
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Lifetime Exception not found
+            description: "Lifetime Exception not found"
           400:
-            description: Cannot decode json parameter list.
+            description: "Cannot decode json parameter list."
         """
         parameters = json_parameters()
         state = param_get(parameters, 'state', default=None)

--- a/lib/rucio/web/rest/flaskapi/v1/locks.py
+++ b/lib/rucio/web/rest/flaskapi/v1/locks.py
@@ -29,13 +29,13 @@ class LockByRSE(ErrorHandlingMethodView):
         """
         ---
         summary: Get locks by rse
-        description: Get all dataset locks for an associated rse.
+        description: "Get all dataset locks for an associated rse."
         tags:
           - Lock
         parameters:
         - name: rse
           in: path
-          description: The rse name.
+          description: "The rse name."
           schema:
             type: string
           style: simple
@@ -46,63 +46,63 @@ class LockByRSE(ErrorHandlingMethodView):
                 type: object
                 properties:
                   did_type:
-                    description: The did type to filter for.
+                    description: "The did type to filter for."
                     type: string
                     enum: ['dataset']
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: Locks associated with the rse.
+                  description: "Locks associated with the rse."
                   type: array
                   items:
-                    description: A lock
+                    description: "A lock"
                     type: object
                     properties:
                       rse_id:
-                        description: The id of the associated rse.
+                        description: "The id of the associated rse."
                         type: string
                       rse:
-                        description: The name of the associated rse.
+                        description: "The name of the associated rse."
                         type: string
                       scope:
-                        description: The scope of the associated rse.
+                        description: "The scope of the associated rse."
                         type: string
                       name:
-                        description: The name of the rule.
+                        description: "The name of the rule."
                         type: string
                       rule_id:
-                        description: The id of the rule.
+                        description: "The id of the rule."
                         type: string
                       account:
-                        description: The associated account.
+                        description: "The associated account."
                         type: string
                       state:
-                        description: The state of the rule.
+                        description: "The state of the rule."
                         type: string
                         enum: ['R', 'O', 'S']
                       length:
-                        description: The length of the rule.
+                        description: "The length of the rule."
                         type: integer
                       bytes:
-                        description: The bytes limit for the lock.
+                        description: "The bytes limit for the lock."
                         type: integer
                       accessed_at:
-                        description: The last time is was accessed.
+                        description: "The last time is was accessed."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           500:
-            description: Wrong did type
+            description: "Wrong did type"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['wrong did_type specified']
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         did_type = request.args.get('did_type', default=None)
         if did_type != 'dataset':
@@ -126,13 +126,13 @@ class LocksByScopeName(ErrorHandlingMethodView):
         """
         ---
         summary: Get locks by scope
-        description: Get all dataset locks for an associated rse.
+        description: "Get all dataset locks for an associated rse."
         tags:
           - Lock
         parameters:
         - name: scope_name
           in: path
-          description: The scope name.
+          description: "The scope name."
           schema:
             type: string
           style: simple
@@ -143,63 +143,63 @@ class LocksByScopeName(ErrorHandlingMethodView):
                 type: object
                 properties:
                   did_type:
-                    description: The did type to filter for.
+                    description: "The did type to filter for."
                     type: string
                     enum: ['dataset']
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: Locks associated with the rse.
+                  description: "Locks associated with the rse."
                   type: array
                   items:
-                    description: A lock
+                    description: "A lock"
                     type: object
                     properties:
                       rse_id:
-                        description: The id of the associated rse.
+                        description: "The id of the associated rse."
                         type: string
                       rse:
-                        description: The name of the associated rse.
+                        description: "The name of the associated rse."
                         type: string
                       scope:
-                        description: The scope of the associated rse.
+                        description: "The scope of the associated rse."
                         type: string
                       name:
-                        description: The name of the rule.
+                        description: "The name of the rule."
                         type: string
                       rule_id:
-                        description: The id of the rule.
+                        description: "The id of the rule."
                         type: string
                       account:
-                        description: The associated account.
+                        description: "The associated account."
                         type: string
                       state:
-                        description: The state of the rule.
+                        description: "The state of the rule."
                         type: string
                         enum: ['R', 'O', 'S']
                       length:
-                        description: The length of the rule.
+                        description: "The length of the rule."
                         type: integer
                       bytes:
-                        description: The bytes limit for the lock.
+                        description: "The bytes limit for the lock."
                         type: integer
                       accessed_at:
-                        description: The last time is was accessed.
+                        description: "The last time is was accessed."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           500:
-            description: Wrong did type
+            description: "Wrong did type"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['wrong did_type specified']
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         did_type = request.args.get('did_type', default=None)
         if did_type != 'dataset':
@@ -230,7 +230,7 @@ class DatasetLocksForDids(ErrorHandlingMethodView):
         :returns: Line separated list of dictionary with lock information.
         ---
         summary: Get locks by dids
-        description: Get all dataset locks for the associated dids.
+        description: "Get all dataset locks for the associated dids."
         tags:
           - Lock
         requestBody:
@@ -240,79 +240,79 @@ class DatasetLocksForDids(ErrorHandlingMethodView):
                 type: object
                 properties:
                   dids:
-                    description: The dids associated with the locks.
+                    description: "The dids associated with the locks."
                     type: array
                     items:
                       type: object
-                      description: A did
+                      description: "A did"
                       required:
                         - scope
                         - name
                       properties:
                         scope:
-                          description: The scope of the did.
+                          description: "The scope of the did."
                           type: string
                         name:
-                          description: The name of the did.
+                          description: "The name of the did."
                           type: string
                         type:
-                          description: The type of the did.
+                          description: "The type of the did."
                           type: string
                           enum: ['dataset', 'container']
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: Locks associated with the rse.
+                  description: "Locks associated with the rse."
                   type: array
                   items:
-                    description: A lock
+                    description: "A lock"
                     type: object
                     properties:
                       rse_id:
-                        description: The id of the associated rse.
+                        description: "The id of the associated rse."
                         type: string
                       rse:
-                        description: The name of the associated rse.
+                        description: "The name of the associated rse."
                         type: string
                       scope:
-                        description: The scope of the associated rse.
+                        description: "The scope of the associated rse."
                         type: string
                       name:
-                        description: The name of the rule.
+                        description: "The name of the rule."
                         type: string
                       rule_id:
-                        description: The id of the rule.
+                        description: "The id of the rule."
                         type: string
                       account:
-                        description: The associated account.
+                        description: "The associated account."
                         type: string
                       state:
-                        description: The state of the rule.
+                        description: "The state of the rule."
                         type: string
                         enum: ['R', 'O', 'S']
                       length:
-                        description: The length of the rule.
+                        description: "The length of the rule."
                         type: integer
                       bytes:
-                        description: The bytes limit for the lock.
+                        description: "The bytes limit for the lock."
                         type: integer
                       accessed_at:
-                        description: The last time is was accessed.
+                        description: "The last time is was accessed."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           400:
-            description: Wrong did type
+            description: "Wrong did type"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Can not find the list of DIDs in the data. Use "dids" keyword.']
           406:
-            description: Not acceptable
+            description: "Not acceptable"
 
         """
 

--- a/lib/rucio/web/rest/flaskapi/v1/meta_conventions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/meta_conventions.py
@@ -32,19 +32,19 @@ class MetaConventions(ErrorHandlingMethodView):
             - Meta
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: array
-                  description: List of all DID keys.
+                  description: "List of all DID keys."
                   items:
                     type: string
-                    description: Data Itentifier key
+                    description: "Data Itentifier key"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         return jsonify(list_keys())
 
@@ -52,13 +52,13 @@ class MetaConventions(ErrorHandlingMethodView):
         """
         ---
         summary: Create key
-        description: Creates a new allowed key (value is NULL).
+        description: "Creates a new allowed key (value is NULL)."
         tags:
             - Meta
         parameters:
         - name: key
           in: path
-          description: The name of the key.
+          description: "The name of the key."
           schema:
             type: string
           style: simple
@@ -69,28 +69,28 @@ class MetaConventions(ErrorHandlingMethodView):
                 type: object
                 properties:
                   key_type:
-                    description: The key type.
+                    description: "The key type."
                     type: string
                   value_type:
-                    description: The value type.
+                    description: "The value type."
                     type: string
                   value_regexp:
-                    description: The value regexpression.
+                    description: "The value regexpression."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           400:
-            description: Cannot decode json parameter list / Unsupported value type.
+            description: "Cannot decode json parameter list / Unsupported value type."
           401:
-            description: Invalid Auth Token.
+            description: "Invalid Auth Token."
           409:
-            description: Key already exists.
+            description: "Key already exists."
         """
         parameters = json_parameters()
 
@@ -119,31 +119,31 @@ class Values(ErrorHandlingMethodView):
         """
         ---
         summary: Get value for key
-        description: List all values for a key.
+        description: "List all values for a key."
         tags:
             - Meta
         parameters:
         - name: key
           in: path
-          description: The reference key.
+          description: "The reference key."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: List of all key values.
+                  description: "List of all key values."
                   type: array
                   items:
                     type: string
-                    description: A value associated with a key.
+                    description: "A value associated with a key."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         return jsonify(list_values(key=key))
 
@@ -151,13 +151,13 @@ class Values(ErrorHandlingMethodView):
         """
         ---
         summary: Create value for key
-        description: Creates a new value for a key.
+        description: "Creates a new value for a key."
         tags:
             - Meta
         parameters:
         - name: key
           in: path
-          description: The reference key.
+          description: "The reference key."
           schema:
             type: string
           style: simple
@@ -170,24 +170,24 @@ class Values(ErrorHandlingMethodView):
                 - value
                 properties:
                   value:
-                    description: The new value associated with a key.
+                    description: "The new value associated with a key."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ['Created']
           400:
-            description: Cannot decode json parameter list / Invalid value for key.
+            description: "Cannot decode json parameter list / Invalid value for key."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Key not found
+            description: "Key not found"
           409:
-            description: Value already exists.
+            description: "Value already exists."
         """
         parameters = json_parameters()
         value = param_get(parameters, 'value')

--- a/lib/rucio/web/rest/flaskapi/v1/nongrid_traces.py
+++ b/lib/rucio/web/rest/flaskapi/v1/nongrid_traces.py
@@ -42,7 +42,7 @@ class XAODTrace(ErrorHandlingMethodView):
         """
         ---
         summary: Trace endpoints
-        description: Trace endpoint used by the XAOD framework to post data access information.
+        description: "Trace endpoint used by the XAOD framework to post data access information."
         tags:
           - Nongrid traces
         requestBody:
@@ -52,18 +52,18 @@ class XAODTrace(ErrorHandlingMethodView):
                 type: object
                 properties:
                   payload:
-                    description: Dictionary containing the trace information.
+                    description: "Dictionary containing the trace information."
                     type: object
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           400:
-            description: Cannot decode json data.
+            description: "Cannot decode json data."
         """
         headers = self.get_headers()
 

--- a/lib/rucio/web/rest/flaskapi/v1/ping.py
+++ b/lib/rucio/web/rest/flaskapi/v1/ping.py
@@ -45,22 +45,22 @@ class Ping(ErrorHandlingMethodView):
         """
         ---
         summary: Ping
-        description: Ping the server and get data about it.
+        description: "Ping the server and get data about it."
         tags:
           - Ping
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: object
                   properties:
                     version:
-                      description: The server version.
+                      description: "The server version."
                       type: string
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         headers = self.get_headers()
         response = jsonify(version=version.version_string())

--- a/lib/rucio/web/rest/flaskapi/v1/redirect.py
+++ b/lib/rucio/web/rest/flaskapi/v1/redirect.py
@@ -45,19 +45,19 @@ class MetaLinkRedirector(ErrorHandlingMethodView):
         """
         ---
         summary: Metalink redirect
-        description: Get Metalink redirect.
+        description: "Get Metalink redirect."
         tags:
           - Redirect
         parameters:
         - name: scope_name
           in: path
-          description: The data identifier (scope)/(name).
+          description: "The data identifier (scope)/(name)."
           schema:
             type: string
           style: simple
         - name: ip
           in: query
-          description: The client ip.
+          description: "The client ip."
           schema:
             type: string
           style: simple
@@ -94,18 +94,18 @@ class MetaLinkRedirector(ErrorHandlingMethodView):
           required: false
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/metalink4+xml:
                 schema:
-                  description: The metalink file.
+                  description: "The metalink file."
                   type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse or did not found
+            description: "Rse or did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         headers = self.get_headers()
 
@@ -197,19 +197,19 @@ class HeaderRedirector(ErrorHandlingMethodView):
         """
         ---
         summary: Header redirect
-        description: Get the header redirect.
+        description: "Get the header redirect."
         tags:
           - Redirect
         parameters:
         - name: scope_name
           in: path
-          description: The data identifier (scope)/(name).
+          description: "The data identifier (scope)/(name)."
           schema:
             type: string
           style: simple
         - name: ip
           in: query
-          description: The client ip.
+          description: "The client ip."
           schema:
             type: string
           style: simple
@@ -252,18 +252,18 @@ class HeaderRedirector(ErrorHandlingMethodView):
           required: false
         responses:
           200:
-            description: OK
+            description: "OK"
           303:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The redirect url.
+                  description: "The redirect url."
                   type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse or did not found
+            description: "Rse or did not found"
         """
         headers = self.get_headers()
 

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -154,76 +154,76 @@ class Replicas(ErrorHandlingMethodView):
         """
         ---
         summary: Get Replicas
-        description: List all replicas for data identifiers.
+        description: "List all replicas for data identifiers."
         tags:
           - Replicas
         parameters:
         - name: scope_name
           in: path
-          description: The DID associated with the replicas.
+          description: "The DID associated with the replicas."
           schema:
             type: string
           style: simple
         - name: X-Forwarded-For
           in: header
-          description: The client ip
+          description: "The client ip"
           schema:
             type: string
         - name: schemes
           in: query
-          description: The schemes of the replicas.
+          description: "The schemes of the replicas."
           schema:
             type: string
         - name: select
           in: query
-          description: The sorting algorithm.
+          description: "The sorting algorithm."
           schema:
             type: string
             enum: ["geoip", "random"]
         - name: limit
           in: query
-          description: The maximum number of replicas returned.
+          description: "The maximum number of replicas returned."
           schema:
             type: integer
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list with all replicas.
+                  description: "A list with all replicas."
                   type: array
                   items:
-                    description: A replica. Possibly contains more information.
+                    description: "A replica. Possibly contains more information."
                     type: object
                     properties:
                       scope:
-                        description: The scope of the replica.
+                        description: "The scope of the replica."
                         type: string
                       name:
-                        description: The name of the replica.
+                        description: "The name of the replica."
                         type: string
                       bytes:
-                        description: The size of the replica in bytes.
+                        description: "The size of the replica in bytes."
                         type: integer
                       md5:
-                        description: The md5 checksum of the replica.
+                        description: "The md5 checksum of the replica."
                         type: string
                       adler32:
-                        description: The adler32 checksum of the replica.
+                        description: "The adler32 checksum of the replica."
                         type: string
                       pfns:
-                        description: The pfns associated with the replica.
+                        description: "The pfns associated with the replica."
                         type: array
                       rses:
-                        description: The rse associated with the replica.
+                        description: "The rse associated with the replica."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found
+            description: "Did not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -277,7 +277,7 @@ class Replicas(ErrorHandlingMethodView):
         """
         ---
         summary: Create File Replicas
-        description: Create file replicas at a given RSE.
+        description: "Create file replicas at a given RSE."
         tags:
           - Replicas
         requestBody:
@@ -290,10 +290,10 @@ class Replicas(ErrorHandlingMethodView):
                 - files
                 properties:
                   rse:
-                    description: The rse for the replication
+                    description: "The rse for the replication"
                     type: string
                   files:
-                    description: The files to replicate
+                    description: "The files to replicate"
                     type: array
                     items:
                       type: object
@@ -303,53 +303,53 @@ class Replicas(ErrorHandlingMethodView):
                         - name
                       properties:
                         pfn:
-                          description: The pfn of the replica.
+                          description: "The pfn of the replica."
                           type: string
                         name:
-                          description: The DID name.
+                          description: "The DID name."
                           type: string
                         bytes:
-                          description: The size of the replica in bytes.
+                          description: "The size of the replica in bytes."
                           type: integer
                         state:
-                          description: The state of the replica.
+                          description: "The state of the replica."
                           type: string
                         path:
-                          description: The path of the new replica.
+                          description: "The path of the new replica."
                           type: string
                         md5:
-                          description: The md5 checksum.
+                          description: "The md5 checksum."
                           type: string
                         adler32:
-                          description: The adler32 checksum.
+                          description: "The adler32 checksum."
                           type: string
                         lcok_cnt:
-                          description: The lock count.
+                          description: "The lock count."
                           type: integer
                         tombstone:
-                          description: The tombstone.
+                          description: "The tombstone."
                           type: string
                   ignore_availability:
-                    description: The ignore availability.
+                    description: "The ignore availability."
                     type: boolean
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           400:
-            description: Invalid Path
+            description: "Invalid Path"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse or scope not found
+            description: "Rse or scope not found"
           409:
-            description: Replica or Did already exists
+            description: "Replica or Did already exists"
           503:
-            description: Resource temporary unavailable
+            description: "Resource temporary unavailable"
         """
         parameters = json_parameters(parse_response)
         rse = param_get(parameters, 'rse')
@@ -380,7 +380,7 @@ class Replicas(ErrorHandlingMethodView):
         """
         ---
         summary: Update File Replicas
-        description: Update file replicas state at a given RSE.
+        description: "Update file replicas state at a given RSE."
         tags:
           - Replicas
         requestBody:
@@ -393,39 +393,39 @@ class Replicas(ErrorHandlingMethodView):
                 - files
                 properties:
                   rse:
-                    description: The rse for the replication
+                    description: "The rse for the replication"
                     type: string
                   files:
-                    description: The files to replicate
+                    description: "The files to replicate"
                     type: array
                     items:
                       type: object
                       properties:
                         name:
-                          description: The pfn of the replica.
+                          description: "The pfn of the replica."
                           type: string
                         state:
-                          description: The pfn of the replica.
+                          description: "The pfn of the replica."
                           type: string
                         path:
-                          description: The pfn of the replica.
+                          description: "The pfn of the replica."
                           type: string
                         error_message:
-                          description: The error message if an error occurred.
+                          description: "The error message if an error occurred."
                           type: string
                         broken_rule_id:
-                          description: The id of the broken rule if one was found.
+                          description: "The id of the broken rule if one was found."
                           type: string
                         broken_message:
-                          description: The message of the broken rule.
+                          description: "The message of the broken rule."
                           type: string
         responses:
           200:
-            description: OK
+            description: "OK"
           400:
-            description: Cannot decode json parameter list
+            description: "Cannot decode json parameter list"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
         """
         parameters = json_parameters(parse_response)
         rse = param_get(parameters, 'rse')
@@ -442,7 +442,7 @@ class Replicas(ErrorHandlingMethodView):
         """
         ---
         summary: Delete File Replicas
-        description: Delete file replicas at a given RSE.
+        description: "Delete file replicas at a given RSE."
         tags:
           - Replicas
         requestBody:
@@ -455,10 +455,10 @@ class Replicas(ErrorHandlingMethodView):
                   - files
                 properties:
                   rse:
-                    description: The rse name.
+                    description: "The rse name."
                     type: string
                   files:
-                    description: The files to delete.
+                    description: "The files to delete."
                     type: array
                     items:
                       type: object
@@ -466,17 +466,17 @@ class Replicas(ErrorHandlingMethodView):
                         - name
                       properties:
                         name:
-                          description: The name of the replica.
+                          description: "The name of the replica."
                           type: string
         responses:
           200:
-            description: OK
+            description: "OK"
           400:
-            description: Cannot decode json parameter list.
+            description: "Cannot decode json parameter list."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse or Replica not found
+            description: "Rse or Replica not found"
         """
         parameters = json_parameters(parse_response)
         rse = param_get(parameters, 'rse')
@@ -507,28 +507,28 @@ class ListReplicas(ErrorHandlingMethodView):
         """
         ---
         summary: List Replicas
-        description: List all replicas for a DID.
+        description: "List all replicas for a DID."
         tags:
           - Replicas
         parameters:
         - name: X-Forwarded-For
           in: header
-          description: The client ip address.
+          description: "The client ip address."
           schema:
             type: string
         - name: limit
           in: query
-          description: The maximum number pfns per replica to return.
+          description: "The maximum number pfns per replica to return."
           schema:
             type: integer
         - name: select
           in: query
-          description: Requested sorting of the result, e.g., 'geoip', 'random'.
+          description: "Requested sorting of the result, e.g., 'geoip', 'random'."
           schema:
             type: string
         - name: sort
           in: query
-          description: Requested sorting of the result, e.g., 'geoip', 'random'.
+          description: "Requested sorting of the result, e.g., 'geoip', 'random'."
           schema:
             type: string
         requestBody:
@@ -538,62 +538,62 @@ class ListReplicas(ErrorHandlingMethodView):
                 type: object
                 properties:
                   client_location:
-                    description: The clients location.
+                    description: "The client's location."
                     type: string
                   dids:
-                    description: List of Dids.
+                    description: "List of Dids."
                     type: array
                     items:
                       type: object
                       properties:
                         scope:
-                          description: The scope of the did.
+                          description: "The scope of the did."
                           type: string
                         name:
-                          description: The name of the did.
+                          description: "The name of the did."
                           type: string
                   schemes:
-                    description: A list of schemes to filter the replicas.
+                    description: "A list of schemes to filter the replicas."
                     type: array
                     items:
                       type: string
                   sort:
-                    description: Requested sorting of the result, e.g., 'geoip', 'random'.
+                    description: "Requested sorting of the result, e.g., 'geoip', 'random'."
                     type: string
                   unavailable:
-                    description: If unavailable rse should be considered.
+                    description: "If unavailable rse should be considered."
                     type: boolean
                     deprecated: true
                   ignore_availability:
-                    description: If the availability should be ignored.
+                    description: "If the availability should be ignored."
                     type: boolean
                   rse_expression:
-                    description: The RSE expression to restrict on a list of RSEs.
+                    description: "The RSE expression to restrict on a list of RSEs."
                     type: string
                   all_states:
-                    description: Return all replicas whatever state they are in. Adds an extra 'states' entry in the result dictionary.
+                    description: "Return all replicas whatever state they are in. Adds an extra 'states' entry in the result dictionary."
                     type: boolean
                   domain:
-                    description: The network domain for the call, either None, 'wan' or 'lan'. None is fallback to 'wan', 'all' is both ['lan','wan']
+                    description: "The network domain for the call, either None, 'wan' or 'lan'. None is fallback to 'wan', 'all' is both ['lan','wan']"
                     type: string
                   signature_lifetime:
-                    description: If supported, in seconds, restrict the lifetime of the signed PFN.
+                    description: "If supported, in seconds, restrict the lifetime of the signed PFN."
                     type: integer
                   resolve_archives:
-                    description:  When set to True, find archives which contain the replicas.
+                    description: "When set to True, find archives which contain the replicas."
                     type: boolean
                   resolve_parents:
-                    description: When set to True, find all parent datasets which contain the replicas.
+                    description: "When set to True, find all parent datasets which contain the replicas."
                     type: boolean
                   updated_after:
-                    description: datetime object (UTC time), only return replicas updated after this time
+                    description: "datetime object (UTC time), only return replicas updated after this time"
                     type: string
                   nrandom:
-                    description: The maximum number of replicas to return.
+                    description: "The maximum number of replicas to return."
                     type: integer
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
@@ -602,59 +602,59 @@ class ListReplicas(ErrorHandlingMethodView):
                     type: object
                     properties:
                       scope:
-                        description: The scope of the replica.
+                        description: "The scope of the replica."
                         type: string
                       name:
-                        description: The name of the replica.
+                        description: "The name of the replica."
                         type: string
                       bytes:
-                        description: The size of the replica in bytes.
+                        description: "The size of the replica in bytes."
                         type: integer
                       md5:
-                        description: The md5 checksum.
+                        description: "The md5 checksum."
                         type: string
                       adler32:
-                        description: The adler32 checksum.
+                        description: "The adler32 checksum."
                         type: string
                       pfns:
-                        description: The pfns.
+                        description: "The pfns."
                         type: array
                       rses:
-                        description: The RSESs.
+                        description: "The RSESs."
                         type: array
               application/metalink4+xml:
                 schema:
                   type: object
                   properties:
                     scope:
-                      description: The scope of the replica.
+                      description: "The scope of the replica."
                       type: string
                     name:
-                      description: The name of the replica.
+                      description: "The name of the replica."
                       type: string
                     bytes:
-                      description: The size of the replica in bytes.
+                      description: "The size of the replica in bytes."
                       type: integer
                     md5:
-                      description: The md5 checksum.
+                      description: "The md5 checksum."
                       type: string
                     adler32:
-                      description: The adler32 checksum.
+                      description: "The adler32 checksum."
                       type: string
                     pfns:
-                      description: The pfns.
+                      description: "The pfns."
                       type: array
                     rses:
-                      description: The RSESs.
+                      description: "The RSESs."
                       type: array
           400:
-            description: Cannot decode json parameter list.
+            description: "Cannot decode json parameter list."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Did not found.
+            description: "Did not found."
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         content_type = request.accept_mimetypes.best_match(['application/x-json-stream', 'application/metalink4+xml'], 'application/x-json-stream')
         metalink = (content_type == 'application/metalink4+xml')
@@ -765,7 +765,7 @@ class ReplicasDIDs(ErrorHandlingMethodView):
         """
         ---
         summary: List Replicas Dids
-        description: List the DIDs associated to a list of replicas.
+        description: "List the DIDs associated to a list of replicas."
         tags:
           - Replicas
         requestBody:
@@ -777,16 +777,16 @@ class ReplicasDIDs(ErrorHandlingMethodView):
                 - rse
                 properties:
                   pfns:
-                    description: The list of pfns.
+                    description: "The list of pfns."
                     type: array
                     items:
                       type: string
                   rse:
-                    description: The RSE name.
+                    description: "The RSE name."
                     type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
@@ -795,23 +795,23 @@ class ReplicasDIDs(ErrorHandlingMethodView):
                     type: object
                     additionalProperties:
                       x-additionalPropertiesName: mapped PFNs to DIDs
-                      description: A mapping from a pfn to a did.
+                      description: "A mapping from a pfn to a did."
                       type: object
                       properties:
                         scope:
-                          description: The scope of the DID.
+                          description: "The scope of the DID."
                           type: string
                         name:
-                          description: The name of the DID.
+                          description: "The name of the DID."
                           type: string
           400:
-            description: Cannot decode json parameter list.
+            description: "Cannot decode json parameter list."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters()
         pfns = param_get(parameters, 'pfns', default=[])
@@ -834,7 +834,7 @@ class BadReplicas(ErrorHandlingMethodView):
         """
         ---
         summary: Declare Bad Replicas
-        description: Declares a list of bad replicas.
+        description: "Declares a list of bad replicas."
         tags:
           - Replicas
         requestBody:
@@ -844,36 +844,36 @@ class BadReplicas(ErrorHandlingMethodView):
                 type: object
                 properties:
                   replicas:
-                    description: The list of pfns or list of dicts with "scope", "name", "rse_id"/"rse"
+                    description: "The list of pfns or list of dicts with 'scope', 'name', 'rse_id'/'rse'"
                     type: array
                     items:
                       type: string
                   pfns:
                     deprecated: true
-                    description: The list of pfns, for backward compatibility with older versions of the ReplicaClient
+                    description: "The list of pfns, for backward compatibility with older versions of the ReplicaClient"
                     type: array
                     items:
                       type: string
                   reason:
-                    description: The reason for the declaration.
+                    description: "The reason for the declaration."
                     type: string
                   force:
-                    description: If true, ignore existing replica status in the bad_replicas table.
+                    description: "If true, ignore existing replica status in the bad_replicas table."
                     type: boolean
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: Returns the not declared files.
+                  description: "Returns the not declared files."
                   type: array
           400:
-            description: Can not decode json parameter list.
+            description: "Can not decode json parameter list."
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters()
         replicas = param_get(parameters, 'replicas', default=[]) or param_get(parameters, 'pfns', default=[])
@@ -897,7 +897,7 @@ class QuarantineReplicas(ErrorHandlingMethodView):
         """
         ---
         summary: Quarantine replicas
-        description: Quarantine replicas.
+        description: "Quarantine replicas."
         tags:
           - Replicas
         requestBody:
@@ -909,7 +909,7 @@ class QuarantineReplicas(ErrorHandlingMethodView):
                     - replicas
                 properties:
                   replicas:
-                    description: replicas
+                    description: "replicas"
                     type: array
                     items:
                       type: object
@@ -917,27 +917,27 @@ class QuarantineReplicas(ErrorHandlingMethodView):
                         - path
                       properties:
                             path:
-                                description: path
+                                description: "path"
                                 type:   string
                             scope:
-                                description: scope
+                                description: "scope"
                                 type:   string
                             name:
-                                description: name
+                                description: "name"
                                 type:   string
                   rse:
-                    description: RSE name
+                    description: "RSE name"
                     type: string
                   rse_id:
-                    description: RSE id
+                    description: "RSE id"
                     type: string
         responses:
           200:
-            description: OK
+            description: "OK"
           403:
-            description: Forbidden.
+            description: "Forbidden."
           404:
-            description: Not found
+            description: "Not found"
         """
 
         parameters = json_parameters()
@@ -965,7 +965,7 @@ class SuspiciousReplicas(ErrorHandlingMethodView):
         """
         ---
         summary: Declare Suspicious Replicas
-        description: Declare a list of suspicious replicas.
+        description: "Declare a list of suspicious replicas."
         tags:
           - Replicas
         requestBody:
@@ -975,27 +975,27 @@ class SuspiciousReplicas(ErrorHandlingMethodView):
                 type: object
                 properties:
                   pfns:
-                    description: The list of pfns.
+                    description: "The list of pfns."
                     type: array
                     items:
                       type: string
                   reason:
-                    description: The reason for the declaration.
+                    description: "The reason for the declaration."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: Returns the not declared files.
+                  description: "Returns the not declared files."
                   type: array
           400:
-            description: Can not decode json parameter list.
+            description: "Can not decode json parameter list."
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters(parse_response)
         pfns = param_get(parameters, 'pfns', default=[])
@@ -1012,28 +1012,28 @@ class SuspiciousReplicas(ErrorHandlingMethodView):
         """
         ---
         summary: List Suspicious Replicas
-        description: List the suspicious replicas on a list of RSEs.
+        description: "List the suspicious replicas on a list of RSEs."
         tags:
           - Replicas
         parameters:
         - name: rse_expression
           in: query
-          description: The RSE expression to filter for.
+          description: "The RSE expression to filter for."
           schema:
             type: string
         - name: younger_than
           in: query
-          description: Date to filter for.
+          description: "Date to filter for."
           schema:
             type: string
         - name: nattempts
           in: query
-          description: The maximum number of attempts to make.
+          description: "The maximum number of attempts to make."
           schema:
             type: integer
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
@@ -1042,29 +1042,29 @@ class SuspiciousReplicas(ErrorHandlingMethodView):
                     type: object
                     properties:
                       scope:
-                        description: The scope of the Replica.
+                        description: "The scope of the Replica."
                         type: string
                       name:
-                        description: The name of the Replica.
+                        description: "The name of the Replica."
                         type: string
                       rse:
-                        description: The rse name.
+                        description: "The rse name."
                         type: string
                       rse_id:
-                        description: The id of the rse.
+                        description: "The id of the rse."
                         type: string
                       cnt:
-                        description: The number of replicas.
+                        description: "The number of replicas."
                         type: integer
                       created_at:
-                        description: The time when the replica was created.
+                        description: "The time when the replica was created."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         rse_expression, younger_than, nattempts = None, None, None
         if request.query_string:
@@ -1092,93 +1092,93 @@ class BadReplicasStates(ErrorHandlingMethodView):
         """
         ---
         summary: List Bad Replicas By States
-        description: List the bad or suspicious replicas by states.
+        description: "List the bad or suspicious replicas by states."
         tags:
           - Replicas
         parameters:
         - name: state
           in: query
-          description: The state of the file.
+          description: "The state of the file."
           schema:
             type: string
             enum: [SUSPICIOUS, BAD]
         - name: rse
           in: query
-          description: The rse name.
+          description: "The rse name."
           schema:
             type: string
         - name: younger_than
           in: query
-          description: Date to select bad replicas younger than this date.
+          description: "Date to select bad replicas younger than this date."
           schema:
             type: string
             format: date-time
         - name: older_than
           in: query
-          description: Date to select bad replicas older than this date.
+          description: "Date to select bad replicas older than this date."
           schema:
             type: string
             format: date-time
         - name: limit
           in: query
-          description: The maximum number of replicas returned.
+          description: "The maximum number of replicas returned."
           schema:
             type: integer
         - name: list_pfns
           in: query
-          description: Flag to include pfns.
+          description: "Flag to include pfns."
           schema:
             type: boolean
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of all result replicas.
+                  description: "A list of all result replicas."
                   type: array
                   items:
                     oneOf:
                       - type: object
                         properties:
                           scope:
-                            description: The scope of the replica.
+                            description: "The scope of the replica."
                             type: string
                           name:
-                            description: The name of the replica.
+                            description: "The name of the replica."
                             type: string
                           type:
-                            description: The type of the replica.
+                            description: "The type of the replica."
                             type: string
                       - type: object
                         properties:
                           scope:
-                            description: The scope of the replica.
+                            description: "The scope of the replica."
                             type: string
                           name:
-                            description: The name of the replica.
+                            description: "The name of the replica."
                             type: string
                           rse:
-                            description: The name of the associated rse.
+                            description: "The name of the associated rse."
                             type: string
                           rse_id:
-                            description: The id of the associated rse.
+                            description: "The id of the associated rse."
                             type: string
                           state:
-                            description: The state of the replica.
+                            description: "The state of the replica."
                             type: string
                           created_at:
-                            description: The date-time the replica was created.
+                            description: "The date-time the replica was created."
                             type: string
                             format: date-time
                           updated_at:
-                            description: The date-time the replica was updated.
+                            description: "The date-time the replica was updated."
                             type: string
                             format: date-time
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         list_pfns = False
         state, rse, younger_than, older_than, limit = None, None, None, None, None
@@ -1219,55 +1219,55 @@ class BadReplicasSummary(ErrorHandlingMethodView):
         """
         ---
         summary: Bad Replicas Summary
-        description: Return a summary of the bad replicas by incident.
+        description: "Return a summary of the bad replicas by incident."
         tags:
           - Replicas
         parameters:
         - name: rse_expression
           in: query
-          description: The RSE expression.
+          description: "The RSE expression."
           schema:
             type: string
         - name: from_date
           in: query
-          description: The start date.
+          description: "The start date."
           schema:
             type: string
             format: date-time
         - name: to_date
           in: query
-          description: The end date.
+          description: "The end date."
           schema:
             type: string
             format: date-time
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of summaries.
+                  description: "A list of summaries."
                   type: array
                   items:
                     type: object
                     properties:
                       rse:
-                        description: The name of the associated RSE.
+                        description: "The name of the associated RSE."
                         type: string
                       rse_id:
-                        description: The id of the associated RSE.
+                        description: "The id of the associated RSE."
                         type: string
                       created_at:
-                        description: The creation date-time.
+                        description: "The creation date-time."
                         type: string
                         format: date-time
                       reason:
-                        description: The reason for the incident.
+                        description: "The reason for the incident."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         rse_expression, from_date, to_date = None, None, None
         if request.query_string:
@@ -1298,77 +1298,77 @@ class DatasetReplicas(ErrorHandlingMethodView):
         """
         ---
         summary: List Dataset Replicas
-        description: List dataset replicas.
+        description: "List dataset replicas."
         tags:
           - Replicas
         parameters:
         - name: scope_name
           in: path
-          description: data identifier (scope)/(name).
+          description: "data identifier (scope)/(name)."
           schema:
             type: string
           style: simple
         - name: deep
           in: query
-          description: Flag to ennable lookup at the file level.
+          description: "Flag to enable lookup at the file level."
           schema:
             type: boolean
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of dataset replicas.
+                  description: "A list of dataset replicas."
                   type: array
                   items:
                     type: object
                     properties:
                       scope:
-                        description: The scope of the replica.
+                        description: "The scope of the replica."
                         type: string
                       name:
-                        description: The name of the replica.
+                        description: "The name of the replica."
                         type: string
                       rse:
-                        description: The name of the associated RSE.
+                        description: "The name of the associated RSE."
                         type: string
                       rse_id:
-                        description: The id of the associated RSE.
+                        description: "The id of the associated RSE."
                         type: string
                       bytes:
-                        description: The size of the replica.
+                        description: "The size of the replica."
                         type: integer
                       length:
-                        description: The length of the replica.
+                        description: "The length of the replica."
                         type: integer
                       available_bytes:
-                        description: The number of available bytes of the replica.
+                        description: "The number of available bytes of the replica."
                         type: integer
                       available_length:
-                        description: The available length of the replica.
+                        description: "The available length of the replica."
                         type: integer
                       state:
-                        description: The state of the replica.
+                        description: "The state of the replica."
                         type: string
                       created_at:
-                        description: The date-time the replica was created.
+                        description: "The date-time the replica was created."
                         type: string
                         format: date-time
                       updated_at:
-                        description: The date-time the replica was updated.
+                        description: "The date-time the replica was updated."
                         type: string
                         format: date-time
                       accessed_at:
-                        description: The date-time the replica was accessed.
+                        description: "The date-time the replica was accessed."
                         type: string
                         format: date-time
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -1391,7 +1391,7 @@ class DatasetReplicasBulk(ErrorHandlingMethodView):
         """
         ---
         summary: List Dataset Replicas for Multiple DIDs
-        description: List dataset replicas for multiple dids.
+        description: "List dataset replicas for multiple dids."
         tags:
           - Replicas
         requestBody:
@@ -1403,76 +1403,76 @@ class DatasetReplicasBulk(ErrorHandlingMethodView):
                 - dids
                 properties:
                   dids:
-                    description: A list of dids.
+                    description: "A list of dids."
                     type: array
                     items:
-                      description: A did.
+                      description: "A did."
                       type: object
                       properties:
                         scope:
-                          description: The scope of the did.
+                          description: "The scope of the did."
                           type: string
                         name:
-                          description: The name of the did.
+                          description: "The name of the did."
                           type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of dataset replicas.
+                  description: "A list of dataset replicas."
                   type: array
                   items:
                     type: object
                     properties:
                       scope:
-                        description: The scope of the replica.
+                        description: "The scope of the replica."
                         type: string
                       name:
-                        description: The name of the replica.
+                        description: "The name of the replica."
                         type: string
                       rse:
-                        description: The name of the associated RSE.
+                        description: "The name of the associated RSE."
                         type: string
                       rse_id:
-                        description: The id of the associated RSE.
+                        description: "The id of the associated RSE."
                         type: string
                       bytes:
-                        description: The size of the replica.
+                        description: "The size of the replica."
                         type: integer
                       length:
-                        description: The length of the replica.
+                        description: "The length of the replica."
                         type: integer
                       available_bytes:
-                        description: The number of available bytes of the replica.
+                        description: "The number of available bytes of the replica."
                         type: integer
                       available_length:
-                        description: The available length of the replica.
+                        description: "The available length of the replica."
                         type: integer
                       state:
-                        description: The state of the replica.
+                        description: "The state of the replica."
                         type: string
                       created_at:
-                        description: The date-time the replica was created.
+                        description: "The date-time the replica was created."
                         type: string
                         format: date-time
                       updated_at:
-                        description: The date-time the replica was updated.
+                        description: "The date-time the replica was updated."
                         type: string
                         format: date-time
                       accessed_at:
-                        description: The date-time the replica was accessed.
+                        description: "The date-time the replica was accessed."
                         type: string
                         format: date-time
           400:
-            description: Bad Request.
+            description: "Bad Request."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters(parse_response)
         dids = param_get(parameters, 'dids')
@@ -1503,22 +1503,22 @@ class DatasetReplicasVP(ErrorHandlingMethodView):
         parameters:
         - name: scope_name
           in: path
-          description: data identifier (scope)/(name).
+          description: "data identifier (scope)/(name)."
           schema:
             type: string
           style: simple
         - name: deep
           in: query
-          description: Flag to ennable lookup at the file level.
+          description: "Flag to ennable lookup at the file level."
           schema:
             type: boolean
         responses:
           200:
-            description: OK. This needs documentation!
+            description: "OK. This needs documentation!"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -1541,70 +1541,70 @@ class ReplicasRSE(ErrorHandlingMethodView):
         """
         ---
         summary: List Dataset Replicas per RSE
-        description: List dataset replicas per RSE.
+        description: "List dataset replicas per RSE."
         tags:
           - Replicas
         parameters:
         - name: rse
           in: path
-          description: The rse to filter for.
+          description: "The rse to filter for."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of dataset replicas.
+                  description: "A list of dataset replicas."
                   type: array
                   items:
                     type: object
                     properties:
                       scope:
-                        description: The scope of the replica.
+                        description: "The scope of the replica."
                         type: string
                       name:
-                        description: The name of the replica.
+                        description: "The name of the replica."
                         type: string
                       rse:
-                        description: The name of the associated RSE.
+                        description: "The name of the associated RSE."
                         type: string
                       rse_id:
-                        description: The id of the associated RSE.
+                        description: "The id of the associated RSE."
                         type: string
                       bytes:
-                        description: The size of the replica.
+                        description: "The size of the replica."
                         type: integer
                       length:
-                        description: The length of the replica.
+                        description: "The length of the replica."
                         type: integer
                       available_bytes:
-                        description: The number of available bytes of the replica.
+                        description: "The number of available bytes of the replica."
                         type: integer
                       available_length:
-                        description: The available length of the replica.
+                        description: "The available length of the replica."
                         type: integer
                       state:
-                        description: The state of the replica.
+                        description: "The state of the replica."
                         type: string
                       created_at:
-                        description: The date-time the replica was created.
+                        description: "The date-time the replica was created."
                         type: string
                         format: date-time
                       updated_at:
-                        description: The date-time the replica was updated.
+                        description: "The date-time the replica was updated."
                         type: string
                         format: date-time
                       accessed_at:
-                        description: The date-time the replica was accessed.
+                        description: "The date-time the replica was accessed."
                         type: string
                         format: date-time
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
 
         def generate(vo):
@@ -1620,7 +1620,7 @@ class BadDIDs(ErrorHandlingMethodView):
         """
         ---
         summary: Mark Bad by DID
-        description: Declare a list of bad replicas by DID.
+        description: "Declare a list of bad replicas by DID."
         tags:
           - Replicas
         requestBody:
@@ -1630,43 +1630,43 @@ class BadDIDs(ErrorHandlingMethodView):
                 type: object
                 properties:
                   expires_at:
-                    description: The expires at value.
+                    description: "The expires at value."
                     type: string
                     format: date-time
                   dids:
-                    description: The list of dids associated with the bad replicas.
+                    description: "The list of dids associated with the bad replicas."
                     type: array
                     items:
                       type: object
                       properties:
                         scope:
-                          description: The scope of the did.
+                          description: "The scope of the did."
                           type: string
                         name:
-                          description: The name of the did.
+                          description: "The name of the did."
                           type: string
                   rse:
-                    description: The name of the rse.
+                    description: "The name of the rse."
                     type: string
                   reason:
-                    description: The reason for the change.
+                    description: "The reason for the change."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: All files not declared as bad.
+                  description: "All files not declared as bad."
                   type: array
                   items:
                     type: string
           400:
-            description: Cannot decode json parameter list.
+            description: "Cannot decode json parameter list."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
         """
         parameters = json_parameters(parse_response)
         expires_at = param_get(parameters, 'expires_at', default=None)
@@ -1701,7 +1701,7 @@ class BadPFNs(ErrorHandlingMethodView):
         """
         ---
         summary: Declare Bad PFNs
-        description: Declare a list of bad PFNs.
+        description: "Declare a list of bad PFNs."
         tags:
           - Replicas
         requestBody:
@@ -1711,32 +1711,32 @@ class BadPFNs(ErrorHandlingMethodView):
                 type: object
                 properties:
                   expires_at:
-                    description: The expires at value. Only apply to TEMPORARY_UNAVAILABLE.
+                    description: "The expires at value. Only apply to TEMPORARY_UNAVAILABLE."
                     type: string
                     format: date-time
                   pfns:
-                    description: The list of pfns associated with the bad PFNs.
+                    description: "The list of pfns associated with the bad PFNs."
                     type: array
                     items:
                       type: string
                   state:
-                    description: The state to set the PFNs to.
+                    description: "The state to set the PFNs to."
                     type: string
                     enum: ["BAD", "SUSPICIOUS", "TEMPORARY_UNAVAILABLE"]
                   reason:
-                    description: The reason for the change.
+                    description: "The reason for the change."
                     type: string
         responses:
           201:
-            description: Created
+            description: "Created"
           400:
-            description: Cannot decode json parameter list.
+            description: "Cannot decode json parameter list."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Replica not found
+            description: "Replica not found"
           409:
-            description: Duplicate
+            description: "Duplicate"
         """
         parameters = json_parameters(parse_response)
         expires_at = param_get(parameters, 'expires_at', default=None)
@@ -1770,7 +1770,7 @@ class Tombstone(ErrorHandlingMethodView):
         """
         ---
         summary: Set Tombstone
-        description: Set a tombstone on a list of replicas.
+        description: "Set a tombstone on a list of replicas."
         tags:
           - Replicas
         requestBody:
@@ -1780,7 +1780,7 @@ class Tombstone(ErrorHandlingMethodView):
                 type: object
                 properties:
                   replicas:
-                    description: The replicas to set the tombstone to.
+                    description: "The replicas to set the tombstone to."
                     type: array
                     items:
                       type: object
@@ -1790,23 +1790,23 @@ class Tombstone(ErrorHandlingMethodView):
                         - name
                       properties:
                         rse:
-                          description: The rse associated with the tombstone.
+                          description: "The rse associated with the tombstone."
                           type: string
                         scope:
-                          description: The scope of the replica
+                          description: "The scope of the replica"
                           type: string
                         name:
-                          description: The name of the replica.
+                          description: "The name of the replica."
                           type: string
         responses:
           201:
-            description: Created
+            description: "Created"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           423:
-            description: Replica is locked.
+            description: "Replica is locked."
         """
         parameters = json_parameters(parse_response)
         replicas = param_get(parameters, 'replicas', default=[])

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -38,144 +38,144 @@ class RequestGet(ErrorHandlingMethodView):
         """
         ---
         summary: Get Request
-        description: Get a request for a given DID to a destination RSE.
+        description: "Get a request for a given DID to a destination RSE."
         tags:
           - Requests
         parameters:
         - name: scope_name
           in: path
-          description: Data identifier (scope)/(name).
+          description: "Data identifier (scope)/(name)."
           schema:
             type: string
           style: simple
         - name: rse
           in: path
-          description: Destination rse.
+          description: "Destination rse."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The request associated with the DID and destination RSE.
+                  description: "The request associated with the DID and destination RSE."
                   type: object
                   properties:
                     id:
-                      description: The id of the request.
+                      description: "The id of the request."
                       type: string
                     request_type:
-                      description: The request type.
+                      description: "The request type."
                       type: string
                       enum: ["T", "U", "D", "I", "O"]
                     scope:
-                      description: The scope of the transfer.
+                      description: "The scope of the transfer."
                       type: string
                     name:
-                      description: The name of the transfer.
+                      description: "The name of the transfer."
                       type: string
                     did_type:
-                      description: The did type.
+                      description: "The did type."
                       type: string
                     dest_rse_id:
-                      description: The destination RSE id.
+                      description: "The destination RSE id."
                       type: string
                     source_rse_id:
-                      description: The source RSE id.
+                      description: "The source RSE id."
                       type: string
                     attributes:
-                      description: All attributes associated with the request.
+                      description: "All attributes associated with the request."
                       type: string
                     state:
-                      description: The state of the request.
+                      description: "The state of the request."
                       type: string
                       enum: ["Q", "G", "S", "F", "D", "L", "N", "O", "A", "M", "U", "W", "P"]
                     external_id:
-                      description: External id of the request.
+                      description: "External id of the request."
                       type: string
                     external_host:
-                      description: External host of the request.
+                      description: "External host of the request."
                       type: string
                     retry_count:
-                      description: The numbers of attempted retires.
+                      description: "The numbers of attempted retries."
                       type: integer
                     err_msg:
-                      description: An error message if one occurred.
+                      description: "An error message if one occurred."
                       type: string
                     previous_attempt_id:
-                      description: The id of the previous attempt.
+                      description: "The id of the previous attempt."
                       type: string
                     rule_id:
-                      description: The id of the associated replication rule.
+                      description: "The id of the associated replication rule."
                       type: string
                     activity:
-                      description: The activity of the request.
+                      description: "The activity of the request."
                       type: string
                     bytes:
-                      description: The size of the did in bytes.
+                      description: "The size of the did in bytes."
                       type: integer
                     md5:
-                      description: The md5 checksum of the did to transfer.
+                      description: "The md5 checksum of the did to transfer."
                       type: string
                     adler32:
-                      description: The adler32 checksum of the did to transfer.
+                      description: "The adler32 checksum of the did to transfer."
                       type: string
                     dest_url:
-                      description: The destination url.
+                      description: "The destination url."
                       type: string
                     submitted_at:
-                      description: The time the request got submitted.
+                      description: "The time the request got submitted."
                       type: string
                     started_at:
-                      description: The time the request got started.
+                      description: "The time the request got started."
                       type: string
                     transferred_at:
-                      description: The time the request got transferred.
+                      description: "The time the request got transferred."
                       type: string
                     estimated_at:
-                      description: The time the request got estimated.
+                      description: "The time the request got estimated."
                       type: string
                     submitter_id:
-                      description: The id of the submitter.
+                      description: "The id of the submitter."
                       type: string
                     estimated_stated_at:
-                      description: The estimation of the started at value.
+                      description: "The estimation of the started at value."
                       type: string
                     estimated_transferred_at:
-                      description: The estimation of the transferred at value.
+                      description: "The estimation of the transferred at value."
                       type: string
                     staging_started_at:
-                      description: The time the staging got started.
+                      description: "The time the staging got started."
                       type: string
                     staging_finished_at:
-                      description: The time the staging got finished.
+                      description: "The time the staging got finished."
                       type: string
                     account:
-                      description: The account which issued the request.
+                      description: "The account which issued the request."
                       type: string
                     requested_at:
-                      description: The time the request got requested.
+                      description: "The time the request got requested."
                       type: string
                     priority:
-                      description: The priority of the request.
+                      description: "The priority of the request."
                       type: integer
                     transfertool:
-                      description: The transfertool used.
+                      description: "The transfertool used."
                       type: string
                     source_rse:
-                      description: The name of the source RSE.
+                      description: "The name of the source RSE."
                       type: string
                     dest_rse:
-                      description: The name of the destination RSE.
+                      description: "The name of the destination RSE."
                       type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, flask.request.environ['vo'])
@@ -203,144 +203,144 @@ class RequestHistoryGet(ErrorHandlingMethodView):
         """
         ---
         summary: Get Historical Request
-        description: List a historical request for a given DID to a destination RSE.
+        description: "List a historical request for a given DID to a destination RSE."
         tags:
           - Requests
         parameters:
         - name: scope_name
           in: path
-          description: Data identifier (scope)/(name).
+          description: "Data identifier (scope)/(name)."
           schema:
             type: string
           style: simple
         - name: rse
           in: path
-          description: Destination rse.
+          description: "Destination rse."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The request associated with the DID and destination RSE.
+                  description: "The request associated with the DID and destination RSE."
                   type: object
                   properties:
                     id:
-                      description: The id of the request.
+                      description: "The id of the request."
                       type: string
                     request_type:
-                      description: The request type.
+                      description: "The request type."
                       type: string
                       enum: ["T", "U", "D", "I", "O"]
                     scope:
-                      description: The scope of the transfer.
+                      description: "The scope of the transfer."
                       type: string
                     name:
-                      description: The name of the transfer.
+                      description: "The name of the transfer."
                       type: string
                     did_type:
-                      description: The did type.
+                      description: "The did type."
                       type: string
                     dest_rse_id:
-                      description: The destination RSE id.
+                      description: "The destination RSE id."
                       type: string
                     source_rse_id:
-                      description: The source RSE id.
+                      description: "The source RSE id."
                       type: string
                     attributes:
-                      description: All attributes associated with the request.
+                      description: "All attributes associated with the request."
                       type: string
                     state:
-                      description: The state of the request.
+                      description: "The state of the request."
                       type: string
                       enum: ["Q", "G", "S", "F", "D", "L", "N", "O", "A", "M", "U", "W", "P"]
                     external_id:
-                      description: External id of the request.
+                      description: "External id of the request."
                       type: string
                     external_host:
-                      description: External host of the request.
+                      description: "External host of the request."
                       type: string
                     retry_count:
-                      description: The numbers of attempted retires.
+                      description: "The numbers of attempted retries."
                       type: integer
                     err_msg:
-                      description: An error message if one occurred.
+                      description: "An error message if one occurred."
                       type: string
                     previous_attempt_id:
-                      description: The id of the previous attempt.
+                      description: "The id of the previous attempt."
                       type: string
                     rule_id:
-                      description: The id of the associated replication rule.
+                      description: "The id of the associated replication rule."
                       type: string
                     activity:
-                      description: The activity of the request.
+                      description: "The activity of the request."
                       type: string
                     bytes:
-                      description: The size of the did in bytes.
+                      description: "The size of the did in bytes."
                       type: integer
                     md5:
-                      description: The md5 checksum of the did to transfer.
+                      description: "The md5 checksum of the did to transfer."
                       type: string
                     adler32:
-                      description: The adler32 checksum of the did to transfer.
+                      description: "The adler32 checksum of the did to transfer."
                       type: string
                     dest_url:
-                      description: The destination url.
+                      description: "The destination url."
                       type: string
                     submitted_at:
-                      description: The time the request got submitted.
+                      description: "The time the request got submitted."
                       type: string
                     started_at:
-                      description: The time the request got started.
+                      description: "The time the request got started."
                       type: string
                     transferred_at:
-                      description: The time the request got transferred.
+                      description: "The time the request got transferred."
                       type: string
                     estimated_at:
-                      description: The time the request got estimated.
+                      description: "The time the request got estimated."
                       type: string
                     submitter_id:
-                      description: The id of the submitter.
+                      description: "The id of the submitter."
                       type: string
                     estimated_stated_at:
-                      description: The estimation of the started at value.
+                      description: "The estimation of the started at value."
                       type: string
                     estimated_transferred_at:
-                      description: The estimation of the transferred at value.
+                      description: "The estimation of the transferred at value."
                       type: string
                     staging_started_at:
-                      description: The time the staging got started.
+                      description: "The time the staging got started."
                       type: string
                     staging_finished_at:
-                      description: The time the staging got finished.
+                      description: "The time the staging got finished."
                       type: string
                     account:
-                      description: The account which issued the request.
+                      description: "The account which issued the request."
                       type: string
                     requested_at:
-                      description: The time the request got requested.
+                      description: "The time the request got requested."
                       type: string
                     priority:
-                      description: The priority of the request.
+                      description: "The priority of the request."
                       type: integer
                     transfertool:
-                      description: The transfertool used.
+                      description: "The transfertool used."
                       type: string
                     source_rse:
-                      description: The name of the source RSE.
+                      description: "The name of the source RSE."
                       type: string
                     dest_rse:
-                      description: The name of the destination RSE.
+                      description: "The name of the destination RSE."
                       type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scope, name = parse_scope_name(scope_name, flask.request.environ['vo'])
@@ -368,13 +368,13 @@ class RequestList(ErrorHandlingMethodView):
         """
         ---
         summary: List Requests
-        description: List requests for a given source and destination RSE or site.
+        description: "List requests for a given source and destination RSE or site."
         tags:
           - Requests
         parameters:
         - name: src_rse
           in: query
-          description: The source rse.
+          description: "The source rse."
           schema:
             type: array
             items:
@@ -383,11 +383,11 @@ class RequestList(ErrorHandlingMethodView):
                 - rse_id
               properties:
                 rse_id:
-                  description: The id of the rse.
+                  description: "The id of the rse."
                   type: string
         - name: dest_rse
           in: query
-          description: The destination rse.
+          description: "The destination rse."
           schema:
             type: array
             items:
@@ -396,148 +396,148 @@ class RequestList(ErrorHandlingMethodView):
                 - rse_id
               properties:
                 rse_id:
-                  description: The id of the rse.
+                  description: "The id of the rse."
                   type: string
         - name: src_site
           in: query
-          description: The source site.
+          description: "The source site."
           schema:
             type: string
         - name: dest_site
           in: query
-          description: The destination site.
+          description: "The destination site."
           schema:
             type: string
         - name: request_states
           in: query
-          description: The accepted request states. Delimited by comma.
+          description: "The accepted request states. Delimited by comma."
           schema:
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: All requests matching the arguments. Separated by the new line character.
+                  description: "All requests matching the arguments. Separated by the new line character."
                   type: array
                   items:
-                    description: A request.
+                    description: "A request."
                     type: object
                     properties:
                       id:
-                        description: The id of the request.
+                        description: "The id of the request."
                         type: string
                       request_type:
-                        description: The request type.
+                        description: "The request type."
                         type: string
                         enum: ["T", "U", "D", "I", "O"]
                       scope:
-                        description: The scope of the transfer.
+                        description: "The scope of the transfer."
                         type: string
                       name:
-                        description: The name of the transfer.
+                        description: "The name of the transfer."
                         type: string
                       did_type:
-                        description: The did type.
+                        description: "The did type."
                         type: string
                       dest_rse_id:
-                        description: The destination RSE id.
+                        description: "The destination RSE id."
                         type: string
                       source_rse_id:
-                        description: The source RSE id.
+                        description: "The source RSE id."
                         type: string
                       attributes:
-                        description: All attributes associated with the request.
+                        description: "All attributes associated with the request."
                         type: string
                       state:
-                        description: The state of the request.
+                        description: "The state of the request."
                         type: string
                         enum: ["Q", "G", "S", "F", "D", "L", "N", "O", "A", "M", "U", "W", "P"]
                       external_id:
-                        description: External id of the request.
+                        description: "External id of the request."
                         type: string
                       external_host:
-                        description: External host of the request.
+                        description: "External host of the request."
                         type: string
                       retry_count:
-                        description: The numbers of attempted retires.
+                        description: "The numbers of attempted retries."
                         type: integer
                       err_msg:
-                        description: An error message if one occurred.
+                        description: "An error message if one occurred."
                         type: string
                       previous_attempt_id:
-                        description: The id of the previous attempt.
+                        description: "The id of the previous attempt."
                         type: string
                       rule_id:
-                        description: The id of the associated replication rule.
+                        description: "The id of the associated replication rule."
                         type: string
                       activity:
-                        description: The activity of the request.
+                        description: "The activity of the request."
                         type: string
                       bytes:
-                        description: The size of the did in bytes.
+                        description: "The size of the did in bytes."
                         type: integer
                       md5:
-                        description: The md5 checksum of the did to transfer.
+                        description: "The md5 checksum of the did to transfer."
                         type: string
                       adler32:
-                        description: The adler32 checksum of the did to transfer.
+                        description: "The adler32 checksum of the did to transfer."
                         type: string
                       dest_url:
-                        description: The destination url.
+                        description: "The destination url."
                         type: string
                       submitted_at:
-                        description: The time the request got submitted.
+                        description: "The time the request got submitted."
                         type: string
                       started_at:
-                        description: The time the request got started.
+                        description: "The time the request got started."
                         type: string
                       transferred_at:
-                        description: The time the request got transferred.
+                        description: "The time the request got transferred."
                         type: string
                       estimated_at:
-                        description: The time the request got estimated.
+                        description: "The time the request got estimated."
                         type: string
                       submitter_id:
-                        description: The id of the submitter.
+                        description: "The id of the submitter."
                         type: string
                       estimated_stated_at:
-                        description: The estimation of the started at value.
+                        description: "The estimation of the started at value."
                         type: string
                       estimated_transferred_at:
-                        description: The estimation of the transferred at value.
+                        description: "The estimation of the transferred at value."
                         type: string
                       staging_started_at:
-                        description: The time the staging got started.
+                        description: "The time the staging got started."
                         type: string
                       staging_finished_at:
-                        description: The time the staging got finished.
+                        description: "The time the staging got finished."
                         type: string
                       account:
-                        description: The account which issued the request.
+                        description: "The account which issued the request."
                         type: string
                       requested_at:
-                        description: The time the request got requested.
+                        description: "The time the request got requested."
                         type: string
                       priority:
-                        description: The priority of the request.
+                        description: "The priority of the request."
                         type: integer
                       transfertool:
-                        description: The transfertool used.
+                        description: "The transfertool used."
                         type: string
                       source_rse:
-                        description: The name of the source RSE.
+                        description: "The name of the source RSE."
                         type: string
                       dest_rse:
-                        description: The name of the destination RSE.
+                        description: "The name of the destination RSE."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         src_rse = flask.request.args.get('src_rse', default=None)
         dst_rse = flask.request.args.get('dst_rse', default=None)
@@ -595,13 +595,13 @@ class RequestHistoryList(ErrorHandlingMethodView):
         """
         ---
         summary: List Historic Requests
-        description: List historical requests for a given source and destination RSE or site.
+        description: "List historical requests for a given source and destination RSE or site."
         tags:
           - Requests
         parameters:
         - name: src_rse
           in: query
-          description: The source rse.
+          description: "The source rse."
           schema:
             type: array
             items:
@@ -610,11 +610,11 @@ class RequestHistoryList(ErrorHandlingMethodView):
                 - rse_id
               properties:
                 rse_id:
-                  description: The id of the rse.
+                  description: "The id of the rse."
                   type: string
         - name: dest_rse
           in: query
-          description: The destination rse.
+          description: "The destination rse."
           schema:
             type: array
             items:
@@ -623,160 +623,160 @@ class RequestHistoryList(ErrorHandlingMethodView):
                 - rse_id
               properties:
                 rse_id:
-                  description: The id of the rse.
+                  description: "The id of the rse."
                   type: string
         - name: src_site
           in: query
-          description: The source site.
+          description: "The source site."
           schema:
             type: string
         - name: dest_site
           in: query
-          description: The destination site.
+          description: "The destination site."
           schema:
             type: string
         - name: request_states
           in: query
-          description: The accepted request states. Delimited by comma.
+          description: "The accepted request states. Delimited by comma."
           schema:
             type: string
         - name: offset
           in: query
-          description: The offset of the list.
+          description: "The offset of the list."
           schema:
             type: integer
             default: 0
         - name: limit
           in: query
-          description: The maximum number of items to return.
+          description: "The maximum number of items to return."
           schema:
             type: integer
             default: 100
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: All requests matching the arguments. Separated by a new line character.
+                  description: "All requests matching the arguments. Separated by a new line character."
                   type: array
                   items:
-                    description: A request.
+                    description: "A request."
                     type: object
                     properties:
                       id:
-                        description: The id of the request.
+                        description: "The id of the request."
                         type: string
                       request_type:
-                        description: The request type.
+                        description: "The request type."
                         type: string
                         enum: ["T", "U", "D", "I", "O"]
                       scope:
-                        description: The scope of the transfer.
+                        description: "The scope of the transfer."
                         type: string
                       name:
-                        description: The name of the transfer.
+                        description: "The name of the transfer."
                         type: string
                       did_type:
-                        description: The did type.
+                        description: "The did type."
                         type: string
                       dest_rse_id:
-                        description: The destination RSE id.
+                        description: "The destination RSE id."
                         type: string
                       source_rse_id:
-                        description: The source RSE id.
+                        description: "The source RSE id."
                         type: string
                       attributes:
-                        description: All attributes associated with the request.
+                        description: "All attributes associated with the request."
                         type: string
                       state:
-                        description: The state of the request.
+                        description: "The state of the request."
                         type: string
                         enum: ["Q", "G", "S", "F", "D", "L", "N", "O", "A", "M", "U", "W", "P"]
                       external_id:
-                        description: External id of the request.
+                        description: "External id of the request."
                         type: string
                       external_host:
-                        description: External host of the request.
+                        description: "External host of the request."
                         type: string
                       retry_count:
-                        description: The numbers of attempted retires.
+                        description: "The numbers of attempted retries."
                         type: integer
                       err_msg:
-                        description: An error message if one occurred.
+                        description: "An error message if one occurred."
                         type: string
                       previous_attempt_id:
-                        description: The id of the previous attempt.
+                        description: "The id of the previous attempt."
                         type: string
                       rule_id:
-                        description: The id of the associated replication rule.
+                        description: "The id of the associated replication rule."
                         type: string
                       activity:
-                        description: The activity of the request.
+                        description: "The activity of the request."
                         type: string
                       bytes:
-                        description: The size of the did in bytes.
+                        description: "The size of the did in bytes."
                         type: integer
                       md5:
-                        description: The md5 checksum of the did to transfer.
+                        description: "The md5 checksum of the did to transfer."
                         type: string
                       adler32:
-                        description: The adler32 checksum of the did to transfer.
+                        description: "The adler32 checksum of the did to transfer."
                         type: string
                       dest_url:
-                        description: The destination url.
+                        description: "The destination url."
                         type: string
                       submitted_at:
-                        description: The time the request got submitted.
+                        description: "The time the request got submitted."
                         type: string
                       started_at:
-                        description: The time the request got started.
+                        description: "The time the request got started."
                         type: string
                       transferred_at:
-                        description: The time the request got transferred.
+                        description: "The time the request got transferred."
                         type: string
                       estimated_at:
-                        description: The time the request got estimated.
+                        description: "The time the request got estimated."
                         type: string
                       submitter_id:
-                        description: The id of the submitter.
+                        description: "The id of the submitter."
                         type: string
                       estimated_stated_at:
-                        description: The estimation of the started at value.
+                        description: "The estimation of the started at value."
                         type: string
                       estimated_transferred_at:
-                        description: The estimation of the transferred at value.
+                        description: "The estimation of the transferred at value."
                         type: string
                       staging_started_at:
-                        description: The time the staging got started.
+                        description: "The time the staging got started."
                         type: string
                       staging_finished_at:
-                        description: The time the staging got finished.
+                        description: "The time the staging got finished."
                         type: string
                       account:
-                        description: The account which issued the request.
+                        description: "The account which issued the request."
                         type: string
                       requested_at:
-                        description: The time the request got requested.
+                        description: "The time the request got requested."
                         type: string
                       priority:
-                        description: The priority of the request.
+                        description: "The priority of the request."
                         type: integer
                       transfertool:
-                        description: The transfertool used.
+                        description: "The transfertool used."
                         type: string
                       source_rse:
-                        description: The name of the source RSE.
+                        description: "The name of the source RSE."
                         type: string
                       dest_rse:
-                        description: The name of the destination RSE.
+                        description: "The name of the destination RSE."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         src_rse = flask.request.args.get('src_rse', default=None)
         dst_rse = flask.request.args.get('dst_rse', default=None)
@@ -836,72 +836,72 @@ class RequestMetricsGet(ErrorHandlingMethodView):
         """
         ---
         summary: Get Request Statistics
-        description: Get statistics of requests grouped by source, destination, and activity.
+        description: "Get statistics of requests grouped by source, destination, and activity."
         tags:
           - Requests
         parameters:
         - name: dest_rse
           in: query
-          description: The destination RSE name
+          description: "The destination RSE name"
           schema:
             type: string
         - name: source_rse
           in: query
-          description: The source RSE name
+          description: "The source RSE name"
           schema:
             type: string
         - name: activity
           in: query
-          description: The activity
+          description: "The activity"
           schema:
             type: string
         - name: group_by_rse_attribute
           in: query
-          description: The parameter to group the RSEs by.
+          description: "The parameter to group the RSEs by."
           schema:
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: Statistics of requests by source, destination, and activity.
+                  description: "Statistics of requests by source, destination, and activity."
                   type: array
                   items:
-                    description: Statistics of the request group for a given (source, destination, activity) tuple.
+                    description: "Statistics of the request group for a given (source, destination, activity) tuple."
                     type: object
                     properties:
                       src_rse:
                         type: string
-                        description: The name of this links source RSE
+                        description: "The name of this links source RSE"
                       dst_rse:
                         type: string
-                        description: The name of this links destination RSE
+                        description: "The name of this links destination RSE"
                       distance:
                         type: integer
-                        description: The distance between the source and destination RSE
+                        description: "The distance between the source and destination RSE"
                       files:
                         type: object
                         properties:
                           done-total-1h:
                             type: integer
-                            description: The total number of files successfully transferred in the last 1 hour
+                            description: "The total number of files successfully transferred in the last 1 hour"
                           done-total-6h:
                             type: integer
-                            description: The total number of files successfully transferred in the last 6 hours
+                            description: "The total number of files successfully transferred in the last 6 hours"
                           failed-total-1h:
                             type: integer
-                            description: The total number of transfer failures in the last 1 hour
+                            description: "The total number of transfer failures in the last 1 hour"
                           failed-total-6h:
                             type: integer
-                            description: The total number of transfer failures in the last 6 hours
+                            description: "The total number of transfer failures in the last 6 hours"
                           queued-total:
                             type: integer
-                            description: The total number of files queued in rucio
+                            description: "The total number of files queued in rucio"
                           queued:
                             type: object
-                            description: Per-activity number of queued files
+                            description: "Per-activity number of queued files"
                             additionalProperties:
                               type: integer
                           done:
@@ -915,7 +915,7 @@ class RequestMetricsGet(ErrorHandlingMethodView):
                                   type: integer
                           failed:
                             type: object
-                            description: Per-activity number of transfer failures in the last 1 and 6 hours
+                            description: "Per-activity number of transfer failures in the last 1 and 6 hours"
                             additionalProperties:
                               type: object
                               properties:
@@ -928,21 +928,21 @@ class RequestMetricsGet(ErrorHandlingMethodView):
                         properties:
                           done-total-1h:
                             type: integer
-                            description: The total number of bytes successfully transferred in the last 1 hour
+                            description: "The total number of bytes successfully transferred in the last 1 hour"
                           done-total-6h:
                             type: integer
-                            description: The total number of bytes successfully transferred in the last 6 hours
+                            description: "The total number of bytes successfully transferred in the last 6 hours"
                           queued-total:
                             type: integer
-                            description: The total number of bytes queued to be transferred by rucio
+                            description: "The total number of bytes queued to be transferred by rucio"
                           queued:
                             type: object
-                            description: Per-activity amount of queued bytes
+                            description: "Per-activity amount of queued bytes"
                             additionalProperties:
                               type: integer
                           done:
                             type: object
-                            description: Per-activity number of transferred bytes in the last 1 and 6 hours
+                            description: "Per-activity number of transferred bytes in the last 1 and 6 hours"
                             additionalProperties:
                               type: object
                               properties:
@@ -955,7 +955,7 @@ class RequestMetricsGet(ErrorHandlingMethodView):
                       - src_rse
                       - dst_rse
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
         """
         dst_rse = flask.request.args.get('dst_rse', default=None)
         src_rse = flask.request.args.get('src_rse', default=None)
@@ -980,6 +980,7 @@ class RequestMetricsGet(ErrorHandlingMethodView):
                 yield render_json(**result) + '\n'
         return try_stream(generate())
 
+
 class TransferLimits(ErrorHandlingMethodView):
     """ REST API to get, set or delete transfer limits. """
 
@@ -988,67 +989,68 @@ class TransferLimits(ErrorHandlingMethodView):
         """
         ---
         summary: Get Transfer Limits
-        description: Get all the transfer limits.
+        description: "Get all the transfer limits."
         tags:
           - Requests
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: All the transfer limits
+                  description: "All the transfer limits"
                   type: array
                   items:
                     type: object
                     properties:
                       id:
-                        description: The transfer limit id.
+                        description: "The transfer limit id."
                         type: string
                       rse_expression:
-                        description: The RSE expression for which the limit applies.
+                        description: "The RSE expression for which the limit applies."
                         type: string
                       direction:
-                        description: The direction in which this limit applies (source/destination)
+                        description: "The direction in which this limit applies (source/destination)"
                         type: string
                       max_transfers:
-                        description: Maximum number of transfers allowed.
+                        description: "Maximum number of transfers allowed."
                         type: integer
                       volume:
-                        description: Maximum transfer volume in bytes.
+                        description: "Maximum transfer volume in bytes."
                         type: integer
                       deadline:
-                        description: Maximum waiting time in hours until a datasets gets released.
+                        description: "Maximum waiting time in hours until a dataset gets released."
                         type: integer
                       strategy:
-                        description: defines how to handle datasets: `fifo` (each file released separately) or `grouped_fifo` (wait for the entire dataset to fit)
+                        description: "Defines how to handle datasets: `fifo` (each file released separately) or `grouped_fifo` (wait for the entire dataset to fit)"
                         type: string
                       transfers:
-                        description: Current number of active transfers
+                        description: "Current number of active transfers"
                         type: integer
                       waitings:
-                        description: Current number of waiting transfers
+                        description: "Current number of waiting transfers"
                         type: integer
                       updated_at:
-                        description: Datetime of the last update.
+                        description: "Datetime of the last update."
                         type: string
                       created_at:
-                        description: Datetime of the creation of the transfer limit.
+                        description: "Datetime of the creation of the transfer limit."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
         """
         transfer_limits = request.list_transfer_limits(issuer=flask.request.environ['issuer'], vo=flask.request.environ['vo'])
+
         def generate() -> "Iterator[str]":
-                for limit in transfer_limits:
-                    yield json.dumps(limit, cls=APIEncoder) + '\n'
+            for limit in transfer_limits:
+                yield json.dumps(limit, cls=APIEncoder) + '\n'
         return try_stream(generate())
 
     def put(self) -> Union[flask.Response, tuple[str, int]]:
         """
         ---
         summary: Set Transfer Limit
-        description: Create or update a transfer limit for a specific RSE expression and activity.
+        description: "Create or update a transfer limit for a specific RSE expression and activity."
         tags:
           - Requests
         requestBody:
@@ -1062,63 +1064,63 @@ class TransferLimits(ErrorHandlingMethodView):
                 properties:
                   rse_expression:
                     type: string
-                    description: The RSE expression for which the transfer limit is being set.
+                    description: "The RSE expression for which the transfer limit is being set."
                   activity:
                     type: string
-                    description: The activity to which the transfer limit applies.
+                    description: "The activity to which the transfer limit applies."
                   max_transfers:
                     type: integer
-                    description: The maximum number of transfers allowed.
+                    description: "The maximum number of transfers allowed."
                   direction:
                     type: string
-                    description: The direction of the transfer limit (source or destination).
+                    description: "The direction of the transfer limit (source or destination)."
                     enum: ["SOURCE", "DESTINATION"]
                     default: "DESTINATION"
                   volume:
                     type: integer
-                    description: The maximum transfer volume in bytes.
+                    description: "The maximum transfer volume in bytes."
                   deadline:
                     type: integer
-                    description: The maximum waiting time in hours until a dataset is released.
+                    description: "The maximum waiting time in hours until a dataset is released."
                   strategy:
                     type: string
-                    description: The strategy for handling datasets (e.g., `fifo` or `grouped_fifo`).
+                    description: "The strategy for handling datasets (e.g., `fifo` or `grouped_fifo`)."
                   transfers:
                     type: integer
-                    description: The current number of active transfers.
+                    description: "The current number of active transfers."
                   waitings:
                     type: integer
-                    description: The current number of waiting transfers.
+                    description: "The current number of waiting transfers."
         responses:
           201:
-            description: Transfer limit set successfully.
+            description: "Transfer limit set successfully."
           400:
-            description: Invalid input data.
+            description: "Invalid input data."
           401:
-            description: Invalid Auth Token.
+            description: "Invalid Auth Token."
           500:
-            description: Internal server error.
+            description: "Internal server error."
         """
         parameters = json_parameters()
         rse_expression = param_get(parameters, 'rse_expression')
         max_transfers = param_get(parameters, 'max_transfers')
 
         try:
-          request.set_transfer_limit(
-            rse_expression=rse_expression,
-            max_transfers=max_transfers,
-            activity=param_get(parameters, 'activity', default=None),
-            direction=param_get(parameters, 'direction', default=TransferLimitDirection.DESTINATION),
-            volume=param_get(parameters, 'volume', default=None),
-            deadline=param_get(parameters, 'deadline', default=None),
-            strategy=param_get(parameters, 'strategy', default=None),
-            transfers=param_get(parameters, 'transfers', default=None),
-            waitings=param_get(parameters, 'waitings', default=None),
-            issuer=flask.request.environ['issuer'],
-            vo=flask.request.environ['vo']
-          )
+            request.set_transfer_limit(
+                rse_expression=rse_expression,
+                max_transfers=max_transfers,
+                activity=param_get(parameters, 'activity', default=None),
+                direction=param_get(parameters, 'direction', default=TransferLimitDirection.DESTINATION),
+                volume=param_get(parameters, 'volume', default=None),
+                deadline=param_get(parameters, 'deadline', default=None),
+                strategy=param_get(parameters, 'strategy', default=None),
+                transfers=param_get(parameters, 'transfers', default=None),
+                waitings=param_get(parameters, 'waitings', default=None),
+                issuer=flask.request.environ['issuer'],
+                vo=flask.request.environ['vo']
+            )
         except AccessDenied as error:
-          return generate_http_error_flask(401, error)
+            return generate_http_error_flask(401, error)
 
         return '', 201
 
@@ -1126,41 +1128,42 @@ class TransferLimits(ErrorHandlingMethodView):
         """
         ---
         summary: Delete Transfer Limit
-        description: Delete a transfer limit for an RSE expression.
+        description: "Delete a transfer limit for an RSE expression."
         tags:
           - Requests
         parameters:
           - name: rse_expression
             in: query
-            description: The RSE expression to delete the limit for.
+            description: "The RSE expression to delete the limit for."
             required: true
             schema:
               type: string
         responses:
           200:
-            description: Transfer limit deleted successfully.
+            description: "Transfer limit deleted successfully."
           400:
-            description: Invalid input data.
+            description: "Invalid input data."
           401:
-            description: Invalid Auth Token.
+            description: "Invalid Auth Token."
           500:
-            description: Internal server error.
+            description: "Internal server error."
         """
         parameters = json_parameters()
         rse_expression = param_get(parameters, 'rse_expression')
 
         try:
-          request.delete_transfer_limit(
-            rse_expression=rse_expression,
-            activity=param_get(parameters, 'activity', default=None),
-            direction=param_get(parameters, 'direction', default=TransferLimitDirection.DESTINATION),
-            issuer=flask.request.environ['issuer'],
-            vo=flask.request.environ['vo']
-          )
+            request.delete_transfer_limit(
+                rse_expression=rse_expression,
+                activity=param_get(parameters, 'activity', default=None),
+                direction=param_get(parameters, 'direction', default=TransferLimitDirection.DESTINATION),
+                issuer=flask.request.environ['issuer'],
+                vo=flask.request.environ['vo']
+            )
         except AccessDenied as error:
-          return generate_http_error_flask(401, error)
+            return generate_http_error_flask(401, error)
 
         return '', 200
+
 
 def blueprint():
     bp = AuthenticatedBlueprint('requests', __name__, url_prefix='/requests')

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -79,96 +79,96 @@ class RSEs(ErrorHandlingMethodView):
         """
         ---
         summary: List RSEs
-        description: Lists all RSEs.
+        description: "Lists all RSEs."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: expression
           in: query
-          description: RSE expression to select RSEs.
+          description: "RSE expression to select RSEs."
           schema:
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: A list with the corresponding rses.
+                  description: "A list with the corresponding rses."
                   type: array
                   items:
                     type: object
                     properties:
                       id:
-                        description: The rse id.
+                        description: "The rse id."
                         type: string
                       rse:
-                        description: The name of the rse.
+                        description: "The name of the rse."
                         type: string
                       rse_type:
-                        description: The type of the rse.
+                        description: "The type of the rse."
                         type: string
                       deterministic:
-                        description: If the rse is deterministic.
+                        description: "If the rse is deterministic."
                         type: boolean
                       volatile:
-                        description: If the rse is volatile.
+                        description: "If the rse is volatile."
                         type: boolean
                       staging_area:
-                        description: Is this rse a staging area?
+                        description: "Is this rse a staging area?"
                         type: boolean
                       city:
-                        description: The city of the rse.
+                        description: "The city of the rse."
                         type: string
                       region_code:
-                        description: The region_code of the rse.
+                        description: "The region_code of the rse."
                         type: string
                       country_name:
-                        description: The country name of the rse.
+                        description: "The country name of the rse."
                         type: string
                       continent:
-                        description: The continent of the rse.
+                        description: "The continent of the rse."
                         type: string
                       time_zone:
-                        description: The time zone of the rse.
+                        description: "The time zone of the rse."
                         type: string
                       ISP:
-                        description: The isp of the rse.
+                        description: "The isp of the rse."
                         type: string
                       ASN:
-                        description: The asn of the rse.
+                        description: "The asn of the rse."
                         type: string
                       longitude:
-                        description: The longitude of the rse.
+                        description: "The longitude of the rse."
                         type: number
                       latitude:
-                        description: The latitude of the rse.
+                        description: "The latitude of the rse."
                         type: number
                       availability:
-                        description: The availability of the rse.
+                        description: "The availability of the rse."
                         type: integer
                         deprecated: true
                       availability_read:
-                        description: If the RSE is readable.
+                        description: "If the RSE is readable."
                         type: integer
                       availability_write:
-                        description: If the RSE is writable.
+                        description: "If the RSE is writable."
                         type: integer
                       availability_delete:
-                        description: If the RSE is deletable.
+                        description: "If the RSE is deletable."
                         type: integer
                       usage:
-                        description: The usage of the rse.
+                        description: "The usage of the rse."
                         type: integer
                       qos_class:
-                        description: The quality of service class.
+                        description: "The quality of service class."
                         type: string
           400:
-            description: Invalid RSE expression
+            description: "Invalid RSE expression"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         expression = request.args.get('expression', default=None)
 
@@ -197,13 +197,13 @@ class RSE(ErrorHandlingMethodView):
         """
         ---
         summary: Create RSE
-        description: Creates a RSE with all the metadata.
+        description: "Creates a RSE with all the metadata."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
@@ -214,74 +214,74 @@ class RSE(ErrorHandlingMethodView):
                 type: object
                 properties:
                   deterministic:
-                    description: If the pfn is generated deterministicly.
+                    description: "If the pfn is generated deterministically."
                     type: boolean
                   volatile:
-                    description: RSE cache.
+                    description: "RSE cache."
                     type: boolean
                   city:
-                    description: The city of the RSE.
+                    description: "The city of the RSE."
                     type: string
                   staging_area:
-                    description: Staging area.
+                    description: "Staging area."
                     type: string
                   region_code:
-                    description: The region code of the RSE.
+                    description: "The region code of the RSE."
                     type: string
                   country_name:
-                    description: The country name of the RSE.
+                    description: "The country name of the RSE."
                     type: string
                   continent:
-                    description: The continent of the RSE.
+                    description: "The continent of the RSE."
                     type: string
                   time_zone:
-                    description: The time zone of the RSE.
+                    description: "The time zone of the RSE."
                     type: string
                   ISP:
-                    description: The internet service provider of the RSE.
+                    description: "The internet service provider of the RSE."
                     type: string
                   rse_type:
-                    description: The rse type.
+                    description: "The rse type."
                     type: string
                     enum: ["DISK", "TAPE"]
                   latitude:
-                    description: The latitude of the RSE.
+                    description: "The latitude of the RSE."
                     type: number
                   longitude:
-                    description: The longitude of the RSE.
+                    description: "The longitude of the RSE."
                     type: number
                   ASN:
-                    description: The access service network of the RSE.
+                    description: "The access service network of the RSE."
                     type: string
                   availability:
-                    description: The availability of the RSE.
+                    description: "The availability of the RSE."
                     type: integer
                     deprecated: true
                   availability_read:
-                    description: If the RSE is readable.
+                    description: "If the RSE is readable."
                     type: boolean
                   availability_write:
-                    description: If the RSE is writable.
+                    description: "If the RSE is writable."
                     type: boolean
                   availability_delete:
-                    description: If the RSE is deletable.
+                    description: "If the RSE is deletable."
                     type: boolean
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           400:
-            description: Cannot decode json parameter dictionary
+            description: "Cannot decode json parameter dictionary"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found
+            description: "RSE not found"
           409:
-            description: RSE already exists.
+            description: "RSE already exists."
         """
         kwargs = {
             'deterministic': True,
@@ -335,13 +335,13 @@ class RSE(ErrorHandlingMethodView):
         """
         ---
         summary: Update RSE
-        description: Update RSE properties.
+        description: "Update RSE properties."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
@@ -352,59 +352,59 @@ class RSE(ErrorHandlingMethodView):
                 type: object
                 properties:
                   availability_read:
-                    description: The vailability of the RSE.
+                    description: "The availability of the RSE."
                     type: boolean
                   availability_write:
-                    description: The vailability of the RSE.
+                    description: "The availability of the RSE."
                     type: boolean
                   availability_delete:
-                    description: The vailability of the RSE.
+                    description: "The availability of the RSE."
                     type: boolean
                   deterministic:
-                    description: If the pfn is generated deterministicly.
+                    description: "If the pfn is generated deterministically."
                     type: boolean
                   volatile:
-                    description: RSE cache.
+                    description: "RSE cache."
                     type: boolean
                   city:
-                    description: The city of the RSE.
+                    description: "The city of the RSE."
                     type: string
                   staging_area:
-                    description: Staging area.
+                    description: "Staging area."
                     type: string
                   region_code:
-                    description: The region code of the RSE.
+                    description: "The region code of the RSE."
                     type: string
                   country_name:
-                    description: The country name of the RSE.
+                    description: "The country name of the RSE."
                     type: string
                   time_zone:
-                    description: The time zone of the RSE.
+                    description: "The time zone of the RSE."
                     type: string
                   rse_type:
-                    description: The rse type.
+                    description: "The rse type."
                     type: string
                     enum: ["DISK", "TAPE"]
                   latitude:
-                    description: The latitude of the RSE.
+                    description: "The latitude of the RSE."
                     type: number
                   longitude:
-                    description: The longitude of the RSE.
+                    description: "The longitude of the RSE."
                     type: number
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           400:
-            description: Cannot decode json parameter dictionary or invalid option provided
+            description: "Cannot decode json parameter dictionary or invalid option provided"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found
+            description: "RSE not found"
         """
         kwargs = {
             'parameters': json_parameters(optional=True),
@@ -429,83 +429,83 @@ class RSE(ErrorHandlingMethodView):
         """
         ---
         summary: Get RSE
-        description: Get details about a specific RSE.
+        description: "Get details about a specific RSE."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The RSE properties.
+                  description: "The RSE properties."
                   type: object
                   properties:
                     deterministic:
-                      description: If the pfn is generated deterministicly.
+                      description: "If the pfn is generated deterministically."
                       type: boolean
                     volatile:
-                      description: RSE cache.
+                      description: "RSE cache."
                       type: boolean
                     city:
-                      description: The city of the RSE.
+                      description: "The city of the RSE."
                       type: string
                     staging_area:
-                      description: Staging area.
+                      description: "Staging area."
                       type: string
                     region_code:
-                      description: The region code of the RSE.
+                      description: "The region code of the RSE."
                       type: string
                     country_name:
-                      description: The country name of the RSE.
+                      description: "The country name of the RSE."
                       type: string
                     continent:
-                      description: The continent of the RSE.
+                      description: "The continent of the RSE."
                       type: string
                     time_zone:
-                      description: The time zone of the RSE.
+                      description: "The time zone of the RSE."
                       type: string
                     ISP:
-                      description: The internet service provider of the RSE.
+                      description: "The internet service provider of the RSE."
                       type: string
                     rse_type:
-                      description: The rse type.
+                      description: "The rse type."
                       type: string
                       enum: ["DISK", "TAPE"]
                     latitude:
-                      description: The latitude of the RSE.
+                      description: "The latitude of the RSE."
                       type: number
                     longitude:
-                      description: The longitude of the RSE.
+                      description: "The longitude of the RSE."
                       type: number
                     ASN:
-                      description: The access service network of the RSE.
+                      description: "The access service network of the RSE."
                       type: string
                     availability:
-                      description: The availability of the RSE.
+                      description: "The availability of the RSE."
                       type: integer
                       deprecated: true
                     availability_read:
-                      description: If the RSE is readable.
+                      description: "If the RSE is readable."
                       type: integer
                     availability_write:
-                      description: If the RSE is writable.
+                      description: "If the RSE is writable."
                       type: integer
                     availability_delete:
-                      description: If the RSE is deletable.
+                      description: "If the RSE is deletable."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found
+            description: "RSE not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             rse = get_rse(rse=rse, vo=request.environ['vo'])
@@ -518,23 +518,23 @@ class RSE(ErrorHandlingMethodView):
         """
         ---
         summary: Disable RSE
-        description: Disable a specific RSE.
+        description: "Disable a specific RSE."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found
+            description: "RSE not found"
         """
         try:
             del_rse(rse=rse, issuer=request.environ['issuer'], vo=request.environ['vo'])
@@ -553,19 +553,19 @@ class Attributes(ErrorHandlingMethodView):
         """
         ---
         summary: Create RSE Attribute
-        description: Create a RSE attribute with given RSE name.
+        description: "Create a RSE attribute with given RSE name."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         - name: key
           in: path
-          description: The name of the attribute of the RSE.
+          description: "The name of the attribute of the RSE."
           schema:
             type: string
           style: simple
@@ -578,24 +578,24 @@ class Attributes(ErrorHandlingMethodView):
                 - value
                 properties:
                   value:
-                    description: The value of the RSE attribute.
+                    description: "The value of the RSE attribute."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           400:
-            description: Cannot decode json parameter dictionary
+            description: "Cannot decode json parameter dictionary"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found
+            description: "RSE not found"
           409:
-            description: Attribute already exists
+            description: "Attribute already exists"
         """
         parameters = json_parameters()
         value = param_get(parameters, 'value')
@@ -615,32 +615,32 @@ class Attributes(ErrorHandlingMethodView):
         """
         ---
         summary: Get RSE Attributes
-        description: Lists all RSE attributes for a RSE.
+        description: "Lists all RSE attributes for a RSE."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The RSE attribute list. Returns a dictionary with the attribute names as keys and the values as values.
+                  description: "The RSE attribute list. Returns a dictionary with the attribute names as keys and the values as values."
                   type: object
                   additionalProperties:
                     type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found
+            description: "RSE not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             rse_attr = list_rse_attributes(rse, vo=request.environ['vo'])
@@ -655,29 +655,29 @@ class Attributes(ErrorHandlingMethodView):
         """
         ---
         summary: Delete RSE Attribute
-        description: Delete an RSE attribute for given RSE name.
+        description: "Delete an RSE attribute for given RSE name."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         - name: key
           in: path
-          description: The name of the attribute of the RSE.
+          description: "The name of the attribute of the RSE."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE or RSE attribute not found
+            description: "RSE or RSE attribute not found"
         """
         try:
             del_rse_attribute(rse=rse, key=key, issuer=request.environ['issuer'], vo=request.environ['vo'])
@@ -697,138 +697,138 @@ class ProtocolList(ErrorHandlingMethodView):
         """
         ---
         summary: List RSE Protocols
-        description: List all supported protocols of the given RSE.
+        description: "List all supported protocols of the given RSE."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: Supported RSE Protocols and other information.
+                  description: "Supported RSE Protocols and other information."
                   type: object
                   properties:
                     deterministic:
-                      description: If the pfn is generated deterministicly.
+                      description: "If the pfn is generated deterministically."
                       type: boolean
                     volatile:
-                      description: RSE cache.
+                      description: "RSE cache."
                       type: boolean
                     staging_area:
-                      description: Staging area.
+                      description: "Staging area."
                       type: string
                     rse_type:
-                      description: The rse type.
+                      description: "The rse type."
                       type: string
                       enum: ["DISK", "TAPE"]
                     availability_read:
-                      description: The read availability of the RSE.
+                      description: "The read availability of the RSE."
                       type: boolean
                     availability_write:
-                      description: The write availability of the RSE.
+                      description: "The write availability of the RSE."
                       type: boolean
                     availability_delete:
-                      description: The delete availability of the RSE.
+                      description: "The delete availability of the RSE."
                       type: boolean
                     credentials:
-                      description: The credentials, currently None.
+                      description: "The credentials, currently None."
                       type: string
                     domain:
-                      description: The domains of the RSE protocols.
+                      description: "The domains of the RSE protocols."
                       type: array
                     id:
-                      description: The RSE id.
+                      description: "The RSE id."
                       type: string
                     lfn2pfn_algorithm:
-                      description: The algorithm used to translate the logical file names to the physical ones.
+                      description: "The algorithm used to translate the logical file names to the physical ones."
                       type: string
                     qos_class:
-                      description: The qos class of the RSE.
+                      description: "The qos class of the RSE."
                       type: string
                     rse:
-                      description: The name of the RSE.
+                      description: "The name of the RSE."
                       type: string
                     sign_url:
-                      description: The sign url of the RSE.
+                      description: "The sign url of the RSE."
                       type: string
                     verify_checksum:
-                      description: If the checksum of the files should be verified.
+                      description: "If the checksum of the files should be verified."
                       type: boolean
                     protocols:
-                      description: All supported protocols of the RSE.
+                      description: "All supported protocols of the RSE."
                       type: array
                       items:
                         type: object
-                        description: A supported RSE protocol.
+                        description: "A supported RSE protocol."
                         properties:
                           hostname:
-                            description: The hostname of the protocol.
+                            description: "The hostname of the protocol."
                             type: string
                           scheme:
-                            description: The scheme of the protocol.
+                            description: "The scheme of the protocol."
                             type: string
                           port:
-                            description: The port of the protocol.
+                            description: "The port of the protocol."
                             type: integer
                           prefix:
-                            description: The prefix of the protocol.
+                            description: "The prefix of the protocol."
                             type: string
                           impl:
-                            description: The implementation of the protocol.
+                            description: "The implementation of the protocol."
                             type: string
                           domains:
-                            description: The domains of the protocol.
+                            description: "The domains of the protocol."
                             type: object
                             properties:
                               lan:
-                                description: The lan domain
+                                description: "The lan domain"
                                 type: object
                                 properties:
                                   read:
-                                    description: The read value of the lan protocol.
+                                    description: "The read value of the lan protocol."
                                     type: integer
                                   write:
-                                    description: The write value of the lan protocol.
+                                    description: "The write value of the lan protocol."
                                     type: integer
                                   delete:
-                                    description: The delete value of the lan protocol.
+                                    description: "The delete value of the lan protocol."
                                     type: integer
                               wan:
-                                description: The wan domain
+                                description: "The wan domain"
                                 type: object
                                 properties:
                                   read:
-                                    description: The read value of the wan protocol.
+                                    description: "The read value of the wan protocol."
                                     type: integer
                                   write:
-                                    description: The read value of the wan protocol.
+                                    description: "The read value of the wan protocol."
                                     type: integer
                                   delete:
-                                    description: The read value of the wan protocol.
+                                    description: "The read value of the wan protocol."
                                     type: integer
                                   third_party_copy_read:
-                                    description: The third party copy read value of the wan protocol.
+                                    description: "The third party copy read value of the wan protocol."
                                     type: integer
                                   third_party_copy_write:
-                                    description: The third party copy write value of the wan protocol.
+                                    description: "The third party copy write value of the wan protocol."
                                     type: integer
                           extended_attributes:
-                            description: The extended attributes of the protocol.
+                            description: "The extended attributes of the protocol."
                             type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found or RSE Operation, RSE Protocol Domain, RSE Protocol not supported
+            description: "RSE not found or RSE Operation, RSE Protocol Domain, RSE Protocol not supported"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             p_list = get_rse_protocols(rse, issuer=request.environ['issuer'], vo=request.environ['vo'])
@@ -849,54 +849,54 @@ class LFNS2PFNS(ErrorHandlingMethodView):
         """
         ---
         summary: Translate LFNs to PFNs
-        description: Return PFNs for a set of LFNs.  Formatted as a JSON object where the key is a LFN and the value is the corresponding PFN.
+        description: "Return PFNs for a set of LFNs.  Formatted as a JSON object where the key is a LFN and the value is the corresponding PFN."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         - name: lfn
           in: query
-          description: The lfns of the request.
+          description: "The lfns of the request."
           schema:
             type: string
           required: True
         - name: scheme
           in: query
-          description: Optional argument to help with the protocol selection (e.g., http / gsiftp / srm)
+          description: "Optional argument to help with the protocol selection (e.g., http / gsiftp / srm)"
           schema:
             type: string
         - name: domain
           in: query
-          description: Optional argument used to select the protocol for wan or lan use cases.
+          description: "Optional argument used to select the protocol for wan or lan use cases."
           schema:
             type: string
         - name: operation
           in: query
-          description: Optional query argument to select the protocol for read-vs-writes.
+          description: "Optional query argument to select the protocol for read-vs-writes."
           schema:
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The PFNs to the LFNs. Dictionary with lfns as keys and pfns as values.
+                  description: "The PFNs to the LFNs. Dictionary with lfns as keys and pfns as values."
                   type: object
                   additionalProperties:
                     type:
                       string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found or RSE Protocol or RSE Protocol Domain not supported
+            description: "RSE not found or RSE Protocol or RSE Protocol Domain not supported"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         lfns = request.args.getlist('lfn')
         lfns = list(map(lambda lfn: lfn.split(":", 1), lfns))
@@ -927,19 +927,19 @@ class Protocol(ErrorHandlingMethodView):
         """
         ---
         summary: Create RSE Protocol
-        description: Create a protocol for a given RSE.
+        description: "Create a protocol for a given RSE."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         - name: scheme
           in: path
-          description: The protocol identifier.
+          description: "The protocol identifier."
           schema:
             type: string
           style: simple
@@ -951,57 +951,57 @@ class Protocol(ErrorHandlingMethodView):
                 type: object
                 properties:
                   domains:
-                    description: The domains for the protocol.
+                    description: "The domains for the protocol."
                     type: array
                   port:
-                    description: The port the protocol uses.
+                    description: "The port the protocol uses."
                     type: integer
                   hostname:
-                    description: The hostname of the protocol.
+                    description: "The hostname of the protocol."
                     type: string
                   extended_attributes:
-                    description: Extended attributes for the protocol.
+                    description: "Extended attributes for the protocol."
                     type: string
                   prefix:
-                    description: The prefix of the Protocol.
+                    description: "The prefix of the Protocol."
                     type: string
                   impl:
-                    description: The impl used by the Protocol.
+                    description: "The impl used by the Protocol."
                     type: string
                   read_lan:
-                    description: If the protocol is readable via lan.
+                    description: "If the protocol is readable via lan."
                     type: integer
                   write_lan:
-                    description: If the protocol is writable via lan.
+                    description: "If the protocol is writable via lan."
                     type: integer
                   delete_lan:
-                    description: If the protocol is deletable via lan.
+                    description: "If the protocol is deletable via lan."
                     type: integer
                   read_wan:
-                    description: If the protocol is readable via wan.
+                    description: "If the protocol is readable via wan."
                     type: integer
                   write_wan:
-                    description: If the protocol is writable via wan.
+                    description: "If the protocol is writable via wan."
                     type: integer
                   delete_wan:
-                    description: If the protocol is deletable via wan.
+                    description: "If the protocol is deletable via wan."
                     type: integer
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           400:
-            description: Cannot decode json parameter dictionary
+            description: "Cannot decode json parameter dictionary"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found or RSE Protocol Domain not supported
+            description: "RSE not found or RSE Protocol Domain not supported"
           409:
-            description: RSE protocol priority error
+            description: "RSE protocol priority error"
         """
         parameters = json_parameters()
 
@@ -1026,145 +1026,145 @@ class Protocol(ErrorHandlingMethodView):
         """
         ---
         summary: Get Protocols
-        description: List all references of the provided RSE for the given protocol.
+        description: "List all references of the provided RSE for the given protocol."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         - name: scheme
           in: path
-          description: The protocol identifier.
+          description: "The protocol identifier."
           schema:
             type: string
           style: simple
           required: False
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: A dict with RSE information and supported protocols.
+                  description: "A dict with RSE information and supported protocols."
                   type: object
                   properties:
                     deterministic:
-                      description: If the pfn is generated deterministicly.
+                      description: "If the pfn is generated deterministically."
                       type: boolean
                     volatile:
-                      description: RSE cache.
+                      description: "RSE cache."
                       type: boolean
                     staging_area:
-                      description: Staging area.
+                      description: "Staging area."
                       type: string
                     rse_type:
-                      description: The rse type.
+                      description: "The rse type."
                       type: string
                       enum: ["DISK", "TAPE"]
                     availability_read:
-                      description: The read availability of the RSE.
+                      description: "The read availability of the RSE."
                       type: boolean
                     availability_write:
-                      description: The write availability of the RSE.
+                      description: "The write availability of the RSE."
                       type: boolean
                     availability_delete:
-                      description: The delete availability of the RSE.
+                      description: "The delete availability of the RSE."
                       type: boolean
                     credentials:
-                      description: The credentials, currently None.
+                      description: "The credentials, currently None."
                       type: string
                     domain:
-                      description: The domains of the RSE protocols.
+                      description: "The domains of the RSE protocols."
                       type: array
                     id:
-                      description: The RSE id.
+                      description: "The RSE id."
                       type: string
                     lfn2pfn_algorithm:
-                      description: The algorithm used to translate the logical file names to the physical ones.
+                      description: "The algorithm used to translate the logical file names to the physical ones."
                       type: string
                     qos_class:
-                      description: The qos class of the RSE.
+                      description: "The qos class of the RSE."
                       type: string
                     rse:
-                      description: The name of the RSE.
+                      description: "The name of the RSE."
                       type: string
                     sign_url:
-                      description: The sign url of the RSE.
+                      description: "The sign url of the RSE."
                       type: string
                     verify_checksum:
-                      description: If the checksum of the files should be verified.
+                      description: "If the checksum of the files should be verified."
                       type: boolean
                     protocols:
-                      description: All supported protocols of the RSE.
+                      description: "All supported protocols of the RSE."
                       type: array
                       items:
                         type: object
-                        description: A supported RSE protocol.
+                        description: "A supported RSE protocol."
                         properties:
                           hostname:
-                            description: The hostname of the protocol.
+                            description: "The hostname of the protocol."
                             type: string
                           scheme:
-                            description: The scheme of the protocol.
+                            description: "The scheme of the protocol."
                             type: string
                           port:
-                            description: The port of the protocol.
+                            description: "The port of the protocol."
                             type: integer
                           prefix:
-                            description: The prefix of the protocol.
+                            description: "The prefix of the protocol."
                             type: string
                           impl:
-                            description: The implementation of the protocol.
+                            description: "The implementation of the protocol."
                             type: string
                           domains:
-                            description: The domains of the protocol.
+                            description: "The domains of the protocol."
                             type: object
                             properties:
                               lan:
-                                description: The lan domain
+                                description: "The lan domain"
                                 type: object
                                 properties:
                                   read:
-                                    description: The read value of the lan protocol.
+                                    description: "The read value of the lan protocol."
                                     type: integer
                                   write:
-                                    description: The write value of the lan protocol.
+                                    description: "The write value of the lan protocol."
                                     type: integer
                                   delete:
-                                    description: The delete value of the lan protocol.
+                                    description: "The delete value of the lan protocol."
                                     type: integer
                               wan:
-                                description: The wan domain
+                                description: "The wan domain"
                                 type: object
                                 properties:
                                   read:
-                                    description: The read value of the wan protocol.
+                                    description: "The read value of the wan protocol."
                                     type: integer
                                   write:
-                                    description: The read value of the wan protocol.
+                                    description: "The read value of the wan protocol."
                                     type: integer
                                   delete:
-                                    description: The read value of the wan protocol.
+                                    description: "The read value of the wan protocol."
                                     type: integer
                                   third_party_copy_read:
-                                    description: The third party copy read value of the wan protocol.
+                                    description: "The third party copy read value of the wan protocol."
                                     type: integer
                                   third_party_copy_write:
-                                    description: The third party copy write value of the wan protocol.
+                                    description: "The third party copy write value of the wan protocol."
                                     type: integer
                           extended_attributes:
-                            description: The extended attributes of the protocol.
+                            description: "The extended attributes of the protocol."
                             type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found or Protocol or Protocol domain not Supported.
+            description: "RSE not found or Protocol or Protocol domain not Supported."
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             p_list = get_rse_protocols(rse, issuer=request.environ['issuer'], vo=request.environ['vo'])
@@ -1177,158 +1177,158 @@ class Protocol(ErrorHandlingMethodView):
         """
         ---
         summary: Update Protocol Attributes
-        description: Updates attributes of an existing protocol entry. Because protocol identifier, hostname, and port are used as unique identifier they are immutable.
+        description: "Updates attributes of an existing protocol entry. Because protocol identifier, hostname, and port are used as unique identifiers, they are immutable."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         - name: scheme
           in: path
-          description: The protocol identifier.
+          description: "The protocol identifier."
           schema:
             type: string
           style: simple
         - name: hostname
           in: path
-          description: The hostname of the protocol.
+          description: "The hostname of the protocol."
           schema:
             type: string
           style: simple
           required: False
         - name: port
           in: path
-          description: The port of the protocol.
+          description: "The port of the protocol."
           schema:
             type: integer
           style: simple
           required: False
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: A dict with RSE information and supported protocols.
+                  description: "A dict with RSE information and supported protocols."
                   type: object
                   properties:
                     deterministic:
-                      description: If the pfn is generated deterministicly.
+                      description: "If the pfn is generated deterministically."
                       type: boolean
                     volatile:
-                      description: RSE cache.
+                      description: "RSE cache."
                       type: boolean
                     staging_area:
-                      description: Staging area.
+                      description: "Staging area."
                       type: string
                     rse_type:
-                      description: The rse type.
+                      description: "The rse type."
                       type: string
                       enum: ["DISK", "TAPE"]
                     availability_read:
-                      description: The read availability of the RSE.
+                      description: "The read availability of the RSE."
                       type: boolean
                     availability_write:
-                      description: The write availability of the RSE.
+                      description: "The write availability of the RSE."
                       type: boolean
                     availability_delete:
-                      description: The delete availability of the RSE.
+                      description: "The delete availability of the RSE."
                       type: boolean
                     credentials:
-                      description: The credentials, currently None.
+                      description: "The credentials, currently None."
                       type: string
                     domain:
-                      description: The domains of the RSE protocols.
+                      description: "The domains of the RSE protocols."
                       type: array
                     id:
-                      description: The RSE id.
+                      description: "The RSE id."
                       type: string
                     lfn2pfn_algorithm:
-                      description: The algorithm used to translate the logical file names to the physical ones.
+                      description: "The algorithm used to translate the logical file names to the physical ones."
                       type: string
                     qos_class:
-                      description: The qos class of the RSE.
+                      description: "The qos class of the RSE."
                       type: string
                     rse:
-                      description: The name of the RSE.
+                      description: "The name of the RSE."
                       type: string
                     sign_url:
-                      description: The sign url of the RSE.
+                      description: "The sign url of the RSE."
                       type: string
                     verify_checksum:
-                      description: If the checksum of the files should be verified.
+                      description: "If the checksum of the files should be verified."
                       type: boolean
                     protocols:
-                      description: All supported protocols of the RSE.
+                      description: "All supported protocols of the RSE."
                       type: array
                       items:
                         type: object
-                        description: A supported RSE protocol.
+                        description: "A supported RSE protocol."
                         properties:
                           hostname:
-                            description: The hostname of the protocol.
+                            description: "The hostname of the protocol."
                             type: string
                           scheme:
-                            description: The scheme of the protocol.
+                            description: "The scheme of the protocol."
                             type: string
                           port:
-                            description: The port of the protocol.
+                            description: "The port of the protocol."
                             type: integer
                           prefix:
-                            description: The prefix of the protocol.
+                            description: "The prefix of the protocol."
                             type: string
                           impl:
-                            description: The implementation of the protocol.
+                            description: "The implementation of the protocol."
                             type: string
                           domains:
-                            description: The domains of the protocol.
+                            description: "The domains of the protocol."
                             type: object
                             properties:
                               lan:
-                                description: The lan domain
+                                description: "The lan domain"
                                 type: object
                                 properties:
                                   read:
-                                    description: The read value of the lan protocol.
+                                    description: "The read value of the lan protocol."
                                     type: integer
                                   write:
-                                    description: The write value of the lan protocol.
+                                    description: "The write value of the lan protocol."
                                     type: integer
                                   delete:
-                                    description: The delete value of the lan protocol.
+                                    description: "The delete value of the lan protocol."
                                     type: integer
                               wan:
-                                description: The wan domain
+                                description: "The wan domain"
                                 type: object
                                 properties:
                                   read:
-                                    description: The read value of the wan protocol.
+                                    description: "The read value of the wan protocol."
                                     type: integer
                                   write:
-                                    description: The read value of the wan protocol.
+                                    description: "The read value of the wan protocol."
                                     type: integer
                                   delete:
-                                    description: The read value of the wan protocol.
+                                    description: "The read value of the wan protocol."
                                     type: integer
                                   third_party_copy_read:
-                                    description: The third party copy read value of the wan protocol.
+                                    description: "The third party copy read value of the wan protocol."
                                     type: integer
                                   third_party_copy_write:
-                                    description: The third party copy write value of the wan protocol.
+                                    description: "The third party copy write value of the wan protocol."
                                     type: integer
                           extended_attributes:
-                            description: The extended attributes of the protocol.
+                            description: "The extended attributes of the protocol."
                             type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: RSE not found or Protocol or Protocol domain not Supported.
+            description: "RSE not found or Protocol or Protocol domain not Supported."
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters()
         try:
@@ -1354,43 +1354,43 @@ class Protocol(ErrorHandlingMethodView):
         """
         ---
         summary: Delete Protocol Attributes
-        description: Delete all protocol attributes.
+        description: "Delete all protocol attributes."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         - name: scheme
           in: path
-          description: The protocol identifier.
+          description: "The protocol identifier."
           schema:
             type: string
           style: simple
         - name: hostname
           in: path
-          description: The hostname of the protocol.
+          description: "The hostname of the protocol."
           schema:
             type: string
           style: simple
           required: False
         - name: port
           in: path
-          description: The port of the protocol.
+          description: "The port of the protocol."
           schema:
             type: integer
           style: simple
           required: False
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found or protocol not supported
+            description: "Rse not found or protocol not supported"
         """
         try:
             del_protocols(
@@ -1415,67 +1415,67 @@ class Usage(ErrorHandlingMethodView):
         """
         ---
         summary: Get Rse Usage Information
-        description: Get rse usage information.
+        description: "Get rse usage information."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         - name: per_account
           in: query
-          description: Boolean whether the usage should be also calculated per account or not.
+          description: "Boolean whether the usage should be also calculated per account or not."
           schema:
             type: boolean
         - name: source
           in: query
-          description: The information source, e.g., srm.
+          description: "The information source, e.g., srm."
           schema:
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list with the rse usage.
+                  description: "A list with the rse usage."
                   type: array
                   items:
                     type: object
                     properties:
                       rse_id:
-                        description: The id of the rse.
+                        description: "The id of the rse."
                         type: string
                       rse:
-                        description: The name of the rse.
+                        description: "The name of the rse."
                         type: string
                       source:
-                        description: The source of the rse.
+                        description: "The source of the rse."
                         type: string
                       used:
-                        description: The number of used bytes.
+                        description: "The number of used bytes."
                         type: integer
                       free:
-                        description: The number of free bytes.
+                        description: "The number of free bytes."
                         type: integer
                       total:
-                        description: The number of total bytes.
+                        description: "The number of total bytes."
                         type: integer
                       files:
-                        description: The number of files.
+                        description: "The number of files."
                         type: integer
                       updated_at:
-                        description: The last time it got updated.
+                        description: "The last time it got updated."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         per_account = request.args.get('per_account') == 'True'
         try:
@@ -1498,13 +1498,13 @@ class Usage(ErrorHandlingMethodView):
         """
         ---
         summary: Update Rse Usage
-        description: Update the RSE Update information.
+        description: "Update the RSE Update information."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
@@ -1515,28 +1515,28 @@ class Usage(ErrorHandlingMethodView):
                 type: object
                 properties:
                   source:
-                    description: The information source, e.g. srm.
+                    description: "The information source, e.g. srm."
                     type: string
                   used:
-                    description: The number of used bytes.
+                    description: "The number of used bytes."
                     type: integer
                   free:
-                    description: The number of free bytes.
+                    description: "The number of free bytes."
                     type: integer
                   files:
-                    description: The number of files.
+                    description: "The number of files."
                     type: integer
         responses:
           200:
-            description: OK
+            description: "OK"
           400:
-            description: Can not decode json parameter list.
+            description: "Can not decode json parameter list."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters()
         kwargs = {'source': None, 'used': None, 'free': None, 'files': None}
@@ -1561,54 +1561,54 @@ class UsageHistory(ErrorHandlingMethodView):
         """
         ---
         summary: Get Rse Usage History
-        description: Get the rse usage history
+        description: "Get the rse usage history"
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list with the rse usage history items.
+                  description: "A list with the rse usage history items."
                   type: array
                   items:
                     type: object
                     properties:
                       rse_id:
-                        description: The id of the rse.
+                        description: "The id of the rse."
                         type: string
                       rse:
-                        description: The name of the rse.
+                        description: "The name of the rse."
                         type: string
                       source:
-                        description: The source of the rse.
+                        description: "The source of the rse."
                         type: string
                       used:
-                        description: The number of used bytes.
+                        description: "The number of used bytes."
                         type: integer
                       free:
-                        description: The number of free bytes.
+                        description: "The number of free bytes."
                         type: integer
                       total:
-                        description: The number of total bytes.
+                        description: "The number of total bytes."
                         type: integer
                       updated_at:
-                        description: The last time it got updated.
+                        description: "The last time it got updated."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             def generate(issuer, source, vo):
@@ -1628,34 +1628,34 @@ class Limits(ErrorHandlingMethodView):
         """
         ---
         summary: Get Rse Limits
-        description: Get the rse limits.
+        description: "Get the rse limits."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The limits.
+                  description: "The limits."
                   type: object
                   additionalProperties:
                     x-additionalPropertiesName: limit name
-                    description: An item with the name as key and the value as value.
+                    description: "An item with the name as key and the value as value."
                     type: integer
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             limits = get_rse_limits(rse=rse, issuer=request.environ['issuer'], vo=request.environ['vo'])
@@ -1667,13 +1667,13 @@ class Limits(ErrorHandlingMethodView):
         """
         ---
         summary: Update Rse Limit
-        description: Update an rse limit.
+        description: "Update an rse limit."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
@@ -1684,20 +1684,20 @@ class Limits(ErrorHandlingMethodView):
                 type: object
                 properties:
                   name:
-                    description: The name of the limit.
+                    description: "The name of the limit."
                     type: string
                   value:
-                    description: The value of the limit.
+                    description: "The value of the limit."
                     type: integer
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters()
         kwargs = {'name': None, 'value': None}
@@ -1717,13 +1717,13 @@ class Limits(ErrorHandlingMethodView):
         """
         ---
         summary: Delete Rse Limit
-        description: Delete an rse limit
+        description: "Delete an rse limit"
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
@@ -1736,17 +1736,17 @@ class Limits(ErrorHandlingMethodView):
                 - name
                 properties:
                   name:
-                    description: The name of the limit.
+                    description: "The name of the limit."
                     type: string
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters()
         name = param_get(parameters, 'name')
@@ -1769,51 +1769,51 @@ class RSEAccountUsageLimit(ErrorHandlingMethodView):
         """
         ---
         summary: Get Rse Account Usage and Limit
-        description: Returns the usage and limit of an account for a rse.
+        description: "Returns the usage and limit of an account for a rse."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: A list with the rse account limits and usages.
+                  description: "A list with the rse account limits and usages."
                   type: array
                   items:
                     type: object
                     properties:
                       rse_id:
-                        description: The id of the rse.
+                        description: "The id of the rse."
                         type: string
                       rse:
-                        description: The name of the rse.
+                        description: "The name of the rse."
                         type: string
                       account:
-                        description: The account.
+                        description: "The account."
                         type: string
                       used_files:
-                        description: The number of used files.
+                        description: "The number of used files."
                         type: integer
                       used_bytes:
-                        description: The number of used bytes.
+                        description: "The number of used bytes."
                         type: integer
                       quota_bytes:
-                        description: The number of quota bytes.
+                        description: "The number of quota bytes."
                         type: integer
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             def generate(vo):
@@ -1833,53 +1833,53 @@ class Distance(ErrorHandlingMethodView):
         """
         ---
         summary: Get Rse Distances
-        description: Returns the distances between a source and destination rse.
+        description: "Returns the distances between a source and destination rse."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: source
           in: path
-          description: The name of the source Rucio Storage Element.
+          description: "The name of the source Rucio Storage Element."
           schema:
             type: string
           style: simple
         - name: destination
           in: path
-          description: The name of the destination Rucio Storage Element.
+          description: "The name of the destination Rucio Storage Element."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The distances between the Rses.
+                  description: "The distances between the Rses."
                   type: array
                   items:
                     type: object
-                    description: One distance between source and destination.
+                    description: "One distance between source and destination."
                     properties:
                       src_rse_id:
-                        description: The source rse id.
+                        description: "The source rse id."
                         type: string
                       dest_rse_id:
-                        description: The destination rse id.
+                        description: "The destination rse id."
                         type: string
                       distance:
-                        description: The distance between RSEs.
+                        description: "The distance between RSEs."
                         type: integer
                       ranking:
                         deprecated: true
-                        description: Same as distance.
+                        description: "Same as distance."
                         type: integer
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             distance = get_distance(source=source, destination=destination, issuer=request.environ['issuer'], vo=request.environ['vo'])
@@ -1891,19 +1891,19 @@ class Distance(ErrorHandlingMethodView):
         """
         ---
         summary: Create Rse Distance
-        description: Post a rse distance.
+        description: "Post a rse distance."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: source
           in: path
-          description: The name of the source Rucio Storage Element.
+          description: "The name of the source Rucio Storage Element."
           schema:
             type: string
           style: simple
         - name: destination
           in: path
-          description: The name of the destination Rucio Storage Element.
+          description: "The name of the destination Rucio Storage Element."
           schema:
             type: string
           style: simple
@@ -1914,26 +1914,26 @@ class Distance(ErrorHandlingMethodView):
                 type: object
                 properties:
                   distance:
-                    description: The distance between RSEs.
+                    description: "The distance between RSEs."
                     type: integer
                   ranking:
                     deprecated: true
-                    description: Same as distance.
+                    description: "Same as distance."
                     type: integer
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters()
 
@@ -1962,19 +1962,19 @@ class Distance(ErrorHandlingMethodView):
         """
         ---
         summary: Update Rse Distance
-        description: Update rse distance information.
+        description: "Update rse distance information."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: source
           in: path
-          description: The name of the source Rucio Storage Element.
+          description: "The name of the source Rucio Storage Element."
           schema:
             type: string
           style: simple
         - name: destination
           in: path
-          description: The name of the destination Rucio Storage Element.
+          description: "The name of the destination Rucio Storage Element."
           schema:
             type: string
           style: simple
@@ -1985,26 +1985,26 @@ class Distance(ErrorHandlingMethodView):
                 type: object
                 properties:
                   distance:
-                    description: The distance between the RSEs.
+                    description: "The distance between the RSEs."
                     type: integer
                   ranking:
                     deprecated: true
-                    description: Same as distance.
+                    description: "Same as distance."
                     type: integer
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters()
 
@@ -2031,36 +2031,36 @@ class Distance(ErrorHandlingMethodView):
         """
         ---
         summary: Delete Rse Distance
-        description: Delete distance information between source RSE and destination RSE.
+        description: "Delete distance information between source RSE and destination RSE."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: source
           in: path
-          description: The name of the source Rucio Storage Element.
+          description: "The name of the source Rucio Storage Element."
           schema:
             type: string
           style: simple
         - name: destination
           in: path
-          description: The name of the destination Rucio Storage Element.
+          description: "The name of the destination Rucio Storage Element."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Deleted"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             delete_distance(
@@ -2085,36 +2085,36 @@ class QoSPolicy(ErrorHandlingMethodView):
         """
         ---
         summary: Add QoS policy
-        description: Add a QoS Policy to a RSE.
+        description: "Add a QoS Policy to a RSE."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         - name: policy
           in: path
-          description: The QoS policy to add to and rse.
+          description: "The QoS policy to add to and rse."
           schema:
             type: string
           style: simple
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             add_qos_policy(rse=rse, qos_policy=policy, issuer=request.environ['issuer'], vo=request.environ['vo'])
@@ -2128,31 +2128,31 @@ class QoSPolicy(ErrorHandlingMethodView):
         """
         ---
         summary: Delete QoS Policy
-        description: Delete QoS policy from RSE.
+        description: "Delete QoS policy from RSE."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         - name: policy
           in: path
-          description: The QoS policy to add to and rse.
+          description: "The QoS policy to add to and rse."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             delete_qos_policy(rse=rse, qos_policy=policy, issuer=request.environ['issuer'], vo=request.environ['vo'])
@@ -2166,39 +2166,39 @@ class QoSPolicy(ErrorHandlingMethodView):
         """
         ---
         summary: Gett QoS Policies
-        description: List all QoS policies for an Rse.
+        description: "List all QoS policies for an Rse."
         tags:
           - Rucio Storage Elements
         parameters:
         - name: rse
           in: path
-          description: The name of the Rucio Storage Element name.
+          description: "The name of the Rucio Storage Element name."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: A list with all the QoS policies for an Rse.
+                  description: "A list with all the QoS policies for an Rse."
                   type: array
                   items:
                     type: object
                     properties:
                       rse_id:
-                        description: The rse id.
+                        description: "The rse id."
                         type: string
                       qos_policy:
-                        description: The qos policy.
+                        description: "The qos policy."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rse not found
+            description: "Rse not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             qos_policies = list_qos_policies(rse=rse, issuer=request.environ['issuer'], vo=request.environ['vo'])

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -68,23 +68,23 @@ class Rule(ErrorHandlingMethodView):
         parameters:
         - name: rule_id
           in: path
-          description: The id of the replication rule.
+          description: "The id of the replication rule."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
           406:
-            description: Not Acceptable
+            description: "Not Acceptable"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No rule found for the given id
+            description: "No rule found for the given id"
         """
         parameters = json_parameters(optional=True)
         estimate_ttc = param_get(parameters, 'estimate_ttc', default=False)
@@ -107,12 +107,12 @@ class Rule(ErrorHandlingMethodView):
         parameters:
         - name: rule_id
           in: path
-          description: The id of the replication rule.
+          description: "The id of the replication rule."
           schema:
             type: string
           style: simple
         requestBody:
-          description: Parameters for the new rule.
+          description: "Parameters for the new rule."
           content:
             'application/json':
               schema:
@@ -121,58 +121,58 @@ class Rule(ErrorHandlingMethodView):
                 - options
                 properties:
                   options:
-                    description: The parameters to change.
+                    description: "The parameters to change."
                     type: object
                     properties:
                       lifetime:
-                        description: The time in which the rule will expire in seconds.
+                        description: "The time in which the rule will expire in seconds."
                         type: integer
                       account:
-                        description: The account of the replication rule.
+                        description: "The account of the replication rule."
                         type: string
                       state:
-                        description: The state of the replication rule.
+                        description: "The state of the replication rule."
                         type: string
                       cancel_requests:
-                        description: Cancels all requests if used together with state.
+                        description: "Cancels all requests if used together with state."
                         type: boolean
                       priority:
-                        description: The priority of a rule.
+                        description: "The priority of a rule."
                         type: integer
                       child_rule_id:
-                        description: The child rule. Parent and child rule must be on the same dataset.
+                        description: "The child rule. Parent and child rule must be on the same dataset."
                         type: string
                       meta:
-                        description: The meta of a rule.
+                        description: "The meta of a rule."
                         type: object
                       boost_rule:
-                        description: Boosts the processing of a rule.
+                        description: "Boosts the processing of a rule."
                         type: object
                       locked:
-                        description: The locked state of the replication rule.
+                        description: "The locked state of the replication rule."
                         type: boolean
                       comment:
-                        description: The comment of the replication rule.
+                        description: "The comment of the replication rule."
                         type: string
                       activity:
-                        description: The activity of a replication rule.
+                        description: "The activity of a replication rule."
                         type: string
                       source_replica_expression:
-                        description: The source replica expression of a replication rule.
+                        description: "The source replica expression of a replication rule."
                         type: string
                       eol_at:
-                        description: The end of life of a replication rule.
+                        description: "The end of life of a replication rule."
                         type: string
                       purge_replicas:
-                        description: Purge replicas
+                        description: "Purge replicas"
                         type: boolean
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No rule found for the given id
+            description: "No rule found for the given id"
        """
         parameters = json_parameters()
         options: dict[str, Any] = param_get(parameters, 'options')
@@ -197,17 +197,17 @@ class Rule(ErrorHandlingMethodView):
         parameters:
         - name: rule_id
           in: path
-          description: The id of the replication rule.
+          description: "The id of the replication rule."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No rule found for the given id
+            description: "No rule found for the given id"
         """
         parameters = json_parameters()
         purge_replicas = param_get(parameters, 'purge_replicas', default=None)
@@ -233,17 +233,17 @@ class AllRule(ErrorHandlingMethodView):
           - Rule
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No rule found for the given id
+            description: "No rule found for the given id"
           406:
-            description: Not Acceptable
+            description: "Not Acceptable"
         """
         try:
             def generate(filters, vo):
@@ -261,7 +261,7 @@ class AllRule(ErrorHandlingMethodView):
         tags:
           - Rule
         requestBody:
-          description: Parameters for the new rule.
+          description: "Parameters for the new rule."
           content:
             'application/json':
               schema:
@@ -273,88 +273,88 @@ class AllRule(ErrorHandlingMethodView):
                 - rse_expression
                 properties:
                   dids:
-                    description: The list of data identifiers.
+                    description: "The list of data identifiers."
                     type: array
                     items:
                       type: object
                       properties:
                         scope:
-                          description: The scope of the data identifier
+                          description: "The scope of the data identifier"
                           type: string
                         name:
-                          description: The name of the data identifier
+                          description: "The name of the data identifier"
                           type: string
                   account:
-                    description: The account of the issuer.
+                    description: "The account of the issuer."
                     type: string
                   copies:
-                    description: The number of replicas.
+                    description: "The number of replicas."
                     type: integer
                   rse_expression:
-                    description: The rse expression which gets resolved into a list of RSEs.
+                    description: "The rse expression which gets resolved into a list of RSEs."
                     type: string
                   grouping:
-                    description: The grouping of the files to take into account. (ALL, DATASET, NONE)
+                    description: "The grouping of the files to take into account. (ALL, DATASET, NONE)"
                     type: string
                   weight:
-                     description: Weighting scheme to be used.
+                     description: "Weighting scheme to be used."
                      type: number
                   lifetime:
-                     description: The lifetime of the replication rule in seconds.
+                     description: "The lifetime of the replication rule in seconds."
                      type: integer
                   locked:
-                     description: If the rule is locked.
+                     description: "If the rule is locked."
                      type: boolean
                   subscription_id:
-                     description: The subscription_id, if the rule is created by a subscription.
+                     description: "The subscription_id, if the rule is created by a subscription."
                      type: string
                   sourse_replica_expression:
-                     description: Only use replicas as source from these RSEs.
+                     description: "Only use replicas as source from these RSEs."
                      type: string
                   activity:
-                     description: Activity to be passed to the conveyor.
+                     description: "Activity to be passed to the conveyor."
                      type: string
                   notify:
-                     description: Notification setting of the rule ('Y', 'N', 'C'; None = 'N').
+                     description: "Notification setting of the rule ('Y', 'N', 'C'; None = 'N')."
                      type: string
                   purge_replicas:
-                     description: Purge setting if a replica should be directly deleted after the rule is deleted.
+                     description: "Purge setting if a replica should be directly deleted after the rule is deleted."
                      type: boolean
                   ignore_availability:
-                     description: Option to ignore the availability of RSEs.
+                     description: "Option to ignore the availability of RSEs."
                      type: boolean
                   comments:
-                     description: Comment about the rule.
+                     description: "Comment about the rule."
                      type: string
                   ask_approval:
-                     description: Ask for approval for this rule.
+                     description: "Ask for approval for this rule."
                      type: boolean
                   asynchronous:
-                     description: Create replication rule asynchronously by the judge-injector.
+                     description: "Create replication rule asynchronously by the judge-injector."
                      type: boolean
                   priority:
-                     description: Priority of the rule and the transfers which should be submitted.
+                     description: "Priority of the rule and the transfers which should be submitted."
                      type: integer
                   split_container:
-                     description: Should a container rule be split into individual dataset rules.
+                     description: "Should a container rule be split into individual dataset rules."
                      type: boolean
                   meta:
-                     description: Dictionary with metadata from the WFMS.
+                     description: "Dictionary with metadata from the WFMS."
                      type: string
         responses:
           201:
-            description: Rule created.
+            description: "Rule created."
             content:
               application/json:
                 schema:
                   type: array
                   items:
                     type: string
-                    description: Id of each created rule.
+                    description: "Id of each created rule."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No rule found for the given id
+            description: "No rule found for the given id"
           409:
             description: |
               - Invalid Replication Rule
@@ -433,13 +433,13 @@ class ReplicaLocks(ErrorHandlingMethodView):
         parameters:
         - name: rule_id
           in: path
-          description: The id of the replication rule.
+          description: "The id of the replication rule."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
@@ -448,29 +448,29 @@ class ReplicaLocks(ErrorHandlingMethodView):
                     type: object
                     properties:
                       scope:
-                        description: The scope of the lock.
+                        description: "The scope of the lock."
                         type: string
                       name:
-                        description: The name of the lock.
+                        description: "The name of the lock."
                         type: string
                       rse_id:
-                        description: The rse_id of the lock.
+                        description: "The rse_id of the lock."
                         type: string
                       rse:
-                        description: Information about the rse of the lock.
+                        description: "Information about the rse of the lock."
                         type: object
                       state:
-                        description: The state of the lock.
+                        description: "The state of the lock."
                         type: string
                       rule_id:
-                        description: The rule_id of the lock.
+                        description: "The rule_id of the lock."
                         type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No rule found for the given id
+            description: "No rule found for the given id"
           406:
-            description: Not Acceptable
+            description: "Not Acceptable"
         """
 
         def generate(vo):
@@ -492,7 +492,7 @@ class ReduceRule(ErrorHandlingMethodView):
         parameters:
         - name: rule_id
           in: path
-          description: The id of the replication rule.
+          description: "The id of the replication rule."
           schema:
             type: string
           style: simple
@@ -505,24 +505,24 @@ class ReduceRule(ErrorHandlingMethodView):
                 - copies
                 properties:
                   copies:
-                    description: Number of copies to keep.
+                    description: "Number of copies to keep."
                     type: integer
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: array
                   items:
                     type: string
-                    description: Rule id.
+                    description: "Rule id."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No rule found for the given id
+            description: "No rule found for the given id"
           409:
-            description: Rule replace failed.
+            description: "Rule replace failed."
         """
         parameters = json_parameters()
         copies = param_get(parameters, 'copies')
@@ -554,7 +554,7 @@ class MoveRule(ErrorHandlingMethodView):
         parameters:
         - name: rule_id
           in: path
-          description: The id of the replication rule.
+          description: "The id of the replication rule."
           schema:
             type: string
           style: simple
@@ -567,33 +567,33 @@ class MoveRule(ErrorHandlingMethodView):
                 - rse_expression
                 properties:
                   rse_expression:
-                    description: The new rse expression.
+                    description: "The new rse expression."
                     type: string
                   rule_id:
-                    description: The rule_id of the rule to moves. If specified, overrides the `rule_id` parameter.
+                    description: "The rule_id of the rule to moves. If specified, overrides the `rule_id` parameter."
                     type: string
                   activity:
-                    description: The `activity` of the moved rule.
+                    description: "The `activity` of the moved rule."
                     type: string
                   source_replica_expression:
-                    description: The `source_replica_expression` of the moved rule.
+                    description: "The `source_replica_expression` of the moved rule."
                     type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: array
                   items:
                     type: string
-                    description: Rule id.
+                    description: "Rule id."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No rule found for the given id
+            description: "No rule found for the given id"
           409:
-            description: Rule replace failed.
+            description: "Rule replace failed."
         """
         parameters = json_parameters()
         rse_expression = param_get(parameters, 'rse_expression')
@@ -635,42 +635,42 @@ class RuleHistory(ErrorHandlingMethodView):
         parameters:
         - name: rule_id
           in: path
-          description: The id of the replication rule.
+          description: "The id of the replication rule."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: array
                   items:
                     type: object
-                    description: Rule history object.
+                    description: "Rule history object."
                     properties:
                       updated_at:
                         type: string
-                        description: The date of the update.
+                        description: "The date of the update."
                       state:
                         type: string
-                        description: The state of the update.
+                        description: "The state of the update."
                       locks_ok_cnt:
                         type: integer
-                        description: The number of locks which are ok.
+                        description: "The number of locks which are ok."
                       locks_stuck_cnt:
                         type: integer
-                        description: The number of locks which are stuck.
+                        description: "The number of locks which are stuck."
                       locks_replicating_cnt:
                         type: integer
-                        description: The number of locks which are replicating.
+                        description: "The number of locks which are replicating."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No rule found for the given id
+            description: "No rule found for the given id"
           406:
-            description: Not acceptable.
+            description: "Not acceptable."
         """
         def generate(issuer, vo):
             for history in list_replication_rule_history(rule_id, issuer=issuer, vo=vo):
@@ -692,52 +692,52 @@ class RuleHistoryFull(ErrorHandlingMethodView):
         parameters:
         - name: scope_name
           in: path
-          description: The data identifier of scope-name to retrieve the history from. ((scope)/(name))
+          description: "The data identifier of scope-name to retrieve the history from. ((scope)/(name))"
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
                   type: array
                   items:
                     type: object
-                    description: Rule history object.
+                    description: "Rule history object."
                     properties:
                       rule_id:
                         type: string
-                        description: The id of the rule.
+                        description: "The id of the rule."
                       updated_at:
                         type: string
-                        description: The date of the update.
+                        description: "The date of the update."
                       created_at:
                         type: string
-                        description: The date of the creation.
+                        description: "The date of the creation."
                       rse_expression:
                         type: string
-                        description: The rse expression.
+                        description: "The rse expression."
                       state:
                         type: string
-                        description: The state of the update.
+                        description: "The state of the update."
                       account:
                         type: string
-                        description: The account who initiated the change.
+                        description: "The account who initiated the change."
                       locks_ok_cnt:
                         type: integer
-                        description: The number of locks which are ok.
+                        description: "The number of locks which are ok."
                       locks_stuck_cnt:
                         type: integer
-                        description: The number of locks which are stuck.
+                        description: "The number of locks which are stuck."
                       locks_replicating_cnt:
                         type: integer
-                        description: The number of locks which are replicating.
+                        description: "The number of locks which are replicating."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable.
+            description: "Not acceptable."
         """
         try:
             scope, name = parse_scope_name(scope_name, request.environ['vo'])
@@ -764,13 +764,13 @@ class RuleAnalysis(ErrorHandlingMethodView):
         parameters:
         - name: rule_id
           in: path
-          description: The id of the replication rule.
+          description: "The id of the replication rule."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
@@ -778,46 +778,46 @@ class RuleAnalysis(ErrorHandlingMethodView):
                   properties:
                     rule_error:
                       type: string
-                      description: The state of the rule.
+                      description: "The state of the rule."
                     transfers:
                       type: array
-                      description: List of all transfer errors.
+                      description: "List of all transfer errors."
                       items:
                         type: object
                         properties:
                           scope:
                             type: string
-                            description: The scope of the transfer.
+                            description: "The scope of the transfer."
                           name:
                             type: string
-                            description: The name of the lock.
+                            description: "The name of the lock."
                           rse_id:
                             type: string
-                            description: The rse_id of the transferred lock.
+                            description: "The rse_id of the transferred lock."
                           rse:
                             type: object
-                            description: Information about the rse of the transferred lock.
+                            description: "Information about the rse of the transferred lock."
                           attempts:
                             type: integer
-                            description: The number of attempts.
+                            description: "The number of attempts."
                           last_error:
                             type: string
-                            description: The last error that occurred.
+                            description: "The last error that occurred."
                           last_source:
                             type: string
-                            description: The last source.
+                            description: "The last source."
                           sources:
                             type: array
-                            description: All available rse sources.
+                            description: "All available rse sources."
                           last_time:
                             type: string
-                            description: The time of the last transfer.
+                            description: "The time of the last transfer."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: No rule found for the given id
+            description: "No rule found for the given id"
           406:
-            description: Not acceptable.
+            description: "Not acceptable."
         """
         analysis = examine_replication_rule(rule_id, issuer=request.environ['issuer'], vo=request.environ['vo'])
         return Response(render_json(**analysis), content_type='application/json')

--- a/lib/rucio/web/rest/flaskapi/v1/scopes.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scopes.py
@@ -27,24 +27,24 @@ class Scope(ErrorHandlingMethodView):
         """
         ---
         summary: List Scopes
-        description: List all scopes
+        description: "List all scopes"
         tags:
           - Scopes
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: All scopes.
+                  description: "All scopes."
                   type: array
                   items:
-                    description: A scope.
+                    description: "A scope."
                     type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         return jsonify(list_scopes(vo=request.environ['vo']))
 
@@ -52,36 +52,36 @@ class Scope(ErrorHandlingMethodView):
         """
         ---
         summary: Add Scope
-        description: Adds a new scope.
+        description: "Adds a new scope."
         tags:
           - Scopes
         parameters:
         - name: account
           in: path
-          description: The account associated with the scope.
+          description: "The account associated with the scope."
           schema:
             type: string
           style: simple
         - name: scope
           in: path
-          description: The name of the scope.
+          description: "The name of the scope."
           schema:
             type: string
           style: simple
         responses:
           201:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
                   type: string
                   enum: ["Created"]
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Account not found
+            description: "Account not found"
           409:
-            description: Scope already exists
+            description: "Scope already exists"
         """
         try:
             add_scope(scope, account, issuer=request.environ['issuer'], vo=request.environ['vo'])
@@ -100,33 +100,33 @@ class AccountScopeList(ErrorHandlingMethodView):
         """
         ---
         summary: List Account Scopes
-        description: List all scopes for an account.
+        description: "List all scopes for an account."
         tags:
           - Scopes
         parameters:
         - name: account
           in: path
-          description: The account associated with the scope.
+          description: "The account associated with the scope."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: All scopes for the account.
+                  description: "All scopes for the account."
                   type: array
                   items:
-                    description: A scope for the account.
+                    description: "A scope for the account."
                     type: string
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Account not found or no scopes
+            description: "Account not found or no scopes"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             scopes = get_scopes(account, vo=request.environ['vo'])

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -32,80 +32,80 @@ class Subscription(ErrorHandlingMethodView):
         """
         ---
         summary: Get Subscription
-        description: Retrieve a subscription.
+        description: "Retrieve a subscription."
         tags:
           - Replicas
         parameters:
         - name: account
           in: path
-          description: The account name.
+          description: "The account name."
           schema:
             type: string
           style: simple
         - name: name
           in: path
-          description: The subscription name.
+          description: "The subscription name."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of subscriptions.
+                  description: "A list of subscriptions."
                   type: array
                   items:
-                    description: A subscription.
+                    description: "A subscription."
                     type: object
                     properties:
                       id:
-                        description: The id of the subscription.
+                        description: "The id of the subscription."
                         type: string
                       name:
-                        description: The name of the subscription.
+                        description: "The name of the subscription."
                         type: string
                       filter:
-                        description: The filter for the subscription.
+                        description: "The filter for the subscription."
                         type: string
                       replication_rules:
-                        description: The replication rules for the subscription.
+                        description: "The replication rules for the subscription."
                         type: string
                       policyid:
-                        description: The policyid for the subscription.
+                        description: "The policyid for the subscription."
                         type: integer
                       state:
-                        description: The state of the subscription.
+                        description: "The state of the subscription."
                         type: string
                         enum: ["A", "I", "N", "U", "B"]
                       last_processed:
-                        description: The time the subscription was processed last.
+                        description: "The time the subscription was processed last."
                         type: string
                         format: date-time
                       account:
-                        description: The account for the subscription.
+                        description: "The account for the subscription."
                         type: string
                       lifetime:
-                        description: The lifetime for the subscription.
+                        description: "The lifetime for the subscription."
                         type: string
                         format: date-time
                       comments:
-                        description: The comments for the subscription.
+                        description: "The comments for the subscription."
                         type: string
                       retroactive:
-                        description: If the subscription is retroactive.
+                        description: "If the subscription is retroactive."
                         type: boolean
                       expired_at:
-                        description: The date-time of the expiration for the subscription.
+                        description: "The date-time of the expiration for the subscription."
                         type: string
                         format: date-time
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Subscription Not found
+            description: "Subscription Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             def generate(vo):
@@ -120,20 +120,20 @@ class Subscription(ErrorHandlingMethodView):
         """
         ---
         summary: Update subscription
-        description: Update an existing subscription.
+        description: "Update an existing subscription."
         tags:
           - Replicas
         parameters:
         - name: account
           in: path
-          description: The account name.
+          description: "The account name."
           schema:
             type: string
           style: simple
           required: true
         - name: name
           in: path
-          description: The subscription name.
+          description: "The subscription name."
           schema:
             type: string
           style: simple
@@ -147,37 +147,37 @@ class Subscription(ErrorHandlingMethodView):
                   - options
                 properties:
                   options:
-                    description: The values for the new subscription.
+                    description: "The values for the new subscription."
                     type: object
                     properties:
                       filter:
-                        description: The filter for the subscription.
+                        description: "The filter for the subscription."
                         type: string
                       replication_rules:
-                        description: The replication rules for the subscription.
+                        description: "The replication rules for the subscription."
                         type: string
                       comments:
-                        description: The comments for the subscription.
+                        description: "The comments for the subscription."
                         type: string
                       lifetime:
-                        description: The lifetime for the subscription.
+                        description: "The lifetime for the subscription."
                         type: string
                         format: date-time
                       retroactive:
-                        description: If the retroactive is activated for a subscription.
+                        description: "If the retroactive is activated for a subscription."
                         type: boolean
                       priority:
-                        description: The priority/policyid for the subscription. Stored as policyid.
+                        description: "The priority/policyid for the subscription. Stored as policyid."
                         type: integer
         responses:
           201:
-            description: OK
+            description: "OK"
           400:
-            description: Cannot decode json parameter list.
+            description: "Cannot decode json parameter list."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
         """
         parameters = json_parameters()
         options = param_get(parameters, 'options')
@@ -207,20 +207,20 @@ class Subscription(ErrorHandlingMethodView):
         """
         ---
         summary: Create subscription
-        description: Create a new subscription
+        description: "Create a new subscription"
         tags:
           - Replicas
         parameters:
         - name: account
           in: path
-          description: The account name.
+          description: "The account name."
           schema:
             type: string
           style: simple
           required: true
         - name: name
           in: path
-          description: The subscription name.
+          description: "The subscription name."
           schema:
             type: string
           style: simple
@@ -234,7 +234,7 @@ class Subscription(ErrorHandlingMethodView):
                   - options
                 properties:
                   options:
-                    description: The values for the new subscription.
+                    description: "The values for the new subscription."
                     type: object
                     required:
                       - filter
@@ -244,44 +244,44 @@ class Subscription(ErrorHandlingMethodView):
                       - retroactive
                     properties:
                       filter:
-                        description: The filter for the subscription.
+                        description: "The filter for the subscription."
                         type: string
                       replication_rules:
-                        description: The replication rules for the subscription.
+                        description: "The replication rules for the subscription."
                         type: string
                       comments:
-                        description: The comments for the subscription.
+                        description: "The comments for the subscription."
                         type: string
                       lifetime:
-                        description: The lifetime for the subscription.
+                        description: "The lifetime for the subscription."
                         type: string
                         format: date-time
                       retroactive:
-                        description: If the retroactive is activated for a subscription.
+                        description: "If the retroactive is activated for a subscription."
                         type: boolean
                       priority:
-                        description: The priority/policyid for the subscription. Stored as policyid.
+                        description: "The priority/policyid for the subscription. Stored as policyid."
                         type: integer
                       dry_run:
-                        description: The priority/policyid for the subscription. Stored as policyid.
+                        description: "The priority/policyid for the subscription. Stored as policyid."
                         type: boolean
                         default: false
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The subscription Id for the new subscription.
+                  description: "The subscription Id for the new subscription."
                   type: string
           400:
-            description: Cannot decode json parameter list.
+            description: "Cannot decode json parameter list."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         parameters = json_parameters()
         options = param_get(parameters, 'options')
@@ -326,74 +326,74 @@ class SubscriptionName(ErrorHandlingMethodView):
         """
         ---
         summary: Get Subscription by Name
-        description: Retrieve a subscription by name.
+        description: "Retrieve a subscription by name."
         tags:
           - Replicas
         parameters:
         - name: name
           in: path
-          description: The subscription name.
+          description: "The subscription name."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of subscriptions.
+                  description: "A list of subscriptions."
                   type: array
                   items:
-                    description: A subscription.
+                    description: "A subscription."
                     type: object
                     properties:
                       id:
-                        description: The id of the subscription.
+                        description: "The id of the subscription."
                         type: string
                       name:
-                        description: The name of the subscription.
+                        description: "The name of the subscription."
                         type: string
                       filter:
-                        description: The filter for the subscription.
+                        description: "The filter for the subscription."
                         type: string
                       replication_rules:
-                        description: The replication rules for the subscription.
+                        description: "The replication rules for the subscription."
                         type: string
                       policyid:
-                        description: The policyid for the subscription.
+                        description: "The policyid for the subscription."
                         type: integer
                       state:
-                        description: The state of the subscription.
+                        description: "The state of the subscription."
                         type: string
                         enum: ["A", "I", "N", "U", "B"]
                       last_processed:
-                        description: The time the subscription was processed last.
+                        description: "The time the subscription was processed last."
                         type: string
                         format: date-time
                       account:
-                        description: The account for the subscription.
+                        description: "The account for the subscription."
                         type: string
                       lifetime:
-                        description: The lifetime for the subscription.
+                        description: "The lifetime for the subscription."
                         type: string
                         format: date-time
                       comments:
-                        description: The comments for the subscription.
+                        description: "The comments for the subscription."
                         type: string
                       retroactive:
-                        description: If the subscription is retroactive.
+                        description: "If the subscription is retroactive."
                         type: boolean
                       expired_at:
-                        description: The date-time of the expiration for the subscription.
+                        description: "The date-time of the expiration for the subscription."
                         type: string
                         format: date-time
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             def generate(vo):
@@ -412,45 +412,45 @@ class Rules(ErrorHandlingMethodView):
         """
         ---
         summary: Get Replication Rules
-        description: Return all rules of a given subscription id.
+        description: "Return all rules of a given subscription id."
         tags:
           - Replicas
         parameters:
         - name: account
           in: path
-          description: The account name.
+          description: "The account name."
           schema:
             type: string
           style: simple
           required: true
         - name: name
           in: path
-          description: The subscription name.
+          description: "The subscription name."
           schema:
             type: string
           style: simple
           required: true
         - name: state
           in: query
-          description: The subscription state to filter for.
+          description: "The subscription state to filter for."
           schema:
             type: string
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list with the associated replication rules.
+                  description: "A list with the associated replication rules."
                   type: array
                   items:
-                    description: A subscription rule.
+                    description: "A subscription rule."
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Rule or Subscription not found
+            description: "Rule or Subscription not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         state = request.args.get('state', default=None)
         try:
@@ -477,53 +477,53 @@ class States(ErrorHandlingMethodView):
         """
         ---
         summary: Get states
-        description: Return a summary of the states of all rules of a given subscription id.
+        description: "Return a summary of the states of all rules of a given subscription id."
         tags:
           - Replicas
         parameters:
         - name: account
           in: path
-          description: The account name.
+          description: "The account name."
           schema:
             type: string
           style: simple
           required: true
         - name: name
           in: path
-          description: The subscription name.
+          description: "The subscription name."
           schema:
             type: string
           style: simple
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/x-json-stream:
                 schema:
-                  description: A list of rule states with counts for each subscription.
+                  description: "A list of rule states with counts for each subscription."
                   type: array
                   items:
                     type: object
                     properties:
                       account:
-                        description: The account for the subscription.
+                        description: "The account for the subscription."
                         type: string
                       name:
-                        description: The name of the subscription.
+                        description: "The name of the subscription."
                         type: string
                       state:
-                        description: The state of the rules.
+                        description: "The state of the rules."
                         type: string
                         enum: ["R", "O", "S", "U", "W", "I"]
                       count:
-                        description: The number of rules with that state.
+                        description: "The number of rules with that state."
                         type: integer
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Not found
+            description: "Not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         def generate(vo):
             for row in list_subscription_rule_states(name=name, account=account, vo=vo):
@@ -539,72 +539,72 @@ class SubscriptionId(ErrorHandlingMethodView):
         """
         ---
         summary: Get Subscription from ID
-        description: Retrieve a subscription matching the given subscription id.
+        description: "Retrieve a subscription matching the given subscription id."
         tags:
           - Replicas
         parameters:
         - name: subscription_id
           in: path
-          description: The subscription id.
+          description: "The subscription id."
           schema:
             type: string
           style: simple
           required: true
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
-                  description: The subscription.
+                  description: "The subscription."
                   type: object
                   properties:
                     id:
-                      description: The id of the subscription.
+                      description: "The id of the subscription."
                       type: string
                     name:
-                      description: The name of the subscription.
+                      description: "The name of the subscription."
                       type: string
                     filter:
-                      description: The filter for the subscription.
+                      description: "The filter for the subscription."
                       type: string
                     replication_rules:
-                      description: The replication rules for the subscription.
+                      description: "The replication rules for the subscription."
                       type: string
                     policyid:
-                      description: The policyid for the subscription.
+                      description: "The policyid for the subscription."
                       type: integer
                     state:
-                      description: The state of the subscription.
+                      description: "The state of the subscription."
                       type: string
                       enum: ["A", "I", "N", "U", "B"]
                     last_processed:
-                      description: The time the subscription was processed last.
+                      description: "The time the subscription was processed last."
                       type: string
                       format: date-time
                     account:
-                      description: The account for the subscription.
+                      description: "The account for the subscription."
                       type: string
                     lifetime:
-                      description: The lifetime for the subscription.
+                      description: "The lifetime for the subscription."
                       type: string
                       format: date-time
                     comments:
-                      description: The comments for the subscription.
+                      description: "The comments for the subscription."
                       type: string
                     retroactive:
-                      description: If the subscription is retroactive.
+                      description: "If the subscription is retroactive."
                       type: boolean
                     expired_at:
-                      description: The date-time of the expiration for the subscription.
+                      description: "The date-time of the expiration for the subscription."
                       type: string
                       format: date-time
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Subscription not found
+            description: "Subscription not found"
           406:
-            description: Not acceptable
+            description: "Not acceptable"
         """
         try:
             subscription = get_subscription_by_id(subscription_id, vo=request.environ['vo'])

--- a/lib/rucio/web/rest/flaskapi/v1/traces.py
+++ b/lib/rucio/web/rest/flaskapi/v1/traces.py
@@ -42,7 +42,7 @@ class Trace(ErrorHandlingMethodView):
         """
         ---
       summary: Trace
-      description: Trace endpoint used by the pilot and CLI clients to post data access information.
+      description: "Trace endpoint used by the pilot and CLI clients to post data access information."
       tags:
         - Trace
       parameters:
@@ -59,49 +59,49 @@ class Trace(ErrorHandlingMethodView):
               oneOf:
                 ObjectSchema:
                   - requires: [eventType, clientState, account]
-                  - description: touch one or more DIDs
+                  - description: "Touch one or more DIDs"
                 UploadSchema:
                   - requires: [eventType, hostname, account, eventVersion, uuid, scope, dataset, remoteSite, filesize, protocol, transferStart]
-                  - description: upload method
+                  - description: "Upload method"
                 DownloadSchema:
                   - requires: [eventType, hostname, localSite, account, eventVersion, uuid, scope, filename, dataset, filesize, clientState, stateReason]
-                  - description: download method
+                  - description: "Download method"
                 GetSchema:
                   - requires: [eventType, localSite, eventVersion, uuid, scope, filename, dataset]
-                  - description: get method, mainly sent by pilots
+                  - description: "Get method, mainly sent by pilots"
                 PutSchema:
                   - requires: [eventType, localSite, eventVersion, uuid, scope, filename, dataset]
-                  - description: put method, mainly sent by pilots
+                  - description: "Put method, mainly sent by pilots"
                 SpecialSchema:
                   - requires: [eventType, clientState, account]
-                  - description: A special schema to capture most unsupported eventTypes
+                  - description: "A special schema to capture most unsupported eventTypes"
             - type: array
               items:
                 type: object
                 oneOf:
                   ObjectSchema:
                     - requires: [eventType, clientState, account]
-                    - description: touch one or more DIDs
+                    - description: "Touch one or more DIDs"
                   UploadSchema:
                     - requires: [eventType, hostname, account, eventVersion, uuid, scope, dataset, remoteSite, filesize, protocol, transferStart]
-                    - description: upload method
+                    - description: "Upload method"
                   DownloadSchema:
                     - requires: [eventType, hostname, localSite, account, eventVersion, uuid, scope, filename, dataset, filesize, clientState, stateReason]
-                    - description: download method
+                    - description: "Download method"
                   GetSchema:
                     - requires: [eventType, localSite, eventVersion, uuid, scope, filename, dataset]
-                    - description: get method, mainly sent by pilots
+                    - description: "Get method, mainly sent by pilots"
                   PutSchema:
                     - requires: [eventType, localSite, eventVersion, uuid, scope, filename, dataset]
-                    - description: put method, mainly sent by pilots
+                    - description: "Put method, mainly sent by pilots"
                   SpecialSchema:
                     - requires: [eventType, clientState, account]
-                    - description: A special schema to capture most unsupported eventTypes
+                    - description: "A special schema to capture most unsupported eventTypes"
       responses:
         201:
-          description: OK
+          description: "OK"
         400:
-          description: Cannot decode json data.
+          description: "Cannot decode json data."
     """
         headers = self.get_headers()
         parameters = request.data
@@ -112,10 +112,10 @@ class Trace(ErrorHandlingMethodView):
         # Trace gateway handles all errors and sends them to a log - no need for any error checking
         trace_ip = request.headers.get("X-Forwarded-For", default=request.remote_addr)
         try:
-          trace(request=parameters, trace_ip=trace_ip)
-          return Response("Created", 201, headers)
+            trace(request=parameters, trace_ip=trace_ip)
+            return Response("Created", 201, headers)
         except JSONDecodeError as err:
-          return generate_http_error_flask(400, err)
+            return generate_http_error_flask(400, err)
 
 
 def blueprint():

--- a/lib/rucio/web/rest/flaskapi/v1/vos.py
+++ b/lib/rucio/web/rest/flaskapi/v1/vos.py
@@ -33,7 +33,7 @@ class VOs(ErrorHandlingMethodView):
           - VO
         responses:
           200:
-            description: OK
+            description: "OK"
             content:
               application/json:
                 schema:
@@ -42,29 +42,29 @@ class VOs(ErrorHandlingMethodView):
                     type: object
                     properties:
                       vo:
-                        description: The vo.
+                        description: "The vo."
                         type: string
                       description:
-                        description: The description of the vo.
+                        description: "The description of the vo."
                         type: string
                       email:
-                        description: The email for the vo.
+                        description: "The email for the vo."
                         type: string
                       created_at:
-                        description: The date the vo was created.
+                        description: "The date the vo was created."
                         type: string
                         format: date-time
                       updated_at:
-                        description: The date the vo was updated.
+                        description: "The date the vo was updated."
                         type: string
                         format: date-time
 
           406:
-            description: Not Acceptable
+            description: "Not Acceptable"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           409:
-            description: Unsupported operation.
+            description: "Unsupported operation."
         """
         try:
             def generate(issuer, vo):
@@ -90,7 +90,7 @@ class VO(ErrorHandlingMethodView):
         parameters:
         - name: vo
           in: path
-          description: The vo to add.
+          description: "The vo to add."
           schema:
             type: string
           style: simple
@@ -101,18 +101,18 @@ class VO(ErrorHandlingMethodView):
                 type: object
                 properties:
                   description:
-                    description: The description of the VO.
+                    description: "The description of the VO."
                     type: string
                   email:
-                    description: The admin email associated with the VO.
+                    description: "The admin email associated with the VO."
                     type: string
         responses:
           201:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           409:
-            description: Unsupported operation.
+            description: "Unsupported operation."
         """
         parameters = json_parameters(optional=True)
         kwargs = {'description': None, 'email': None}
@@ -137,7 +137,7 @@ class VO(ErrorHandlingMethodView):
         parameters:
         - name: vo
           in: path
-          description: The vo to add.
+          description: "The vo to add."
           schema:
             type: string
           style: simple
@@ -148,20 +148,20 @@ class VO(ErrorHandlingMethodView):
                 type: object
                 properties:
                   description:
-                    description: The description of the VO.
+                    description: "The description of the VO."
                     type: string
                   email:
-                    description: The admin email associated with the VO.
+                    description: "The admin email associated with the VO."
                     type: string
         responses:
           200:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: VO not found.
+            description: "VO not found."
           409:
-            description: Unsupported operation.
+            description: "Unsupported operation."
         """
         parameters = json_parameters()
         try:
@@ -188,7 +188,7 @@ class RecoverVO(ErrorHandlingMethodView):
         parameters:
         - name: vo
           in: path
-          description: The vo to add.
+          description: "The vo to add."
           schema:
             type: string
           style: simple
@@ -203,29 +203,29 @@ class RecoverVO(ErrorHandlingMethodView):
                 - email
                 properties:
                   identity:
-                    description: Identity key to use.
+                    description: "Identity key to use."
                     type: string
                   authtype:
-                    description: The authtype of the account.
+                    description: "The authtype of the account."
                     type: string
                   email:
-                    description: The admin email for the vo.
+                    description: "The admin email for the vo."
                     type: string
                   password:
-                    description: Password for identity.
+                    description: "Password for identity."
                     type: string
                   default:
-                    description: Whether to use identity as account default.
+                    description: "Whether to use identity as account default."
                     type: boolean
         responses:
           201:
-            description: OK
+            description: "OK"
           401:
-            description: Invalid Auth Token
+            description: "Invalid Auth Token"
           404:
-            description: Account not found.
+            description: "Account not found."
           409:
-            description: Unsupported operation.
+            description: "Unsupported operation."
         """
         parameters = json_parameters()
         identity = param_get(parameters, 'identity')

--- a/tests/test_gateway_external_representation.py
+++ b/tests/test_gateway_external_representation.py
@@ -137,7 +137,7 @@ class TestGatewayExternalRepresentation:
         gateway_acc_lim.set_local_account_limit(account_name, rse1, 10000, issuer='root', vo=vo)
         gateway_acc_lim.set_global_account_limit(account_name, rse_expr, 20000, issuer='root', vo=vo)
 
-        out = gateway_acc_lim.get_local_account_limit(account_name,rse=None, vo=vo)
+        out = gateway_acc_lim.get_local_account_limit(account_name, rse=None, vo=vo)
         assert rse1 in out
         assert rse1_id not in out
 


### PR DESCRIPTION
**Suggested change**
Wrap every one-line description: value in double quotes across our OpenAPI specs.

**Why**
We could have quoted only the fields that currently contain reserved YAML characters, but applying the rule everywhere makes the style self-evident for future authors, likely avoiding subtle parse errors.

**Next step**
Add validation to enforce either proper escaping or mandatory double-quotes so the rule stays consistent (see https://github.com/rucio/documentation/issues/567).