### PR TITLE
Database: cx oracle upgrade; Fix #6467

### DIFF
--- a/etc/alembic.ini.template
+++ b/etc/alembic.ini.template
@@ -18,7 +18,7 @@
 # Choose one of the databases+schema below
 # Oracle, PostgreSQL, MySQL/MariaDB are fully supported
 
-sqlalchemy.url=oracle://user:pass@servicename
+sqlalchemy.url=oracle+oracledb://user:pass@servicename
 version_table_schema=rucio
 
 #sqlalchemy.url=postgresql+psycopg://rucio:rucio@psql-hostname:5432/rucio

--- a/etc/alembic_offline.ini.template
+++ b/etc/alembic_offline.ini.template
@@ -18,7 +18,7 @@
 # Choose one of the databases+schema below
 # Oracle, PostgreSQL, MySQL/MariaDB are fully supported
 
-#sqlalchemy.url=oracle://user:pass@servicename
+#sqlalchemy.url=oracle+oracledb://user:pass@servicename
 #version_table_schema=rucio
 
 #sqlalchemy.url=postgresql+psycopg://rucio:rucio@psql-hostname:5432/rucio

--- a/etc/docker/test/extra/alembic_oracle.ini
+++ b/etc/docker/test/extra/alembic_oracle.ini
@@ -24,7 +24,7 @@ script_location = lib/rucio/db/sqla/migrate_repo/
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-sqlalchemy.url = oracle://system:rucio@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=oracle)(PORT=1521))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=XE)))
+sqlalchemy.url = oracle+oracledb://system:rucio@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=oracle)(PORT=1521))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=XE)))
 version_table_schema = SYSTEM
 
 # Logging configuration

--- a/etc/docker/test/extra/rucio_oracle.cfg
+++ b/etc/docker/test/extra/rucio_oracle.cfg
@@ -1,5 +1,5 @@
 [database]
-default = oracle://system:rucio@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=oracle)(PORT=1521))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=XE)))
+default = oracle+oracledb://system:rucio@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=oracle)(PORT=1521))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=XE)))
 schema=system
 pool_size = 20
 max_overflow = 20

--- a/etc/rucio.cfg.template
+++ b/etc/rucio.cfg.template
@@ -73,8 +73,8 @@ default_mail_from = spamspamspam@cern.ch
 
 [database]
 default = sqlite:////tmp/rucio.db
-#default = oracle://_____________:___________@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=_________)(PORT=______))(ADDRESS=(PROTOCOL=TCP)(HOST=_________)(PORT=_____))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=__________)))
-#default = oracle://_____________:___________@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=______))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=_____________)))
+#default = oracle+oracledb://_____________:___________@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=_________)(PORT=______))(ADDRESS=(PROTOCOL=TCP)(HOST=_________)(PORT=_____))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=__________)))
+#default = oracle+oracledb://_____________:___________@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=______))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=_____________)))
 #schema=atlas_rucio  # only for cern oracle
 #default = mysql+pymysql://rucio:rucio@localhost/rucio
 #default = postgresql+psycopg://rucio:rucio@localhost/rucio

--- a/etc/rucio_multi_vo.cfg.template
+++ b/etc/rucio_multi_vo.cfg.template
@@ -56,8 +56,8 @@ default_mail_from = spamspamspam@cern.ch
 
 [database]
 default = sqlite:////tmp/rucio.db
-#default = oracle://_____________:___________@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=_________)(PORT=______))(ADDRESS=(PROTOCOL=TCP)(HOST=_________)(PORT=_____))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=__________)))
-#default = oracle://_____________:___________@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=______))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=_____________)))
+#default = oracle+oracledb://_____________:___________@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=_________)(PORT=______))(ADDRESS=(PROTOCOL=TCP)(HOST=_________)(PORT=_____))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=__________)))
+#default = oracle+oracledb://_____________:___________@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=______))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=_____________)))
 #schema=atlas_rucio  # only for cern oracle
 #default = mysql+pymysql://rucio:rucio@localhost/rucio
 #default = postgresql+psycopg://rucio:rucio@localhost/rucio

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -102,7 +102,7 @@ cryptography==44.0.2
     #   pyjwt
     #   pyspnego
     #   requests-kerberos
-cx-oracle==8.3.0
+oracledb==3.1.1
     # via -r requirements.server.txt
 databind==4.5.2
     # via

--- a/requirements/requirements.server.in
+++ b/requirements/requirements.server.in
@@ -29,9 +29,9 @@ requests-kerberos==0.15.0                                   # kerberos_extras fo
 python-swiftclient==4.7.0                                   # swift_extras
 argcomplete==3.5.3                                          # argcomplete_extras; Bash tab completion for argparse
 python-magic==0.4.27                                        # dumper_extras; File type identification using libmagic
-cx_oracle==8.3.0                                            # oracle_extras
+oracledb==3.1.1                                             # oracle_extras
 psycopg[pool]==3.2.3                                        # postgresql
-psycopg[binary]==3.2.3; implementation_name=="cpython"       # postgresql binary optimizations
+psycopg[binary]==3.2.3; implementation_name=="cpython"      # postgresql binary optimizations
 PyMySQL==1.1.1                                              # mysql_extras
 PyYAML==6.0.2                                               # globus_extras and used for reading test configuration files
 globus-sdk==3.41.0                                          # globus_extras

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -57,7 +57,7 @@ cryptography==44.0.2
     #   pyjwt
     #   pyspnego
     #   requests-kerberos
-cx-oracle==8.3.0
+oracledb==3.1.1
     # via -r requirements.server.in
 decorator==5.2.1
     # via

--- a/setuputil.py
+++ b/setuputil.py
@@ -89,7 +89,7 @@ server_requirements_table = {
         'prometheus_client<=0.21.1',
     ],
     'extras_require': {
-        'oracle': ['cx_oracle<=8.3.0'],
+        'oracle': ['oracledb<=3.1.1'],
         'mongo': ['pymongo<=4.11.2'],
         'elastic': ['elasticsearch<=8.15.1'],
         'postgresql': [

--- a/tools/pytest.sh
+++ b/tools/pytest.sh
@@ -41,8 +41,7 @@ elif [[ "${RDBMS:-}" =~ mysql.* ]]; then
   echo "Disabling parallel testing for mysql"
   NO_XDIST="True"
 elif [[ "${RDBMS:-}" == "oracle" ]]; then
-  # no parallel tests on oracle, because of random "cx_Oracle.DatabaseError:
-  # ORA-00060: deadlock detected while waiting for resource"
+  # no parallel tests on oracle, because of potential database deadlock errors.
   echo "Disabling parallel testing for oracle"
   NO_XDIST="True"
 fi


### PR DESCRIPTION
- Replaced the old `cx_oracle` extra with the new `oracledb` driver in setup utilities
- Updated server requirements
- Revised default Oracle connection strings to use the `oracle+oracledb://` dialect
- Instant Client removal from the Dockerfiles (needs to be handled also at the containers side)
    _Regarding this, I assumed that the Dockerfile previously installed the Oracle Instant Client libraries since the `cx_oracle` package is a Python wrapper around Oracle’s OCI libraries and so, the native libraries (provided by the Instant Client RPMs) had to be available at runtime. With the migration to `oracledb`, these libraries are no longer needed, so I cleared that part._
- Tests seem to be fine (https://github.com/Geogouz/rucio/actions/runs/15416890108/job/43381695039#step:4:1967)
- I hope the universe doesn't explode