### PR TITLE
Core & Internals: Adjust FileToUploadDict-related types; Fixes #7762

### DIFF
--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -21,7 +21,8 @@ import os.path
 import random
 import socket
 import time
-from typing import TYPE_CHECKING, Any, Final, Optional, cast
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final, Optional, Union, cast
 
 from rucio import version
 from rucio.client.client import Client
@@ -106,7 +107,7 @@ class UploadClient:
     def upload(
             self,
             items: "Iterable[FileToUploadDict]",
-            summary_file_path: Optional[str] = None,
+            summary_file_path: Optional[Union[str, os.PathLike[str]]] = None,
             traces_copy_out: Optional[list["TraceBaseDict"]] = None,
             ignore_availability: bool = False,
             activity: Optional[str] = None
@@ -226,7 +227,7 @@ class UploadClient:
             rse_attributes = {}
             try:
                 rse_attributes = self.client.list_rse_attributes(rse)
-            except:
+            except Exception:
                 logger(logging.WARNING, 'Attributes of the RSE: %s not available.' % rse)
             if (self.client_location and 'lan' in rse_settings['domain'] and RseAttr.SITE in rse_attributes):
                 if self.client_location['site'] == rse_attributes[RseAttr.SITE]:
@@ -377,7 +378,8 @@ class UploadClient:
                     if checksum_name in file:
                         final_summary[file_did_str][checksum_name] = file[checksum_name]
 
-            with open(summary_file_path, 'w') as summary_file:
+            summary_path = Path(summary_file_path)
+            with summary_path.open('w') as summary_file:
                 json.dump(final_summary, summary_file, sort_keys=True, indent=1)
 
         if num_succeeded == 0:

--- a/lib/rucio/common/types.py
+++ b/lib/rucio/common/types.py
@@ -17,10 +17,10 @@ from collections.abc import Callable
 from os import PathLike
 
 if sys.version_info < (3, 11):  # pragma: no cover
-    from typing_extensions import TYPE_CHECKING, Any, Literal, NotRequired, Optional, TypedDict, TypeGuard, Union  # noqa: UP035
+    from typing_extensions import TYPE_CHECKING, Any, Literal, NotRequired, Optional, Required, TypedDict, TypeGuard, Union  # noqa: UP035
     PathTypeAlias = Union[PathLike, str]
 else:
-    from typing import TYPE_CHECKING, Any, Literal, NotRequired, Optional, TypedDict, TypeGuard, Union
+    from typing import TYPE_CHECKING, Any, Literal, NotRequired, Optional, Required, TypedDict, TypeGuard, Union
     PathTypeAlias = PathLike
 
 
@@ -389,8 +389,8 @@ class TraceSchemaDict(TypedDict):
 class FileToUploadDict(TypedDict):
     path: PathTypeAlias
     rse: str
-    did_scope: str
-    did_name: str
+    did_scope: NotRequired[str]
+    did_name: NotRequired[str]
     dataset_scope: NotRequired[str]
     dataset_name: NotRequired[str]
     dataset_meta: NotRequired[str]
@@ -406,6 +406,8 @@ class FileToUploadDict(TypedDict):
 
 
 class FileToUploadWithCollectedInfoDict(FileToUploadDict):
+    did_name: Required[str]
+    did_scope: Required[str]
     basename: str
     adler32: str
     md5: str
@@ -415,12 +417,11 @@ class FileToUploadWithCollectedInfoDict(FileToUploadDict):
     dirname: str
     upload_result: dict
     bytes: int
-    basename: str
 
 
 class FileToUploadWithCollectedAndDatasetInfoDict(FileToUploadWithCollectedInfoDict):
-    dataset_scope: str
-    dataset_name: str
+    dataset_scope: Required[str]
+    dataset_name: Required[str]
 
 
 class RequestGatewayDict(TypedDict):

--- a/tests/temp_factories.py
+++ b/tests/temp_factories.py
@@ -485,7 +485,7 @@ class TemporaryDidFactory:
             'guid': generate_uuid(),
         }
         activity = get_schema_value('ACTIVITY')['enum'][0]
-        self.upload_client.upload([item], activity=activity)
+        self.upload_client.upload(items=[item], activity=activity)
         did: DIDDict = {'scope': scope, 'name': name}
         self.created_dids.add((scope, name))
         return item if return_full_item else did
@@ -515,7 +515,7 @@ class TemporaryDidFactory:
                          'guid': generate_uuid(),
                          })
             self.created_dids.add((scope, name))
-        self.upload_client.upload(items)
+        self.upload_client.upload(items=items)
         return items
 
 

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -13,12 +13,16 @@
 # limitations under the License.
 import json
 import tempfile
+from typing import TYPE_CHECKING
 
 import pytest
 
 from rucio.common.exception import RucioException
 from rucio.common.utils import generate_uuid
 from rucio.tests.common import account_name_generator, execute, file_generator, rse_name_generator, scope_name_generator
+
+if TYPE_CHECKING:
+    from rucio.common.types import FileToUploadDict
 
 
 def test_main_args():
@@ -401,7 +405,15 @@ def test_lifetime_exception(rucio_client, mock_scope):
     mock_did = tempfile.NamedTemporaryFile()
     mock_rse = "MOCK-POSIX"
     upload_client = UploadClient(rucio_client)
-    upload_client.upload(items=[{"path": mock_did.name, "rse": mock_rse, "did_scope": mock_scope.external}])
+
+    item: FileToUploadDict = {
+        'path': mock_did.name,
+        'rse': mock_rse,
+        'did_scope': mock_scope.external,
+    }
+
+    upload_client.upload(items=[item])
+
     with open(input_file.name, "w") as f:
         f.write(f"{mock_scope}:{mock_did.name.split('/')[-1]}")
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -25,7 +25,7 @@ import pytest
 from rucio.client.downloadclient import DownloadClient
 from rucio.common.config import config_add_section, config_set
 from rucio.common.exception import InputValidationError, NoFilesDownloaded, RucioException
-from rucio.common.types import InternalScope
+from rucio.common.types import FileToUploadDict, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core import did as did_core
 from rucio.core import scope as scope_core
@@ -653,17 +653,20 @@ def test_download_file_with_impl(rse_factory, did_factory, download_client, mock
                               'wan': {'read': 2, 'write': 2, 'delete': 2}}})
     path = file_generator()
     name = os.path.basename(path)
-    item = {
+
+    item: FileToUploadDict = {
         'path': path,
         'rse': rse,
         'did_scope': str(mock_scope),
         'did_name': name,
         'guid': generate_uuid(),
     }
-    did_factory.upload_client.upload([item])
+
+    did_factory.upload_client.upload(items=[item])
     did_str = '%s:%s' % (mock_scope, name)
+
     with patch('rucio.rse.protocols.%s.Default.get' % impl, side_effect=lambda pfn, dest, **kw: shutil.copy(path, dest)) as mock_get, \
-            patch('rucio.rse.protocols.%s.Default.connect' % impl),\
+            patch('rucio.rse.protocols.%s.Default.connect' % impl), \
             patch('rucio.rse.protocols.%s.Default.close' % impl):
         download_client.download_dids([{'did': did_str, 'impl': impl}])
         mock_get.assert_called()
@@ -710,18 +713,20 @@ def test_download_file_with_supported_protocol_from_config(rse_factory, did_fact
 
     path = file_generator()
     name = os.path.basename(path)
-    item = {
+
+    item: FileToUploadDict = {
         'path': path,
         'rse': rse,
         'did_scope': str(mock_scope),
         'did_name': name,
         'guid': generate_uuid(),
     }
-    did_factory.upload_client.upload([item])
+
+    did_factory.upload_client.upload(items=[item])
     did_str = '%s:%s' % (mock_scope, name)
 
     with patch('rucio.rse.protocols.%s.Default.get' % supported_impl, side_effect=lambda pfn, dest, **kw: shutil.copy(path, dest)) as mock_get, \
-            patch('rucio.rse.protocols.%s.Default.connect' % supported_impl),\
+            patch('rucio.rse.protocols.%s.Default.connect' % supported_impl), \
             patch('rucio.rse.protocols.%s.Default.close' % supported_impl):
         download_client.download_dids([{'did': did_str, 'impl': supported_impl}])
         mock_get.assert_called()

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -124,7 +124,7 @@ def test_trace_ip():
             validate_schema(obj)
 
 
-def test_non_existant_event_type_validation_rejection():
+def test_non_existent_event_type_validation_rejection():
     event_type = "put_new_type"
     obj = json.dumps({"eventType": f"{event_type}"})
     with pytest.raises(TraceValidationSchemaNotFound):


### PR DESCRIPTION
As described in #7762, the main goal of this PR is to use typed item `FileToUploadDict` properly.
The commits dive into more details about the introduced changes.