### PR TITLE
Move TransferLimitDirection db/sqla/constants.py to common/constants.py and fix its imports

### DIFF
--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -19,8 +19,8 @@ from urllib.parse import quote_plus
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import TransferLimitDirection
 from rucio.common.utils import build_url
-from rucio.db.sqla.constants import TransferLimitDirection
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence

--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -69,6 +69,10 @@ FTS_JOB_TYPE = namedtuple('FTS_JOB_TYPE', ['MULTIPLE_REPLICA', 'MULTI_HOP', 'SES
 
 MAX_MESSAGE_LENGTH = 4000
 
+@enum.unique
+class TransferLimitDirection(enum.Enum):
+    SOURCE = 'S'
+    DESTINATION = 'D'
 
 @enum.unique
 class SuspiciousAvailability(enum.Enum):

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -31,7 +31,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.sql.expression import asc, false, func, null, true
 
 from rucio.common.config import config_get_bool, config_get_int
-from rucio.common.constants import RseAttr
+from rucio.common.constants import RseAttr, TransferLimitDirection
 from rucio.common.exception import InvalidRSEExpression, RequestNotFound, RucioException, UnsupportedOperation
 from rucio.common.types import FilterDict, InternalAccount, InternalScope, LoggerFunction, RequestDict
 from rucio.common.utils import chunks, generate_uuid
@@ -41,7 +41,7 @@ from rucio.core.monitor import MetricManager
 from rucio.core.rse import RseCollection, RseData, get_rse_attribute, get_rse_name, get_rse_vo
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla import filter_thread_work, models
-from rucio.db.sqla.constants import LockState, ReplicaState, RequestErrMsg, RequestState, RequestType, TransferLimitDirection
+from rucio.db.sqla.constants import LockState, ReplicaState, RequestErrMsg, RequestState, RequestType
 from rucio.db.sqla.session import read_session, stream_session, transactional_session
 from rucio.db.sqla.util import temp_table_mngr
 

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -28,7 +28,7 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 
 from rucio.common.config import config_get, config_get_list
-from rucio.common.constants import SUPPORTED_PROTOCOLS, RseAttr
+from rucio.common.constants import SUPPORTED_PROTOCOLS, RseAttr, TransferLimitDirection
 from rucio.common.exception import InvalidRSEExpression, RequestNotFound, RSEProtocolNotSupported, RucioException, UnsupportedOperation
 from rucio.common.utils import construct_non_deterministic_pfn, get_transfer_schemas
 from rucio.core import did
@@ -39,7 +39,7 @@ from rucio.core.monitor import MetricManager
 from rucio.core.request import DirectTransfer, RequestSource, RequestWithSources, TransferDestination, transition_request_state
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla import models
-from rucio.db.sqla.constants import DIDType, RequestState, RequestType, TransferLimitDirection
+from rucio.db.sqla.constants import DIDType, RequestState, RequestType
 from rucio.db.sqla.session import read_session, stream_session, transactional_session
 from rucio.rse import rsemanager as rsemgr
 from rucio.transfertool.bittorrent import BittorrentTransfertool

--- a/lib/rucio/daemons/conveyor/throttler.py
+++ b/lib/rucio/daemons/conveyor/throttler.py
@@ -26,13 +26,14 @@ from sqlalchemy import null
 
 import rucio.db.sqla.util
 from rucio.common import exception
+from rucio.common.constants import TransferLimitDirection
 from rucio.common.logging import setup_logging
 from rucio.core.monitor import MetricManager
 from rucio.core.request import get_request_stats, re_sync_all_transfer_limits, release_all_waiting_requests, release_waiting_requests_fifo, release_waiting_requests_grouped_fifo, reset_stale_waiting_requests, set_transfer_limit_stats
 from rucio.core.rse import RseCollection, RseData
 from rucio.core.transfer import applicable_rse_transfer_limits
 from rucio.daemons.common import ProducerConsumerDaemon, db_workqueue
-from rucio.db.sqla.constants import RequestState, TransferLimitDirection
+from rucio.db.sqla.constants import RequestState
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/lib/rucio/db/sqla/constants.py
+++ b/lib/rucio/db/sqla/constants.py
@@ -196,9 +196,9 @@ class SubscriptionState(Enum):
     BROKEN = 'B'
 
 
-class TransferLimitDirection(Enum):
-    SOURCE = 'S'
-    DESTINATION = 'D'
+#class TransferLimitDirection(Enum):
+#    SOURCE = 'S'
+#    DESTINATION = 'D'
 
 
 class DatabaseOperationType(Enum):

--- a/lib/rucio/db/sqla/migrate_repo/versions/13d4f70c66a9_introduce_transfer_limits.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/13d4f70c66a9_introduce_transfer_limits.py
@@ -19,7 +19,7 @@ import sqlalchemy as sa
 from alembic import context
 from alembic.op import create_check_constraint, create_foreign_key, create_index, create_primary_key, create_table, drop_table
 
-from rucio.db.sqla.constants import TransferLimitDirection
+from rucio.common.constants import TransferLimitDirection
 from rucio.db.sqla.types import GUID
 
 # Alembic revision identifiers

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -29,6 +29,7 @@ from sqlalchemy.types import LargeBinary
 # and it must be renamed to avoid conflicts with the policy package schema modules
 from rucio.common import schema as common_schema
 from rucio.common import utils
+from rucio.common.constants import TransferLimitDirection
 from rucio.common.types import InternalAccount, InternalScope  # noqa: TCH001 (types are needed by SQLAlchemy)
 from rucio.db.sqla.constants import (
     AccountStatus,
@@ -51,7 +52,6 @@ from rucio.db.sqla.constants import (
     RuleState,
     ScopeStatus,
     SubscriptionState,
-    TransferLimitDirection,
 )
 from rucio.db.sqla.session import BASE
 from rucio.db.sqla.types import GUID, JSON, BooleanString, InternalAccountString, InternalScopeString

--- a/lib/rucio/gateway/request.py
+++ b/lib/rucio/gateway/request.py
@@ -19,11 +19,12 @@ Interface for the requests abstraction layer
 from typing import TYPE_CHECKING, Any, Optional
 
 from rucio.common import exception
+from rucio.common.constants import TransferLimitDirection
 from rucio.common.types import InternalAccount, InternalScope, RequestGatewayDict
 from rucio.common.utils import gateway_update_return_dict
 from rucio.core import request
 from rucio.core.rse import get_rse_id
-from rucio.db.sqla.constants import DatabaseOperationType, TransferLimitDirection
+from rucio.db.sqla.constants import DatabaseOperationType
 from rucio.db.sqla.session import db_session
 from rucio.gateway import permission
 

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -18,10 +18,11 @@ from typing import TYPE_CHECKING, Union, cast
 import flask
 from flask import Flask, Response
 
+from rucio.common.constants import TransferLimitDirection
 from rucio.common.exception import AccessDenied, RequestNotFound
 from rucio.common.utils import APIEncoder, render_json
 from rucio.core.rse import get_rses_with_attribute_value
-from rucio.db.sqla.constants import RequestState, TransferLimitDirection
+from rucio.db.sqla.constants import RequestState
 from rucio.gateway import request
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, generate_http_error_flask, json_parameters, param_get, parse_scope_name, response_headers, try_stream

--- a/tests/test_throttler.py
+++ b/tests/test_throttler.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 import pytest
 from sqlalchemy import delete
 
+from rucio.common.constants import TransferLimitDirection
 from rucio.common.utils import generate_uuid
 from rucio.core.did import add_did, attach_dids
 from rucio.core.distance import add_distance
@@ -34,7 +35,7 @@ from rucio.core.request import (
 from rucio.daemons.conveyor.preparer import preparer
 from rucio.daemons.conveyor.throttler import throttler
 from rucio.db.sqla import models
-from rucio.db.sqla.constants import DIDType, RequestState, RequestType, TransferLimitDirection
+from rucio.db.sqla.constants import DIDType, RequestState, RequestType
 from rucio.db.sqla.session import get_session, transactional_session
 from rucio.tests.common import skiplimitedsql
 


### PR DESCRIPTION
Fixes #7746 

Follow up from https://github.com/rucio/rucio/pull/7747
