### PR TITLE
Change output message when adding new scope

### DIFF
--- a/lib/rucio/cli/bin_legacy/rucio_admin.py
+++ b/lib/rucio/cli/bin_legacy/rucio_admin.py
@@ -752,7 +752,7 @@ def add_scope(args, client, logger, console, spinner):
 
     """
     client.add_scope(account=args.account, scope=args.scope)
-    print('Added new scope to account: %s-%s' % (args.scope, args.account))
+    print(f'Added new scope to {args.account}: {args.scope}')
     return SUCCESS
 
 

--- a/tests/test_bin_rucio.py
+++ b/tests/test_bin_rucio.py
@@ -225,7 +225,7 @@ class TestBinRucio:
         print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         print(out, err)
-        assert 'Added new scope to account: %s-%s\n' % (tmp_scp, tmp_acc) in out
+        assert f'Added new scope to {tmp_acc}: {tmp_scp}' in out
 
     def test_add_rse(self):
         """CLIENT(ADMIN): Add RSE"""


### PR DESCRIPTION
Closes #7729 

"Added new scope to account: `acct`-`scope`" -> "Added new scope to `acct`: `scope`"