### PR TITLE
Release-35-LTS: Fix CI tests failing due to `current_version()`

### DIFF
--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -2098,7 +2098,7 @@ class PriorityQueue:
 def check_policy_package_version(package: str) -> None:
     import importlib
 
-    from rucio.version import version_string
+    from rucio.version import current_version
     '''
     Checks that the Rucio version supported by the policy package is compatible
     with this version. Raises an exception if not.
@@ -2113,10 +2113,8 @@ def check_policy_package_version(package: str) -> None:
         # package is not versioned
         return
     supported_version = module.SUPPORTED_VERSION if isinstance(module.SUPPORTED_VERSION, list) else [module.SUPPORTED_VERSION]
-    components = 2 if version_string().startswith("1.") else 1
-    current_version = ".".join(version_string().split(".")[:components])
-    if current_version not in supported_version:
-        raise PolicyPackageVersionError(package, current_version, supported_version)
+    if current_version() not in supported_version:
+        raise PolicyPackageVersionError(package, current_version(), supported_version)
 
 
 class Availability:

--- a/lib/rucio/version.py
+++ b/lib/rucio/version.py
@@ -37,6 +37,7 @@ def version_string_with_vcs() -> str:
     """ Get the version string with VCS """
     return "%s-%s" % (canonical_version_string(), vcs_version_string())
 
+
 def current_version() -> str:
     """ Get the current version """
     components = 2 if version_string().startswith("1.") else 1

--- a/lib/rucio/version.py
+++ b/lib/rucio/version.py
@@ -36,3 +36,8 @@ def vcs_version_string() -> str:
 def version_string_with_vcs() -> str:
     """ Get the version string with VCS """
     return "%s-%s" % (canonical_version_string(), vcs_version_string())
+
+def current_version() -> str:
+    """ Get the current version """
+    components = 2 if version_string().startswith("1.") else 1
+    return ".".join(version_string().split(".")[:components])


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Ref: https://github.com/rucio/rucio/actions/runs/15679292371/job/44166954820
