### PR TITLE
Add client endpoint to mark subscription as inactive

### DIFF
--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -180,6 +180,36 @@ class SubscriptionClient(BaseClient):
             exc_cls, exc_msg = self._get_exception(headers=result.headers, status_code=result.status_code, data=result.content)
             raise exc_cls(exc_msg)
 
+    def deactivate_subscription(
+            self,
+            name: str,
+            account: Optional[str] = None
+    ) -> Literal[True]:
+        """
+        Mark a subscription as inactive
+
+        Parameters
+        ----------
+        name : Name of the subscription
+        account : Account identifier
+
+        Raises
+        ------
+        NotFound
+            If subscription is not found
+        """
+        if not account:
+            account = self.account
+        path = self.SUB_BASEURL + '/' + account + '/' + name  # type: ignore
+        url = build_url(choice(self.list_hosts), path=path)
+        data = dumps({'options': {'state': 'I'}})
+        result = self._send_request(url, type_='PUT', data=data)
+        if result.status_code == codes.created:   # pylint: disable=no-member
+            return True
+        else:
+            exc_cls, exc_msg = self._get_exception(headers=result.headers, status_code=result.status_code, data=result.content)
+            raise exc_cls(exc_msg)
+
     def list_subscription_rules(
             self,
             account: str,

--- a/lib/rucio/gateway/subscription.py
+++ b/lib/rucio/gateway/subscription.py
@@ -20,7 +20,7 @@ from rucio.common.exception import AccessDenied, InvalidObject
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.core import subscription
-from rucio.db.sqla.constants import DatabaseOperationType
+from rucio.db.sqla.constants import DatabaseOperationType, SubscriptionState
 from rucio.db.sqla.session import db_session
 from rucio.gateway.permission import has_permission
 
@@ -109,7 +109,7 @@ def update_subscription(
 
     :param name: Name of the subscription
     :param account: Account identifier
-    :param metadata: Dictionary of metadata to update. Supported keys : filter, replication_rules, comments, lifetime, retroactive, dry_run, priority, last_processed
+    :param metadata: Dictionary of metadata to update. Supported keys : filter, replication_rules, comments, lifetime, retroactive, dry_run, priority, last_processed, state
     :param issuer: The account issuing this operation.
     :param vo: The VO to act on.
     :raises: SubscriptionNotFound if subscription is not found
@@ -131,6 +131,9 @@ def update_subscription(
                 else:
                     for rule in metadata['replication_rules']:
                         validate_schema(name='activity', obj=rule.get('activity', 'default'), vo=vo)
+            if 'state' in metadata and metadata['state'] is not None:
+                metadata['state'] = SubscriptionState(metadata['state'])
+
         except ValueError as error:
             raise TypeError(error)
 
@@ -147,7 +150,6 @@ def update_subscription(
                         filter_[_key] = [_type(val, vo=vo).internal for val in filter_[_key]]
                     else:
                         filter_[_key] = _type(filter_[_key], vo=vo).internal
-
         return subscription.update_subscription(name=name, account=internal_account, metadata=metadata, session=session)
 
 

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -169,6 +169,10 @@ class Subscription(ErrorHandlingMethodView):
                       priority:
                         description: "The priority/policyid for the subscription. Stored as policyid."
                         type: integer
+                      state:
+                        description: "The state of the subscription. If not supplied, the state will be set to 'U' (updated)."
+                        type: string
+                        enum: ["A", "I", "N", "U", "B"]
         responses:
           201:
             description: "OK"
@@ -188,6 +192,7 @@ class Subscription(ErrorHandlingMethodView):
             'lifetime': None,
             'retroactive': None,
             'priority': None,
+            'state': None,
         }
         for keyword in list(metadata):
             metadata[keyword] = param_get(options, keyword, default=metadata[keyword])


### PR DESCRIPTION
Closes #7784 

Creates a new function in `subscriptionclient` which just sets the provided subscription to `inactive`. Uses the existing "update" method and works off those permissions. 

Makes "state" an allowable field in gateway.subscription, includes "state" in the REST API (put subscriptions/account/name)