### PR TITLE
add obsolete replica check to core/rse_counter

### DIFF
--- a/bin/rucio-abacus-rse-expired
+++ b/bin/rucio-abacus-rse-expired
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Abacus rse is a daemon to update rse counters. This script can run independently 2 daemons, one for expired and one for OBSOLETE replicas.
+"""
+
+import argparse
+import signal
+
+from rucio.daemons.abacus.rse_expired import run, stop
+
+
+def get_parser():
+    """
+    Returns the argparse parser.
+    """
+    parser = argparse.ArgumentParser(description="The abacus-rse-obsolete daemon is responsible for updating the 'expired' or 'obsolete' RSE usage counter", formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--run-once", action="store_true", default=False, help='One iteration only')
+    parser.add_argument('--sleep-time', action="store", default=3600, type=int, help='Thread sleep time after each chunk of work (there is only one OBSOLETE replica thread)')
+    parser.add_argument('--obsolete', action="store_true", default=False, help='Count obsolete replicas rather than expired ones')
+    return parser
+
+
+if __name__ == "__main__":
+
+    signal.signal(signal.SIGTERM, stop)
+    parser = get_parser()
+    args = parser.parse_args()
+    try:
+        run(once=args.run_once, obsolete=args.obsolete, sleep_time=args.sleep_time)
+    except KeyboardInterrupt:
+        stop()

--- a/lib/rucio/core/rse_counter_expired.py
+++ b/lib/rucio/core/rse_counter_expired.py
@@ -1,0 +1,74 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Select, func, select
+
+from rucio.core.rse import set_rse_usage
+from rucio.db.sqla import models
+from rucio.db.sqla.constants import OBSOLETE, ReplicaState
+from rucio.db.sqla.session import transactional_session
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+@transactional_session
+def check_obsolete_replicas(rse_id: str, *, session: "Session") -> None:
+    """
+    Get number of files and bytes used by obsolete replicas for a given RSE and
+    update RSE usage accordingly.
+
+    :param rse_id: id of the RSE to check.
+    :param session: Database session in use.
+    """
+
+    stmt = _select_query(
+    ).where(
+        models.RSEFileAssociation.rse_id == rse_id,
+        models.RSEFileAssociation.tombstone == OBSOLETE
+    )
+    bytes, files = session.execute(stmt).one()
+    set_rse_usage(rse_id, 'obsolete', bytes, None, files, session=session)
+
+
+@transactional_session
+def check_deletable_replicas(rse_id: str, *, session: "Session") -> None:
+    """
+    Get number of files and bytes used by deletable replicas for a given RSE and
+    update RSE usage accordingly. OBSOLETE replicas are included in the calculation.
+
+    :param rse_id: id of the RSE to check.
+    :param session: Database session in use.
+    """
+
+    stmt = _select_query(
+    ).where(
+        models.RSEFileAssociation.rse_id == rse_id,
+        models.RSEFileAssociation.tombstone < datetime.now(timezone.utc),
+        models.RSEFileAssociation.state.in_((ReplicaState.AVAILABLE, ReplicaState.UNAVAILABLE, ReplicaState.BAD))
+    )
+    bytes, files = session.execute(stmt).one()
+    set_rse_usage(rse_id, 'expired', bytes, None, files, session=session)
+
+
+def _select_query() -> Select:
+    query = select(
+        func.coalesce(func.sum(models.RSEFileAssociation.bytes), 0).label('bytes'),
+        func.count().label('files')
+    ).with_hint(
+        models.RSEFileAssociation, 'INDEX(replicas REPLICAS_RSE_ID_TOMBSTONE_IDX)', 'oracle'
+    )
+    return query

--- a/lib/rucio/daemons/abacus/rse_expired.py
+++ b/lib/rucio/daemons/abacus/rse_expired.py
@@ -1,0 +1,118 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This is a daemon to update RSE counters for deletable and obsolete replicas. The type of replica counted is determined
+by obsolete variable.
+"""
+
+import functools
+import logging
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import rucio.db.sqla.util
+from rucio.common import exception
+from rucio.common.logging import setup_logging
+from rucio.core.rse import list_rses
+from rucio.core.rse_counter_expired import check_deletable_replicas, check_obsolete_replicas
+from rucio.daemons.common import HeartbeatHandler, run_daemon
+
+if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Optional
+
+graceful_stop = threading.Event()
+DAEMON_NAME = 'abacus-rse-deletable'
+
+
+def rse_update(
+        once: bool = False,
+        obsolete: bool = False,
+        sleep_time: int = 3600
+) -> None:
+    """
+    Main loop to check and update the RSE Counters.
+    """
+    run_daemon(
+        once=once,
+        graceful_stop=graceful_stop,
+        executable=DAEMON_NAME,
+        partition_wait_time=1,
+        sleep_time=sleep_time,
+        run_once_fnc=functools.partial(
+            run_once,
+            obsolete=obsolete,
+        ),
+    )
+
+
+def run_once(
+        heartbeat_handler: HeartbeatHandler,
+        obsolete: bool,
+        **_kwargs: object
+) -> None:
+
+    start_time = time.time()
+    _, _, logger = heartbeat_handler.live()
+    rses = list_rses()  # NOQA
+    for rse in rses:
+        if graceful_stop.is_set():
+            break
+        start = time.time()
+        if obsolete:
+            check_obsolete_replicas(rse['id'])
+        else:
+            check_deletable_replicas(rse['id'])
+        logger(logging.DEBUG, '%s replica backlog query for RSE %s took %f s.' % ('Expired' if not obsolete else 'Obsolete', rse['id'], time.time() - start))
+
+    logger(logging.DEBUG, 'update of all RSEs took %f s.' % (time.time() - start_time))
+
+
+def stop(signum: "Optional[int]" = None, frame: "Optional[FrameType]" = None) -> None:
+    """
+    Graceful exit.
+    """
+
+    graceful_stop.set()
+
+
+def run(
+        once: bool = False,
+        obsolete: bool = False,
+        sleep_time: int = 3600
+) -> None:
+    """
+    Starts up the Abacus-RSE deletable/obsolete threads.
+    """
+    global DAEMON_NAME
+    if obsolete:
+        DAEMON_NAME = 'abacus-rse-obsolete'
+    setup_logging(process_name=DAEMON_NAME)
+
+    if rucio.db.sqla.util.is_old_db():
+        raise exception.DatabaseException('Database was not updated, daemon won\'t start')
+
+    if once:
+        logging.info('main: executing one iteration only')
+        rse_update(once, obsolete=obsolete)
+    else:
+        logging.info('main: starting the RSE usage thread')
+        thread = threading.Thread(target=rse_update, kwargs={'once': once, 'obsolete': obsolete, 'sleep_time': sleep_time})
+        thread.start()
+        logging.info('main: waiting for interrupts')
+        # Interruptible joins require a timeout.
+        while thread.is_alive():
+            thread.join(timeout=3.14)

--- a/tests/test_abacus_rse_expired.py
+++ b/tests/test_abacus_rse_expired.py
@@ -1,0 +1,78 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import delete
+
+from rucio.core.replica import add_replica, get_replica, set_tombstone
+from rucio.core.rse import get_rse_usage
+from rucio.daemons.abacus.rse_expired import run
+from rucio.db.sqla import models
+from rucio.db.sqla.constants import OBSOLETE
+from rucio.db.sqla.session import get_session
+from rucio.tests.common import did_name_generator
+
+
+@pytest.mark.noparallel(reason='uses daemon, failing in parallel to other tests')
+class TestAbacusRSEObsolete:
+
+    def test_abacus_rse_obsolete(self, mock_scope, rse_factory, root_account):
+        """ ABACUS (RSE): Test update of RSE usage for obsolete replicas. """
+        # Get RSE usage of all sources
+        session = get_session()
+        for model in [models.UpdatedRSECounter, models.RSEUsage]:
+            stmt = delete(model)
+            session.execute(stmt)
+        session.commit()
+
+        # create an RSE and some replicas with a tombstone:
+        _, rse_id = rse_factory.make_mock_rse()
+        nbfiles = 3
+        for _ in range(nbfiles):
+            name = did_name_generator('file')
+            add_replica(rse_id, mock_scope, name, 4, root_account)
+            assert get_replica(rse_id, mock_scope, name)['tombstone'] is None
+            set_tombstone(rse_id, mock_scope, name)
+            assert get_replica(rse_id, mock_scope, name)['tombstone'] == OBSOLETE
+
+        # add one more expired replica on the RSE
+        name3 = did_name_generator('file')
+        add_replica(rse_id, mock_scope, name3, 27, root_account)
+        assert get_replica(rse_id, mock_scope, name3)['tombstone'] is None
+        set_tombstone(rse_id, mock_scope, name3, datetime.now(timezone.utc) - timedelta(hours=1))
+        assert get_replica(rse_id, mock_scope, name3)['tombstone'] is not None
+        # now one more replica, on a different RSE, but not obsolete:
+        _, rse_id2 = rse_factory.make_mock_rse()
+        name2 = did_name_generator('file')
+        add_replica(rse_id2, mock_scope, name2, 4, root_account)
+        assert get_replica(rse_id2, mock_scope, name2)['tombstone'] is None
+        # usage is not accumulated:
+        for _ in range(2):
+            run(once=True, obsolete=True)
+            res = get_rse_usage(rse_id, 'obsolete')[0]  # 3 files, 12 bytes
+            assert res['used'] == 12
+            assert res['files'] == 3
+            run(once=True)
+            res = get_rse_usage(rse_id, 'expired')[0]  # 4 files (OBSOLETE included), 37 bytes
+            assert res['used'] == 39
+            assert res['files'] == 4
+            # rse_id2 undisturbed ..
+            res = get_rse_usage(rse_id2, 'obsolete')[0]  # 0 files, 0 bytes
+            assert res['used'] == 0
+            assert res['files'] == 0
+            res = get_rse_usage(rse_id2, 'expired')[0]  # 0 files, 0 bytes
+            assert res['used'] == 0
+            assert res['files'] == 0

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -15,7 +15,7 @@
 import hashlib
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from json import dumps
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -32,7 +32,8 @@ from rucio.common.utils import clean_pfns, generate_uuid, parse_response
 from rucio.core.config import set as cconfig_set
 from rucio.core.did import add_did, attach_dids, get_did, get_did_access_cnt, get_did_atime, list_files, set_status
 from rucio.core.replica import add_bad_dids, add_replica, add_replicas, delete_replicas, get_bad_pfns, get_replica, get_replica_atime, get_replicas_state, get_rse_coverage_of_dataset, list_replicas, set_tombstone, touch_replica, update_replica_state
-from rucio.core.rse import add_protocol, add_rse_attribute, del_rse_attribute
+from rucio.core.rse import add_protocol, add_rse_attribute, del_rse_attribute, get_rse_usage
+from rucio.core.rse_counter_expired import check_deletable_replicas, check_obsolete_replicas
 from rucio.daemons.badreplicas.minos import minos
 from rucio.daemons.badreplicas.minos_temporary_expiration import minos_tu_expiration
 from rucio.db.sqla import models
@@ -554,6 +555,37 @@ class TestReplicaCore:
         name = did_name_generator('file')
         with pytest.raises(ReplicaNotFound):
             set_tombstone(rse_id, mock_scope, name)
+
+    def test_check_expired_replicas(self, rse_factory, mock_scope, root_account):
+        """ REPLICA (CORE): check obsolete replicas for a given rse """
+        # Set tombstone on replicas
+        rse, rse_id = rse_factory.make_mock_rse()
+        nbfiles = 3
+        # add OBSOLETE replicas first
+        for _ in range(nbfiles):
+            name = did_name_generator('file')
+            add_replica(rse_id, mock_scope, name, 4, root_account)
+            assert get_replica(rse_id, mock_scope, name)['tombstone'] is None
+            set_tombstone(rse_id, mock_scope, name)
+            assert get_replica(rse_id, mock_scope, name)['tombstone'] == OBSOLETE
+        check_obsolete_replicas(rse_id)
+        # we expect 3 files, 12 bytes in total for our rse_id.
+        res = get_rse_usage(rse_id, 'obsolete')[0]  # 3 files, 12 bytes
+        assert res['used'] == 12
+        assert res['files'] == 3
+
+        # add deletable replicas
+        for _ in range(nbfiles):
+            name = did_name_generator('file')
+            add_replica(rse_id, mock_scope, name, 4, root_account)
+            assert get_replica(rse_id, mock_scope, name)['tombstone'] is None
+            set_tombstone(rse_id, mock_scope, name, datetime.now(timezone.utc) - timedelta(hours=1))
+            assert get_replica(rse_id, mock_scope, name)['tombstone'] is not None
+        check_deletable_replicas(rse_id)
+        # OBSOLETE replica counts are included in deletable replica counts
+        res = get_rse_usage(rse_id, 'expired')[0]  # 6 files, 24 bytes
+        assert res['used'] == 24
+        assert res['files'] == 6
 
     def test_core_default_tombstone_correctly_set(self, rse_factory, did_factory, root_account):
         """ REPLICA (CORE): Per-RSE default tombstone is correctly taken into consideration"""


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
This PR converts `check_obsolete_replica`  probe code to a daemon using SQLAlchemy.  It also add handling of deletable replicas:

for obsolete replicas:

`rucio-abacus-rse-expired --run-once --obsolete`

for deletable replicas:

`rucio-abacus-rse-expired --run-once` 

N.B obsolete replica counts are included in expired replica counts. 
