### PR TITLE
Move CLI error handling to exception_handler where applicable. 

### DIFF
--- a/lib/rucio/cli/utils.py
+++ b/lib/rucio/cli/utils.py
@@ -30,7 +30,7 @@ from rucio.common.exception import (
     DataIdentifierNotFound,
     Duplicate,
     DuplicateContent,
-    InvalidObject,
+    InputValidationError,
     InvalidRSEExpression,
     MissingDependency,
     RSENotFound,
@@ -52,12 +52,13 @@ def exception_handler(function):
     def new_funct(*args, **kwargs):
         try:
             return function(*args, **kwargs)
+        except InputValidationError as error:
+            logger.error(error)
+            logger.debug("This means that one you provided an invalid combination of parameters, or incorrect types. Please check the command help (-h/--help).")
+            return FAILURE
         except NotImplementedError as error:
             logger.error(f"Cannot run that operation/command combination {error}")
             return FAILURE
-        except InvalidObject as error:
-            logger.error(error)
-            return error.error_code
         except DataIdentifierNotFound as error:
             logger.error(error)
             logger.debug("This means that the Data IDentifier you provided is not known by Rucio.")


### PR DESCRIPTION
Closes #7720 

* Removes instances of a function in bin_legacy returning a FAILURE status when raising an error is more descriptive
* Raises a "InputValidationError" when conflicting arguments are given
* Raises a specific error when schemas cannot be validated or objects not found`
* Raises a general "RucioException" with a verbose description when no existing error matches
* Removes error catches that result in returning FAILURE
* Expands the "@exception_handler" decorator to catch input validation errors

Note: All exitcode=1's are still in place, just shifted to being handled in the exception_handler, instead of being handled twice.

Most of this is just mapping "Cannot use -x and -y" or "Must include one of -x, -y, -z" to "InputValidationError", which was present in upload and seemed to be working just fine. Tests didn't have to be touched. 