### PR TITLE
Database: Refactor drop_everything() → purge_db(), destroy_database() → drop_orm_tables() #7795

### DIFF
--- a/lib/rucio/db/sqla/util.py
+++ b/lib/rucio/db/sqla/util.py
@@ -81,7 +81,7 @@ def dump_schema() -> None:
     models.register_models(engine)
 
 
-def destroy_database() -> None:
+def drop_orm_tables() -> None:
     """ Removes the schema from the database. Only useful for test cases or malicious intents. """
     engine = get_engine()
 
@@ -91,7 +91,7 @@ def destroy_database() -> None:
         print('Cannot destroy schema -- assuming already gone, continuing:', e)
 
 
-def drop_everything() -> None:
+def purge_db() -> None:
     """
     Pre-gather all named constraints and table names, and drop everything.
     This is better than using metadata.reflect(); metadata.drop_all()

--- a/tools/destroy_database.py
+++ b/tools/destroy_database.py
@@ -22,14 +22,14 @@ os.chdir(base_path)
 
 import argparse  # noqa: E402
 
-from rucio.db.sqla.util import destroy_database, drop_everything  # noqa: E402
+from rucio.db.sqla.util import drop_orm_tables, purge_db  # noqa: E402
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--drop-everything", action="store_true", default=False, help='Drop all tables+constraints')
+    parser.add_argument("--purge-db", action="store_true", default=False, help='Drop all tables+constraints')
     args = parser.parse_args()
-    if args.drop_everything:
-        drop_everything()
+    if args.purge_db:
+        purge_db()
     else:
-        destroy_database()
+        drop_orm_tables()

--- a/tools/reset_database.py
+++ b/tools/reset_database.py
@@ -22,18 +22,18 @@ os.chdir(base_path)
 
 from argparse import ArgumentParser  # noqa: E402
 
-from rucio.db.sqla.util import build_database, create_base_vo, create_root_account, destroy_database, drop_everything  # noqa: E402
+from rucio.db.sqla.util import build_database, create_base_vo, create_root_account, drop_orm_tables, purge_db  # noqa: E402
 
 if __name__ == '__main__':
 
     parser = ArgumentParser()
-    parser.add_argument('-d', '--drop-everything', action="store_true", default=False, help='Drop all tables and constraints')
+    parser.add_argument('-d', '--purge-db', action="store_true", default=False, help='Drop all tables and constraints')
     args = parser.parse_args()
 
-    if args.drop_everything:
-        drop_everything()
+    if args.purge_db:
+        purge_db()
     else:
-        destroy_database()
+        drop_orm_tables()
 
     build_database()
     create_base_vo()


### PR DESCRIPTION

I simply renamed the methods as suggested. I also renamed the argument in the command for sake of consistency.