### PR TITLE
Policies: simplify registration of policy package algorithms #7405

### DIFF
--- a/lib/rucio/core/dirac.py
+++ b/lib/rucio/core/dirac.py
@@ -114,7 +114,7 @@ def add_files(
     for lfn in lfns:
         # First check if the file exists
         filename = lfn['lfn']
-        lfn_scope, _ = extract_scope(filename, scopes)
+        lfn_scope, _ = extract_scope(filename, scopes, vo=vo)
         lfn_scope = InternalScope(lfn_scope, vo=vo)
 
         exists, did_type = _exists(lfn_scope, filename)
@@ -129,7 +129,7 @@ def add_files(
 
         # The parent must be a dataset. Register it as well as the rule
         dsn_name = lpns[0]
-        dsn_scope, _ = extract_scope(dsn_name, scopes)
+        dsn_scope, _ = extract_scope(dsn_name, scopes, vo=vo)
         dsn_scope = InternalScope(dsn_scope, vo=vo)
         dsn_meta = parents_metadata.get(dsn_name, {})
 
@@ -162,7 +162,7 @@ def add_files(
                     session=session)
             exist_lfn.append(dsn_name)
             parent_name = lpns[1]
-            parent_scope, _ = extract_scope(parent_name, scopes)
+            parent_scope, _ = extract_scope(parent_name, scopes, vo=vo)
             parent_scope = InternalScope(parent_scope, vo=vo)
             attachments.append({'scope': parent_scope, 'name': parent_name, 'dids': [{'scope': dsn_scope, 'name': dsn_name}]})
             rule_extension_list.append((dsn_scope, dsn_name))
@@ -207,7 +207,7 @@ def add_files(
 
         # Now loop over the ascendants of the dataset and created them
         for lpn in lpns[1:]:
-            child_scope, _ = extract_scope(lpn, scopes)
+            child_scope, _ = extract_scope(lpn, scopes, vo=vo)
             child_scope = InternalScope(child_scope, vo=vo)
             exists, did_type = _exists(child_scope, lpn)
             child_meta = parents_metadata.get(lpn, {})
@@ -228,7 +228,7 @@ def add_files(
                         session=session)
                 exist_lfn.append(lpn)
                 parent_name = lpns[lpns.index(lpn) + 1]
-                parent_scope, _ = extract_scope(parent_name, scopes)
+                parent_scope, _ = extract_scope(parent_name, scopes, vo=vo)
                 parent_scope = InternalScope(parent_scope, vo=vo)
                 attachments.append({'scope': parent_scope, 'name': parent_name, 'dids': [{'scope': child_scope, 'name': lpn}]})
     # Finally attach everything

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -239,7 +239,7 @@ class DirectTransferImplementation(DirectTransfer):
             # DQ2 path always starts with /, but prefix might not end with /
             naming_convention = dst.rse.attributes.get(RseAttr.NAMING_CONVENTION, None)
             if rws.scope.external is not None:
-                dest_path = construct_non_deterministic_pfn(dsn, rws.scope.external, rws.name, naming_convention)
+                dest_path = construct_non_deterministic_pfn(dsn, rws.scope.external, rws.name, naming_convention, rws.scope.vo)
             if dst.rse.is_tape():
                 if rws.retry_count or rws.activity == 'Recovery':
                     dest_path = '%s_%i' % (dest_path, int(time.time()))

--- a/lib/rucio/gateway/dirac.py
+++ b/lib/rucio/gateway/dirac.py
@@ -56,7 +56,7 @@ def add_files(
         dids = []
         rses = {}
         for lfn in lfns:
-            scope, name = extract_scope(lfn['lfn'], scopes)
+            scope, name = extract_scope(lfn['lfn'], scopes, vo=vo)
             dids.append({'scope': scope, 'name': name})
             rse = lfn['rse']
             if rse not in rses:

--- a/lib/rucio/rse/protocols/protocol.py
+++ b/lib/rucio/rse/protocols/protocol.py
@@ -69,11 +69,15 @@ class RSEProtocol(ABC):
         self.rse = rse_settings
         self.logger = logger
         if self.rse['deterministic']:
-            self.translator = RSEDeterministicTranslation(self.rse['rse'], rse_settings, self.attributes)
-            if getattr(rsemanager, 'CLIENT_MODE', None) and \
-                    not RSEDeterministicTranslation.supports(self.rse.get('lfn2pfn_algorithm')):
-                # Remote server has an algorithm we don't understand; always make the server do the lookup.
-                setattr(self, 'lfns2pfns', self.__lfns2pfns_client)
+            if getattr(rsemanager, 'SERVER_MODE', None):
+                vo = get_rse_vo(self.rse['id'])
+            if getattr(rsemanager, 'CLIENT_MODE', None):
+                # assume client has only one VO policy package configured
+                vo = ''
+                if not RSEDeterministicTranslation.supports(self.rse.get('lfn2pfn_algorithm')):
+                    # Remote server has an algorithm we don't understand; always make the server do the lookup.
+                    setattr(self, 'lfns2pfns', self.__lfns2pfns_client)
+            self.translator = RSEDeterministicTranslation(self.rse['rse'], rse_settings, self.attributes, vo)
         else:
             if getattr(rsemanager, 'CLIENT_MODE', None):
                 setattr(self, 'lfns2pfns', self.__lfns2pfns_client)

--- a/lib/rucio/transfertool/fts3.py
+++ b/lib/rucio/transfertool/fts3.py
@@ -1046,6 +1046,7 @@ class FTS3Transfertool(Transfertool):
                 t_file['scitag'] = self.scitags_exp_id << 6 | activity_id
 
         if t_file['metadata']['dst_type'] == 'TAPE':
+            t_file['metadata']['vo'] = rws.scope.vo
             for plugin in self.tape_metadata_plugins:
                 t_file = deep_merge_dict(source=plugin.hints(t_file['metadata']), destination=t_file)
 

--- a/lib/rucio/transfertool/fts3_plugins.py
+++ b/lib/rucio/transfertool/fts3_plugins.py
@@ -17,6 +17,7 @@ import sys
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
 from rucio.common.config import config_get_int
+from rucio.common.constants import DEFAULT_VO
 from rucio.common.exception import InvalidRequest
 from rucio.common.plugins import PolicyPackageAlgorithms
 
@@ -85,7 +86,11 @@ class FTS3TapeMetadataPlugin(PolicyPackageAlgorithms):
         """
         return {"collocation_hints": collocation_func(**hints)}
 
-    def _default(self, *hints: dict) -> dict:
+    def _default(self, hint_dict: dict[str, Any]) -> dict:
+        vo = hint_dict['vo'] if 'vo' in hint_dict else DEFAULT_VO
+        default_algorithm = self._get_default_algorithm(self.ALGORITHM_NAME, vo=vo)
+        if default_algorithm is not None:
+            return default_algorithm(hint_dict)
         return {}
 
     def _verify_in_format(self, hint_dict: dict[str, Any]) -> None:


### PR DESCRIPTION
This PR allows algorithms to be implemented in policy packages simply by putting them in a function and module with a certain name. For example, an LFN2PFN algorithm can be placed in a function named `lfn2pfn` in a module named `lfn2pfn` in the policy package and Rucio will find it and use it as the default LFN2PFN algorithm. No registration or configuration is necessary. However other algorithms can still be used as before by specifying them in the configuration file or as RSE attributes.

Much of the complexity here is due to the requirement to support multi VO installations. In this case, each VO can have its own policy package, so we have to know the active VO to be able to decide which package's default algorithms should be used. In some cases the VO was not immediately available and had to be passed down through a few layers of code.

I will submit a documentation PR as well. However, my main concern is that this will give us 3 different ways of registering policy package algorithms - the original method using `get_algorithms` as used by DUNE and possibly others, the method currently described in the documentation involving subclassing a core algorithm from Rucio as used by ATLAS, and now this new method. In the interests of simplicity and consistency we should probably deprecate at least one of these methods.