### PR TITLE
conveyor: sslport only when use_ssl for reciever #7833

### DIFF
--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -154,7 +154,8 @@ def receiver(
     except Exception:
         logging.info('could not find use_ssl in configuration -- please update your rucio.cfg')
 
-    port = config_get_int('messaging-fts3', 'port')
+    if use_ssl:
+        port = config_get_int('messaging-fts3', 'port')
     vhost = config_get('messaging-fts3', 'broker_virtual_host', raise_exception=False)
     if not use_ssl:
         username = config_get('messaging-fts3', 'username')


### PR DESCRIPTION
ssl port requirement only when use_ssl is True.
This change was made because when use_ssl is False ,  it  currently complains of not having ssl port but non_ssl port is already specified.
closes: #7833 