### PR TITLE
Dependencies: server, dev, bump aiohttp from 3.11.13 to 3.12.14 (resolve security warning)

### DIFF
--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -8,11 +8,11 @@ aiohappyeyeballs==2.5.0
     # via
     #   -r requirements.server.txt
     #   aiohttp
-aiohttp==3.11.13
+aiohttp==3.12.14
     # via
     #   -r requirements.server.txt
     #   geoip2
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -r requirements.server.txt
     #   aiohttp
@@ -484,6 +484,7 @@ typeapi==2.2.4
 typing-extensions==4.14.0
     # via
     #   -r requirements.server.txt
+    #   aiosignal
     #   alembic
     #   astroid
     #   black

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -6,9 +6,9 @@
 #
 aiohappyeyeballs==2.5.0
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.12.14
     # via geoip2
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via aiohttp
 alembic==1.14.1
     # via -r requirements.server.in
@@ -263,6 +263,7 @@ tabulate==0.9.0
     # via -r requirements.server.in
 typing-extensions==4.14.0
     # via
+    #   aiosignal
     #   alembic
     #   dogpile-cache
     #   globus-sdk


### PR DESCRIPTION
Follow up from https://github.com/rucio/rucio/pull/7849/commits