### PR TITLE
Patch 6718 remove most print calls in tests and added some asserts

### DIFF
--- a/tests/test_bin_rucio.py
+++ b/tests/test_bin_rucio.py
@@ -246,8 +246,7 @@ def test_create_dataset(rucio_client, mock_scope):
     tmp_name = f"{scope}:DSet_{generate_uuid()}"
     cmd = f'rucio add-dataset {tmp_name}'
     exitcode, out, err = execute(cmd)
-    print(err, out)
-    assert exitcode == 0
+    assert exitcode == 0, f"Failed to create dataset: {err} {out}"
     assert re.search('Added ' + tmp_name, out) is not None
     assert tmp_name in [f"{scope}:{did}" for did in rucio_client.list_dids(scope=scope, did_type="dataset", filters={})]
 
@@ -423,8 +422,7 @@ def test_create_rule(did_factory, rse_factory, rucio_client):
     # add rules
     cmd = f"rucio add-rule {temp_scope}:{temp_file_name} {n_replicas} 'spacetoken=ATLASSCRATCHDISK'"
     exitcode, out, err = execute(cmd)
-    print(out, err)
-    assert exitcode == 0
+    assert exitcode == 0, f"Failed to add rule: {err} {out}"
     assert "ERROR" not in err
     rule = out.split('\n')[-2]
     assert re.match(r'^\w+$', rule)
@@ -751,8 +749,7 @@ def test_set_tombstone(rse_factory, mock_scope, rucio_client):
     rucio_client.add_replica(rse, scope, name, 4, 'aaaaaaaa')
     cmd = f'rucio-admin replicas set-tombstone {scope}:{name} --rse {rse}'
     exitcode, out, err = execute(cmd)
-    print(out, err)
-    assert exitcode == 0
+    assert exitcode == 0, f"Failed to set tombstone: {err} {out}"
     assert 'Set tombstone successfully' in err
 
     # Set tombstone on locked replica
@@ -1157,8 +1154,7 @@ def test_download_metalink(rse_factory, mock_scope, did_factory, rucio_client):
             cmd = f'rucio download --legacy --dir {tmp_dir} --metalink {metalink_file.name}'
             exitcode, out, err = execute(cmd)
 
-            print(out, err)
-            assert exitcode == 0
+            assert exitcode == 0, f"Failed to download with metalink: {err} {out}"
             assert f'{tmp_file} successfully downloaded' in err
             assert re.search('Total files.*1', out) is not None
             assert os.path.exists(f"{tmp_dir}/{scope}/{tmp_file}")

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -135,8 +135,7 @@ def test_account_attribute(jdoe_account):
 
     cmd = f"rucio account attribute list {jdoe_account}"
     exitcode, out, err = execute(cmd)
-    print(err)
-    assert exitcode == 0
+    assert exitcode == 0, f"Failed to list account attributes: {err}"
     assert "ERROR" not in err
     assert f"test_{fake_key}_key" in out
 
@@ -419,8 +418,7 @@ def test_lifetime_exception(rucio_client, mock_scope):
 
     cmd = f"rucio lifetime-exception add -f {input_file.name} --reason mock_test -x 2100-12-30"
     exitcode, _, err = execute(cmd)
-    print(err)
-    assert exitcode == 0
+    assert exitcode == 0, f"Failed to add lifetime exception: {err}"
     if "ERROR" not in err:
         assert "not affected by the lifetime model" in err
     else:
@@ -473,8 +471,7 @@ def test_replica_state(mock_scope, rucio_client):
 
     cmd = f"rucio replica state update bad {scope}:{name1} --rse {mock_rse} --reason testing"
     exitcode, _, err = execute(cmd)
-    print(err)
-    assert exitcode == 0
+    assert exitcode == 0, f"Failed to update replica state: {err}"
     if "ERROR" in err:
         assert "Details: ERROR, multiple matches" in err  # The test rses are strange. I don't know why this happens.
 
@@ -549,8 +546,7 @@ def test_rse_protocol():
     domain_json = """{"wan": {"read": 1, "write": 1, "delete": 1, "third_party_copy_read": 1, "third_party_copy_write": 1}}"""
     cmd = f"rucio rse protocol add {rse_name} --host-name blocklistreplica --scheme file --prefix /rucio --port 0 --impl rucio.rse.protocols.posix.Default --domain-json '{domain_json}'"
     exitcode, _, err = execute(cmd)
-    print(err)
-    assert "ERROR" not in err
+    assert "ERROR" not in err, f"Failed to add protocol: {err}"
     assert exitcode == 0
 
     cmd = f"rucio rse protocol remove {rse_name} --host-name blocklistreplica --scheme file"
@@ -689,8 +685,7 @@ def test_rule(rucio_client, mock_scope):
     # Testing the two different lifetime type options
     cmd = f"rucio rule update {rule_id} --lifetime 10"
     exitcode, out, err = execute(cmd)
-    print(out, err)
-    assert exitcode == 0
+    assert exitcode == 0, f"Failed to update rule lifetime: {err} {out}"
     assert "ERROR" not in err
     rule_info = rucio_client.get_replication_rule(rule_id)
     assert abs(rule_info["updated_at"] - rule_info["expires_at"]).seconds == 10
@@ -771,6 +766,5 @@ def test_subscription(rucio_client, mock_scope):
     rule = json.dumps({})
     cmd = f"rucio subscription update {subscription_name} --filter '{filter_}' --rule {rule}"
     exitcode, _, err = execute(cmd)
-    print(err)
-    assert exitcode == 0
+    assert exitcode == 0, f"Failed to update subscription: {err}"
     assert "ERROR" not in err

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -210,8 +210,7 @@ class TestRucioClients:
         """
 
         exitcode, _, err = execute("python -c 'from rucio.client import Client'")
-        print(exitcode, err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Failed to import Client without config file: {err}"
         assert "Could not load Rucio configuration file." not in err
 
     @pytest.mark.noparallel(reason='We temporarily remove the config file.')

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -39,29 +39,23 @@ class TestCurlRucio:
     def test_ping(self):
         """PING (CURL): Get Version"""
         cmd = 'curl --cacert %s -s -X GET %s/ping' % (self.cacert, self.host)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, )
         ret = json.loads(out)
-        assert 'version' in ret
+        assert 'version' in ret, f"Version not found in response : {out} {ret}"
         assert isinstance(ret, dict)
 
     def test_get_auth_userpass(self):
         """AUTH (CURL): Test auth token retrieval with via username and password"""
         cmd = 'curl -s -i --cacert %s -X GET -H "X-Rucio-Account: root" -H "X-Rucio-Username: ddmlab" -H "X-Rucio-Password: secret" %s %s/auth/userpass' % (self.cacert, self.vo_header, self.auth_host)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, )
-        assert 'X-Rucio-Auth-Token' in out
+        assert 'X-Rucio-Auth-Token' in out, f"Auth token not found in response: {out}"
 
     @skip_outside_gh_actions
     def test_get_auth_x509(self):
         """AUTH (CURL): Test auth token retrieval with via x509"""
         cmd = 'curl -s -i --cacert %s -H "X-Rucio-Account: root" %s -cert %s --key %s -X GET %s/auth/x509' % (self.cacert, self.vo_header, self.usercert, self.userkey, self.auth_host)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, )
-        assert 'X-Rucio-Auth-Token' in out
+        assert 'X-Rucio-Auth-Token' in out, f"Auth token not found in response: {out}"
 
     def test_get_auth_gss(self):
         """AUTH (CURL): Test auth token retrieval with via gss"""
@@ -95,10 +89,8 @@ class TestCurlRucio:
         assert 'X-Rucio-Auth-Token' in out
         os.environ['RUCIO_TOKEN'] = out[len('X-Rucio-Auth-Token: '):].rstrip()
         cmd = 'curl -s -i --cacert %s  -H "X-Rucio-Auth-Token: $RUCIO_TOKEN" -X GET %s/auth/validate' % (self.cacert, self.auth_host)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        assert 'datetime.datetime' in out
+        assert 'datetime.datetime' in out, f"Token validation failed: {out}"
 
     @skip_outside_gh_actions
     @pytest.mark.dirty
@@ -116,25 +108,19 @@ class TestCurlRucio:
                "-d '{\"type\": \"USER\", \"email\": \"rucio@email.com\"}' "
                "-X POST %s/accounts/%s"
                ) % (self.cacert, self.host, account_name_generator())
-
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        assert '201 Created'.lower() in out.lower()
+        assert '201 Created'.lower() in out.lower(), f"Account creation failed: {out}"
 
     @skip_outside_gh_actions
     def test_get_accounts_whoami(self):
         """ACCOUNT (CURL): Test whoami method"""
         cmd = 'curl -s -i --cacert %s -H "X-Rucio-Account: root" %s --cert %s --key %s -X GET %s/auth/x509 | tr -d \'\r\' | grep X-Rucio-Auth-Token:' % (self.cacert, self.vo_header, self.usercert, self.userkey, self.auth_host)
-        print(cmd)
         exitcode, out, err = execute(cmd)
-        assert 'X-Rucio-Auth-Token' in out
+        assert 'X-Rucio-Auth-Token' in out, f"Auth token not found in response: {out}"
         os.environ['RUCIO_TOKEN'] = out[len('X-Rucio-Auth-Token: '):].rstrip()
         cmd = '''curl -s -i -L --cacert %s -H "X-Rucio-Auth-Token: $RUCIO_TOKEN" -X GET %s/accounts/whoami''' % (self.cacert, self.host)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        assert '303 See Other'.lower() in out.lower()
+        assert '303 See Other'.lower() in out.lower(), f"Whoami failed: {out}"
 
     @skip_outside_gh_actions
     @pytest.mark.dirty
@@ -145,7 +131,5 @@ class TestCurlRucio:
         assert 'X-Rucio-Auth-Token' in out
         os.environ['RUCIO_TOKEN'] = out[len('X-Rucio-Auth-Token: '):].rstrip()
         cmd = '''curl -s -i --cacert %s -H "X-Rucio-Auth-Token: $RUCIO_TOKEN" -X POST %s/rses/%s''' % (self.cacert, self.host, rse_name_generator())
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        assert '201 Created'.lower() in out.lower()
+        assert '201 Created'.lower() in out.lower(), f"RSE creation failed: {out}"

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -41,6 +41,7 @@ class TestCurlRucio:
         cmd = 'curl --cacert %s -s -X GET %s/ping' % (self.cacert, self.host)
         exitcode, out, err = execute(cmd)
         ret = json.loads(out)
+        assert exitcode == 0, f"Ping failed: {self.marker} {cmd}"
         assert 'version' in ret, f"Version not found in response : {out} {ret}"
         assert isinstance(ret, dict)
 
@@ -48,6 +49,7 @@ class TestCurlRucio:
         """AUTH (CURL): Test auth token retrieval with via username and password"""
         cmd = 'curl -s -i --cacert %s -X GET -H "X-Rucio-Account: root" -H "X-Rucio-Username: ddmlab" -H "X-Rucio-Password: secret" %s %s/auth/userpass' % (self.cacert, self.vo_header, self.auth_host)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Auth token retrieval failed: {self.marker} {cmd}"
         assert 'X-Rucio-Auth-Token' in out, f"Auth token not found in response: {out}"
 
     @skip_outside_gh_actions
@@ -55,6 +57,7 @@ class TestCurlRucio:
         """AUTH (CURL): Test auth token retrieval with via x509"""
         cmd = 'curl -s -i --cacert %s -H "X-Rucio-Account: root" %s -cert %s --key %s -X GET %s/auth/x509' % (self.cacert, self.vo_header, self.usercert, self.userkey, self.auth_host)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Auth token retrieval failed: {self.marker} {cmd}"
         assert 'X-Rucio-Auth-Token' in out, f"Auth token not found in response: {out}"
 
     def test_get_auth_gss(self):
@@ -90,6 +93,7 @@ class TestCurlRucio:
         os.environ['RUCIO_TOKEN'] = out[len('X-Rucio-Auth-Token: '):].rstrip()
         cmd = 'curl -s -i --cacert %s  -H "X-Rucio-Auth-Token: $RUCIO_TOKEN" -X GET %s/auth/validate' % (self.cacert, self.auth_host)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Token validation failed: {self.marker} {cmd}"
         assert 'datetime.datetime' in out, f"Token validation failed: {out}"
 
     @skip_outside_gh_actions
@@ -109,6 +113,7 @@ class TestCurlRucio:
                "-X POST %s/accounts/%s"
                ) % (self.cacert, self.host, account_name_generator())
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Account creation failed: {self.marker} {cmd}"
         assert '201 Created'.lower() in out.lower(), f"Account creation failed: {out}"
 
     @skip_outside_gh_actions
@@ -116,10 +121,12 @@ class TestCurlRucio:
         """ACCOUNT (CURL): Test whoami method"""
         cmd = 'curl -s -i --cacert %s -H "X-Rucio-Account: root" %s --cert %s --key %s -X GET %s/auth/x509 | tr -d \'\r\' | grep X-Rucio-Auth-Token:' % (self.cacert, self.vo_header, self.usercert, self.userkey, self.auth_host)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Auth token retrieval failed: {cmd}"
         assert 'X-Rucio-Auth-Token' in out, f"Auth token not found in response: {out}"
         os.environ['RUCIO_TOKEN'] = out[len('X-Rucio-Auth-Token: '):].rstrip()
         cmd = '''curl -s -i -L --cacert %s -H "X-Rucio-Auth-Token: $RUCIO_TOKEN" -X GET %s/accounts/whoami''' % (self.cacert, self.host)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Whoami failed: {self.marker} {cmd}"
         assert '303 See Other'.lower() in out.lower(), f"Whoami failed: {out}"
 
     @skip_outside_gh_actions
@@ -132,4 +139,5 @@ class TestCurlRucio:
         os.environ['RUCIO_TOKEN'] = out[len('X-Rucio-Auth-Token: '):].rstrip()
         cmd = '''curl -s -i --cacert %s -H "X-Rucio-Auth-Token: $RUCIO_TOKEN" -X POST %s/rses/%s''' % (self.cacert, self.host, rse_name_generator())
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"RSE creation failed: {self.marker} {cmd}"
         assert '201 Created'.lower() in out.lower(), f"RSE creation failed: {out}"

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -1260,20 +1260,19 @@ def test_list_by_length(vo, root_account, rse_factory, mock_scope, did_factory, 
     results = []
     for d in dids:
         results.append(d)
-    print(results)
-    assert len(results) != 0
+    assert len(results) != 0, "No DIDs found with length > 0"
 
     dids = did_client.list_dids(tmp_scope, {'length.gt': -1, 'length.lt': 1})
     results = []
     for d in dids:
         results.append(d)
-    assert len(results) == 0
+    assert len(results) == 0, "DIDs found with length > -1 and < 1"
 
     dids = did_client.list_dids(tmp_scope, {'length': 0})
     results = []
     for d in dids:
         results.append(d)
-    assert len(results) == 0
+    assert len(results) == 0, "DIDs found with length = 0"
 
 
 @pytest.mark.dirty

--- a/tests/test_did_meta_plugins.py
+++ b/tests/test_did_meta_plugins.py
@@ -736,9 +736,8 @@ def test_did_set_metadata_bulk_single(testdid):
 
     set_metadata_bulk(meta=testmeta, recursive=False, **testdid)
     meta = get_metadata(plugin="ALL", **testdid)
-    print('Metadata:', meta)
 
-    assert testkey in meta and meta[testkey] == testmeta[testkey]
+    assert testkey in meta and meta[testkey] == testmeta[testkey], f"Expected {testkey} to be {testmeta[testkey]}, but got {meta[testkey]}"
 
 
 def test_did_set_metadata_bulk_multi(testdid):
@@ -752,10 +751,9 @@ def test_did_set_metadata_bulk_multi(testdid):
 
     set_metadata_bulk(meta=testmeta, recursive=False, **testdid)
     meta = get_metadata(plugin="ALL", **testdid)
-    print('Metadata:', meta)
 
     for testkey in testkeys:
-        assert testkey in meta and meta[testkey] == testmeta[testkey]
+        assert testkey in meta and meta[testkey] == testmeta[testkey], f"Expected {testkey} to be {testmeta[testkey]}, but got {meta[testkey]}"
 
 
 def test_set_dids_metadata_bulk_multi(did_factory):
@@ -773,11 +771,9 @@ def test_set_dids_metadata_bulk_multi(did_factory):
     set_dids_metadata_bulk(dids=dids, recursive=False)
     for did in dids:
         testmeta = did['meta']
-        print('Metadata:', testmeta)
         meta = get_metadata(plugin="ALL", scope=did['scope'], name=did['name'])
-        print('Metadata:', meta)
         for testkey in testmeta:
-            assert testkey in meta and meta[testkey] == testmeta[testkey]
+            assert testkey in meta and meta[testkey] == testmeta[testkey], f"Expected {testkey} to be {testmeta[testkey]}, but got {meta[testkey]}"
 
 
 def test_did_set_metadata_bulk_multi_client(testdid):
@@ -796,10 +792,9 @@ def test_did_set_metadata_bulk_multi_client(testdid):
     assert result is True
 
     meta = get_metadata(plugin="ALL", **testdid)
-    print('Metadata:', meta)
 
     for testkey in testkeys:
-        assert testkey in meta and meta[testkey] == testmeta[testkey]
+        assert testkey in meta and meta[testkey] == testmeta[testkey], f"Expected {testkey} to be {testmeta[testkey]}, but got {meta[testkey]}"
 
 
 def test_set_dids_metadata_bulk_multi_client(did_factory, rucio_client):
@@ -823,8 +818,6 @@ def test_set_dids_metadata_bulk_multi_client(did_factory, rucio_client):
 
     for did in dids:
         testmeta = did['meta']
-        print('Metadata:', testmeta)
         meta = get_metadata(plugin="ALL", scope=did['scope'], name=did['name'])
-        print('Metadata:', meta)
         for testkey in testmeta:
-            assert testkey in meta and meta[testkey] == testmeta[testkey]
+            assert testkey in meta and meta[testkey] == testmeta[testkey], f"Expected {testkey} to be {testmeta[testkey]}, but got {meta[testkey]}"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -519,8 +519,7 @@ def test_disable_no_files_download_error(vo, rse_factory, did_factory, download_
     rse, _ = rse_factory.make_posix_rse()
     with TemporaryDirectory() as tmp_dir:
         res = download_client.download_dids([{'did': 'some:randomNonExistingDid', 'base_dir': tmp_dir}], deactivate_file_download_exceptions=True)
-        print('Downloaded object', res)
-        assert res[0]['clientState'] == 'FILE_NOT_FOUND'
+        assert res[0]['clientState'] == 'FILE_NOT_FOUND', 'Expected FILE_NOT_FOUND state, got %s' % res[0]['clientState']
 
 
 def test_nrandom_respected(rse_factory, did_factory, download_client, root_account):

--- a/tests/test_gateway_external_representation.py
+++ b/tests/test_gateway_external_representation.py
@@ -383,8 +383,7 @@ class TestGatewayExternalRepresentation:
         abacus_rse.run(once=True)
 
         out = gateway_rse.get_rse_usage(rse_mock, per_account=True, issuer='root', vo=vo)
-        print(out)
-        assert rse_mock_id in [o['rse_id'] for o in out]
+        assert rse_mock_id in [o['rse_id'] for o in out], f"RSE ID not found in usage output: {out}"
         for usage in out:
             if usage['rse_id'] == rse_mock_id:
                 assert usage['rse'] == rse_mock

--- a/tests/test_hermes.py
+++ b/tests/test_hermes.py
@@ -248,9 +248,8 @@ def test_hermes(core_config_mock, caches_mock, monkeypatch):
     response = requests.post(
         "http://localhost:9200/_search?size=1000", data=data, headers=headers
     )
-    assert response.status_code == 200
+    assert response.status_code == 200, f"Response status code should be 200, got {response.status_code}"
     res = response.json()
-    print(res)
     elastic_messages = []
     for entry in res["hits"]["hits"]:
         message = entry["_source"]
@@ -265,7 +264,7 @@ def test_hermes(core_config_mock, caches_mock, monkeypatch):
             }
         )
     for message in list_messages:
-        assert message in elastic_messages
+        assert message in elastic_messages, f"Message {message} not found in elastic messages, res = {res}"
 
     # Checking ActiveMQ
     assert service_dict["activemq"] == 0

--- a/tests/test_impl_upload_download.py
+++ b/tests/test_impl_upload_download.py
@@ -47,40 +47,26 @@ class TestImplUploadDownload:
 
         # Uploading file
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} {3}'.format(rse, scope, impl, tmp_file1)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # List the files
         cmd = 'rucio list-files {0}:{1}'.format(scope, tmp_file1.name)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # List the replicas
         cmd = 'rucio list-file-replicas {0}:{1}'.format(scope, tmp_file1.name)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"List file replicas failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # Downloading the file
         cmd = 'rucio download --legacy --dir /tmp/ {0}:{1} --impl {2}'.format(scope, tmp_file1.name, impl)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
         # The file should be there
         cmd = 'find /tmp/{0}/{1}'.format(scope, tmp_file1.name)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(err, out)
-        assert exitcode == 0
+        assert exitcode == 0, f"File not found after download: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
     def test_upload_download_datasets_using_impl(self, file_factory, did_factory, scope, rse):
         """CLIENT(USER): rucio upload files to dataset/download dataset"""
@@ -93,40 +79,26 @@ class TestImplUploadDownload:
 
         # Adding files to a new dataset
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} {3} {4} {5} {1}:{6}'.format(rse, scope, impl, tmp_file1, tmp_file2, tmp_file3, tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # List the files
         cmd = 'rucio list-files {0}:{1}'.format(scope, tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # List the replicas
         cmd = 'rucio list-file-replicas {0}:{1}'.format(scope, tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"List file replicas failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # Downloading dataset
         cmd = 'rucio download --legacy --dir /tmp/ {0}:{1} --impl {2}'.format(scope, tmp_dsn, impl)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
         # The files should be there
         cmd = 'ls /tmp/{0}/*'.format(tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(err, out)
-        assert exitcode == 0
+        assert exitcode == 0, f"Files not found after download: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert tmp_file1.name in out
         assert tmp_file2.name in out
         assert tmp_file3.name in out
@@ -141,35 +113,23 @@ class TestImplUploadDownload:
 
         # Upload the file
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} {3}'.format(rse, scope, impl, tmp_file1)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
         # get the rule for the file
         cmd = r"rucio rule list {0}:{1} | grep {0}:{1} | cut -f1 -d\ ".format(scope, tmp_file1.name)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         rule = out
         # delete the file from the catalog
         cmd = "rucio delete-rule {0}".format(rule)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         # delete the physical file
         cmd = 'rucio replica list file --pfns {0}:{1}'.format(scope, tmp_file1.name)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         url = out
         cmd = 'gfal-rm {0}'.format(url)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
-        assert re.search(r'DELETED', out) is not None
+        assert re.search(r'DELETED', out) is not None, f"File deletion failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         # upload the files to the dataset
         cmd = 'rucio -v upload --legacy --rse {0} --scope {1} --impl {2} {3} {4} {5}'.format(rse, scope, impl, tmp_file1, tmp_file2, tmp_file3)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
         upload_string_1 = ('Successfully uploaded file %s' % tmp_file1.name)
         assert re.search(upload_string_1, err) is not None
@@ -183,55 +143,35 @@ class TestImplUploadDownload:
 
         # Upload the file
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} {3}'.format(rse, scope, impl, tmp_file1)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # List the file
         cmd = 'rucio list-files {0}:{1}'.format(scope, tmp_file1_name)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # List the replicas
         cmd = 'rucio list-file-replicas {0}:{1}'.format(scope, tmp_file1_name)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"List file replicas failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # Re-Upload the file
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} {3}'.format(rse, scope, impl, tmp_file1)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
         assert re.search(r'File already exists on RSE. Skipping upload', err) is not None
 
         # Downloading the file
         cmd = 'rucio download --legacy --dir /tmp/ {0}:{1} --impl {2}'.format(scope, tmp_file1_name, impl)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
         # The file should be there
         cmd = 'find /tmp/{0}/{1}'.format(scope, tmp_file1_name)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(err, out)
-        assert exitcode == 0
+        assert exitcode == 0, f"File not found after download: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # Re-download file
         cmd = 'rucio download --legacy --dir /tmp/ {0}:{1} --impl {2}'.format(scope, tmp_file1_name, impl)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
         assert re.search(r'Downloaded files:\s+0', out) is not None
         assert re.search(r'Files already found locally:\s+1', out) is not None
 
@@ -248,56 +188,38 @@ class TestImplUploadDownload:
 
         # Adding files to a new dataset
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} {3} {1}:{4}'.format(rse, scope, impl, tmp_file1, tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
         # upload the files to the dataset
         cmd = 'rucio -v upload --legacy --rse {0} --scope {1} --impl {2} {3} {4} {5} {1}:{6}'.format(rse, scope, impl, tmp_file1, tmp_file2, tmp_file3, tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
 
         # List the files
         cmd = 'rucio list-files {0}:{1}'.format(scope, tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search("{0}:{1}".format(scope, tmp_file1_name), out) is not None
         assert re.search("{0}:{1}".format(scope, tmp_file3_name), out) is not None
 
         # List the replicas
         cmd = 'rucio list-file-replicas {0}:{1}'.format(scope, tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"List file replicas failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # Downloading dataset
         cmd = 'rucio download --legacy --dir /tmp/ {0}:{1} --impl {2}'.format(scope, tmp_dsn, impl)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
         # The files should be there
         cmd = 'ls /tmp/{0}/*'.format(tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(err, out)
-        assert exitcode == 0
+        assert exitcode == 0, f"Files not found after download: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert tmp_file1.name in out
         assert tmp_file2.name in out
         assert tmp_file3.name in out
 
         # Re-download dataset
         cmd = 'rucio download --legacy --dir /tmp/ {0}:{1} --impl {2}'.format(scope, tmp_dsn, impl)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Re-download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search(r'Downloaded files:\s+0', out) is not None
         assert re.search(r'Files already found locally:\s+3', out) is not None
 
@@ -308,11 +230,8 @@ class TestImplUploadDownload:
         tmp_guid = uuid()
         impl = 'xrootd'
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} --guid {3} {4}'.format(rse, scope, impl, tmp_guid, tmp_file1)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         upload_string_1 = ('Successfully uploaded file %s' % path.basename(tmp_file1))
         assert re.search(upload_string_1, err) is not None
 
@@ -325,30 +244,19 @@ class TestImplUploadDownload:
         did_factory.register_dids([{'scope': scope, 'name': tmp_file1.name}])
         tmp_guid = uuid()
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} --guid {3} {4}'.format(rse, scope, impl, tmp_guid, tmp_file1)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         wrong_guid = uuid()
         cmd = 'rucio -v download --legacy --dir /tmp {0}:{1} --impl {2} --filter guid={3}'.format(scope, '*', impl, wrong_guid)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         cmd = 'ls /tmp/{0}'.format(scope)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         assert re.search(tmp_file1.name, out) is None
         cmd = 'rucio -v download --legacy --dir /tmp {0}:{1} --impl {2} --filter guid={3}'.format(scope, '*', impl, tmp_guid)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'ls /tmp/{0}'.format(scope)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         assert re.search(tmp_file1.name, out) is not None
 
         # Only use filter option to download file
@@ -356,30 +264,19 @@ class TestImplUploadDownload:
         did_factory.register_dids([{'scope': scope, 'name': tmp_file1.name}])
         tmp_guid = uuid()
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} --guid {3} {4}'.format(rse, scope, impl, tmp_guid, tmp_file1)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         wrong_guid = uuid()
         cmd = 'rucio -v download --legacy --dir /tmp --scope {0} --impl {1} --filter guid={2}'.format(scope, impl, wrong_guid)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         cmd = 'ls /tmp/{0}'.format(scope)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         assert re.search(tmp_file1.name, out) is None
         cmd = 'rucio -v download --legacy --dir /tmp --scope {0} --impl {1} --filter guid={2}'.format(scope, impl, tmp_guid)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'ls /tmp/{0}'.format(scope)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         assert re.search(tmp_file1.name, out) is not None
 
         # Use filter option to download dataset with wildcarded name
@@ -387,28 +284,17 @@ class TestImplUploadDownload:
         tmp_dsn = 'tests.rucio_client_test_server_impl_check' + uuid()
         did_factory.register_dids([{'scope': scope, 'name': n} for n in (tmp_file1.name, tmp_dsn)])
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} {3} {1}:{4}'.format(rse, scope, impl, tmp_file1, tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'rucio download --legacy --dir /tmp --scope {0} --filter created_before=1900-01-01T00:00:00.000Z'.format(scope)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         cmd = 'ls /tmp/{0}'.format(tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         assert re.search(tmp_file1.name, out) is None
         cmd = 'rucio download --legacy --dir /tmp --scope {0} --filter created_after=1900-01-01T00:00:00.000Z'.format(scope)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         cmd = 'ls /tmp/{0}'.format(tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         # assert re.search(tmp_file1[5:], out) is not None
 
         # Use filter option to download dataset with wildcarded name
@@ -416,26 +302,15 @@ class TestImplUploadDownload:
         tmp_dsn = 'tests.rucio_client_test_server_impl_check' + uuid()
         did_factory.register_dids([{'scope': scope, 'name': n} for n in (tmp_file1.name, tmp_dsn)])
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} {3} {1}:{4}'.format(rse, scope, impl, tmp_file1, tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'rucio download --legacy --dir /tmp {0}:{1} --filter created_before=1900-01-01T00:00:00.000Z'.format(scope, tmp_dsn[0:-1] + '*')
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         cmd = 'ls /tmp/{0}'.format(tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         assert re.search(tmp_file1.name, out) is None
         cmd = 'rucio download --legacy --dir /tmp {0}:{1} --filter created_after=1900-01-01T00:00:00.000Z'.format(scope, tmp_dsn[0:-1] + '*')
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         cmd = 'ls /tmp/{0}'.format(tmp_dsn)
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         assert re.search(tmp_file1.name, out) is not None

--- a/tests/test_impl_upload_download.py
+++ b/tests/test_impl_upload_download.py
@@ -63,6 +63,7 @@ class TestImplUploadDownload:
         # Downloading the file
         cmd = 'rucio download --legacy --dir /tmp/ {0}:{1} --impl {2}'.format(scope, tmp_file1.name, impl)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         # The file should be there
         cmd = 'find /tmp/{0}/{1}'.format(scope, tmp_file1.name)
         exitcode, out, err = execute(cmd)
@@ -95,6 +96,7 @@ class TestImplUploadDownload:
         # Downloading dataset
         cmd = 'rucio download --legacy --dir /tmp/ {0}:{1} --impl {2}'.format(scope, tmp_dsn, impl)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         # The files should be there
         cmd = 'ls /tmp/{0}/*'.format(tmp_dsn)
         exitcode, out, err = execute(cmd)
@@ -114,16 +116,20 @@ class TestImplUploadDownload:
         # Upload the file
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} {3}'.format(rse, scope, impl, tmp_file1)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         # get the rule for the file
         cmd = r"rucio rule list {0}:{1} | grep {0}:{1} | cut -f1 -d\ ".format(scope, tmp_file1.name)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Get rule failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         rule = out
         # delete the file from the catalog
         cmd = "rucio delete-rule {0}".format(rule)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Delete rule failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         # delete the physical file
         cmd = 'rucio replica list file --pfns {0}:{1}'.format(scope, tmp_file1.name)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"List replicas failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         url = out
         cmd = 'gfal-rm {0}'.format(url)
         exitcode, out, err = execute(cmd)
@@ -132,6 +138,7 @@ class TestImplUploadDownload:
         cmd = 'rucio -v upload --legacy --rse {0} --scope {1} --impl {2} {3} {4} {5}'.format(rse, scope, impl, tmp_file1, tmp_file2, tmp_file3)
         exitcode, out, err = execute(cmd)
         upload_string_1 = ('Successfully uploaded file %s' % tmp_file1.name)
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search(upload_string_1, err) is not None
 
     def test_repeat_upload_download_file_using_impl(self, file_factory, did_factory, scope, rse):
@@ -159,11 +166,13 @@ class TestImplUploadDownload:
         # Re-Upload the file
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} {3}'.format(rse, scope, impl, tmp_file1)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Re-upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search(r'File already exists on RSE. Skipping upload', err) is not None
 
         # Downloading the file
         cmd = 'rucio download --legacy --dir /tmp/ {0}:{1} --impl {2}'.format(scope, tmp_file1_name, impl)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         # The file should be there
         cmd = 'find /tmp/{0}/{1}'.format(scope, tmp_file1_name)
         exitcode, out, err = execute(cmd)
@@ -172,6 +181,7 @@ class TestImplUploadDownload:
         # Re-download file
         cmd = 'rucio download --legacy --dir /tmp/ {0}:{1} --impl {2}'.format(scope, tmp_file1_name, impl)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Re-download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search(r'Downloaded files:\s+0', out) is not None
         assert re.search(r'Files already found locally:\s+1', out) is not None
 
@@ -189,9 +199,11 @@ class TestImplUploadDownload:
         # Adding files to a new dataset
         cmd = 'rucio upload --legacy --rse {0} --scope {1} --impl {2} {3} {1}:{4}'.format(rse, scope, impl, tmp_file1, tmp_dsn)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         # upload the files to the dataset
         cmd = 'rucio -v upload --legacy --rse {0} --scope {1} --impl {2} {3} {4} {5} {1}:{6}'.format(rse, scope, impl, tmp_file1, tmp_file2, tmp_file3, tmp_dsn)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
 
         # List the files
         cmd = 'rucio list-files {0}:{1}'.format(scope, tmp_dsn)
@@ -208,6 +220,7 @@ class TestImplUploadDownload:
         # Downloading dataset
         cmd = 'rucio download --legacy --dir /tmp/ {0}:{1} --impl {2}'.format(scope, tmp_dsn, impl)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         # The files should be there
         cmd = 'ls /tmp/{0}/*'.format(tmp_dsn)
         exitcode, out, err = execute(cmd)
@@ -249,14 +262,17 @@ class TestImplUploadDownload:
         wrong_guid = uuid()
         cmd = 'rucio -v download --legacy --dir /tmp {0}:{1} --impl {2} --filter guid={3}'.format(scope, '*', impl, wrong_guid)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'ls /tmp/{0}'.format(scope)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search(tmp_file1.name, out) is None
         cmd = 'rucio -v download --legacy --dir /tmp {0}:{1} --impl {2} --filter guid={3}'.format(scope, '*', impl, tmp_guid)
         exitcode, out, err = execute(cmd)
         assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'ls /tmp/{0}'.format(scope)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search(tmp_file1.name, out) is not None
 
         # Only use filter option to download file
@@ -269,14 +285,17 @@ class TestImplUploadDownload:
         wrong_guid = uuid()
         cmd = 'rucio -v download --legacy --dir /tmp --scope {0} --impl {1} --filter guid={2}'.format(scope, impl, wrong_guid)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'ls /tmp/{0}'.format(scope)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search(tmp_file1.name, out) is None
         cmd = 'rucio -v download --legacy --dir /tmp --scope {0} --impl {1} --filter guid={2}'.format(scope, impl, tmp_guid)
         exitcode, out, err = execute(cmd)
         assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'ls /tmp/{0}'.format(scope)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search(tmp_file1.name, out) is not None
 
         # Use filter option to download dataset with wildcarded name
@@ -288,13 +307,17 @@ class TestImplUploadDownload:
         assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'rucio download --legacy --dir /tmp --scope {0} --filter created_before=1900-01-01T00:00:00.000Z'.format(scope)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'ls /tmp/{0}'.format(tmp_dsn)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search(tmp_file1.name, out) is None
         cmd = 'rucio download --legacy --dir /tmp --scope {0} --filter created_after=1900-01-01T00:00:00.000Z'.format(scope)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'ls /tmp/{0}'.format(tmp_dsn)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         # assert re.search(tmp_file1[5:], out) is not None
 
         # Use filter option to download dataset with wildcarded name
@@ -306,11 +329,15 @@ class TestImplUploadDownload:
         assert exitcode == 0, f"Upload failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'rucio download --legacy --dir /tmp {0}:{1} --filter created_before=1900-01-01T00:00:00.000Z'.format(scope, tmp_dsn[0:-1] + '*')
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'ls /tmp/{0}'.format(tmp_dsn)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search(tmp_file1.name, out) is None
         cmd = 'rucio download --legacy --dir /tmp {0}:{1} --filter created_after=1900-01-01T00:00:00.000Z'.format(scope, tmp_dsn[0:-1] + '*')
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Download failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         cmd = 'ls /tmp/{0}'.format(tmp_dsn)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"List files failed: {self.marker} {cmd}. Error: {err}. Output: {out}"
         assert re.search(tmp_file1.name, out) is not None

--- a/tests/test_multi_vo.py
+++ b/tests/test_multi_vo.py
@@ -957,20 +957,24 @@ class TestMultiVOBinRucio:
 
         cmd = 'rucio-admin --vo %s rse list' % long_vo
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Command failed : {self.marker + cmd}. Error: {err}. Output: {out}"
         assert self.rse_tst in out
         assert self.rse_new not in out
 
         cmd = 'rucio-admin --vo %s rse list' % second_vo
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Command failed : {self.marker + cmd}. Error: {err}. Output: {out}"
         assert self.rse_tst not in out
         assert self.rse_new in out
 
         cmd = 'rucio-admin --vo %s rse list' % fake_vo
         exitcode, out, err = execute(cmd)
+        assert exitcode != 0, f"Command should have failed : {self.marker + cmd}. Error: {err}. Output: {out}"
         assert 'Details: CannotAuthenticate' in err
 
         cmd = 'rucio-admin rse list'
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Command failed : {self.marker + cmd}. Error: {err}. Output: {out}"
         assert self.rse_tst in out
         assert self.rse_new not in out
 
@@ -980,20 +984,24 @@ class TestMultiVOBinRucio:
 
         cmd = 'rucio --vo %s list-rses' % long_vo
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Command failed : {self.marker + cmd}. Error: {err}. Output: {out}"
         assert self.rse_tst in out
         assert self.rse_new not in out
 
         cmd = 'rucio --vo %s list-rses' % second_vo
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Command failed : {self.marker + cmd}. Error: {err}. Output: {out}"
         assert self.rse_tst not in out
         assert self.rse_new in out
 
         cmd = 'rucio --vo %s list-rses' % fake_vo
         exitcode, out, err = execute(cmd)
+        assert exitcode != 0, f"Command should have failed : {self.marker + cmd}. Error: {err}. Output: {out}"
         assert 'Details: CannotAuthenticate' in err
 
         cmd = 'rucio list-rses'
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Command failed : {self.marker + cmd}. Error: {err}. Output: {out}"
         assert self.rse_tst in out
         assert self.rse_new not in out
 

--- a/tests/test_multi_vo.py
+++ b/tests/test_multi_vo.py
@@ -956,29 +956,21 @@ class TestMultiVOBinRucio:
         fake_vo = 'fke'
 
         cmd = 'rucio-admin --vo %s rse list' % long_vo
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, )
         assert self.rse_tst in out
         assert self.rse_new not in out
 
         cmd = 'rucio-admin --vo %s rse list' % second_vo
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, )
         assert self.rse_tst not in out
         assert self.rse_new in out
 
         cmd = 'rucio-admin --vo %s rse list' % fake_vo
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         assert 'Details: CannotAuthenticate' in err
 
         cmd = 'rucio-admin rse list'
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, )
         assert self.rse_tst in out
         assert self.rse_new not in out
 
@@ -987,29 +979,21 @@ class TestMultiVOBinRucio:
         fake_vo = 'fke'
 
         cmd = 'rucio --vo %s list-rses' % long_vo
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, )
         assert self.rse_tst in out
         assert self.rse_new not in out
 
         cmd = 'rucio --vo %s list-rses' % second_vo
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, )
         assert self.rse_tst not in out
         assert self.rse_new in out
 
         cmd = 'rucio --vo %s list-rses' % fake_vo
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         assert 'Details: CannotAuthenticate' in err
 
         cmd = 'rucio list-rses'
-        print(self.marker + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, )
         assert self.rse_tst in out
         assert self.rse_new not in out
 

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -1743,8 +1743,7 @@ class TestAuthCoreAPIoidc:
         new_token_dict = get_token_for_account_operation(req_account, req_audience=req_audience, req_scope=req_scope, admin=req_admin, session=self.db_session)
         # ---------------------------
         # Check if token has been received
-        print('NEW TOKEN DICT ==', new_token_dict)
-        assert new_token_dict
+        assert new_token_dict, 'No token received from get_token_for_account_operation'
         # ---------------------------
         # Check of token being in DB under the expected account
         db_token = get_token_row(new_token_dict['token'], account=final_token_account, session=self.db_session)

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -627,8 +627,7 @@ class TestReplicaCore:
 
         # test empty dataset
         cov = get_rse_coverage_of_dataset(scope=mock_scope, name=dsn)
-        print(cov)
-        assert cov == {}
+        assert cov == {}, f"Expected empty coverage, got {cov}"
         # add files/replicas
         for i in range(1, 8):
             add_replica(rse_id=rse1_id, scope=mock_scope, name=dsn + '_%06d.data' % i, bytes_=100, account=root_account)
@@ -639,10 +638,9 @@ class TestReplicaCore:
 
         attach_dids(scope=mock_scope, name=dsn, dids=[{'scope': mock_scope, 'name': dsn + '_%06d.data' % i} for i in range(1, 16)], account=root_account)
         cov = get_rse_coverage_of_dataset(scope=mock_scope, name=dsn)
-        print(cov)
-        assert cov[rse1_id] == 700
-        assert cov[rse2_id] == 300
-        assert cov[rse3_id] == 500
+        assert cov[rse1_id] == 700, f"Expected 700 bytes on rse1, got {cov[rse1_id]}"
+        assert cov[rse2_id] == 300, f"Expected 300 bytes on rse2, got {cov[rse2_id]}"
+        assert cov[rse3_id] == 500, f"Expected 500 bytes on rse3, got {cov[rse3_id]}"
 
     @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
         'rucio.core.rse_expression_parser.REGION',
@@ -947,8 +945,7 @@ def test_client_add_temporary_unavailable_pfns(rse_factory, mock_scope, replica_
     # Check the state in the replica table
     for did in files:
         rep = get_replicas_state(scope=mock_scope, name=did['name'])
-        print(rep)
-        assert list(rep.keys())[0] == ReplicaState.AVAILABLE
+        assert list(rep.keys())[0] == ReplicaState.AVAILABLE, f"rep {rep} for {did['name']} should be AVAILABLE, but is {list(rep.keys())[0]}"
 
 
 def test_client_declare_bad_pfns(rse_factory, mock_scope, replica_client):
@@ -1189,11 +1186,7 @@ def test_client_list_replicas_streaming_error(content_type, vo, did_client, repl
             from rucio.web.rest.flaskapi.v1.replicas import ListReplicas
             list_replicas_restapi = ListReplicas()
             list_replicas_restapi.post()
-            # for debugging when this test fails
-            print(f'Response({response_mock.call_args})')
-            print(f'  args = {response_mock.call_args[0]}')
-            print(f'kwargs = {response_mock.call_args[1]}')
-            assert response_mock.call_args[1]['content_type'] == content_type
+            assert response_mock.call_args[1]['content_type'] == content_type, f"unexpected content type {response_mock.call_args[1]['content_type']} Resp: {response_mock.call_args} args: {response_mock.call_args[0]} kwargs: {response_mock.call_args[1]}"
             response_iter = response_mock.call_args[0][0]
             assert response_iter != '', 'unexpected empty response'
             # since we're directly accessing the generator for Flask, there is no error handling
@@ -1218,8 +1211,7 @@ def test_client_list_replicas_streaming_error(content_type, vo, did_client, repl
             if json_doc:
                 replicas.append(parse_response(json_doc))
         assert replicas
-        print(replicas)
-        assert replicas == [mock_api_response]
+        assert replicas == [mock_api_response], f"unexpected replicas {replicas}. Expected: {mock_api_response}"
 
     else:
         pytest.fail('unknown content_type parameter on test: ' + content_type)

--- a/tests/test_replica_recoverer.py
+++ b/tests/test_replica_recoverer.py
@@ -71,30 +71,26 @@ class TestReplicaRecoverer:
             # Upload files with scope "mock_scope"
             cmd = 'rucio -v upload --legacy --rse {0} --scope {1} {2} {3} {4} {5} {6} {7} {8}'.format(rse, mock_scope.external, self.tmp_file1, self.tmp_file2, self.tmp_file3, self.tmp_file4, self.tmp_file5, self.tmp_file6, self.tmp_file12)
             exitcode, out, err = execute(cmd)
-            print("mock_scope:", exitcode, out, err)
             # checking if Rucio upload went OK
-            assert exitcode == 0
+            assert exitcode == 0, f"Command failed: {cmd}. Error: {err}. Output: {out}"
 
             # Upload files with scope "scope_declarebad"
             cmd = 'rucio -v upload --legacy --rse {0} --scope {1} {2} {3} {4} {5}'.format(rse, self.scope_declarebad.external, self.tmp_file7, self.tmp_file9, self.tmp_file11, self.tmp_file13)
             exitcode, out, err = execute(cmd)
-            print("scope_declarebad:", exitcode, out, err)
             # checking if Rucio upload went OK
-            assert exitcode == 0
+            assert exitcode == 0, f"Command failed: {cmd}. Error: {err}. Output: {out}"
 
             # Upload files with scope "scope_nopolicy"
             cmd = 'rucio -v upload --legacy --rse {0} --scope {1} {2}'.format(rse, self.scope_nopolicy.external, self.tmp_file8)
             exitcode, out, err = execute(cmd)
-            print("scope_nopolicy:", exitcode, out, err)
             # checking if Rucio upload went OK
-            assert exitcode == 0
+            assert exitcode == 0, f"Command failed: {cmd}. Error: {err}. Output: {out}"
 
             # Upload files with scope "scope_nopolicy"
             cmd = 'rucio -v upload --legacy --rse {0} --scope {1} {2}'.format(rse, self.scope_ignore.external, self.tmp_file10)
             exitcode, out, err = execute(cmd)
-            print("scope_ignore:", exitcode, out, err)
             # checking if Rucio upload went OK
-            assert exitcode == 0
+            assert exitcode == 0, f"Command failed: {cmd}. Error: {err}. Output: {out}"
 
         # Explanation of the fictional data types:
         # testtypedeclarebad: Files are specified to be declared bad

--- a/tests/test_rse.py
+++ b/tests/test_rse.py
@@ -572,11 +572,10 @@ class TestRSEClient:
             rucio_client.add_protocol(protocol_rse, p)
         resp = mgr.get_rse_info(rse=protocol_rse, vo=vo)
         for p in resp['protocols']:
-            if ((p['port'] == 19) and (p['domains']['lan']['read'] != 1)) or \
-                    ((p['port'] == 20) and (p['domains']['lan']['read'] != 2)) or \
-                    ((p['port'] == 18) and (p['domains']['lan']['read'] != 1)) or \
-                    ((p['port'] == 17) and (p['domains']['lan']['read'] != 4)):
-                assert False
+            assert not (((p['port'] == 19) and (p['domains']['lan']['read'] != 1)) or
+                        ((p['port'] == 20) and (p['domains']['lan']['read'] != 2)) or
+                        ((p['port'] == 18) and (p['domains']['lan']['read'] != 1)) or
+                        ((p['port'] == 17) and (p['domains']['lan']['read'] != 4))), f"Protocol {p['port']} has wrong read value {p['domains']['lan']['read']}. Response: {resp}"
 
         rucio_client.delete_protocols(protocol_rse, scheme='MOCK')
         rucio_client.delete_rse(protocol_rse)
@@ -1279,11 +1278,9 @@ class TestRSEClient:
         prots = rucio_client.get_protocols(protocol_rse)
         for p in prots:
             if p['scheme'] == 'MOCKA':
-                if p['domains']['lan']['read'] != 3:
-                    assert False
+                assert p['domains']['lan']['read'] == 3, f"MOCKA with unexpected priority: {p['domains']['lan']['read']}. Protocols: {prots}"
             if p['scheme'] == 'MOCKC':
-                if p['domains']['lan']['read'] != 1:
-                    assert False
+                assert p['domains']['lan']['read'] == 1, f"MOCKC with unexpected priority: {p['domains']['lan']['read']}. Protocols: {prots}"
         assert True
 
     def test_update_protocols_rse_not_found(self, rucio_client):

--- a/tests/test_rse.py
+++ b/tests/test_rse.py
@@ -576,7 +576,6 @@ class TestRSEClient:
                     ((p['port'] == 20) and (p['domains']['lan']['read'] != 2)) or \
                     ((p['port'] == 18) and (p['domains']['lan']['read'] != 1)) or \
                     ((p['port'] == 17) and (p['domains']['lan']['read'] != 4)):
-                print(resp)
                 assert False
 
         rucio_client.delete_protocols(protocol_rse, scheme='MOCK')
@@ -1281,13 +1280,9 @@ class TestRSEClient:
         for p in prots:
             if p['scheme'] == 'MOCKA':
                 if p['domains']['lan']['read'] != 3:
-                    print('MOCKA with unexpected priority')
-                    print(prots)
                     assert False
             if p['scheme'] == 'MOCKC':
                 if p['domains']['lan']['read'] != 1:
-                    print('MOCKC with unexpected priority')
-                    print(prots)
                     assert False
         assert True
 
@@ -1494,8 +1489,7 @@ class TestRSEClient:
                                      parameters={'distance': 0})
 
         for distance in rucio_client.get_distance(source=source, destination=destination):
-            print(distance)
-            assert distance['distance'] == 0
+            assert distance['distance'] == 0, f"Distance should be 0, but is {distance['distance']}. {distance}"
 
     def test_get_rse_protocols_includes_verify_checksum(self, vo):
         """ RSE (CORE): Test validate_checksum in RSEs info"""

--- a/tests/test_rse_protocol_xrootd.py
+++ b/tests/test_rse_protocol_xrootd.py
@@ -33,9 +33,7 @@ class TestRseXROOTD(MgrTestCases):
         """XROOTD (RSE/PROTOCOLS): Creating necessary directories and files """
 
         cmd = "rucio list-rses --rses 'test_container_xrd=True'"
-        print(cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
         rses = out.split()
 
         data = load_test_conf_file('rse_repository.json')

--- a/tests/test_rse_protocol_xrootd.py
+++ b/tests/test_rse_protocol_xrootd.py
@@ -34,6 +34,7 @@ class TestRseXROOTD(MgrTestCases):
 
         cmd = "rucio list-rses --rses 'test_container_xrd=True'"
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Failed to execute command: {cmd}. Error: {err}, output: {out}"
         rses = out.split()
 
         data = load_test_conf_file('rse_repository.json')

--- a/tests/test_rucio_server.py
+++ b/tests/test_rucio_server.py
@@ -25,16 +25,12 @@ MARKER = '$ > '
 
 def delete_rules(did):
     # get the rules for the file
-    print('Deleting rules')
     cmd = "rucio rule list {0} | grep {0} | cut -f1 -d\\ ".format(did)
-    print(cmd)
     exitcode, out, err = execute(cmd)
-    print(out, err)
     rules = out.split()
     # delete the rules for the file
     for rule in rules:
         cmd = "rucio rule remove {0}".format(rule)
-        print(cmd)
         exitcode, out, err = execute(cmd)
 
 
@@ -44,18 +40,14 @@ class TestRucioServer:
     def test_ping(self):
         """CLIENT (USER): rucio ping"""
         cmd = 'rucio ping'
-        print(MARKER + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Failed to ping Rucio server with command {cmd}. Error: {err}, output: {out}"
 
     def test_whoami(self):
         """CLIENT (USER): rucio whoami"""
         cmd = 'rucio whoami'
-        print(MARKER + cmd)
         exitcode, out, err = execute(cmd)
-        print(out, err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Failed to execute whoami with command {cmd}. Error: {err}, output: {out}"
 
     def test_upload_download(self, file_factory, scope_and_rse):
         """CLIENT(USER): rucio upload files to dataset/download dataset"""
@@ -72,43 +64,30 @@ class TestRucioServer:
 
         # Adding files to a new dataset
         cmd = 'rucio upload --rse {0} --scope {1} {2} {3} {4} {1}:{5}'.format(rse, scope, tmp_file1, tmp_file2, tmp_file3, tmp_dsn)
-        print(MARKER + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
         remove(tmp_file1)
         remove(tmp_file2)
         remove(tmp_file3)
-        assert exitcode == 0
+        assert exitcode == 0, f"Failed to upload files with command {cmd}. Error: {err}, output: {out}"
 
         # List the files
         cmd = 'rucio did content list {0}:{1}'.format(scope, tmp_dsn)
-        print(MARKER + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Failed to list content with command {cmd}. Error: {err}, output: {out}"
 
         # List the replicas
         cmd = 'rucio replica list file {0}:{1}'.format(scope, tmp_dsn)
-        print(MARKER + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
-        assert exitcode == 0
+        assert exitcode == 0, f"Failed to list replicas with command {cmd}. Error: {err}, output: {out}"
 
         # Downloading dataset
         cmd = 'rucio download --dir /tmp/ {0}:{1}'.format(scope, tmp_dsn)
-        print(MARKER + cmd)
         exitcode, out, err = execute(cmd)
-        print(out)
-        print(err)
+        assert exitcode == 0, f"Failed to download dataset with command {cmd}. Error: {err}, output: {out}"
         # The files should be there
         cmd = 'ls /tmp/{0}/*'.format(tmp_dsn)
-        print(MARKER + cmd)
         exitcode, out, err = execute(cmd)
-        print(err, out)
-        assert exitcode == 0
+        assert exitcode == 0, f"Failed to list downloaded files with command {cmd}. Error: {err}, output: {out}"
         assert tmp_file1.name in out
         assert tmp_file2.name in out
         assert tmp_file3.name in out

--- a/tests/test_rucio_server.py
+++ b/tests/test_rucio_server.py
@@ -27,11 +27,13 @@ def delete_rules(did):
     # get the rules for the file
     cmd = "rucio rule list {0} | grep {0} | cut -f1 -d\\ ".format(did)
     exitcode, out, err = execute(cmd)
+    assert exitcode == 0, f"Failed to list rules with command {cmd}. Error: {err}, output: {out}"
     rules = out.split()
     # delete the rules for the file
     for rule in rules:
         cmd = "rucio rule remove {0}".format(rule)
         exitcode, out, err = execute(cmd)
+        assert exitcode == 0, f"Failed to remove rule {rule} with command {cmd}. Error: {err}, output: {out}"
 
 
 @pytest.mark.noparallel(reason='uses pre-defined RSE')

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1265,18 +1265,14 @@ class TestCore:
         rule_ids = add_rule(dids=[{'scope': scope, 'name': 'container1213'}], copies=1, rse_expression=f'{self.rse1}|{self.rse2}|{self.rse3}|{self.rse4}',
                             grouping='ALL', account=account, weight=None, lifetime=None, locked=False, subscription_id=None)
         rule = get_rule(rule_ids[0])
-        print(rule['locks_ok_cnt'], rule['locks_replicating_cnt'])
-        assert (rule['locks_ok_cnt'] == 11)
-        assert (rule['locks_replicating_cnt'] == 14)
+        assert (rule['locks_ok_cnt'] == 11), f"Expected 11 locks_ok, got {rule['locks_ok_cnt']}"
+        assert (rule['locks_replicating_cnt'] == 14), f"Expected 14 locks_replicating, got {rule['locks_replicating_cnt']}"
         dsl1 = list(get_dataset_locks(scope, 'ds1'))
         dsl2 = list(get_dataset_locks(scope, 'ds2'))
         dsl3 = list(get_dataset_locks(scope, 'ds3'))
-        print(dsl1)
-        print(dsl2)
-        print(dsl3)
-        assert (len(dsl1) == 1 and dsl1[0]['rse'] == self.rse1)
-        assert (len(dsl2) == 1 and dsl2[0]['rse'] == self.rse1)
-        assert (len(dsl3) == 1 and dsl3[0]['rse'] == self.rse1)
+        assert (len(dsl1) == 1 and dsl1[0]['rse'] == self.rse1), f"Expected ds1 to have 1 lock at {self.rse1}, got {len(dsl1)} locks: {dsl1}"
+        assert (len(dsl2) == 1 and dsl2[0]['rse'] == self.rse1), f"Expected ds2 to have 1 lock at {self.rse1}, got {len(dsl2)} locks: {dsl2}"
+        assert (len(dsl3) == 1 and dsl3[0]['rse'] == self.rse1), f"Expected ds3 to have 1 lock at {self.rse1}, got {len(dsl3)} locks: {dsl3}"
 
         # test2 : DATASET grouping -> select rse1 for ds1, rse3 for ds2 and rse1 for ds3
         scope = InternalScope(('scope2_' + str(uuid()))[:21], vo=vo)  # scope field has max 25 chars
@@ -1285,18 +1281,14 @@ class TestCore:
         rule_ids = add_rule(dids=[{'scope': scope, 'name': 'container1213'}], copies=1, rse_expression=f'{self.rse1}|{self.rse2}|{self.rse3}|{self.rse4}',
                             grouping='DATASET', account=account, weight=None, lifetime=None, locked=False, subscription_id=None)
         rule = get_rule(rule_ids[0])
-        print(rule['locks_ok_cnt'], rule['locks_replicating_cnt'])
-        assert (rule['locks_ok_cnt'] == 17)
-        assert (rule['locks_replicating_cnt'] == 8)
+        assert (rule['locks_ok_cnt'] == 17), f"Expected 17 locks_ok, got {rule['locks_ok_cnt']}"
+        assert (rule['locks_replicating_cnt'] == 8), f"Expected 8 locks_replicating, got {rule['locks_replicating_cnt']}"
         dsl1 = list(get_dataset_locks(scope, 'ds1'))
         dsl2 = list(get_dataset_locks(scope, 'ds2'))
         dsl3 = list(get_dataset_locks(scope, 'ds3'))
-        print(dsl1)
-        print(dsl2)
-        print(dsl3)
-        assert (len(dsl1) == 1 and dsl1[0]['rse'] == self.rse1)
-        assert (len(dsl2) == 1 and dsl2[0]['rse'] == self.rse3)
-        assert (len(dsl3) == 1 and dsl3[0]['rse'] == self.rse1)
+        assert (len(dsl1) == 1 and dsl1[0]['rse'] == self.rse1), f"Expected ds1 to have 1 lock at {self.rse1}, got {len(dsl1)} locks: {dsl1}"
+        assert (len(dsl2) == 1 and dsl2[0]['rse'] == self.rse3), f"Expected ds2 to have 1 lock at {self.rse3}, got {len(dsl2)} locks: {dsl2}"
+        assert (len(dsl3) == 1 and dsl3[0]['rse'] == self.rse1), f"Expected ds3 to have 1 lock at {self.rse1}, got {len(dsl3)} locks: {dsl3}"
 
         # test3 : NONE grouping
         scope = InternalScope(('scope3_' + str(uuid()))[:21], vo=vo)  # scope field has max 25 chars
@@ -1305,18 +1297,14 @@ class TestCore:
         rule_ids = add_rule(dids=[{'scope': scope, 'name': 'container1213'}], copies=1, rse_expression=f'{self.rse1}|{self.rse2}|{self.rse3}|{self.rse4}',
                             grouping='NONE', account=account, weight=None, lifetime=None, locked=False, subscription_id=None)
         rule = get_rule(rule_ids[0])
-        print(rule['locks_ok_cnt'], rule['locks_replicating_cnt'])
-        assert (rule['locks_ok_cnt'] == 25)
-        assert (rule['locks_replicating_cnt'] == 0)
+        assert (rule['locks_ok_cnt'] == 25), f"Expected 25 locks_ok, got {rule['locks_ok_cnt']}"
+        assert (rule['locks_replicating_cnt'] == 0), f"Expected 0 locks_replicating, got {rule['locks_replicating_cnt']}"
         dsl1 = list(get_dataset_locks(scope, 'ds1'))
         dsl2 = list(get_dataset_locks(scope, 'ds2'))
         dsl3 = list(get_dataset_locks(scope, 'ds3'))
-        print(dsl1)
-        print(dsl2)
-        print(dsl3)
-        assert (len(dsl1) == 0)
-        assert (len(dsl2) == 0)
-        assert (len(dsl3) == 0)
+        assert (len(dsl1) == 0), f"Expected ds1 to have 0 locks, got {len(dsl1)} locks: {dsl1}"
+        assert (len(dsl2) == 0), f"Expected ds2 to have 0 locks, got {len(dsl2)} locks: {dsl2}"
+        assert (len(dsl3) == 0), f"Expected ds3 to have 0 locks, got {len(dsl3)} locks: {dsl3}"
 
 
 def test_rule_boost(vo, mock_scope, rse_factory, jdoe_account):
@@ -1533,10 +1521,8 @@ def test_detach_dataset_lock_removal(did_client, did_factory, root_account, rse_
     add_rse_attribute(rse_id=rse2_id, key='fakeweight', value=5)
 
     rule_id = add_rule(dids=[container_internal], account=root_account, copies=2, rse_expression='fakeweight>0', grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)[0]
-    print("Rule id: {0}".format(rule_id))
     dataset_locks = list(get_dataset_locks(scope=dataset_internal['scope'], name=dataset['name']))
-    print("Dataset locks before detach: {0}".format(dataset_locks))
-    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 2)
+    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 2), f"Expected 2 locks, got {len(dataset_locks)} locks: {dataset_locks}. Rule ID: {rule_id}"
 
     # Detach dataset from container, this should delete all locks on the dataset
     did_client.detach_dids(**container, dids=[dataset_internal])
@@ -1544,8 +1530,7 @@ def test_detach_dataset_lock_removal(did_client, did_factory, root_account, rse_
     re_evaluator(once=True, did_limit=None)
 
     dataset_locks = list(get_dataset_locks(**dataset_internal))
-    print("Dataset locks after detach: {0}".format(dataset_locks))
-    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 0)
+    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 0), f"Expected 0 locks, got {len(dataset_locks)} locks: {dataset_locks}. Rule ID: {rule_id}"
 
 
 @pytest.mark.noparallel(reason='Asynchronos behavior when loading locks')
@@ -1569,10 +1554,8 @@ def test_detach_dataset_lock_removal_shared_dataset(did_client, did_factory, roo
     add_rse_attribute(rse_id=rse2_id, key='fakeweight', value=5)
 
     rule_id = add_rule(dids=[container_internal], account=root_account, copies=2, rse_expression='fakeweight>0', grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)[0]
-    print("Rule id: {0}".format(rule_id))
     dataset_locks = list(get_dataset_locks(scope=dataset_internal['scope'], name=dataset['name']))
-    print("Dataset locks before detach: {0}".format(dataset_locks))
-    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 2)
+    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 2), f"Expected 2 locks, got {len(dataset_locks)} locks: {dataset_locks}. Rule ID: {rule_id}"
 
     # Detach dataset from container, this should delete all locks on the dataset
     did_client.detach_dids(**container, dids=[dataset_internal])
@@ -1580,8 +1563,7 @@ def test_detach_dataset_lock_removal_shared_dataset(did_client, did_factory, roo
     re_evaluator(once=True, did_limit=None)
 
     dataset_locks = list(get_dataset_locks(**dataset_internal))
-    print("Dataset locks after detach: {0}".format(dataset_locks))
-    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 0)
+    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 0), f"Expected 0 locks, got {len(dataset_locks)} locks: {dataset_locks}. Rule ID: {rule_id}"
 
 
 @pytest.mark.noparallel(reason='Asynchronos behavior when loading locks')
@@ -1605,10 +1587,8 @@ def test_detach_dataset_lock_removal_shared_file(did_client, did_factory, root_a
     add_rse_attribute(rse_id=rse2_id, key='fakeweight', value=5)
 
     rule_id = add_rule(dids=[container_internal], account=root_account, copies=2, rse_expression='fakeweight>0', grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)[0]
-    print("Rule id: {0}".format(rule_id))
     dataset_locks = list(get_dataset_locks(scope=dataset_internal['scope'], name=dataset['name']))
-    print("Dataset locks before detach: {0}".format(dataset_locks))
-    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 2)
+    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 2), f"Expected 2 locks, got {len(dataset_locks)} locks: {dataset_locks}. Rule ID: {rule_id}"
 
     # Detach dataset from container, this should delete all locks on the dataset
     did_client.detach_dids(**container, dids=[dataset_internal])
@@ -1616,8 +1596,7 @@ def test_detach_dataset_lock_removal_shared_file(did_client, did_factory, root_a
     re_evaluator(once=True, did_limit=None)
 
     dataset_locks = list(get_dataset_locks(**dataset_internal))
-    print("Dataset locks after detach: {0}".format(dataset_locks))
-    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 0)
+    assert (len([d for d in dataset_locks if d["rule_id"] == rule_id]) == 0), f"Expected 0 locks, got {len(dataset_locks)} locks: {dataset_locks}. Rule ID: {rule_id}"
 
 
 def test_move_rule_invalid_argument(vo, rse_factory, did_factory, mock_scope, root_account):

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -660,10 +660,9 @@ class TestDaemon:
                                               priority=1)
         run(threads=1, bulk=1000000, once=True)
         rules = [rule for rule in rucio_client.list_did_rules(scope=mock_scope.external, name=dsn) if str(rule['subscription_id']) == str(subid)]
-        print(rules)
-        assert rules[0]['rse_expression'] == rse_expression
-        assert rules[0]['state'] == RuleState.INJECT.name
-        assert (rules[0]['created_at'] - datetime.now()).days == 1
+        assert rules[0]['rse_expression'] == rse_expression, f"Expected {rse_expression}, got {rules[0]['rse_expression']}. Rules: {rules}"
+        assert rules[0]['state'] == RuleState.INJECT.name, f"Expected state INJECT, got {rules[0]['state']}. Rules: {rules}"
+        assert (rules[0]['created_at'] - datetime.now()).days == 1, f"Expected created_at to be 1 day ago, got {rules[0]['created_at']}. Rules: {rules}"
 
     def test_run_transmogrifier_invalid_subscription(self, rse_factory, vo, rucio_client, root_account, mock_scope):
         """ SUBSCRIPTION (DAEMON): Test the transmogrifier with invalid subscription """
@@ -831,18 +830,17 @@ class TestDaemon:
             rules = [rule for rule in rucio_client.list_did_rules(scope=tmp_scope.external, name=dsn) if str(rule['subscription_id']) == str(subid)]
             if rules[0]['source_replica_expression']:
                 rules.reverse()
-            print(rules, dict_rse)
-            assert len(rules) == 2
+            assert len(rules) == 2, f"Expected 2 rules, got {len(rules)}. Rules: {rules}, Dict RSE: {dict_rse}"
             chosen_rse = rules[0]['rse_expression']
             chosen_site = dict_rse[chosen_rse]['site']
             chosen_rse_type = dict_rse[chosen_rse]['rse_type']
-            assert chosen_rse_type == 'disk'
+            assert chosen_rse_type == 'disk', f"Expected disk RSE, got {chosen_rse_type}. Rules: {rules}, Dict RSE: {dict_rse}"
 
             chained_rse = rules[1]['rse_expression']
             chained_site = dict_rse[chained_rse]['site']
             chained_rse_type = dict_rse[chained_rse]['rse_type']
-            assert chained_rse_type == 'tape'
-            assert chained_site != chosen_site
+            assert chained_rse_type == 'tape', f"Expected tape RSE, got {chained_rse_type}. Rules: {rules}, Dict RSE: {dict_rse}"
+            assert chained_site != chosen_site, f"Expected different sites, got {chosen_site} and {chained_site}. Rules: {rules}, Dict RSE: {dict_rse}"
 
     def test_run_transmogrifier_wildcard_copies_blocklisted_rse(self, rse_factory, vo, rucio_client, root_account):
         """ SUBSCRIPTION (DAEMON): Test the transmogrifier with wildcard copies and blocklisted RSE"""


### PR DESCRIPTION
Removed most print calls (went from 329 calls to 69) and added some asserts to keep functionality of some prints. In the tests there were some operations where the results were seemingly only checked via a print call so I added asserts for those cases.