### PR TITLE
Testing: Refactor CI / Test Infrastructure to use Runtime Mounted Source Code and Registry Caching in Autotests.

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -135,6 +135,11 @@ jobs:
           tools/run_pyright.sh compare --Werror \
             ${{ env.PYRIGHT_ANCESTOR_REPORT }} \
             ${{ env.PYRIGHT_CURRENT_REPORT }}
+  # Build runtime images for tests
+  runtime_images:
+    if: github.event_name != 'schedule'
+    name: Build Runtime Images
+    uses: ./.github/workflows/runtime_images.yml
   setup:
     if: github.repository_owner == 'rucio' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
@@ -160,7 +165,7 @@ jobs:
       branch: ${{ steps.branch.outputs.branch }}
       matrix: ${{ steps.matrix.outputs.matrix }}
   test:
-    needs: setup
+    needs: [runtime_images, setup]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -168,23 +173,15 @@ jobs:
         cfg: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Build images
-        id: images
-        shell: bash
-        run: |
-          docker login https://ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
-          i=0; until [ "$i" -ge 3 ]; do
-            IMAGES=$(echo '${{ toJson(matrix.cfg) }}' | ./tools/test/build_images.py \
-                --cache-repo ghcr.io/${{ github.repository }} \
-                --branch "${{ needs.setup.outputs.branch }}" ./etc/docker/test || echo "")
-            if [[ -n $IMAGES ]]; then break;
-            else
-              i=$((i+1)); sleep 5;
-              echo "::warning::Building images failed, retrying…"
-            fi
-          done
-          docker logout https://ghcr.io
-          if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
-          echo "images=$IMAGES" >> $GITHUB_OUTPUT
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run test with cfg
-        run: 'echo ''{"matrix": ${{ toJson(matrix.cfg) }}, "images": ${{ steps.images.outputs.images }} }'' | ./tools/test/run_tests.py'
+        env:
+          PY39_RUNTIME_IMAGE: ${{ needs.runtime_images.outputs.py39_image }}
+          PY310_RUNTIME_IMAGE: ${{ needs.runtime_images.outputs.py310_image }}
+        run: |
+          echo '{"matrix": ${{ toJson(matrix.cfg) }}, "runtime_images": {"3.9": "${{ needs.runtime_images.outputs.py39_image }}", "3.10": "${{ needs.runtime_images.outputs.py310_image }}"} }' | ./tools/test/run_tests.py

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -174,7 +174,7 @@ jobs:
       matrix:
         cfg: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -140,6 +140,8 @@ jobs:
     if: github.event_name != 'schedule'
     name: Build Runtime Images
     uses: ./.github/workflows/runtime_images.yml
+    permissions:
+      packages: write
   setup:
     if: github.repository_owner == 'rucio' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
@@ -172,16 +174,46 @@ jobs:
       matrix:
         cfg: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Login to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+      - name: Build Python 3.9 image locally
+        if: needs.runtime_images.outputs.build_locally == 'true' && matrix.cfg.PYTHON == '3.9'
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: etc/docker/test/runtime.Dockerfile
+          target: final
+          build-args: |
+            PYTHON=3.9
+          push: false
+          tags: ${{ needs.runtime_images.outputs.py39_image }}
+          outputs: type=docker
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py39-buildcache
+        continue-on-error: false
+      - name: Build Python 3.10 image locally
+        if: needs.runtime_images.outputs.build_locally == 'true' && matrix.cfg.PYTHON == '3.10'
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: etc/docker/test/runtime.Dockerfile
+          target: final
+          build-args: |
+            PYTHON=3.10
+          push: false
+          tags: ${{ needs.runtime_images.outputs.py310_image }}
+          outputs: type=docker
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py310-buildcache
+        continue-on-error: false
       - name: Run test with cfg
         env:
           PY39_RUNTIME_IMAGE: ${{ needs.runtime_images.outputs.py39_image }}
           PY310_RUNTIME_IMAGE: ${{ needs.runtime_images.outputs.py310_image }}
+          BUILD_LOCALLY: ${{ needs.runtime_images.outputs.build_locally }}
         run: |
-          echo '{"matrix": ${{ toJson(matrix.cfg) }}, "runtime_images": {"3.9": "${{ needs.runtime_images.outputs.py39_image }}", "3.10": "${{ needs.runtime_images.outputs.py310_image }}"} }' | ./tools/test/run_tests.py
+          echo '{"matrix": ${{ toJson(matrix.cfg) }}, "runtime_images": {"3.9": "${{ needs.runtime_images.outputs.py39_image }}", "3.10": "${{ needs.runtime_images.outputs.py310_image }}"}, "build_locally": "${{ needs.runtime_images.outputs.build_locally }}" }' | ./tools/test/run_tests.py

--- a/.github/workflows/cleanup_runtime_images.yml
+++ b/.github/workflows/cleanup_runtime_images.yml
@@ -1,0 +1,111 @@
+name: Cleanup Runtime Images
+
+on:
+  schedule:
+    # Clean untagged images every 7 days (Sundays at 02:00 UTC)
+    - cron: '0 2 * * 0'
+    # Clean tagged images every 30 days (1st of month at 03:00 UTC)  
+    - cron: '0 3 1 * *'
+  workflow_dispatch:
+    inputs:
+      cleanup_type:
+        description: 'Type of cleanup to run'
+        required: true
+        default: 'both'
+        type: choice
+        options:
+        - untagged
+        - tagged
+        - both
+
+jobs:
+  cleanup-untagged:
+    name: Delete untagged images older than 7 days
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.schedule == '0 2 * * 0') || 
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.cleanup_type == 'untagged' || github.event.inputs.cleanup_type == 'both')) ||
+      (github.event_name == 'pull_request')
+    steps:
+      - name: Delete untagged images older than 7 days
+        run: |
+          echo "Cleaning untagged images older than 7 days..."
+          
+          # Calculate cutoff date (7 days ago)
+          CUTOFF_DATE=$(date -d '7 days ago' --iso-8601=seconds)
+          echo "Cutoff date: $CUTOFF_DATE"
+          
+          # Get all package versions
+          VERSIONS=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/users/${{ github.repository_owner }}/packages/container/rucio%2Frucio-dev-runtime/versions?per_page=100")
+          
+          # Process each version
+          echo "$VERSIONS" | jq -c '.[]' | while read -r VERSION; do
+            VERSION_ID=$(echo "$VERSION" | jq -r '.id')
+            UPDATED_AT=$(echo "$VERSION" | jq -r '.updated_at')
+            TAGS=$(echo "$VERSION" | jq -r '.metadata.container.tags | length')
+            
+            # Check if image has no tags (untagged)
+            if [ "$TAGS" = "0" ]; then
+              # Check if older than 7 days
+              if [[ "$UPDATED_AT" < "$CUTOFF_DATE" ]]; then
+                echo "Deleting untagged image ID: $VERSION_ID (updated: $UPDATED_AT)"
+                curl -s -X DELETE \
+                  -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                  "https://api.github.com/users/${{ github.repository_owner }}/packages/container/rucio%2Frucio-dev-runtime/versions/$VERSION_ID"
+              else
+                echo "Keeping untagged image ID: $VERSION_ID (updated: $UPDATED_AT - less than 7 days old)"
+              fi
+            fi
+          done
+          
+          echo "Untagged image cleanup completed :)"
+
+  cleanup-tagged:
+    name: Delete tagged images older than 30 days
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.schedule == '0 3 1 * *') || 
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.cleanup_type == 'tagged' || github.event.inputs.cleanup_type == 'both')) ||
+      (github.event_name == 'pull_request')
+    steps:
+      - name: Delete tagged images older than 30 days
+        run: |
+          echo "Cleaning tagged images older than 30 days..."
+          
+          # Calculate cutoff date (30 days ago)
+          CUTOFF_DATE=$(date -d '30 days ago' --iso-8601=seconds)
+          echo "Cutoff date: $CUTOFF_DATE"
+          
+          VERSIONS=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/users/${{ github.repository_owner }}/packages/container/rucio%2Frucio-dev-runtime/versions?per_page=100")
+          
+          echo "$VERSIONS" | jq -c '.[]' | while read -r VERSION; do
+            VERSION_ID=$(echo "$VERSION" | jq -r '.id')
+            UPDATED_AT=$(echo "$VERSION" | jq -r '.updated_at')
+            TAGS=$(echo "$VERSION" | jq -r '.metadata.container.tags')
+            TAG_COUNT=$(echo "$TAGS" | jq -r 'length')
+            
+            # Check if image has tags and exclude buildcache images
+            if [ "$TAG_COUNT" -gt "0" ]; then
+              TAG_LIST=$(echo "$TAGS" | jq -r '.[]')
+              
+              # Skip buildcache images (they should be kept)
+              if echo "$TAG_LIST" | grep -q "buildcache"; then
+                echo "Skipping buildcache image with tags: $TAG_LIST"
+                continue
+              fi
+              
+              if [[ "$UPDATED_AT" < "$CUTOFF_DATE" ]]; then
+                echo "Deleting tagged image ID: $VERSION_ID with tags: $TAG_LIST (updated: $UPDATED_AT)"
+                curl -s -X DELETE \
+                  -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                  "https://api.github.com/users/${{ github.repository_owner }}/packages/container/rucio%2Frucio-dev-runtime/versions/$VERSION_ID"
+              else
+                echo "Keeping tagged image with tags: $TAG_LIST (updated: $UPDATED_AT - less than 30 days old)"
+              fi
+            fi
+          done
+          
+          echo "Tagged image cleanup completed :)"
+ 

--- a/.github/workflows/cleanup_runtime_images.yml
+++ b/.github/workflows/cleanup_runtime_images.yml
@@ -108,4 +108,3 @@ jobs:
           done
           
           echo "Tagged image cleanup completed :)"
- 

--- a/.github/workflows/runtime_images.yml
+++ b/.github/workflows/runtime_images.yml
@@ -1,0 +1,139 @@
+name: Build Runtime Images
+
+on:
+  workflow_call:
+    outputs:
+      py39_image:
+        description: "Python 3.9 runtime image tag"
+        value: ${{ jobs.build_runtime_images.outputs.py39_image }}
+      py310_image:
+        description: "Python 3.10 runtime image tag"
+        value: ${{ jobs.build_runtime_images.outputs.py310_image }}
+
+jobs:
+  build_runtime_images:
+    name: Build Runtime Images
+    runs-on: ubuntu-latest
+    outputs:
+      py39_image: ${{ steps.image_tags.outputs.py39_image }}
+      py310_image: ${{ steps.image_tags.outputs.py310_image }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Calculate image tags based on file hashes
+        id: image_tags
+        run: |
+          # Files that affect the build
+          FILES_TO_HASH="etc/docker/test/runtime.Dockerfile requirements/requirements.server.txt requirements/requirements.dev.txt"
+          
+          # Calculate hash for Python 3.9
+          PY39_HASH=$(echo "PYTHON=3.9" | cat - $FILES_TO_HASH | sha256sum | cut -d' ' -f1 | head -c 12)
+          PY39_IMAGE="ghcr.io/${{ github.repository }}/rucio-dev-runtime:py39-${PY39_HASH}"
+          echo "py39_image=${PY39_IMAGE}" >> $GITHUB_OUTPUT
+          echo "Python 3.9 image tag: ${PY39_IMAGE}"
+          
+          # Calculate hash for Python 3.10
+          PY310_HASH=$(echo "PYTHON=3.10" | cat - $FILES_TO_HASH | sha256sum | cut -d' ' -f1 | head -c 12)
+          PY310_IMAGE="ghcr.io/${{ github.repository }}/rucio-dev-runtime:py310-${PY310_HASH}"
+          echo "py310_image=${PY310_IMAGE}" >> $GITHUB_OUTPUT
+          echo "Python 3.10 image tag: ${PY310_IMAGE}"
+
+      - name: Generate build metadata
+        id: build_metadata
+        run: |
+          # Get build timestamp
+          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
+          echo "Build date: ${BUILD_DATE}"
+          
+          # Get commit info for metadata
+          COMMIT_SHA="${{ github.sha }}"
+          COMMIT_REF="${{ github.ref }}"
+          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "commit_ref=${COMMIT_REF}" >> $GITHUB_OUTPUT
+      
+      - name: Check if Python 3.9 image exists
+        id: check_py39_image
+        run: |
+          if docker manifest inspect ${{ steps.image_tags.outputs.py39_image }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Image already exists, skipping build"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Image does not exist, will build"
+          fi
+      
+      - name: Build and push Python 3.9 image
+        if: steps.check_py39_image.outputs.exists != 'true'
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: etc/docker/test/runtime.Dockerfile
+          target: final
+          build-args: |
+            PYTHON=3.9
+          push: true
+          tags: ${{ steps.image_tags.outputs.py39_image }}
+          labels: |
+            org.opencontainers.image.title=Rucio Runtime Image Python 3.9
+            org.opencontainers.image.description=Runtime image for Rucio autotests with Python 3.9
+            org.opencontainers.image.version=py39-${{ steps.image_tags.outputs.py39_image }}
+            org.opencontainers.image.created=${{ steps.build_metadata.outputs.build_date }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.build_metadata.outputs.commit_sha }}
+            org.opencontainers.image.ref.name=${{ steps.build_metadata.outputs.commit_ref }}
+            rucio.image.python.version=3.9
+            rucio.image.build.date=${{ steps.build_metadata.outputs.build_date }}
+            rucio.image.build.workflow=${{ github.workflow }}
+            rucio.image.build.run_id=${{ github.run_id }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py39-buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py39-buildcache,mode=max
+
+      - name: Check if Python 3.10 image exists
+        id: check_py310_image
+        run: |
+          if docker manifest inspect ${{ steps.image_tags.outputs.py310_image }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Image already exists, skipping build"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Image does not exist, will build"
+          fi
+      
+      - name: Build and push Python 3.10 image
+        if: steps.check_py310_image.outputs.exists != 'true'
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: etc/docker/test/runtime.Dockerfile
+          target: final
+          build-args: |
+            PYTHON=3.10
+          push: true
+          tags: ${{ steps.image_tags.outputs.py310_image }}
+          labels: |
+            org.opencontainers.image.title=Rucio Runtime Image Python 3.10
+            org.opencontainers.image.description=Runtime image for Rucio autotests with Python 3.10
+            org.opencontainers.image.version=py310-${{ steps.image_tags.outputs.py310_image }}
+            org.opencontainers.image.created=${{ steps.build_metadata.outputs.build_date }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.build_metadata.outputs.commit_sha }}
+            org.opencontainers.image.ref.name=${{ steps.build_metadata.outputs.commit_ref }}
+            rucio.image.python.version=3.10
+            rucio.image.build.date=${{ steps.build_metadata.outputs.build_date }}
+            rucio.image.build.workflow=${{ github.workflow }}
+            rucio.image.build.run_id=${{ github.run_id }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py310-buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py310-buildcache,mode=max

--- a/.github/workflows/runtime_images.yml
+++ b/.github/workflows/runtime_images.yml
@@ -30,9 +30,9 @@ jobs:
     permissions:
       packages: write
     outputs:
-      py39_image: ${{ steps.image_tags.outputs.py39_image }}
-      py310_image: ${{ steps.image_tags.outputs.py310_image }}
-      build_locally: ${{ steps.final_strategy.outputs.build_locally }}
+      py39_image: ${{ steps.set_outputs.outputs.py39_image }}
+      py310_image: ${{ steps.set_outputs.outputs.py310_image }}
+      build_locally: ${{ steps.set_outputs.outputs.build_locally }}
 
     steps:
       - name: Checkout code
@@ -49,133 +49,75 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - name: Calculate image tags based on file hashes
-        id: image_tags
+      - name: Prepare metadata
+        id: metadata
         run: |
-          # Files that affect the build
+          echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+          echo "commit_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "commit_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+
+      - name: Build Runtime Images
+        id: build_images
+        run: |
           FILES_TO_HASH="etc/docker/test/runtime.Dockerfile requirements/requirements.server.txt requirements/requirements.dev.txt"
-          
-          # Calculate hash for Python 3.9
-          PY39_HASH=$(echo "PYTHON=3.9" | cat - $FILES_TO_HASH | sha256sum | cut -d' ' -f1 | head -c 12)
-          PY39_IMAGE="ghcr.io/${{ github.repository }}/rucio-dev-runtime:py39-${PY39_HASH}"
-          echo "py39_image=${PY39_IMAGE}" >> $GITHUB_OUTPUT
-          echo "Python 3.9 image tag: ${PY39_IMAGE}"
-          
-          # Calculate hash for Python 3.10
-          PY310_HASH=$(echo "PYTHON=3.10" | cat - $FILES_TO_HASH | sha256sum | cut -d' ' -f1 | head -c 12)
-          PY310_IMAGE="ghcr.io/${{ github.repository }}/rucio-dev-runtime:py310-${PY310_HASH}"
-          echo "py310_image=${PY310_IMAGE}" >> $GITHUB_OUTPUT
-          echo "Python 3.10 image tag: ${PY310_IMAGE}"
+          BUILD_LOCALLY=false
+          BUILD_DATE="${{ steps.metadata.outputs.build_date }}"
+          COMMIT_SHA="${{ steps.metadata.outputs.commit_sha }}"
+          COMMIT_REF="${{ steps.metadata.outputs.commit_ref }}"
 
-      - name: Generate build metadata
-        id: build_metadata
-        run: |
-          # Get build timestamp
-          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
-          echo "Build date: ${BUILD_DATE}"
-          
-          # Get commit info for metadata
-          COMMIT_SHA="${{ github.sha }}"
-          COMMIT_REF="${{ github.ref }}"
-          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
-          echo "commit_ref=${COMMIT_REF}" >> $GITHUB_OUTPUT
+          for PYVER in 3.9 3.10; do
+            HASH=$(echo "PYTHON=${PYVER}" | cat - $FILES_TO_HASH | sha256sum | cut -d' ' -f1 | head -c 12)
+            IMAGE="ghcr.io/${{ github.repository }}/rucio-dev-runtime:py${PYVER//.}-${HASH}"
+            echo "Python ${PYVER} image tag: $IMAGE"
 
-      - name: Check if Python 3.9 image exists and set build strategy
-        id: check_py39_image
-        run: |
-          if docker manifest inspect ${{ steps.image_tags.outputs.py39_image }} > /dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Python 3.9 image already exists, skipping build"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Python 3.9 image does not exist or cannot access registry"
-            
-            # If image doesn't exist AND this is a PR targeting master, build locally
-            if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "master" ]]; then
-              echo "build_locally=true" >> $GITHUB_OUTPUT
-              echo "PR targets master and Python 3.9 image missing - will build locally to avoid permission issues"
+            # Export dynamic outputs
+            if [[ "$PYVER" == "3.9" ]]; then
+              echo "py39_image=$IMAGE" >> $GITHUB_OUTPUT
+            else
+              echo "py310_image=$IMAGE" >> $GITHUB_OUTPUT
             fi
-          fi
 
-      - name: Build Python 3.9 image (push if permissions allow)
-        if: steps.check_py39_image.outputs.exists != 'true' && steps.check_py39_image.outputs.build_locally != 'true'
-        id: build_py39
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
-          file: etc/docker/test/runtime.Dockerfile
-          target: final
-          build-args: |
-            PYTHON=3.9
-          push: true
-          tags: ${{ steps.image_tags.outputs.py39_image }}
-          labels: |
-            org.opencontainers.image.title=Rucio Runtime Image Python 3.9
-            org.opencontainers.image.description=Runtime image for Rucio autotests with Python 3.9
-            org.opencontainers.image.version=py39-${{ steps.image_tags.outputs.py39_image }}
-            org.opencontainers.image.created=${{ steps.build_metadata.outputs.build_date }}
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ steps.build_metadata.outputs.commit_sha }}
-            org.opencontainers.image.ref.name=${{ steps.build_metadata.outputs.commit_ref }}
-            rucio.image.python.version=3.9
-            rucio.image.build.date=${{ steps.build_metadata.outputs.build_date }}
-            rucio.image.build.workflow=${{ github.workflow }}
-            rucio.image.build.run_id=${{ github.run_id }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py39-buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py39-buildcache,mode=max
-        continue-on-error: true
-
-      - name: Check if Python 3.10 image exists and set build strategy
-        id: check_py310_image
-        run: |
-          if docker manifest inspect ${{ steps.image_tags.outputs.py310_image }} > /dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Python 3.10 image already exists, skipping build"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Python 3.10 image does not exist or cannot access registry"
-            
-            # If image doesn't exist AND this is a PR targeting master, build locally
-            if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "master" ]]; then
-              echo "build_locally=true" >> $GITHUB_OUTPUT
-              echo "PR targets master and Python 3.10 image missing - will build locally to avoid permission issues"
+            # Skip build if image exists
+            if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+              echo "Python ${PYVER} image already exists, skipping build"
+              continue
             fi
-          fi
 
-      - name: Build Python 3.10 image (push if permissions allow)
-        if: steps.check_py310_image.outputs.exists != 'true' && steps.check_py310_image.outputs.build_locally != 'true'
-        id: build_py310
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: .
-          file: etc/docker/test/runtime.Dockerfile
-          target: final
-          build-args: |
-            PYTHON=3.10
-          push: true
-          tags: ${{ steps.image_tags.outputs.py310_image }}
-          labels: |
-            org.opencontainers.image.title=Rucio Runtime Image Python 3.10
-            org.opencontainers.image.description=Runtime image for Rucio autotests with Python 3.10
-            org.opencontainers.image.version=py310-${{ steps.image_tags.outputs.py310_image }}
-            org.opencontainers.image.created=${{ steps.build_metadata.outputs.build_date }}
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ steps.build_metadata.outputs.commit_sha }}
-            org.opencontainers.image.ref.name=${{ steps.build_metadata.outputs.commit_ref }}
-            rucio.image.python.version=3.10
-            rucio.image.build.date=${{ steps.build_metadata.outputs.build_date }}
-            rucio.image.build.workflow=${{ github.workflow }}
-            rucio.image.build.run_id=${{ github.run_id }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py310-buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py310-buildcache,mode=max
-        continue-on-error: true
+            # Build locally if PR to master (can't push)
+            if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "master" ]]; then
+              echo "Python ${PYVER} image missing, will build locally"
+              BUILD_LOCALLY=true
+              continue
+            fi
 
-      - name: Determine final build strategy
-        id: final_strategy  
+            echo "Building Python ${PYVER} image..."
+            docker buildx build \
+              --file etc/docker/test/runtime.Dockerfile \
+              --target final \
+              --build-arg PYTHON=${PYVER} \
+              --push \
+              --tag "$IMAGE" \
+              --label "org.opencontainers.image.title=Rucio Runtime Image Python ${PYVER}" \
+              --label "org.opencontainers.image.description=Runtime image for Rucio autotests with Python ${PYVER}" \
+              --label "org.opencontainers.image.version=py${PYVER//.}-${HASH}" \
+              --label "org.opencontainers.image.created=${BUILD_DATE}" \
+              --label "org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
+              --label "org.opencontainers.image.revision=${COMMIT_SHA}" \
+              --label "org.opencontainers.image.ref.name=${COMMIT_REF}" \
+              --label "rucio.image.python.version=${PYVER}" \
+              --label "rucio.image.build.date=${BUILD_DATE}" \
+              --label "rucio.image.build.workflow=${{ github.workflow }}" \
+              --label "rucio.image.build.run_id=${{ github.run_id }}" \
+              --cache-from type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py${PYVER//.}-buildcache \
+              --cache-to type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py${PYVER//.}-buildcache,mode=max \
+              .
+          done
+
+          echo "build_locally=$BUILD_LOCALLY" >> $GITHUB_OUTPUT
+
+      - name: Set Final Outputs
+        id: set_outputs
         run: |
-          if [[ "${{ steps.check_py39_image.outputs.build_locally }}" == "true" || "${{ steps.check_py310_image.outputs.build_locally }}" == "true" ]]; then
-            echo "build_locally=true" >> $GITHUB_OUTPUT
-          else
-            echo "build_locally=false" >> $GITHUB_OUTPUT
-          fi
+          echo "py39_image=${{ steps.build_images.outputs.py39_image }}" >> $GITHUB_OUTPUT
+          echo "py310_image=${{ steps.build_images.outputs.py310_image }}" >> $GITHUB_OUTPUT
+          echo "build_locally=${{ steps.build_images.outputs.build_locally }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/runtime_images.yml
+++ b/.github/workflows/runtime_images.yml
@@ -9,14 +9,30 @@ on:
       py310_image:
         description: "Python 3.10 runtime image tag"
         value: ${{ jobs.build_runtime_images.outputs.py310_image }}
+      build_locally:
+        description: "Whether images should be built locally in autotests"
+        value: ${{ jobs.build_runtime_images.outputs.build_locally }}
+  schedule:
+    - cron: '0 3 * * *'
+  push:
+    branches:
+      - master
+    paths:
+      - 'etc/docker/test/runtime.Dockerfile'
+      - 'requirements/requirements.server.txt'
+      - 'requirements/requirements.dev.txt'
+  workflow_dispatch:
 
 jobs:
   build_runtime_images:
     name: Build Runtime Images
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     outputs:
       py39_image: ${{ steps.image_tags.outputs.py39_image }}
       py310_image: ${{ steps.image_tags.outputs.py310_image }}
+      build_locally: ${{ steps.final_strategy.outputs.build_locally }}
 
     steps:
       - name: Checkout code
@@ -31,6 +47,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
 
       - name: Calculate image tags based on file hashes
         id: image_tags
@@ -63,20 +80,27 @@ jobs:
           COMMIT_REF="${{ github.ref }}"
           echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
           echo "commit_ref=${COMMIT_REF}" >> $GITHUB_OUTPUT
-      
-      - name: Check if Python 3.9 image exists
+
+      - name: Check if Python 3.9 image exists and set build strategy
         id: check_py39_image
         run: |
           if docker manifest inspect ${{ steps.image_tags.outputs.py39_image }} > /dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Image already exists, skipping build"
+            echo "Python 3.9 image already exists, skipping build"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Image does not exist, will build"
+            echo "Python 3.9 image does not exist or cannot access registry"
+            
+            # If image doesn't exist AND this is a PR targeting master, build locally
+            if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "master" ]]; then
+              echo "build_locally=true" >> $GITHUB_OUTPUT
+              echo "PR targets master and Python 3.9 image missing - will build locally to avoid permission issues"
+            fi
           fi
-      
-      - name: Build and push Python 3.9 image
-        if: steps.check_py39_image.outputs.exists != 'true'
+
+      - name: Build Python 3.9 image (push if permissions allow)
+        if: steps.check_py39_image.outputs.exists != 'true' && steps.check_py39_image.outputs.build_locally != 'true'
+        id: build_py39
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
@@ -100,20 +124,28 @@ jobs:
             rucio.image.build.run_id=${{ github.run_id }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py39-buildcache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py39-buildcache,mode=max
+        continue-on-error: true
 
-      - name: Check if Python 3.10 image exists
+      - name: Check if Python 3.10 image exists and set build strategy
         id: check_py310_image
         run: |
           if docker manifest inspect ${{ steps.image_tags.outputs.py310_image }} > /dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Image already exists, skipping build"
+            echo "Python 3.10 image already exists, skipping build"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Image does not exist, will build"
+            echo "Python 3.10 image does not exist or cannot access registry"
+            
+            # If image doesn't exist AND this is a PR targeting master, build locally
+            if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "master" ]]; then
+              echo "build_locally=true" >> $GITHUB_OUTPUT
+              echo "PR targets master and Python 3.10 image missing - will build locally to avoid permission issues"
+            fi
           fi
-      
-      - name: Build and push Python 3.10 image
-        if: steps.check_py310_image.outputs.exists != 'true'
+
+      - name: Build Python 3.10 image (push if permissions allow)
+        if: steps.check_py310_image.outputs.exists != 'true' && steps.check_py310_image.outputs.build_locally != 'true'
+        id: build_py310
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
@@ -137,3 +169,13 @@ jobs:
             rucio.image.build.run_id=${{ github.run_id }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py310-buildcache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/rucio-dev-runtime:py310-buildcache,mode=max
+        continue-on-error: true
+
+      - name: Determine final build strategy
+        id: final_strategy  
+        run: |
+          if [[ "${{ steps.check_py39_image.outputs.build_locally }}" == "true" || "${{ steps.check_py310_image.outputs.build_locally }}" == "true" ]]; then
+            echo "build_locally=true" >> $GITHUB_OUTPUT
+          else
+            echo "build_locally=false" >> $GITHUB_OUTPUT
+          fi

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ../../../bin:/opt/rucio/bin:Z
       - ../../../lib:/opt/rucio/lib:Z
       - ../../../tests:/opt/rucio/tests:Z
-      - ../../../:/rucio_source:ro
+      - ../../../:/rucio_source:Z
     environment:
       - REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
       - RUCIO_SOURCE_DIR=/rucio_source
@@ -56,7 +56,7 @@ services:
       - ../../../bin:/opt/rucio/bin:Z
       - ../../../lib:/opt/rucio/lib:Z
       - ../../../tests:/opt/rucio/tests:Z
-      - ../../../:/rucio_source:ro
+      - ../../../:/rucio_source
     environment:
       - REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
       - RUCIO_SOURCE_DIR=/rucio_source

--- a/etc/docker/dev/rucio/entrypoint.sh
+++ b/etc/docker/dev/rucio/entrypoint.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CFG_PATH="$RUCIO_SOURCE_DIR"/etc/docker/test/extra/
+CFG_PATH="$RUCIO_SOURCE_DIR/etc/docker/test/extra"
 if [ -z "$RUCIO_HOME" ]; then
     RUCIO_HOME=/opt/rucio
 fi
@@ -26,7 +26,7 @@ generate_rucio_cfg(){
   	local destination=$2
 
     python3 $RUCIO_SOURCE_DIR/tools/merge_rucio_configs.py --use-env \
-        -s "$CFG_PATH"/rucio_autotests_common.cfg "$override" \
+        -s "$CFG_PATH/rucio_autotests_common.cfg" "$override" \
         -d "$destination"
 }
 
@@ -41,24 +41,24 @@ fi
 echo "Generating alembic.ini and rucio.cfg"
 
 if [ -z "$RDBMS" ]; then
-    cp "$CFG_PATH"/rucio_default.cfg $RUCIO_HOME/etc/rucio.cfg
-    cp "$CFG_PATH"/alembic_default.ini $RUCIO_HOME/etc/alembic.ini
+    cp "$CFG_PATH/rucio_default.cfg" $RUCIO_HOME/etc/rucio.cfg
+    cp "$CFG_PATH/alembic_default.ini" $RUCIO_HOME/etc/alembic.ini
 
 elif [ "$RDBMS" == "oracle" ]; then
-    generate_rucio_cfg "$CFG_PATH"/rucio_oracle.cfg $RUCIO_HOME/etc/rucio.cfg
-    cp "$CFG_PATH"/alembic_oracle.ini $RUCIO_HOME/etc/alembic.ini
+    generate_rucio_cfg "$CFG_PATH/rucio_oracle.cfg" $RUCIO_HOME/etc/rucio.cfg
+    cp "$CFG_PATH/alembic_oracle.ini" $RUCIO_HOME/etc/alembic.ini
 
 elif [ "$RDBMS" == "mysql8" ]; then
-    generate_rucio_cfg "$CFG_PATH"/rucio_mysql8.cfg $RUCIO_HOME/etc/rucio.cfg
-    cp "$CFG_PATH"/alembic_mysql8.ini $RUCIO_HOME/etc/alembic.ini
+    generate_rucio_cfg "$CFG_PATH/rucio_mysql8.cfg" $RUCIO_HOME/etc/rucio.cfg
+    cp "$CFG_PATH/alembic_mysql8.ini" $RUCIO_HOME/etc/alembic.ini
 
 elif [ "$RDBMS" == "sqlite" ]; then
-    generate_rucio_cfg "$CFG_PATH"/rucio_sqlite.cfg $RUCIO_HOME/etc/rucio.cfg
-    cp "$CFG_PATH"/alembic_sqlite.ini $RUCIO_HOME/etc/alembic.ini
+    generate_rucio_cfg "$CFG_PATH/rucio_sqlite.cfg" $RUCIO_HOME/etc/rucio.cfg
+    cp "$CFG_PATH/alembic_sqlite.ini" $RUCIO_HOME/etc/alembic.ini
 
 elif [ "$RDBMS" == "postgres14" ]; then
-    generate_rucio_cfg "$CFG_PATH"/rucio_postgres14.cfg $RUCIO_HOME/etc/rucio.cfg
-    cp "$CFG_PATH"/alembic_postgres14.ini $RUCIO_HOME/etc/alembic.ini
+    generate_rucio_cfg "$CFG_PATH/rucio_postgres14.cfg" $RUCIO_HOME/etc/rucio.cfg
+    cp "$CFG_PATH/alembic_postgres14.ini" $RUCIO_HOME/etc/alembic.ini
 
 fi
 

--- a/etc/docker/test/runtime.Dockerfile
+++ b/etc/docker/test/runtime.Dockerfile
@@ -1,0 +1,181 @@
+FROM almalinux:9.1 AS base
+    WORKDIR /usr/local/src
+    ARG PYTHON
+    ENV PYTHON=$PYTHON
+    ENV LANG=en_US.UTF-8
+    ENV LC_ALL=en_US.UTF-8
+    ENV CPLUS_INCLUDE_PATH="/usr/local/include/python${PYTHON}:/usr/include/python${PYTHON}"
+    ENV C_INCLUDE_PATH="/usr/include/python${PYTHON}"
+    ENV PYTHON_VENV="/opt/venv"
+    ENV PATH="${PYTHON_VENV}/bin:${PATH}"
+    ENV PYTHON_310_PATCH_VERSION="4"
+    ENV RUCIO_HOME="/opt/rucio"
+
+FROM base AS oracle-client
+    RUN dnf install -y libnsl libaio nodejs npm
+    RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm && \
+        echo "/usr/lib/oracle/19.12/client64/lib" > /etc/ld.so.conf.d/oracle-instantclient.conf;
+
+FROM base AS python
+    RUN if [ "$PYTHON" == "3.9" ] ; then \
+            dnf install -y epel-release.noarch && \
+            dnf install -y 'dnf-command(config-manager)' && \
+            dnf config-manager --set-enabled crb && \
+            dnf -y update && \
+            dnf -y install boost-python3 python3-pip python3-devel && \
+            python3 -m pip --no-cache-dir install --upgrade pip && \
+            python3 -m pip --no-cache-dir install --upgrade setuptools wheel; \
+        elif [ "$PYTHON" == "3.10" ] ; then \
+            PYTHON_VERSION="3.10.${PYTHON_310_PATCH_VERSION}" && \
+            dnf install -y 'dnf-command(config-manager)' && \
+            dnf config-manager --enable crb && \
+            dnf -y update && \
+            dnf -y install dnf-plugins-core && \
+            dnf -y builddep python3 && \
+            dnf -y install wget yum-utils make gcc openssl-devel bzip2-devel libffi-devel zlib-devel && \
+            wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz && \
+            tar xzf Python-${PYTHON_VERSION}.tgz && \
+            cd Python-${PYTHON_VERSION} && \
+            ./configure --enable-optimizations --enable-shared --libdir=/usr/local/lib LDFLAGS="-Wl,-rpath /usr/local/lib" && \
+            make -j $(nproc) && \
+            make altinstall exec_prefix=/usr && \
+            rm -rf Python-${PYTHON_VERSION}.tgz && \
+            echo "/usr/local/lib" > /etc/ld.so.conf.d/python${PYTHON}.conf && \
+            ldconfig && \
+            python${PYTHON} -m pip --no-cache-dir install --upgrade pip && \
+            python${PYTHON} -m pip --no-cache-dir install --upgrade setuptools wheel; \
+        fi
+    RUN python${PYTHON} -m venv ${PYTHON_VENV}
+
+FROM python AS gfal2
+    RUN dnf install -y epel-release.noarch && \
+        dnf install -y 'dnf-command(config-manager)' && \
+        dnf config-manager --enable crb && \
+        dnf -y update && \
+        dnf -y install gfal2-devel && \
+        if [ "$PYTHON" == "3.9" ] ; then \
+            dnf -y install gfal2-python3 && \
+            cp /usr/lib64/python3.9/site-packages/gfal2.so /usr/lib64/gfal2.so; \
+        elif [ "$PYTHON" == "3.10" ] ; then \
+            wget https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && \
+            tar -xvzf boost_1_80_0.tar.gz && \
+            cd boost_1_80_0 && \
+            ./bootstrap.sh --with-libraries=python --with-python=/usr/bin/python3.10 --prefix=/usr --libdir=/usr/local/lib && \
+            ./b2 --with-python --libdir=/usr/local/lib --link=shared && \
+            cp /usr/local/src/boost_1_80_0/stage/lib/lib* /usr/lib64/ && \
+            dnf install -y git dnf-plugins-core git rpm-build tree which cmake make gcc gcc-c++ && \
+            git clone --depth 1 --branch v1.12.0 https://github.com/cern-fts/gfal2-python.git && \
+            cd gfal2-python && \
+            cd ./packaging && \
+            RPMBUILD_SRC_EXTRA_FLAGS="--without docs --without python2" make srpm && \
+            dnf -y builddep gfal2-python-1.12.0-1.el9.src.rpm && \
+            cd ../ && \
+            CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/local/src/boost_1_80_0  python3 -m pip --no-cache-dir install . && \
+            cd .. && rm -rf gfal2-python && \
+            dnf remove -y boost-python3 && \
+            cp ${PYTHON_VENV}/lib/python${PYTHON}/site-packages/gfal2.so /usr/lib64/gfal2.so; \
+        fi
+
+FROM python AS mod_wsgi
+    RUN if [ "$PYTHON" == "3.9" ] ; then \
+            dnf install -y python3-mod_wsgi && \
+            cp /usr/lib64/httpd/modules/mod_wsgi_python3.so /usr/lib64/httpd/modules/mod_wsgi.so; \
+        elif [ "$PYTHON" == "3.10" ] ; then \
+            dnf install -y httpd-devel && \
+            curl -sSL https://github.com/GrahamDumpleton/mod_wsgi/archive/4.9.1.tar.gz | tar xzv && \
+            cd mod_wsgi-4.9.1 && \
+            ./configure --with-python=/usr/bin/python${PYTHON} --prefix=/usr --libdir=/usr/local/lib && \
+            make -j && \
+            make install; \
+        fi && \
+        echo -e '# NOTE:\n# Only one mod_wsgi can be loaded at a time.\n# Don'"'"'t attempt to load if already loaded.\n<IfModule !wsgi_module>\n    LoadModule wsgi_module modules/mod_wsgi.so\n</IfModule>\n' > /etc/httpd/conf.modules.d/05-wsgi-python.conf;
+
+FROM python AS rucio-runtime
+    WORKDIR /usr/local/src
+
+    RUN dnf install -y epel-release.noarch && \
+        dnf install -y 'dnf-command(config-manager)' && \
+        dnf config-manager --enable crb && \
+        dnf -y update && \
+        dnf install -y \
+        xmlsec1-devel xmlsec1-openssl-devel pkg-config libtool-ltdl-devel \
+        httpd-devel \
+        libnsl libaio \
+        memcached \
+        gridsite \
+        sqlite \
+        gfal2-devel \
+        nodejs npm \
+        glibc-langpack-en \
+        git
+
+    # Set up directories and permissions for mounting source code
+    RUN mkdir -p /opt/rucio/lib /opt/rucio/bin /opt/rucio/tools /opt/rucio/etc /opt/rucio/tests && \
+        mkdir -p /var/log/rucio/trace && \
+        chmod -R 777 /var/log/rucio && \
+        mkdir -p /etc/grid-security
+
+    # Set up Apache configuration
+    COPY etc/docker/test/extra/httpd.conf /etc/httpd/conf/httpd.conf
+    COPY etc/docker/test/extra/rucio.conf /etc/httpd/conf.d/rucio.conf
+    COPY etc/docker/test/extra/00-mpm.conf /etc/httpd/conf.modules.d/00-mpm.conf
+    RUN rm -f /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/userdir.conf /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/zgridsite.conf
+
+    # Copy certificates
+    COPY etc/certs/hostcert_rucio.pem /etc/grid-security/hostcert.pem
+    COPY etc/certs/hostcert_rucio.key.pem /etc/grid-security/hostkey.pem
+    COPY etc/certs/rucio_ca.pem /opt/rucio/etc/rucio_ca.pem
+    COPY etc/certs/ruciouser.pem /opt/rucio/etc/ruciouser.pem
+    COPY etc/certs/ruciouser.key.pem /opt/rucio/etc/ruciouser.key.pem
+    
+    # Create certs dir and symlink for compatibility
+    RUN mkdir -p /opt/rucio/etc/certs && \
+        ln -s /opt/rucio/etc/rucio_ca.pem /opt/rucio/etc/certs/rucio_ca.pem
+    
+    RUN chmod 0400 /etc/grid-security/hostkey.pem && \
+        chmod 0400 /opt/rucio/etc/ruciouser.key.pem
+
+    # Copy entrypoint script
+    COPY etc/docker/dev/rucio/entrypoint.sh /usr/local/bin/entrypoint.sh
+    RUN chmod +x /usr/local/bin/entrypoint.sh
+
+    # Set environment variable for source directory
+    ENV RUCIO_SOURCE_DIR="/rucio_source"
+
+FROM rucio-runtime AS requirements
+    # Install Python dependencies
+    COPY requirements /tmp/requirements
+    RUN dnf -y update --nobest && \
+        dnf -y --skip-broken install make gcc krb5-devel xmlsec1-devel xmlsec1-openssl-devel pkg-config libtool-ltdl-devel git && \
+        python3 -m pip --no-cache-dir install --upgrade pip && \
+        python3 -m pip --no-cache-dir install --upgrade setuptools wheel && \
+        python3 -m pip --no-cache-dir install --upgrade -r /tmp/requirements/requirements.server.txt -r /tmp/requirements/requirements.dev.txt
+
+FROM requirements AS final
+
+    COPY --from=gfal2 /usr/include/gfal2 /usr/include/gfal2
+    COPY --from=gfal2 /usr/lib64/* /usr/lib64/
+    COPY --from=gfal2 /usr/lib64/libboost_python3* /usr/lib64/
+    COPY --from=gfal2 /usr/lib64/gfal2.so /usr/lib64/gfal2.so
+
+    RUN mv /usr/lib64/gfal2.so ${PYTHON_VENV}/lib/python${PYTHON}/site-packages/gfal2.so;
+
+    COPY --from=oracle-client /usr/share/oracle /usr/share/oracle
+    COPY --from=oracle-client /usr/lib/oracle /usr/lib/oracle/
+    COPY --from=oracle-client /etc/ld.so.conf.d/oracle-instantclient.conf /etc/ld.so.conf.d/oracle-instantclient.conf
+
+    COPY --from=mod_wsgi /usr/lib64/httpd/modules /usr/lib64/httpd/modules
+    COPY --from=mod_wsgi /etc/httpd/conf.modules.d/05-wsgi-python.conf  /etc/httpd/conf.modules.d/05-wsgi-python.conf
+
+    WORKDIR /opt/rucio
+    RUN ldconfig
+
+    # Create a volume mount point for source code
+    VOLUME /opt/rucio/lib
+    VOLUME /opt/rucio/bin
+    VOLUME /opt/rucio/tools
+    VOLUME /opt/rucio/tests
+    VOLUME /opt/rucio/etc
+
+    ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+    CMD ["httpd","-D","FOREGROUND"] 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ pythonpath = [
 testpaths = [
     "tests",
 ]
+filterwarnings = [
+    "ignore::BytesWarning",
+]
 
 [tool.coverage.report]
 exclude_also = [

--- a/tools/pytest.ini
+++ b/tools/pytest.ini
@@ -4,3 +4,5 @@ pythonpath =
     lib
 testpaths =
     tests
+filterwarnings =
+    ignore::BytesWarning

--- a/tools/pytest.sh
+++ b/tools/pytest.sh
@@ -25,7 +25,17 @@ if [[ ${#@} -eq 0 ]]; then
   ARGS=(".")
 else
   echo "Running pytest with extra arguments: $@"
-  ARGS=($@)
+  # Convert /opt/rucio/tests/ paths to relative paths when in /rucio_source
+  ARGS=()
+  for arg in "$@"; do
+    if [[ "$arg" =~ ^/opt/rucio/tests/ ]]; then
+      # Convert /opt/rucio/tests/test_file.py to tests/test_file.py
+      relative_path="${arg#/opt/rucio/}"
+      ARGS+=("$relative_path")
+    else
+      ARGS+=("$arg")
+    fi
+  done
 fi
 
 export PYTEST_DISABLE_PLUGIN_AUTOLOAD="True"

--- a/tools/test/run_tests.py
+++ b/tools/test/run_tests.py
@@ -346,7 +346,7 @@ def run_with_httpd(
             # Install Rucio directly from the mounted source
             run('docker', *namespace_args, 'exec', rucio_container, 'pip', 'install', '--no-cache-dir', '-e', '/rucio_source')
 
-            # Running test.sh from the source directory
+            # Running test.sh
             if tests:
                 tests_env = ('--env', 'TESTS=' + ' '.join(tests))
                 tests_arg = ('-p', )

--- a/tools/test/test.sh
+++ b/tools/test/test.sh
@@ -18,8 +18,8 @@ set -eo pipefail
 
 echo "* Using $(command -v python) $(python --version 2>&1) and $(command -v pip) $(pip --version 2>&1)"
 
-SOURCE_PATH=/usr/local/src/rucio
-CFG_PATH=/usr/local/src/rucio/etc/docker/test/extra/
+SOURCE_PATH=${RUCIO_SOURCE_DIR:-/usr/local/src/rucio}
+CFG_PATH=${RUCIO_SOURCE_DIR:-/usr/local/src/rucio}/etc/docker/test/extra/
 if [ -z "$RUCIO_HOME" ]; then
     RUCIO_HOME=/opt/rucio
 fi
@@ -50,7 +50,7 @@ function wait_for_database() {
 if [ "$SUITE" == "client" ]; then
     tools/run_tests.sh -i
 
-    cp "$SOURCE_PATH"/etc/docker/test/extra/rucio_client.cfg "$SOURCE_PATH"/etc/rucio.cfg
+    cp "$SOURCE_PATH"/etc/docker/test/extra/rucio_client.cfg "$RUCIO_HOME"/etc/rucio.cfg    
     srchome
     tools/pytest.sh -v --tb=short tests/test_clients.py tests/test_bin_rucio.py tests/test_module_import.py
 


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Ref: #7839 #7840 

This PR updates the CI testing approach by switching from building Docker images with the source baked in to using pre-built base runtime images and mounting the PR’s source code at runtime in `autotests.yml`.

- The base images (for Python 3.9 and 3.10) are built and pushed to GHCR using `runtime.Dockerfile` and the `runtime_images.yml` workflow (only if the image isn’t already available).

- These runtime images are then used by autotests.yml to execute tests. Inside `run_tests.py`, `test.sh`, and `docker-compose.yml`, the paths are configured to use the mounted PR code, which is installed in editable mode via `pip install -e`.

- Image builds uses registry based caching (rebuilding only when dependencies change), otherwise pulling the existing image. In case of dependencies bump or change, It uses old layers from the cache which hasn't changed.

The whole workflow with caching takes around [30-35 mins](https://github.com/0xquark/rucio/actions/runs/16190100219) instead of around [1h](https://github.com/rucio/rucio/actions/runs/16216539701). This happens because we only build the image once so we save a lot of time while running other tests in the matrix using the same image.

The whole testing workflow for autotests is described below:
<img width="2278" height="973" alt="image" src="https://github.com/user-attachments/assets/28a293f1-5f3a-46b8-aed9-68cd6427c918" />