### PR TITLE
Tests: Add fixtures for db session (read/write)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,9 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import pytest
 
+from rucio.db.sqla.constants import DatabaseOperationType
+from rucio.db.sqla.session import db_session
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
     from configparser import ConfigParser
@@ -80,6 +83,18 @@ def pytest_make_parametrize_id(
         return argname + str(cfg)
     # return None to let pytest handle the formatting
     return None
+
+
+@pytest.fixture
+def db_read_session():
+    with db_session(DatabaseOperationType.READ) as session:
+        yield session
+
+
+@pytest.fixture
+def db_write_session():
+    with db_session(DatabaseOperationType.WRITE) as session:
+        yield session
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
This PR adds some fixtures useful for tests which require a db session.

The original PR where this change was introduced (https://github.com/rucio/rucio/pull/7592) was failing with a non-descript error, I was able to track it down to the changes present in this PR.

There is a deeper issue I cannot figure out that is making this change fail the CI.