### PR TITLE
dependencies: Remove unused `libnsl` and `libaio` from dev test image; Fix #7861

### DIFF
--- a/etc/docker/test/alma9.Dockerfile
+++ b/etc/docker/test/alma9.Dockerfile
@@ -101,7 +101,6 @@ FROM python as rucio-runtime
         dnf install -y \
         xmlsec1-devel xmlsec1-openssl-devel pkg-config libtool-ltdl-devel \
         httpd-devel \
-        libnsl libaio \
         memcached \
         gridsite \
         sqlite \


### PR DESCRIPTION
Similar to https://github.com/rucio/containers/pull/424, but for the dev test image in rucio/rucio as explained in https://github.com/rucio/rucio/issues/7861.