### PR TITLE
Rename from TestCollocationPlugin to MockCollocationPlugin to avoid Test prefix #7860

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -69,7 +69,7 @@ Individual contributors to the source code
 - Maximilian Linhoff, <maximilian.linhoff@tu-dortmund.de>, 2024
 - Eric Banzuzi, <eric.banzuzi@gmail.com>, 2024
 - Paul Millar, <paul.millar@desy.de>, 2025
-- Vimalan S <vimalan.github@gmail.com>, 202
+- Vimalan S <vimalan.github@gmail.com>, 2025
 
 Organisations employing contributors
 ------------------------------------

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -69,6 +69,7 @@ Individual contributors to the source code
 - Maximilian Linhoff, <maximilian.linhoff@tu-dortmund.de>, 2024
 - Eric Banzuzi, <eric.banzuzi@gmail.com>, 2024
 - Paul Millar, <paul.millar@desy.de>, 2025
+- Vimalan S <vimalan.github@gmail.com>, 202
 
 Organisations employing contributors
 ------------------------------------

--- a/tests/test_transfer_plugins.py
+++ b/tests/test_transfer_plugins.py
@@ -157,7 +157,7 @@ def test_activity_missing(file_config_mock, did_factory, rse_factory, root_accou
 
 
 class TestCollocationHints:
-    class TestCollocationPlugin(FTS3TapeMetadataPlugin):
+    class MockCollocationPlugin(FTS3TapeMetadataPlugin):
         def __init__(self) -> None:
             self.register(
                 'test',
@@ -167,7 +167,7 @@ class TestCollocationHints:
         def _test_collocation(self, hints: dict[str, str]) -> dict[str, dict]:
             return {"collocation_hints": {"0": "", "1": "", "2": "", "3": ""}}
 
-    TestCollocationPlugin()
+    MockCollocationPlugin()
 
     @pytest.mark.parametrize("file_config_mock", [
         {


### PR DESCRIPTION
I have Renamed the class name to as you have requested in MockCollocationPlugin in issue PR #7860. Kindly review the code and reach out to me in case of further changes. Thank you for allowing me to contribute 😊