### PR TITLE
Testing: Refactor CI / Test Infrastructure to use Runtime Mounted Source Code and Registry Caching in Integration Tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -112,8 +112,8 @@ jobs:
         if: needs.runtime_images.outputs.build_locally == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
-          context: .
-          file: etc/docker/test/runtime.Dockerfile
+          context: dev/rucio
+          file: dev/rucio/etc/docker/test/runtime.Dockerfile
           target: final
           build-args: |
             PYTHON=3.9

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -9,6 +9,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  runtime_images:
+    name: Build Python 3.9 Runtime Image
+    uses: ./.github/workflows/runtime_images.yml
+    permissions:
+      packages: write
   setup:
     runs-on: ubuntu-latest
     steps:
@@ -28,7 +33,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
 
   integration-tests:
-    needs: setup
+    needs: [runtime_images, setup]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -93,34 +98,39 @@ jobs:
               echo "Tag $GIT_REF not found in rucio/containers. Integration test containers will be built against the master branch instead."
               git checkout master
           fi
-      - name: Use rucio/containers Dockerfile for integration tests
-        shell: bash
-        run: |
-          sed -i 's;RUN git clone .*;COPY ./rucio /tmp/rucio;' $GITHUB_WORKSPACE/dev/alma9.Dockerfile
-      - name: Build rucio-dev images
+      - name: Set up Docker Buildx
+        if: needs.runtime_images.outputs.build_locally == 'true'
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+      - name: Build Python 3.9 image locally
+        if: needs.runtime_images.outputs.build_locally == 'true'
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: etc/docker/test/runtime.Dockerfile
+          target: final
+          build-args: |
+            PYTHON=3.9
+          push: false
+          tags: ${{ needs.runtime_images.outputs.py39_image }}
+          outputs: type=docker
+        continue-on-error: false
+      - name: Pull all required images
         id: images
         shell: bash
         run: |
-          docker login https://ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           docker compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile storage --profile externalmetadata --profile iam pull
-          i=0; until [ "$i" -ge 3 ]; do
-            IMAGES=$(echo '${{ toJson(matrix.cfg) }}' | $GITHUB_WORKSPACE/dev/rucio/tools/test/build_images.py --output list \
-                --cache-repo ghcr.io/${{ github.repository }} --branch "${{ needs.setup.outputs.branch }}" \
-                $GITHUB_WORKSPACE/dev || echo "")
-            if [[ -n $IMAGES ]]; then break;
-            else
-              i=$((i+1)); sleep 5;
-              echo "::warning::Building images failed, retrying…"
-            fi
-          done
-          docker logout https://ghcr.io
-          if [[ -z "$IMAGES" ]]; then echo "::error::Building images failed ultimately"; exit 1; fi
-          echo "images=$IMAGES" >> $GITHUB_OUTPUT
-      - name: Prepare Docker Compose
+      - name: Set Runtime Image in Docker Compose
         shell: bash
         run: |
           docker image ls
-          sed -i 's;image: docker.io/rucio/rucio-dev.*;image: ${{ fromJSON(steps.images.outputs.images)[0] }};' \
+          sed -i 's;image: .*rucio-dev.*;image: ${{ needs.runtime_images.outputs.py39_image }};' \
               $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml
       - name: Start containers
         run: |
@@ -129,8 +139,13 @@ jobs:
       - name: Initialize tests
         shell: bash
         run: |
-          docker exec -t dev-rucio-1 cp etc/rse-accounts.cfg.template etc/rse-accounts.cfg
-          docker exec -t dev-rucio-1 tools/run_tests.sh -ir
+          docker exec -t dev-rucio-1 bash -c "
+            set -e
+            cd /rucio_source
+            cp etc/rse-accounts.cfg.template etc/rse-accounts.cfg
+            pip install --no-cache-dir -e /rucio_source
+            tools/run_tests.sh -ir
+          "
       - name: File Upload/Download Test
         run: docker exec -t dev-rucio-1 tools/pytest.sh -v --tb=short tests/test_rucio_server.py
       - name: UploadClient Test

--- a/etc/docker/test/runtime.Dockerfile
+++ b/etc/docker/test/runtime.Dockerfile
@@ -99,15 +99,33 @@ FROM python AS rucio-runtime
         dnf -y update && \
         dnf install -y \
         xmlsec1-devel xmlsec1-openssl-devel pkg-config libtool-ltdl-devel \
-        httpd-devel \
+        httpd httpd-devel \
         libnsl libaio \
         memcached \
         gridsite \
         sqlite \
-        gfal2-devel \
+        gfal2-devel gfal2-all python3-gfal2-util python3-gfal2 \
         nodejs npm \
         glibc-langpack-en \
-        git
+        xrootd-client \
+        git \
+        swig \
+        gmp-devel \
+        krb5-devel \
+        libxml2-devel \
+        mariadb-connector-c \
+        mod_ssl \
+        mod_auth_gssapi \
+        multitail \
+        nmap-ncat \
+        openssh-clients \
+        openssl-devel \
+        python3-m2crypto \
+        rsync \
+        unzip \
+        vim \
+        voms-clients-java \
+        which
 
     # Set up directories and permissions for mounting source code
     RUN mkdir -p /opt/rucio/lib /opt/rucio/bin /opt/rucio/tools /opt/rucio/etc /opt/rucio/tests && \
@@ -148,8 +166,10 @@ FROM rucio-runtime AS requirements
     RUN dnf -y update --nobest && \
         dnf -y --skip-broken install make gcc krb5-devel xmlsec1-devel xmlsec1-openssl-devel pkg-config libtool-ltdl-devel git && \
         python3 -m pip --no-cache-dir install --upgrade pip && \
+        python3 -m pip --no-cache-dir install --upgrade fts3 && \
         python3 -m pip --no-cache-dir install --upgrade setuptools wheel && \
         python3 -m pip --no-cache-dir install --upgrade -r /tmp/requirements/requirements.server.txt -r /tmp/requirements/requirements.dev.txt
+    RUN curl https://rclone.org/install.sh | bash
 
 FROM requirements AS final
 
@@ -178,4 +198,4 @@ FROM requirements AS final
     VOLUME /opt/rucio/etc
 
     ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-    CMD ["httpd","-D","FOREGROUND"] 
+    CMD ["httpd","-D","FOREGROUND"]


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Ref: https://github.com/rucio/rucio/issues/7839 https://github.com/rucio/rucio/issues/7840 

This PR builds on #7853 by adding refactoring and caching for the **Integration Tests**. It should be rebased and merged after the autotests PR.

This PR includes the following:

- The `runtime.Dockerfile` has been updated to include the dependencies needed for integration tests, based on `alma9.dockerfile` from the `rucio/containers` repo.

- The `Integration_tests.yml` workflow now uses a pre-built runtime image instead of rebuilding the rucio-dev image every time. If the runtime image isn’t available in the registry, it will build one locally.

- Added registry layer caching so image builds are faster by reusing existing layers.

- The Rucio source code is now mounted and installed in editable mode for running tests.

Before the integration, the **integration tests** took about **19 minutes** on average. Now, they only take around **8 minutes**. The tests are running about **58%-60%** faster than before.

Here's the full workflow attached:

<img width="1079" height="933" alt="image" src="https://github.com/user-attachments/assets/858251d1-d3bd-4cbc-b4fd-5ae4689cd52f" />