### PR TITLE
Testing: remove redundant --ranking flag from RSE setup #7898

### DIFF
--- a/tools/docker_activate_rses.sh
+++ b/tools/docker_activate_rses.sh
@@ -92,18 +92,18 @@ rucio-admin rse set-attribute --rse WEB1 --key fts --value https://fts:8446
 rucio-admin rse set-attribute --rse XRD3 --key available_for_multihop --value True
 
 # Connect the RSEs
-rucio-admin rse add-distance --distance 1 --ranking 1 XRD1 XRD2
-rucio-admin rse add-distance --distance 1 --ranking 1 XRD1 XRD3
-rucio-admin rse add-distance --distance 1 --ranking 1 XRD2 XRD1
-rucio-admin rse add-distance --distance 2 --ranking 2 XRD2 XRD3
-rucio-admin rse add-distance --distance 1 --ranking 1 XRD3 XRD1
-rucio-admin rse add-distance --distance 2 --ranking 2 XRD3 XRD2
-rucio-admin rse add-distance --distance 3 --ranking 3 XRD3 XRD4
-rucio-admin rse add-distance --distance 3 --ranking 3 XRD4 XRD3
-rucio-admin rse add-distance --distance 1 --ranking 1 XRD4 XRD5
-rucio-admin rse add-distance --distance 1 --ranking 1 XRD5 XRD4
-rucio-admin rse add-distance --distance 1 --ranking 1 XRD5 WEB1
-rucio-admin rse add-distance --distance 1 --ranking 1 WEB1 XRD5
+rucio-admin rse add-distance --distance 1 XRD1 XRD2
+rucio-admin rse add-distance --distance 1 XRD1 XRD3
+rucio-admin rse add-distance --distance 1 XRD2 XRD1
+rucio-admin rse add-distance --distance 2 XRD2 XRD3
+rucio-admin rse add-distance --distance 1 XRD3 XRD1
+rucio-admin rse add-distance --distance 2 XRD3 XRD2
+rucio-admin rse add-distance --distance 3 XRD3 XRD4
+rucio-admin rse add-distance --distance 3 XRD4 XRD3
+rucio-admin rse add-distance --distance 1 XRD4 XRD5
+rucio-admin rse add-distance --distance 1 XRD5 XRD4
+rucio-admin rse add-distance --distance 1 XRD5 WEB1
+rucio-admin rse add-distance --distance 1 WEB1 XRD5
 
 # Indefinite limits for root
 rucio-admin account set-limits root XRD1 -1


### PR DESCRIPTION
### Summary

This PR removes the unnecessary `--ranking` flag from the `rucio-admin rse add-distance` commands in the `docker_activate_rses.sh` script.

### Context

According to issue #7898, if the `--distance` flag is provided, the `--ranking` parameter is ignored. Including both is redundant.