### PR TITLE
Docker & Kubernetes: Add health checks and service dependencies in docker-compose

### DIFF
--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -71,6 +71,9 @@ services:
       postgres14:
         condition: service_healthy
         required: false
+      elasticsearch:
+        condition: service_healthy
+        required: false
 
   # ------------------------------------------------------------------
   # Database, MQ, metrics, and other external services
@@ -124,6 +127,11 @@ services:
     image: docker.io/elasticsearch:7.8.0
     environment:
       - discovery.type=single-node
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow" ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
   activemq:
     container_name: dev-activemq-1

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -61,6 +61,16 @@ services:
       - REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
       - RUCIO_SOURCE_DIR=/rucio_source
       - RDBMS
+    depends_on:
+      oracle:
+        condition: service_healthy
+        required: false
+      ruciodb:
+        condition: service_healthy
+        required: false
+      postgres14:
+        condition: service_healthy
+        required: false
 
   # ------------------------------------------------------------------
   # Database, MQ, metrics, and other external services
@@ -75,6 +85,12 @@ services:
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
     volumes:
       - vol-ruciodb-data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 10
 
   graphite:
     container_name: dev-graphite-1
@@ -132,6 +148,12 @@ services:
     command: ["-c", "fsync=off","-c", "synchronous_commit=off","-c", "full_page_writes=off"]
     volumes:
       - vol-postgres14-data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 10
 
   mysql8:
     container_name: dev-mysql8-1
@@ -165,6 +187,12 @@ services:
       - transactions=1215
     volumes:
       - ./oracle_setup.sh:/container-entrypoint-initdb.d/oracle_setup.sh:Z
+    healthcheck:
+      test: [ "CMD-SHELL", "/opt/oracle/healthcheck.sh > /dev/null || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      start_period: 60s
+      retries: 10
 
   # ------------------------------------------------------------------
   # FTS and XRootD containers (test RSEs)

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -74,6 +74,9 @@ services:
       elasticsearch:
         condition: service_healthy
         required: false
+      influxdb:
+        condition: service_healthy
+        required: false
 
   # ------------------------------------------------------------------
   # Database, MQ, metrics, and other external services
@@ -121,6 +124,11 @@ services:
     volumes:
       - vol-influxdb-etc:/etc/influxdb2
       - vol-influxdb-var:/var/lib/influxdb2
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8086/ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   elasticsearch:
     container_name: dev-elasticsearch-1


### PR DESCRIPTION
Fixes rucio/rucio#7909

Now rucio container waits first for the various services to become healthy (up until our defined time-window of tries) before it spins up, giving ultimately a warning when some dependency service isn't started or available

<img width="260" height="538" alt="image" src="https://github.com/user-attachments/assets/221b9413-d62c-4f39-b698-ba5304163025" />

<img width="225" height="535" alt="image" src="https://github.com/user-attachments/assets/3643a893-c080-44c9-a706-42ee91bf6b56" />
