### PR TITLE
Clients, API: Refactor HTTP method strings for enums

### DIFF
--- a/lib/rucio/client/accountclient.py
+++ b/lib/rucio/client/accountclient.py
@@ -19,6 +19,7 @@ from urllib.parse import quote_plus
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url
 
 if TYPE_CHECKING:
@@ -59,7 +60,7 @@ class AccountClient(BaseClient):
         path = '/'.join([self.ACCOUNTS_BASEURL, account])
         url = build_url(choice(self.list_hosts), path=path)
 
-        res = self._send_request(url, type_='POST', data=data)
+        res = self._send_request(url, method=HTTPMethod.POST, data=data)
         if res.status_code == codes.created:
             return True
         exc_cls, exc_msg = self._get_exception(headers=res.headers, status_code=res.status_code, data=res.content)
@@ -88,7 +89,7 @@ class AccountClient(BaseClient):
         path = '/'.join([self.ACCOUNTS_BASEURL, account])
         url = build_url(choice(self.list_hosts), path=path)
 
-        res = self._send_request(url, type_='DEL')
+        res = self._send_request(url, method=HTTPMethod.DELETE)
 
         if res.status_code == codes.ok:
             return True
@@ -118,7 +119,7 @@ class AccountClient(BaseClient):
         path = '/'.join([self.ACCOUNTS_BASEURL, account])
         url = build_url(choice(self.list_hosts), path=path)
 
-        res = self._send_request(url)
+        res = self._send_request(url, method=HTTPMethod.GET)
         if res.status_code == codes.ok:
             acc = self._load_json_data(res)
             return next(acc)
@@ -152,7 +153,7 @@ class AccountClient(BaseClient):
         path = '/'.join([self.ACCOUNTS_BASEURL, account])
         url = build_url(choice(self.list_hosts), path=path)
 
-        res = self._send_request(url, type_='PUT', data=data)
+        res = self._send_request(url, method=HTTPMethod.PUT, data=data)
 
         if res.status_code == codes.ok:
             return True
@@ -199,7 +200,7 @@ class AccountClient(BaseClient):
             for key in filters:
                 params[key] = filters[key]
 
-        res = self._send_request(url, params=params)
+        res = self._send_request(url, method=HTTPMethod.GET, params=params)
 
         if res.status_code == codes.ok:
             accounts = self._load_json_data(res)
@@ -263,7 +264,7 @@ class AccountClient(BaseClient):
 
         url = build_url(choice(self.list_hosts), path=path)
 
-        res = self._send_request(url, type_='POST', data=data)
+        res = self._send_request(url, method=HTTPMethod.POST, data=data)
 
         if res.status_code == codes.created:
             return True
@@ -300,7 +301,7 @@ class AccountClient(BaseClient):
 
         url = build_url(choice(self.list_hosts), path=path)
 
-        res = self._send_request(url, type_='DEL', data=data)
+        res = self._send_request(url, method=HTTPMethod.DELETE, data=data)
 
         if res.status_code == codes.ok:
             return True
@@ -319,7 +320,7 @@ class AccountClient(BaseClient):
         """
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'identities'])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url)
+        res = self._send_request(url, method=HTTPMethod.GET)
         if res.status_code == codes.ok:
             identities = self._load_json_data(res)
             return identities
@@ -340,7 +341,7 @@ class AccountClient(BaseClient):
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'rules'])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url, type_='GET')
+        res = self._send_request(url, method=HTTPMethod.GET)
         if res.status_code == codes.ok:
             return self._load_json_data(res)
         else:
@@ -385,7 +386,7 @@ class AccountClient(BaseClient):
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'limits', 'global', quote_plus(rse_expression)])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url, type_='GET')
+        res = self._send_request(url, method=HTTPMethod.GET)
         if res.status_code == codes.ok:
             return next(self._load_json_data(res))
         exc_cls, exc_msg = self._get_exception(headers=res.headers, status_code=res.status_code, data=res.content)
@@ -403,7 +404,7 @@ class AccountClient(BaseClient):
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'limits', 'global'])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url, type_='GET')
+        res = self._send_request(url, method=HTTPMethod.GET)
         if res.status_code == codes.ok:
             return next(self._load_json_data(res))
         exc_cls, exc_msg = self._get_exception(headers=res.headers, status_code=res.status_code, data=res.content)
@@ -421,7 +422,7 @@ class AccountClient(BaseClient):
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'limits', 'local'])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url, type_='GET')
+        res = self._send_request(url, method=HTTPMethod.GET)
         if res.status_code == codes.ok:
             return next(self._load_json_data(res))
         exc_cls, exc_msg = self._get_exception(headers=res.headers, status_code=res.status_code, data=res.content)
@@ -441,7 +442,7 @@ class AccountClient(BaseClient):
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'limits', 'local', rse])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url, type_='GET')
+        res = self._send_request(url, method=HTTPMethod.GET)
         if res.status_code == codes.ok:
             return next(self._load_json_data(res))
         exc_cls, exc_msg = self._get_exception(headers=res.headers, status_code=res.status_code, data=res.content)
@@ -463,7 +464,7 @@ class AccountClient(BaseClient):
         else:
             path = '/'.join([self.ACCOUNTS_BASEURL, account, 'usage', 'local'])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url, type_='GET')
+        res = self._send_request(url, method=HTTPMethod.GET)
         if res.status_code == codes.ok:
             return self._load_json_data(res)
         else:
@@ -486,7 +487,7 @@ class AccountClient(BaseClient):
         else:
             path = '/'.join([self.ACCOUNTS_BASEURL, account, 'usage', 'global'])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url, type_='GET')
+        res = self._send_request(url, method=HTTPMethod.GET)
         if res.status_code == codes.ok:
             return self._load_json_data(res)
         else:
@@ -506,7 +507,7 @@ class AccountClient(BaseClient):
         """
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'usage/history', rse])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url, type_='GET')
+        res = self._send_request(url, method=HTTPMethod.GET)
         if res.status_code == codes.ok:
             return next(self._load_json_data(res))
         else:
@@ -524,7 +525,7 @@ class AccountClient(BaseClient):
         """
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'attr/'])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url, type_='GET')
+        res = self._send_request(url, method=HTTPMethod.GET)
         if res.status_code == codes.ok:
             return self._load_json_data(res)
         else:
@@ -548,7 +549,7 @@ class AccountClient(BaseClient):
         data = dumps({'key': key, 'value': value})
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'attr', key])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url, type_='POST', data=data)
+        res = self._send_request(url, method=HTTPMethod.POST, data=data)
         if res.status_code == codes.created:
             return True
         else:
@@ -569,7 +570,7 @@ class AccountClient(BaseClient):
 
         path = '/'.join([self.ACCOUNTS_BASEURL, account, 'attr', key])
         url = build_url(choice(self.list_hosts), path=path)
-        res = self._send_request(url, type_='DEL', data=None)
+        res = self._send_request(url, method=HTTPMethod.DELETE, data=None)
         if res.status_code == codes.ok:
             return True
         else:

--- a/lib/rucio/client/accountlimitclient.py
+++ b/lib/rucio/client/accountlimitclient.py
@@ -19,6 +19,7 @@ from urllib.parse import quote_plus
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url
 
 
@@ -123,7 +124,7 @@ class AccountLimitClient(BaseClient):
         path = '/'.join([self.ACCOUNTLIMIT_BASEURL, 'local', account, rse])
         url = build_url(choice(self.list_hosts), path=path)
 
-        r = self._send_request(url, type_='POST', data=data)
+        r = self._send_request(url, method=HTTPMethod.POST, data=data)
 
         if r.status_code == codes.created:
             return True
@@ -160,7 +161,7 @@ class AccountLimitClient(BaseClient):
         path = '/'.join([self.ACCOUNTLIMIT_BASEURL, 'local', account, rse])
         url = build_url(choice(self.list_hosts), path=path)
 
-        r = self._send_request(url, type_='DEL')
+        r = self._send_request(url, method=HTTPMethod.DELETE)
 
         if r.status_code == codes.ok:
             return True
@@ -196,7 +197,7 @@ class AccountLimitClient(BaseClient):
         path = '/'.join([self.ACCOUNTLIMIT_BASEURL, 'global', account, quote_plus(rse_expression)])
         url = build_url(choice(self.list_hosts), path=path)
 
-        r = self._send_request(url, type_='POST', data=data)
+        r = self._send_request(url, method=HTTPMethod.POST, data=data)
 
         if r.status_code == codes.created:
             return True
@@ -233,7 +234,7 @@ class AccountLimitClient(BaseClient):
         path = '/'.join([self.ACCOUNTLIMIT_BASEURL, 'global', account, quote_plus(rse_expression)])
         url = build_url(choice(self.list_hosts), path=path)
 
-        r = self._send_request(url, type_='DEL')
+        r = self._send_request(url, method=HTTPMethod.DELETE)
 
         if r.status_code == codes.ok:
             return True

--- a/lib/rucio/client/configclient.py
+++ b/lib/rucio/client/configclient.py
@@ -18,6 +18,7 @@ from typing import Any, Optional
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url
 
 
@@ -54,7 +55,7 @@ class ConfigClient(BaseClient):
 
         url = build_url(choice(self.list_hosts), path=path)
 
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             return r.json()
         else:
@@ -104,11 +105,11 @@ class ConfigClient(BaseClient):
                     option: value
                 }
             })
-            r = self._send_request(url, type_='POST', data=data)
+            r = self._send_request(url, method=HTTPMethod.POST, data=data)
         else:
             path = '/'.join([self.CONFIG_BASEURL, section, option, value])
             url = build_url(choice(self.list_hosts), path=path)
-            r = self._send_request(url, type_='PUT')
+            r = self._send_request(url, method=HTTPMethod.PUT)
 
         if r.status_code == codes.created:
             return True
@@ -140,7 +141,7 @@ class ConfigClient(BaseClient):
         path = '/'.join([self.CONFIG_BASEURL, section, option])
         url = build_url(choice(self.list_hosts), path=path)
 
-        r = self._send_request(url, type_='DEL')
+        r = self._send_request(url, method=HTTPMethod.DELETE)
 
         if r.status_code == codes.ok:
             return True
@@ -163,7 +164,7 @@ class ConfigClient(BaseClient):
         """
         path = '/'.join([self.CONFIG_BASEURL, section])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='DEL')
+        r = self._send_request(url, method=HTTPMethod.DELETE)
 
         if r.status_code == codes.ok:
             return True

--- a/lib/rucio/client/credentialclient.py
+++ b/lib/rucio/client/credentialclient.py
@@ -15,6 +15,7 @@
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url
 
 
@@ -60,7 +61,7 @@ class CredentialClient(BaseClient):
         params['op'] = operation
         params['url'] = url
         rurl = build_url(choice(self.list_hosts), path=path, params=params)
-        r = self._send_request(rurl, type_='GET')
+        r = self._send_request(rurl, method=HTTPMethod.GET)
 
         if r.status_code == codes.ok:
             return r.text

--- a/lib/rucio/client/diracclient.py
+++ b/lib/rucio/client/diracclient.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url
 
 if TYPE_CHECKING:
@@ -113,7 +114,7 @@ class DiracClient(BaseClient):
 
         r = self._send_request(
             url,
-            type_='POST',
+            method=HTTPMethod.POST,
             data=dumps({'lfns': lfns, 'ignore_availability': ignore_availability, 'parents_metadata': parents_metadata})
         )
 

--- a/lib/rucio/client/exportclient.py
+++ b/lib/rucio/client/exportclient.py
@@ -17,6 +17,7 @@ from typing import Any
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url, parse_response
 
 
@@ -83,7 +84,7 @@ class ExportClient(BaseClient):
         path = '/'.join([self.EXPORT_BASEURL])
         url = build_url(choice(self.list_hosts), path=path, params=payload)
 
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             return parse_response(r.text)
         else:

--- a/lib/rucio/client/importclient.py
+++ b/lib/rucio/client/importclient.py
@@ -17,6 +17,7 @@ from typing import Any
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url, render_json
 
 
@@ -37,7 +38,7 @@ class ImportClient(BaseClient):
         path = '/'.join([self.IMPORT_BASEURL])
         url = build_url(choice(self.list_hosts), path=path)
 
-        r = self._send_request(url, type_='POST', data=render_json(**data))
+        r = self._send_request(url, method=HTTPMethod.POST, data=render_json(**data))
         if r.status_code == codes.created:
             return r.text
         else:

--- a/lib/rucio/client/lifetimeclient.py
+++ b/lib/rucio/client/lifetimeclient.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url, render_json
 
 if TYPE_CHECKING:
@@ -81,7 +82,7 @@ class LifetimeClient(BaseClient):
             params['states'] = exception_id
         url = build_url(choice(self.list_hosts), path=path, params=params)
 
-        result = self._send_request(url)
+        result = self._send_request(url, method=HTTPMethod.GET)
         if result.status_code == codes.ok:
             lifetime_exceptions = self._load_json_data(result)
             return lifetime_exceptions
@@ -133,7 +134,7 @@ class LifetimeClient(BaseClient):
         path = self.LIFETIME_BASEURL + '/'
         url = build_url(choice(self.list_hosts), path=path)
         data = {'dids': dids, 'account': account, 'pattern': pattern, 'comments': comments, 'expires_at': expires_at}
-        result = self._send_request(url, type_='POST', data=render_json(**data))
+        result = self._send_request(url, method=HTTPMethod.POST, data=render_json(**data))
         if result.status_code == codes.created:
             return loads(result.text)
         exc_cls, exc_msg = self._get_exception(headers=result.headers, status_code=result.status_code, data=result.content)

--- a/lib/rucio/client/lockclient.py
+++ b/lib/rucio/client/lockclient.py
@@ -18,6 +18,7 @@ from urllib.parse import quote_plus
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url, render_json
 
 if TYPE_CHECKING:
@@ -50,7 +51,7 @@ class LockClient(BaseClient):
         path = '/'.join([self.LOCKS_BASEURL, quote_plus(scope), quote_plus(name)])
         url = build_url(choice(self.list_hosts), path=path, params={'did_type': 'dataset'})
 
-        result = self._send_request(url)
+        result = self._send_request(url, method=HTTPMethod.GET)
         if result.status_code == codes.ok:   # pylint: disable-msg=E1101
             locks = self._load_json_data(result)
             return locks
@@ -87,7 +88,7 @@ class LockClient(BaseClient):
         path = '/'.join([self.LOCKS_BASEURL, "bulk_locks_for_dids"])
         url = build_url(choice(self.list_hosts), path=path)
 
-        result = self._send_request(url, type_='POST', data=render_json(dids=dids))
+        result = self._send_request(url, method=HTTPMethod.POST, data=render_json(dids=dids))
         if result.status_code == codes.ok:   # pylint: disable-msg=E1101
             out = []
             for lock in self._load_json_data(result):
@@ -113,7 +114,7 @@ class LockClient(BaseClient):
         path = '/'.join([self.LOCKS_BASEURL, rse])
         url = build_url(choice(self.list_hosts), path=path, params={'did_type': 'dataset'})
 
-        result = self._send_request(url)
+        result = self._send_request(url, method=HTTPMethod.GET)
         if result.status_code == codes.ok:   # pylint: disable-msg=E1101
             locks = self._load_json_data(result)
             return locks

--- a/lib/rucio/client/metaconventionsclient.py
+++ b/lib/rucio/client/metaconventionsclient.py
@@ -19,6 +19,7 @@ from urllib.parse import quote_plus
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url
 
 if TYPE_CHECKING:
@@ -63,7 +64,7 @@ class MetaConventionClient(BaseClient):
                       'value_regexp': value_regexp,
                       'key_type': key_type})
 
-        r = self._send_request(url, type_='POST', data=data)
+        r = self._send_request(url, method=HTTPMethod.POST, data=data)
 
         if r.status_code == codes.created:
             return True
@@ -81,7 +82,7 @@ class MetaConventionClient(BaseClient):
         """
         path = self.META_BASEURL + '/'
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url)
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             keys = loads(r.text)
             return keys
@@ -99,7 +100,7 @@ class MetaConventionClient(BaseClient):
         """
         path = '/'.join([self.META_BASEURL, quote_plus(key)]) + '/'
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url)
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             values = loads(r.text)
             return values
@@ -131,7 +132,7 @@ class MetaConventionClient(BaseClient):
         path = '/'.join([self.META_BASEURL, quote_plus(key)]) + '/'
         data = dumps({'value': value})
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='POST', data=data)
+        r = self._send_request(url, method=HTTPMethod.POST, data=data)
         if r.status_code == codes.created:
             return True
         else:

--- a/lib/rucio/client/opendataclient.py
+++ b/lib/rucio/client/opendataclient.py
@@ -20,6 +20,7 @@ from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
 from rucio.common.config import config_get
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url, render_json
 
 if TYPE_CHECKING:
@@ -85,7 +86,7 @@ class OpenDataClient(BaseClient):
             raise ValueError('state and public cannot be provided at the same time.')
 
         url = build_url(self.get_opendata_host(public=public), path=path)
-        r = self._send_request(url, type_='GET', params=params)
+        r = self._send_request(url, method=HTTPMethod.GET, params=params)
         if r.status_code == codes.ok:
             return json.loads(r.content.decode('utf-8'))
         else:
@@ -115,7 +116,7 @@ class OpenDataClient(BaseClient):
         path = '/'.join([self.opendata_private_dids_base_url, quote_plus(scope), quote_plus(name)])
         url = build_url(self.get_opendata_host(public=False), path=path)
 
-        r = self._send_request(url, type_='POST')
+        r = self._send_request(url, method=HTTPMethod.POST)
 
         if r.status_code == codes.created:
             return True
@@ -146,7 +147,7 @@ class OpenDataClient(BaseClient):
         path = '/'.join([self.opendata_private_dids_base_url, quote_plus(scope), quote_plus(name)])
         url = build_url(self.get_opendata_host(public=False), path=path)
 
-        r = self._send_request(url, type_='DEL')
+        r = self._send_request(url, method=HTTPMethod.DELETE)
 
         if r.status_code == codes.no_content:
             return True
@@ -198,7 +199,7 @@ class OpenDataClient(BaseClient):
         if doi is not None:
             data['doi'] = doi
 
-        r = self._send_request(url, type_='PUT', data=render_json(**data))
+        r = self._send_request(url, method=HTTPMethod.PUT, data=render_json(**data))
 
         if r.status_code == codes.ok:
             return True
@@ -236,7 +237,7 @@ class OpenDataClient(BaseClient):
         path = '/'.join([base_url, quote_plus(scope), quote_plus(name)])
         url = build_url(self.get_opendata_host(public=public), path=path)
 
-        r = self._send_request(url, type_='GET', params={
+        r = self._send_request(url, method=HTTPMethod.GET, params={
             'files': 1 if include_files else 0,
             'meta': 1 if include_metadata else 0,
             'doi': 1 if include_doi else 0,

--- a/lib/rucio/client/pingclient.py
+++ b/lib/rucio/client/pingclient.py
@@ -18,6 +18,7 @@ from typing import Any
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url
 
 
@@ -67,7 +68,7 @@ class PingClient(BaseClient):
         headers = None
         path = 'ping'
         url = build_url(self.host, path=path)
-        r = self._send_request(url, headers=headers, type_='GET')
+        r = self._send_request(url, headers=headers, method=HTTPMethod.GET)
 
         if r.status_code == codes.ok:
             server_info = loads(r.text)

--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -19,7 +19,7 @@ from urllib.parse import quote_plus
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
-from rucio.common.constants import TransferLimitDirection
+from rucio.common.constants import HTTPMethod, TransferLimitDirection
 from rucio.common.utils import build_url
 
 if TYPE_CHECKING:
@@ -45,7 +45,7 @@ class RequestClient(BaseClient):
         path = '/'.join([self.REQUEST_BASEURL, 'list']) + '?' + '&'.join(['src_rse={}'.format(src_rse), 'dst_rse={}'.format(
             dst_rse), 'request_states={}'.format(request_states)])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
 
         if r.status_code == codes.ok:
             return self._load_json_data(r)
@@ -70,7 +70,7 @@ class RequestClient(BaseClient):
         path = '/'.join([self.REQUEST_BASEURL, 'history', 'list']) + '?' + '&'.join(['src_rse={}'.format(src_rse), 'dst_rse={}'.format(
             dst_rse), 'request_states={}'.format(request_states), 'offset={}'.format(offset), 'limit={}'.format(limit)])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
 
         if r.status_code == codes.ok:
             return self._load_json_data(r)
@@ -106,7 +106,7 @@ class RequestClient(BaseClient):
         if scope is not None:
             path = '/'.join([self.REQUEST_BASEURL, quote_plus(scope), quote_plus(name), rse])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
 
         if r.status_code == codes.ok:
             return next(self._load_json_data(r))
@@ -144,7 +144,7 @@ class RequestClient(BaseClient):
         if scope is not None:
             path = '/'.join([self.REQUEST_BASEURL, 'history', quote_plus(scope), quote_plus(name), rse])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
 
         if r.status_code == codes.ok:
             return next(self._load_json_data(r))
@@ -161,7 +161,7 @@ class RequestClient(BaseClient):
         """
         path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
 
         if r.status_code == codes.ok:
             return self._load_json_data(r)
@@ -201,7 +201,7 @@ class RequestClient(BaseClient):
                       'direction': direction.value, 'max_transfers': max_transfers,
                       'volume': volume, 'deadline': deadline, 'strategy': strategy,
                       'transfers': transfers, 'waitings': waitings})
-        r = self._send_request(url, type_='PUT', data=data)
+        r = self._send_request(url, method=HTTPMethod.PUT, data=data)
 
         if r.status_code == codes.created:
             return True
@@ -225,7 +225,7 @@ class RequestClient(BaseClient):
         path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
         url = build_url(choice(self.list_hosts), path=path)
         data = dumps({'rse_expression': rse_expression, 'activity': activity, 'direction': direction.value})
-        r = self._send_request(url, type_='DEL', data=data)
+        r = self._send_request(url, method=HTTPMethod.DELETE, data=data)
 
         if r.status_code == codes.ok:
             return True

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -19,6 +19,7 @@ from urllib.parse import quote
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url
 
 if TYPE_CHECKING:
@@ -53,7 +54,7 @@ class RSEClient(BaseClient):
         path = '/'.join([self.RSE_BASEURL, rse])
         url = build_url(choice(self.list_hosts), path=path)
 
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             rse_dict = loads(r.text)
             return rse_dict
@@ -110,7 +111,7 @@ class RSEClient(BaseClient):
         """
         path = 'rses/' + rse
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='POST', data=dumps(kwargs))
+        r = self._send_request(url, method=HTTPMethod.POST, data=dumps(kwargs))
         if r.status_code == codes.created:
             return True
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
@@ -129,7 +130,7 @@ class RSEClient(BaseClient):
         """
         path = 'rses/' + rse
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='PUT', data=dumps(parameters))
+        r = self._send_request(url, method=HTTPMethod.PUT, data=dumps(parameters))
         if r.status_code == codes.created:
             return True
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
@@ -150,7 +151,7 @@ class RSEClient(BaseClient):
         """
         path = 'rses/' + rse
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='DEL')
+        r = self._send_request(url, method=HTTPMethod.DELETE)
         if r.status_code == codes.ok:
             return True
         else:
@@ -175,7 +176,7 @@ class RSEClient(BaseClient):
         else:
             path = 'rses/'
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             return self._load_json_data(r)
         else:
@@ -213,7 +214,7 @@ class RSEClient(BaseClient):
         url = build_url(choice(self.list_hosts), path=path)
         data = dumps({'value': value})
 
-        r = self._send_request(url, type_='POST', data=data)
+        r = self._send_request(url, method=HTTPMethod.POST, data=data)
         if r.status_code == codes.created:
             return True
         else:
@@ -238,7 +239,7 @@ class RSEClient(BaseClient):
         path = '/'.join([self.RSE_BASEURL, rse, 'attr', key])
         url = build_url(choice(self.list_hosts), path=path)
 
-        r = self._send_request(url, type_='DEL')
+        r = self._send_request(url, method=HTTPMethod.DELETE)
         if r.status_code == codes.ok:
             return True
         else:
@@ -260,7 +261,7 @@ class RSEClient(BaseClient):
         """
         path = '/'.join([self.RSE_BASEURL, rse, 'attr/'])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             attributes = loads(r.text)
             return attributes
@@ -306,7 +307,7 @@ class RSEClient(BaseClient):
         scheme = params['scheme']
         path = '/'.join([self.RSE_BASEURL, rse, 'protocols', scheme])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='POST', data=dumps(params))
+        r = self._send_request(url, method=HTTPMethod.POST, data=dumps(params))
         if r.status_code == codes.created:
             return True
         else:
@@ -366,7 +367,7 @@ class RSEClient(BaseClient):
         params['protocol_domain'] = protocol_domain
         url = build_url(choice(self.list_hosts), path=path, params=params)
 
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             protocols = loads(r.text)
             return protocols
@@ -426,7 +427,7 @@ class RSEClient(BaseClient):
 
         url = build_url(choice(self.list_hosts), path=path, params=params, doseq=True)
 
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             pfns = loads(r.text)
             return pfns
@@ -477,7 +478,7 @@ class RSEClient(BaseClient):
 
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='DEL')
+        r = self._send_request(url, method=HTTPMethod.DELETE)
         if r.status_code == codes.ok:
             return True
         else:
@@ -530,7 +531,7 @@ class RSEClient(BaseClient):
 
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='PUT', data=dumps(data))
+        r = self._send_request(url, method=HTTPMethod.PUT, data=dumps(data))
         if r.status_code == codes.ok:
             return True
         else:
@@ -586,8 +587,10 @@ class RSEClient(BaseClient):
 
         priority_a = protocol_a['domains'][domain][operation]
         priority_b = protocol_b['domains'][domain][operation]
-        self.update_protocols(rse, protocol_a['scheme'], {'domains': {domain: {operation: priority_b}}}, protocol_a['hostname'], protocol_a['port'])
-        self.update_protocols(rse, protocol_b['scheme'], {'domains': {domain: {operation: priority_a}}}, protocol_b['hostname'], protocol_b['port'])
+        self.update_protocols(rse, protocol_a['scheme'], {'domains': {domain: {operation: priority_b}}},
+                              protocol_a['hostname'], protocol_a['port'])
+        self.update_protocols(rse, protocol_b['scheme'], {'domains': {domain: {operation: priority_a}}},
+                              protocol_b['hostname'], protocol_b['port'])
         return True
 
     def add_qos_policy(self, rse: str, qos_policy: str) -> Literal[True]:
@@ -614,7 +617,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, rse, 'qos_policy', qos_policy]
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='POST')
+        r = self._send_request(url, method=HTTPMethod.POST)
         if r.status_code == codes.created:
             return True
         else:
@@ -649,7 +652,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, rse, 'qos_policy', qos_policy]
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='DEL')
+        r = self._send_request(url, method=HTTPMethod.DELETE)
         if r.status_code == codes.ok:
             return True
         else:
@@ -669,7 +672,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, rse, 'qos_policy']
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             return loads(r.text)
         else:
@@ -708,7 +711,7 @@ class RSEClient(BaseClient):
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
         data = {'source': source, 'used': used, 'free': free, 'files': files}
-        r = self._send_request(url, type_='PUT', data=dumps(data))
+        r = self._send_request(url, method=HTTPMethod.PUT, data=dumps(data))
         if r.status_code == codes.ok:
             return True
         else:
@@ -737,7 +740,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, rse, 'usage']
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET', params=filters)
+        r = self._send_request(url, method=HTTPMethod.GET, params=filters)
         if r.status_code == codes.ok:
             return self._load_json_data(r)
         else:
@@ -766,7 +769,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, rse, 'usage', 'history']
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET', params=filters)
+        r = self._send_request(url, method=HTTPMethod.GET, params=filters)
         if r.status_code == codes.ok:
             return self._load_json_data(r)
         else:
@@ -800,7 +803,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, rse, 'limits']
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='PUT', data=dumps({'name': name, 'value': value}))
+        r = self._send_request(url, method=HTTPMethod.PUT, data=dumps({'name': name, 'value': value}))
         if r.status_code == codes.ok:
             return True
         exc_cls, exc_msg = self._get_exception(headers=r.headers,
@@ -827,7 +830,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, rse, 'limits']
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             return next(self._load_json_data(r))
         exc_cls, exc_msg = self._get_exception(headers=r.headers,
@@ -853,7 +856,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, rse, 'limits']
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='DEL', data=dumps({'name': name}))
+        r = self._send_request(url, method=HTTPMethod.DELETE, data=dumps({'name': name}))
         if r.status_code == codes.ok:
             return True
         exc_cls, exc_msg = self._get_exception(headers=r.headers,
@@ -878,7 +881,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='POST', data=dumps(parameters))
+        r = self._send_request(url, method=HTTPMethod.POST, data=dumps(parameters))
         if r.status_code == codes.created:
             return True
         exc_cls, exc_msg = self._get_exception(headers=r.headers,
@@ -907,7 +910,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='PUT', data=dumps(parameters))
+        r = self._send_request(url, method=HTTPMethod.PUT, data=dumps(parameters))
         if r.status_code == codes.ok:
             return True
         exc_cls, exc_msg = self._get_exception(headers=r.headers,
@@ -938,7 +941,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             return next(self._load_json_data(r))
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
@@ -962,7 +965,7 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='DEL')
+        r = self._send_request(url, method=HTTPMethod.DELETE)
         if r.status_code == codes.ok:
             return True
         exc_cls, exc_msg = self._get_exception(headers=r.headers,

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -19,6 +19,7 @@ from urllib.parse import quote_plus
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url
 
 if TYPE_CHECKING:
@@ -110,7 +111,7 @@ class RuleClient(BaseClient):
                       'activity': activity, 'notify': notify, 'purge_replicas': purge_replicas,
                       'ignore_availability': ignore_availability, 'comment': comment, 'ask_approval': ask_approval,
                       'asynchronous': asynchronous, 'delay_injection': delay_injection, 'priority': priority, 'meta': meta})
-        r = self._send_request(url, type_='POST', data=data)
+        r = self._send_request(url, method=HTTPMethod.POST, data=data)
         if r.status_code == codes.created:
             return loads(r.text)
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
@@ -140,7 +141,7 @@ class RuleClient(BaseClient):
 
         data = dumps({'purge_replicas': purge_replicas})
 
-        r = self._send_request(url, type_='DEL', data=data)
+        r = self._send_request(url, method=HTTPMethod.DELETE, data=data)
 
         if r.status_code == codes.ok:
             return True
@@ -162,7 +163,7 @@ class RuleClient(BaseClient):
         """
         path = self.RULE_BASEURL + '/' + rule_id
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             return next(self._load_json_data(r))
         else:
@@ -185,7 +186,7 @@ class RuleClient(BaseClient):
         path = self.RULE_BASEURL + '/' + rule_id
         url = build_url(choice(self.list_hosts), path=path)
         data = dumps({'options': options})
-        r = self._send_request(url, type_='PUT', data=data)
+        r = self._send_request(url, method=HTTPMethod.PUT, data=data)
         if r.status_code == codes.ok:
             return True
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
@@ -216,7 +217,7 @@ class RuleClient(BaseClient):
         path = self.RULE_BASEURL + '/' + rule_id + '/reduce'
         url = build_url(choice(self.list_hosts), path=path)
         data = dumps({'copies': copies, 'exclude_expression': exclude_expression})
-        r = self._send_request(url, type_='POST', data=data)
+        r = self._send_request(url, method=HTTPMethod.POST, data=data)
         if r.status_code == codes.ok:
             return loads(r.text)
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
@@ -252,7 +253,7 @@ class RuleClient(BaseClient):
             'rse_expression': rse_expression,
             'override': override,
         })
-        r = self._send_request(url, type_='POST', data=data)
+        r = self._send_request(url, method=HTTPMethod.POST, data=data)
         if r.status_code == codes.created:
             return loads(r.text)
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
@@ -273,7 +274,7 @@ class RuleClient(BaseClient):
         path = self.RULE_BASEURL + '/' + rule_id
         url = build_url(choice(self.list_hosts), path=path)
         data = dumps({'options': {'approve': True}})
-        r = self._send_request(url, type_='PUT', data=data)
+        r = self._send_request(url, method=HTTPMethod.PUT, data=data)
         if r.status_code == codes.ok:
             return True
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
@@ -300,7 +301,7 @@ class RuleClient(BaseClient):
         if reason:
             options['comment'] = reason
         data = dumps({'options': options})
-        r = self._send_request(url, type_='PUT', data=data)
+        r = self._send_request(url, method=HTTPMethod.PUT, data=data)
         if r.status_code == codes.ok:
             return True
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
@@ -321,7 +322,7 @@ class RuleClient(BaseClient):
         """
         path = '/'.join([self.RULE_BASEURL, quote_plus(scope), quote_plus(name), 'history'])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             return self._load_json_data(r)
         exc_cls, exc_msg = self._get_exception(r.headers, r.status_code)
@@ -341,7 +342,7 @@ class RuleClient(BaseClient):
         """
         path = self.RULE_BASEURL + '/' + rule_id + '/analysis'
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             return next(self._load_json_data(r))
         exc_cls, exc_msg = self._get_exception(r.headers, r.status_code)
@@ -361,7 +362,7 @@ class RuleClient(BaseClient):
         """
         path = self.RULE_BASEURL + '/' + rule_id + '/locks'
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET')
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             return self._load_json_data(r)
         exc_cls, exc_msg = self._get_exception(r.headers, r.status_code)
@@ -382,7 +383,7 @@ class RuleClient(BaseClient):
         filters = filters or {}
         path = self.RULE_BASEURL + '/'
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='GET', params=filters)
+        r = self._send_request(url, method=HTTPMethod.GET, params=filters)
         if r.status_code == codes.ok:
             return self._load_json_data(r)
         else:

--- a/lib/rucio/client/scopeclient.py
+++ b/lib/rucio/client/scopeclient.py
@@ -18,6 +18,7 @@ from urllib.parse import quote_plus
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url
 
 
@@ -56,7 +57,7 @@ class ScopeClient(BaseClient):
 
         path = '/'.join([self.SCOPE_BASEURL, account, 'scopes', quote_plus(scope)])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, type_='POST')
+        r = self._send_request(url, method=HTTPMethod.POST)
         if r.status_code == codes.created:
             return True
         else:
@@ -74,7 +75,7 @@ class ScopeClient(BaseClient):
 
         path = '/'.join(['scopes/'])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url)
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             scopes = loads(r.text)
             return scopes
@@ -106,7 +107,7 @@ class ScopeClient(BaseClient):
         path = '/'.join([self.SCOPE_BASEURL, account, 'scopes/'])
         url = build_url(choice(self.list_hosts), path=path)
 
-        r = self._send_request(url)
+        r = self._send_request(url, method=HTTPMethod.GET)
         if r.status_code == codes.ok:
             scopes = loads(r.text)
             return scopes

--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 from requests.status_codes import codes
 
 from rucio.client.baseclient import BaseClient, choice
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import build_url
 
 if TYPE_CHECKING:
@@ -78,7 +79,7 @@ class SubscriptionClient(BaseClient):
             raise TypeError('replication_rules should be a list')
         data = dumps({'options': {'filter': filter_, 'replication_rules': replication_rules, 'comments': comments,
                                   'lifetime': lifetime, 'retroactive': retroactive, 'dry_run': dry_run, 'priority': priority}})
-        result = self._send_request(url, type_='POST', data=data)
+        result = self._send_request(url, method=HTTPMethod.POST, data=data)
         if result.status_code == codes.created:   # pylint: disable=no-member
             return result.text
         else:
@@ -120,7 +121,7 @@ class SubscriptionClient(BaseClient):
         else:
             path += '/'
         url = build_url(choice(self.list_hosts), path=path)
-        result = self._send_request(url, type_='GET')
+        result = self._send_request(url, method=HTTPMethod.GET)
         if result.status_code == codes.ok:   # pylint: disable=no-member
             return self._load_json_data(result)
         if result.status_code == codes.not_found:
@@ -173,7 +174,7 @@ class SubscriptionClient(BaseClient):
             raise TypeError('replication_rules should be a list')
         data = dumps({'options': {'filter': filter_, 'replication_rules': replication_rules, 'comments': comments,
                                   'lifetime': lifetime, 'retroactive': retroactive, 'dry_run': dry_run, 'priority': priority}})
-        result = self._send_request(url, type_='PUT', data=data)
+        result = self._send_request(url, method=HTTPMethod.PUT, data=data)
         if result.status_code == codes.created:   # pylint: disable=no-member
             return True
         else:
@@ -203,7 +204,7 @@ class SubscriptionClient(BaseClient):
         path = self.SUB_BASEURL + '/' + account + '/' + name  # type: ignore
         url = build_url(choice(self.list_hosts), path=path)
         data = dumps({'options': {'state': 'I'}})
-        result = self._send_request(url, type_='PUT', data=data)
+        result = self._send_request(url, method=HTTPMethod.PUT, data=data)
         if result.status_code == codes.created:   # pylint: disable=no-member
             return True
         else:
@@ -228,7 +229,7 @@ class SubscriptionClient(BaseClient):
 
         path = '/'.join([self.SUB_BASEURL, account, name, 'rules'])
         url = build_url(choice(self.list_hosts), path=path)
-        result = self._send_request(url, type_='GET')
+        result = self._send_request(url, method=HTTPMethod.GET)
         if result.status_code == codes.ok:   # pylint: disable=no-member
             return self._load_json_data(result)
         else:

--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import enum
+import sys
 from collections import namedtuple
 from typing import Literal, get_args
 
@@ -224,3 +225,20 @@ OPENDATA_DID_STATE_LITERAL_LIST = list(get_args(OPENDATA_DID_STATE_LITERAL))
 
 POLICY_ALGORITHM_TYPES_LITERAL = Literal['non_deterministic_pfn', 'scope', 'lfn2pfn', 'pfn2lfn', 'fts3_tape_metadata_plugins', 'fts3_plugins_init', 'auto_approve']
 POLICY_ALGORITHM_TYPES = list(get_args(POLICY_ALGORITHM_TYPES_LITERAL))
+
+# https://github.com/rucio/rucio/issues/7958
+# When Python 3.11 is the minimum supported version, we can use the standard library enum and remove this logic
+if sys.version_info >= (3, 11):
+    from http import HTTPMethod
+else:
+    @enum.unique
+    class HTTPMethod(str, enum.Enum):
+        """HTTP verbs used in Rucio requests."""
+
+        HEAD = "HEAD"
+        OPTIONS = "OPTIONS"
+        PATCH = "PATCH"
+        GET = "GET"
+        POST = "POST"
+        PUT = "PUT"
+        DELETE = "DELETE"

--- a/lib/rucio/rse/protocols/webdav.py
+++ b/lib/rucio/rse/protocols/webdav.py
@@ -25,6 +25,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.poolmanager import PoolManager
 
 from rucio.common import exception
+from rucio.common.constants import HTTPMethod
 from rucio.rse.protocols import protocol
 
 
@@ -259,9 +260,11 @@ class Default(protocol.RSEProtocol):
         try:
             # use GET instead of HEAD for presigned urls
             if not using_presigned_urls:
-                result = self.session.request('HEAD', path, verify=False, timeout=self.timeout, cert=self.cert)
+                result = self.session.request(HTTPMethod.HEAD.value, path, verify=False, timeout=self.timeout,
+                                              cert=self.cert)
             else:
-                result = self.session.request('GET', path, verify=False, timeout=self.timeout, cert=self.cert)
+                result = self.session.request(HTTPMethod.GET.value, path, verify=False, timeout=self.timeout,
+                                              cert=self.cert)
             if result.status_code == 200:
                 return True
             elif result.status_code in [401, ]:

--- a/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accountlimits.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from flask import Flask, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import AccessDenied, AccountNotFound, RSENotFound
 from rucio.gateway.account_limit import delete_global_account_limit, delete_local_account_limit, set_global_account_limit, set_local_account_limit
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
@@ -219,11 +220,11 @@ def blueprint(with_doc: bool = False) -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('accountlimits', __name__, url_prefix='/accountlimits')
 
     local_account_limit_view = LocalAccountLimit.as_view('local_account_limit')
-    bp.add_url_rule('/local/<account>/<rse>', view_func=local_account_limit_view, methods=['post', 'delete'])
+    bp.add_url_rule('/local/<account>/<rse>', view_func=local_account_limit_view, methods=[HTTPMethod.POST.value, HTTPMethod.DELETE.value])
     if not with_doc:
-        bp.add_url_rule('/<account>/<rse>', view_func=local_account_limit_view, methods=['post', 'delete'])
+        bp.add_url_rule('/<account>/<rse>', view_func=local_account_limit_view, methods=[HTTPMethod.POST.value, HTTPMethod.DELETE.value])
     global_account_limit_view = GlobalAccountLimit.as_view('global_account_limit')
-    bp.add_url_rule('/global/<account>/<rse_expression>', view_func=global_account_limit_view, methods=['post', 'delete'])
+    bp.add_url_rule('/global/<account>/<rse_expression>', view_func=global_account_limit_view, methods=[HTTPMethod.POST.value, HTTPMethod.DELETE.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 from flask import Flask, Response, jsonify, redirect, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import AccessDenied, AccountNotFound, CounterNotFound, Duplicate, IdentityError, InvalidAccountType, InvalidObject, RSENotFound, RuleNotFound, ScopeNotFound
 from rucio.common.utils import APIEncoder, render_json
 from rucio.gateway.account import add_account, add_account_attribute, del_account, del_account_attribute, get_account_info, get_usage_history, list_account_attributes, list_accounts, list_identities, update_account
@@ -1047,44 +1048,44 @@ def blueprint(with_doc: bool = False) -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('accounts', __name__, url_prefix='/accounts')
 
     attributes_view = Attributes.as_view('attributes')
-    bp.add_url_rule('/<account>/attr/', view_func=attributes_view, methods=['get', ])
-    bp.add_url_rule('/<account>/attr/<key>', view_func=attributes_view, methods=['post', 'delete'])
+    bp.add_url_rule('/<account>/attr/', view_func=attributes_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/attr/<key>', view_func=attributes_view, methods=[HTTPMethod.POST.value, HTTPMethod.DELETE.value])
     scopes_view = Scopes.as_view('scopes')
-    bp.add_url_rule('/<account>/scopes/', view_func=scopes_view, methods=['get', ])
-    bp.add_url_rule('/<account>/scopes/<scope>', view_func=scopes_view, methods=['post', ])
+    bp.add_url_rule('/<account>/scopes/', view_func=scopes_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/scopes/<scope>', view_func=scopes_view, methods=[HTTPMethod.POST.value])
     local_account_limits_view = LocalAccountLimits.as_view('local_account_limit')
-    bp.add_url_rule('/<account>/limits/local', view_func=local_account_limits_view, methods=['get', ])
-    bp.add_url_rule('/<account>/limits', view_func=local_account_limits_view, methods=['get', ])
-    bp.add_url_rule('/<account>/limits/local/<rse>', view_func=local_account_limits_view, methods=['get', ])
-    bp.add_url_rule('/<account>/limits/<rse>', view_func=local_account_limits_view, methods=['get', ])
+    bp.add_url_rule('/<account>/limits/local', view_func=local_account_limits_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/limits', view_func=local_account_limits_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/limits/local/<rse>', view_func=local_account_limits_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/limits/<rse>', view_func=local_account_limits_view, methods=[HTTPMethod.GET.value])
     global_account_limits_view = GlobalAccountLimits.as_view('global_account_limit')
-    bp.add_url_rule('/<account>/limits/global', view_func=global_account_limits_view, methods=['get', ])
-    bp.add_url_rule('/<account>/limits/global/<rse_expression>', view_func=global_account_limits_view, methods=['get', ])
+    bp.add_url_rule('/<account>/limits/global', view_func=global_account_limits_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/limits/global/<rse_expression>', view_func=global_account_limits_view, methods=[HTTPMethod.GET.value])
     identities_view = Identities.as_view('identities')
-    bp.add_url_rule('/<account>/identities', view_func=identities_view, methods=['get', 'post', 'delete'])
+    bp.add_url_rule('/<account>/identities', view_func=identities_view, methods=[HTTPMethod.GET.value, HTTPMethod.POST.value, HTTPMethod.DELETE.value])
     rules_view = Rules.as_view('rules')
-    bp.add_url_rule('/<account>/rules', view_func=rules_view, methods=['get', ])
+    bp.add_url_rule('/<account>/rules', view_func=rules_view, methods=[HTTPMethod.GET.value])
     usagehistory_view = UsageHistory.as_view('usagehistory')
-    bp.add_url_rule('/<account>/usage/history/<rse>', view_func=usagehistory_view, methods=['get', ])
+    bp.add_url_rule('/<account>/usage/history/<rse>', view_func=usagehistory_view, methods=[HTTPMethod.GET.value])
     usage_view = LocalUsage.as_view('usage')
-    bp.add_url_rule('/<account>/usage/local', view_func=usage_view, methods=['get', ])
-    bp.add_url_rule('/<account>/usage', view_func=usage_view, methods=['get', ])
+    bp.add_url_rule('/<account>/usage/local', view_func=usage_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/usage', view_func=usage_view, methods=[HTTPMethod.GET.value])
     if not with_doc:
         # for backwards-compatibility
         # rule without trailing slash needs to be added before rule with trailing slash
-        bp.add_url_rule('/<account>/usage/', view_func=usage_view, methods=['get', ])
-    bp.add_url_rule('/<account>/usage/local/<rse>', view_func=usage_view, methods=['get', ])
-    bp.add_url_rule('/<account>/usage/<rse>', view_func=usage_view, methods=['get', ])
+        bp.add_url_rule('/<account>/usage/', view_func=usage_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/usage/local/<rse>', view_func=usage_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/usage/<rse>', view_func=usage_view, methods=[HTTPMethod.GET.value])
     global_usage_view = GlobalUsage.as_view('global_usage')
-    bp.add_url_rule('/<account>/usage/global', view_func=global_usage_view, methods=['get', ])
-    bp.add_url_rule('/<account>/usage/global/<rse_expression>', view_func=global_usage_view, methods=['get', ])
+    bp.add_url_rule('/<account>/usage/global', view_func=global_usage_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/usage/global/<rse_expression>', view_func=global_usage_view, methods=[HTTPMethod.GET.value])
     account_parameter_view = AccountParameter.as_view('account_parameter')
-    bp.add_url_rule('/<account>', view_func=account_parameter_view, methods=['get', 'put', 'post', 'delete'])
+    bp.add_url_rule('/<account>', view_func=account_parameter_view, methods=[HTTPMethod.GET.value, HTTPMethod.PUT.value, HTTPMethod.POST.value, HTTPMethod.DELETE.value])
     account_view = Account.as_view('account')
     if not with_doc:
         # rule without trailing slash needs to be added before rule with trailing slash
-        bp.add_url_rule('', view_func=account_view, methods=['get', ])
-    bp.add_url_rule('/', view_func=account_view, methods=['get', ])
+        bp.add_url_rule('', view_func=account_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/', view_func=account_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/archives.py
+++ b/lib/rucio/web/rest/flaskapi/v1/archives.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 
 from flask import Flask, Response, request
 
-from rucio.common.constants import DEFAULT_VO
+from rucio.common.constants import DEFAULT_VO, HTTPMethod
 from rucio.gateway.did import list_archive_content
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, generate_http_error_flask, parse_scope_name, response_headers, try_stream
@@ -90,7 +90,7 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('archives', __name__, url_prefix='/archives')
 
     archive_view = Archive.as_view('archive')
-    bp.add_url_rule('/<path:scope_name>/files', view_func=archive_view, methods=['get', ])
+    bp.add_url_rule('/<path:scope_name>/files', view_func=archive_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -23,6 +23,7 @@ from jinja2.exceptions import TemplateNotFound
 from werkzeug.datastructures import Headers
 
 from rucio.common.config import config_get
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import AccessDenied, CannotAuthenticate, CannotAuthorize, ConfigurationError, IdentityError, IdentityNotFound, InvalidRequest
 from rucio.common.extra import import_extras
 from rucio.common.utils import date_to_str
@@ -1632,31 +1633,31 @@ def blueprint() -> Blueprint:
     bp = Blueprint('auth', __name__, url_prefix='/auth')
 
     user_pass_view = UserPass.as_view('user_pass')
-    bp.add_url_rule('/userpass', view_func=user_pass_view, methods=['get', 'options'])
+    bp.add_url_rule('/userpass', view_func=user_pass_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
     gss_view = GSS.as_view('gss')
-    bp.add_url_rule('/gss', view_func=gss_view, methods=['get', 'options'])
+    bp.add_url_rule('/gss', view_func=gss_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
     x509_view = x509.as_view('x509')
-    bp.add_url_rule('/x509', view_func=x509_view, methods=['get', 'options'])
-    bp.add_url_rule('/x509/webui', view_func=x509_view, methods=['get', 'options'])
-    bp.add_url_rule('/x509_proxy', view_func=x509_view, methods=['get', 'options'])
+    bp.add_url_rule('/x509', view_func=x509_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
+    bp.add_url_rule('/x509/webui', view_func=x509_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
+    bp.add_url_rule('/x509_proxy', view_func=x509_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
     ssh_view = SSH.as_view('ssh')
-    bp.add_url_rule('/ssh', view_func=ssh_view, methods=['get', 'options'])
+    bp.add_url_rule('/ssh', view_func=ssh_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
     ssh_challenge_token_view = SSHChallengeToken.as_view('ssh_challenge_token')
-    bp.add_url_rule('/ssh_challenge_token', view_func=ssh_challenge_token_view, methods=['get', 'options'])
+    bp.add_url_rule('/ssh_challenge_token', view_func=ssh_challenge_token_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
     saml_view = SAML.as_view('saml')
-    bp.add_url_rule('/saml', view_func=saml_view, methods=['get', 'post', 'options'])
+    bp.add_url_rule('/saml', view_func=saml_view, methods=[HTTPMethod.GET.value, HTTPMethod.POST.value, HTTPMethod.OPTIONS.value])
     validate_view = Validate.as_view('validate')
-    bp.add_url_rule('/validate', view_func=validate_view, methods=['get', 'options'])
+    bp.add_url_rule('/validate', view_func=validate_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
     oidc_view = OIDC.as_view('oidc_view')
-    bp.add_url_rule('/oidc', view_func=oidc_view, methods=['get', 'options'])
+    bp.add_url_rule('/oidc', view_func=oidc_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
     token_oidc_view = TokenOIDC.as_view('token_oidc_view')
-    bp.add_url_rule('/oidc_token', view_func=token_oidc_view, methods=['get', 'options'])
+    bp.add_url_rule('/oidc_token', view_func=token_oidc_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
     code_oidc_view = CodeOIDC.as_view('code_oidc_view')
-    bp.add_url_rule('/oidc_code', view_func=code_oidc_view, methods=['get', 'options'])
+    bp.add_url_rule('/oidc_code', view_func=code_oidc_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
     redirect_oidc_view = RedirectOIDC.as_view('redirect_oidc_view')
-    bp.add_url_rule('/oidc_redirect', view_func=redirect_oidc_view, methods=['get', 'options'])
+    bp.add_url_rule('/oidc_redirect', view_func=redirect_oidc_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
     refresh_oidc_view = RefreshOIDC.as_view('refresh_oidc_view')
-    bp.add_url_rule('/oidc_refresh', view_func=refresh_oidc_view, methods=['get', 'options'])
+    bp.add_url_rule('/oidc_refresh', view_func=refresh_oidc_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
 
     return bp
 

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -31,7 +31,7 @@ from werkzeug.exceptions import HTTPException
 from werkzeug.wrappers import Request, Response
 
 from rucio.common import config
-from rucio.common.constants import DEFAULT_VO
+from rucio.common.constants import DEFAULT_VO, HTTPMethod
 from rucio.common.exception import CannotAuthenticate, DatabaseException, IdentityError, RucioException, UnsupportedRequestedContentType
 from rucio.common.schema import get_schema_value
 from rucio.common.utils import generate_uuid, render_json
@@ -66,7 +66,7 @@ class CORSMiddleware:
     def __call__(self, environ: 'WSGIEnvironment', start_response: 'StartResponse') -> 'Iterable[bytes]':
         request: Request = Request(environ)
 
-        if request.environ.get('REQUEST_METHOD') == 'OPTIONS':
+        if request.environ.get('REQUEST_METHOD') == HTTPMethod.OPTIONS.value:
             try:
                 webui_urls = config.config_get_list('webui', 'urls')
             except (NoOptionError, NoSectionError, RuntimeError) as error:
@@ -145,7 +145,7 @@ class ErrorHandlingMethodView(MethodView):
 
 
 def request_auth_env() -> Optional['ResponseReturnValue']:
-    if flask.request.environ.get('REQUEST_METHOD') == 'OPTIONS':
+    if flask.request.environ.get('REQUEST_METHOD') == HTTPMethod.OPTIONS.value:
         return '', 200
 
     auth_token = flask.request.headers.get('X-Rucio-Auth-Token', default=None)
@@ -176,7 +176,7 @@ def response_headers(response: ResponseTypeVar) -> ResponseTypeVar:
     response.headers['Access-Control-Allow-Methods'] = '*'
     response.headers['Access-Control-Allow-Credentials'] = 'true'
 
-    if flask.request.environ.get('REQUEST_METHOD') == 'GET':
+    if flask.request.environ.get('REQUEST_METHOD') == HTTPMethod.GET.value:
         response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
         response.headers['Cache-Control'] = 'post-check=0, pre-check=0'
         response.headers['Pragma'] = 'no-cache'

--- a/lib/rucio/web/rest/flaskapi/v1/config.py
+++ b/lib/rucio/web/rest/flaskapi/v1/config.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 from flask import Flask, jsonify
 from flask import request as request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import AccessDenied, ConfigNotFound, ConfigurationError
 from rucio.gateway import config
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
@@ -323,13 +324,14 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('config', __name__, url_prefix='/config')
 
     option_set_view = OptionSet.as_view('option_set')
-    bp.add_url_rule('/<section>/<option>/<value>', view_func=option_set_view, methods=['put', ])
+    bp.add_url_rule('/<section>/<option>/<value>', view_func=option_set_view, methods=[HTTPMethod.PUT.value])
     option_get_del_view = OptionGetDel.as_view('option_get_del')
-    bp.add_url_rule('/<section>/<option>', view_func=option_get_del_view, methods=['get', 'delete'])
+    bp.add_url_rule('/<section>/<option>', view_func=option_get_del_view, methods=[HTTPMethod.GET.value, HTTPMethod.DELETE.value])
     section_view = Section.as_view('section')
-    bp.add_url_rule('/<section>', view_func=section_view, methods=['get', 'delete'])
+
+    bp.add_url_rule('/<section>', view_func=section_view, methods=[HTTPMethod.GET.value, HTTPMethod.DELETE.value])
     config_view = Config.as_view('config')
-    bp.add_url_rule('', view_func=config_view, methods=['get', 'post'])
+    bp.add_url_rule('', view_func=config_view, methods=[HTTPMethod.GET.value, HTTPMethod.POST.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/credentials.py
+++ b/lib/rucio/web/rest/flaskapi/v1/credentials.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, cast
 from flask import Flask, request
 from werkzeug.datastructures import Headers
 
-from rucio.common.constants import RSE_BASE_SUPPORTED_PROTOCOL_OPERATIONS, RSE_BASE_SUPPORTED_PROTOCOL_OPERATIONS_LITERAL, SUPPORTED_SIGN_URL_SERVICES, SUPPORTED_SIGN_URL_SERVICES_LITERAL
+from rucio.common.constants import RSE_BASE_SUPPORTED_PROTOCOL_OPERATIONS, RSE_BASE_SUPPORTED_PROTOCOL_OPERATIONS_LITERAL, SUPPORTED_SIGN_URL_SERVICES, SUPPORTED_SIGN_URL_SERVICES_LITERAL, HTTPMethod
 from rucio.common.exception import CannotAuthenticate
 from rucio.gateway.credential import get_signed_url
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
@@ -203,10 +203,10 @@ def blueprint(with_doc=False):
     bp = AuthenticatedBlueprint('credentials', __name__, url_prefix='/credentials')
 
     signurl_view = SignURL.as_view('signurl')
-    bp.add_url_rule('/signurl', view_func=signurl_view, methods=['get', 'options'])
+    bp.add_url_rule('/signurl', view_func=signurl_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
     if not with_doc:
         # yes, /signur ~= '/signurl?$'
-        bp.add_url_rule('/signur', view_func=signurl_view, methods=['get', 'options'])
+        bp.add_url_rule('/signur', view_func=signurl_view, methods=[HTTPMethod.GET.value, HTTPMethod.OPTIONS.value])
 
     bp.after_request(response_headers)
 

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 
 from flask import Flask, Response, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import (
     AccessDenied,
     DatabaseException,
@@ -1838,7 +1839,7 @@ class BulkDIDsMeta(ErrorHandlingMethodView):
         # 0. Extract & validate the mode argument
         mode_opt = class_kwargs.pop("mode", None)
         if mode_opt not in (cls.MODE_SET, cls.MODE_GET):
-            raise ValueError("BulkDIDsMeta.as_view() needs mode='set' or mode='get'")
+            raise ValueError("BulkDIDsMeta.as_view() needs mode='set' or mode=HTTPMethod.GET.value")
 
         # Tell the type checker that `mode_opt` is definitely str here
         mode = cast('str', mode_opt)
@@ -2532,12 +2533,12 @@ def blueprint() -> AuthenticatedBlueprint:
     bp.add_url_rule(
         '/<path:scope_name>/status',
         view_func=dids_view,
-        methods=['put', 'get'],
+        methods=[HTTPMethod.PUT.value, HTTPMethod.GET.value],
     )
     bp.add_url_rule(
         '/<path:scope_name>',
         view_func=dids_view,
-        methods=['get', 'post'],
+        methods=[HTTPMethod.GET.value, HTTPMethod.POST.value],
     )
 
     meta_view = Meta.as_view('meta')
@@ -2545,126 +2546,126 @@ def blueprint() -> AuthenticatedBlueprint:
         '/<path:scope_name>/meta',
         defaults={'key': None},
         view_func=meta_view,
-        methods=['get', 'post', 'delete'],
+        methods=[HTTPMethod.GET.value, HTTPMethod.POST.value, HTTPMethod.DELETE.value],
     )
     bp.add_url_rule(
         '/<path:scope_name>/meta/<key>',
         view_func=meta_view,
-        methods=['post'],
+        methods=[HTTPMethod.POST.value],
     )
 
     bp.add_url_rule(
         "/bulkdidsmeta",
         view_func=BulkDIDsMeta.as_view("bulkdidsmeta", mode=BulkDIDsMeta.MODE_SET),
-        methods=["post"],
+        methods=[HTTPMethod.POST.value],
     )
 
     bp.add_url_rule(
         "/bulkmeta",
         view_func=BulkDIDsMeta.as_view("bulkmeta", mode=BulkDIDsMeta.MODE_GET),
-        methods=["post"],
+        methods=[HTTPMethod.POST.value],
     )
 
     bp.add_url_rule(
         '/<path:scope_name>/dids',
         view_func=Attachment.as_view('attachment'),
-        methods=['get', 'post', 'delete'],
+        methods=[HTTPMethod.GET.value, HTTPMethod.POST.value, HTTPMethod.DELETE.value],
     )
 
     bp.add_url_rule(
         '/new',
         view_func=NewDIDs.as_view('new_dids'),
-        methods=['get'],
+        methods=[HTTPMethod.GET.value],
     )
 
     bp.add_url_rule(
         '',
         view_func=BulkDIDS.as_view('bulkdids'),
-        methods=['post'],
+        methods=[HTTPMethod.POST.value],
     )
 
     bp.add_url_rule(
         '/<path:scope_name>/dids/history',
         view_func=AttachmentHistory.as_view('attachment_history'),
-        methods=['get'],
+        methods=[HTTPMethod.GET.value],
     )
 
     bp.add_url_rule(
         '/attachments',
         view_func=Attachments.as_view('attachments'),
-        methods=['post'],
+        methods=[HTTPMethod.POST.value],
     )
 
     bp.add_url_rule(
         '/<scope>/dids/search',
         view_func=Search.as_view('search'),
-        methods=['get'],
+        methods=[HTTPMethod.GET.value],
     )
 
     bp.add_url_rule(
         '/<scope>/',
         view_func=Scope.as_view('scope'),
-        methods=['get'],
+        methods=[HTTPMethod.GET.value],
     )
 
     bp.add_url_rule(
         '/<guid>/guid',
         view_func=GUIDLookup.as_view('guid_lookup'),
-        methods=['get'],
+        methods=[HTTPMethod.GET.value],
     )
 
     bp.add_url_rule(
         '/<path:scope_name>/files',
         view_func=Files.as_view('files'),
-        methods=['get'],
+        methods=[HTTPMethod.GET.value],
     )
 
     bp.add_url_rule(
         '/bulkfiles',
         view_func=BulkFiles.as_view('bulkfiles'),
-        methods=['post'],
+        methods=[HTTPMethod.POST.value],
     )
 
     bp.add_url_rule(
         '/<path:scope_name>/rules',
         view_func=Rules.as_view('rules'),
-        methods=['get'],
+        methods=[HTTPMethod.GET.value],
     )
 
     bp.add_url_rule(
         '/<path:scope_name>/parents',
         view_func=Parents.as_view('parents'),
-        methods=['get'],
+        methods=[HTTPMethod.GET.value],
     )
 
     bp.add_url_rule(
         '/<path:scope_name>/associated_rules',
         view_func=AssociatedRules.as_view('associated_rules'),
-        methods=['get'],
+        methods=[HTTPMethod.GET.value],
     )
 
     bp.add_url_rule(
         '/<path:scope_name>/follow',
         view_func=Follow.as_view('follow'),
-        methods=['get', 'post', 'delete'],
+        methods=[HTTPMethod.GET.value, HTTPMethod.POST.value, HTTPMethod.DELETE.value],
     )
 
     bp.add_url_rule(
         '/<input_scope>/<input_name>/<output_scope>/<output_name>/<nbfiles>/sample',
         view_func=SampleLegacy.as_view('sample'),
-        methods=['post'],
+        methods=[HTTPMethod.POST.value],
     )
 
     bp.add_url_rule(
         '/sample',
         view_func=Sample.as_view('sample_new'),
-        methods=['post'],
+        methods=[HTTPMethod.POST.value],
     )
 
     bp.add_url_rule(
         '/resurrect',
         view_func=Resurrect.as_view('resurrect'),
-        methods=['post'],
+        methods=[HTTPMethod.POST.value],
     )
 
     bp.after_request(response_headers)

--- a/lib/rucio/web/rest/flaskapi/v1/dirac.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dirac.py
@@ -14,6 +14,7 @@
 
 from flask import Flask, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifierAlreadyExists, Duplicate, InvalidPath, ResourceTemporaryUnavailable, RSENotFound, UnsupportedOperation
 from rucio.common.utils import parse_response
 from rucio.gateway.dirac import add_files
@@ -102,8 +103,8 @@ def blueprint(with_doc=False):
     bp = AuthenticatedBlueprint('dirac', __name__, url_prefix='/dirac')
 
     add_file_view = AddFiles.as_view('addfiles')
-    bp.add_url_rule('/addfiles', view_func=add_file_view, methods=['post', ])
-    bp.add_url_rule('/addfiles/', view_func=add_file_view, methods=['post', ])
+    bp.add_url_rule('/addfiles', view_func=add_file_view, methods=[HTTPMethod.POST.value])
+    bp.add_url_rule('/addfiles/', view_func=add_file_view, methods=[HTTPMethod.POST.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/export.py
+++ b/lib/rucio/web/rest/flaskapi/v1/export.py
@@ -14,6 +14,7 @@
 
 from flask import Flask, Response, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import render_json
 from rucio.gateway.exporter import export_data
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
@@ -61,8 +62,9 @@ def blueprint(with_doc=False):
     export_view = Export.as_view('scope')
     if not with_doc:
         # rule without trailing slash needs to be added before rule with trailing slash
-        bp.add_url_rule('', view_func=export_view, methods=['get', ])
-    bp.add_url_rule('/', view_func=export_view, methods=['get', ])
+        bp.add_url_rule('', view_func=export_view, methods=[HTTPMethod.GET.value])
+
+    bp.add_url_rule('/', view_func=export_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
+++ b/lib/rucio/web/rest/flaskapi/v1/heartbeats.py
@@ -16,6 +16,7 @@ import json
 
 from flask import Flask, Response, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import AccessDenied, KeyNotFound, UnsupportedKeyType, UnsupportedValueType
 from rucio.common.utils import APIEncoder
 from rucio.gateway.heartbeat import create_heartbeat, list_heartbeats
@@ -114,7 +115,7 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('heartbeats', __name__, url_prefix='/heartbeats')
 
     heartbeat_view = Heartbeat.as_view('heartbeat')
-    bp.add_url_rule('', view_func=heartbeat_view, methods=['get', 'post'])
+    bp.add_url_rule('', view_func=heartbeat_view, methods=[HTTPMethod.GET.value, HTTPMethod.POST.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/identities.py
+++ b/lib/rucio/web/rest/flaskapi/v1/identities.py
@@ -14,6 +14,7 @@
 
 from flask import Flask, jsonify, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.gateway.identity import add_account_identity, add_identity, list_accounts_for_identity
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, generate_http_error_flask, response_headers
@@ -266,13 +267,13 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('identities', __name__, url_prefix='/identities')
 
     userpass_view = UserPass.as_view('userpass')
-    bp.add_url_rule('/<account>/userpass', view_func=userpass_view, methods=['put', ])
+    bp.add_url_rule('/<account>/userpass', view_func=userpass_view, methods=[HTTPMethod.PUT.value])
     x509_view = X509.as_view('x509')
-    bp.add_url_rule('/<account>/x509', view_func=x509_view, methods=['put', ])
+    bp.add_url_rule('/<account>/x509', view_func=x509_view, methods=[HTTPMethod.PUT.value])
     gss_view = GSS.as_view('gss')
-    bp.add_url_rule('/<account>/gss', view_func=gss_view, methods=['put', ])
+    bp.add_url_rule('/<account>/gss', view_func=gss_view, methods=[HTTPMethod.PUT.value])
     accounts_view = Accounts.as_view('accounts')
-    bp.add_url_rule('/<identity_key>/<type>/accounts', view_func=accounts_view, methods=['get', ])
+    bp.add_url_rule('/<identity_key>/<type>/accounts', view_func=accounts_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/import.py
+++ b/lib/rucio/web/rest/flaskapi/v1/import.py
@@ -14,6 +14,7 @@
 
 from flask import Flask, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.utils import parse_response
 from rucio.gateway.importer import import_data
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
@@ -118,8 +119,8 @@ def blueprint(with_doc=False):
     import_view = Import.as_view('scope')
     if not with_doc:
         # rule without trailing slash needs to be added before rule with trailing slash
-        bp.add_url_rule('', view_func=import_view, methods=['post', ])
-    bp.add_url_rule('/', view_func=import_view, methods=['post', ])
+        bp.add_url_rule('', view_func=import_view, methods=[HTTPMethod.POST.value])
+    bp.add_url_rule('/', view_func=import_view, methods=[HTTPMethod.POST.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/lifetime_exceptions.py
@@ -16,6 +16,7 @@ from json import dumps
 
 from flask import Flask, Response, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import AccessDenied, InvalidObject, LifetimeExceptionDuplicate, LifetimeExceptionNotFound, UnsupportedOperation
 from rucio.common.utils import APIEncoder
 from rucio.gateway.lifetime_exception import add_exception, list_exceptions, update_exception
@@ -297,9 +298,9 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('lifetime_exceptions', __name__, url_prefix='/lifetime_exceptions')
 
     lifetime_exception_view = LifetimeException.as_view('lifetime_exception')
-    bp.add_url_rule('/', view_func=lifetime_exception_view, methods=['get', 'post'])
+    bp.add_url_rule('/', view_func=lifetime_exception_view, methods=[HTTPMethod.GET.value, HTTPMethod.POST.value])
     lifetime_exception_id_view = LifetimeExceptionId.as_view('lifetime_exception_id')
-    bp.add_url_rule('/<exception_id>', view_func=lifetime_exception_id_view, methods=['get', 'put'])
+    bp.add_url_rule('/<exception_id>', view_func=lifetime_exception_id_view, methods=[HTTPMethod.GET.value, HTTPMethod.PUT.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/locks.py
+++ b/lib/rucio/web/rest/flaskapi/v1/locks.py
@@ -14,6 +14,7 @@
 
 from flask import Flask, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import RSENotFound
 from rucio.common.utils import render_json
 from rucio.gateway.lock import get_dataset_locks, get_dataset_locks_bulk, get_dataset_locks_by_rse
@@ -339,13 +340,13 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('locks', __name__, url_prefix='/locks')
 
     lock_by_rse_view = LockByRSE.as_view('lock_by_rse')
-    bp.add_url_rule('/<rse>', view_func=lock_by_rse_view, methods=['get', ])
+    bp.add_url_rule('/<rse>', view_func=lock_by_rse_view, methods=[HTTPMethod.GET.value])
 
     lock_by_scope_name_view = LocksByScopeName.as_view('locks_by_scope_name')
-    bp.add_url_rule('/<path:scope_name>', view_func=lock_by_scope_name_view, methods=['get', ])
+    bp.add_url_rule('/<path:scope_name>', view_func=lock_by_scope_name_view, methods=[HTTPMethod.GET.value])
 
     locks_for_dids_view = DatasetLocksForDids.as_view('locks_for_dids')
-    bp.add_url_rule('/bulk_locks_for_dids', view_func=locks_for_dids_view, methods=['post', ])
+    bp.add_url_rule('/bulk_locks_for_dids', view_func=locks_for_dids_view, methods=[HTTPMethod.POST.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/meta_conventions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/meta_conventions.py
@@ -14,6 +14,7 @@
 
 from flask import Flask, jsonify, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import Duplicate, InvalidValueForKey, KeyNotFound, UnsupportedKeyType, UnsupportedValueType
 from rucio.gateway.meta_conventions import add_key, add_value, list_keys, list_values
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
@@ -208,10 +209,10 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('meta_conventions', __name__, url_prefix='/meta_conventions')
 
     meta_view = MetaConventions.as_view('meta_conventions')
-    bp.add_url_rule('/', view_func=meta_view, methods=['get', ])
-    bp.add_url_rule('/<key>', view_func=meta_view, methods=['post', ])
+    bp.add_url_rule('/', view_func=meta_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<key>', view_func=meta_view, methods=[HTTPMethod.POST.value])
     values_view = Values.as_view('values')
-    bp.add_url_rule('/<key>/', view_func=values_view, methods=['get', 'post'])
+    bp.add_url_rule('/<key>/', view_func=values_view, methods=[HTTPMethod.GET.value, HTTPMethod.POST.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/metrics.py
+++ b/lib/rucio/web/rest/flaskapi/v1/metrics.py
@@ -14,6 +14,7 @@
 
 from flask import Blueprint, Flask
 
+from rucio.common.constants import HTTPMethod
 from rucio.core.monitor import generate_prometheus_metrics
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView
 
@@ -26,7 +27,7 @@ class Metrics(ErrorHandlingMethodView):
 def blueprint(standalone=False):
     bp = Blueprint('metrics', __name__, url_prefix='/' if standalone else '/metrics')
     metrics_view = Metrics.as_view('metrics')
-    bp.add_url_rule('/', view_func=metrics_view, methods=['get', ])
+    bp.add_url_rule('/', view_func=metrics_view, methods=[HTTPMethod.GET.value])
     return bp
 
 

--- a/lib/rucio/web/rest/flaskapi/v1/nongrid_traces.py
+++ b/lib/rucio/web/rest/flaskapi/v1/nongrid_traces.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from flask import Blueprint, Flask, request
 from werkzeug.datastructures import Headers
 
+from rucio.common.constants import HTTPMethod
 from rucio.core.nongrid_trace import trace
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, json_parameters, response_headers
 
@@ -84,7 +85,7 @@ def blueprint() -> Blueprint:
     bp = Blueprint('nongrid_traces', __name__, url_prefix='/nongrid_traces')
 
     xaod_trace_view = XAODTrace.as_view('xaod_trace')
-    bp.add_url_rule('/', view_func=xaod_trace_view, methods=['post', ])
+    bp.add_url_rule('/', view_func=xaod_trace_view, methods=[HTTPMethod.POST.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/opendata.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata.py
@@ -14,7 +14,7 @@
 
 from flask import Blueprint, Flask, Response, request
 
-from rucio.common.constants import DEFAULT_VO
+from rucio.common.constants import DEFAULT_VO, HTTPMethod
 from rucio.common.exception import AccessDenied, DataIdentifierNotFound, OpenDataDataIdentifierAlreadyExists, OpenDataDataIdentifierNotFound
 from rucio.common.utils import render_json
 from rucio.core.opendata import validate_opendata_did_state
@@ -374,10 +374,11 @@ def blueprint() -> "Blueprint":
     bp = AuthenticatedBlueprint("opendata", __name__, url_prefix="/opendata")
 
     opendata_view = OpenDataView.as_view("opendata")
-    bp.add_url_rule("/dids", view_func=opendata_view, methods=["get"])
+    bp.add_url_rule("/dids", view_func=opendata_view, methods=[HTTPMethod.GET.value])
 
     opendata_did_view = OpenDataDIDsView.as_view("opendata_did")
-    bp.add_url_rule("/dids/<scope>/<name>", view_func=opendata_did_view, methods=["get", "post", "put", "delete"])
+    bp.add_url_rule("/dids/<scope>/<name>", view_func=opendata_did_view,
+                    methods=[HTTPMethod.GET.value, HTTPMethod.POST.value, HTTPMethod.PUT.value, HTTPMethod.DELETE.value])
 
     bp.after_request(response_headers)
 

--- a/lib/rucio/web/rest/flaskapi/v1/opendata_public.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata_public.py
@@ -14,6 +14,7 @@
 
 from flask import Blueprint, Flask, Response
 
+from rucio.common.constants import HTTPMethod
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, response_headers
 from rucio.web.rest.flaskapi.v1.opendata import OpenDataDIDsView, OpenDataView
 
@@ -129,10 +130,10 @@ def blueprint() -> "Blueprint":
     bp = Blueprint("opendata_public", __name__, url_prefix="/opendata/public")
 
     opendata_public_view = OpenDataPublicView.as_view("opendata")
-    bp.add_url_rule("/dids", view_func=opendata_public_view, methods=["get"])
+    bp.add_url_rule("/dids", view_func=opendata_public_view, methods=[HTTPMethod.GET.value])
 
     opendata_private_did_view = OpenDataPublicDIDsView.as_view("opendata_did")
-    bp.add_url_rule("/dids/<scope>/<name>", view_func=opendata_private_did_view, methods=["get"])
+    bp.add_url_rule("/dids/<scope>/<name>", view_func=opendata_private_did_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
 

--- a/lib/rucio/web/rest/flaskapi/v1/ping.py
+++ b/lib/rucio/web/rest/flaskapi/v1/ping.py
@@ -18,6 +18,7 @@ from flask import Blueprint, Flask, jsonify, request
 from werkzeug.datastructures import Headers
 
 from rucio import version
+from rucio.common.constants import HTTPMethod
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, response_headers
 
 if TYPE_CHECKING:
@@ -74,8 +75,8 @@ def blueprint(standalone=False, with_doc=False):
     ping_view = Ping.as_view('ping')
     if not with_doc:
         # rule without trailing slash needs to be added before rule with trailing slash
-        bp.add_url_rule('', view_func=ping_view, methods=['get', ])
-    bp.add_url_rule('/', view_func=ping_view, methods=['get', ])
+        bp.add_url_rule('', view_func=ping_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/', view_func=ping_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/redirect.py
+++ b/lib/rucio/web/rest/flaskapi/v1/redirect.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from flask import Blueprint, Flask, redirect, request
 from werkzeug.datastructures import Headers
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import DataIdentifierNotFound, ReplicaNotFound, SortingAlgorithmNotSupported
 from rucio.core.replica_sorter import site_selector, sort_replicas
 from rucio.gateway.replica import list_replicas
@@ -350,11 +351,11 @@ def blueprint(with_doc=False):
     bp = Blueprint('redirect', __name__, url_prefix='/redirect')
 
     metalink_redirector_view = MetaLinkRedirector.as_view('metalink_redirector')
-    bp.add_url_rule('/<path:scope_name>/metalink', view_func=metalink_redirector_view, methods=['get', ])
+    bp.add_url_rule('/<path:scope_name>/metalink', view_func=metalink_redirector_view, methods=[HTTPMethod.GET.value])
     header_redirector_view = HeaderRedirector.as_view('header_redirector')
-    bp.add_url_rule('/<path:scope_name>', view_func=header_redirector_view, methods=['get', ])
+    bp.add_url_rule('/<path:scope_name>', view_func=header_redirector_view, methods=[HTTPMethod.GET.value])
     if not with_doc:
-        bp.add_url_rule('/<path:scope_name>/', view_func=header_redirector_view, methods=['get', ])
+        bp.add_url_rule('/<path:scope_name>/', view_func=header_redirector_view, methods=[HTTPMethod.GET.value])
 
     return bp
 

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -22,7 +22,7 @@ from xml.sax.saxutils import escape
 from flask import Flask, Response, request
 
 from rucio.common.config import config_get, config_get_int
-from rucio.common.constants import SUPPORTED_PROTOCOLS
+from rucio.common.constants import SUPPORTED_PROTOCOLS, HTTPMethod
 from rucio.common.exception import (
     AccessDenied,
     DataIdentifierAlreadyExists,
@@ -1832,57 +1832,57 @@ def blueprint(with_doc=False):
     bp = AuthenticatedBlueprint('replicas', __name__, url_prefix='/replicas')
 
     list_replicas_view = ListReplicas.as_view('list_replicas')
-    bp.add_url_rule('/list', view_func=list_replicas_view, methods=['post', ])
+    bp.add_url_rule('/list', view_func=list_replicas_view, methods=[HTTPMethod.POST.value])
     replicas_view = Replicas.as_view('replicas')
     if not with_doc:
         # rule without trailing slash needs to be added before rule with trailing slash
-        bp.add_url_rule('', view_func=replicas_view, methods=['post', 'put', 'delete'])
-    bp.add_url_rule('/', view_func=replicas_view, methods=['post', 'put', 'delete'])
+        bp.add_url_rule('', view_func=replicas_view, methods=[HTTPMethod.POST.value, HTTPMethod.PUT.value, HTTPMethod.DELETE.value])
+    bp.add_url_rule('/', view_func=replicas_view, methods=[HTTPMethod.POST.value, HTTPMethod.PUT.value, HTTPMethod.DELETE.value])
     suspicious_replicas_view = SuspiciousReplicas.as_view('suspicious_replicas')
-    bp.add_url_rule('/suspicious', view_func=suspicious_replicas_view, methods=['get', 'post'])
+    bp.add_url_rule('/suspicious', view_func=suspicious_replicas_view, methods=[HTTPMethod.GET.value, HTTPMethod.POST.value])
     bad_replicas_states_view = BadReplicasStates.as_view('bad_replicas_states')
-    bp.add_url_rule('/bad/states', view_func=bad_replicas_states_view, methods=['get', ])
+    bp.add_url_rule('/bad/states', view_func=bad_replicas_states_view, methods=[HTTPMethod.GET.value])
     bad_replicas_summary_view = BadReplicasSummary.as_view('bad_replicas_summary')
-    bp.add_url_rule('/bad/summary', view_func=bad_replicas_summary_view, methods=['get', ])
+    bp.add_url_rule('/bad/summary', view_func=bad_replicas_summary_view, methods=[HTTPMethod.GET.value])
     bad_replicas_pfn_view = BadPFNs.as_view('add_bad_pfns')
-    bp.add_url_rule('/bad/pfns', view_func=bad_replicas_pfn_view, methods=['post', ])
+    bp.add_url_rule('/bad/pfns', view_func=bad_replicas_pfn_view, methods=[HTTPMethod.POST.value])
     bad_replicas_dids_view = BadDIDs.as_view('add_bad_dids')
-    bp.add_url_rule('/bad/dids', view_func=bad_replicas_dids_view, methods=['post', ])
+    bp.add_url_rule('/bad/dids', view_func=bad_replicas_dids_view, methods=[HTTPMethod.POST.value])
     replicas_rse_view = ReplicasRSE.as_view('replicas_rse')
-    bp.add_url_rule('/rse/<rse>', view_func=replicas_rse_view, methods=['get', ])
+    bp.add_url_rule('/rse/<rse>', view_func=replicas_rse_view, methods=[HTTPMethod.GET.value])
 
     bad_replicas_view = BadReplicas.as_view('bad_replicas')
-    bp.add_url_rule('/bad', view_func=bad_replicas_view, methods=['post', ])
+    bp.add_url_rule('/bad', view_func=bad_replicas_view, methods=[HTTPMethod.POST.value])
 
     quarantine_replicas_view = QuarantineReplicas.as_view('quarantine_replicas')
-    bp.add_url_rule('/quarantine', view_func=quarantine_replicas_view, methods=['post', ])
+    bp.add_url_rule('/quarantine', view_func=quarantine_replicas_view, methods=[HTTPMethod.POST.value])
 
     replicas_dids_view = ReplicasDIDs.as_view('replicas_dids')
-    bp.add_url_rule('/dids', view_func=replicas_dids_view, methods=['post', ])
+    bp.add_url_rule('/dids', view_func=replicas_dids_view, methods=[HTTPMethod.POST.value])
     dataset_replicas_view = DatasetReplicas.as_view('dataset_replicas')
-    bp.add_url_rule('/<path:scope_name>/datasets', view_func=dataset_replicas_view, methods=['get', ])
+    bp.add_url_rule('/<path:scope_name>/datasets', view_func=dataset_replicas_view, methods=[HTTPMethod.GET.value])
     dataset_replicas_bulk_view = DatasetReplicasBulk.as_view('dataset_replicas_bulk')
-    bp.add_url_rule('/datasets_bulk', view_func=dataset_replicas_bulk_view, methods=['post', ])
+    bp.add_url_rule('/datasets_bulk', view_func=dataset_replicas_bulk_view, methods=[HTTPMethod.POST.value])
     dataset_replicas_vp_view = DatasetReplicasVP.as_view('dataset_replicas_vp')
-    bp.add_url_rule('/<path:scope_name>', view_func=replicas_view, methods=['get', ])
+    bp.add_url_rule('/<path:scope_name>', view_func=replicas_view, methods=[HTTPMethod.GET.value])
     set_tombstone_view = Tombstone.as_view('set_tombstone')
-    bp.add_url_rule('/tombstone', view_func=set_tombstone_view, methods=['post', ])
+    bp.add_url_rule('/tombstone', view_func=set_tombstone_view, methods=[HTTPMethod.POST.value])
 
     if not with_doc:
-        bp.add_url_rule('/list/', view_func=list_replicas_view, methods=['post', ])
-        bp.add_url_rule('/suspicious/', view_func=suspicious_replicas_view, methods=['get', 'post'])
-        bp.add_url_rule('/bad/states/', view_func=bad_replicas_states_view, methods=['get', ])
-        bp.add_url_rule('/bad/summary/', view_func=bad_replicas_summary_view, methods=['get', ])
-        bp.add_url_rule('/bad/pfns/', view_func=bad_replicas_pfn_view, methods=['post', ])
-        bp.add_url_rule('/bad/dids/', view_func=bad_replicas_dids_view, methods=['post', ])
-        bp.add_url_rule('/rse/<rse>/', view_func=replicas_rse_view, methods=['get', ])
-        bp.add_url_rule('/bad/', view_func=bad_replicas_view, methods=['post', ])
-        bp.add_url_rule('/dids/', view_func=replicas_dids_view, methods=['post', ])
-        bp.add_url_rule('/datasets_bulk/', view_func=dataset_replicas_bulk_view, methods=['post', ])
-        bp.add_url_rule('/<path:scope_name>/datasets_vp', view_func=dataset_replicas_vp_view, methods=['get', ])
-        bp.add_url_rule('/<path:scope_name>/', view_func=replicas_view, methods=['get', ])
-        bp.add_url_rule('/tombstone/', view_func=set_tombstone_view, methods=['post', ])
-        bp.add_url_rule('/quarantine/', view_func=quarantine_replicas_view, methods=['post', ])
+        bp.add_url_rule('/list/', view_func=list_replicas_view, methods=[HTTPMethod.POST.value])
+        bp.add_url_rule('/suspicious/', view_func=suspicious_replicas_view, methods=[HTTPMethod.GET.value, HTTPMethod.POST.value])
+        bp.add_url_rule('/bad/states/', view_func=bad_replicas_states_view, methods=[HTTPMethod.GET.value])
+        bp.add_url_rule('/bad/summary/', view_func=bad_replicas_summary_view, methods=[HTTPMethod.GET.value])
+        bp.add_url_rule('/bad/pfns/', view_func=bad_replicas_pfn_view, methods=[HTTPMethod.POST.value])
+        bp.add_url_rule('/bad/dids/', view_func=bad_replicas_dids_view, methods=[HTTPMethod.POST.value])
+        bp.add_url_rule('/rse/<rse>/', view_func=replicas_rse_view, methods=[HTTPMethod.GET.value])
+        bp.add_url_rule('/bad/', view_func=bad_replicas_view, methods=[HTTPMethod.POST.value])
+        bp.add_url_rule('/dids/', view_func=replicas_dids_view, methods=[HTTPMethod.POST.value])
+        bp.add_url_rule('/datasets_bulk/', view_func=dataset_replicas_bulk_view, methods=[HTTPMethod.POST.value])
+        bp.add_url_rule('/<path:scope_name>/datasets_vp', view_func=dataset_replicas_vp_view, methods=[HTTPMethod.GET.value])
+        bp.add_url_rule('/<path:scope_name>/', view_func=replicas_view, methods=[HTTPMethod.GET.value])
+        bp.add_url_rule('/tombstone/', view_func=set_tombstone_view, methods=[HTTPMethod.POST.value])
+        bp.add_url_rule('/quarantine/', view_func=quarantine_replicas_view, methods=[HTTPMethod.POST.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Union, cast
 import flask
 from flask import Flask, Response
 
-from rucio.common.constants import TransferLimitDirection
+from rucio.common.constants import HTTPMethod, TransferLimitDirection
 from rucio.common.exception import AccessDenied, RequestNotFound
 from rucio.common.utils import APIEncoder, render_json
 from rucio.core.rse import get_rses_with_attribute_value
@@ -1170,17 +1170,17 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('requests', __name__, url_prefix='/requests')
 
     request_get_view = RequestGet.as_view('request_get')
-    bp.add_url_rule('/<path:scope_name>/<rse>', view_func=request_get_view, methods=['get', ])
+    bp.add_url_rule('/<path:scope_name>/<rse>', view_func=request_get_view, methods=[HTTPMethod.GET.value])
     request_history_get_view = RequestHistoryGet.as_view('request_history_get')
-    bp.add_url_rule('/history/<path:scope_name>/<rse>', view_func=request_history_get_view, methods=['get', ])
+    bp.add_url_rule('/history/<path:scope_name>/<rse>', view_func=request_history_get_view, methods=[HTTPMethod.GET.value])
     request_list_view = RequestList.as_view('request_list')
-    bp.add_url_rule('/list', view_func=request_list_view, methods=['get', ])
+    bp.add_url_rule('/list', view_func=request_list_view, methods=[HTTPMethod.GET.value])
     request_history_list_view = RequestHistoryList.as_view('request_history_list')
-    bp.add_url_rule('/history/list', view_func=request_history_list_view, methods=['get', ])
+    bp.add_url_rule('/history/list', view_func=request_history_list_view, methods=[HTTPMethod.GET.value])
     request_metrics_view = RequestMetricsGet.as_view('request_metrics_get')
-    bp.add_url_rule('/metrics', view_func=request_metrics_view, methods=['get', ])
+    bp.add_url_rule('/metrics', view_func=request_metrics_view, methods=[HTTPMethod.GET.value])
     transfer_limits_view = TransferLimits.as_view('transfer_limits_get')
-    bp.add_url_rule('/transfer_limits', view_func=transfer_limits_view, methods=['get', 'put', 'delete'])
+    bp.add_url_rule('/transfer_limits', view_func=transfer_limits_view, methods=[HTTPMethod.GET.value, HTTPMethod.PUT.value, HTTPMethod.DELETE.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 from flask import Flask, Response, jsonify, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import (
     AccessDenied,
     CounterNotFound,
@@ -2211,33 +2212,39 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('rses', __name__, url_prefix='/rses')
 
     attributes_view = Attributes.as_view('attributes')
-    bp.add_url_rule('/<rse>/attr/<key>', view_func=attributes_view, methods=['post', 'delete'])
-    bp.add_url_rule('/<rse>/attr/', view_func=attributes_view, methods=['get', ])
+    bp.add_url_rule('/<rse>/attr/<key>', view_func=attributes_view, methods=[HTTPMethod.POST.value, HTTPMethod.DELETE.value])
+    bp.add_url_rule('/<rse>/attr/', view_func=attributes_view, methods=[HTTPMethod.GET.value])
     distance_view = Distance.as_view('distance')
-    bp.add_url_rule('/<source>/distances/<destination>', view_func=distance_view, methods=['get', 'post', 'put', 'delete'])
+    bp.add_url_rule('/<source>/distances/<destination>', view_func=distance_view,
+                    methods=[HTTPMethod.GET.value, HTTPMethod.POST.value, HTTPMethod.PUT.value, HTTPMethod.DELETE.value])
     protocol_view = Protocol.as_view('protocol')
-    bp.add_url_rule('/<rse>/protocols/<scheme>/<hostname>/<port>', view_func=protocol_view, methods=['delete', 'put'])
-    bp.add_url_rule('/<rse>/protocols/<scheme>/<hostname>', view_func=protocol_view, methods=['delete', 'put'])
-    bp.add_url_rule('/<rse>/protocols/<scheme>', view_func=protocol_view, methods=['get', 'post', 'delete', 'put'])
+    bp.add_url_rule('/<rse>/protocols/<scheme>/<hostname>/<port>', view_func=protocol_view,
+                    methods=[HTTPMethod.DELETE.value, HTTPMethod.PUT.value])
+    bp.add_url_rule('/<rse>/protocols/<scheme>/<hostname>', view_func=protocol_view,
+                    methods=[HTTPMethod.DELETE.value, HTTPMethod.PUT.value])
+    bp.add_url_rule('/<rse>/protocols/<scheme>', view_func=protocol_view,
+                    methods=[HTTPMethod.GET.value, HTTPMethod.POST.value, HTTPMethod.DELETE.value, HTTPMethod.PUT.value])
     protocol_list_view = ProtocolList.as_view('protocol_list')
-    bp.add_url_rule('/<rse>/protocols', view_func=protocol_list_view, methods=['get', ])
+    bp.add_url_rule('/<rse>/protocols', view_func=protocol_list_view, methods=[HTTPMethod.GET.value])
     lfns2pfns_view = LFNS2PFNS.as_view('lfns2pfns')
-    bp.add_url_rule('/<rse>/lfns2pfns', view_func=lfns2pfns_view, methods=['get', ])
+    bp.add_url_rule('/<rse>/lfns2pfns', view_func=lfns2pfns_view, methods=[HTTPMethod.GET.value])
     rse_account_usage_limit_view = RSEAccountUsageLimit.as_view('rse_account_usage_limit')
-    bp.add_url_rule('/<rse>/accounts/usage', view_func=rse_account_usage_limit_view, methods=['get', ])
+    bp.add_url_rule('/<rse>/accounts/usage', view_func=rse_account_usage_limit_view, methods=[HTTPMethod.GET.value])
     usage_view = Usage.as_view('usage')
-    bp.add_url_rule('/<rse>/usage', view_func=usage_view, methods=['get', 'put'])
+    bp.add_url_rule('/<rse>/usage', view_func=usage_view, methods=[HTTPMethod.GET.value, HTTPMethod.PUT.value])
     usage_history_view = UsageHistory.as_view('usage_history')
-    bp.add_url_rule('/<rse>/usage/history', view_func=usage_history_view, methods=['get', ])
+    bp.add_url_rule('/<rse>/usage/history', view_func=usage_history_view, methods=[HTTPMethod.GET.value])
     limits_view = Limits.as_view('limits')
-    bp.add_url_rule('/<rse>/limits', view_func=limits_view, methods=['get', 'put', 'delete'])
+    bp.add_url_rule('/<rse>/limits', view_func=limits_view, methods=[HTTPMethod.GET.value, HTTPMethod.PUT.value, HTTPMethod.DELETE.value])
     qos_policy_view = QoSPolicy.as_view('qos_policy')
-    bp.add_url_rule('/<rse>/qos_policy', view_func=qos_policy_view, methods=['get', ])
-    bp.add_url_rule('/<rse>/qos_policy/<policy>', view_func=qos_policy_view, methods=['post', 'delete'])
+    bp.add_url_rule('/<rse>/qos_policy', view_func=qos_policy_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<rse>/qos_policy/<policy>', view_func=qos_policy_view,
+                    methods=[HTTPMethod.POST.value, HTTPMethod.DELETE.value])
     rse_view = RSE.as_view('rse')
-    bp.add_url_rule('/<rse>', view_func=rse_view, methods=['get', 'delete', 'put', 'post'])
+    bp.add_url_rule('/<rse>', view_func=rse_view,
+                    methods=[HTTPMethod.GET.value, HTTPMethod.DELETE.value, HTTPMethod.PUT.value, HTTPMethod.POST.value])
     rses_view = RSEs.as_view('rses')
-    bp.add_url_rule('/', view_func=rses_view, methods=['get', ])
+    bp.add_url_rule('/', view_func=rses_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/rules.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rules.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from flask import Flask, Response, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import (
     AccessDenied,
     AccountNotFound,
@@ -827,21 +828,21 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('rules', __name__, url_prefix='/rules')
 
     rule_view = Rule.as_view('rule')
-    bp.add_url_rule('/<rule_id>', view_func=rule_view, methods=['get', 'put', 'delete'])
+    bp.add_url_rule('/<rule_id>', view_func=rule_view, methods=[HTTPMethod.GET.value, HTTPMethod.PUT.value, HTTPMethod.DELETE.value])
     all_rule_view = AllRule.as_view('all_rule')
-    bp.add_url_rule('/', view_func=all_rule_view, methods=['get', 'post'])
+    bp.add_url_rule('/', view_func=all_rule_view, methods=[HTTPMethod.GET.value, HTTPMethod.POST.value])
     replica_locks_view = ReplicaLocks.as_view('replica_locks')
-    bp.add_url_rule('/<rule_id>/locks', view_func=replica_locks_view, methods=['get', ])
+    bp.add_url_rule('/<rule_id>/locks', view_func=replica_locks_view, methods=[HTTPMethod.GET.value])
     reduce_rule_view = ReduceRule.as_view('reduce_rule')
-    bp.add_url_rule('/<rule_id>/reduce', view_func=reduce_rule_view, methods=['post', ])
+    bp.add_url_rule('/<rule_id>/reduce', view_func=reduce_rule_view, methods=[HTTPMethod.POST.value])
     move_rule_view = MoveRule.as_view('move_rule')
-    bp.add_url_rule('/<rule_id>/move', view_func=move_rule_view, methods=['post', ])
+    bp.add_url_rule('/<rule_id>/move', view_func=move_rule_view, methods=[HTTPMethod.POST.value])
     rule_history_view = RuleHistory.as_view('rule_history')
-    bp.add_url_rule('/<rule_id>/history', view_func=rule_history_view, methods=['get', ])
+    bp.add_url_rule('/<rule_id>/history', view_func=rule_history_view, methods=[HTTPMethod.GET.value])
     rule_history_full_view = RuleHistoryFull.as_view('rule_history_full')
-    bp.add_url_rule('/<path:scope_name>/history', view_func=rule_history_full_view, methods=['get', ])
+    bp.add_url_rule('/<path:scope_name>/history', view_func=rule_history_full_view, methods=[HTTPMethod.GET.value])
     rule_analysis_view = RuleAnalysis.as_view('rule_analysis')
-    bp.add_url_rule('/<rule_id>/analysis', view_func=rule_analysis_view, methods=['get', ])
+    bp.add_url_rule('/<rule_id>/analysis', view_func=rule_analysis_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/scopes.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scopes.py
@@ -14,6 +14,7 @@
 
 from flask import Flask, jsonify, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import AccountNotFound, Duplicate, ScopeNotFound
 from rucio.gateway.scope import add_scope, get_scopes, list_scopes
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
@@ -143,10 +144,10 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('scopes', __name__, url_prefix='/scopes')
 
     scope_view = Scope.as_view('scope')
-    bp.add_url_rule('/', view_func=scope_view, methods=['get', ])
-    bp.add_url_rule('/<account>/<scope>', view_func=scope_view, methods=['post', ])
+    bp.add_url_rule('/', view_func=scope_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/<scope>', view_func=scope_view, methods=[HTTPMethod.POST.value])
     account_scope_list_view = AccountScopeList.as_view('account_scope_list')
-    bp.add_url_rule('/<account>/scopes', view_func=account_scope_list_view, methods=['get', ])
+    bp.add_url_rule('/<account>/scopes', view_func=account_scope_list_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -16,6 +16,7 @@ from json import dumps
 
 from flask import Flask, Response, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import AccessDenied, InvalidObject, RuleNotFound, SubscriptionDuplicate, SubscriptionNotFound
 from rucio.common.utils import APIEncoder, render_json
 from rucio.gateway.rule import list_replication_rules
@@ -623,18 +624,18 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('subscriptions', __name__, url_prefix='/subscriptions')
 
     subscription_id_view = SubscriptionId.as_view('subscription_id')
-    bp.add_url_rule('/id/<subscription_id>', view_func=subscription_id_view, methods=['get', ])
+    bp.add_url_rule('/id/<subscription_id>', view_func=subscription_id_view, methods=[HTTPMethod.GET.value])
     states_view = States.as_view('states')
-    bp.add_url_rule('/<account>/<name>/rules/states', view_func=states_view, methods=['get', ])
-    bp.add_url_rule('/<account>/rules/states', view_func=states_view, methods=['get', ])
+    bp.add_url_rule('/<account>/<name>/rules/states', view_func=states_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/<account>/rules/states', view_func=states_view, methods=[HTTPMethod.GET.value])
     rules_view = Rules.as_view('rules')
-    bp.add_url_rule('/<account>/<name>/rules', view_func=rules_view, methods=['get', ])
+    bp.add_url_rule('/<account>/<name>/rules', view_func=rules_view, methods=[HTTPMethod.GET.value])
     subscription_view = Subscription.as_view('subscription')
-    bp.add_url_rule('/<account>/<name>', view_func=subscription_view, methods=['get', 'post', 'put'])
-    bp.add_url_rule('/<account>', view_func=subscription_view, methods=['get', ])
-    bp.add_url_rule('/', view_func=subscription_view, methods=['get', ])
+    bp.add_url_rule('/<account>/<name>', view_func=subscription_view, methods=[HTTPMethod.GET.value, HTTPMethod.POST.value, HTTPMethod.PUT.value])
+    bp.add_url_rule('/<account>', view_func=subscription_view, methods=[HTTPMethod.GET.value])
+    bp.add_url_rule('/', view_func=subscription_view, methods=[HTTPMethod.GET.value])
     subscription_name_view = SubscriptionName.as_view('subscription_name')
-    bp.add_url_rule('/name/<name>', view_func=subscription_name_view, methods=['get', ])
+    bp.add_url_rule('/name/<name>', view_func=subscription_name_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/traces.py
+++ b/lib/rucio/web/rest/flaskapi/v1/traces.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from flask import Blueprint, Flask, Response, request
 from werkzeug.datastructures import Headers
 
+from rucio.common.constants import HTTPMethod
 from rucio.gateway.trace import trace
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, generate_http_error_flask, response_headers
 
@@ -122,7 +123,7 @@ def blueprint() -> Blueprint:
     bp = Blueprint('traces', __name__, url_prefix='/traces')
 
     trace_view = Trace.as_view('trace')
-    bp.add_url_rule('/', view_func=trace_view, methods=['post', ])
+    bp.add_url_rule('/', view_func=trace_view, methods=[HTTPMethod.POST.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/rest/flaskapi/v1/vos.py
+++ b/lib/rucio/web/rest/flaskapi/v1/vos.py
@@ -14,6 +14,7 @@
 
 from flask import Flask, request
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import AccessDenied, AccountNotFound, Duplicate, UnsupportedOperation, VONotFound
 from rucio.common.utils import render_json
 from rucio.gateway.vo import add_vo, list_vos, recover_vo_root_identity, update_vo
@@ -259,11 +260,11 @@ def blueprint() -> AuthenticatedBlueprint:
     bp = AuthenticatedBlueprint('vos', __name__, url_prefix='/vos')
 
     recover_view = RecoverVO.as_view('recover')
-    bp.add_url_rule('/<vo>/recover', view_func=recover_view, methods=['post', ])
+    bp.add_url_rule('/<vo>/recover', view_func=recover_view, methods=[HTTPMethod.POST.value])
     vo_view = VO.as_view('vo')
-    bp.add_url_rule('/<vo>', view_func=vo_view, methods=['put', 'post'])
+    bp.add_url_rule('/<vo>', view_func=vo_view, methods=[HTTPMethod.PUT.value, HTTPMethod.POST.value])
     vos_view = VOs.as_view('vos')
-    bp.add_url_rule('/', view_func=vos_view, methods=['get', ])
+    bp.add_url_rule('/', view_func=vos_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
     return bp

--- a/lib/rucio/web/ui/flask/bp.py
+++ b/lib/rucio/web/ui/flask/bp.py
@@ -16,7 +16,7 @@
 from flask import Blueprint, make_response, render_template, request
 
 from rucio.common.config import config_get_bool
-from rucio.common.constants import DEFAULT_VO
+from rucio.common.constants import DEFAULT_VO, HTTPMethod
 from rucio.common.policy import get_policy
 from rucio.gateway.authentication import get_auth_token_x509
 from rucio.web.rest.flaskapi.v1.common import generate_http_error_flask
@@ -41,15 +41,16 @@ def auth():
         else:
             return generate_http_error_flask(401, 'CannotAuthenticate', 'Cannot get token')
     else:
-        return render_template('select_login_method.html', oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT)
+        return render_template('select_login_method.html', oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT,
+                               userpass_support=USERPASS_SUPPORT)
 
 
 def login():
-    if request.method == 'GET':
+    if request.method == HTTPMethod.GET.value:
         account = request.args.get('account')
         vo = request.args.get('vo')
         return render_template('login.html', account=account, vo=vo, userpass_support=USERPASS_SUPPORT)
-    if request.method == 'POST':
+    if request.method == HTTPMethod.POST.value:
         return userpass_auth()
 
 
@@ -80,12 +81,12 @@ def x509():
 
 
 AUTH_URLS = (
-    ('/auth', 'auth', auth, ['GET', ]),
-    ('/login', 'login', login, ['GET', 'POST']),
-    ('/oidc', 'oidc', oidc, ['GET', ]),
-    ('/oidc_final', 'oidc_final', oidc_final, ['GET', ]),
-    ('/saml', 'saml', saml, ['GET', 'POST']),
-    ('/x509', 'x509', x509, ['GET', ])
+    ('/auth', 'auth', auth, [HTTPMethod.GET]),
+    ('/login', 'login', login, [HTTPMethod.GET, HTTPMethod.POST]),
+    ('/oidc', 'oidc', oidc, [HTTPMethod.GET]),
+    ('/oidc_final', 'oidc_final', oidc_final, [HTTPMethod.GET]),
+    ('/saml', 'saml', saml, [HTTPMethod.GET, HTTPMethod.POST]),
+    ('/x509', 'x509', x509, [HTTPMethod.GET])
 )
 
 COMMON_URLS = (

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
+from rucio.common.constants import HTTPMethod
 from rucio.common.exception import CannotAuthenticate, ClientProtocolNotFound, ClientProtocolNotSupported, MissingClientParameter, RucioException
 from rucio.common.utils import execute
 from rucio.tests.common import remove_config, skip_outside_gh_actions
@@ -175,7 +176,7 @@ class TestBaseClient:
             del invocations[:]
             client = BaseClient(rucio_host=server.base_url, auth_host=server.base_url, account='root', auth_type='userpass', creds=creds, vo=vo)
             del invocations[:]
-            client._send_request(server.base_url)  # noqa
+            client._send_request(server.base_url, method=HTTPMethod.GET)  # noqa
         # The client did back-off multiple times before succeeding: 2 * 0.25s (authentication) + 2 * 0.25s (request) = 1s
         assert datetime.utcnow() - start_time > timedelta(seconds=0.9)
 


### PR DESCRIPTION
Closes #7620 

This PR modifies `_send_request` which is an internal api. The parameter `type_` has been renamed to `method` and now takes an enum instead of a string.

When an invalid method is used an exception is raised. Previously it was just ignored. This resulted in some hard to track bugs in my experience, since this is an internal method I don't see any reason why this should not raise exception in this case as it should always be called properly (and now this error condition can be statically checked).

I updated all occurrences of this method to match the new usage.

**Changes**

The `_send_request` method now does not have a default value for the method (used to be `GET`). It also does not have a type hint. This is done due to `pyright` complaining in the CI, I was unable to fix this or even add an ignore directive. After discussing with @bari12 offline this was deemed acceptable as this method is interal only.