### PR TITLE
Kronos: Increment DID access_cnt in touch_replica

### DIFF
--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -2874,7 +2874,11 @@ def touch_replica(
         ).prefix_with(
             '/*+ INDEX(DIDS DIDS_PK) */', dialect='oracle'
         ).values({
-            models.DataIdentifier.accessed_at: accessed_at
+            models.DataIdentifier.accessed_at: accessed_at,
+            models.DataIdentifier.access_cnt: case(
+                (models.DataIdentifier.access_cnt == none_value, 1),
+                else_=(models.DataIdentifier.access_cnt + 1)
+            )  # type: ignore
         }).execution_options(
             synchronize_session=False
         )

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -30,7 +30,7 @@ from rucio.common.constants import RseAttr
 from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifierNotFound, InputValidationError, ReplicaIsLocked, ReplicaNotFound, RucioException, ScopeNotFound
 from rucio.common.utils import clean_pfns, generate_uuid, parse_response
 from rucio.core.config import set as cconfig_set
-from rucio.core.did import add_did, attach_dids, get_did, get_did_atime, get_did_access_cnt, list_files, set_status
+from rucio.core.did import add_did, attach_dids, get_did, get_did_access_cnt, get_did_atime, list_files, set_status
 from rucio.core.replica import add_bad_dids, add_replica, add_replicas, delete_replicas, get_bad_pfns, get_replica, get_replica_atime, get_replicas_state, get_rse_coverage_of_dataset, list_replicas, set_tombstone, touch_replica, update_replica_state
 from rucio.core.rse import add_protocol, add_rse_attribute, del_rse_attribute
 from rucio.daemons.badreplicas.minos import minos


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Fixes #6832

Kronos updates `accessed_at` but not `access_cnt` for files when calling `touch_replica`. 
Updated touch_replica to increment the DID-level access_cnt using the same NULL-safe logic as `touch_dids` in https://github.com/rucio/rucio/blob/b6854f44e1e3bf003497256aa0a1c6dc3e00628c/lib/rucio/core/did.py#L2865-L2866
