### PR TITLE
Testing: Adjust `test_hermes` configuration and remove unused `influxdb_elastic` service from test matrix files

### DIFF
--- a/etc/docker/test/matrix.yml
+++ b/etc/docker/test/matrix.yml
@@ -37,8 +37,6 @@ suites:
       - oracle
       - mysql8
       - postgres14
-    services:
-      - influxdb_elastic
   - id: sqlite
     RDBMS:
       - sqlite

--- a/etc/docker/test/matrix_nightly.yml
+++ b/etc/docker/test/matrix_nightly.yml
@@ -19,8 +19,6 @@ suites:
       - oracle
       - mysql8
       - postgres14
-    services:
-      - influxdb_elastic
   - id: sqlite
     RDBMS:
       - sqlite

--- a/tests/test_hermes.py
+++ b/tests/test_hermes.py
@@ -76,7 +76,9 @@ class MyListener:
                 ("messaging-hermes", "username", "hermes"),
                 ("messaging-hermes", "password", "supersecret"),
                 ("messaging-hermes", "nonssl_port", 61613),
-                ("messaging-hermes", "send_email", False),
+                ("messaging-hermes", "send_email", True),
+                ("messaging-hermes", "smtp_host", "testing.host"),
+                ("messaging-hermes", "smtp_port", 1234),
             ]
         },
         {
@@ -99,9 +101,9 @@ class MyListener:
                 ("messaging-hermes", "username", "hermes"),
                 ("messaging-hermes", "password", "supersecret"),
                 ("messaging-hermes", "nonssl_port", 61613),
-                ("messaging-hermes", "send_email", False),
-                ("messaging-hermes", "smtp-host", "testing.host"),
-                ("messaging-hermes", "smtp-port", 1234),
+                ("messaging-hermes", "send_email", True),
+                ("messaging-hermes", "smtp_host", "testing.host"),
+                ("messaging-hermes", "smtp_port", 1234),
             ]
         }
     ],
@@ -205,7 +207,11 @@ def test_hermes(core_config_mock, caches_mock, monkeypatch):
         smtp_mock = MagicMock()
         m.setattr(hermes.smtplib, "SMTP", smtp_mock)
         hermes.hermes(once=True)
-        smtp_mock.assert_called_with(host="testing.host", port=1234)
+        smtp_host = config_get("messaging-hermes", "smtp_host", default='', raise_exception=False)
+        if not smtp_host:
+            smtp_mock.assert_called_with()
+        else:
+            smtp_mock.assert_called_with(host="testing.host", port=1234)
     service_dict = {"influx": 0, "elastic": 0, "email": 0, "activemq": 0}
     messages = retrieve_messages(50, old_mode=False)
     for message in messages:


### PR DESCRIPTION
Fixes #7872

We should then also merge #7871.

Also, `influxdb_elastic` was removed because we have no such service in our docker-compose actually. Influx and elastic containers are always available (no profile needed).