### PR TITLE
Testing: Add `needs_iam` marker to run tests with the IAM profile

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -123,7 +123,9 @@ jobs:
           sed -i 's;image: docker.io/rucio/rucio-dev.*;image: ${{ fromJSON(steps.images.outputs.images)[0] }};' \
               $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml
       - name: Start containers
-        run: docker compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile storage --profile externalmetadata --profile iam up -d
+        run: |
+          export DEV_PROFILES=storage,externalmetadata,iam
+          docker compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile storage --profile externalmetadata --profile iam up -d
       - name: Initialize tests
         shell: bash
         run: |

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
       - RUCIO_SOURCE_DIR=/rucio_source
       - RDBMS
+      - DEV_PROFILES
     depends_on:
       oracle:
         condition: service_healthy

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -1761,6 +1761,7 @@ def test_transfer_plugins(rse_factory, did_factory, root_account, file_config_mo
 
 @skip_rse_tests_with_accounts
 @pytest.mark.noparallel(groups=[NoParallelGroups.XRD, NoParallelGroups.SUBMITTER, NoParallelGroups.POLLER, NoParallelGroups.FINISHER])
+@pytest.mark.needs_iam
 @pytest.mark.parametrize("file_config_mock", [{
     "overrides": [('client', 'register_bittorrent_meta', 'true')]
 }], indirect=True)

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -1617,6 +1617,7 @@ def test_checksum_validation(rse_factory, did_factory, root_account):
 
 @pytest.mark.skip(reason="Pending https://cern.service-now.com/service-portal?id=ticket&table=incident&n=INC4506150")
 @skip_rse_tests_with_accounts
+@pytest.mark.needs_iam
 @pytest.mark.noparallel(groups=[NoParallelGroups.XRD, NoParallelGroups.SUBMITTER, NoParallelGroups.RECEIVER])
 @pytest.mark.parametrize("file_config_mock", [
     {"overrides": [('oidc', 'admin_issuer', 'indigoiam')]},

--- a/tests/test_reaper.py
+++ b/tests/test_reaper.py
@@ -498,6 +498,7 @@ def test_reaper_without_rse_usage(vo, caches_mock):
 
 @skip_rse_tests_with_accounts
 @pytest.mark.dirty(reason="leaves files in XRD containers")
+@pytest.mark.needs_iam
 @pytest.mark.noparallel(groups=[NoParallelGroups.WEB])
 @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
     'rucio.daemons.reaper.reaper.REGION'

--- a/tools/bootstrap_dev.sh
+++ b/tools/bootstrap_dev.sh
@@ -553,6 +553,13 @@ echo ">>> Using Docker images with RUCIO_TAG=\"$RUCIO_TAG\" and RUCIO_DEV_PREFIX
 export RUCIO_TAG="$RUCIO_TAG"
 export RUCIO_DEV_PREFIX="$RUCIO_DEV_PREFIX"
 
+# Export the DEV_PROFILES environment variable for containers
+if [[ "${#PROFILES[@]}" -gt 0 ]]; then
+  export DEV_PROFILES=$(IFS=,; echo "${PROFILES[*]}")
+else
+  export DEV_PROFILES=""
+fi
+
 cd "$RUCIO_REPO_ROOT/etc/docker/dev"
 
 # Build an array of '--profile' arguments if the user gave them


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Fixes #7933 

Most of our test suites (both locally and in CI) use profiles, I introduced a `DEV_PROFILES` variable to get the profiles while running the tests and skip tests with the markers that doesn't have the profile required to run the test while also warning the user about it. 

Only these three tests need IAM profiles:
```
-  test_conveyer::test_transfer_with_tokens
-  test_reaper::test_deletion_with_tokens
-  test_Conveyer::test_bittorrent_submission
```