### PR TITLE
CI: Enforce Conventional Commits using `commitlint` 

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,6 +9,7 @@ concurrency:
 jobs:
   commitlint:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,33 @@
+name: Commitlint
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Validate current commit (push)
+        if: github.event_name == 'push'
+        run: npx commitlint --from HEAD~1 --to HEAD --verbose
+
+      - name: Validate PR commits
+        if: github.event_name == 'pull_request'
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ tools/test.file.1G
 
 # VSCode
 .vscode/
+
+# Node.js dependencies for commitlint
+node_modules/
+package-lock.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,9 @@ repos:
   hooks:
     - id: ruff
       args: [ --fix ]
+- repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+  rev: v9.22.0
+  hooks:
+    - id: commitlint
+      stages: [commit-msg]
+      additional_dependencies: ['@commitlint/config-conventional@^19.8.1']

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,122 @@
+// NOTE: Any changes to this list should also be applied to the [GitHub labels](https://github.com/rucio/rucio/issues/labels) and the [documentation](https://rucio.cern.ch/documentation/contributing/)
+const rucioComponents = [
+  'Auth', // Authentication & Authorisation
+  'API', // REST & API
+  'CI', // Continuous Integration
+  'Clients',
+  'Consistency', // Consistency checks
+  'Core', // Core & Internals
+  'Containerization', // Docker, Kubernetes, and container-related functionality
+  'Database',
+  'DatasetDeletion', // Dataset deletion
+  'Deletion',
+  'DIRAC',
+  'Documentation',
+  'LifetimeModel', // Life time model
+  'Messaging',
+  'Metadata',
+  'Monitoring', // Monitoring, observability, and traces
+  'MultiVO', // Multi VO
+  'OpenData', // Open data
+  'Policies',
+  'Probes', // Probes & Alarms
+  'Protocols',
+  'Rebalancing',
+  'Recovery',
+  'Replicas',
+  'Rules',
+  'Subscriptions',
+  'Testing',
+  'Transfers',
+  'WebUI'
+];
+
+const rucioTypes = [
+  // Functional changes
+  'feat',     // New feature
+  'fix',      // Bug fix
+
+  // Non-functional changes
+  'docs',     // Documentation only changes
+  'style',    // Changes that do not affect the meaning of the code
+  'refactor', // Code change that neither fixes a bug nor adds a feature
+  'test',     // Adding missing tests or correcting existing tests
+  'ci',       // Changes to CI configuration files and scripts
+
+  // Miscellaneous
+  'revert',   // Reverts a previous commit
+];
+
+const gitTrailerPlugin = {
+  rules: {
+    'issue-trailer-required': (parsed, _when, _value) => {
+      const { body, footer } = parsed;
+      const fullMessage = [body, footer].filter(Boolean).join('\n');
+
+      if (!fullMessage) {
+        return [false, 'Commit message must include an issue-related Git trailer'];
+      }
+
+      // Issue-related trailer tokens (case-insensitive)
+      const issueTrailerTokens = [
+        'issue', 'closes'
+      ];
+
+      // Create pattern for issue-related trailers: "Token: Value" or "Token #Value"
+      const tokenPattern = issueTrailerTokens.join('|');
+      const issueTrailerPattern = new RegExp(`^(${tokenPattern})\\s*[:#]\\s*.+$`, 'im');
+
+      if (!issueTrailerPattern.test(fullMessage)) {
+        return [false, 'Commit message must include an issue-related Git trailer (e.g., "Issue: #123", "Closes: #456"). You can add a trailer using: git commit -m "message" --trailer "Issue: #123"'];
+      }
+
+      return [true];
+    },
+    'breaking-change-consistency': (parsed, _when, _value) => {
+      const { header = '', body, footer } = parsed;
+      const fullMessage = [body, footer].filter(Boolean).join('\n');
+
+      const headerHasBang = /^[^:]+!\s*:/.test(header);
+      const breakingChangeMatch = fullMessage.match(/^BREAKING CHANGE\s*:\s*(.*)$/im);
+      const hasBreakingFooter = Boolean(breakingChangeMatch);
+
+      if (headerHasBang && !hasBreakingFooter) {
+        return [false, 'Commit messages that use "!" must include a BREAKING CHANGE footer.'];
+      }
+
+      if (!headerHasBang && hasBreakingFooter) {
+        return [false, 'BREAKING CHANGE footer requires "!" in the commit header (e.g., "feat(API)!: ...").'];
+      }
+
+      if (hasBreakingFooter) {
+        const description = breakingChangeMatch[1].trim();
+        if (!description) {
+          return [false, 'BREAKING CHANGE footer must include a description (e.g., "BREAKING CHANGE: describe the impact").'];
+        }
+      }
+
+      return [true];
+    }
+  }
+};
+
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  plugins: [gitTrailerPlugin],
+  rules: {
+    'type-enum': [2, 'always', rucioTypes], // Require a valid type
+    'scope-enum': [2, 'always', rucioComponents], // Require a valid scope
+    'scope-case': [0], // Disable case checking since we use custom scopes
+    'scope-empty': [2, 'never'], // Scope is required
+    'subject-case': [0], // Disable subject case checking
+    'subject-empty': [2, 'never'], // Subject is required
+    'subject-full-stop': [2, 'never', '.'], // Subject should not end with a period
+    'header-max-length': [1, 'always', 100], // Warn about exceeding 100 characters
+    'body-max-line-length': [0], // Disable body line length limit
+    'body-leading-blank': [1, 'always'], // Body should start with a blank line
+    'footer-leading-blank': [1, 'always'], // Footer should start with a blank line
+    'issue-trailer-required': [2, 'always'], // Issue-related Git trailer is required
+    'breaking-change-consistency': [2, 'always'] // Ensure BREAKING CHANGE footer usage is consistent
+  },
+  helpUrl: 'https://rucio.cern.ch/documentation/contributing/'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "rucio-commitlint",
+  "version": "1.0.0",
+  "description": "Rucio project commitlint configuration",
+  "devDependencies": {
+    "@commitlint/cli": "^19.8.1",
+    "@commitlint/config-conventional": "^19.8.1"
+  },
+  "scripts": {
+    "commitlint": "commitlint --from HEAD~1 --to HEAD --verbose"
+  }
+}


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Fixes #7945 

I am using [commitlint](https://commitlint.js.org/) as a linter for our commit messages to enforce conventional commits. It is widely used in the community and [is properly maintained](https://github.com/conventional-changelog/commitlint). It also offers a pre-commit hook to enable it locally. 

We are using this format: `<type>(<scope>): <description>` 

eg. `feat(Core): Add new rule evaluation engine`

I've added some types based on the types used in [standardized conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). 
The scope is based on the available labels in rucio and is taken from what the [rucio's contributing guide](https://rucio.github.io/documentation/contributing/) mentions. 

These are the rules that i am enforcing through this:
1. **Type**: Must be one of the allowed types listed above
2. **Scope**: Must be one of the predefined Rucio components (PascalCase)
3. **Description**: 
   - Should not end with a period
   - Should be concise but descriptive
4. **Issue Number**: Must reference a GitHub issue using [git-trailer](https://alchemists.io/articles/git_trailers) with `#<number>`
     - In order to add a git trailer, you need to commit using `git commit -m "chore(client): fix xyz" --trailer "Closes: #Issue Number"`
     - Only `closes` and `issue` trailer are currently supported. 
     - Note: You can also add a git-trailer by just adding the line at the end of the commit body
     
5. **Line Length**: Header must not exceed 100 characters (This prevents commit titles from being truncated in the GitHub UI. Additional details can always be included in the commit body. )

Attaching screenshot of how it works: 
<img width="1501" height="785" alt="image" src="https://github.com/user-attachments/assets/ad034dbf-a5a1-462c-b490-aba859dd9fe0" />

Note: The only drawback I can foresee is that commitlint is written in JavaScript, while Rucio is a Python-heavy project. To use this tool, we would need to maintain a small JavaScript configuration and install it via npm, which requires maintaining a package.json file.