### PR TITLE
Replicas: Skip if there are no replicas to quarantine - Fix #7943

### DIFF
--- a/lib/rucio/core/quarantined_replica.py
+++ b/lib/rucio/core/quarantined_replica.py
@@ -75,7 +75,9 @@ def add_quarantined_replicas(rse_id: str, replicas: list[dict[str, Any]], *, ses
     )
     quarantine_replicas = [(path, rseid) for path, rseid in session.execute(stmt).all()]
     replicas = [replica for replica in replicas if (replica['path'], rse_id) not in quarantine_replicas]
-
+    if not replicas:
+        return
+    
     values = [{'rse_id': rse_id,
                'path': replica['path'],
                'scope': replica.get('scope'),


### PR DESCRIPTION
A very simple patch to avoid database exceptions. The database exception is that RSE ID is null in the case where there are no new replicas to quarantine.
