### PR TITLE
Add a `config update` method, restrict `config add` to new fields

### DIFF
--- a/lib/rucio/cli/command.py
+++ b/lib/rucio/cli/command.py
@@ -69,7 +69,7 @@ class LazyGroup(click.Group):
     def invoke(self, ctx: click.Context):
         result = self._invoke_with_handler(ctx)
         if result not in (None, 0):
-            sys.exit(1 if result != 2 else 2)
+            sys.exit(1 if result != 2 else 1)
         return result
 
 

--- a/lib/rucio/cli/command.py
+++ b/lib/rucio/cli/command.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import importlib
 import signal
+import sys
 import time
 
 import click
@@ -60,6 +61,16 @@ class LazyGroup(click.Group):
         if not isinstance(cmd_object, click.BaseCommand):
             raise ValueError(f"Lazy loading of {import_path} failed by returning " "a non-command object")
         return cmd_object
+
+    @exception_handler
+    def _invoke_with_handler(self, ctx: click.Context):
+        return super().invoke(ctx)
+
+    def invoke(self, ctx: click.Context):
+        result = self._invoke_with_handler(ctx)
+        if result not in (None, 0):
+            sys.exit(1 if result != 2 else 2)
+        return result
 
 
 @click.group(
@@ -146,33 +157,32 @@ class LazyGroup(click.Group):
 @click.version_option(version.version_string(), message="%(prog)s %(version)s")
 # Hidden options at the end
 @click.option("--no-pager", is_flag=True, default=False, hidden=True)
-@exception_handler
 @click.pass_context
 def main(
-    ctx,
-    config,
-    verbose,
-    host,
-    auth_host,
-    issuer,
-    auth_strategy,
-    timeout,
-    user_agent,
-    vo,
-    no_pager,
-    user,
-    password,
-    oidc_user,
-    oidc_password,
-    oidc_scope,
-    oidc_audience,
-    oidc_auto,
-    oidc_polling,
-    oidc_refresh_lifetime,
-    oidc_issuer,
-    certificate,
-    client_key,
-    ca_certificate,
+    ctx: click.Context,
+    config: str,
+    verbose: bool,
+    host: str,
+    auth_host: str,
+    issuer: str,
+    auth_strategy: str,
+    timeout: float,
+    user_agent: str,
+    vo: str,
+    no_pager: bool,
+    user: str,
+    password: str,
+    oidc_user: str,
+    oidc_password: str,
+    oidc_scope: str,
+    oidc_audience: str,
+    oidc_auto: str,
+    oidc_polling: str,
+    oidc_refresh_lifetime: str,
+    oidc_issuer: str,
+    certificate: str,
+    client_key: str,
+    ca_certificate: str,
 ):
     ctx.ensure_object(Arguments)
     ctx.obj.start_time = time.time()

--- a/lib/rucio/cli/command.py
+++ b/lib/rucio/cli/command.py
@@ -69,7 +69,7 @@ class LazyGroup(click.Group):
     def invoke(self, ctx: click.Context):
         result = self._invoke_with_handler(ctx)
         if result not in (None, 0):
-            sys.exit(1 if result != 2 else 1)
+            sys.exit(1 if result != 2 else 2)
         return result
 
 

--- a/lib/rucio/cli/config.py
+++ b/lib/rucio/cli/config.py
@@ -27,7 +27,7 @@ def config():
 @click.option("-s", "--section", help="Filter by sections")
 @click.option("-k", "--key", help="Show key's value, section required.")
 @click.pass_context
-def list_(ctx, section, key):
+def list_(ctx: click.Context, section: str, key: str):
     """List the sections or content of sections in the rucio.cfg"""
     get_config(Arguments({"no_pager": ctx.obj.no_pager, "section": section, "key": key}), ctx.obj.client, ctx.obj.logger, ctx.obj.console, ctx.obj.spinner)
 
@@ -37,7 +37,7 @@ def list_(ctx, section, key):
 @click.option('--key', help='Attribute key', required=True)
 @click.option('--value', help='Attribute value', required=True)
 @click.pass_context
-def add_(ctx, section, key, value):
+def add_(ctx: click.Context, section: str, key: str, value: str):
     """
     Add a new key/value to a section.
 
@@ -59,7 +59,7 @@ def add_(ctx, section, key, value):
 @click.option("-s", "--section", help="Section", required=True)
 @click.option("-k", "--key", help="Key in section", required=True)
 @click.pass_context
-def remove(ctx, section, key):
+def remove(ctx: click.Context, section: str, key: str):
     """Remove the section.key from the config."""
     args = Arguments({"no_pager": ctx.obj.no_pager, "section": section, "option": key})
     delete_config_option(args, ctx.obj.client, ctx.obj.logger, ctx.obj.console, ctx.obj.spinner)
@@ -76,7 +76,7 @@ def show(ctx):
 @click.option("-k", "--key", help='Attribute key', required=True)
 @click.option("-v", "--value", help='Attribute value', required=True)
 @click.pass_context
-def update(ctx, section: str, key: str, value: str):
+def update(ctx: click.Context, section: str, key: str, value: str):
     """Modify an existing command"""
     has_option = ctx.obj.client.get_config().get(section, {}).get(key) is not None
     if has_option:

--- a/lib/rucio/cli/config.py
+++ b/lib/rucio/cli/config.py
@@ -14,10 +14,11 @@
 import click
 
 from rucio.cli.bin_legacy.rucio_admin import delete_config_option, get_config, set_config_option
-from rucio.cli.utils import Arguments
+from rucio.cli.utils import Arguments, exception_handler
 
 
 @click.group()
+@exception_handler
 def config():
     "Modify the configuration table"
 
@@ -32,7 +33,6 @@ def list_(ctx, section, key):
     get_config(Arguments({"no_pager": ctx.obj.no_pager, "section": section, "key": key}), ctx.obj.client, ctx.obj.logger, ctx.obj.console, ctx.obj.spinner)
 
 
-# TODO Change to only add new fields and cannot modify an existing field
 @config.command("add")
 @click.option("-s", "--section", help="Section name", required=True)
 @click.option('--key', help='Attribute key', required=True)
@@ -46,6 +46,13 @@ def add_(ctx, section, key, value):
     Example, Add a key to an existing section:
         $ rucio config add --section my-section --key key --value value
     """
+    has_option = ctx.obj.client.get_config().get(section, {}).get(key) is not None
+    print(has_option)
+    if has_option:
+        msg = f"Config already has field {section}: {key}, please use \n\
+            rucio config update --section {section} --key {key} --value {value}"
+        raise ValueError(msg)
+
     args = Arguments({"no_pager": ctx.obj.no_pager, "section": section, "option": key, "value": value})
     set_config_option(args, ctx.obj.client, ctx.obj.logger, ctx.obj.console, ctx.obj.spinner)
 
@@ -66,7 +73,17 @@ def show(ctx):
     """Show a single sections options"""
 
 
-# TODO Change this so that it only modifies existing fields
-def update():
+@config.command("update")
+@click.option("-s", "--section", required=True)
+@click.option("-k", "--key", help='Attribute key', required=True)
+@click.option("-v", "--value", help='Attribute value', required=True)
+@click.pass_context
+def update(ctx, section: str, key: str, value: str):
     """Modify an existing command"""
-    pass
+    has_option = ctx.obj.client.get_config().get(section, {}).get(key) is not None
+    if has_option:
+        ctx.obj.client.set_config_option(section, key, value)
+    else:
+        msg = f"{section} {key} not present. Please use \n\
+            rucio config add --section {section} --key {key} --value {value}"
+        raise ValueError(msg)

--- a/lib/rucio/cli/config.py
+++ b/lib/rucio/cli/config.py
@@ -14,11 +14,10 @@
 import click
 
 from rucio.cli.bin_legacy.rucio_admin import delete_config_option, get_config, set_config_option
-from rucio.cli.utils import Arguments, exception_handler
+from rucio.cli.utils import Arguments
 
 
 @click.group()
-@exception_handler
 def config():
     "Modify the configuration table"
 
@@ -47,7 +46,6 @@ def add_(ctx, section, key, value):
         $ rucio config add --section my-section --key key --value value
     """
     has_option = ctx.obj.client.get_config().get(section, {}).get(key) is not None
-    print(has_option)
     if has_option:
         msg = f"Config already has field {section}: {key}, please use \n\
             rucio config update --section {section} --key {key} --value {value}"

--- a/lib/rucio/cli/utils.py
+++ b/lib/rucio/cli/utils.py
@@ -57,6 +57,14 @@ def exception_handler(function):
     def new_funct(*args, **kwargs):
         try:
             return function(*args, **kwargs)
+        except click.exceptions.Exit:
+            # Exit is evoked every time click ends a program without running anything
+            # This error is raised when the help menu is called
+            logger.debug("Exited click context")
+            if ("-h" in sys.argv) or ("--help" in sys.argv):
+                return SUCCESS
+            else:
+                return FAILURE
         except InputValidationError as error:
             logger.error(error)
             logger.debug("This means that one you provided an invalid combination of parameters, or incorrect types. Please check the command help (-h/--help).")
@@ -170,10 +178,10 @@ def get_client(args, logger):
                 auth_type = config_get("client", "auth_type").lower()
             except (NoOptionError, NoSectionError):
                 logger.error("Cannot get AUTH_TYPE")
-                sys.exit(1)
+                raise
     else:
         auth_type = args.auth_strategy.lower()
-
+    print("Setting Creds")
     if auth_type in ["userpass", "saml"] and args.username is not None and args.password is not None:
         creds = {"username": args.username, "password": args.password}
     elif auth_type == "oidc":

--- a/lib/rucio/cli/utils.py
+++ b/lib/rucio/cli/utils.py
@@ -61,10 +61,9 @@ def exception_handler(function):
             # Exit is evoked every time click ends a program without running anything
             # This error is raised when the help menu is called
             logger.debug("Exited click context")
-            if ("-h" in sys.argv) or ("--help" in sys.argv):
-                return SUCCESS
-            else:
+            if ("-h" not in sys.argv) or ("--help" not in sys.argv):
                 return FAILURE
+            return SUCCESS
         except InputValidationError as error:
             logger.error(error)
             logger.debug("This means that one you provided an invalid combination of parameters, or incorrect types. Please check the command help (-h/--help).")
@@ -178,10 +177,10 @@ def get_client(args, logger):
                 auth_type = config_get("client", "auth_type").lower()
             except (NoOptionError, NoSectionError):
                 logger.error("Cannot get AUTH_TYPE")
-                raise
+                sys.exit(1)
     else:
         auth_type = args.auth_strategy.lower()
-    print("Setting Creds")
+
     if auth_type in ["userpass", "saml"] and args.username is not None and args.password is not None:
         creds = {"username": args.username, "password": args.password}
     elif auth_type == "oidc":

--- a/lib/rucio/cli/utils.py
+++ b/lib/rucio/cli/utils.py
@@ -57,14 +57,19 @@ def exception_handler(function):
     def new_funct(*args, **kwargs):
         try:
             return function(*args, **kwargs)
-        except click.exceptions.Exit:
+        except click.exceptions.Exit as error:
             # Exit is evoked every time click ends a program without running anything
             # This error is raised when the help menu is called
             logger.debug("Exited click context")
             if ("-h" not in sys.argv) or ("--help" not in sys.argv):
-                return FAILURE
+                return error.exit_code
             return SUCCESS
-        except InputValidationError as error:
+        except click.MissingParameter as error:
+            error.show()
+            msg = f"{error}. Please check the command help (-h/--help)."
+            logger.error(msg)
+            return 2  # Always return an error 2 for an incorrect specification
+        except (InputValidationError, click.exceptions.UsageError) as error:
             logger.error(error)
             logger.debug("This means that one you provided an invalid combination of parameters, or incorrect types. Please check the command help (-h/--help).")
             return FAILURE

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -184,7 +184,7 @@ def test_account_identities(rucio_client):
 
     cmd = f"rucio account identity add --account {tmp_account} --type NotAType --email {email} --id {email}"
     exitcode, _, _ = execute(cmd)
-    assert exitcode == 2  # Fails with the argparse validation
+    assert exitcode == 1
 
 
 def test_account_limit(jdoe_account, rucio_client):
@@ -209,7 +209,7 @@ def test_account_limit(jdoe_account, rucio_client):
 
     cmd = f"rucio account limit add {jdoe_account} --rse {mock_rse} --bytes {bytes_limit} --locality NotAnOption"
     exitcode, _, _ = execute(cmd)
-    assert exitcode == 2  # Fails bc locality is limited to local or global
+    assert exitcode == 1  # Fails bc locality is limited to local or global
 
 
 @pytest.mark.noparallel("Changes config settings")

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -518,11 +518,11 @@ class TestOpenDataCLI:
 
         exitcode, stdout, stderr = execute(f"rucio opendata did add {mock_scope}:{name}")
         assert exitcode == 1, f"Expected failure when adding bad DID: {stderr.strip()}"
-        assert "DataIdentifierNotFound" in stderr, "Expected 'DataIdentifierNotFound' error in output"
+        assert "Data identifier not found" in stderr
 
         exitcode, stdout, stderr = execute(f"rucio opendata did remove {mock_scope}:{name}")
         assert exitcode == 1, f"Expected failure when removing unregistered DID: {stderr.strip()}"
-        assert "OpenDataDataIdentifierNotFound" in stderr, "Expected 'OpenDataDataIdentifierNotFound' error in output"
+        assert "Data identifier not found in the open data catalog" in stderr
 
         exitcode, _, stderr = execute(f"rucio did add --type dataset {mock_scope}:{name}")
         assert exitcode == 0, f"Failed to add dataset: {stderr.strip()}"
@@ -532,7 +532,7 @@ class TestOpenDataCLI:
 
         exitcode, stdout, stderr = execute(f"rucio opendata did add {mock_scope}:{name}")
         assert exitcode == 1, f"Expected failure when adding existing opendata DID: {stderr.strip()}"
-        assert "OpenDataDataIdentifierAlreadyExists" in stderr, "Expected 'OpenDataDataIdentifierAlreadyExists' error in output"
+        assert "Data identifier already exists in the open data catalog" in stderr
 
         exitcode, _, stderr = execute(f"rucio opendata did show {mock_scope}:{name}")
         assert exitcode == 0, f"Failed to show opendata DID: {stderr.strip()}"


### PR DESCRIPTION
Closes #7977 

Also changes the error handler routing, the exceptions raised by the new `update` and `add` methods were not being handled due to the lazy loading. 