### PR TITLE
WebUI: Add dataset size to rules page #7937

### DIFF
--- a/lib/rucio/web/ui/flask/templates/list_rules.html
+++ b/lib/rucio/web/ui/flask/templates/list_rules.html
@@ -102,8 +102,8 @@
     <div id="loader"></div>
     <div id="results_panel" style="visibility:false;">
       <table id="resulttable" class="compact stripe order-column" style="word-wrap: break-word;">
-        <thead><tr><th>Name</th><th>Account</th><th>RSE Expression</th><th>Creation Date</th><th>Remaining Lifetime</th><th>State</th><th>Locks OK</th><th>Locks Replicating</th><th>Locks Stuck</th></tr></thead>
-        <tfoot><tr><th>Name</th><th>Account</th><th>RSE Expression</th><th>Creation Date</th><th>Remaining Lifetime</th><th>State</th><th>Locks OK</th><th>Locks Replicating</th><th>Locks Stuck</th></tr></tfoot>
+        <thead><tr><th>Name</th><th>Account</th><th>RSE Expression</th><th>Creation Date</th><th>Remaining Lifetime</th><th>State</th><th>Size</th><th>Locks OK</th><th>Locks Replicating</th><th>Locks Stuck</th></tr></thead>
+        <tfoot><tr><th>Name</th><th>Account</th><th>RSE Expression</th><th>Creation Date</th><th>Remaining Lifetime</th><th>State</th><th>Size</th><th>Locks OK</th><th>Locks Replicating</th><th>Locks Stuck</th></tr></tfoot>
     </table>
     </div>
     </br>

--- a/lib/rucio/web/ui/static/list_rules.js
+++ b/lib/rucio/web/ui/static/list_rules.js
@@ -139,6 +139,7 @@ get_rules = function(account, rse, activity, state, created_before, created_afte
                 if (value.state == 'INJECT') {
                     value.state = '<font color="pink">' + value.state + '</font>';
                 }
+                value.size = value.bytes != null ? filesize(value.bytes, {'base': 10}) : 'N/A';
 
                 value.created_at = new Date(value.created_at).toISOString();
                 filtered_data.push(value);
@@ -168,9 +169,10 @@ get_rules = function(account, rse, activity, state, created_before, created_afte
                           {'data': 'created_at', width: '10%'},
                           {'data': 'lifetime', width: '7%'},
                           {'data': 'state', width: '10%'},
-                          {'data': 'locks_ok_cnt', width: '5%'},
-                          {'data': 'locks_replicating_cnt', width: '7%'},
-                          {'data': 'locks_stuck_cnt', width: '6%'}]
+                          {'data': 'size', width: '5%'},
+                          {'data': 'locks_ok_cnt', width: '4%'},
+                          {'data': 'locks_replicating_cnt', width: '5%'},
+                          {'data': 'locks_stuck_cnt', width: '4%'}]
             });
             $("#selectall").html("<a class=\"button small\" id=\"selectall_button\">Select all</a>");
             $("#delete").html("<a class=\"alert button tiny\" id=\"delete_button\">Delete rule(s)</a>");


### PR DESCRIPTION
This comes with some known limitations, notably:

  1. The DID of the rule must be closed for its volume to be populated (limitation in the Rucio core layer).
  2. The sorting of the column will not work due to its content being a string (limitation in the DataTables library).

The three columns related to locks were reduced in width to make up for the additional column.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
