### PR TITLE
Documentation: fix small typo, likely-hood -> likelihood

### DIFF
--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1513,7 +1513,7 @@ class TransferStatsManager:
     def __enter__(self) -> "TransferStatsManager":
         self.record_stats = config_get_bool('transfers', 'stats_enabled', default=self.record_stats)
         downsample_period = config_get_int('transfers', 'stats_downsample_period', default=self.downsample_period)
-        # Introduce some voluntary jitter to reduce the likely-hood of performing this database
+        # Introduce some voluntary jitter to reduce the likelihood of performing this database
         # operation multiple times in parallel.
         self.downsample_period = random.randint(downsample_period * 3 // 4, math.ceil(downsample_period * 5 / 4))  # noqa: S311
         if self.record_stats:


### PR DESCRIPTION
> likelyhood (obsolete, now a misspelling)
> - https://en.wiktionary.org/wiki/likelihood

Super small change for a PR, but I noticed while doing a PR in the docs repo and so I couldn't bundle those changes with this PR