### PR TITLE
API: use different docstring tags for `Opendata` and `Opendata Public`

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/opendata.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata.py
@@ -128,7 +128,7 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
         ---
         summary: Get Opendata DID Information
         description: "Retrieves detailed Opendata information for the given scope and name. Supports optional query parameters to control the inclusion of files, metadata, and DOI information."
-        Tags:
+        tags:
           - Opendata
         parameters:
           - name: scope

--- a/lib/rucio/web/rest/flaskapi/v1/opendata_public.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata_public.py
@@ -27,7 +27,7 @@ class OpenDataPublicView(ErrorHandlingMethodView):
         summary: List Opendata DIDs marked as public
         description: "Retrieves a list of public Opendata Data Identifiers (DIDs). Supports optional query parameters for pagination."
         tags:
-          - Opendata
+          - Opendata Public
         parameters:
           - name: limit
             in: query
@@ -66,8 +66,8 @@ class OpenDataPublicDIDsView(ErrorHandlingMethodView):
         ---
         summary: Get Opendata DID Information for public Opendata DIDs
         description: "Retrieves detailed Opendata information for the given scope and name. Only works for public opendata DIDs. Supports optional query parameters to control the inclusion of files, metadata, and DOI information."
-        Tags:
-          - Opendata
+        tags:
+          - Opendata Public
         parameters:
           - name: scope
             in: path


### PR DESCRIPTION
Closes #8018

I tested by building docs pointing to this branch of Rucio and the two endpoints are correctly display.

<img width="512" height="1650" alt="image" src="https://github.com/user-attachments/assets/e7f742bd-aff7-4def-b653-9826a3160cac" />

As a comment I think it would be nice to have some kind of ordering (`Opendata` and `Opendata Public` should be together), but its unrelated to this PR.

