### PR TITLE
Clients: Support rich client and table output for opendata CLI

### DIFF
--- a/lib/rucio/cli/opendata.py
+++ b/lib/rucio/cli/opendata.py
@@ -81,17 +81,14 @@ def list_opendata_dids(ctx: "Context", state: Optional["OPENDATA_DID_STATE_LITER
         else:
             table_data.append([f"{did['scope']}:{did['name']}", did['state']])
 
-    if cli_config == 'rich':
-        if short:
-            table = generate_table([[did] for did, _ in table_data], headers=['SCOPE:NAME'], col_alignments=['left'])
-        else:
-            table = generate_table(table_data, headers=['SCOPE:NAME', '[STATE]'], col_alignments=['left', 'left'])
-        spinner.stop()
-        print_output(table, console=ctx.obj.console, no_pager=ctx.obj.no_pager)
+    if short:
+        for did, _ in table_data:
+            print(did)
     else:
-        if short:
-            for did, _ in table_data:
-                print(did)
+        if cli_config == 'rich':
+            table = generate_table(table_data, headers=['SCOPE:NAME', '[STATE]'], col_alignments=['left', 'left'])
+            spinner.stop()
+            print_output(table, console=ctx.obj.console, no_pager=ctx.obj.no_pager)
         else:
             print(tabulate(table_data, tablefmt="psql", headers=['SCOPE:NAME', '[STATE]']))
 

--- a/lib/rucio/client/richclient.py
+++ b/lib/rucio/client/richclient.py
@@ -131,6 +131,12 @@ class CLITheme:
         'SERVICE': 'yellow'
     }
 
+    OPENDATA_DID_STATE = {
+        'PUBLIC': 'bold green',
+        'DRAFT': 'bold default',
+        'SUSPENDED': 'bold red',
+    }
+
 
 def setup_rich_logger(
     module_name: Optional[str] = None,

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -494,7 +494,7 @@ class TestOpenDataCLI:
 
     @pytest.mark.parametrize("subcommand, expected_options", [
         ("add", {"--help"}),
-        ("list", {"--help", "--state", "--public"}),
+        ("list", {"--help", "--state", "--public", "--short"}),
         ("show", {"--help", "--meta", "--files", "--public"}),
         ("update", {"--help", "--meta", "--state", "--doi"}),
         ("remove", {"--help"}),


### PR DESCRIPTION
Closes #8023.

Add table and rich client support to `opendata did show` and `opendata did list` cli commands.

The did code where I got inspiration from defines the logic in `bin_legacy`. I decided to put the code in `cli`. Let me know if you think I should arrange things differently.

Example with rich client:

<img width="696" height="322" alt="Screenshot 2025-09-16 at 16 25 29" src="https://github.com/user-attachments/assets/e0d222e2-0fcd-41d8-93a1-28a8d4591ebc" />

Example without rich client:

<img width="670" height="291" alt="Screenshot 2025-09-16 at 16 26 06" src="https://github.com/user-attachments/assets/2a139444-f7f9-4e5f-b15b-19225bff3749" />

new `short` option without rich client:

```
❯ rucio opendata did list --short
demo:demo-1
```

new `short` option with rich client:

```
❯ rucio opendata did list --short
┌─────────────┐
│ SCOPE:NAME  │
├─────────────┤
│ demo:demo-1 │
└─────────────┘
```

(is this last one supposed to like like this?)
