### PR TITLE
Opendata did add also adds rule if configured

### DIFF
--- a/lib/rucio/client/opendataclient.py
+++ b/lib/rucio/client/opendataclient.py
@@ -162,7 +162,7 @@ class OpenDataClient(BaseClient):
             state: Optional["OPENDATA_DID_STATE_LITERAL"] = None,
             meta: Optional[dict] = None,
             doi: Optional[str] = None,
-    ) -> bool:
+    ) -> dict[str, Any]:
         """
         Update an existing Opendata DID in the Opendata catalog.
 
@@ -201,7 +201,7 @@ class OpenDataClient(BaseClient):
         r = self._send_request(url, type_='PUT', data=render_json(**data))
 
         if r.status_code == codes.ok:
-            return True
+            return json.loads(r.content.decode('utf-8'))
         else:
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -321,7 +321,7 @@ def get_opendata_did(
         session: SQLAlchemy session to use for the query.
 
     Returns:
-        A dictionary containing metadata about the specified DID.
+        A dictionary containing info about the specified DID which include "scope", "name", "state", "meta" (if requested), etc.
     """
 
     query = select(
@@ -528,6 +528,9 @@ def update_opendata_did(
         doi: DOI to associate with the DID. Must be a valid DOI string (e.g., "10.1234/foo.bar").
         session: SQLAlchemy session to use for the operation.
 
+    Returns:
+        A dictionary containing the scope and name of the DID and details of the updates performed. (e.g., new/old state, new/old DOI, etc.)
+
     Raises:
         InputValidationError: If none of 'state', 'meta', or 'doi' are provided, or if the provided data is invalid.
         OpenDataDataIdentifierNotFound: If the Opendata DID does not exist.
@@ -554,6 +557,7 @@ def update_opendata_did(
 
     return result
 
+
 def update_opendata_meta(
         *,
         scope: "InternalScope",
@@ -569,6 +573,9 @@ def update_opendata_meta(
         name: The name of the Opendata DID.
         meta: Metadata to update for the DID. Must be a valid JSON object or string.
         session: SQLAlchemy session to use for the operation.
+
+    Returns:
+        A dictionary containing the scope, name, and updated metadata of the Opendata DID.
 
     Raises:
         InputValidationError: If 'meta' is not a dictionary or a valid JSON string.
@@ -609,7 +616,7 @@ def update_opendata_meta(
     except DataError as error:
         raise exception.InputValidationError(f"Invalid data: {error}")
 
-    return {"scope": scope, "name": name, "meta": meta}
+    return {"scope": scope, "name": name, "meta_new": meta}
 
 
 def _fetch_opendata_rule(scope: "InternalScope",
@@ -715,7 +722,7 @@ def update_opendata_state(
         session: SQLAlchemy session to use for the operation.
 
     Returns:
-        A dictionary with the scope and name of the DID and the rule id if a rule was created.
+        A dictionary with the scope and name of the DID and the rule id if a rule was created and the old and new state.
 
     Raises:
         InputValidationError: If the provided state is not a valid OpenDataDIDState.
@@ -819,6 +826,9 @@ def update_opendata_doi(
         doi: The new DOI to associate with the Opendata DID. Must be a valid DOI string.
         session: SQLAlchemy session to use for the operation.
 
+    Returns:
+        A dictionary containing the scope, name, new DOI, and previous DOI of the Opendata DID.
+
     Raises:
         InputValidationError: If the provided DOI is not a valid string or does not match the expected format.
         OpenDataDataIdentifierNotFound: If the Opendata DID does not exist.
@@ -860,4 +870,4 @@ def update_opendata_doi(
     except DataError as error:
         raise exception.InputValidationError(f"Invalid data: {error}")
 
-    return {"scope": scope, "name": name, "doi_new": doi, "doi_previous": doi_before}
+    return {"scope": scope, "name": name, "doi_new": doi, "doi_old": doi_before}

--- a/lib/rucio/gateway/opendata.py
+++ b/lib/rucio/gateway/opendata.py
@@ -151,7 +151,7 @@ def update_opendata_did(
         meta: Optional[dict] = None,
         doi: Optional[str] = None,
         vo: str = DEFAULT_VO,
-) -> None:
+) -> dict[str, Any]:
     """
     Update an existing Opendata DID in the Opendata catalog.
 
@@ -164,7 +164,7 @@ def update_opendata_did(
         vo: The virtual organization.
 
     Returns:
-        None
+        A dictionary containing the scope and name of the DID and details of the updates performed. (e.g., new/old state, new/old DOI, etc.)
 
     Raises:
         ValueError: If meta is a string and cannot be parsed as valid JSON.

--- a/lib/rucio/web/rest/flaskapi/v1/opendata.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata.py
@@ -310,7 +310,7 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
             state = param_get(parameters, 'state', default=None)
             meta = param_get(parameters, 'meta', default=None)
             doi = param_get(parameters, 'doi', default=None)
-            opendata.update_opendata_did(scope=scope,
+            result = opendata.update_opendata_did(scope=scope,
                                          name=name,
                                          state=state,
                                          meta=meta,
@@ -324,7 +324,7 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
         except Exception as error:
             return generate_http_error_flask(400, error)
 
-        return Response(status=200, mimetype='application/json')
+        return Response(status=200, mimetype='application/json', response=render_json(**result))
 
     def delete(self, scope: str, name: str) -> "Response":
         """


### PR DESCRIPTION
Closes #8031 

This PR adds improved output to `rucio did opendata update` and introduces the optional functionality of adding a rule when making an opendata did public.

The rule is controlled via the server rucio config (I will update the documentation page when this is merged).