### PR TITLE
test(Authentication & Authorisation): Establish OIDC integration testing infrastructure with BaseClient support #7969

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -148,6 +148,9 @@ jobs:
             pip install --no-cache-dir -e /rucio_source
             tools/run_tests.sh -ir
           "
+      
+      - name: Test OIDC Integration 
+        run: docker exec -t dev-rucio-1 tools/pytest.sh -v --tb=short -m integration tests/test_oidc_with_keycloak.py tests/test_baseclient_with_keycloak.py
       - name: File Upload/Download Test
         run: docker exec -t dev-rucio-1 tools/pytest.sh -v --tb=short tests/test_rucio_server.py
       - name: UploadClient Test

--- a/etc/docker/dev/docker-compose.ports.yml
+++ b/etc/docker/dev/docker-compose.ports.yml
@@ -84,3 +84,7 @@ services:
   indigoiam-login-service:
     ports:
       - "127.0.0.1:8090:8090"
+  keycloak:
+    ports:
+      - "127.0.0.1:8082:8080"  # Keycloak HTTP - avoids 8080 (graphite) and 8081
+      - "127.0.0.1:8445:8443"  # Keycloak HTTPS - avoids 8443 (rucio) and 8444

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -545,7 +545,7 @@ services:
   keycloak:
     container_name: dev-keycloak-1
     image: quay.io/keycloak/keycloak:23.0.1
-    command: start-dev --features=token-exchange,admin-fine-grained-authz,dynamic-scopes --db mariadb --db-url-host iam-db --db-username keycloak --db-password secret --https-certificate-file=/cert.pem --https-certificate-key-file=/key.pem
+    command: start-dev --features=token-exchange,admin-fine-grained-authz,dynamic-scopes --db mariadb --db-url-host iam-db --db-username keycloak --db-password secret --https-certificate-file=/cert.pem --https-certificate-key-file=/key.pem --health-enabled=true --import-realm
     profiles:
       - iam
     environment:
@@ -555,6 +555,7 @@ services:
       - ../../certs/rucio_ca.pem:/etc/grid-security/certificates/5fca1cb1.0:z
       - ../../certs/hostcert_keycloak.pem:/cert.pem:z
       - ../../certs/hostcert_keycloak.key.pem:/key.pem:z
+      - ./iam/rucio-test-realm.json:/opt/keycloak/data/import/rucio-test-realm.json:ro
     depends_on:
       iam-db:
         condition: service_healthy

--- a/etc/docker/dev/iam/rucio-test-realm.json
+++ b/etc/docker/dev/iam/rucio-test-realm.json
@@ -1,0 +1,35 @@
+{
+  "realm": "rucio-test",
+  "enabled": true,
+  "accessTokenLifespan": 3600,
+  "refreshTokenMaxReuse": 1,
+  "clients": [
+    {
+      "clientId": "rucio-test-client",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "rucio-test-secret",
+      "publicClient": false,
+      "redirectUris": [
+        "http://dev-keycloak-1:*/auth/oidc_token",
+        "http://dev-keycloak-1:*/auth/oidc_code"
+      ],
+      "standardFlowEnabled": true,
+      "serviceAccountsEnabled": true,
+      "directAccessGrantsEnabled": true
+    }
+  ],
+  "users": [
+    {
+      "username": "testuser",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "testpass123",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/etc/docker/dev/rucio/idpsecrets.json
+++ b/etc/docker/dev/rucio/idpsecrets.json
@@ -2,11 +2,31 @@
   "indigoiam": {
     "client_id": "85e6f7a5-580b-4a1c-a6d2-39055143063d",
     "client_secret": "AIYIneAVGs9PTVvQnxNGqDmh3rNTsyFOrrwRIqy1Zc6ngPN9hQe6I2VzDzN2uGLCPsvQI8nhYxf_V09NHk-yv7o",
-    "issuer": "https://indigoiam/"
+    "issuer": "https://indigoiam/",
+    "redirect_uris": ["https://rucio/auth/oidc_token", "https://rucio/auth/oidc_code"],
+    "SCIM": {
+      "client_id": "scim-client-id",
+      "client_secret": "scim-client-secret"
+    }
   },
   "keycloak": {
-    "client_id": "rucio",
-    "client_secret": "DzmZKUfTsGz9bynGIp1gSwI5xen5ce8b",
-    "issuer": "https://keycloak:8443/realms/ruciodev/protocol/openid-connect/"
+    "client_id": "rucio-test-client",
+    "client_secret": "rucio-test-secret",
+    "issuer": "http://dev-keycloak-1:8080/realms/rucio-test",
+    "redirect_uris": ["https://rucio/auth/oidc_token", "https://rucio/auth/oidc_code"],
+    "SCIM": {
+      "client_id": "rucio-test-client",
+      "client_secret": "rucio-test-secret"
+    }
+  },
+  "http://dev-keycloak-1:8080/realms/rucio-test": {
+    "client_id": "rucio-test-client", 
+    "client_secret": "rucio-test-secret",
+    "issuer": "http://dev-keycloak-1:8080/realms/rucio-test",
+    "redirect_uris": ["https://rucio/auth/oidc_token", "https://rucio/auth/oidc_code"],
+    "SCIM": {
+      "client_id": "rucio-test-client",
+      "client_secret": "rucio-test-secret"
+    }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,9 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line('markers', 'dirty: marks test as dirty, i.e. tests are leaving structures behind')
     config.addinivalue_line('markers', 'noparallel(reason, groups): marks test being unable to run in parallel to other tests')
     config.addinivalue_line('markers', 'needs_iam: requires the dev iam profile (OIDC/IdP)')
+    config.addinivalue_line('markers', 'debug: marks test for debugging/branch coverage purposes')
+    config.addinivalue_line('markers', 'integration: marks tests as integration tests')
+    config.addinivalue_line('markers', 'external: tests that verify external service behavior without invoking internal Rucio functions')
 
     if config.pluginmanager.hasplugin("xdist"):
         from .ruciopytest import xdist_noparallel_scheduler

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,13 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/helpers/keycloak_helper.py
+++ b/tests/helpers/keycloak_helper.py
@@ -1,0 +1,91 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+import requests
+
+
+class ExternalKeycloakHelper:
+    """Simplified helper for pre-configured Keycloak instance"""
+    
+    def __init__(self, base_url='http://dev-keycloak-1:8080', realm='rucio-test'):
+        self.base_url = base_url
+        self.realm = realm
+        self.keycloak_url = self.base_url
+        
+    def wait_for_ready(self, timeout=30):
+        """Wait for external Keycloak to be ready"""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                response = requests.get(f'{self.keycloak_url}/health/ready', timeout=5)
+                if response.status_code == 200:
+                    return True
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(2)
+        return False
+    
+    def get_user_token(self):
+        """Get user access token for testing - assumes realm/client/user exist"""
+        response = requests.post(
+            f'{self.keycloak_url}/realms/{self.realm}/protocol/openid-connect/token',
+            data={
+                'grant_type': 'password',
+                'client_id': 'rucio-test-client',
+                'client_secret': 'rucio-test-secret',
+                'username': 'testuser',
+                'password': 'testpass123',
+                'scope': 'openid profile'
+            }
+        )
+        response.raise_for_status()
+        return response.json()
+    
+    def get_client_credentials_token(self, scope='profile'):
+        """Get client credentials token"""
+        response = requests.post(
+            f'{self.keycloak_url}/realms/{self.realm}/protocol/openid-connect/token',
+            data={
+                'grant_type': 'client_credentials',
+                'client_id': 'rucio-test-client',
+                'client_secret': 'rucio-test-secret',
+                'scope': scope
+            }
+        )
+        response.raise_for_status()
+        return response.json()
+    
+    def refresh_token(self, refresh_token):
+        """Refresh an access token"""
+        response = requests.post(
+            f'{self.keycloak_url}/realms/{self.realm}/protocol/openid-connect/token',
+            data={
+                'grant_type': 'refresh_token',
+                'client_id': 'rucio-test-client',
+                'client_secret': 'rucio-test-secret',
+                'refresh_token': refresh_token
+            }
+        )
+        response.raise_for_status()
+        return response.json()
+    
+    def is_available(self):
+        """Check if Keycloak is available"""
+        try:
+            response = requests.get(f'{self.keycloak_url}/health/ready', timeout=5)
+            return response.status_code == 200
+        except Exception:
+            return False

--- a/tests/test_baseclient.py
+++ b/tests/test_baseclient.py
@@ -1,0 +1,310 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+from rucio.client.baseclient import BaseClient
+from rucio.common.config import config_set
+from rucio.common.exception import CannotAuthenticate, NoAuthInformation
+from tests.mocks.mock_http_server import MockServer
+
+
+@pytest.fixture
+def client_token_path_override(file_config_mock, function_scope_prefix, tmp_path):
+    """
+    Ensure each running client has a different path for the token, otherwise tests cannot run in parallel
+    """
+    config_set('client', 'auth_token_file_path', str(tmp_path / f'{function_scope_prefix}token'))
+
+class TestOIDCAuthentication:
+    """
+    Tests for OIDC authentication flow in BaseClient using mock HTTP server.
+    
+    Rationale for keeping these tests:
+    - Unit Testing Focus: Test specific BaseClient OIDC authentication logic in isolation
+    - Branch Coverage: Verify all code paths (auto, polling, manual) are exercised
+    - Error Handling: Test edge cases and failure scenarios with controlled mock responses
+    - Fast Execution: Mock server provides immediate responses without external dependencies
+    - Deterministic Testing: Predictable behavior for CI/CD pipelines and parallel test execution
+    - Integration Complement: These unit tests complement external Keycloak integration tests
+    
+    These tests answer: "Does BaseClient's OIDC authentication logic work correctly?"
+    They complement external integration tests which answer: "Does the system work with real services?"
+    """
+
+    @staticmethod
+    def safe_reduce_data(self, data, maxlen: int = 132) -> str:
+        """Safe _reduce_data implementation that handles dictionaries"""
+        if isinstance(data, dict):
+            data_str = str(data)
+            if len(data_str) > maxlen:
+                return f"{data_str[:maxlen-15]} ... {data_str[-10:]}"
+            return data_str
+        # Original logic for str/bytes
+        text = data if isinstance(data, str) else data.decode("utf-8")
+        if len(text) > maxlen:
+            text = "%s ... %s" % (text[:maxlen - 15], text[-10:])
+        return text
+
+    @staticmethod
+    def get_server_url(server_address, path="/auth/login"):
+        """Helper to build server URL from address"""
+        if isinstance(server_address, tuple) and len(server_address) >= 2:
+            server_name, server_port = server_address[:2]
+            return f'http://{server_name}:{server_port}{path}'
+        return f'http://localhost:0{path}'
+
+    def create_base_client(self, server, creds, vo, ca_cert=False):
+        """Helper to create BaseClient with common patches"""
+        
+        with patch('rucio.client.baseclient.wlcg_token_discovery', return_value=None):
+            with patch('rucio.client.baseclient.BaseClient._reduce_data', self.safe_reduce_data):
+                return BaseClient(
+                    rucio_host=server.base_url,
+                    auth_host=server.base_url,
+                    account='root',
+                    ca_cert=None,
+                    auth_type='oidc',
+                    creds=creds,
+                    vo=vo
+                )
+
+    def test_oidc_auto_authentication_success(self, vo, client_token_path_override):
+        """Test successful OIDC auto authentication """
+        
+        class OIDCMockHandler(MockServer.Handler):
+            def do_GET(self):
+                if '/auth/oidc' in self.path:
+                    auth_url = TestOIDCAuthentication.get_server_url(self.server.server_address)
+                    self.send_code_and_message(200, {
+                        'X-Rucio-OIDC-Auth-URL': auth_url
+                    }, '')
+                elif '/auth/login' in self.path:
+                    self.send_code_and_message(200, {
+                        'X-Rucio-Auth-Token': 'test-oidc-token-12345'
+                    }, 'redirect_success')
+                else:
+                    self.send_code_and_message(404, {}, '')
+            
+            def do_POST(self): # noqa: N802
+                if '/auth/login' in self.path:
+                    self.send_code_and_message(200, {
+                        'X-Rucio-Auth-Token': 'test-oidc-token-12345'
+                    }, '')
+                else:
+                    self.send_code_and_message(404, {}, '')
+
+        creds = {
+            'oidc_auto': True,
+            'oidc_username': 'testuser',
+            'oidc_password': 'testpass',
+            'oidc_scope': 'openid profile',
+            'oidc_audience': 'rucio',
+            'oidc_issuer': 'test-issuer',
+            'oidc_refresh_lifetime': None,
+            'oidc_polling': False
+        }
+
+        with MockServer(OIDCMockHandler) as server:
+            client = self.create_base_client(server, creds, vo)
+            assert client.auth_token == 'test-oidc-token-12345'
+
+    def test_oidc_polling_authentication_success(self, vo, client_token_path_override):
+        """Test successful OIDC polling authentication """
+        
+        poll_attempts = []
+        
+        class OIDCPollingMockHandler(MockServer.Handler):
+            def do_GET(self):
+                if '/auth/oidc' in self.path:
+                    auth_url = TestOIDCAuthentication.get_server_url(self.server.server_address, '/auth/polling')
+                    self.send_code_and_message(200, {
+                        'X-Rucio-OIDC-Auth-URL': auth_url
+                    }, '')
+                elif '/auth/polling' in self.path:
+                    poll_attempts.append(1)
+                    if len(poll_attempts) <= 2:
+                        # First two polls return no token
+                        self.send_code_and_message(200, {}, '')
+                    else:
+                        # Third poll returns token
+                        self.send_code_and_message(200, {
+                            'X-Rucio-Auth-Token': 'test-polling-token-67890'
+                        }, '')
+                else:
+                    self.send_code_and_message(404, {}, '')
+
+        creds = {
+            'oidc_auto': False,
+            'oidc_polling': True,
+            'oidc_scope': 'openid profile',
+            'oidc_audience': 'rucio',
+            'oidc_issuer': 'test-issuer',
+            'oidc_refresh_lifetime': None
+        }
+
+        # Mock time.sleep to speed up test
+        with patch('time.sleep'):
+            with MockServer(OIDCPollingMockHandler) as server:
+                client = self.create_base_client(server, creds, vo)
+                assert client.auth_token == 'test-polling-token-67890'
+                assert len(poll_attempts) == 3
+
+    def test_oidc_manual_code_authentication_success(self, vo, client_token_path_override):
+        """Test successful OIDC manual code authentication """
+        
+        class OIDCManualMockHandler(MockServer.Handler):
+            def do_GET(self):
+                if '/auth/oidc_redirect' in self.path:
+                    if 'valid-code-123' in self.path:
+                        self.send_code_and_message(200, {
+                            'X-Rucio-Auth-Token': 'test-manual-token-abc'
+                        }, '')
+                    else:
+                        self.send_code_and_message(400, {}, 'Invalid code')
+                elif '/auth/oidc' in self.path:
+                    auth_url = TestOIDCAuthentication.get_server_url(self.server.server_address, '/auth/manual')
+                    self.send_code_and_message(200, {
+                        'X-Rucio-OIDC-Auth-URL': auth_url
+                    }, '')
+                elif '/auth/manual' in self.path:
+                    # Return the manual auth page
+                    self.send_code_and_message(200, {}, 'manual_auth_page')
+                else:
+                    self.send_code_and_message(404, {}, '')
+
+        creds = {
+            'oidc_auto': False,
+            'oidc_polling': False,
+            'oidc_scope': 'openid profile',
+            'oidc_audience': 'rucio',
+            'oidc_issuer': 'test-issuer',
+            'oidc_refresh_lifetime': None
+        }
+
+        # Mock user input for fetchcode
+        with patch('builtins.input', return_value='valid-code-123'):
+            with MockServer(OIDCManualMockHandler) as server:
+                client = self.create_base_client(server, creds, vo)
+                assert client.auth_token == 'test-manual-token-abc'
+
+    def test_oidc_authentication_missing_auth_url(self, vo, client_token_path_override):
+        """Test OIDC authentication fails without auth URL """
+        
+        class OIDCNoAuthUrlHandler(MockServer.Handler):
+            def do_GET(self):
+                if '/auth/oidc' in self.path:
+                    # Don't return X-Rucio-OIDC-Auth-URL header
+                    self.send_code_and_message(200, {}, '')
+                else:
+                    self.send_code_and_message(404, {}, '')
+
+        creds = {
+            'oidc_auto': True,
+            'oidc_username': 'testuser',
+            'oidc_password': 'testpass',
+            'oidc_scope': 'openid profile'
+        }
+
+        with MockServer(OIDCNoAuthUrlHandler) as server:
+            with pytest.raises(CannotAuthenticate):
+                self.create_base_client(server, creds, vo)
+
+    def test_oidc_authentication_oauth_error(self, vo, client_token_path_override):
+        """Test OIDC authentication fails with OAuth error """
+        
+        class OIDCOAuthErrorHandler(MockServer.Handler):
+            def do_GET(self):
+                if '/auth/oidc' in self.path:
+                    auth_url = TestOIDCAuthentication.get_server_url(self.server.server_address)
+                    self.send_code_and_message(200, {
+                        'X-Rucio-OIDC-Auth-URL': auth_url
+                    }, '')
+                elif '/auth/login' in self.path:
+                    self.send_code_and_message(200, {}, 'OAuth Error: invalid_client')
+                else:
+                    self.send_code_and_message(404, {}, '')
+            
+            def do_POST(self): # noqa: N802
+                if '/auth/login' in self.path:
+                    # Return OAuth error in response body
+                    self.send_code_and_message(400, {}, 'OAuth Error: invalid_client')
+                else:
+                    self.send_code_and_message(404, {}, '')
+
+        creds = {
+            'oidc_auto': True,
+            'oidc_username': 'testuser',
+            'oidc_password': 'testpass',
+            'oidc_scope': 'openid profile'
+        }
+
+        with MockServer(OIDCOAuthErrorHandler) as server:
+            with pytest.raises(CannotAuthenticate):
+                self.create_base_client(server, creds, vo)
+
+    def test_oidc_manual_invalid_code_retries(self, vo, client_token_path_override):
+        """Test OIDC manual authentication with invalid codes and retries """
+        
+        class OIDCInvalidCodeHandler(MockServer.Handler):
+            def do_GET(self):
+                if '/auth/oidc_redirect' in self.path:
+                    # Always return error for invalid codes
+                    self.send_code_and_message(400, {}, 'Invalid code')
+                elif '/auth/oidc' in self.path:
+                    auth_url = TestOIDCAuthentication.get_server_url(self.server.server_address, '/auth/manual')
+                    self.send_code_and_message(200, {
+                        'X-Rucio-OIDC-Auth-URL': auth_url
+                    }, '')
+                else:
+                    self.send_code_and_message(404, {}, '')
+
+        creds = {
+            'oidc_auto': False,
+            'oidc_polling': False,
+            'oidc_scope': 'openid profile'
+        }
+
+        # Mock user input to provide invalid codes 3 times
+        with patch('builtins.input', side_effect=['invalid-1', 'invalid-2', 'invalid-3']):
+            with MockServer(OIDCInvalidCodeHandler) as server:
+                with pytest.raises(CannotAuthenticate):
+                    self.create_base_client(server, creds, vo)
+
+    def test_oidc_missing_credentials_auto(self, vo, client_token_path_override):
+        """Test OIDC authentication fails with missing auto credentials """
+        
+        creds = {
+            'oidc_auto': True,
+            'oidc_username': None,  # Missing username
+            'oidc_password': 'testpass',
+            'oidc_scope': 'openid profile'
+        }
+
+        # This test doesn't need a server since it fails before authentication
+        
+        with patch('rucio.client.baseclient.wlcg_token_discovery', return_value=None):
+            with pytest.raises(NoAuthInformation,
+                              match='For automatic OIDC log-in with your Identity Provider username and password are required.'):
+                BaseClient(
+                    rucio_host='http://localhost:8080',
+                    auth_host='http://localhost:8080',
+                    account='root',
+                    ca_cert=None,
+                    auth_type='oidc',
+                    creds=creds,
+                    vo=vo
+                )

--- a/tests/test_baseclient_with_keycloak.py
+++ b/tests/test_baseclient_with_keycloak.py
@@ -1,0 +1,284 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from rucio.client.baseclient import BaseClient
+from rucio.common.config import config_set
+from tests.helpers.keycloak_helper import ExternalKeycloakHelper
+
+
+@pytest.fixture
+def client_token_path_override(file_config_mock, function_scope_prefix, tmp_path):
+    """
+    Ensure each running client has a different path for the token, otherwise tests cannot run in parallel
+    """
+    config_set('client', 'auth_token_file_path', str(tmp_path / f'{function_scope_prefix}token'))
+
+
+@pytest.mark.external
+class TestBaseClientOIDCExternalAPI:
+    """
+    External API tests that verify OIDC server endpoints without invoking internal BaseClient functions.
+    
+    Rationale for keeping these tests:
+    - Server-side Validation: Verify OIDC server endpoints work correctly
+    - Configuration Validation: Test server-side OIDC integration setup
+    - Endpoint Contract Testing: Ensure API contracts haven't changed
+    - Environment Validation: Confirm server environment is properly configured
+    
+    These tests serve the purpose: "Does the OIDC server integration work as expected?"
+    They complement internal tests which answer: "Does BaseClient integrate with the server correctly?"
+    """
+    
+    def test_baseclient_oidc_integration_endpoint(self, vo):
+        """Test that OIDC server-side integration is properly configured"""
+        keycloak = ExternalKeycloakHelper()
+        
+        if not keycloak.is_available():
+            pytest.skip("Keycloak not available for integration test")
+        
+        # Test the OIDC endpoint directly - this verifies all server-side config
+        response = requests.get('https://rucio/auth/oidc',
+                              headers={
+                                  'X-Rucio-Client-Authorize-Auto': 'True',
+                                  'X-Rucio-Client-Authorize-Issuer': f'{keycloak.keycloak_url}/realms/{keycloak.realm}',
+                                  'X-Rucio-Client-Authorize-Audience': 'rucio'
+                              }, verify=False)
+        
+        # These assertions verify the entire OIDC integration chain
+        assert response.status_code == 200, f"OIDC endpoint failed: {response.text}"
+        assert 'X-Rucio-OIDC-Auth-URL' in response.headers, "No auth URL generated"
+        
+        auth_url = response.headers['X-Rucio-OIDC-Auth-URL']
+        assert keycloak.keycloak_url in auth_url, "Auth URL doesn't point to Keycloak"
+        assert 'client_id=rucio-test-client' in auth_url, "Wrong client_id in URL"
+        assert 'scope=openid+profile' in auth_url, "Missing scopes"
+        assert 'audience=rucio' in auth_url, "Missing audience"
+
+
+@pytest.mark.integration
+class TestBaseClientOIDCIntegration:
+    """
+    Integration tests that verify BaseClient OIDC authentication works correctly with real servers.
+    
+    These tests invoke internal BaseClient functions and verify they integrate properly with
+    external OIDC services. They complement the external API tests by proving our client codes
+    works with the verified server endpoints.
+    """
+    
+    def test_baseclient_oidc_manual_code_branch(self, vo, client_token_path_override):
+        """
+        Test that verifies manual code branch is reached and behaves correctly.
+        
+        Note: This test only verifies branch execution up to the user interaction point.
+        A full end-to-end test of the manual code flow (including browser redirect,
+        user authentication, and code entry) would require E2E testing tools with
+        browser automation (e.g. Selenium, Playwright) and is beyond the scope
+        of this integration test.
+        
+        This test validates:
+        - Correct branch selection logic (manual vs polling vs auto)
+        - Auth URL generation and structure
+        - User prompt messages
+        - Integration with Keycloak up to the user interaction boundary
+        """
+        
+        keycloak = ExternalKeycloakHelper()
+        if not keycloak.is_available():
+            pytest.skip("Keycloak not available")
+            
+        creds = {
+            'oidc_auto': False,      # Enter manual flow
+            'oidc_polling': False,   # Hit manual code branch
+            'oidc_username': 'testuser',
+            'oidc_password': 'testpass123',
+            'oidc_scope': 'openid profile',
+            'oidc_audience': 'rucio',
+            'oidc_issuer': f'{keycloak.keycloak_url}/realms/{keycloak.realm}',
+            'oidc_refresh_lifetime': None
+        }
+        
+        captured_output = io.StringIO()
+        
+        with patch('sys.stdout', captured_output):
+            try:
+                _ = BaseClient(
+                    rucio_host='https://rucio',
+                    auth_host='https://rucio',
+                    account='root',
+                    ca_cert=None,
+                    auth_type='oidc',
+                    creds=creds,
+                    vo=vo
+                )
+                pytest.fail("Should not succeed without user input")
+            except Exception:
+                # Expected to fail due to EOF on input()
+                pass
+        
+        output = captured_output.getvalue()
+        
+        # Verify the branch was reached by checking output messages
+        assert "Copy paste the code from the browser" in output, "Manual code branch not reached"
+        assert "authenticate with your Identity Provider" in output, "Auth prompt not shown"
+        assert "https://" in output, "Auth URL not generated"
+        
+        # Verify it's NOT the polling branch
+        assert "polling" not in output.lower(), "Should not show polling messages"
+        
+        # Extract the auth URL from output
+        lines = output.split('\n')
+        auth_url_line = [line for line in lines if 'https://' in line and 'auth' in line]
+        
+        if auth_url_line:
+            auth_url = auth_url_line[0].strip()
+            # Verify URL structure
+            assert 'oidc_redirect' in auth_url, "Should contain oidc_redirect endpoint"
+            assert '?' in auth_url, "Should contain auth code parameter"
+            
+        
+    def test_baseclient_oidc_polling_branch(self, vo, client_token_path_override):
+        """
+        Test polling branch with reliable timeout mechanism
+        
+        Note: This test validates polling logic up to the server interaction boundary.
+        It cannot test the complete polling cycle where a user authenticates in a browser
+        and the server eventually returns a token, as this would require browser automation
+        and user interaction beyond the scope of integration testing.
+        
+        This test validates:
+        - Correct branch selection (polling vs manual vs auto)
+        - Polling loop initialization and timeout setup
+        - User prompt messages and timeout communication
+        - Integration with Keycloak up to the polling request phase
+        """
+        
+        keycloak = ExternalKeycloakHelper()
+        if not keycloak.is_available():
+            pytest.skip("Keycloak not available")
+            
+        creds = {
+            'oidc_auto': False,
+            'oidc_polling': True,
+            'oidc_username': 'testuser',
+            'oidc_password': 'testpass123',
+            'oidc_scope': 'openid profile',
+            'oidc_audience': 'rucio',
+            'oidc_issuer': f'{keycloak.keycloak_url}/realms/{keycloak.realm}',
+            'oidc_refresh_lifetime': None
+        }
+        
+        import threading
+        import time
+        
+        # Use a flag to interrupt the test
+        timeout_occurred = threading.Event()
+        
+        def timeout_callback():
+            timeout_occurred.set()
+        
+        # Set up timer
+        timer = threading.Timer(2.0, timeout_callback)
+        timer.start()
+        
+        captured_output = io.StringIO()
+        
+        try:
+            with patch('sys.stdout', captured_output):
+                # Mock time.time() to accelerate timeout
+                original_time = time.time
+                start_time = original_time()
+                
+                def mock_time():
+                    if timeout_occurred.is_set():
+                        # Force timeout by returning time 200 seconds in future
+                        return start_time + 200
+                    return original_time()
+                
+                with patch('time.time', side_effect=mock_time):
+                    with patch('time.sleep'):  # Skip actual sleep
+                        try:
+                            _ = BaseClient(
+                                rucio_host='https://rucio',
+                                auth_host='https://rucio',
+                                account='root',
+                                ca_cert=None,
+                                auth_type='oidc',
+                                creds=creds,
+                                vo=vo
+                            )
+                        except Exception:
+                            pass  # Expected to fail
+        finally:
+            timer.cancel()
+        
+        output = captured_output.getvalue()
+        
+        # Verify polling branch was reached
+        assert "polling" in output.lower(), "Polling branch not reached"
+        assert "3 minutes" in output, "Polling message not shown"
+        assert "Copy paste" not in output, "Should not show manual code message"
+
+    def test_baseclient_oidc_auto_with_keycloak(self, vo, client_token_path_override):
+        """
+        Test BaseClient OIDC auto authentication against real Keycloak
+        
+        DEPRECATED: This test covers the oidc_auto=True branch which violates OAuth2/OIDC
+        security standards by sharing user credentials with third-party applications.
+        This branch is planned for removal in future versions.
+        
+        TODO: Remove this test when oidc_auto functionality is deprecated and removed.
+        """
+        keycloak = ExternalKeycloakHelper()
+        
+        if not keycloak.is_available():
+            pytest.skip("Keycloak not available for integration test")
+        
+        creds = {
+            'oidc_auto': True,  # This functionality will be deprecated
+            'oidc_username': 'testuser',
+            'oidc_password': 'testpass123',
+            'oidc_scope': 'openid profile',
+            'oidc_audience': 'rucio',
+            'oidc_issuer': f'{keycloak.keycloak_url}/realms/{keycloak.realm}'
+        }
+        
+        captured_output = io.StringIO()
+
+        with patch('sys.stdout', captured_output):
+            try:
+                _ = BaseClient(
+                    rucio_host='https://rucio',
+                    auth_host='https://rucio',
+                    account='root',
+                    ca_cert=None,
+                    auth_type='oidc',
+                    creds=creds,
+                    vo=vo
+                )
+                        
+            except Exception:
+                pass  # Test passes
+
+        output = captured_output.getvalue()
+        
+        # Verify the branch was reached by checking output messages
+        assert "According to the OAuth2/OIDC standard you should NOT be sharing" in output, "oidc_auto=True branch not reached"
+        assert "your password with any 3rd party application, therefore," in output, "oidc_auto=True branch not reached"
+        assert "we strongly discourage you from following this --oidc-auto approach." in output, "oidc_auto=True branch not reached"

--- a/tests/test_oidc_with_keycloak.py
+++ b/tests/test_oidc_with_keycloak.py
@@ -1,0 +1,277 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import json
+from contextlib import contextmanager
+from unittest.mock import mock_open, patch
+
+import pytest
+import requests
+
+from rucio.core.oidc import request_token
+from tests.helpers.keycloak_helper import ExternalKeycloakHelper
+
+
+@contextmanager
+def external_keycloak_environment():
+    """Context manager for external Keycloak test environment"""
+    keycloak = ExternalKeycloakHelper(base_url='http://dev-keycloak-1:8080', realm='rucio-test')
+    
+    if not keycloak.wait_for_ready():
+        pytest.skip(f"Keycloak not available at {keycloak.keycloak_url}")
+    
+    yield keycloak
+
+
+@pytest.mark.external
+class TestKeycloakExternalAPI:
+    """
+    External API tests that verify Keycloak service behavior without invoking internal Rucio functions.
+    
+    Rationale for keeping these tests:
+    - Dependency Verification: Prove external services (Keycloak) work as expected
+    - Contract Testing: Verify API contracts haven't changed
+    - Environment Validation: Confirm test environment is properly configured
+    - Integration Confidence: Provide confidence that external pieces work before testing internal integration
+    
+    These tests serve the purpose: "Does Keycloak work as we expect?"
+    They complement internal tests which answer: "Does our code integrate with Keycloak correctly?"
+    """
+    
+    def test_keycloak_connectivity(self):
+        """Test basic connectivity to Keycloak"""
+        with external_keycloak_environment() as keycloak:
+            assert keycloak.is_available()
+            
+            # Test health endpoint
+            response = requests.get(f'{keycloak.keycloak_url}/health/ready')
+            assert response.status_code == 200
+    
+    def test_user_password_authentication(self):
+        """Test user password authentication flow"""
+        with external_keycloak_environment() as keycloak:
+            token_data = keycloak.get_user_token()
+            
+            assert 'access_token' in token_data
+            assert 'token_type' in token_data
+            assert token_data['token_type'] == 'Bearer'
+            
+            # Verify JWT structure
+            access_token = token_data['access_token']
+            parts = access_token.split('.')
+            assert len(parts) == 3  # header.payload.signature
+    
+    def test_client_credentials_flow(self):
+        """Test client credentials flow"""
+        with external_keycloak_environment() as keycloak:
+            token_data = keycloak.get_client_credentials_token()
+            
+            assert 'access_token' in token_data
+            assert 'token_type' in token_data
+            assert token_data['token_type'] == 'Bearer'
+            assert len(token_data['access_token'].split('.')) == 3
+    
+    def test_token_refresh_flow(self):
+        """Test token refresh mechanism"""
+        with external_keycloak_environment() as keycloak:
+            # Get initial token with offline_access scope
+            response = requests.post(
+                f'{keycloak.keycloak_url}/realms/{keycloak.realm}/protocol/openid-connect/token',
+                data={
+                    'grant_type': 'password',
+                    'client_id': 'rucio-test-client',
+                    'client_secret': 'rucio-test-secret',
+                    'username': 'testuser',
+                    'password': 'testpass123',
+                    'scope': 'openid profile offline_access'
+                }
+            )
+            
+            if response.status_code == 200:
+                token_data = response.json()
+                
+                if 'refresh_token' in token_data:
+                    # Test refresh
+                    new_token_data = keycloak.refresh_token(token_data['refresh_token'])
+                    
+                    assert 'access_token' in new_token_data
+                    assert new_token_data['access_token'] != token_data['access_token']
+    
+    def test_discovery_endpoint(self):
+        """Test OIDC discovery endpoint"""
+        with external_keycloak_environment() as keycloak:
+            discovery_url = f'{keycloak.keycloak_url}/realms/{keycloak.realm}/.well-known/openid-configuration'
+            response = requests.get(discovery_url)
+            
+            assert response.status_code == 200
+            config_data = response.json()
+            
+            # Verify required endpoints
+            required_endpoints = ['authorization_endpoint', 'token_endpoint', 'jwks_uri', 'userinfo_endpoint']
+            for endpoint in required_endpoints:
+                assert endpoint in config_data
+                assert keycloak.keycloak_url in config_data[endpoint]
+    
+    def test_token_claims_structure(self):
+        """Test JWT token claims structure"""
+        with external_keycloak_environment() as keycloak:
+            token_data = keycloak.get_user_token()
+            access_token = token_data['access_token']
+            
+            # Decode payload (without signature verification)
+            parts = access_token.split('.')
+            payload = base64.urlsafe_b64decode(parts[1] + '==')
+            claims = json.loads(payload)
+            
+            # Verify expected claims
+            assert 'sub' in claims
+            assert 'iss' in claims
+            assert claims['iss'] == f"{keycloak.keycloak_url}/realms/{keycloak.realm}"
+            assert 'exp' in claims
+            assert 'iat' in claims
+    
+    def test_realm_cleanup_on_failure(self):
+        """Test graceful handling of unavailable Keycloak"""
+        # Test with non-existent instance
+        keycloak = ExternalKeycloakHelper(base_url='http://dev-keycloak-1:99999')
+        
+        assert not keycloak.is_available()
+        assert not keycloak.wait_for_ready(timeout=5)
+
+
+@pytest.mark.integration
+class TestRucioOIDCIntegration:
+    """
+    Integration tests that verify Rucio's internal OIDC functions work correctly with Keycloak.
+    
+    These tests invoke internal Rucio functions and verify they integrate properly with external services.
+    They complement the external API tests by proving our code works with the verified dependencies.
+    """
+    
+    def test_rucio_oidc_integration_mocked(self):
+        """Test Rucio OIDC integration with mocked idpsecrets"""
+        with external_keycloak_environment() as keycloak:
+            # Mock idpsecrets configuration
+            test_secrets = {
+                "test-issuer": {
+                    "issuer": f"{keycloak.keycloak_url}/realms/{keycloak.realm}",
+                    "client_id": "rucio-test-client",
+                    "client_secret": "rucio-test-secret",
+                    "redirect_uris": [
+                        f"{keycloak.keycloak_url}/auth/oidc_token",
+                        f"{keycloak.keycloak_url}/auth/oidc_code"
+                    ],
+                    "SCIM": {
+                        "client_id": "rucio-test-client",
+                        "client_secret": "rucio-test-secret"
+                    }
+                }
+            }
+            
+            # Mock configuration and test token request
+            with patch('rucio.core.oidc.IDPSECRETS', '/tmp/test_idpsecrets.json'):
+                with patch('builtins.open', mock_open(read_data=json.dumps(test_secrets))):
+                    with patch('rucio.core.oidc.OIDC_CLIENT_ID', 'rucio-test-client'), \
+                         patch('rucio.core.oidc.OIDC_CLIENT_SECRET', 'rucio-test-secret'), \
+                         patch('rucio.core.oidc.OIDC_PROVIDER_ENDPOINT',
+                               f'{keycloak.keycloak_url}/realms/{keycloak.realm}/protocol/openid-connect/token'):
+                        
+                        # Test request_token function
+                        token = request_token(
+                            audience='rucio',
+                            scope='profile',
+                            use_cache=False
+                        )
+                        
+                        if token:
+                            assert len(token.split('.')) == 3
+                            # Decode payload (without signature verification)
+                            parts = token.split('.')
+                            payload = base64.urlsafe_b64decode(parts[1] + '==')
+                            claims = json.loads(payload)
+                            
+                            # Verify expected claims
+                            assert 'sub' in claims
+                            assert 'iss' in claims
+                            assert claims['iss'] == f"{keycloak.keycloak_url}/realms/{keycloak.realm}"
+                            assert 'exp' in claims
+                            assert 'iat' in claims
+
+
+@pytest.mark.external
+class TestOIDCFlowSimulation:
+    """
+    Flow simulation tests that verify OIDC authentication flow structures and URL patterns.
+    
+    These tests simulate the expected behavior of different OIDC flows without full end-to-end execution.
+    They verify URL construction, parameter handling, and response structure expectations.
+    """
+    
+    def test_oidc_polling_flow_simulation(self):
+        """Simulate OIDC polling authentication flow"""
+        with external_keycloak_environment() as keycloak:
+            # Simulate the polling mechanism from BaseClient
+            auth_url = f"{keycloak.keycloak_url}/realms/{keycloak.realm}/protocol/openid-connect/auth"
+            auth_params = {
+                'client_id': 'rucio-test-client',
+                'response_type': 'code',
+                'scope': 'openid profile',
+                'redirect_uri': f'{keycloak.keycloak_url}/auth/oidc_token',
+                'state': 'test-state-123'
+            }
+            
+            full_auth_url = auth_url + '?' + '&'.join([f'{k}={v}' for k, v in auth_params.items()])
+            
+            # Verify polling URL structure
+            assert 'oidc_token' in full_auth_url  # Polling uses oidc_token endpoint
+            assert 'response_type=code' in full_auth_url
+            
+            # Simulate successful authentication (user would do this in browser)
+            token_data = keycloak.get_user_token()
+            
+            # Simulate polling result (server would return token after user auth)
+            mock_polling_response = {'X-Rucio-Auth-Token': token_data['access_token']}
+            assert 'X-Rucio-Auth-Token' in mock_polling_response
+    
+    def test_oidc_manual_code_flow_simulation(self):
+        """Simulate OIDC manual code entry flow"""
+        with external_keycloak_environment() as keycloak:
+            # Simulate manual code flow
+            auth_url = f"{keycloak.keycloak_url}/realms/{keycloak.realm}/protocol/openid-connect/auth"
+            auth_params = {
+                'client_id': 'rucio-test-client',
+                'response_type': 'code',
+                'scope': 'openid profile',
+                'redirect_uri': f'{keycloak.keycloak_url}/auth/oidc_code',
+                'state': 'test-state-456'
+            }
+            
+            full_auth_url = auth_url + '?' + '&'.join([f'{k}={v}' for k, v in auth_params.items()])
+            
+            # Verify manual code URL structure
+            assert 'oidc_code' in full_auth_url  # Manual uses oidc_code endpoint
+            
+            # Simulate user getting fetchcode and entering it
+            mock_fetchcode = "test-fetch-code-12345"
+            fetch_url = f"{keycloak.keycloak_url}/auth/oidc_redirect?{mock_fetchcode}"
+            
+            # Verify fetch URL structure
+            assert 'oidc_redirect' in fetch_url
+            assert mock_fetchcode in fetch_url
+            
+            # Simulate successful code exchange
+            token_data = keycloak.get_user_token()
+            mock_code_response = {'X-Rucio-Auth-Token': token_data['access_token']}
+            assert 'X-Rucio-Auth-Token' in mock_code_response


### PR DESCRIPTION
Closes #7969

---

**Summary:** Establish OIDC integration testing against Keycloak
    
- Fix OIDC configuration issues: add missing SCIM and redirect_uris to idpsecrets.json
- Add OIDC and BaseClient authentication tests with branch coverage for polling/manual flows
- Add external API validation and internal integration test categories
- Configure pre-built Keycloak realm with test users and clients for CI
- Update pytest markers for better test organization

---

Depends on: #8057