### PR TITLE
Show json extended attributes in Rich CLI

### DIFF
--- a/lib/rucio/cli/bin_legacy/rucio_admin.py
+++ b/lib/rucio/cli/bin_legacy/rucio_admin.py
@@ -446,7 +446,13 @@ def info_rse(args, client, logger, console, spinner):
                             branch.add(f'[{CLITheme.JSON_STR}]{k}[/]: [{CLITheme.JSON_NUM}]{v}[/]')
                     table_data.append([item, tree])
                 else:
-                    table_data.append([item, Text(str(protocol[item]), style=keyword_styles.get(protocol[item], 'default'))])
+                    if isinstance(protocol[item], dict):
+                        tree = Tree('')
+                        for proto, values in protocol[item].items():
+                            branch = tree.add(f'[{CLITheme.JSON_STR}]{proto}: [{CLITheme.JSON_NUM}]{json.dumps(values)}[/]')
+                        table_data.append([item, tree])
+                    else:
+                        table_data.append([item, Text(str(protocol[item]), style=keyword_styles.get(protocol[item], 'default'))])
             else:
                 if item == 'domains':
                     print('    ' + item + ': \'' + json.dumps(protocol[item]) + '\'')


### PR DESCRIPTION
Closes #7693 

Please note that the tests here are not??? Working as intended. Example with forcing a failure to see the actual config status

```
FAILED tests/test_bin_rucio.py::test_show_extended_rses[file_config_mock{'experimental': {'cli': 'tabulate'}}] - AssertionError: c.get_config("experimental", "cli") = tabular
FAILED tests/test_bin_rucio.py::test_show_extended_rses[file_config_mock{'experimental': {'cli': 'rich'}}] - AssertionError: c.get_config("experimental", "cli") = tabular
```

The actual output on a srm RSE is as follows: 
```
  srm
  ┌─────────────────────┬─────────────────────────────────────────────┐
  │ domains             │                                             │
  │                     │ ├── lan                                     │
  │                     │ │   ├── read: 2                             │
  │                     │ │   ├── write: 2                            │
  │                     │ │   └── delete: 2                           │
  │                     │ └── wan                                     │
  │                     │     ├── read: 2                             │
  │                     │     ├── write: 2                            │
  │                     │     ├── delete: 2                           │
  │                     │     ├── third_party_copy_read: 0            │
  │                     │     └── third_party_copy_write: 0           │
  │ extended_attributes │                                             │
  │                     │ ├── web_service_path: "/srm/managerv2?SFN=" │
  │                     │ └── space_token: "RUCIODISK"                │
  │ hostname            │ mock.com                                    │
  │ impl                │ rucio.rse.protocols.srm.Default             │
  │ port                │ 8443                                        │
  │ prefix              │ /rucio/tmpdisk/rucio_tests/                 │
  │ scheme              │ srm                                         │
  └─────────────────────┴─────────────────────────────────────────────┘
  ```