### PR TITLE
Core: Simplify timestamp diff calculation #8044

### DIFF
--- a/lib/rucio/core/rule_grouping.py
+++ b/lib/rucio/core/rule_grouping.py
@@ -921,8 +921,8 @@ def __is_retry_required(lock, activity):
     :param activity:             The activity of the rule.
     """
 
-    created_at_diff = (datetime.utcnow() - lock.created_at).days * 24 * 3600 + (datetime.utcnow() - lock.created_at).seconds
-    updated_at_diff = (datetime.utcnow() - lock.updated_at).days * 24 * 3600 + (datetime.utcnow() - lock.updated_at).seconds
+    created_at_diff = (datetime.utcnow() - lock.created_at).total_seconds()
+    updated_at_diff = (datetime.utcnow() - lock.updated_at).total_seconds()
 
     if activity == 'Express':
         if updated_at_diff > 3600 * 2:


### PR DESCRIPTION
The original implementation was from when Rucio was being run with Python 2. Note that the `total_seconds()` method returns a float.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
