### PR TITLE
Testing: Correctly fetch db session fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from dogpile.cache.region import CacheRegion
     from flask.testing import FlaskClient
     from prometheus_client import CollectorRegistry
+    from sqlalchemy.orm import Session
     from sqlalchemy.orm.scoping import scoped_session
     from werkzeug.test import TestResponse
 
@@ -391,6 +392,16 @@ def containerized_rses(rucio_client: "Client") -> list[tuple[str, str]]:
     return rses
 
 
+def _get_db_session_from_request(request: pytest.FixtureRequest) -> Optional["Session"]:
+    db_session = None
+    if 'db_session' in request.fixturenames:
+        db_session = request.getfixturevalue('db_session')
+    elif 'db_read_session' in request.fixturenames:
+        db_session = request.getfixturevalue('db_read_session')
+    elif 'db_write_session' in request.fixturenames:
+        db_session = request.getfixturevalue('db_write_session')
+    return db_session
+
 @pytest.fixture
 def rse_factory(
     request: pytest.FixtureRequest,
@@ -399,11 +410,9 @@ def rse_factory(
 ) -> "Iterator[TemporaryRSEFactory]":
     from .temp_factories import TemporaryRSEFactory
 
-    session = None
-    if 'db_session' in request.fixturenames:
-        session = request.getfixturevalue('db_session')
+    db_session=_get_db_session_from_request(request)
 
-    with TemporaryRSEFactory(vo=vo, name_prefix=function_scope_prefix, db_session=session) as factory:
+    with TemporaryRSEFactory(vo=vo, name_prefix=function_scope_prefix, db_session=db_session) as factory:
         yield factory
 
 
@@ -434,12 +443,10 @@ def did_factory(
 ) -> "Iterator[TemporaryDidFactory]":
     from .temp_factories import TemporaryDidFactory
 
-    session = None
-    if 'db_session' in request.fixturenames:
-        session = request.getfixturevalue('db_session')
+    db_session = _get_db_session_from_request(request)
 
     with TemporaryDidFactory(vo=vo, default_scope=mock_scope, name_prefix=function_scope_prefix, file_factory=file_factory,
-                             default_account=root_account, db_session=session) as factory:
+                             default_account=root_account, db_session=db_session) as factory:
         yield factory
 
 


### PR DESCRIPTION
I suspect this will explain why I needed to add some explicit db writes on opendata tests, I will check and remove them in a distinct PR.

Closes #8052