### PR TITLE
Docker & Kubernetes: Use `PROFILE_COUNT` for reliable profile selection in bootstrap_dev.sh #8062

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
         # Check if we're running in a dev environment with IAM profile available
         dev_profiles = environ.get('DEV_PROFILES', '').split(',')
         dev_profiles = [profile.strip() for profile in dev_profiles if profile.strip()]
-        
+
         if 'iam' not in dev_profiles:
             pytest.skip("Test requires IAM profile - start dev environment with: --profile iam")
 
@@ -402,15 +402,16 @@ def _get_db_session_from_request(request: pytest.FixtureRequest) -> Optional["Se
         db_session = request.getfixturevalue('db_write_session')
     return db_session
 
+
 @pytest.fixture
 def rse_factory(
-    request: pytest.FixtureRequest,
-    vo: str,
-    function_scope_prefix: str
+        request: pytest.FixtureRequest,
+        vo: str,
+        function_scope_prefix: str
 ) -> "Iterator[TemporaryRSEFactory]":
     from .temp_factories import TemporaryRSEFactory
 
-    db_session=_get_db_session_from_request(request)
+    db_session = _get_db_session_from_request(request)
 
     with TemporaryRSEFactory(vo=vo, name_prefix=function_scope_prefix, db_session=db_session) as factory:
         yield factory

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -296,6 +296,7 @@ class TestOpenDataCore:
         assert opendata_did_public_new["name"] == did_public_name, "Name does not match"
         assert opendata_did_public_new["state"] == OpenDataDIDState.PUBLIC, "State does not match"
 
+
 @pytest.mark.noparallel(reason="Changes in configuration values and race conditions")
 class TestOpenDataClient:
     def test_opendata_dids_list_client(self, mock_scope, rucio_client):
@@ -383,6 +384,7 @@ class TestOpenDataClient:
         meta = opendata_did["meta"]
         assert meta == {}, "'meta' should be empty"
 
+
 @pytest.mark.noparallel(reason="Changes in configuration values and race conditions")
 class TestOpenDataAPI:
     api_endpoint = '/opendata/dids'
@@ -450,6 +452,7 @@ class TestOpenDataAPI:
             headers=request_headers,
         )
         assert response.status_code == 404, f"Expected 404 Not Found, got {response.status_code}"
+
 
 @pytest.mark.noparallel(reason="Changes in configuration values and race conditions")
 class TestOpenDataCLI:

--- a/tests/test_policy_package.py
+++ b/tests/test_policy_package.py
@@ -121,7 +121,7 @@ class TestPolicyPackage:
 
         # call it to check we get the expected result
         assert algo('did') == 'Default scope algorithm loaded correctly!'
-        
+
         # restore original policy package environment variable
         if old_pp_env is not None:
             os.environ['RUCIO_POLICY_PACKAGE'] = old_pp_env


### PR DESCRIPTION
Fixes #8062