### PR TITLE
Clients: optimise rucio upload #7968

### DIFF
--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -153,6 +153,29 @@ class ReplicaClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
+    def replica_exists(self, scope: str, name: str, rse: str) -> bool:
+        """
+        Checks whether a replica of the specified file exists on the specified RSE.
+
+        Parameters
+        ----------
+        scope :
+            The scope of the file.
+        name :
+            The name of the file.
+        rse :
+            The RSE name.
+        """
+        payload = {'rse': rse}
+        url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, quote_plus(scope), quote_plus(name), 'exists']), params=payload)
+        r = self._send_request(url, method=HTTPMethod.GET)
+        if r.status_code == codes.ok:
+            return True
+        elif r.status_code == codes.not_found:
+            return False
+        exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+        raise exc_cls(exc_msg)
+
     def list_replicas(self, dids, schemes=None, ignore_availability=True,
                       all_states=False, metalink=False, rse_expression=None,
                       client_location=None, sort=None, domain=None,

--- a/lib/rucio/client/replicaclient.py
+++ b/lib/rucio/client/replicaclient.py
@@ -153,6 +153,27 @@ class ReplicaClient(BaseClient):
         exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
         raise exc_cls(exc_msg)
 
+    def replica_exists(self, scope: str, name: str, rse: str) -> bool:
+        """
+        Checks whether a replica of the specified file exists on the specified RSE.
+
+        Parameters
+        ----------
+        scope :
+            The scope of the file.
+        name :
+            The name of the file.
+        rse :
+            The RSE name.
+        """
+        payload = {'rse': rse}
+        url = build_url(self.host, path='/'.join([self.REPLICAS_BASEURL, quote_plus(scope), quote_plus(name), 'exists']), params=payload)
+        r = self._send_request(url, method=HTTPMethod.GET)
+        if r.status_code == codes.ok:
+            return r.text == 'True'
+        exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+        raise exc_cls(exc_msg)
+
     def list_replicas(self, dids, schemes=None, ignore_availability=True,
                       all_states=False, metalink=False, rse_expression=None,
                       client_location=None, sort=None, domain=None,

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -353,7 +353,10 @@ class UploadClient:
         rse_expression = None
         for file in files:
             rse_expression = file['rse']
-            rse = self.rse_expressions.setdefault(rse_expression, _pick_random_rse(rse_expression))
+
+            if rse_expression not in self.rse_expressions:
+                self.rse_expressions[rse_expression] = _pick_random_rse(rse_expression)
+            rse = self.rse_expressions[rse_expression]
 
             if not self.rses.get(rse):
                 rse_settings = self.rses.setdefault(rse, rsemgr.get_rse_info(rse, vo=self.client.vo))
@@ -378,6 +381,7 @@ class UploadClient:
         registered_dataset_dids = set()
         num_succeeded = 0
         summary = []
+        rse_attribute_cache = {}
         for file in files:
             basename = file['basename']
             logger(logging.INFO, 'Preparing upload for file %s' % basename)
@@ -416,11 +420,15 @@ class UploadClient:
 
             # resolving local area networks
             domain = 'wan'
-            rse_attributes = {}
-            try:
-                rse_attributes = self.client.list_rse_attributes(rse)
-            except Exception:
-                logger(logging.WARNING, 'Attributes of the RSE: %s not available.' % rse)
+            if rse in rse_attribute_cache:
+                rse_attributes = rse_attribute_cache[rse]
+            else:
+                rse_attributes = {}
+                try:
+                    rse_attributes = self.client.list_rse_attributes(rse)
+                except Exception:
+                    logger(logging.WARNING, 'Attributes of the RSE: %s not available.' % rse)
+                rse_attribute_cache[rse] = rse_attributes
             if self.client_location and 'lan' in rse_settings['domain'] and RseAttr.SITE in rse_attributes:
                 if self.client_location['site'] == rse_attributes[RseAttr.SITE]:
                     domain = 'lan'
@@ -738,10 +746,16 @@ class UploadClient:
                 raise DataIdentifierAlreadyExists
 
             # add the file to rse if it is not registered yet
-            replicastate = list(self.client.list_replicas([file_did], all_states=True))
-            if rse not in replicastate[0]['rses']:
+            try:
+                replica_exists = self.client.replica_exists(file_scope, file_name, rse)
+            except Exception:  # TODO: Remove via issue #8742
+                # if the new endpoint fails, fall back to the old code for now
+                replicastate = list(self.client.list_replicas([file_did], all_states=True))
+                replica_exists = rse in replicastate[0]['rses']
+            if not replica_exists:
                 self.client.add_replicas(rse=rse, files=[replica_for_api])
                 logger(logging.INFO, 'Successfully added replica in Rucio catalogue at %s' % rse)
+
         except DataIdentifierNotFound:
             logger(logging.DEBUG, 'File DID does not exist')
             self.client.add_replicas(rse=rse, files=[replica_for_api])

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1189,6 +1189,33 @@ def _list_replicas(
         }
 
 
+@read_session
+def replica_exists(
+        scope: InternalScope,
+        name: str,
+        rse_id: int,
+        *,
+        session: "Session"
+) -> bool:
+    """
+    Returns true if a replica of the given file exists on the given RSE.
+    :param scope: The scope of the file.
+    :param name: The name of the file.
+    :param rse_id: The ID of the RSE to check.
+    :param session: The database session in use.
+    """
+    stmt = select(
+        models.RSEFileAssociation.rse_id
+    ).select_from(
+        models.RSEFileAssociation
+    ).where(
+        and_(models.RSEFileAssociation.rse_id == rse_id,
+             models.RSEFileAssociation.scope == scope,
+             models.RSEFileAssociation.name == name)
+    )
+    return session.execute(stmt).first() is not None
+
+
 @stream_session
 def list_replicas(
         dids: "Sequence[dict[str, Any]]",

--- a/lib/rucio/core/replica.py
+++ b/lib/rucio/core/replica.py
@@ -1183,6 +1183,33 @@ def _list_replicas(
         }
 
 
+@read_session
+def replica_exists(
+        scope: InternalScope,
+        name: str,
+        rse_id: int,
+        *,
+        session: "Session"
+) -> bool:
+    """
+    Returns true if a replica of the given file exists on the given RSE.
+    :param scope: The scope of the file.
+    :param name: The name of the file.
+    :param rse_id: The ID of the RSE to check.
+    :param session: The database session in use.
+    """
+    stmt = select(
+        func.count()
+    ).select_from(
+        models.RSEFileAssociation
+    ).where(
+        and_(models.RSEFileAssociation.rse_id == rse_id,
+             models.RSEFileAssociation.scope == scope,
+             models.RSEFileAssociation.name == name)
+    )
+    return session.execute(stmt).scalar_one() != 0
+
+
 @stream_session
 def list_replicas(
         dids: "Sequence[dict[str, Any]]",

--- a/lib/rucio/gateway/replica.py
+++ b/lib/rucio/gateway/replica.py
@@ -297,6 +297,27 @@ def list_replicas(
             yield rep
 
 
+def replica_exists(
+        did: dict[str, Any],
+        rse: str,
+        issuer: str,
+        vo: str = DEFAULT_VO
+) -> bool:
+    """
+    Returns true if a replica of the given file exists on the given RSE.
+    :param did: The DID of the file.
+    :param rse: The name of the RSE to check.
+    :param issuer: The issuer account.
+    :param vo: The VO to act on.
+    """
+    scope = InternalScope(did['scope'], vo=vo)
+    name = did['name']
+
+    with db_session(DatabaseOperationType.READ) as session:
+        rse_id = get_rse_id(rse=rse, vo=vo, session=session)
+        return replica.replica_exists(scope=scope, name=name, rse_id=rse_id, session=session)
+
+
 def add_replicas(
         rse: str,
         files: "Iterable[dict[str, Any]]",

--- a/lib/rucio/gateway/replica.py
+++ b/lib/rucio/gateway/replica.py
@@ -298,6 +298,27 @@ def list_replicas(
             yield rep
 
 
+def replica_exists(
+        did: dict[str, Any],
+        rse: str,
+        issuer: str,
+        vo: str = DEFAULT_VO
+) -> bool:
+    """
+    Returns true if a replica of the given file exists on the given RSE.
+    :param did: The DID of the file.
+    :param rse: The name of the RSE to check.
+    :param issuer: The issuer account.
+    :param vo: The VO to act on.
+    """
+    scope = InternalScope(did['scope'], vo=vo)
+    name = did['name']
+
+    with db_session(DatabaseOperationType.READ) as session:
+        rse_id = get_rse_id(rse=rse, vo=vo, session=session)
+        return replica.replica_exists(scope=scope, name=name, rse_id=rse_id, session=session)
+
+
 def add_replicas(
         rse: str,
         files: "Iterable[dict[str, Any]]",

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -58,6 +58,7 @@ from rucio.gateway.replica import (
     list_dataset_replicas_vp,
     list_datasets_per_rse,
     list_replicas,
+    replica_exists,
     set_tombstone,
     update_replicas_states,
 )
@@ -65,6 +66,8 @@ from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, generate_http_error_flask, json_parameters, param_get, param_get_bool, parse_scope_name, response_headers, try_stream
 
 if TYPE_CHECKING:
+    from flask.typing import ResponseReturnValue
+
     from rucio.common.types import IPDict
 
 
@@ -1829,6 +1832,51 @@ class Tombstone(ErrorHandlingMethodView):
         return 'Created', 201
 
 
+class ReplicaExists(ErrorHandlingMethodView):
+
+    def get(self, scope_name: str) -> 'ResponseReturnValue':
+        """
+        ---
+        summary: Check replica existence
+        description: "Check replica existence."
+        tags:
+         - Replicas
+        parameters:
+        - name: scope_name
+          in: path
+          description: "data identifier (scope)/(name)."
+          schema:
+            type: string
+          style: simple
+        - name: rse
+          in: query
+          description: "RSE name."
+          schema:
+            type: string
+        responses:
+          200:
+            description: "OK"
+          400:
+            description: "Bad request."
+          404:
+            description: "Not found"
+        """
+        try:
+            scope, name = parse_scope_name(scope_name, request.environ['vo'])
+            did = {'scope': scope, 'name': name}
+            rse = request.args.get('rse', default='')
+            exists = replica_exists(
+                did=did,
+                rse=rse,
+                issuer=request.environ['issuer'],
+                vo=request.environ['vo'])
+        except ValueError as error:
+            return generate_http_error_flask(400, error)
+        except (RSENotFound) as error:
+            return generate_http_error_flask(404, error)
+        return str(exists), 200
+
+
 def blueprint(with_doc=False):
     bp = AuthenticatedBlueprint('replicas', __name__, url_prefix='/replicas')
 
@@ -1869,6 +1917,9 @@ def blueprint(with_doc=False):
     set_tombstone_view = Tombstone.as_view('set_tombstone')
     bp.add_url_rule('/tombstone', view_func=set_tombstone_view, methods=[HTTPMethod.POST.value])
 
+    replica_exists_view = ReplicaExists.as_view('replica_exists')
+    bp.add_url_rule('/<path:scope_name>/exists', view_func=replica_exists_view, methods=['get', ])
+
     if not with_doc:
         bp.add_url_rule('/list/', view_func=list_replicas_view, methods=[HTTPMethod.POST.value])
         bp.add_url_rule('/suspicious/', view_func=suspicious_replicas_view, methods=[HTTPMethod.GET.value, HTTPMethod.POST.value])
@@ -1884,6 +1935,7 @@ def blueprint(with_doc=False):
         bp.add_url_rule('/<path:scope_name>/', view_func=replicas_view, methods=[HTTPMethod.GET.value])
         bp.add_url_rule('/tombstone/', view_func=set_tombstone_view, methods=[HTTPMethod.POST.value])
         bp.add_url_rule('/quarantine/', view_func=quarantine_replicas_view, methods=[HTTPMethod.POST.value])
+        bp.add_url_rule('/<path:scope_name>/exists/', view_func=replica_exists_view, methods=[HTTPMethod.GET.value])
 
     bp.after_request(response_headers)
     return bp

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -33,7 +33,22 @@ from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifi
 from rucio.common.utils import clean_pfns, generate_uuid, parse_response
 from rucio.core.config import set as cconfig_set
 from rucio.core.did import add_did, attach_dids, get_did, get_did_access_cnt, get_did_atime, list_files, set_status
-from rucio.core.replica import add_bad_dids, add_replica, add_replicas, delete_replicas, get_bad_pfns, get_replica, get_replica_atime, get_replicas_state, get_rse_coverage_of_dataset, list_replicas, set_tombstone, touch_replica, update_replica_state
+from rucio.core.replica import (
+    add_bad_dids,
+    add_replica,
+    add_replicas,
+    delete_replicas,
+    get_bad_pfns,
+    get_replica,
+    get_replica_atime,
+    get_replicas_state,
+    get_rse_coverage_of_dataset,
+    list_replicas,
+    replica_exists,
+    set_tombstone,
+    touch_replica,
+    update_replica_state,
+)
 from rucio.core.rse import add_protocol, add_rse_attribute, del_rse_attribute
 from rucio.daemons.badreplicas.minos import minos
 from rucio.daemons.badreplicas.minos_temporary_expiration import minos_tu_expiration
@@ -719,6 +734,23 @@ class TestReplicaCore:
         [replica] = list(list_replicas([did2], rse_expression='group2=true'))
         assert len(replica['pfns']) == 1
 
+    def test_replica_exists(self, rse_factory, mock_scope, root_account):
+        """ REPLICA (CORE): Replica existence check """
+        _, rse_id = rse_factory.make_mock_rse()
+        filename = did_name_generator('file')
+
+        assert not replica_exists(scope=mock_scope, name=filename, rse_id=rse_id)
+
+        files = [{'scope': mock_scope, 'name': filename, 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}}]
+
+        add_replicas(rse_id=rse_id, files=files, account=root_account, ignore_availability=True)
+
+        assert replica_exists(scope=mock_scope, name=filename, rse_id=rse_id)
+
+        delete_replicas(rse_id=rse_id, files=files)
+
+        assert not replica_exists(scope=mock_scope, name=filename, rse_id=rse_id)
+
 
 class TestReplicaGateway:
 
@@ -1269,3 +1301,21 @@ def test_client_list_replicas_streaming_error(content_type, vo, did_client, repl
 
     else:
         pytest.fail('unknown content_type parameter on test: ' + content_type)
+
+
+def test_client_replica_exists(rse_factory, mock_scope, root_account, replica_client):
+    """ REPLICA (CLIENT): Replica existence check """
+    rse, rse_id = rse_factory.make_mock_rse()
+    filename = did_name_generator('file')
+
+    assert not replica_client.replica_exists(scope=mock_scope.external, name=filename, rse=rse)
+
+    files = [{'scope': mock_scope, 'name': filename, 'bytes': 1, 'adler32': '0cc737eb', 'meta': {'events': 10}}]
+
+    add_replicas(rse_id=rse_id, files=files, account=root_account, ignore_availability=True)
+
+    assert replica_client.replica_exists(scope=mock_scope.external, name=filename, rse=rse)
+
+    delete_replicas(rse_id=rse_id, files=files)
+
+    assert not replica_client.replica_exists(scope=mock_scope.external, name=filename, rse=rse)


### PR DESCRIPTION
The purpose of this work is to optimise the upload client by reducing the number of calls made to the server. Specifically:

- `list_rses` is only called if the RSE to be used is not already known
- RSE attribute are cached so that they're only retrieved once per RSE rather than once per file
- a new `replica_exists` endpoint is used instead of the much more expensive `list_replicas` call that was previously used to check replica existence

It would be possible to save another call by removing the warning message that is printed if the scope is not found for the account, but I have removed this change as I cannot be certain there isn't a good reason for this warning.