### PR TITLE
Support for Open Data record IDs

### DIFF
--- a/lib/rucio/alembicrevision.py
+++ b/lib/rucio/alembicrevision.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ALEMBIC_REVISION = 'a62db546a1f1'  # the current alembic head revision
+ALEMBIC_REVISION = 'a7e76cf4881d'  # the current alembic head revision

--- a/lib/rucio/cli/opendata.py
+++ b/lib/rucio/cli/opendata.py
@@ -166,11 +166,15 @@ def get_opendata_did(ctx: "Context", did: str, files: bool, meta: bool, public: 
 @click.option("--state", type=click.Choice(OPENDATA_DID_STATE_LITERAL_LIST, case_sensitive=False), required=False,
               help="State of the Opendata DID")
 @click.option("--doi", required=False,
-              help="Digital Object Identifier (DOI) for the Opendata DID (e.g., 10.1234/foo.bar)")
+              help="Digital Object Identifier (DOI) for the Opendata DID (e.g., 10.1234/foo.bar). Must be unique between all Opendata DIDs")
+@click.option("--record-id", type=int, required=False,
+              help="Record ID to associate with the Opendata DID. Must be unique between all Opendata DIDs")
 @click.pass_context
 def update_opendata_did(ctx: "Context", did: str, meta: Optional[str],
                         state: Optional["OPENDATA_DID_STATE_LITERAL"],
-                        doi: Optional[str]) -> None:
+                        doi: Optional[str],
+                        record_id: Optional[int]
+                        ) -> None:
     """
     Update an existing Opendata DID in the Opendata catalog.
     """
@@ -198,3 +202,5 @@ def update_opendata_did(ctx: "Context", did: str, meta: Optional[str],
     else:
         table = [(k + ':', str(v)) for (k, v) in sorted(info.items())]
         print(tabulate(table, tablefmt='plain', disable_numparse=True))
+
+    client.update_opendata_did(scope=scope, name=name, meta=meta, state=state, doi=doi, record_id=record_id)

--- a/lib/rucio/client/opendataclient.py
+++ b/lib/rucio/client/opendataclient.py
@@ -163,6 +163,7 @@ class OpenDataClient(BaseClient):
             state: Optional["OPENDATA_DID_STATE_LITERAL"] = None,
             meta: Optional[dict] = None,
             doi: Optional[str] = None,
+            record_id: Optional[int] = None,
     ) -> dict[str, Any]:
         """
         Update an existing Opendata DID in the Opendata catalog.
@@ -172,7 +173,8 @@ class OpenDataClient(BaseClient):
             name: The name of the DID.
             state: The new state to set for the DID.
             meta: Metadata to update for the DID. Must be a valid JSON object.
-            doi: DOI to associate with the DID. Must be a valid DOI string (e.g., "10.1234/foo.bar").
+            doi: DOI to associate with the DID. Must be a valid DOI string (e.g., "10.1234/foo.bar") and unique across all DIDs.
+            record_id: The record ID of the DID to update. This can be used to cross-reference with external systems. Must be unique across all DIDs.
 
         Returns:
             True if the update was successful.
@@ -185,8 +187,8 @@ class OpenDataClient(BaseClient):
         path = '/'.join([self.opendata_private_dids_base_url, quote_plus(scope), quote_plus(name)])
         url = build_url(self.get_opendata_host(public=False), path=path)
 
-        if not any([meta, state, doi]):
-            raise ValueError("Either 'meta', 'state', or 'doi' must be provided.")
+        if not any([meta, state, doi, record_id]):
+            raise ValueError("Either 'meta', 'state', 'doi' or 'record_id' must be provided.")
 
         data: dict[str, Any] = {}
 
@@ -198,6 +200,9 @@ class OpenDataClient(BaseClient):
 
         if doi is not None:
             data['doi'] = doi
+
+        if record_id is not None:
+            data['record_id'] = record_id
 
         r = self._send_request(url, method=HTTPMethod.PUT, data=render_json(**data))
 
@@ -215,6 +220,7 @@ class OpenDataClient(BaseClient):
             include_files: bool = False,
             include_metadata: bool = False,
             include_doi: bool = True,
+            include_record_id: bool = True,
             public: bool = False,
     ) -> dict[str, Any]:
         """
@@ -226,6 +232,7 @@ class OpenDataClient(BaseClient):
             include_files: If True, include a list of associated files. Defaults to False.
             include_metadata: If True, include extended metadata. Defaults to False.
             include_doi: If True, include DOI (Digital Object Identifier) information. Defaults to True.
+            include_record_id: If True, include the record ID of the DID. Defaults to True.
             public: If True, only return data if the DID is publicly accessible. Defaults to False.
 
         Returns:
@@ -241,6 +248,7 @@ class OpenDataClient(BaseClient):
             'files': 1 if include_files else 0,
             'meta': 1 if include_metadata else 0,
             'doi': 1 if include_doi else 0,
+            'record_id': 1 if include_record_id else 0,
         })
 
         if r.status_code == codes.ok:

--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1282,6 +1282,7 @@ class InvalidAccountType(RucioException):
         self._message = "Cannot create an account with an invalid type."
         self.error_code = 121
 
+
 class OpenDataDuplicateDOI(OpenDataError):
     """
     Throws when a data identifier with the same DOI already exists in the open data catalog.
@@ -1291,3 +1292,14 @@ class OpenDataDuplicateDOI(OpenDataError):
         super(OpenDataDuplicateDOI, self).__init__(*args)
         self._message = f"Data identifier with the same DOI ({doi}) already exists in the open data catalog."
         self.error_code = 122
+
+
+class OpenDataDuplicateRecordID(OpenDataError):
+    """
+    Throws when a data identifier with the same Record ID already exists in the open data catalog.
+    """
+
+    def __init__(self, record_id: int, *args):
+        super(OpenDataDuplicateRecordID, self).__init__(*args)
+        self._message = f"Data identifier with the same Record ID ({record_id}) already exists in the open data catalog."
+        self.error_code = 123

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -980,6 +980,20 @@ def update_opendata_record_id(
         if result.rowcount == 0:
             raise ValueError(f"Error updating Opendata Record ID for DID '{scope}:{name}'.")
 
+    except IntegrityError as error:
+        msg = str(error)
+
+        if (
+                search(r'ORA-00001: unique constraint \([^)]+\) violated', msg)
+                or search(r'UNIQUE constraint failed: dids_opendata_record\.record_id', msg)
+                or search(r'1062.*Duplicate entry.*for key', msg)
+                or search(r'duplicate key value violates unique constraint', msg)
+                or search(r'columns?.*not unique', msg)
+        ):
+            raise exception.OpenDataDuplicateRecordID(record_id=record_id)
+
+        raise exception.OpenDataError()
+
     except DataError as error:
         raise exception.InputValidationError(f"Invalid data: {error}")
 

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -236,6 +236,39 @@ def get_opendata_doi(
     else:
         return result["doi"]
 
+def get_opendata_record_id(
+        *,
+        scope: "InternalScope",
+        name: str,
+        session: "Session",
+) -> Optional[int]:
+    """
+    Retrieve the record ID associated with an Opendata DID.
+
+    Parameters:
+        scope: The scope of the Opendata DID.
+        name: The name of the Opendata DID.
+        session: SQLAlchemy session to use for the query.
+
+    Returns:
+        The Record ID associated with the Opendata DID, or None if not found.
+    """
+
+    query = select(
+        models.OpenDataRecord.record_id,
+    ).where(
+        and_(
+            models.OpenDataRecord.name == name,
+            models.OpenDataRecord.scope == scope,
+        )
+    )
+
+    result = session.execute(query).mappings().fetchone()
+
+    if not result:
+        return None
+    else:
+        return int(result["record_id"])
 
 def get_opendata_did_files(
         *,
@@ -305,6 +338,7 @@ def get_opendata_did(
         include_metadata: bool = False,
         include_doi: bool = True,
         include_rule: bool = True,
+        include_record_id: bool = True,
         session: "Session",
 ) -> dict[str, Any]:
     """
@@ -318,6 +352,7 @@ def get_opendata_did(
         include_metadata: If True, include extended metadata. Defaults to False.
         include_doi: If True, include DOI (Digital Object Identifier) information. Defaults to True.
         include_rule: If True, include the Opendata replication rule. Defaults to True.
+        include_record_id: If True, include the record ID of the DID. Defaults to True.
         session: SQLAlchemy session to use for the query.
 
     Returns:
@@ -349,6 +384,8 @@ def get_opendata_did(
 
     if include_doi:
         result["doi"] = get_opendata_doi(scope=scope, name=name, session=session)
+    if include_record_id:
+        result["record_id"] = get_opendata_record_id(scope=scope, name=name, session=session)
     if include_metadata:
         result["meta"] = get_opendata_meta(scope=scope, name=name, session=session)
     if include_rule:
@@ -515,6 +552,7 @@ def update_opendata_did(
         state: Optional[OpenDataDIDState] = None,
         meta: Optional[Union[dict, str]] = None,
         doi: Optional[str] = None,
+        record_id: Optional[int] = None,
         session: "Session",
 ) -> dict[str, Any]:
     """
@@ -526,6 +564,7 @@ def update_opendata_did(
         state: The new state to set for the DID.
         meta: Metadata to update for the DID. Must be a valid JSON object or string.
         doi: DOI to associate with the DID. Must be a valid DOI string (e.g., "10.1234/foo.bar").
+        record_id: The record ID of the DID to update. This can be used to cross-reference with external systems.
         session: SQLAlchemy session to use for the operation.
 
     Returns:
@@ -538,9 +577,9 @@ def update_opendata_did(
         ValueError: If there is an error during the update process.
     """
 
-    if state is None and meta is None and doi is None:
+    if not any([ state, meta, doi, record_id]):
         raise exception.InputValidationError(
-            "Either 'state', 'meta', or 'doi' must be provided to update the Opendata DID.")
+            "Either 'state', 'meta', 'doi', or 'record_id' must be provided to update the Opendata DID.")
     if not _check_opendata_did_exists(scope=scope, name=name, session=session):
         raise exception.OpenDataDataIdentifierNotFound(f"OpenData DID '{scope}:{name}' not found.")
 
@@ -555,8 +594,10 @@ def update_opendata_did(
     if doi is not None:
         result |= update_opendata_doi(scope=scope, name=name, doi=doi, session=session)
 
-    return result
+    if record_id is not None:
+        result |= update_opendata_record_id(scope=scope, name=name, record_id=record_id, session=session)
 
+    return result
 
 def update_opendata_meta(
         *,
@@ -884,3 +925,62 @@ def update_opendata_doi(
         raise exception.InputValidationError(f"Invalid data: {error}")
 
     return {"scope": scope, "name": name, "doi_new": doi, "doi_old": doi_before}
+
+def update_opendata_record_id(
+        *,
+        scope: "InternalScope",
+        name: str,
+        record_id: int,
+        session: "Session",
+) -> dict[str, Any]:
+    """
+    Update the Record ID associated with an Opendata DID.
+
+    Parameters:
+        scope: The scope under which the Opendata DID is registered.
+        name: The name of the Opendata DID.
+        record_id: The new Record ID to associate with the Opendata DID. Must be a valid integer.
+        session: SQLAlchemy session to use for the operation.
+
+    Returns:
+        A dictionary containing the scope, name, new Record ID, and previous Record ID of the Opendata DID.
+
+    Raises:
+        InputValidationError: If the provided DOI is not a valid string or does not match the expected format.
+        OpenDataDataIdentifierNotFound: If the Opendata DID does not exist.
+        ValueError: If there is an error during the update process.
+    """
+
+    if not _check_opendata_did_exists(scope=scope, name=name, session=session):
+        raise exception.OpenDataDataIdentifierNotFound(f"OpenData DID '{scope}:{name}' not found.")
+
+    if not isinstance(record_id, int) or record_id < 0:
+        raise exception.InputValidationError("DOI must be a positive integer.")
+
+    # insert on the table if it does not exist, otherwise update it
+    record_id_before = session.execute(select(models.OpenDataRecord.record_id).where(
+        and_(
+            models.OpenDataRecord.scope == scope,
+            models.OpenDataRecord.name == name
+        )
+    )).scalar()
+    if record_id_before is None:
+        update_query = insert(models.OpenDataRecord).values(scope=scope, name=name, record_id=record_id)
+    else:
+        update_query = update(models.OpenDataRecord).where(
+            and_(
+                models.OpenDataRecord.scope == scope,
+                models.OpenDataRecord.name == name
+            )
+        ).values(record_id=record_id)
+
+    try:
+        result = session.execute(update_query)
+
+        if result.rowcount == 0:
+            raise ValueError(f"Error updating Opendata Record ID for DID '{scope}:{name}'.")
+
+    except DataError as error:
+        raise exception.InputValidationError(f"Invalid data: {error}")
+
+    return {"scope": scope, "name": name, "record_id_new": record_id, "record_id_old": record_id_before}

--- a/lib/rucio/db/sqla/migrate_repo/versions/a62db546a1f1_opendata_initial_model.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a62db546a1f1_opendata_initial_model.py
@@ -74,7 +74,11 @@ def upgrade():
 
 def downgrade():
     op.drop_table('dids_opendata_meta')
+
+    op.drop_index('OPENDATA_DOI_CREATED_AT_IDX', table_name='dids_opendata_doi')
+    op.drop_index('OPENDATA_DOI_UPDATED_AT_IDX', table_name='dids_opendata_doi')
     op.drop_table('dids_opendata_doi')
+
     op.drop_index('OPENDATA_DID_STATE_UPDATED_AT_IDX', table_name='dids_opendata')
     op.drop_index('OPENDATA_DID_STATE_IDX', table_name='dids_opendata')
     op.drop_index('OPENDATA_DID_CREATED_AT_IDX', table_name='dids_opendata')

--- a/lib/rucio/db/sqla/migrate_repo/versions/a7e76cf4881d_opendata_record.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/a7e76cf4881d_opendata_record.py
@@ -1,0 +1,46 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Opendata Record ID"""  # noqa: D400, D415
+
+import sqlalchemy as sa
+from alembic import op
+
+from rucio.common.schema import get_schema_value
+
+# Alembic revision identifiers
+revision = 'a7e76cf4881d'
+down_revision = 'a62db546a1f1'
+
+
+def upgrade():
+    op.create_table(
+        'dids_opendata_record',
+        sa.Column('scope', sa.String(length=get_schema_value('SCOPE_LENGTH')), nullable=False),
+        sa.Column('name', sa.String(length=get_schema_value('NAME_LENGTH')), nullable=False),
+        sa.Column('record_id', sa.Integer(), nullable=False, unique=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('scope', 'name', name='OPENDATA_RECORD_PK'),
+        sa.ForeignKeyConstraint(['scope', 'name'], ['dids_opendata.scope', 'dids_opendata.name'],
+                                ondelete='CASCADE', name='OPENDATA_RECORD_FK')
+    )
+    op.create_index('OPENDATA_RECORD_CREATED_AT_IDX', 'dids_opendata_record', ['created_at'])
+    op.create_index('OPENDATA_RECORD_UPDATED_AT_IDX', 'dids_opendata_record', ['updated_at'])
+
+
+def downgrade():
+    op.drop_index('OPENDATA_RECORD_CREATED_AT_IDX', table_name='dids_opendata_record')
+    op.drop_index('OPENDATA_RECORD_UPDATED_AT_IDX', table_name='dids_opendata_record')
+    op.drop_table('dids_opendata_record')

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -517,6 +517,25 @@ class OpenDataDOI(BASE, ModelBase):
         Index('OPENDATA_DOI_CREATED_AT_IDX', 'created_at'),
     )
 
+class OpenDataRecord(BASE, ModelBase):
+    """Mapping between OpenData DIDs and Open Data Portal Record IDs"""
+    __tablename__ = 'dids_opendata_record'
+
+    scope: Mapped[InternalScope] = mapped_column(InternalScopeString(common_schema.get_schema_value('SCOPE_LENGTH')))
+    name: Mapped[str] = mapped_column(String(common_schema.get_schema_value('NAME_LENGTH')))
+    record_id: Mapped[int] = mapped_column(Integer(), unique=True)
+
+    __table_args__ = (
+        PrimaryKeyConstraint('scope', 'name', name='OPENDATA_RECORD_PK'),
+        ForeignKeyConstraint(
+            ['scope', 'name'],
+            ['dids_opendata.scope', 'dids_opendata.name'],
+            name='OPENDATA_RECORD_FK',
+            ondelete='CASCADE',
+        ),
+        Index('OPENDATA_RECORD_UPDATED_AT_IDX', 'updated_at'),
+        Index('OPENDATA_RECORD_CREATED_AT_IDX', 'created_at'),
+    )
 
 class OpenDataMeta(BASE, ModelBase):
     """Mapping between OpenData DIDs and DOIs"""

--- a/lib/rucio/gateway/opendata.py
+++ b/lib/rucio/gateway/opendata.py
@@ -62,6 +62,7 @@ def get_opendata_did(
         include_files: bool = True,
         include_metadata: bool = False,
         include_doi: bool = True,
+        include_record_id: bool = True,
         vo: str = DEFAULT_VO,
 ) -> dict[str, Any]:
     """
@@ -74,6 +75,7 @@ def get_opendata_did(
         include_files: Whether to include files in the result.
         include_metadata: Whether to include metadata in the result.
         include_doi: Whether to include DOI information in the result.
+        include_record_id: Whether to include the record ID in the result.
         vo: The virtual organization.
 
     Returns:
@@ -93,6 +95,7 @@ def get_opendata_did(
                                            include_files=include_files,
                                            include_metadata=include_metadata,
                                            include_doi=include_doi,
+                                           include_record_id=include_record_id,
                                            session=session)
         return gateway_update_return_dict(result, session=session)
 
@@ -150,6 +153,7 @@ def update_opendata_did(
         state: Optional["OPENDATA_DID_STATE_LITERAL"] = None,
         meta: Optional[dict] = None,
         doi: Optional[str] = None,
+        record_id: Optional[int] = None,
         vo: str = DEFAULT_VO,
 ) -> dict[str, Any]:
     """
@@ -161,6 +165,7 @@ def update_opendata_did(
         state: Optional new state for the DID.
         meta: Optional metadata dictionary or JSON string.
         doi: Optional DOI string.
+        record_id: Optional record ID
         vo: The virtual organization.
 
     Returns:
@@ -187,4 +192,5 @@ def update_opendata_did(
                                             state=state_enum,
                                             meta=meta,
                                             doi=doi,
+                                            record_id=record_id,
                                             session=session)

--- a/lib/rucio/web/rest/flaskapi/v1/opendata.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata.py
@@ -106,11 +106,13 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
             include_files = request.args.get("files", default="0").lower() == "1"
             include_metadata = request.args.get("meta", default="0").lower() == "1"
             include_doi = request.args.get("doi", default="1").lower() == "1"
+            include_record_id = request.args.get("record_id", default="1").lower() == "1"
             result = opendata.get_opendata_did(scope=scope, name=name, vo=vo,
                                                state=state,
                                                include_files=include_files,
                                                include_metadata=include_metadata,
                                                include_doi=include_doi,
+                                               include_record_id=include_record_id,
                                                )
 
             result = render_json(**result)
@@ -164,6 +166,14 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
           - name: doi
             in: query
             description: "Whether to include the Digital Object Identifier (DOI). '1' to include, '0' to exclude. Default is '1'."
+            schema:
+              type: string
+              enum: ['0', '1']
+            required: false
+            style: form
+          - name: record_id
+            in: query
+            description: "Whether to include the record ID. '1' to include, '0' to exclude. Default is '1'."
             schema:
               type: string
               enum: ['0', '1']
@@ -289,6 +299,10 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
                       type: string
                       description: "Digital Object Identifier (DOI) for the DID.
                       example: '10.1234/abcd.efgh'."
+                    record_id:
+                      type: integer
+                      description: "Record ID for the DID."
+                      example: 123456
         responses:
           200:
             description: "Opendata DID successfully updated."
@@ -310,11 +324,13 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
             state = param_get(parameters, 'state', default=None)
             meta = param_get(parameters, 'meta', default=None)
             doi = param_get(parameters, 'doi', default=None)
+            record_id = param_get(parameters, 'record_id', default=None, type_=int)
             result = opendata.update_opendata_did(scope=scope,
                                          name=name,
                                          state=state,
                                          meta=meta,
                                          doi=doi,
+                                         record_id=record_id,
                                          vo=request.environ.get("vo", DEFAULT_VO),
                                          )
         except AccessDenied as error:

--- a/lib/rucio/web/rest/flaskapi/v1/opendata_public.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata_public.py
@@ -108,6 +108,14 @@ class OpenDataPublicDIDsView(ErrorHandlingMethodView):
               enum: ['0', '1']
             required: false
             style: form
+          - name: record_id
+            in: query
+            description: "Whether to include the record ID. '1' to include, '0' to exclude. Default is '1'."
+            schema:
+              type: string
+              enum: ['0', '1']
+            required: false
+            style: form
         responses:
           200:
             description: "Successful retrieval of Opendata DID information."

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -19,7 +19,7 @@ import pytest
 
 from rucio.common.config import config_add_section, config_get_bool, config_remove_option, config_set
 from rucio.common.constants import OPENDATA_DID_STATE_LITERAL
-from rucio.common.exception import DataIdentifierNotFound, OpenDataDataIdentifierAlreadyExists, OpenDataDataIdentifierNotFound, OpenDataDuplicateDOI, OpenDataInvalidStateUpdate
+from rucio.common.exception import DataIdentifierNotFound, OpenDataDataIdentifierAlreadyExists, OpenDataDataIdentifierNotFound, OpenDataDuplicateDOI, OpenDataDuplicateRecordID, OpenDataInvalidStateUpdate
 from rucio.common.utils import execute
 from rucio.core import opendata
 from rucio.core.did import add_did, set_status
@@ -266,6 +266,72 @@ class TestOpenDataCore:
         with pytest.raises(OpenDataDuplicateDOI):
             opendata.update_opendata_doi(scope=mock_scope, name=name_second, doi=doi, session=db_write_session)
 
+    def test_opendata_record_id_update(self, mock_scope, root_account, db_write_session):
+        name = did_name_generator(did_type="dataset")
+
+        add_did(scope=mock_scope, name=name, account=root_account, did_type=DIDType.DATASET,
+                session=db_write_session)
+        opendata.add_opendata_did(scope=mock_scope, name=name, session=db_write_session)
+
+        record_id_first = 12345
+
+        opendata.update_opendata_did(scope=mock_scope, name=name, record_id=record_id_first, session=db_write_session)
+
+        db_write_session.commit()
+
+        record_id_after = opendata.get_opendata_did(scope=mock_scope, name=name, session=db_write_session)["record_id"]
+
+        assert record_id_after == record_id_first, f"Record ID should be updated to {record_id_first}, fetched from `get_opendata_did`"
+
+        db_write_session.commit()
+
+        record_id_after = opendata.get_opendata_record_id(scope=mock_scope, name=name, session=db_write_session)
+
+        assert record_id_after == record_id_first, f"Record ID should be updated to {record_id_first}, fetched from `get_opendata_record_id`"
+
+        record_id_second = 54321
+        opendata.update_opendata_record_id(scope=mock_scope, name=name, record_id=record_id_second, session=db_write_session)
+
+        db_write_session.commit()
+
+        record_id_after = opendata.get_opendata_did(scope=mock_scope, name=name, session=db_write_session)["record_id"]
+
+        assert record_id_after == record_id_second, f"Record ID should be updated (second time) to {record_id_second}, fetched from `get_opendata_did`"
+
+        opendata.delete_opendata_did(scope=mock_scope, name=name, session=db_write_session)
+
+        db_write_session.commit()
+
+    def test_opendata_record_id_duplicate(self, mock_scope, root_account, db_write_session):
+        name_first = did_name_generator(did_type="dataset")
+        name_second = did_name_generator(did_type="dataset")
+
+        for name in [name_first, name_second]:
+            add_did(scope=mock_scope, name=name, account=root_account, did_type=DIDType.DATASET,
+                    session=db_write_session)
+            opendata.add_opendata_did(scope=mock_scope, name=name, session=db_write_session)
+
+        record_id = 1337
+
+        opendata.update_opendata_did(scope=mock_scope, name=name_first, record_id=record_id, session=db_write_session)
+
+        db_write_session.commit()
+
+        # delete it so we can use the record id in another did
+        opendata.delete_opendata_did(scope=mock_scope, name=name_first, session=db_write_session)
+
+        db_write_session.commit()
+
+        # set previously used record id to another did
+        opendata.update_opendata_did(scope=mock_scope, name=name_second, record_id=record_id, session=db_write_session)
+
+        # add back previously deleted did so we can test for duplicates
+        opendata.add_opendata_did(scope=mock_scope, name=name_first, session=db_write_session)
+
+        with pytest.raises(OpenDataDuplicateRecordID):
+            # using a record id that is in use by another open data did will throw
+            opendata.update_opendata_did(scope=mock_scope, name=name_first, record_id=record_id, session=db_write_session)
+
     def test_opendata_dids_list(self, mock_scope, root_account, db_write_session):
         dids = [
             {"scope": mock_scope, "name": did_name_generator(did_type="dataset")} for _ in range(5)
@@ -457,12 +523,15 @@ class TestOpenDataClient:
 
         # Here we also test that doi is returned as key by default because `include_doi` is True by default
         assert opendata_did["doi"] is None, "DOI should be None"
+        assert opendata_did["record_id"] is None, "Record ID should be None"
         assert "files" not in opendata_did, "Files should not be present in the response"
         assert "meta" not in opendata_did, "Meta should not be present in the response"
 
         opendata_did = rucio_client.get_opendata_did(scope=scope, name=name,
-                                                     include_files=True, include_metadata=True, include_doi=True)
+                                                     include_files=True, include_metadata=True,
+                                                     include_doi=True, include_record_id=True)
         assert opendata_did["doi"] is None, "DOI should still be None"
+        assert opendata_did["record_id"] is None, "Record ID should still be None"
         assert "files" in opendata_did, "Files should be present in the response"
         assert "meta" in opendata_did, "Meta should be present in the response"
         meta = opendata_did["meta"]
@@ -582,7 +651,7 @@ class TestOpenDataCLI:
         ("add", {"--help"}),
         ("list", {"--help", "--state", "--public", "--short"}),
         ("show", {"--help", "--meta", "--files", "--public"}),
-        ("update", {"--help", "--meta", "--state", "--doi"}),
+        ("update", {"--help", "--meta", "--state", "--doi", "--record-id"}),
         ("remove", {"--help"}),
     ])
     def test_opendata_cli_options(self, subcommand, expected_options):


### PR DESCRIPTION
This PR adds support for Records IDs in a similar way to how DOI is implemented.

Record IDs are an optional attribute that must be globally unique, in order to implement this in the DB, we must use a dedicated table.