### PR TITLE
Correct textbox wrapping in config client docs

### DIFF
--- a/lib/rucio/client/configclient.py
+++ b/lib/rucio/client/configclient.py
@@ -90,7 +90,7 @@ class ConfigClient(BaseClient):
         Note:
         ------
         The format of the /config endpoint was recently changed. We migrated from performing a PUT on
-        "/config/<section>/<option>/<value>" to sending the parameters using a json-encoded body.
+        "/config/{section}/{option}/{value}" to sending the parameters using a json-encoded body.
         This was done to fix multiple un-wanted side effects related to how the middleware treats
         values encoded in a path.
         For a smooth transition, we allow both cases for now, but we should migrate to only passing


### PR DESCRIPTION
Closes #8083 

Looks like this now: 
<img width="978" height="207" alt="image" src="https://github.com/user-attachments/assets/78bce7b7-b168-40b5-98b0-4681becc3a3b" />

