### PR TITLE
Metadata: Feature add jsonschema validation postgres jsonb; Fix rucio#8036

### DIFF
--- a/lib/rucio/core/did_meta_plugins/postgres_meta.py
+++ b/lib/rucio/core/did_meta_plugins/postgres_meta.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import json
 import operator
-import jsonschema
+import os
 from typing import TYPE_CHECKING, Any, Optional
 
+import jsonschema
 import psycopg
 from psycopg import sql
 from psycopg.rows import dict_row
@@ -28,8 +28,6 @@ from rucio.core.did_meta_plugins.did_meta_plugin_interface import DidMetaPlugin
 from rucio.core.did_meta_plugins.filter_engine import FilterEngine
 
 if TYPE_CHECKING:
-    from typing import Optional
-
     from sqlalchemy.orm import Session
 
 
@@ -211,7 +209,7 @@ class ExternalPostgresJSONDidMeta(DidMetaPlugin):
                 with open(schema_path, 'r') as f:
                     schema = json.load(f)
                 return schema
-            except (json.JSONDecodeError, IOError) as e:
+            except (json.JSONDecodeError, OSError) as e:
                 raise exception.ConfigurationError(f"Invalid JSON schema file: {e}")
         else:
             return None
@@ -263,7 +261,15 @@ class ExternalPostgresJSONDidMeta(DidMetaPlugin):
         """
         self.set_metadata_bulk(scope=scope, name=name, metadata={key: value}, recursive=recursive, session=session)
 
-    def set_metadata_bulk(self, scope, name, metadata, recursive=False, *, session: "Optional[Session]" = None):
+    def set_metadata_bulk(
+        self,
+        scope: InternalScope,
+        name: str,
+        metadata: dict[str, Any],
+        recursive: bool = False,
+        *,
+        session: "Optional[Session]" = None,
+    ) -> None:
         """
         Bulk set metadata keys.
 
@@ -375,7 +381,12 @@ class ExternalPostgresJSONDidMeta(DidMetaPlugin):
                     ignore_dids.add(did)
                     yield row['name']
 
-    def manages_key(self, key, *, session: "Optional[Session]" = None):
+    def manages_key(
+        self,
+        key: str,
+        *,
+        session: "Optional[Session]" = None,
+    ) -> bool:
         if self.metadata_schema:
             if key in self.metadata_schema.get("properties", {}):
                 return True

--- a/lib/rucio/core/did_meta_plugins/postgres_meta.py
+++ b/lib/rucio/core/did_meta_plugins/postgres_meta.py
@@ -223,7 +223,7 @@ class ExternalPostgresJSONDidMeta(DidMetaPlugin):
                 jsonschema.validate(instance=metadata, schema=self.metadata_schema)
             except jsonschema.ValidationError as e:
                 raise exception.InvalidMetadata(
-                    f"Metadata validation failed: {e.message} at {'.'.join(str(x) for x in e.path)}"
+                    f"Metadata validation failed: {e.message} at {'.'.join(str(x) for x in e.path)}")
 
     def get_metadata(self, scope, name, *, session: "Optional[Session]" = None):
         """

--- a/lib/rucio/core/did_meta_plugins/postgres_meta.py
+++ b/lib/rucio/core/did_meta_plugins/postgres_meta.py
@@ -66,7 +66,7 @@ class ExternalPostgresJSONDidMeta(DidMetaPlugin):
         if table_column_data is None:
             table_column_data = config.config_get('metadata', 'postgres_table_column_data', default='data')
         if not json_schema:
-            json_schema = config.config_get('metadata', 'postgres_json_schema_path', default=None)
+            json_schema = config.config_get('metadata', 'postgres_json_schema_path', raise_exception=False, default=None)
             self.metadata_schema = self._load_json_schema(json_schema)
 
         self.fixed_table_columns = {

--- a/tests/test_did_meta_plugins.py
+++ b/tests/test_did_meta_plugins.py
@@ -488,8 +488,10 @@ class TestDidMetaExternalPostgresJSON:
         assert len(results) == 1
         # assert [{'scope': (tmp_scope), 'name': tmp_dsn4}] == results
         assert [tmp_dsn4] == results
-    
+
+    @pytest.mark.dirty
     def test_did_set_metadata_json_schema(self, mock_scope, root_account, postgres_json_meta):
+        """ DID Meta (POSTGRES_JSON): Set DID meta with JSON schema validation """
         #Define a simple JSON schema
         schema = {
             "type": "object",
@@ -503,14 +505,14 @@ class TestDidMetaExternalPostgresJSON:
         }
         # Assign schema to the instance
         postgres_json_meta.metadata_schema = schema
-        did_name = f'dataset_{uuid4()}'
+        did_name = did_name_generator('dataset')
         add_did(scope=mock_scope, name=did_name, did_type='DATASET', account=root_account)
 
         # Valid metadata according to schema
         valid_metadata = {
-            "meta_key3": randint(1, 100),
-            "meta_key4": f"value_{uuid4()}",
-            "meta_key5": f"value_{uuid4()}"
+            "meta_key3": 50,
+            "meta_key4": "value_{%s}" % generate_uuid(),
+            "meta_key5": "value_{%s}" % generate_uuid(),
         }
         # This should succeed
         postgres_json_meta.set_metadata_bulk(scope=mock_scope, name=did_name, metadata=valid_metadata)
@@ -523,7 +525,7 @@ class TestDidMetaExternalPostgresJSON:
         }
         with pytest.raises(InvalidMetadata):
             postgres_json_meta.set_metadata_bulk(scope=mock_scope, name=did_name, metadata=invalid_metadata)
-        
+
         # Invalid metadata (meta_key3 type check failed)
         invalid_metadata_type = {
             "meta_key3": "not-an-integer",
@@ -531,7 +533,7 @@ class TestDidMetaExternalPostgresJSON:
         }
         with pytest.raises(InvalidMetadata):
             postgres_json_meta.set_metadata_bulk(scope=mock_scope, name=did_name, metadata=invalid_metadata_type)
-        
+
         # Invalid metadata (unknown_key check failed)
         invalid_extra_key = {
             "meta_key3": 42,

--- a/tests/test_did_meta_plugins.py
+++ b/tests/test_did_meta_plugins.py
@@ -17,7 +17,7 @@ from copy import deepcopy
 import pytest
 
 from rucio.client.didclient import DIDClient
-from rucio.common.exception import KeyNotFound, InvalidMetadata
+from rucio.common.exception import InvalidMetadata, KeyNotFound
 from rucio.common.utils import generate_uuid
 from rucio.core.did import add_did, delete_dids, get_metadata_bulk, set_dids_metadata_bulk, set_metadata_bulk
 from rucio.core.did_meta_plugins import get_metadata, list_dids, set_metadata


### PR DESCRIPTION
Add optional json schema validation on set_metadata_bulk of postgres_meta jsonb plugin.

- schema is applied globally regardless of did type if turned on
- Can be turned on as using `postgres_json_schema_path`:
```
[metadata]
plugins = rucio.core.did_meta_plugins.postgres_meta.ExternalPostgresJSONDidMeta
.......
........
postgres_json_schema_path=/opt/rucio/etc/schema.json
```
- added a test for this logic