### PR TITLE
Metadata: fix delete metadata in postgres_json plugin Fix #8090

### DIFF
--- a/lib/rucio/core/did_meta_plugins/postgres_meta.py
+++ b/lib/rucio/core/did_meta_plugins/postgres_meta.py
@@ -260,17 +260,19 @@ class ExternalPostgresJSONDidMeta(DidMetaPlugin):
 
     def delete_metadata(self, scope, name, key, *, session: "Optional[Session]" = None):
         """
-        Delete a key from metadata.
+        Delete a key from metadata of DID.
 
         :param scope: the scope of DID
         :param name: the name of the DID
         :param key: the key to be deleted
         :param session: the database session in use
         """
-        statement = sql.SQL("UPDATE {} SET data = {}.data - {}").format(
+        statement = sql.SQL("UPDATE {} SET data = {}.data - {} WHERE scope = {} AND name = {}").format(
             sql.Identifier(self.table),
             sql.Identifier(self.table),
-            sql.Literal(key)
+            sql.Literal(key),
+            sql.Literal(scope.internal),
+            sql.Literal(name)
         )
 
         cur = self.client.cursor()

--- a/tests/test_did_meta_plugins.py
+++ b/tests/test_did_meta_plugins.py
@@ -432,6 +432,27 @@ class TestDidMetaExternalPostgresJSON:
         assert postgres_json_meta.get_metadata(scope=mock_scope, name=did_name)[meta_key] == meta_value
 
     @pytest.mark.dirty
+    def test_delete_metadata(self, mock_scope, root_account, postgres_json_meta):
+        """ DID Meta (POSTGRES_JSON): delete DID meta """
+
+        did_name = did_name_generator('dataset')
+        meta_key1 = 'my_key_%s' % generate_uuid()
+        meta_value1 = 'my_value_%s' % generate_uuid()
+        meta_key2 = 'my_key_%s' % generate_uuid()
+        meta_value2 = 'my_value_%s' % generate_uuid()
+        add_did(scope=mock_scope, name=did_name, did_type='DATASET', account=root_account)
+        postgres_json_meta.set_metadata(scope=mock_scope, name=did_name, key=meta_key1, value=meta_value1)
+        postgres_json_meta.set_metadata(scope=mock_scope, name=did_name, key=meta_key2, value=meta_value2)
+        
+        assert postgres_json_meta.get_metadata(scope=mock_scope, name=did_name)[meta_key1] == meta_value1
+        assert postgres_json_meta.get_metadata(scope=mock_scope, name=did_name)[meta_key2] == meta_value2
+       
+        postgres_json_meta.delete_metadata(scope=mock_scope, name=did_name, key=meta_key2)
+        metadata = postgres_json_meta.get_metadata(scope=mock_scope, name=did_name)
+        assert metadata[meta_key1] == meta_value1
+        assert meta_key2 not in metadata
+
+    @pytest.mark.dirty
     def test_list_did_meta(self, mock_scope, root_account, postgres_json_meta):
         """ DID Meta (POSTGRES_JSON): List DID meta """
 


### PR DESCRIPTION
 - add WHERE stm for delete metadata so that only key from that did is deleted. NOT the key from all rows as it is now
 - add a test for delete metadata.

