### PR TITLE
Fix client: Convert tuple to string for file path parameters in replica CLI #8099

### DIFF
--- a/lib/rucio/cli/replica.py
+++ b/lib/rucio/cli/replica.py
@@ -129,11 +129,13 @@ def update_bad(ctx, replicas, reason, as_file, collection, lfn, scope, rse):
     """Mark a replica bad"""
     args = {"reason": reason, "allow_collection": collection, "scope": scope, "rse": rse}
     if as_file:
-        args["inputfile"] = replicas
+        # For file input, expect a single filename
+        args["inputfile"] = replicas[0] if replicas else None
     elif lfn:
         if (scope is None) or (rse is None):
             raise ValueError("Scope and RSE are required when using LFNs")
-        args["lfns"] = replicas
+        # For LFN file input, expect a single filename
+        args["lfns"] = replicas[0] if replicas else None
     else:
         args["listbadfiles"] = replicas
     declare_bad_file_replicas(Arguments(args), ctx.obj.client, ctx.obj.logger, ctx.obj.console, ctx.obj.spinner)
@@ -149,7 +151,8 @@ def update_unavailable(ctx, replicas, reason, as_file, duration):
     """Declare a replica unavailable"""
     args = {"reason": reason, "duration": duration}
     if as_file:
-        args["inputfile"] = replicas
+        # For file input, expect a single filename
+        args["inputfile"] = replicas[0] if replicas else None
     else:
         args["listbadfiles"] = replicas
     declare_temporary_unavailable_replicas(Arguments(args), ctx.obj.client, ctx.obj.logger, ctx.obj.console, ctx.obj.spinner)
@@ -164,7 +167,8 @@ def update_quarantine(ctx, replicas, as_file, rse):
     """Quarantine a replica"""
     args = {"rse": rse}
     if as_file:
-        args["paths_file"] = replicas
+        # For file input, expect a single filename
+        args["paths_file"] = replicas[0] if replicas else None
     else:
         args["paths_list"] = replicas
 


### PR DESCRIPTION
When using --lfn, --as-file flags with 'rucio replica state update' commands, the replicas argument (captured by nargs=-1) is a tuple. However, the underlying functions expect a string file path to open.

This fix extracts the first element from the tuple when file-based flags are used (--lfn, --as-file) for the following commands:
- replica state update bad
- replica state update unavailable
- replica state update quarantine

Fixes the error: 'expected str, bytes or os.PathLike object, not tuple' that occurred when using these flags.