### PR TITLE
Rules: Apply exponential backoff on rules with a source replica expression #8104

### DIFF
--- a/lib/rucio/core/rule_grouping.py
+++ b/lib/rucio/core/rule_grouping.py
@@ -690,7 +690,7 @@ def __repair_stuck_locks_with_none_grouping(datasetfiles, locks, replicas, sourc
                     associated_replica.lock_cnt = session.execute(stmt).scalar_one()
                     continue
                 # Check if this is a STUCK lock due to source_replica filtering
-                if source_rses:
+                if source_rses and not lock.repair_cnt:
                     associated_replica = [replica for replica in replicas[(file['scope'], file['name'])] if replica.rse_id == lock.rse_id][0]
                     # Check if there is an eligible source replica for this lock
                     if set(source_replicas.get((file['scope'], file['name']), [])).intersection(source_rses) and (selector_rse_dict.get(lock.rse_id, {}).get('availability_write', True) or rule.ignore_availability):
@@ -806,7 +806,7 @@ def __repair_stuck_locks_with_all_grouping(datasetfiles, locks, replicas, source
                     associated_replica.lock_cnt = session.execute(stmt).scalar_one()
                     continue
                 # Check if this is a STUCK lock due to source_replica filtering
-                if source_rses:
+                if source_rses and not lock.repair_cnt:
                     associated_replica = [replica for replica in replicas[(file['scope'], file['name'])] if replica.rse_id == lock.rse_id][0]
                     # Check if there is an eligible source replica for this lock
                     if set(source_replicas.get((file['scope'], file['name']), [])).intersection(source_rses) and (selector_rse_dict.get(lock.rse_id, {}).get('availability_write', True) or rule.ignore_availability):
@@ -891,7 +891,7 @@ def __repair_stuck_locks_with_dataset_grouping(datasetfiles, locks, replicas, so
                     associated_replica.lock_cnt = session.execute(stmt).scalar_one()
                     continue
                 # Check if this is a STUCK lock due to source_replica filtering
-                if source_rses:
+                if source_rses and not lock.repair_cnt:
                     associated_replica = [replica for replica in replicas[(file['scope'], file['name'])] if replica.rse_id == lock.rse_id][0]
                     # Check if there is an eligible source replica for this lock
                     if set(source_replicas.get((file['scope'], file['name']), [])).intersection(source_rses) and (selector_rse_dict.get(lock.rse_id, {}).get('availability_write', True) or rule.ignore_availability):


### PR DESCRIPTION
Previously, the Repairer would always try to create new requests on rules with a source replica expression, irrespective of when the rules were created.

The motivation behind this was chained rules. Suppose a DID is registered on RSE A, and some mechanism simultaneously creates replication rules on RSEs B and C, the latter with a source replica expression so that the requests use the B→C path and not the A→C path. Such a rule would be created in state STUCK, given that the replicas are not yet available on B. Under such conditions, the Repairer should not apply the exponential backoff in order for the rule on C to pick up on the replication on B as soon as possible.

This commit tweaks the condition so that the exponential backoff is not applied before a request is created and at the first time it is recreated (by the Repairer, not the Finisher). The latter is unintentional but unavoidable.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
