### PR TITLE
Testing: Set Python target version to 3.9 in Ruff configuration; rucio#8108

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ exclude_also = [
 
 [tool.ruff]
 line-length = 256
+target-version = "py39"
 
 extend-include = [
     "bin/*",


### PR DESCRIPTION
Fixes #8108