### PR TITLE
Core, API: Fix exception when filtering RSEs by bool column; Fix #6405

### DIFF
--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -824,8 +824,12 @@ def list_rses(filters: Optional[dict[str, Any]] = None, *, session: "Session") -
 
         for (k, v) in filters.items():
             if hasattr(models.RSE, k):
-                if k == 'rse_type':
-                    stmt = stmt.where(getattr(models.RSE, k) == RSEType[v])
+                # API calls always provide str, but some core calls use the right type
+                if isinstance(v, str):
+                    try:
+                        stmt = stmt.where(getattr(models.RSE, k) == models.RSE.from_str(k, v))
+                    except ValueError as e:
+                        raise exception.InvalidObject(*e.args)
                 else:
                     stmt = stmt.where(getattr(models.RSE, k) == v)
             else:

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -877,6 +877,28 @@ class RSE(BASE, SoftModelBase):
                    CheckConstraint('RSE_TYPE IS NOT NULL', name='RSES_TYPE_NN'),
                    ForeignKeyConstraint(['vo'], ['vos.vo'], name='RSES_VOS_FK'), )
 
+    @staticmethod
+    def from_str(key: str, value: str) -> Any:
+        """Parses str value to key-specific database type."""
+
+        if key in ['deterministic', 'volatile', 'staging_area', 'availability_read', 'availability_write', 'availability_delete']:
+            # boolean types
+            if value == '1' or value.casefold() == 'true'.casefold():
+                return True
+            elif value == '0' or value.casefold() == 'false'.casefold():
+                return False
+            else:
+                raise ValueError(f'Invalid boolean value: {value}')
+
+        elif key == 'rse_type':
+            try:
+                return RSEType[value]
+            except KeyError:
+                raise ValueError(f'Invalid rse_type: {value}')
+
+        else:
+            return value
+
 
 class RSELimit(BASE, ModelBase):
     """Represents RSE limits"""

--- a/tests/test_rse.py
+++ b/tests/test_rse.py
@@ -119,6 +119,20 @@ class TestRSECoreApi:
 
         del_rse(rse_id)
 
+    def test_list_rse_string_bool_filter(self, vo):
+        """ RSE (CORE): Test the listing of RSE with column filters """
+        rse = rse_name_generator()
+        rse_id = add_rse(rse, vo=vo, rse_type=RSEType.TAPE, availability_read=True, availability_write=False)
+        assert rse_exists(rse=rse, vo=vo)
+        rses = list_rses(filters={'availability_read': '1', 'availability_write': False, 'rse_type': 'TAPE'})
+        assert (rse_id, rse) in [(r['id'], r['rse']) for r in rses]
+        rses = list_rses(filters={'availability_read': 'True', 'availability_write': 'false', 'rse_type': 'TAPE'})
+        assert (rse_id, rse) in [(r['id'], r['rse']) for r in rses]
+        rses = list_rses(filters={'availability_read': True, 'availability_write': '0', 'rse_type': RSEType.TAPE})
+        assert (rse_id, rse) in [(r['id'], r['rse']) for r in rses]
+
+        del_rse(rse_id)
+
     @pytest.mark.dirty
     def test_list_rse_attributes(self, vo):
         """ RSE (CORE): Test the listing of RSE attributes """


### PR DESCRIPTION
Arguably a patch, because it fixes broken behaviour (see #6405).