### PR TITLE
Policies: remove surl algorithm name alias #8102

### DIFF
--- a/lib/rucio/common/plugins.py
+++ b/lib/rucio/common/plugins.py
@@ -218,10 +218,6 @@ class PolicyPackageAlgorithms:
             if hasattr(module, 'get_algorithms'):
                 all_algorithms = module.get_algorithms()
 
-                # for backward compatibility, rename 'surl' to 'non_deterministic_pfn' here
-                if 'surl' in all_algorithms:
-                    all_algorithms['non_deterministic_pfn'] = all_algorithms['surl']
-
                 # check that the names are correctly prefixed for multi-VO
                 if vo:
                     for _, algorithms in all_algorithms.items():


### PR DESCRIPTION
Last year we renamed `surl` algorithms to `non_deterministic_pfn` algorithms to make it clearer what they do. This code was added to allow policy packages that used `surl` to continue working for the moment, but recently this aliasing was broken by https://github.com/rucio/rucio/pull/7981 . We could fix the alias but unless it's going to majorly inconvenience anyone, my preference would be to just remove it as we don't want to maintain it forever. (DUNE was relying on it but I have now updated their policy package to use the new name).