### PR TITLE
CI: Resolve integration test failures: move configs to `/opt/rucio/etc`

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -144,7 +144,15 @@ jobs:
           docker exec -t dev-rucio-1 bash -c "
             set -e
             cd /rucio_source
-            cp etc/rse-accounts.cfg.template etc/rse-accounts.cfg
+            cp etc/rse-accounts.cfg.template /opt/rucio/etc/rse-accounts.cfg
+            cp etc/rse-accounts.cfg.template /opt/rucio/etc/rse-accounts.cfg.template
+            cp etc/rse_repository.json /opt/rucio/etc/rse_repository.json
+            cp etc/rclone-init.cfg /opt/rucio/etc/rclone-init.cfg
+
+            # Create symlinks to the mounted SSH keys in standard locations
+            ln -sf /root/.ssh/ruciouser_sshkey /root/.ssh/id_rsa 2>/dev/null || true
+            ln -sf /root/.ssh/ruciouser_sshkey.pub /root/.ssh/id_rsa.pub 2>/dev/null || true
+
             pip install --no-cache-dir -e /rucio_source
             tools/run_tests.sh -ir
           "

--- a/etc/docker/dev/rucio/entrypoint.sh
+++ b/etc/docker/dev/rucio/entrypoint.sh
@@ -64,4 +64,9 @@ fi
 
 update-ca-trust
 
+# Create python symlink for gfal-rm compatibility
+if [ ! -f /usr/bin/python ] && [ -f /usr/bin/python3 ]; then
+    ln -sf /usr/bin/python3 /usr/bin/python
+fi
+
 exec "$@"


### PR DESCRIPTION
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
Fixes #8106 

This is a immediate fix to ensure the integration tests continue running for the active PRs while the discussion in issue #8106 is still in progress.
