### PR TITLE
Testing: mark `test_judge_double_container_with_existing_rule` as flaky

### DIFF
--- a/tests/test_judge_evaluator.py
+++ b/tests/test_judge_evaluator.py
@@ -466,7 +466,7 @@ def test_judge_double_rule_on_container(
         assert len(locks) == 2  # 2 locks
         assert all([lock["state"] == LockState.OK for lock in locks])  # all OK
 
-
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_judge_double_container_with_existing_rule(
     did_factory: "TemporaryDidFactory",
     rse_factory: "TemporaryRSEFactory",


### PR DESCRIPTION
Partially addresses #8116 .