### PR TITLE
Metadata: Fix incorrect assignment of 'account' instead of 'scope' in DID filtering logic; rucio#8144

### DIFF
--- a/lib/rucio/gateway/did.py
+++ b/lib/rucio/gateway/did.py
@@ -62,7 +62,7 @@ def list_dids(
         if 'account' in or_group:
             or_group['account'] = InternalAccount(or_group['account'], vo=vo)
         if 'scope' in or_group:
-            or_group['account'] = InternalScope(or_group['scope'], vo=vo)
+            or_group['scope'] = InternalScope(or_group['scope'], vo=vo)
 
     with db_session(DatabaseOperationType.READ) as session:
         result = did.list_dids(scope=internal_scope, filters=filters, did_type=did_type, ignore_case=ignore_case,


### PR DESCRIPTION
Fixes #8144 