### PR TITLE
transfer: fix fts transfer_with_token test #8133

### DIFF
--- a/etc/docker/dev/fts/entrypoint.sh
+++ b/etc/docker/dev/fts/entrypoint.sh
@@ -39,4 +39,5 @@ update-ca-trust
 /usr/sbin/fts_server               # main FTS server daemonizes
 /usr/sbin/fts_qos                  # for the stager tests
 /usr/sbin/fts_activemq             # daemon to send messages to activemq
+/usr/sbin/fts_token                # daemon to manage token
 /usr/sbin/httpd -DFOREGROUND       # FTS REST frontend & FTSMON

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -1624,7 +1624,6 @@ def test_checksum_validation(rse_factory, did_factory, root_account):
 
 
 @skip_rse_tests_with_accounts
-@pytest.mark.skip(reason="Pending https://github.com/rucio/rucio/issues/8133")
 @pytest.mark.needs_iam
 @pytest.mark.noparallel(groups=[NoParallelGroups.XRD, NoParallelGroups.SUBMITTER, NoParallelGroups.RECEIVER])
 @pytest.mark.parametrize("file_config_mock", [


### PR DESCRIPTION
closes: #8133 

The issue was: by default transfer with token submitted to FTS is managed token. For that we need `fts_token` daemon  in FTS running (which does token management in FTS)

- add fts_token token in fts entrypoint. 
- remove skip pytest from transfer_with_token

The token with unmanged true was working because they don't need fts_token daemon as they will not be managed by FTS.

