### PR TITLE
Testing: Add `needs_postgre`s marker to run tests with the postgres profile

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -127,7 +127,7 @@ jobs:
         id: images
         shell: bash
         run: |
-          docker compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile storage --profile externalmetadata --profile iam pull
+          docker compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile default --profile iam pull
       - name: Set Runtime Image in Docker Compose
         shell: bash
         run: |
@@ -136,7 +136,7 @@ jobs:
               $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml
       - name: Start containers
         run: |
-          export DEV_PROFILES=storage,externalmetadata,iam
+          export DEV_PROFILES=default,iam
           docker compose -f $GITHUB_WORKSPACE/dev/rucio/etc/docker/dev/docker-compose.yml --profile storage --profile externalmetadata --profile iam up -d
       - name: Initialize tests
         shell: bash

--- a/tests/test_did_meta_plugins.py
+++ b/tests/test_did_meta_plugins.py
@@ -417,7 +417,6 @@ def postgres_json_meta():
 
 
 @pytest.mark.noparallel(reason='race condition on try-create table')
-@pytest.mark.needs_postgres
 @skip_rse_tests_with_accounts
 class TestDidMetaExternalPostgresJSON:
 

--- a/tests/test_did_meta_plugins.py
+++ b/tests/test_did_meta_plugins.py
@@ -417,6 +417,7 @@ def postgres_json_meta():
 
 
 @pytest.mark.noparallel(reason='race condition on try-create table')
+@pytest.mark.needs_postgres
 @skip_rse_tests_with_accounts
 class TestDidMetaExternalPostgresJSON:
 


### PR DESCRIPTION
Fixes #8129

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
