### PR TITLE
Migrate core/account_counter and core/rse_counter away from session decorators, make `session` a required argument

### DIFF
--- a/lib/rucio/core/account_counter.py
+++ b/lib/rucio/core/account_counter.py
@@ -18,7 +18,7 @@ from sqlalchemy import and_, delete, insert, literal, select
 from sqlalchemy.exc import NoResultFound
 
 from rucio.db.sqla import filter_thread_work, models
-from rucio.db.sqla.session import read_session, transactional_session
+from rucio.db.sqla.session import transactional_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -114,11 +114,9 @@ def del_counter(
     session.execute(stmt)
 
 
-@read_session
 def get_updated_account_counters(
     total_workers: int,
     worker_number: int,
-    *,
     session: "Session"
 ) -> list["RSEAccountCounterDict"]:
     """

--- a/lib/rucio/core/account_counter.py
+++ b/lib/rucio/core/account_counter.py
@@ -18,7 +18,6 @@ from sqlalchemy import and_, delete, insert, literal, select
 from sqlalchemy.exc import NoResultFound
 
 from rucio.db.sqla import filter_thread_work, models
-from rucio.db.sqla.session import transactional_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -28,11 +27,9 @@ if TYPE_CHECKING:
 MAX_COUNTERS = 10
 
 
-@transactional_session
 def add_counter(
     rse_id: str,
     account: "InternalAccount",
-    *,
     session: "Session"
 ) -> None:
     """
@@ -46,13 +43,11 @@ def add_counter(
     models.AccountUsage(rse_id=rse_id, account=account, files=0, bytes=0).save(session=session)
 
 
-@transactional_session
 def increase(
     rse_id: str,
     account: "InternalAccount",
     files: int,
     bytes_: int,
-    *,
     session: "Session"
 ) -> None:
     """
@@ -67,13 +62,11 @@ def increase(
     models.UpdatedAccountCounter(account=account, rse_id=rse_id, files=files, bytes=bytes_).save(session=session)
 
 
-@transactional_session
 def decrease(
     rse_id: str,
     account: "InternalAccount",
     files: int,
     bytes_: int,
-    *,
     session: "Session"
 ) -> None:
     """
@@ -88,11 +81,9 @@ def decrease(
     return increase(rse_id=rse_id, account=account, files=-files, bytes_=-bytes_, session=session)
 
 
-@transactional_session
 def del_counter(
     rse_id: str,
     account: "InternalAccount",
-    *,
     session: "Session"
 ) -> None:
     """
@@ -139,11 +130,9 @@ def get_updated_account_counters(
     return [row._asdict() for row in session.execute(query).all()]  # type: ignore (pending SQLA2.1: https://github.com/rucio/rucio/discussions/6615)
 
 
-@transactional_session
 def update_account_counter(
     account: "InternalAccount",
     rse_id: str,
-    *,
     session: "Session"
 ) -> None:
     """
@@ -182,11 +171,9 @@ def update_account_counter(
         update.delete(flush=False, session=session)
 
 
-@transactional_session
 def update_account_counter_history(
     account: "InternalAccount",
     rse_id: str,
-    *,
     session: "Session"
 ) -> None:
     """
@@ -209,8 +196,7 @@ def update_account_counter_history(
         models.AccountUsageHistory(rse_id=rse_id, account=account, files=0, bytes=0).save(session=session)
 
 
-@transactional_session
-def fill_account_counter_history_table(*, session: "Session") -> None:
+def fill_account_counter_history_table(session: "Session") -> None:
     """
     Make a snapshot of current counters
 

--- a/lib/rucio/core/rse_counter.py
+++ b/lib/rucio/core/rse_counter.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy import and_, delete, select
 from sqlalchemy.exc import NoResultFound
@@ -20,10 +20,15 @@ from rucio.common.exception import CounterNotFound
 from rucio.db.sqla import filter_thread_work, models
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from sqlalchemy.orm import Session
 
 
-def add_counter(rse_id, session: "Session"):
+def add_counter(
+        rse_id: str,
+        session: "Session"
+) -> None:
     """
     Creates the specified counter for a rse_id.
 
@@ -34,7 +39,12 @@ def add_counter(rse_id, session: "Session"):
         save(session=session)
 
 
-def increase(rse_id, files, bytes_, session: "Session"):
+def increase(
+        rse_id: str,
+        files: int,
+        bytes_: int,
+        session: "Session"
+) -> None:
     """
     Increments the specified counter by the specified amount.
 
@@ -47,7 +57,12 @@ def increase(rse_id, files, bytes_, session: "Session"):
         save(session=session)
 
 
-def decrease(rse_id, files, bytes_, session: "Session"):
+def decrease(
+        rse_id: str,
+        files: int,
+        bytes_: int,
+        session: "Session"
+) -> None:
     """
     Decreases the specified counter by the specified amount.
 
@@ -59,7 +74,10 @@ def decrease(rse_id, files, bytes_, session: "Session"):
     return increase(rse_id=rse_id, files=-files, bytes_=-bytes_, session=session)
 
 
-def del_counter(rse_id, session: "Session"):
+def del_counter(
+        rse_id: str,
+        session: "Session"
+) -> None:
     """
     Delete specified counter.
 
@@ -78,7 +96,10 @@ def del_counter(rse_id, session: "Session"):
     session.execute(stmt)
 
 
-def get_counter(rse_id, session: "Session"):
+def get_counter(
+        rse_id: str,
+        session: "Session"
+) -> dict[str, Any]:
     """
     Returns current values of the specified counter or raises CounterNotFound if the counter does not exist.
 
@@ -108,7 +129,11 @@ def get_counter(rse_id, session: "Session"):
         raise CounterNotFound()
 
 
-def get_updated_rse_counters(total_workers, worker_number, session: "Session"):
+def get_updated_rse_counters(
+        total_workers: Optional[int],
+        worker_number: Optional[int],
+        session: "Session"
+) -> "Sequence[str]":
     """
     Get updated rse_counters.
 
@@ -126,7 +151,10 @@ def get_updated_rse_counters(total_workers, worker_number, session: "Session"):
     return session.execute(stmt).scalars().all()
 
 
-def update_rse_counter(rse_id, session: "Session"):
+def update_rse_counter(
+        rse_id: str,
+        session: "Session"
+) -> None:
     """
     Read the updated_rse_counters and update the rse_counter.
 
@@ -163,7 +191,7 @@ def update_rse_counter(rse_id, session: "Session"):
         update.delete(flush=False, session=session)
 
 
-def fill_rse_counter_history_table(session: "Session"):
+def fill_rse_counter_history_table(session: "Session") -> None:
     """
     Fill the RSE usage history table with the current usage.
 

--- a/lib/rucio/core/rse_counter.py
+++ b/lib/rucio/core/rse_counter.py
@@ -105,7 +105,6 @@ def get_counter(
 
     :param rse_id:           The id of the RSE.
     :param session:          The database session in use.
-    :returns:                A dictionary with total and bytes.
     :raises CounterNotFound: If the counter does not exist.
     :returns:                A dictionary with total and bytes.
     """

--- a/lib/rucio/core/rse_counter.py
+++ b/lib/rucio/core/rse_counter.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import NoResultFound
 
 from rucio.common.exception import CounterNotFound
 from rucio.db.sqla import filter_thread_work, models
-from rucio.db.sqla.session import read_session, transactional_session
+from rucio.db.sqla.session import transactional_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -83,8 +83,7 @@ def del_counter(rse_id, *, session: "Session"):
     session.execute(stmt)
 
 
-@read_session
-def get_counter(rse_id, *, session: "Session"):
+def get_counter(rse_id, session: "Session"):
     """
     Returns current values of the specified counter or raises CounterNotFound if the counter does not exist.
 
@@ -114,8 +113,7 @@ def get_counter(rse_id, *, session: "Session"):
         raise CounterNotFound()
 
 
-@read_session
-def get_updated_rse_counters(total_workers, worker_number, *, session: "Session"):
+def get_updated_rse_counters(total_workers, worker_number, session: "Session"):
     """
     Get updated rse_counters.
 

--- a/lib/rucio/core/rse_counter.py
+++ b/lib/rucio/core/rse_counter.py
@@ -18,14 +18,12 @@ from sqlalchemy.exc import NoResultFound
 
 from rucio.common.exception import CounterNotFound
 from rucio.db.sqla import filter_thread_work, models
-from rucio.db.sqla.session import transactional_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 
-@transactional_session
-def add_counter(rse_id, *, session: "Session"):
+def add_counter(rse_id, session: "Session"):
     """
     Creates the specified counter for a rse_id.
 
@@ -36,8 +34,7 @@ def add_counter(rse_id, *, session: "Session"):
         save(session=session)
 
 
-@transactional_session
-def increase(rse_id, files, bytes_, *, session: "Session"):
+def increase(rse_id, files, bytes_, session: "Session"):
     """
     Increments the specified counter by the specified amount.
 
@@ -50,8 +47,7 @@ def increase(rse_id, files, bytes_, *, session: "Session"):
         save(session=session)
 
 
-@transactional_session
-def decrease(rse_id, files, bytes_, *, session: "Session"):
+def decrease(rse_id, files, bytes_, session: "Session"):
     """
     Decreases the specified counter by the specified amount.
 
@@ -63,8 +59,7 @@ def decrease(rse_id, files, bytes_, *, session: "Session"):
     return increase(rse_id=rse_id, files=-files, bytes_=-bytes_, session=session)
 
 
-@transactional_session
-def del_counter(rse_id, *, session: "Session"):
+def del_counter(rse_id, session: "Session"):
     """
     Delete specified counter.
 
@@ -131,8 +126,7 @@ def get_updated_rse_counters(total_workers, worker_number, session: "Session"):
     return session.execute(stmt).scalars().all()
 
 
-@transactional_session
-def update_rse_counter(rse_id, *, session: "Session"):
+def update_rse_counter(rse_id, session: "Session"):
     """
     Read the updated_rse_counters and update the rse_counter.
 
@@ -169,8 +163,7 @@ def update_rse_counter(rse_id, *, session: "Session"):
         update.delete(flush=False, session=session)
 
 
-@transactional_session
-def fill_rse_counter_history_table(*, session: "Session"):
+def fill_rse_counter_history_table(session: "Session"):
     """
     Fill the RSE usage history table with the current usage.
 

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -2505,7 +2505,10 @@ def update_rules_for_lost_replica(
             rule.locks_replicating_cnt -= 1
         elif lock.state == LockState.STUCK:
             rule.locks_stuck_cnt -= 1
-        account_counter.decrease(rse_id=rse_id, account=rule.account, files=1, bytes_=lock.bytes, session=session)
+        if lock.bytes:
+            account_counter.decrease(rse_id=rse_id, account=rule.account, files=1, bytes_=lock.bytes, session=session)
+        else:
+            raise ValueError('Lock %s has no bytes value associated to it: account_counter not decreased for RSE %s, account %s' % (lock, rse_id, rule.account))
         if rule.state == RuleState.SUSPENDED:
             pass
         elif rule.state == RuleState.STUCK:

--- a/tests/test_abacus_account.py
+++ b/tests/test_abacus_account.py
@@ -23,7 +23,8 @@ from rucio.daemons.abacus.account import account_update
 from rucio.daemons.judge import cleaner
 from rucio.daemons.reaper import reaper
 from rucio.db.sqla import models
-from rucio.db.sqla.session import get_session
+from rucio.db.sqla.constants import DatabaseOperationType
+from rucio.db.sqla.session import db_session, get_session
 
 
 @pytest.mark.noparallel(reason='uses daemon, failing in parallel to other tests, updates account')
@@ -51,7 +52,8 @@ class TestAbacusAccount2:
         assert account_usage['files'] == nfiles
 
         # Update and check the account history with the core method
-        update_account_counter_history(account=root_account, rse_id=rse_id)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            update_account_counter_history(account=root_account, rse_id=rse_id, session=session)
         usage_history = get_usage_history(rse_id=rse_id, account=root_account)
         assert usage_history[-1]['bytes'] == nfiles * file_sizes
         assert usage_history[-1]['files'] == nfiles

--- a/tests/test_bin_rucio.py
+++ b/tests/test_bin_rucio.py
@@ -24,6 +24,8 @@ import pytest
 
 from rucio.common.checksum import md5
 from rucio.common.utils import generate_uuid, render_json
+from rucio.db.sqla.constants import DatabaseOperationType
+from rucio.db.sqla.session import db_session
 from rucio.rse import rsemanager as rsemgr
 from rucio.tests.common import account_name_generator, execute, rse_name_generator, scope_name_generator
 
@@ -858,7 +860,8 @@ def test_list_account_usage(rse_factory, rucio_client, random_account):
 
     rucio_client.set_local_account_limit(random_account.external, rse, local_limit)
     rucio_client.set_global_account_limit(random_account.external, rse_expression, global_limit)
-    increase(rse_id, random_account, 1, usage)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        increase(rse_id, random_account, 1, usage, session=session)
     abacus_account.run(once=True)
     cmd = f'rucio list-account-usage {random_account}'
     exitcode, out, err = execute(cmd)

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -23,6 +23,7 @@ from rucio.daemons.abacus.account import account_update
 from rucio.daemons.abacus.rse import rse_update
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import DatabaseOperationType
+from rucio.db.sqla.session import db_session as db_session_context
 
 
 @pytest.mark.noparallel(reason='runs abacus daemons')
@@ -99,55 +100,66 @@ class TestCoreAccountCounter:
         _, rse_id = rse_factory.make_mock_rse(session=db_session)
         db_session.commit()
         account = jdoe_account
-        with db_session(DatabaseOperationType.WRITE) as session:
+        with db_session_context(DatabaseOperationType.WRITE) as session:
             account_counter.del_counter(rse_id=rse_id, account=account, session=session)
             account_counter.add_counter(rse_id=rse_id, account=account, session=session)
+
+        with db_session_context(DatabaseOperationType.READ) as session:
             cnt = get_usage(rse_id=rse_id, account=account)
             del cnt['updated_at']
             assert cnt == {'files': 0, 'bytes': 0}
 
-            count, sum_ = 0, 0
-            for i in range(10):
+        count, sum_ = 0, 0
+        for i in range(10):
+            with db_session_context(DatabaseOperationType.WRITE) as session:
                 account_counter.increase(rse_id=rse_id, account=account, files=1, bytes_=2147000000, session=session)
-                account_update(once=True)
-                count += 1
-                sum_ += 2147000000
-                cnt = get_usage(rse_id=rse_id, account=account)
-                del cnt['updated_at']
-                assert cnt == {'files': count, 'bytes': sum_}
+            account_update(once=True)
+            count += 1
+            sum_ += 2147000000
+            with db_session_context(DatabaseOperationType.READ) as session:
+                cnt = get_usage(rse_id=rse_id, account=account, session=session)
+            del cnt['updated_at']
+            assert cnt == {'files': count, 'bytes': sum_}
 
-            for i in range(4):
+        for i in range(4):
+            with db_session_context(DatabaseOperationType.WRITE) as session:
                 account_counter.decrease(rse_id=rse_id, account=account, files=1, bytes_=2147000000, session=session)
-                account_update(once=True)
-                count -= 1
-                sum_ -= 2147000000
-                cnt = get_usage(rse_id=rse_id, account=account)
-                del cnt['updated_at']
-                assert cnt == {'files': count, 'bytes': sum_}
+            account_update(once=True)
+            count -= 1
+            sum_ -= 2147000000
+            with db_session_context(DatabaseOperationType.READ) as session:
+                cnt = get_usage(rse_id=rse_id, account=account, session=session)
+            del cnt['updated_at']
+            assert cnt == {'files': count, 'bytes': sum_}
 
-            for i in range(5):
+        for i in range(5):
+            with db_session_context(DatabaseOperationType.WRITE) as session:
                 account_counter.increase(rse_id=rse_id, account=account, files=1, bytes_=2147000000, session=session)
-                account_update(once=True)
-                count += 1
-                sum_ += 2147000000
-                cnt = get_usage(rse_id=rse_id, account=account)
-                del cnt['updated_at']
-                assert cnt == {'files': count, 'bytes': sum_}
+            account_update(once=True)
+            count += 1
+            sum_ += 2147000000
+            with db_session_context(DatabaseOperationType.READ) as session:
+                cnt = get_usage(rse_id=rse_id, account=account, session=session)
+            del cnt['updated_at']
+            assert cnt == {'files': count, 'bytes': sum_}
 
-            for i in range(8):
+        for i in range(8):
+            with db_session_context(DatabaseOperationType.WRITE) as session:
                 account_counter.decrease(rse_id=rse_id, account=account, files=1, bytes_=2147000000, session=session)
-                account_update(once=True)
-                count -= 1
-                sum_ -= 2147000000
-                cnt = get_usage(rse_id=rse_id, account=account)
-                del cnt['updated_at']
-                assert cnt == {'files': count, 'bytes': sum_}
+            account_update(once=True)
+            count -= 1
+            sum_ -= 2147000000
+            with db_session_context(DatabaseOperationType.READ) as session:
+                cnt = get_usage(rse_id=rse_id, account=account, session=session)
+            del cnt['updated_at']
+            assert cnt == {'files': count, 'bytes': sum_}
 
         # check that the counters are correctly copied into the history table
         stmt = delete(models.AccountUsageHistory)
         db_session.execute(stmt)
         db_session.commit()
-        account_counter.fill_account_counter_history_table()
+        with db_session_context(DatabaseOperationType.WRITE) as session:
+            account_counter.fill_account_counter_history_table(session=session)
         stmt = select(models.AccountUsageHistory)
         history_usage = {(usage['rse_id'], usage['files'], usage['account'], usage['bytes']) for usage in db_session.execute(stmt).scalars()}
         stmt = select(models.AccountUsage)
@@ -168,7 +180,8 @@ class TestCoreAccountCounter:
         })
         db_session.execute(stmt)
         db_session.commit()
-        account_counter.fill_account_counter_history_table()
+        with db_session_context(DatabaseOperationType.WRITE) as session:
+            account_counter.fill_account_counter_history_table(session=session)
         stmt = select(models.AccountUsageHistory)
         history_usage = {(usage['rse_id'], usage['files'], usage['account'], usage['bytes']) for usage in db_session.execute(stmt).scalars()}
         assert (rse_id, count, account, sum_) in history_usage

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -40,37 +40,37 @@ class TestCoreRSECounter:
 
         count, sum_ = 0, 0
         for i in range(10):
-            rse_counter.increase(rse_id=rse_id, files=1, bytes_=2.147e+9)
+            rse_counter.increase(rse_id=rse_id, files=1, bytes_=2147000000)
             rse_update(once=True)
             count += 1
-            sum_ += 2.147e+9
+            sum_ += 2147000000
             cnt = rse_counter.get_counter(rse_id=rse_id)
             del cnt['updated_at']
             assert cnt == {'files': count, 'bytes': sum_}
 
         for i in range(4):
-            rse_counter.decrease(rse_id=rse_id, files=1, bytes_=2.147e+9)
+            rse_counter.decrease(rse_id=rse_id, files=1, bytes_=2147000000)
             rse_update(once=True)
             count -= 1
-            sum_ -= 2.147e+9
+            sum_ -= 2147000000
             cnt = rse_counter.get_counter(rse_id=rse_id)
             del cnt['updated_at']
             assert cnt == {'files': count, 'bytes': sum_}
 
         for i in range(5):
-            rse_counter.increase(rse_id=rse_id, files=1, bytes_=2.147e+9)
+            rse_counter.increase(rse_id=rse_id, files=1, bytes_=2147000000)
             rse_update(once=True)
             count += 1
-            sum_ += 2.147e+9
+            sum_ += 2147000000
             cnt = rse_counter.get_counter(rse_id=rse_id)
             del cnt['updated_at']
             assert cnt == {'files': count, 'bytes': sum_}
 
         for i in range(8):
-            rse_counter.decrease(rse_id=rse_id, files=1, bytes_=2.147e+9)
+            rse_counter.decrease(rse_id=rse_id, files=1, bytes_=2147000000)
             rse_update(once=True)
             count -= 1
-            sum_ -= 2.147e+9
+            sum_ -= 2147000000
             cnt = rse_counter.get_counter(rse_id=rse_id)
             del cnt['updated_at']
             assert cnt == {'files': count, 'bytes': sum_}
@@ -108,37 +108,37 @@ class TestCoreAccountCounter:
 
             count, sum_ = 0, 0
             for i in range(10):
-                account_counter.increase(rse_id=rse_id, account=account, files=1, bytes_=2.147e+9, session=session)
+                account_counter.increase(rse_id=rse_id, account=account, files=1, bytes_=2147000000, session=session)
                 account_update(once=True)
                 count += 1
-                sum_ += 2.147e+9
+                sum_ += 2147000000
                 cnt = get_usage(rse_id=rse_id, account=account)
                 del cnt['updated_at']
                 assert cnt == {'files': count, 'bytes': sum_}
 
             for i in range(4):
-                account_counter.decrease(rse_id=rse_id, account=account, files=1, bytes_=2.147e+9, session=session)
+                account_counter.decrease(rse_id=rse_id, account=account, files=1, bytes_=2147000000, session=session)
                 account_update(once=True)
                 count -= 1
-                sum_ -= 2.147e+9
+                sum_ -= 2147000000
                 cnt = get_usage(rse_id=rse_id, account=account)
                 del cnt['updated_at']
                 assert cnt == {'files': count, 'bytes': sum_}
 
             for i in range(5):
-                account_counter.increase(rse_id=rse_id, account=account, files=1, bytes_=2.147e+9, session=session)
+                account_counter.increase(rse_id=rse_id, account=account, files=1, bytes_=2147000000, session=session)
                 account_update(once=True)
                 count += 1
-                sum_ += 2.147e+9
+                sum_ += 2147000000
                 cnt = get_usage(rse_id=rse_id, account=account)
                 del cnt['updated_at']
                 assert cnt == {'files': count, 'bytes': sum_}
 
             for i in range(8):
-                account_counter.decrease(rse_id=rse_id, account=account, files=1, bytes_=2.147e+9, session=session)
+                account_counter.decrease(rse_id=rse_id, account=account, files=1, bytes_=2147000000, session=session)
                 account_update(once=True)
                 count -= 1
-                sum_ -= 2.147e+9
+                sum_ -= 2147000000
                 cnt = get_usage(rse_id=rse_id, account=account)
                 del cnt['updated_at']
                 assert cnt == {'files': count, 'bytes': sum_}

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -105,9 +105,9 @@ class TestCoreAccountCounter:
             account_counter.add_counter(rse_id=rse_id, account=account, session=session)
 
         with db_session_context(DatabaseOperationType.READ) as session:
-            cnt = get_usage(rse_id=rse_id, account=account)
-            del cnt['updated_at']
-            assert cnt == {'files': 0, 'bytes': 0}
+            cnt = get_usage(rse_id=rse_id, account=account, session=session)
+        del cnt['updated_at']
+        assert cnt == {'files': 0, 'bytes': 0}
 
         count, sum_ = 0, 0
         for i in range(10):

--- a/tests/test_multi_vo.py
+++ b/tests/test_multi_vo.py
@@ -44,7 +44,8 @@ from rucio.core.rule import add_rule
 from rucio.core.vo import map_vo
 from rucio.daemons.automatix.automatix import automatix
 from rucio.db.sqla import models
-from rucio.db.sqla import session as db_session
+from rucio.db.sqla.constants import DatabaseOperationType
+from rucio.db.sqla.session import db_session
 from rucio.gateway import vo as vo_gateway
 from rucio.gateway.account import add_account, list_accounts
 from rucio.gateway.account_limit import set_local_account_limit
@@ -892,8 +893,6 @@ class TestMultiVoClients:
     def test_account_counters_at_different_vos(self, vo, second_vo, rse_client):
         """ MULTI VO (CLIENT): Test that account counters from 2nd vo don't interfere """
 
-        session = db_session.get_session()
-
         # add some RSEs to test create_counters_for_new_account
         rse_str = ''.join(choice(ascii_uppercase) for x in range(10))
         tst_rse1 = 'TST1_%s' % rse_str
@@ -911,19 +910,21 @@ class TestMultiVoClients:
         new_acc_vo2 = InternalAccount(new_acc_str, vo=second_vo)
 
         # Create counters
-        add_counter(new_rse1_vo1_id, new_acc_vo1)
-        add_counter(new_rse1_vo2_id, new_acc_vo2)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            add_counter(new_rse1_vo1_id, new_acc_vo1, session=session)
+            add_counter(new_rse1_vo2_id, new_acc_vo2, session=session)
 
-        stmt = select(
-            models.AccountUsage.account,
-            models.AccountUsage.rse_id
-        ).distinct(
-        ).where(
-            models.AccountUsage.account == new_acc_vo2
-        )
-        acc_counters = session.execute(stmt).one()
-        rse_id = acc_counters[1]
-        vo = get_rse_vo(rse_id)
+        with db_session(DatabaseOperationType.READ) as session:
+            stmt = select(
+                models.AccountUsage.account,
+                models.AccountUsage.rse_id
+            ).distinct(
+            ).where(
+                models.AccountUsage.account == new_acc_vo2
+            )
+            acc_counters = session.execute(stmt).one()
+            rse_id = acc_counters[1]
+            vo = get_rse_vo(rse_id, session=session)
         assert vo == second_vo
 
 

--- a/tests/test_rse_selector.py
+++ b/tests/test_rse_selector.py
@@ -19,6 +19,8 @@ from rucio.common.exception import InsufficientAccountLimit, InsufficientTargetR
 from rucio.core.account_counter import increase, update_account_counter
 from rucio.core.account_limit import set_global_account_limit, set_local_account_limit
 from rucio.core.rse_selector import RSESelector
+from rucio.db.sqla.constants import DatabaseOperationType
+from rucio.db.sqla.session import db_session
 
 
 @pytest.fixture
@@ -48,8 +50,9 @@ class TestRSESelectorInit:
         copies = 2
         rses = [rse1, rse2]
         set_local_account_limit(account=random_account, rse_id=rse1_id, bytes_=10)
-        increase(rse1_id, random_account, 10, 10)
-        update_account_counter(account=random_account, rse_id=rse1_id)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            increase(rse1_id, random_account, 10, 10, session=session)
+            update_account_counter(account=random_account, rse_id=rse1_id, session=session)
         with pytest.raises(InsufficientAccountLimit):
             RSESelector(random_account, rses, None, copies)
 
@@ -60,8 +63,9 @@ class TestRSESelectorInit:
         rses = [rse1, rse2]
         set_local_account_limit(account=random_account, rse_id=rse1_id, bytes_=20)
         set_global_account_limit(account=random_account, rse_expression=rse1_name, bytes_=10)
-        increase(rse1_id, random_account, 10, 10)
-        update_account_counter(account=random_account, rse_id=rse1_id)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            increase(rse1_id, random_account, 10, 10, session=session)
+            update_account_counter(account=random_account, rse_id=rse1_id, session=session)
         with pytest.raises(InsufficientAccountLimit):
             RSESelector(random_account, rses, None, copies)
 
@@ -83,8 +87,9 @@ class TestRSESelectorInit:
         copies = 1
         rses = [rse1, rse2]
         set_global_account_limit(account=random_account, rse_expression=rse1_name, bytes_=10)
-        increase(rse1_id, random_account, 10, 10)
-        update_account_counter(account=random_account, rse_id=rse1_id)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            increase(rse1_id, random_account, 10, 10, session=session)
+            update_account_counter(account=random_account, rse_id=rse1_id, session=session)
         set_local_account_limit(account=random_account, rse_id=rse2_id, bytes_=20)
         set_local_account_limit(account=random_account, rse_id=rse1_id, bytes_=20)
         rse_selector = RSESelector(random_account, rses, None, copies)
@@ -97,8 +102,9 @@ class TestRSESelectorInit:
         copies = 1
         set_global_account_limit(account=random_account, rse_expression=rse1_name, bytes_=10)
         set_local_account_limit(account=random_account, rse_id=rse1_id, bytes_=10)
-        increase(rse1_id, random_account, 10, 10)
-        update_account_counter(account=random_account, rse_id=rse1_id)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            increase(rse1_id, random_account, 10, 10, session=session)
+            update_account_counter(account=random_account, rse_id=rse1_id, session=session)
         set_local_account_limit(account=random_account, rse_id=rse2_id, bytes_=10)
         set_global_account_limit(account=random_account, rse_expression=rse2_name, bytes_=10)
         rse_selector = RSESelector(random_account, rses, None, copies)

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -694,7 +694,8 @@ class TestCore:
         """ REPLICATION RULE (CORE): Test if creating UNAVAILABLE replicas updates the RSE Counter correctly"""
 
         rse_update(once=True)
-        rse_counter_before = get_rse_counter(self.rse2_id)
+        with db_session(DatabaseOperationType.READ) as session:
+            rse_counter_before = get_rse_counter(self.rse2_id, session=session)
 
         files = create_files(3, mock_scope, self.rse1_id, bytes_=100)
         dataset = did_factory.random_dataset_did()
@@ -705,7 +706,8 @@ class TestCore:
 
         # Check if the rse has been updated correctly
         rse_update(once=True)
-        rse_counter_after = get_rse_counter(self.rse2_id)
+        with db_session(DatabaseOperationType.READ) as session:
+            rse_counter_after = get_rse_counter(self.rse2_id, session=session)
         assert (rse_counter_before['bytes'] + 3 * 100 == rse_counter_after['bytes'])
         assert (rse_counter_before['files'] + 3 == rse_counter_after['files'])
 


### PR DESCRIPTION
Part of #6989