### PR TITLE
Core: naming_convention, migrate away from session decorators, pass session as required parameter

### DIFF
--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -556,7 +556,7 @@ def __add_files_to_dataset(
     """
     # Get metadata from dataset
     try:
-        dataset_meta = validate_name(scope=parent_did.scope, name=parent_did.name, did_type='D')
+        dataset_meta = validate_name(scope=parent_did.scope, name=parent_did.name, did_type='D', session=session)
     except Exception:
         dataset_meta = None
 

--- a/lib/rucio/core/naming_convention.py
+++ b/lib/rucio/core/naming_convention.py
@@ -24,7 +24,6 @@ from rucio.common.cache import MemcacheRegion
 from rucio.common.exception import Duplicate, InvalidObject, RucioException
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import KeyType
-from rucio.db.sqla.session import transactional_session
 
 if TYPE_CHECKING:
     from typing import TypedDict
@@ -40,12 +39,10 @@ if TYPE_CHECKING:
 REGION = MemcacheRegion(expiration_time=900)
 
 
-@transactional_session
 def add_naming_convention(
     scope: "InternalScope",
     regexp: str,
     convention_type: KeyType,
-    *,
     session: "Session"
 ) -> None:
     """
@@ -96,7 +93,6 @@ def get_naming_convention(
     return session.execute(stmt).scalar()
 
 
-@transactional_session
 def delete_naming_convention(
     scope: "InternalScope",
     convention_type: KeyType,

--- a/lib/rucio/core/naming_convention.py
+++ b/lib/rucio/core/naming_convention.py
@@ -24,7 +24,7 @@ from rucio.common.cache import MemcacheRegion
 from rucio.common.exception import Duplicate, InvalidObject, RucioException
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import KeyType
-from rucio.db.sqla.session import read_session, transactional_session
+from rucio.db.sqla.session import transactional_session
 
 if TYPE_CHECKING:
     from typing import TypedDict
@@ -73,11 +73,9 @@ def add_naming_convention(
         raise RucioException(str(format_exc()))
 
 
-@read_session
 def get_naming_convention(
     scope: "InternalScope",
     convention_type: KeyType,
-    *,
     session: "Session"
 ) -> Optional[str]:
     """
@@ -124,8 +122,7 @@ def delete_naming_convention(
     return session.execute(stmt).rowcount
 
 
-@read_session
-def list_naming_conventions(*, session: "Session") -> list["NamingConventionDict"]:
+def list_naming_conventions(session: "Session") -> list["NamingConventionDict"]:
     """
     List all naming conventions.
 
@@ -140,12 +137,10 @@ def list_naming_conventions(*, session: "Session") -> list["NamingConventionDict
     return [cast("NamingConventionDict", row._asdict()) for row in session.execute(stmt).all()]
 
 
-@read_session
 def validate_name(
     scope: "InternalScope",
     name: str,
     did_type: str,
-    *,
     session: "Session"
 ) -> Optional[dict[str, Any]]:
     """
@@ -154,7 +149,6 @@ def validate_name(
     :param scope: the name for the scope.
     :param name: the name.
     :param did_type: the type of did.
-
     :param session: The database session in use.
 
     :returns: a dictionary with metadata.

--- a/lib/rucio/gateway/did.py
+++ b/lib/rucio/gateway/did.py
@@ -131,10 +131,10 @@ def add_did(
 
         if did_type == 'DATASET':
             # naming_convention validation
-            extra_meta = naming_convention.validate_name(scope=internal_scope, name=name, did_type='D', session=session)
+            extra_meta = naming_convention.validate_name(scope=internal_scope, name=name, did_type='D', session=session) or {}
 
             # merge extra_meta with meta
-            for k in extra_meta or {}:
+            for k in extra_meta:
                 if k not in meta:
                     meta[k] = extra_meta[k]
                 elif meta[k] != extra_meta[k]:


### PR DESCRIPTION
Part of #6989