### PR TITLE
Core & Internals: Add centralized startup diagnostics; Fixes rucio#8197

### DIFF
--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -1303,3 +1303,14 @@ class OpenDataDuplicateRecordID(OpenDataError):
         super(OpenDataDuplicateRecordID, self).__init__(*args)
         self._message = f"Data identifier with the same Record ID ({record_id}) already exists in the open data catalog."
         self.error_code = 123
+
+
+class StartupCheckError(RucioException):
+    """
+    Raised when a startup diagnostic check fails.
+    """
+
+    def __init__(self, *args):
+        super(StartupCheckError, self).__init__(*args)
+        self._message = "Startup diagnostic failed."
+        self.error_code = 124

--- a/lib/rucio/common/startup_checks.py
+++ b/lib/rucio/common/startup_checks.py
@@ -1,0 +1,489 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import inspect
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Protocol
+
+from rucio.common.config import config_get_bool, config_get_int, config_get_list
+from rucio.common.exception import StartupCheckError
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable, Mapping
+
+
+class StartupCheckCallback(Protocol):
+    def __call__(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class StartupCheck:
+    """
+    Definition of a startup diagnostic.
+
+    Attributes
+    ----------
+    name:
+        Unique identifier of the diagnostic.
+    callback:
+        Callable invoked to run the diagnostic.
+    tags:
+        Normalised set of tags describing the environments where the
+        diagnostic should execute.
+    description:
+        Optional human readable text describing the diagnostic. Logged when
+        the check runs so that operators know what is happening.
+    """
+
+    name: str
+    callback: StartupCheckCallback
+    tags: frozenset[str]
+    description: Optional[str] = None
+
+
+_registry: dict[str, StartupCheck] = {}
+_registry_lock = threading.Lock()
+
+
+def _normalize_name(name: str) -> str:
+    """
+    Canonicalise a diagnostic name.
+
+    A lot of the public API accepts free-form strings. Before storing the
+    value we trim surrounding whitespace to avoid treating ``" db "`` as a
+    distinct check. The same helper is used for validation when registering
+    new checks and when processing configuration overrides, which keeps the
+    matching logic consistent.
+
+    Parameters
+    ----------
+    name:
+        Raw name supplied by the caller.
+
+    Returns
+    -------
+    str
+        The trimmed diagnostic name.
+
+    Raises
+    ------
+    ValueError
+        If the normalised name would be empty.
+    """
+
+    normalized = name.strip()
+    if not normalized:
+        raise ValueError("Startup check name cannot be empty")
+    return normalized
+
+
+def _normalize_tags(tags: Optional[Iterable[str]]) -> frozenset[str]:
+    """
+    Normalise a collection of tags.
+
+    Tags are used to scope checks to specific services (for example ``daemon``
+    or ``rest``). We trim whitespace and fold everything to lowercase. The return
+    type is a :class:`frozenset` so the result can be safely cached and shared
+    between helpers without the risk of accidental mutation.
+
+    Parameters
+    ----------
+    tags:
+        Iterable containing the raw tag identifiers. ``None`` or empty values
+        result in an empty set.
+
+    Returns
+    -------
+    frozenset of str
+        The cleaned, lower-cased tags with surrounding whitespace removed.
+    """
+
+    if not tags:
+        return frozenset()
+    return frozenset(tag.strip().lower() for tag in tags if tag and tag.strip())
+
+
+def _collect_configured_names(
+        option: str,
+        tags: frozenset[str],
+        tag_suffixes: Mapping[str, Collection[str]]
+) -> set[str]:
+    """
+    Collect the check names configured for a given option.
+
+    Configuration may list checks under generic ``enabled`` / ``disabled``
+    keys as well as under tag specific variants such as ``enabled_daemon``.
+    This helper gathers all the possible spellings for the requested tags and
+    collates the configured check names into a single cleaned set. The caller
+    is still responsible for reconciling these names with the registry.
+
+    Parameters
+    ----------
+    option:
+        Name of the configuration option (``"enabled"`` or ``"disabled"``).
+    tags:
+        Set of tags describing the current service.
+
+    Returns
+    -------
+    set of str
+        Cleaned set of check names extracted from the configuration.
+    """
+
+    # ConfigParser normalizes option names, but config table lookups are case-sensitive,
+    # so query common case variants to avoid missing mixed-case entries.
+    options_to_query = {
+        option,
+        option.lower(),
+        option.upper(),
+    }
+
+    for tag in tags:
+        suffixes = tag_suffixes.get(tag)
+        if not suffixes:
+            suffixes = {tag}
+        for suffix in suffixes:
+            tag_option = f'{option}_{suffix}'
+            options_to_query.add(tag_option)
+            options_to_query.add(tag_option.lower())
+            options_to_query.add(tag_option.upper())
+
+    values: set[str] = set()
+    for config_option in options_to_query:
+        values.update(config_get_list(
+            'startup_checks',
+            config_option,
+            raise_exception=False,
+            default=[],
+            check_config_table=False,
+        ))
+    return {value.strip() for value in values if value and value.strip()}
+
+
+def _select_checks(tags: frozenset[str]) -> tuple[list[StartupCheck], set[str]]:
+    """
+    Return the set of checks applicable to the supplied tags.
+
+    The registry is protected by a lock during iteration so that late
+    registrations do not race with an ongoing startup check run. The function
+    returns a snapshot rather than a live view because the caller will filter
+    the list based on configuration overrides.
+
+    Parameters
+    ----------
+    tags:
+        Set of normalised tags describing the current service.
+
+    Returns
+    -------
+    tuple
+        Two elements where the first item is the list of registered checks
+        whose tag set intersects *tags* (or which are unscoped) and the
+        second item is the set of all registered check names.
+    """
+
+    with _registry_lock:
+        checks = list(_registry.values())
+        all_names = set(_registry)
+
+    if not tags:
+        return checks, all_names
+
+    return [
+        check for check in checks
+        if not check.tags or check.tags.intersection(tags)
+    ], all_names
+
+
+def _prepare_tags(tags: Optional[Iterable[str]]) -> tuple[frozenset[str], dict[str, frozenset[str]]]:
+    """
+    Normalise tags and compute the variants used for configuration lookups.
+
+    Besides producing the cleaned :class:`frozenset` of tags, this helper also
+    pre-computes a map of case variants for each tag. Configuration files may
+    spell options with different casing (``ENABLED_DAEMON`` vs ``enabled_daemon``),
+    so keeping all the candidate variants upfront avoids repeating that work in
+    the hot path.
+    """
+
+    if not tags:
+        return frozenset(), {}
+
+    normalized: set[str] = set()
+    suffixes: dict[str, set[str]] = {}
+
+    for raw_tag in tags:
+        if not raw_tag:
+            continue
+        trimmed = raw_tag.strip()
+        if not trimmed:
+            continue
+        normalized_tag = trimmed.lower()
+        normalized.add(normalized_tag)
+        variants = suffixes.setdefault(normalized_tag, set())
+        variants.add(normalized_tag)
+        variants.add(trimmed)
+        variants.add(trimmed.lower())
+        variants.add(trimmed.upper())
+
+    return frozenset(normalized), {tag: frozenset(variants) for tag, variants in suffixes.items()}
+
+
+def run_startup_checks(
+        *,
+        tags: Optional[Iterable[str]] = None,
+        logger: Optional[logging.Logger] = None
+) -> None:
+    """
+    Run startup diagnostics applicable to the given service tags.
+
+    Collects all registered checks that apply to ``tags`` (plus untagged ones),
+    optionally filters them according to the ``[startup_checks]`` section in
+    ``rucio.cfg``, and executes them. On any failure, raises
+    :class:`~rucio.common.exception.StartupCheckError`.
+
+    Parameters
+    ----------
+    tags : Collection[str]
+        Tags describing the current service(s). Common values are ``{"daemon"}`` and ``{"rest"}``.
+    logger : logging.Logger | Callable[..., None] | None, optional
+        Component‑specific logger. If omitted, uses the module logger ``rucio.startup_checks``.
+
+    Behavior
+    --------
+    - **Default selection**: all checks whose tag set intersects the supplied ``tags``,
+      plus untagged checks.
+    - **Config filters (optional)** from ``[startup_checks]`` in ``rucio.cfg``:
+        * ``enabled`` / ``enabled_<TAG>`` restrict the set (union) after tag filtering.
+        * ``disabled`` / ``disabled_<TAG>`` remove names. **Disabled wins** when both apply.
+        * Name and tag comparisons are case‑insensitive; duplicates are deduplicated.
+        * Unknown names are ignored with a warning (or fail in strict mode).
+        * If enabled lists select nothing applicable, the runner falls back to the default set
+          and logs that fallback (unless strict mode is on).
+    - **Soft time budget**: ``startup_checks.timeout_ms`` sets a soft limit for the whole run.
+      Exceeding the cumulative runtime logs a warning once and execution continues.
+    - **Strict mode**: ``startup_checks.strict = true`` turns these into hard errors:
+        * unknown names in any ``enabled*``/``disabled*``,
+        * enabled lists containing only non‑applicable names,
+        * configuration that removes all applicable checks.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    StartupCheckError
+        If any check fails, or if configuration is invalid under strict mode.
+
+    Logging
+    -------
+    - Logs each check's ``description`` (if provided) before execution.
+    - Logs a completion summary like:
+      ``Startup checks completed successfully: N ran, M disabled by config``.
+
+    Examples
+    --------
+    >>> run_startup_checks(tags={"daemon"})
+    """
+
+    normalized_tags, tag_suffixes = _prepare_tags(tags)
+    tags_display = ', '.join(sorted(normalized_tags)) or 'default'
+    log = logger or logging.getLogger('rucio.startup_checks')
+
+    checks_snapshot, all_registered_names = _select_checks(normalized_tags)
+    checks = list(checks_snapshot)
+
+    strict_mode = config_get_bool(
+        'startup_checks',
+        'strict',
+        raise_exception=False,
+        default=False,
+        check_config_table=False,
+    )
+    soft_timeout_ms = config_get_int(
+        'startup_checks',
+        'timeout_ms',
+        raise_exception=False,
+        default=0,
+        check_config_table=False,
+    )
+    if soft_timeout_ms <= 0:
+        soft_timeout_ms = None
+
+    enabled = _collect_configured_names('enabled', normalized_tags, tag_suffixes)
+    disabled = _collect_configured_names('disabled', normalized_tags, tag_suffixes)
+
+    registered_names = {check.name for check in checks}
+    lower_all_registered_names = {name.lower(): name for name in all_registered_names}
+    all_registered_lower_names = set(lower_all_registered_names.keys())
+
+    disabled_applied_lower: set[str] = set()
+
+    if enabled:
+        configured_enabled_map = {name.lower(): name for name in enabled}
+        enabled_lower = set(configured_enabled_map)
+        unknown = enabled_lower - all_registered_lower_names
+        if unknown:
+            unknown_enabled_display = sorted(configured_enabled_map[name] for name in unknown)
+            log.warning(
+                'Unknown startup check(s) in `startup_checks.enabled`: %s - ignored',
+                ', '.join(unknown_enabled_display),
+            )
+            if strict_mode:
+                raise StartupCheckError(
+                    'Strict startup checks mode rejected unknown check(s) configured in '
+                    '`startup_checks.enabled`: '
+                    f"{', '.join(unknown_enabled_display)}"
+                )
+        registered_names_lower = {name.lower() for name in registered_names}
+        missing = (enabled_lower - registered_names_lower) - unknown
+        missing_display: list[str] = []
+        if missing:
+            missing_display = [
+                configured_enabled_map.get(name)
+                or lower_all_registered_names.get(name, name)
+                for name in sorted(missing)
+            ]
+            log.info(
+                'Startup check(s) in `startup_checks.enabled` are not applicable to tags %s - ignored: %s',
+                tags_display,
+                ', '.join(missing_display),
+            )
+        enabled_effective = enabled_lower & registered_names_lower
+        checks = [check for check in checks if check.name.lower() in enabled_effective]
+        if not checks:
+            if strict_mode:
+                details = f' Non-applicable enabled check(s): {", ".join(missing_display)}.' if missing_display else ''
+                raise StartupCheckError(
+                    'Strict startup checks mode requires that `startup_checks.enabled` selects at least one '
+                    f'check applicable to tags {tags_display}.{details}'
+                )
+            log.warning(
+                'All configured `startup_checks.enabled` names were unknown or not applicable; '
+                'falling back to default checks for tags %s',
+                tags_display,
+            )
+            checks = list(checks_snapshot)
+
+    if disabled:
+        configured_disabled_map = {name.lower(): name for name in disabled}
+        disabled_lower = set(configured_disabled_map)
+        checks_before_disabled = {check.name.lower() for check in checks}
+        checks = [check for check in checks if check.name.lower() not in disabled_lower]
+        disabled_applied_lower = checks_before_disabled - {check.name.lower() for check in checks}
+        unknown_disabled = disabled_lower - all_registered_lower_names
+        if unknown_disabled:
+            unknown_disabled_display = sorted(configured_disabled_map[name] for name in unknown_disabled)
+            log.warning(
+                'Unknown startup check(s) in `startup_checks.disabled`: %s - ignored',
+                ', '.join(unknown_disabled_display),
+            )
+            if strict_mode:
+                raise StartupCheckError(
+                    'Strict startup checks mode rejected unknown check(s) configured in '
+                    '`startup_checks.disabled`: '
+                    f"{', '.join(unknown_disabled_display)}"
+                )
+
+    if disabled_applied_lower and log.isEnabledFor(logging.DEBUG):
+        disabled_applied_display = [
+            lower_all_registered_names.get(name, name)
+            for name in sorted(disabled_applied_lower)
+        ]
+        log.debug('Startup checks disabled by config: %s', ', '.join(disabled_applied_display))
+
+    if not checks:
+        if strict_mode and (enabled or disabled):
+            raise StartupCheckError(
+                'No startup checks remain after applying enabled/disabled filters for tags '
+                f'{tags_display} in strict mode'
+            )
+        log.info('No startup checks to run for tags %s', tags_display)
+        return
+
+    log.info('Running startup checks%s', f' [{tags_display}]' if normalized_tags else '')
+
+    checks = sorted(checks, key=lambda check: check.name.casefold())
+
+    durations: list[tuple[str, float]] = []
+
+    run_start_time = time.perf_counter()
+    soft_timeout_logged = False
+
+    for check in checks:
+        description = f' ({check.description})' if check.description else ''
+        log.info('Running startup check %s%s', check.name, description)
+        start_time = time.perf_counter()
+        try:
+            result = check.callback()
+            if inspect.isawaitable(result):
+                if inspect.iscoroutine(result):
+                    result.close()
+                raise StartupCheckError(
+                    f'Startup check "{check.name}" returned an awaitable; asynchronous callbacks are not supported'
+                )
+        except StartupCheckError:
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            log.critical('Startup check %s failed after %.1f ms', check.name, duration_ms, exc_info=True)
+            raise
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            log.critical(
+                'Startup check %s raised an unexpected exception after %.1f ms',
+                check.name,
+                duration_ms,
+                exc_info=True,
+            )
+            raise StartupCheckError(
+                f'Startup check "{check.name}" failed with unexpected error: {error}'
+            ) from error
+        end_time = time.perf_counter()
+        duration_ms = (end_time - start_time) * 1000
+        log.debug('Startup check "%s" passed in %.1f ms', check.name, duration_ms)
+        total_runtime_ms = (end_time - run_start_time) * 1000
+        if soft_timeout_ms is not None and not soft_timeout_logged and total_runtime_ms > soft_timeout_ms:
+            log.warning(
+                'Startup checks exceeded soft timeout after "%s" (%.0f > %d ms)',
+                check.name,
+                total_runtime_ms,
+                soft_timeout_ms,
+            )
+            soft_timeout_logged = True
+        durations.append((check.name, duration_ms))
+
+    disabled_count = len(disabled_applied_lower)
+    if durations:
+        slowest_name, slowest_duration = max(durations, key=lambda item: item[1])
+        log.info(
+            'Startup checks completed successfully: %d ran, %d disabled by config, '
+            'slowest=%s (%.1f ms)',
+            len(durations),
+            disabled_count,
+            slowest_name,
+            slowest_duration,
+        )
+    else:
+        log.info(
+            'Startup checks completed successfully: no checks ran, %d disabled by config',
+            disabled_count,
+        )
+
+
+__all__ = ['run_startup_checks', 'StartupCheck', 'StartupCheckCallback']

--- a/lib/rucio/daemons/bb8/bb8.py
+++ b/lib/rucio/daemons/bb8/bb8.py
@@ -26,11 +26,11 @@ from rucio.common.config import config_get_float
 from rucio.common.constants import DEFAULT_VO
 from rucio.common.exception import InvalidRSEExpression
 from rucio.common.logging import setup_logging
-from rucio.core.heartbeat import list_payload_counts, sanity_check
+from rucio.core.heartbeat import list_payload_counts
 from rucio.core.rse import get_rse_usage
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.daemons.bb8.common import get_active_locks, rebalance_rse
-from rucio.daemons.common import HeartbeatHandler, run_daemon
+from rucio.daemons.common import HeartbeatHandler, run_daemon, run_daemon_startup_checks
 
 if TYPE_CHECKING:
     from types import FrameType
@@ -334,7 +334,7 @@ def run(
 
     setup_logging(process_name=DAEMON_NAME)
     hostname = socket.gethostname()
-    sanity_check(executable=DAEMON_NAME, hostname=hostname)
+    run_daemon_startup_checks(executable=DAEMON_NAME, hostname=hostname)
     logging.info("BB8 starting %s threads", str(threads))
     thread_list = [
         threading.Thread(

--- a/lib/rucio/daemons/cache/consumer.py
+++ b/lib/rucio/daemons/cache/consumer.py
@@ -32,6 +32,7 @@ from rucio.common.types import InternalScope, LoggerFunction
 from rucio.core.monitor import MetricManager
 from rucio.core.rse import get_rse_id
 from rucio.core.volatile_replica import add_volatile_replicas, delete_volatile_replicas
+from rucio.daemons.common import run_daemon_startup_checks
 from rucio.db.sqla.constants import DatabaseOperationType
 from rucio.db.sqla.session import db_session
 
@@ -183,6 +184,8 @@ def run(num_thread: int = 1) -> None:
     Starts up the rucio cache consumer thread
     """
     setup_logging(process_name=DAEMON_NAME)
+
+    run_daemon_startup_checks(executable=DAEMON_NAME)
 
     if rucio.db.sqla.util.is_old_db():
         raise exception.DatabaseException('Database was not updated, daemon won\'t start')

--- a/lib/rucio/daemons/common.py
+++ b/lib/rucio/daemons/common.py
@@ -23,6 +23,7 @@ import time
 from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union
 
 from rucio.common.logging import formatted_logger
+from rucio.common.startup_checks import run_startup_checks
 from rucio.common.utils import PriorityQueue
 from rucio.core import heartbeat as heartbeat_core
 from rucio.core.monitor import MetricManager
@@ -34,6 +35,91 @@ if TYPE_CHECKING:
 
 T = TypeVar('T')
 METRICS = MetricManager(module=__name__)
+
+_daemon_startup_checks_lock = threading.Lock()
+_daemon_startup_checks_ran = False
+
+
+def _hard_exit(exit_code: int = 1) -> None:
+    """Terminate the whole process immediately.
+
+    Used when startup diagnostics fail from a non-main thread. Raising an exception
+    would only stop that worker thread and can leave the process partially running.
+    """
+    try:
+        # best-effort flush of logs before terminating
+        logging.shutdown()
+    finally:
+        os._exit(exit_code)  # nosec - deliberate fail-fast termination
+
+
+def run_daemon_startup_checks(executable: str, hostname: Optional[str] = None) -> None:
+    """
+    Execute the daemon-specific startup diagnostics and the heartbeat sanity check.
+
+    This helper is called from :class:`HeartbeatHandler` every time a daemon enters
+    its ``with`` block. On the first invocation inside a Python process it acquires
+    a process-wide lock, executes :func:`run_startup_checks` with the ``{"daemon"}``
+    tag filter (alongside any untagged ones), and the global ``_daemon_startup_checks_ran``
+    flag is flipped only after that runner returns successfully. Because
+    the flag is cached per process, later calls in the same process skip the
+    diagnostic runner and proceed straight to the heartbeat verification.
+
+    The helper can also be used to register checks by itself. If you follow the
+    "central catalog" convention from :mod:`rucio.common.startup_checks`, register
+    your checks (for example by importing ``startup_checks_catalog.register_all``)
+    before the first call to this function. Other registration strategies (local
+    definitions, ad-hoc imports, etc.) work as long as the checks are registered
+    before this helper runs.
+
+    The lock ensures that concurrent daemons in the same process cannot run the
+    diagnostics in parallel—every other caller blocks until the first one exits
+    the ``with`` block. If the runner raises (for example because a diagnostic
+    failed), the exception bubbles out, the flag remains ``False``, and the lock
+    is released by normal ``with``-statement unwinding; the next daemon that
+    acquires the lock therefore retries the runner instead of skipping it.
+
+    If a fatal startup failure happens while this helper is invoked from a
+    worker thread (e.g. for multi-threaded daemons), the process is terminated
+    with a non-zero exit code. This avoids a partially started process where only
+    one worker thread died while the rest of the process keeps running.
+
+    Irrespective of whether the diagnostic suite just ran, every invocation of
+    this helper performs :func:`heartbeat_core.sanity_check` afterwards so that the
+    daemon confirms its heartbeat record before starting real work.
+    """
+
+    global _daemon_startup_checks_ran
+
+    logger = logging.getLogger(executable)
+    resolved_hostname = hostname or socket.getfqdn()
+
+    current_thread = threading.current_thread()
+    is_main_thread = current_thread is threading.main_thread()
+
+    with _daemon_startup_checks_lock:
+        if not _daemon_startup_checks_ran:
+            if not is_main_thread:
+                logger.warning(
+                    'Running daemon startup checks from non-main thread "%s". '
+                    'For multi-threaded daemons, call run_daemon_startup_checks() in the main thread '
+                    'before starting worker threads to get a clean fail-fast behaviour.',
+                    current_thread.name,
+                )
+            try:
+                run_startup_checks(tags={'daemon'}, logger=logger)
+            except Exception:
+                logger.critical(
+                    'Daemon startup checks failed in thread "%s". Aborting process startup.',
+                    current_thread.name,
+                    exc_info=True,
+                )
+                if not is_main_thread:
+                    _hard_exit(1)
+                raise
+            _daemon_startup_checks_ran = True
+
+    heartbeat_core.sanity_check(executable=executable, hostname=resolved_hostname)
 
 
 class HeartbeatHandler:
@@ -62,7 +148,7 @@ class HeartbeatHandler:
         self.last_payload = None
 
     def __enter__(self) -> 'HeartbeatHandler':
-        heartbeat_core.sanity_check(executable=self.executable, hostname=self.hostname)
+        run_daemon_startup_checks(executable=self.executable, hostname=self.hostname)
         self.live()
         return self
 

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -25,6 +25,7 @@ from rucio.common import exception
 from rucio.common.config import config_get_bool
 from rucio.common.logging import setup_logging
 from rucio.core.monitor import MetricManager
+from rucio.daemons.common import run_daemon_startup_checks
 from rucio.daemons.conveyor.common import get_conveyor_rses
 from rucio.daemons.conveyor.submitter import submitter
 from rucio.db.sqla.constants import RequestType
@@ -103,6 +104,8 @@ def run(
     """
     activities = activities or []
     setup_logging(process_name=DAEMON_NAME)
+
+    run_daemon_startup_checks(executable=DAEMON_NAME)
 
     if rucio.db.sqla.util.is_old_db():
         raise exception.DatabaseException('Database was not updated, daemon won\'t start')

--- a/lib/rucio/daemons/follower/follower.py
+++ b/lib/rucio/daemons/follower/follower.py
@@ -24,7 +24,8 @@ from rucio.common import exception
 from rucio.common.logging import setup_logging
 from rucio.common.utils import get_thread_with_periodic_running_function
 from rucio.core.did import create_reports
-from rucio.core.heartbeat import die, live, sanity_check
+from rucio.core.heartbeat import die, live
+from rucio.daemons.common import run_daemon_startup_checks
 
 if TYPE_CHECKING:
     from types import FrameType
@@ -84,7 +85,7 @@ def run(
         raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     hostname = socket.gethostname()
-    sanity_check(executable=DAEMON_NAME, hostname=hostname)
+    run_daemon_startup_checks(executable=DAEMON_NAME, hostname=hostname)
 
     if once:
         logging.info("executing one follower iteration only")

--- a/lib/rucio/daemons/rsedecommissioner/rse_decommissioner.py
+++ b/lib/rucio/daemons/rsedecommissioner/rse_decommissioner.py
@@ -29,9 +29,8 @@ from rucio.common.config import config_get_int
 from rucio.common.constants import RseAttr
 from rucio.common.exception import RucioException
 from rucio.common.logging import setup_logging
-from rucio.core.heartbeat import sanity_check
 from rucio.core.rse import get_rse_attribute, get_rses_with_attribute
-from rucio.daemons.common import run_daemon
+from rucio.daemons.common import run_daemon, run_daemon_startup_checks
 from rucio.db.sqla.constants import RuleState
 
 from .config import DecommissioningStatus, InvalidStatusName, attr_to_config, set_status
@@ -144,7 +143,7 @@ def run(
     """
     setup_logging(process_name=DAEMON_NAME)
     hostname = socket.gethostname()
-    sanity_check(executable='rucio-rsedecommissioner', hostname=hostname)
+    run_daemon_startup_checks(executable='rucio-rsedecommissioner', hostname=hostname)
 
     logging.info('RSE-Decommissioner starting 1 thread')
 

--- a/lib/rucio/daemons/storage/consistency/actions.py
+++ b/lib/rucio/daemons/storage/consistency/actions.py
@@ -37,11 +37,12 @@ from rucio.common import exception
 from rucio.common.logging import formatted_logger, setup_logging
 from rucio.common.types import InternalAccount, InternalScope, LFNDict
 from rucio.common.utils import daemon_sleep
-from rucio.core.heartbeat import die, live, sanity_check
+from rucio.core.heartbeat import die, live
 from rucio.core.monitor import MetricManager
 from rucio.core.quarantined_replica import add_quarantined_replicas
 from rucio.core.replica import __exist_replicas, update_replicas_states
 from rucio.core.rse import get_rse_id, list_rses
+from rucio.daemons.common import run_daemon_startup_checks
 
 # FIXME: these are needed by local version of declare_bad_file_replicas()
 # TODO: remove after move of this code to core/replica.py - see https://github.com/rucio/rucio/pull/5068
@@ -823,7 +824,7 @@ def run(
            miss_threshold_percent, force_proceed, scanner_files_path))
 
     hostname = socket.gethostname()
-    sanity_check(executable=DAEMON_NAME, hostname=hostname)
+    run_daemon_startup_checks(executable=DAEMON_NAME, hostname=hostname)
 
 # It was decided that for the time being this daemon is best executed in a single thread
 # TODO: If this decicion is reversed in the future, the following line should be removed.

--- a/lib/rucio/web/rest/flaskapi/v1/main.py
+++ b/lib/rucio/web/rest/flaskapi/v1/main.py
@@ -21,6 +21,7 @@ from flask import Flask
 from rucio.common.config import config_get_list
 from rucio.common.exception import ConfigurationError
 from rucio.common.logging import setup_logging
+from rucio.common.startup_checks import run_startup_checks
 from rucio.web.rest.flaskapi.v1.common import CORSMiddleware
 
 if TYPE_CHECKING:
@@ -89,6 +90,7 @@ application = Flask(__name__)
 application.wsgi_app = CORSMiddleware(application.wsgi_app)
 apply_endpoints(application, endpoints)
 setup_logging(application)
+run_startup_checks(tags={'rest'}, logger=application.logger)
 
 
 if __name__ == '__main__':

--- a/tests/rucio/common/test_startup_checks.py
+++ b/tests/rucio/common/test_startup_checks.py
@@ -1,0 +1,345 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: UP007, UP045
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pytest
+
+from rucio.common import startup_checks
+from rucio.common.exception import StartupCheckError
+
+
+LOGGER_NAME = 'rucio.startup_checks'
+
+
+class FakeConfigValues(dict):  # type: ignore[type-arg]
+    """
+    In-memory configuration storage for startup_checks tests.
+
+    The real Rucio configuration layer normalizes option names to lowercase when
+    reading from the file-based config. We mimic that here so tests use the same
+    "public" behaviour seen in production.
+
+    The object acts like a dict for list-valued options and exposes `.bools` and
+    `.ints` for boolean/integer options.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bools = {}
+        self.ints = {}
+
+    def __setitem__(self, key, value) -> None:  # type: ignore[override]
+        super().__setitem__(str(key).lower(), value)
+
+    def get_list(self, option: str) -> list[str]:
+        return list(super().get(option.lower(), []))
+
+    def get_bool(self, option: str) -> Optional[bool]:
+        return self.bools.get(option.lower())
+
+    def get_int(self, option: str) -> Optional[int]:
+        return self.ints.get(option.lower())
+
+
+def _messages(caplog, *, min_level: int) -> list[str]:
+    """
+    Extract captured messages from the startup_checks logger."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER_NAME and record.levelno >= min_level
+    ]
+
+
+# ---------------------------
+# Fixtures
+# ---------------------------
+
+@pytest.fixture(autouse=True)
+def isolated_registry(monkeypatch) -> None:
+    """
+    Isolate startup check registrations per test.
+
+    We replace the module-level registry with a fresh dict for the duration of each
+    test and let monkeypatch restore the original afterwards. This avoids polluting
+    other tests in the suite which may rely on registrations performed elsewhere.
+    """
+    monkeypatch.setattr(startup_checks, '_registry', {})  # type: ignore[attr-defined]
+    yield
+
+
+@pytest.fixture
+def config_values(monkeypatch) -> FakeConfigValues:
+    """Patch config accessors used by startup_checks to read from an in-memory dict."""
+    values = FakeConfigValues()
+
+    def fake_config_get_list(
+            section: str,
+            option: str,
+            *,
+            raise_exception: bool = True,
+            default=None,
+            check_config_table: bool = True,
+            **kwargs,
+    ) -> list[str]:
+        assert section == 'startup_checks'
+        # Startup checks should not require DB access during startup.
+        assert check_config_table is False
+        result = values.get_list(option)
+        if result:
+            return result
+        return [] if default is None else default
+
+    def fake_config_get_bool(
+            section: str,
+            option: str,
+            raise_exception: bool = True,
+            default=None,
+            check_config_table: bool = True,
+            **kwargs,
+    ):
+        assert section == 'startup_checks'
+        assert check_config_table is False
+        result = values.get_bool(option)
+        if result is not None:
+            return result
+        if raise_exception:
+            raise RuntimeError(f'No boolean config for {option}')
+        return default
+
+    def fake_config_get_int(
+            section: str,
+            option: str,
+            raise_exception: bool = True,
+            default=None,
+            check_config_table: bool = True,
+            **kwargs,
+    ):
+        assert section == 'startup_checks'
+        assert check_config_table is False
+        result = values.get_int(option)
+        if result is not None:
+            return result
+        if raise_exception:
+            raise RuntimeError(f'No integer config for {option}')
+        return default
+
+    monkeypatch.setattr(startup_checks, 'config_get_list', fake_config_get_list)
+    monkeypatch.setattr(startup_checks, 'config_get_bool', fake_config_get_bool)
+    monkeypatch.setattr(startup_checks, 'config_get_int', fake_config_get_int)
+    return values
+
+
+# ---------------------------
+# Helper
+# ---------------------------
+
+def _register(name: str, callback, *, tags: Optional[set[str]] = None) -> None:
+    startup_checks.register_startup_check(name=name, callback=callback, tags=tags, replace=False)
+
+
+# ---------------------------
+# Config override tests
+# ---------------------------
+
+def test_enabled_restricts_set(config_values) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+    _register('gamma', lambda: executed.append('gamma'), tags={'daemon'})
+
+    config_values['enabled'] = ['beta']  # only beta should run
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed == ['beta']
+
+
+def test_enabled_option_name_is_case_insensitive(config_values) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+    config_values['EnAbLeD'] = ['beta']  # config access normalizes option names
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed == ['beta']
+
+
+def test_enabled_check_names_are_case_insensitive(config_values) -> None:
+    executed: list[str] = []
+
+    _register('NeTwOrK', lambda: executed.append('NeTwOrK'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+
+    config_values['enabled'] = ['network']  # name matching should be case-insensitive
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed == ['NeTwOrK']
+
+
+def test_disabled_global_excludes_when_no_enabled(config_values) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+
+    config_values['disabled'] = ['beta']
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed == ['alpha']
+
+
+def test_disabled_can_remove_all_checks_and_logs_info(config_values, caplog) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+
+    config_values['disabled'] = ['alpha', 'beta']
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+    assert executed == []
+    assert any('No startup checks to run for tags daemon' in m for m in _messages(caplog, min_level=logging.INFO))
+
+
+def test_disable_overrides_enable_per_tag(config_values) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'rest'})
+    _register('beta', lambda: executed.append('beta'), tags={'rest'})
+
+    config_values['enabled'] = ['alpha', 'beta']
+    config_values['disabled_REST'] = ['beta']  # per-tag disabled wins over enabled
+
+    startup_checks.run_startup_checks(tags={'rest'})
+    assert executed == ['alpha']
+
+
+def test_enabled_per_tag_suffix_is_honoured(config_values) -> None:
+    executed = False
+
+    def _cb() -> None:
+        nonlocal executed
+        executed = True
+
+    _register('network', _cb, tags={'rest'})
+    config_values['enabled_REST'] = ['network']
+
+    startup_checks.run_startup_checks(tags={'rest'})
+    assert executed is True
+
+
+def test_unknown_names_in_config_are_ignored(config_values, caplog) -> None:
+    executed: list[str] = []
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+
+    config_values['enabled'] = ['ghost']  # does not exist
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+    assert executed == ['alpha']
+    warning_messages = _messages(caplog, min_level=logging.WARNING)
+    assert any('Unknown startup check(s) in `startup_checks.enabled`' in m for m in warning_messages)
+    assert any('falling back to default checks' in m for m in warning_messages)
+
+
+def test_unknown_disabled_names_raise_warning(config_values, caplog) -> None:
+    executed: list[str] = []
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+
+    config_values['disabled'] = ['ghost']
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+    assert executed == ['alpha']
+    warning_messages = _messages(caplog, min_level=logging.WARNING)
+    assert any('Unknown startup check(s) in `startup_checks.disabled`' in m for m in warning_messages)
+
+
+def test_enabled_not_applicable_names_fall_back_to_defaults(config_values, caplog) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'rest'})
+
+    config_values['enabled'] = ['beta']  # valid check but not for daemon tag
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+    assert executed == ['alpha']
+    info_messages = _messages(caplog, min_level=logging.INFO)
+    assert any('not applicable to tags' in m for m in info_messages)
+    assert any('falling back to default checks' in m for m in info_messages)
+
+
+def test_strict_mode_unknown_names_fail(config_values) -> None:
+    _register('alpha', lambda: None, tags={'daemon'})
+    config_values['enabled'] = ['ghost']
+    config_values.bools['strict'] = True
+
+    with pytest.raises(StartupCheckError):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+
+def test_strict_mode_unknown_disabled_names_fail(config_values) -> None:
+    _register('alpha', lambda: None, tags={'daemon'})
+    config_values['disabled'] = ['ghost']
+    config_values.bools['strict'] = True
+
+    with pytest.raises(StartupCheckError):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+
+def test_strict_mode_missing_names_fail(config_values) -> None:
+    _register('alpha', lambda: None, tags={'rest'})
+    config_values['enabled'] = ['alpha']
+    config_values.bools['strict'] = True
+
+    with pytest.raises(StartupCheckError):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+
+def test_strict_mode_filters_removing_all_checks_fail(config_values) -> None:
+    _register('alpha', lambda: None, tags={'daemon'})
+    config_values['enabled'] = ['alpha']
+    config_values['disabled'] = ['alpha']
+    config_values.bools['strict'] = True
+
+    with pytest.raises(StartupCheckError):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+
+def test_enabled_may_list_names_from_other_tags_but_only_current_tags_run(config_values) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'rest'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+
+    # both listed, but we run with 'rest' only; expect only alpha
+    config_values['enabled'] = ['alpha', 'beta']
+
+    startup_checks.run_startup_checks(tags={'rest'})
+    assert executed == ['alpha']

--- a/tests/rucio/common/test_startup_checks.py
+++ b/tests/rucio/common/test_startup_checks.py
@@ -14,6 +14,21 @@
 
 # ruff: noqa: UP007, UP045
 
+"""
+Tests for :mod:`rucio.common.startup_checks`.
+
+This suite exercises the startup-check registry and runner contract:
+- registration validation (names, callability, async rejection, replace semantics, tag normalization)
+- tag-based selection (scoped vs unscoped checks, multi-tag intersection, snapshot semantics for late registration)
+- config-driven filtering (enabled/disabled lists, per-tag overrides, case-insensitive matching, deduping, fallback behaviour, strict mode)
+- runtime/observability guarantees (exception wrapping as StartupCheckError, awaitable return rejection, soft-timeout warnings, summary log counts)
+
+Implementation notes:
+- Config accessors are monkeypatched to an in-memory store and must not consult the config table/DB.
+- The internal registry is isolated per test to avoid cross-test coupling.
+- Log assertions focus on operator-facing warnings/info rather than implementation details.
+"""
+
 from __future__ import annotations
 
 import logging
@@ -23,7 +38,6 @@ import pytest
 
 from rucio.common import startup_checks
 from rucio.common.exception import StartupCheckError
-
 
 LOGGER_NAME = 'rucio.startup_checks'
 


### PR DESCRIPTION
Handles rucio#8197

I have placed at the top of `startup_checks.py` a documentation/guide about this framework and its use. Nevertheless, I am placing this also here to understand what this does. Once we agree/merge this, we can also place it in the dev documentation. In summary, with this testing framework, we can now add easily checks that unless they pass, the services are blocked from starting. And such a test is needed for the new Metadata system. I will now push another PR where this framework is used. But it can wait till we agree on this one.

Keep in mind that the startup check registry in `lib/rucio/common/startup_checks.py` is initialized as an empty dictionary `(_registry: dict[str, StartupCheck] = {})`, and there are currently no calls that populate it outside of documentation examples and unit tests. Hence, there are currently zero startup checks registered at process startup (i.e. no-op for the moment) and so it should be quite safe to merge. Nevertheless, the introduced tests are passing.

Startup diagnostics registry and runner
======================================

This module provides a small framework to **register** and **run** fast, synchronous “startup checks” at process start. Its use is to assert prerequisites (database reachable, configuration sanity, network access, etc.) *before* the process begins normal work. It supports **simple/central** configuration but allows also **advanced operator controls**.

TL;DR summary
----------------------------

- A *startup check* is a **fast**, **side‑effect‑free**, **synchronous** function with **no arguments**.
- Register checks with :func:`register_startup_check`.
- Run them at startup with :func:`run_startup_checks(tags={...})` (or :func:`rucio.daemons.common.run_daemon_startup_checks` for daemons).
- **Untagged checks run for every service** (“always”).
- If **any** check fails, a :class:`~rucio.common.exception.StartupCheckError` is raised and your startup should abort.
- **No configuration is required.** If there is no ``[startup_checks]`` in ``rucio.cfg``, all checks whose tags match the service **plus** all untagged checks run.

From simple to advanced setups
-------------------------------------------

**1) Minimal – no config, run by tags (default behaviour)**

- The various check definitions can be kept at one place/module or spread however prefered.
- Register checks with an optional tag; leave ``tags=None`` for “always”.
- In each service, call ``run_startup_checks(tags={'daemon'})`` or ``run_startup_checks(tags={'rest'})``.
- Any failure raises :class:`~rucio.common.exception.StartupCheckError` and should stop startup.

**2) Centralized catalog – keep *all* checks in one module (convention)**

Put all checks in one file (e.g. ``rucio.common.startup_checks_catalog``) and import it at process start.

```python
# rucio/common/startup_checks_catalog.py
from rucio.common.startup_checks import register_startup_check

def register_all() -> None:
    # ALWAYS (untagged) – runs for every service
    def _config_sanity() -> None:
        pass  # raise on failure
    register_startup_check(
        name="config-sanity",
        callback=_config_sanity,
        description="Validate core configuration."
    )

    # Single-tag checks by convention
    def _db_ready() -> None:
        pass
    register_startup_check(
        name="database",
        callback=_db_ready,
        tags={"daemon"},
        description="Database connectivity."
    )

    def _rest_key_material() -> None:
        pass
    register_startup_check(
        name="rest-key-material",
        callback=_rest_key_material,
        tags={"rest"},
        description="REST auth key/cert presence."
    )
```

Import the catalog before running checks:

```python
# Daemon entrypoint
from rucio.common import startup_checks_catalog
startup_checks_catalog.register_all()
from rucio.daemons.common import run_daemon_startup_checks
run_daemon_startup_checks(executable="my-daemon")  # runs {'daemon'} + untagged

# Flask/REST app factory
from rucio.common import startup_checks_catalog
from rucio.common.startup_checks import run_startup_checks
def create_app():
    startup_checks_catalog.register_all()
    run_startup_checks(tags={"rest"})  # raises on failure -> abort startup
    ...
```

**2b) Operator-provided checks – register without modifying Rucio code**

Operators can register deployment-specific checks by shipping a small Python module/package that calls :func:`register_startup_check` and making sure it is imported **in the same Python process** before :func:`run_startup_checks` executes. The module must be importable (installed package or directory on ``PYTHONPATH``).

Choose tags depending on which services should run the check. For example, use ``tags={"daemon"}`` for daemon-only checks, ``tags={"rest"}`` for REST-only checks, or include both to run in both contexts. Omitting ``tags`` leaves the check untagged (“always”), so it will run for any :func:`run_startup_checks` call.

Example deployment module::

```python
# rucio_site_checks/custom_checks.py
import os
from rucio.common.startup_checks import register_startup_check

def check_nfs_mount() -> None:
    if not os.path.ismount("/data/rucio"):
        raise RuntimeError("NFS not mounted: /data/rucio")

register_startup_check(
    "nfs-mount",
    check_nfs_mount,
    tags={"daemon", "rest"},
    description="Ensure /data/rucio is mounted before services start",
)
```

Then ensure it is imported early::

```python
# REST/WSGI app factory / WSGI entrypoint
from rucio.common.startup_checks import run_startup_checks
import rucio_site_checks.custom_checks  # registers checks
run_startup_checks(tags={"rest"})
```

Note: the import must happen in the *same* Python process which calls ``run_startup_checks(...)``. Importing in a shell wrapper which then spawns a new Python process will not register anything in the child process.

**3) Operator controls via config (optional)**

If you add a ``[startup_checks]`` section in ``rucio.cfg``, operators can enable/disable checks without code changes, globally or per service. If you don’t add it, behaviour remains as in (1)/(2).

- ``enabled`` / ``enabled_<TAG>`` – restrict execution to this union (after tag filtering).
- ``disabled`` / ``disabled_<TAG>`` – remove these from the set (**disabled wins** if both listed).
- ``strict = true`` – treat misconfiguration as fatal (unknown names; enabling only non‑applicable names; removing all applicable checks).
- ``timeout_ms`` – **soft** time budget for the whole run (warning if exceeded; execution continues).

Tags & selection
----------------

- Each check can have **zero or more** tags.
- When you call :func:`run_startup_checks(tags=...)`, the runner executes:
  * all checks whose tag set **intersects** the supplied tags, **and**
  * all **untagged** checks (i.e. “always”).
- If you prefer a literal ``"always"`` tag, you can use ``tags={"always"}`` and pass it at runtime,
  but leaving checks untagged is simpler and equivalent.

Public API
----------

``register_startup_check(name, callback, *, tags=None, description=None, replace=False)``
    Register a diagnostic.

  * **name** – unique (case‑insensitive). Trimmed; empty names rejected.
  * **callback** – synchronous callable with no parameters; raise on failure.
    Returning an awaitable is invalid.
  * **tags** – optional iterable of strings (case‑insensitive, trimmed). If omitted, the check applies to all services.
  * **description** – text logged when the check runs.
  * **replace** – set ``True`` to replace an existing registration with the same name.

``run_startup_checks(*, tags, logger=None)``
    Execute all checks applicable to ``tags`` after applying optional configuration.
    On failure, raises :class:`~rucio.common.exception.StartupCheckError`.

Behaviour & selection algorithm
-------------------------------

1. Build the default **applicable** set: all checks whose tag set intersects ``tags`` **plus** all untagged checks.
2. If *any* ``enabled``/``enabled_<TAG>`` is present, restrict to the **union** of those names (still must be applicable).
3. Remove names in ``disabled``/``disabled_<TAG>``. If a name is both enabled and disabled, **disabled wins**.
4. Unknown names are **warned** and ignored (or **fail** in strict mode).
5. If enabled lists select nothing applicable, the runner **falls back** to the default applicable set and logs it
   (this fallback is a **failure** in strict mode).

Thread‑safety & duplication protection
--------------------------------------

- Registration is process‑wide and **thread‑safe**.
- Names are unique **case‑insensitively**. Attempting to register a duplicate name raises unless ``replace=True``.

Configuration quick reference
-----------------------------

```ini
[startup_checks]
# Optional soft time budget for ALL checks (milliseconds)
timeout_ms = 500

# Execute only the following checks (case‑insensitive names)
enabled = database, cache, storage

# Per‑tag enable/disable (suffix is case‑insensitive)
enabled_REST = database
disabled_DAEMON = storage

# Be strict about configuration correctness
strict = false
```