### PR TITLE
Clients: Ensure temp dir is created in flow of browser-based token retrieval. Fix #8210

### DIFF
--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -242,6 +242,22 @@ class BaseClient:
         except ValueError:
             self.logger.debug('request_retries must be an integer. Taking default.')
 
+    def __create_temp_directory(self) -> None:
+        """
+        Ensure the temporary directory is there.
+        """
+        # check if rucio temp directory is there. If not create it with permissions only for the current user
+        if not os.path.isdir(self.token_path):
+            try:
+                self.logger.debug('rucio token folder \'%s\' not found. Create it.' % self.token_path)
+                try:
+                    makedirs(self.token_path, 0o700)
+                except FileExistsError:
+                    msg = f'Token directory already exists at {self.token_path} - skipping'
+                    self.logger.debug(msg)
+            except Exception:
+                raise
+
     def _get_auth_tokens(self) -> tuple[Optional[str], str, str, str]:
         # if token file path is defined in the rucio.cfg file, use that file. Currently this prevents authenticating as another user or VO.
         auth_token_file_path = config_get('client', 'auth_token_file_path', False, None)
@@ -734,6 +750,7 @@ class BaseClient:
             self.logger.debug("Resetting the token expiration epoch file content.")
             # reset the token expiration epoch file content
             # at new CLI OIDC authentication
+            self.__create_temp_directory()
             self.token_exp_epoch = None
             file_d, file_n = mkstemp(dir=self.token_path)
             with fdopen(file_d, "w") as f_exp_epoch:
@@ -975,18 +992,7 @@ class BaseClient:
         """
         Write the current auth_token to the local token file.
         """
-        # check if rucio temp directory is there. If not create it with permissions only for the current user
-        if not os.path.isdir(self.token_path):
-            try:
-                self.logger.debug('rucio token folder \'%s\' not found. Create it.' % self.token_path)
-                try:
-                    makedirs(self.token_path, 0o700)
-                except FileExistsError:
-                    msg = f'Token directory already exists at {self.token_path} - skipping'
-                    self.logger.debug(msg)
-            except Exception:
-                raise
-
+        self.__create_temp_directory()
         try:
             file_d, file_n = mkstemp(dir=self.token_path)
             with fdopen(file_d, "w") as f_token:

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -253,3 +253,24 @@ class TestRucioClients:
 
         # rule
         assert list(client.list_replication_rules()) is not None
+
+    def test_run_client_oidc_directory_creation (self):
+        rucio_host = "https://rucio:443"
+        auth_host = "https://rucio:443"
+
+        from getpass import getuser
+        from shutil import rmtree
+        from rucio.client.client import Client
+
+        target_directory = f"{Client.TOKEN_PATH_PREFIX}{getuser()}"
+        rmtree (target_directory, ignore_errors=True)
+        client = Client(
+            rucio_host=rucio_host,
+            auth_host=auth_host,
+            auth_type="oidc")
+
+        # Ensure directory exists and permissions are set to 'rwx------'
+        try:
+            assert os.stat(target_directory).st_mode & 0o777 == 0o700
+        except FileNotFoundError:
+            pytest.fail(f"directory not created: {target_directory}")


### PR DESCRIPTION
This commit extracts the creation of a temporary directory which is used in a call to ‘mkstemp’.  It then ensures that this new procedure ‘__create_temp_directory()’ is called before the call to ‘mkstemp’.

* lib/rucio/client/baseclient.py: Implement and use ‘__create_temp_directory’.
