### PR TITLE
Core & Internals: Enhance dev/test logging; Fixes rucio#8208

### DIFF
--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -62,6 +62,9 @@ services:
       - RUCIO_SOURCE_DIR=/rucio_source
       - RDBMS
       - DEV_PROFILES
+      - RUCIO_LOG_STREAM=stderr
+      - RUCIO_LOGGING_REDIRECT_STDOUT_TO_STDERR=true
+      - PYTHONUNBUFFERED=true
     depends_on:
       oracle:
         condition: service_healthy

--- a/etc/docker/test/extra/rucio.conf
+++ b/etc/docker/test/extra/rucio.conf
@@ -1,9 +1,18 @@
 SSLSessionCache  shmcb:/var/log/httpd/ssl_scache(512000)
 
 Listen 443
+# In mod_wsgi *daemon* mode, direct writes to sys.stderr (and, with WSGIRestrictStdout Off,
+# also sys.stdout) can end up in the *main* server error log instead of the vhost ErrorLog.
+# For the docker test setup we want all REST-related output in one place, so we point the
+# main ErrorLog to /var/log/rucio/httpd_error_log and let the vhost inherit it.
+ErrorLog /var/log/rucio/httpd_error_log
 
 WSGIRestrictEmbedded On
 WSGIDaemonProcess rucio processes=4 threads=4
+# Allow the app to access and write to sys.stdout (e.g., via print statements or direct writes).
+# Keep in mind that any output sent to sys.stdout gets redirected to sys.stderr instead.
+# This setting is mainly for debugging (not for production systems).
+WSGIRestrictStdout Off
 WSGIApplicationGroup %{GLOBAL}
 WSGIProcessGroup rucio
 
@@ -21,8 +30,6 @@ WSGIProcessGroup rucio
  SSLOptions +StdEnvVars
 
  LogLevel debug authz_core:info ssl:info socache_shmcb:info
-
- ErrorLog /var/log/rucio/httpd_error_log
  TransferLog /var/log/rucio/httpd_access_log
 
  WSGIScriptAlias /  /opt/rucio/lib/rucio/web/rest/main.py

--- a/etc/docker/test/extra/rucio_autotests_common.cfg
+++ b/etc/docker/test/extra/rucio_autotests_common.cfg
@@ -1,7 +1,7 @@
 [common]
 logdir = /var/log/rucio
 loglevel = DEBUG
-logformat = %%(levelname)-8s [%%(name)s] %%(message)s
+logformat = %%(levelname)-10s [%%(name)s] %%(message)s
 mailtemplatedir=/opt/rucio/etc/mail_templates
 
 [client]

--- a/etc/docker/test/extra/rucio_autotests_common.cfg
+++ b/etc/docker/test/extra/rucio_autotests_common.cfg
@@ -1,6 +1,7 @@
 [common]
 logdir = /var/log/rucio
 loglevel = DEBUG
+logformat = %%(levelname)-8s [%%(name)s] %%(message)s
 mailtemplatedir=/opt/rucio/etc/mail_templates
 
 [client]

--- a/etc/docker/test/extra/rucio_default.cfg
+++ b/etc/docker/test/extra/rucio_default.cfg
@@ -1,6 +1,7 @@
 [common]
 logdir = /var/log/rucio
 loglevel = DEBUG
+logformat = %%(levelname)-8s [%%(name)s] %%(message)s
 mailtemplatedir=/opt/rucio/etc/mail_templates
 
 [oidc]

--- a/etc/docker/test/extra/rucio_default.cfg
+++ b/etc/docker/test/extra/rucio_default.cfg
@@ -1,7 +1,7 @@
 [common]
 logdir = /var/log/rucio
 loglevel = DEBUG
-logformat = %%(levelname)-8s [%%(name)s] %%(message)s
+logformat = %%(levelname)-10s [%%(name)s] %%(message)s
 mailtemplatedir=/opt/rucio/etc/mail_templates
 
 [oidc]

--- a/tests/rucio/common/test_setup_logging.py
+++ b/tests/rucio/common/test_setup_logging.py
@@ -1,0 +1,211 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import io
+import logging
+import sys
+import types
+
+import pytest
+
+from rucio.common import logging as rucio_logging
+
+
+@pytest.fixture(autouse=True)
+def _reset_root_handlers_and_streams():
+    """Ensure each test has a clean logging configuration and doesn't leak std stream changes."""
+    original_stdout, original_stderr = sys.stdout, sys.stderr
+    logging.root.handlers = []
+    yield
+    logging.root.handlers = []
+    sys.stdout = original_stdout
+    sys.stderr = original_stderr
+
+
+def _mock_config_get(value_map):
+    def _mock(section, option, raise_exception=False, default=None):
+        return value_map.get(option, default)
+
+    return _mock
+
+
+def _install_flask_default_handler(monkeypatch, default_handler):
+    """
+    Ensure `from flask.logging import default_handler` resolves to `default_handler`
+    without requiring Flask to be installed and without replacing the real `flask`
+    module when it is available.
+    """
+    try:
+        # If Flask is installed, just patch the attribute on the real module.
+        import flask.logging as flask_logging  # type: ignore
+    except Exception:
+        # Flask is not installed (or cannot be imported). Provide minimal stubs
+        # so the import inside setup_logging works.
+        flask_mod = types.ModuleType("flask")
+        # Mark as a package (best-effort) so submodule imports behave predictably.
+        flask_mod.__path__ = []  # type: ignore[attr-defined]
+        # Provide minimal attributes used by _get_request_data().
+        flask_mod.has_request_context = lambda: False  # type: ignore[attr-defined]
+        flask_mod.request = object()  # type: ignore[attr-defined]
+
+        flask_logging = types.ModuleType("flask.logging")
+        monkeypatch.setitem(sys.modules, "flask", flask_mod)
+        monkeypatch.setitem(sys.modules, "flask.logging", flask_logging)
+
+    monkeypatch.setattr(flask_logging, "default_handler", default_handler, raising=False)
+
+
+def test_setup_logging_prefers_env_stream(monkeypatch):
+    monkeypatch.setenv("RUCIO_LOG_STREAM", "stderr")
+    monkeypatch.setattr(rucio_logging, "config_get", _mock_config_get({"loglevel": "INFO", "logstream": "stdout"}))
+    monkeypatch.setattr(rucio_logging, "config_get_bool", _mock_config_get({"redirect_stdout_to_stderr": False}))
+
+    recorded = {}
+    monkeypatch.setattr(logging, "basicConfig", lambda **kwargs: recorded.update(kwargs))
+
+    rucio_logging.setup_logging()
+
+    handler = recorded["handlers"][0]
+    assert handler.stream is sys.stderr
+    assert handler.level == logging.INFO
+
+
+def test_setup_logging_redirect_env_overrides_config(monkeypatch):
+    # env explicitly disables redirect even if config enables it
+    fake_stdout = io.StringIO()
+    fake_stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", fake_stdout)
+    monkeypatch.setattr(sys, "stderr", fake_stderr)
+    monkeypatch.setenv("RUCIO_LOGGING_REDIRECT_STDOUT_TO_STDERR", "0")
+
+    monkeypatch.setattr(rucio_logging, "config_get", _mock_config_get({"loglevel": "INFO", "logstream": "stderr"}))
+    monkeypatch.setattr(rucio_logging, "config_get_bool", _mock_config_get({"redirect_stdout_to_stderr": True}))
+
+    recorded = {}
+    monkeypatch.setattr(logging, "basicConfig", lambda **kwargs: recorded.update(kwargs))
+
+    rucio_logging.setup_logging()
+
+    assert sys.stdout is fake_stdout
+
+
+def test_setup_logging_redirects_stdout(monkeypatch):
+    # Ensure global CI env doesn't influence this testcase
+    monkeypatch.delenv("RUCIO_LOG_STREAM", raising=False)
+
+    fake_stdout = io.StringIO()
+    fake_stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", fake_stdout)
+    monkeypatch.setattr(sys, "stderr", fake_stderr)
+    monkeypatch.setenv("RUCIO_LOGGING_REDIRECT_STDOUT_TO_STDERR", "1")
+    monkeypatch.setattr(
+        rucio_logging,
+        "config_get",
+        _mock_config_get({"loglevel": "WARNING", "logstream": "stdout"}),
+    )
+    monkeypatch.setattr(
+        rucio_logging,
+        "config_get_bool",
+        _mock_config_get({"redirect_stdout_to_stderr": False}),
+    )
+
+    recorded = {}
+    monkeypatch.setattr(logging, "basicConfig", lambda **kwargs: recorded.update(kwargs))
+
+    rucio_logging.setup_logging()
+
+    assert sys.stdout is fake_stderr
+    handler = recorded["handlers"][0]
+    assert handler.stream is fake_stdout
+    assert handler.level == logging.WARNING
+
+
+def test_setup_logging_configures_application_logger(monkeypatch):
+    # Provide a fake flask.logging.default_handler so the test doesn't depend on Flask.
+    default_handler = object()
+    _install_flask_default_handler(monkeypatch, default_handler)
+
+    class DummyLogger:
+        def __init__(self):
+            # Mimic Flask defaults: one default handler + propagate=False
+            self.handlers = [default_handler]
+            self.level = None
+            self.propagate = False
+
+        def addHandler(self, handler):  # noqa: N802
+            self.handlers.append(handler)
+
+        def removeHandler(self, handler):  # noqa: N802
+            self.handlers.remove(handler)
+
+        def setLevel(self, level):  # noqa: N802
+            self.level = level
+
+    class DummyApp:
+        def __init__(self):
+            self.logger = DummyLogger()
+
+    monkeypatch.setattr(rucio_logging, "config_get", _mock_config_get({"loglevel": "ERROR", "logstream": "stderr"}))
+    monkeypatch.setattr(rucio_logging, "config_get_bool", _mock_config_get({"redirect_stdout_to_stderr": False}))
+
+    recorded = {}
+    monkeypatch.setattr(logging, "basicConfig", lambda **kwargs: recorded.update(kwargs))
+
+    app = DummyApp()
+    rucio_logging.setup_logging(application=app, process_name="worker")
+
+    handler = recorded["handlers"][0]
+    assert app.logger.handlers == [handler]
+    assert app.logger.level == logging.ERROR
+    assert app.logger.propagate is False
+
+
+def test_setup_logging_does_not_clear_custom_app_handlers(monkeypatch):
+    # Provide a fake flask.logging.default_handler so the test doesn't depend on Flask.
+    default_handler = object()
+    custom_handler = object()
+    _install_flask_default_handler(monkeypatch, default_handler)
+
+    class DummyLogger:
+        def __init__(self):
+            self.handlers = [default_handler, custom_handler]
+            self.level = None
+            self.propagate = False
+
+        def addHandler(self, handler):  # noqa: N802
+            self.handlers.append(handler)
+
+        def removeHandler(self, handler):  # noqa: N802
+            self.handlers.remove(handler)
+
+        def setLevel(self, level):  # noqa: N802
+            self.level = level
+
+    class DummyApp:
+        def __init__(self):
+            self.logger = DummyLogger()
+
+    monkeypatch.setattr(rucio_logging, "config_get", _mock_config_get({"loglevel": "ERROR", "logstream": "stderr"}))
+    monkeypatch.setattr(rucio_logging, "config_get_bool", _mock_config_get({"redirect_stdout_to_stderr": False}))
+
+    recorded = {}
+    monkeypatch.setattr(logging, "basicConfig", lambda **kwargs: recorded.update(kwargs))
+
+    app = DummyApp()
+    rucio_logging.setup_logging(application=app, process_name="worker")
+
+    handler = recorded["handlers"][0]
+    assert default_handler not in app.logger.handlers
+    assert custom_handler in app.logger.handlers
+    assert handler not in app.logger.handlers
+    assert app.logger.level == logging.ERROR


### PR DESCRIPTION
Handles #8208

This PR mainly enhances dev/test observability while keeping production defaults untouched. Some points:

- The logging helper now lets you choose the destination via config or environment variables, and it only redirects `stdout` to `stderr` when one of the new toggles is explicitly enabled. Without those toggles the runtime behaviour is identical to the previous release, so merging this change keeps production defaults intact.
- The Docker dev stack opts into the new behaviour (forces logging to stderr and unbuffers Python output), but this is limited to the development compose profile and doesn’t affect deployed instances.
- Also, test configuration files got an explicit logformat setting because without it, logs look ugly with redundant timestamps (one from apache and one from python) and `/t`'s instead of spaces. The merge utility now reads INI sources with interpolation disabled (we don't use/need it even) so that the introduced percent tokens survive intact the parsing. These files live also under the test-only tree and won’t be consumed by production services.

The only potentially risky part is `WSGIRestrictStdout Off`, which is explicitly annotated as a debugging aid and lives inside the test Apache config. It should stay disabled in real deployments, but its presence here doesn’t (shouldn't) affect production assets.

_Note:_

The use of the `logformat` is to get from the top state to the bottom state:

<img width="3370" height="2186" alt="image" src="https://github.com/user-attachments/assets/4e72b791-d50e-42d0-a8ed-3051e119b8a0" />
