### PR TITLE
Database: Support JSON natively in Rucio; Fixes rucio #7648

### DIFF
--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -62,6 +62,9 @@ services:
       - RUCIO_SOURCE_DIR=/rucio_source
       - RDBMS
       - DEV_PROFILES
+      - RUCIO_LOG_STREAM=stderr
+      - RUCIO_LOGGING_REDIRECT_STDOUT_TO_STDERR=true
+      - PYTHONUNBUFFERED=true
     depends_on:
       oracle:
         condition: service_healthy

--- a/etc/docker/test/extra/rucio.conf
+++ b/etc/docker/test/extra/rucio.conf
@@ -1,9 +1,17 @@
 SSLSessionCache  shmcb:/var/log/httpd/ssl_scache(512000)
 
 Listen 443
+# In mod_wsgi *daemon* mode, the daemon workers write stderr to the *main* Apache
+# error log (not the vhost error log). By pointing the main ErrorLog to the same file
+# as the vhost below, we unify all REST outputs
+ErrorLog /var/log/rucio/httpd_error_log
 
 WSGIRestrictEmbedded On
 WSGIDaemonProcess rucio processes=4 threads=4
+# Allow the app to access and write to sys.stdout (e.g., via print statements or direct writes).
+# Keep in mind that any output sent to sys.stdout gets redirected to sys.stderr instead.
+# This setting is mainly for debugging (not for production systems).
+WSGIRestrictStdout Off
 WSGIApplicationGroup %{GLOBAL}
 WSGIProcessGroup rucio
 
@@ -21,7 +29,8 @@ WSGIProcessGroup rucio
  SSLOptions +StdEnvVars
 
  LogLevel debug authz_core:info ssl:info socache_shmcb:info
-
+ # Point the vhost error logging to the same file as the main ErrorLog (at the top).
+ # This way we keep all outputs at one place.
  ErrorLog /var/log/rucio/httpd_error_log
  TransferLog /var/log/rucio/httpd_access_log
 

--- a/etc/docker/test/extra/rucio_autotests_common.cfg
+++ b/etc/docker/test/extra/rucio_autotests_common.cfg
@@ -1,6 +1,7 @@
 [common]
 logdir = /var/log/rucio
 loglevel = DEBUG
+logformat = %%(levelname)-8s [%%(name)s] %%(message)s
 mailtemplatedir=/opt/rucio/etc/mail_templates
 
 [client]

--- a/etc/docker/test/extra/rucio_default.cfg
+++ b/etc/docker/test/extra/rucio_default.cfg
@@ -1,6 +1,7 @@
 [common]
 logdir = /var/log/rucio
 loglevel = DEBUG
+logformat = %%(levelname)-8s [%%(name)s] %%(message)s
 mailtemplatedir=/opt/rucio/etc/mail_templates
 
 [oidc]

--- a/lib/rucio/common/exception.py
+++ b/lib/rucio/common/exception.py
@@ -124,6 +124,15 @@ class ConfigurationError(RucioException):
         self.error_code = 8
 
 
+class StartupCheckError(RucioException):
+    """Raised when a startup diagnostic check fails."""
+
+    def __init__(self, *args):
+        super(StartupCheckError, self).__init__(*args)
+        self._message = "Startup diagnostic failed."
+        self.error_code = 124
+
+
 class CounterNotFound(RucioException):
     """
     RucioException

--- a/lib/rucio/common/startup_checks.py
+++ b/lib/rucio/common/startup_checks.py
@@ -433,7 +433,13 @@ def _collect_configured_names(
 
     values: set[str] = set()
     for config_option in options_to_query:
-        values.update(config_get_list('startup_checks', config_option, raise_exception=False, default=[]))
+        values.update(config_get_list(
+            'startup_checks',
+            config_option,
+            raise_exception=False,
+            default=[],
+            check_config_table=False,
+        ))
     return {value.strip() for value in values if value and value.strip()}
 
 
@@ -571,8 +577,20 @@ def run_startup_checks(
     checks_snapshot, all_registered_names = _select_checks(normalized_tags)
     checks = list(checks_snapshot)
 
-    strict_mode = config_get_bool('startup_checks', 'strict', raise_exception=False, default=False)
-    soft_timeout_ms = config_get_int('startup_checks', 'timeout_ms', raise_exception=False, default=0)
+    strict_mode = config_get_bool(
+        'startup_checks',
+        'strict',
+        raise_exception=False,
+        default=False,
+        check_config_table=False,
+    )
+    soft_timeout_ms = config_get_int(
+        'startup_checks',
+        'timeout_ms',
+        raise_exception=False,
+        default=0,
+        check_config_table=False,
+    )
     if soft_timeout_ms <= 0:
         soft_timeout_ms = None
 

--- a/lib/rucio/common/startup_checks.py
+++ b/lib/rucio/common/startup_checks.py
@@ -1,0 +1,731 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: UP007,UP045
+
+"""
+Startup diagnostics registry and runner
+======================================
+
+This module provides a small framework to **register** and **run** fast, synchronous
+“startup checks” at process start. Its use is to assert prerequisites (database reachable,
+configuration sanity, network access, etc.) *before* the process begins normal work. It
+supports **simple/central** configuration but allows also **advanced operator controls**.
+
+TL;DR summary
+----------------------------
+
+- A *startup check* is a **fast**, **side‑effect‑free**, **synchronous** function with **no arguments**.
+- Register checks with :func:`register_startup_check`.
+- Run them at startup with :func:`run_startup_checks(tags={...})` (or :func:`rucio.daemons.common.run_daemon_startup_checks` for daemons).
+- **Untagged checks run for every service** (“always”).
+- If **any** check fails, a :class:`~rucio.common.exception.StartupCheckError` is raised and your startup should abort.
+- **No configuration is required.** If there is no ``[startup_checks]`` in ``rucio.cfg``, all checks whose tags match the service **plus** all untagged checks run.
+
+From simple to advanced setups
+-------------------------------------------
+
+**1) Minimal – no config, run by tags (default behaviour)**
+
+- The various check definitions can be kept at one place/module or spread however prefered.
+- Register checks with an optional tag; leave ``tags=None`` for “always”.
+- In each service, call ``run_startup_checks(tags={'daemon'})`` or ``run_startup_checks(tags={'rest'})``.
+- Any failure raises :class:`~rucio.common.exception.StartupCheckError` and should stop startup.
+
+**2) Centralized catalog – keep *all* checks in one module (convention)**
+
+Put all checks in one file (e.g. ``rucio.common.startup_checks_catalog``) and import it at process start.
+
+.. code-block:: python
+
+    # rucio/common/startup_checks_catalog.py
+    from rucio.common.startup_checks import register_startup_check
+
+    def register_all() -> None:
+        # ALWAYS (untagged) – runs for every service
+        def _config_sanity() -> None:
+            pass  # raise on failure
+        register_startup_check(
+            name="config-sanity",
+            callback=_config_sanity,
+            description="Validate core configuration."
+        )
+
+        # Single-tag checks by convention
+        def _db_ready() -> None:
+            pass
+        register_startup_check(
+            name="database",
+            callback=_db_ready,
+            tags={"daemon"},
+            description="Database connectivity."
+        )
+
+        def _rest_key_material() -> None:
+            pass
+        register_startup_check(
+            name="rest-key-material",
+            callback=_rest_key_material,
+            tags={"rest"},
+            description="REST auth key/cert presence."
+        )
+
+Import the catalog before running checks:
+
+.. code-block:: python
+
+    # Daemon entrypoint
+    from rucio.common import startup_checks_catalog
+    startup_checks_catalog.register_all()
+    from rucio.daemons.common import run_daemon_startup_checks
+    run_daemon_startup_checks(executable="my-daemon")   # runs {'daemon'} + untagged
+
+    # Flask/REST app factory
+    from rucio.common import startup_checks_catalog
+    from rucio.common.startup_checks import run_startup_checks
+    def create_app():
+        startup_checks_catalog.register_all()
+        run_startup_checks(tags={"rest"})               # raises on failure -> abort startup
+        ...
+
+**3) Operator controls via config (optional)**
+
+If you add a ``[startup_checks]`` section in ``rucio.cfg``, operators can enable/disable checks
+without code changes, globally or per service. If you don’t add it, behaviour remains as in (1)/(2).
+
+- ``enabled`` / ``enabled_<TAG>`` – restrict execution to this union (after tag filtering).
+- ``disabled`` / ``disabled_<TAG>`` – remove these from the set (**disabled wins** if both listed).
+- ``strict = true`` – treat misconfiguration as fatal (unknown names; enabling only non‑applicable names; removing all applicable checks).
+- ``timeout_ms`` – **soft** time budget for the whole run (warning if exceeded; execution continues).
+
+Tags & selection
+----------------
+
+- Each check can have **zero or more** tags.
+- When you call :func:`run_startup_checks(tags=...)`, the runner executes:
+  * all checks whose tag set **intersects** the supplied tags, **and**
+  * all **untagged** checks (i.e. “always”).
+- If you prefer a literal ``"always"`` tag, you can use ``tags={"always"}`` and pass it at runtime,
+  but leaving checks untagged is simpler and equivalent.
+
+Public API
+----------
+
+``register_startup_check(name, callback, *, tags=None, description=None, replace=False)``
+    Register a diagnostic.
+
+* **name** – unique (case‑insensitive). Trimmed; empty names rejected.
+* **callback** – synchronous callable with no parameters; raise on failure. Returning an awaitable is invalid.
+* **tags** – optional iterable of strings (case‑insensitive, trimmed). If omitted, the check applies to all services.
+* **description** – text logged when the check runs.
+* **replace** – set ``True`` to replace an existing registration with the same name.
+
+``run_startup_checks(*, tags, logger=None)``
+    Execute all checks applicable to ``tags`` after applying optional configuration.
+    On failure, raises :class:`~rucio.common.exception.StartupCheckError`.
+
+Behaviour & selection algorithm
+-------------------------------
+
+1. Build the default **applicable** set: all checks whose tag set intersects ``tags`` **plus** all untagged checks.
+2. If *any* ``enabled``/``enabled_<TAG>`` is present, restrict to the **union** of those names (still must be applicable).
+3. Remove names in ``disabled``/``disabled_<TAG>``. If a name is both enabled and disabled, **disabled wins**.
+4. Unknown names are **warned** and ignored (or **fail** in strict mode).
+5. If enabled lists select nothing applicable, the runner **falls back** to the default applicable set and logs it
+   (this fallback is a **failure** in strict mode).
+
+Logging & failure semantics
+---------------------------
+
+- Before each check, its ``description`` (if provided) is logged so operators know what is being validated.
+- On success, a concise summary is emitted, e.g.:
+
+    Startup checks completed successfully: 3 ran, 1 disabled by config
+
+- Any exception from a callback is wrapped in :class:`~rucio.common.exception.StartupCheckError`.
+- A callback that is asynchronous or returns a coroutine is rejected with :class:`~rucio.common.exception.StartupCheckError`.
+
+Thread‑safety & duplication protection
+--------------------------------------
+
+- Registration is process‑wide and **thread‑safe**.
+- Names are unique **case‑insensitively**. Attempting to register a duplicate name raises unless ``replace=True``.
+
+Configuration quick reference
+-----------------------------
+
+.. code-block:: ini
+
+    [startup_checks]
+    # Optional soft time budget for ALL checks (milliseconds)
+    timeout_ms = 500
+
+    # Execute only the following checks (case‑insensitive names)
+    enabled = database, cache, storage
+
+    # Per‑tag enable/disable (suffix is case‑insensitive)
+    enabled_REST = database
+    disabled_DAEMON = storage
+
+    # Be strict about configuration correctness
+    strict = false
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Protocol
+
+from rucio.common.config import config_get_bool, config_get_int, config_get_list
+from rucio.common.exception import StartupCheckError
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable, Mapping
+
+
+class StartupCheckCallback(Protocol):
+    def __call__(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class StartupCheck:
+    """
+    Definition of a startup diagnostic.
+
+    Attributes
+    ----------
+    name:
+        Unique identifier of the diagnostic.
+    callback:
+        Callable invoked to run the diagnostic.
+    tags:
+        Normalised set of tags describing the environments where the
+        diagnostic should execute.
+    description:
+        Optional human readable text describing the diagnostic. Logged when
+        the check runs so that operators know what is happening.
+    """
+
+    name: str
+    callback: StartupCheckCallback
+    tags: frozenset[str]
+    description: Optional[str] = None
+
+
+_registry: dict[str, StartupCheck] = {}
+_registry_lock = threading.Lock()
+
+
+def _normalize_name(name: str) -> str:
+    """
+    Canonicalise a diagnostic name.
+
+    A lot of the public API accepts free-form strings. Before storing the
+    value we trim surrounding whitespace to avoid treating ``" db "`` as a
+    distinct check. The same helper is used for validation when registering
+    new checks and when processing configuration overrides, which keeps the
+    matching logic consistent.
+
+    Parameters
+    ----------
+    name:
+        Raw name supplied by the caller.
+
+    Returns
+    -------
+    str
+        The trimmed diagnostic name.
+
+    Raises
+    ------
+    ValueError
+        If the normalised name would be empty.
+    """
+
+    normalized = name.strip()
+    if not normalized:
+        raise ValueError("Startup check name cannot be empty")
+    return normalized
+
+
+def _normalize_tags(tags: Optional[Iterable[str]]) -> frozenset[str]:
+    """
+    Normalise a collection of tags.
+
+    Tags are used to scope checks to specific services (for example ``daemon``
+    or ``rest``). We trim whitespace and fold everything to lowercase. The return
+    type is a :class:`frozenset` so the result can be safely cached and shared
+    between helpers without the risk of accidental mutation.
+
+    Parameters
+    ----------
+    tags:
+        Iterable containing the raw tag identifiers. ``None`` or empty values
+        result in an empty set.
+
+    Returns
+    -------
+    frozenset of str
+        The cleaned, lower-cased tags with surrounding whitespace removed.
+    """
+
+    if not tags:
+        return frozenset()
+    return frozenset(tag.strip().lower() for tag in tags if tag and tag.strip())
+
+
+def register_startup_check(
+        name: str,
+        callback: StartupCheckCallback,
+        *,
+        tags: Optional[Iterable[str]] = None,
+        description: Optional[str] = None,
+        replace: bool = False
+) -> None:
+    """
+    Register a startup diagnostic check.
+
+    Registers a synchronous, no‑argument callable in the process‑wide registry so it can
+    be executed at process start by :func:`run_startup_checks`. Names are unique in a
+    case‑insensitive manner; tags select which services should run the check.
+
+    **Callback contract**
+
+    - Must be synchronous and accept no parameters.
+    - It should raise on failure; any exception will be reported as a
+      :class:`~rucio.common.exception.StartupCheckError` during execution.
+    - Returning a coroutine/awaitable is considered invalid and will cause
+      :class:`~rucio.common.exception.StartupCheckError` when the check is run.
+
+    Parameters
+    ----------
+    name : str
+        Unique identifier (case‑insensitive). Leading/trailing whitespace is trimmed.
+    callback : Callable[[], None]
+        Synchronous callable with no parameters. Raise on failure.
+    tags : Iterable[str] | None, optional
+        Which services should run this check (e.g. ``{"daemon"}``, ``{"rest"}``). If
+        omitted, the check applies to **all** services. Tags are normalized (trimmed,
+        case‑insensitive).
+    description : str | None, optional
+        Human‑readable text logged before the check executes.
+    replace : bool, optional
+        If ``True``, replaces any existing registration with the same name (case‑insensitive).
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError
+        If ``name`` is empty after trimming, or if a check with the same name already
+        exists and ``replace`` is ``False``.
+
+    Thread‑safety
+    -------------
+    Registration is thread‑safe and global to the process.
+
+    Examples
+    --------
+    >>> def _check_db() -> None:
+    ...     with get_engine().connect() as c:
+    ...         c.execute("SELECT 1")
+    >>> register_startup_check(
+    ...     "database",
+    ...     _check_db,
+    ...     tags={"daemon"},
+    ...     description="Validate DB connection",
+    ... )
+    """
+
+    if not callable(callback):
+        raise TypeError("Startup check callback must be callable")
+    if inspect.iscoroutinefunction(callback) or inspect.iscoroutinefunction(getattr(callback, '__call__', None)):
+        raise TypeError('Startup check callback cannot be asynchronous')
+
+    normalized_name = _normalize_name(name)
+    normalized_tags = _normalize_tags(tags)
+    normalized_name_lower = normalized_name.lower()
+
+    with _registry_lock:
+        lower_to_name = {existing_name.lower(): existing_name for existing_name in _registry}
+
+        if not replace:
+            if normalized_name in _registry:
+                raise ValueError(f'Startup check "{normalized_name}" is already registered')
+            existing_case_insensitive = lower_to_name.get(normalized_name_lower)
+            if existing_case_insensitive is not None:
+                raise ValueError(
+                    'Startup check '
+                    f'"{existing_case_insensitive}" is already registered (matches new name "{normalized_name}")'
+                )
+            target_name = normalized_name
+        else:
+            existing_case_insensitive = lower_to_name.get(normalized_name_lower)
+            target_name = existing_case_insensitive or normalized_name
+
+        _registry[target_name] = StartupCheck(
+            name=target_name,
+            callback=callback,
+            tags=normalized_tags,
+            description=description,
+        )
+
+
+def _collect_configured_names(
+        option: str,
+        tags: frozenset[str],
+        tag_suffixes: Mapping[str, Collection[str]]
+) -> set[str]:
+    """
+    Collect the check names configured for a given option.
+
+    Configuration may list checks under generic ``enabled`` / ``disabled``
+    keys as well as under tag specific variants such as ``enabled_daemon``.
+    This helper gathers all the possible spellings for the requested tags and
+    collates the configured check names into a single cleaned set. The caller
+    is still responsible for reconciling these names with the registry.
+
+    Parameters
+    ----------
+    option:
+        Name of the configuration option (``"enabled"`` or ``"disabled"``).
+    tags:
+        Set of tags describing the current service.
+
+    Returns
+    -------
+    set of str
+        Cleaned set of check names extracted from the configuration.
+    """
+
+    options_to_query = {
+        option,
+        option.lower(),
+        option.upper(),
+    }
+
+    for tag in tags:
+        suffixes = tag_suffixes.get(tag)
+        if not suffixes:
+            suffixes = {tag}
+        for suffix in suffixes:
+            tag_option = f'{option}_{suffix}'
+            options_to_query.add(tag_option)
+            options_to_query.add(tag_option.lower())
+            options_to_query.add(tag_option.upper())
+
+    values: set[str] = set()
+    for config_option in options_to_query:
+        values.update(config_get_list('startup_checks', config_option, raise_exception=False, default=[]))
+    return {value.strip() for value in values if value and value.strip()}
+
+
+def _select_checks(tags: frozenset[str]) -> tuple[list[StartupCheck], set[str]]:
+    """
+    Return the set of checks applicable to the supplied tags.
+
+    The registry is protected by a lock during iteration so that late
+    registrations do not race with an ongoing startup check run. The function
+    returns a snapshot rather than a live view because the caller will filter
+    the list based on configuration overrides.
+
+    Parameters
+    ----------
+    tags:
+        Set of normalised tags describing the current service.
+
+    Returns
+    -------
+    tuple
+        Two elements where the first item is the list of registered checks
+        whose tag set intersects *tags* (or which are unscoped) and the
+        second item is the set of all registered check names.
+    """
+
+    with _registry_lock:
+        checks = list(_registry.values())
+        all_names = set(_registry)
+
+    if not tags:
+        return checks, all_names
+
+    return [
+        check for check in checks
+        if not check.tags or check.tags.intersection(tags)
+    ], all_names
+
+
+def _prepare_tags(tags: Optional[Iterable[str]]) -> tuple[frozenset[str], dict[str, frozenset[str]]]:
+    """
+    Normalise tags and compute the variants used for configuration lookups.
+
+    Besides producing the cleaned :class:`frozenset` of tags, this helper also
+    pre-computes a map of case variants for each tag. Configuration files may
+    spell options with different casing (``ENABLED_DAEMON`` vs ``enabled_daemon``),
+    so keeping all the candidate variants upfront avoids repeating that work in
+    the hot path.
+    """
+
+    if not tags:
+        return frozenset(), {}
+
+    normalized: set[str] = set()
+    suffixes: dict[str, set[str]] = {}
+
+    for raw_tag in tags:
+        if not raw_tag:
+            continue
+        trimmed = raw_tag.strip()
+        if not trimmed:
+            continue
+        normalized_tag = trimmed.lower()
+        normalized.add(normalized_tag)
+        variants = suffixes.setdefault(normalized_tag, set())
+        variants.add(normalized_tag)
+        variants.add(trimmed)
+        variants.add(trimmed.lower())
+        variants.add(trimmed.upper())
+
+    return frozenset(normalized), {tag: frozenset(variants) for tag, variants in suffixes.items()}
+
+
+def run_startup_checks(
+        *,
+        tags: Optional[Iterable[str]] = None,
+        logger: Optional[logging.Logger] = None
+) -> None:
+    """
+    Run startup diagnostics applicable to the given service tags.
+
+    Collects all registered checks that apply to ``tags`` (plus untagged ones),
+    optionally filters them according to the ``[startup_checks]`` section in
+    ``rucio.cfg``, and executes them. On any failure, raises
+    :class:`~rucio.common.exception.StartupCheckError`.
+
+    Parameters
+    ----------
+    tags : Collection[str]
+        Tags describing the current service(s). Common values are ``{"daemon"}`` and ``{"rest"}``.
+    logger : logging.Logger | Callable[..., None] | None, optional
+        Component‑specific logger. If omitted, uses the module logger ``rucio.startup_checks``.
+
+    Behavior
+    --------
+    - **Default selection**: all checks whose tag set intersects the supplied ``tags``,
+      plus untagged checks.
+    - **Config filters (optional)** from ``[startup_checks]`` in ``rucio.cfg``:
+        * ``enabled`` / ``enabled_<TAG>`` restrict the set (union) after tag filtering.
+        * ``disabled`` / ``disabled_<TAG>`` remove names. **Disabled wins** when both apply.
+        * Name and tag comparisons are case‑insensitive; duplicates are deduplicated.
+        * Unknown names are ignored with a warning (or fail in strict mode).
+        * If enabled lists select nothing applicable, the runner falls back to the default set
+          and logs that fallback (unless strict mode is on).
+    - **Soft time budget**: ``startup_checks.timeout_ms`` sets a soft limit for the whole run.
+      Exceeding the cumulative runtime logs a warning once and execution continues.
+    - **Strict mode**: ``startup_checks.strict = true`` turns these into hard errors:
+        * unknown names in any ``enabled*``/``disabled*``,
+        * enabled lists containing only non‑applicable names,
+        * configuration that removes all applicable checks.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    StartupCheckError
+        If any check fails, or if configuration is invalid under strict mode.
+
+    Logging
+    -------
+    - Logs each check's ``description`` (if provided) before execution.
+    - Logs a completion summary like:
+      ``Startup checks completed successfully: N ran, M disabled by config``.
+
+    Examples
+    --------
+    >>> run_startup_checks(tags={"daemon"})
+    """
+
+    normalized_tags, tag_suffixes = _prepare_tags(tags)
+    tags_display = ', '.join(sorted(normalized_tags)) or 'default'
+    log = logger or logging.getLogger('rucio.startup_checks')
+
+    checks_snapshot, all_registered_names = _select_checks(normalized_tags)
+    checks = list(checks_snapshot)
+
+    strict_mode = config_get_bool('startup_checks', 'strict', raise_exception=False, default=False)
+    soft_timeout_ms = config_get_int('startup_checks', 'timeout_ms', raise_exception=False, default=0)
+    if soft_timeout_ms <= 0:
+        soft_timeout_ms = None
+
+    enabled = _collect_configured_names('enabled', normalized_tags, tag_suffixes)
+    disabled = _collect_configured_names('disabled', normalized_tags, tag_suffixes)
+
+    registered_names = {check.name for check in checks}
+    lower_all_registered_names = {name.lower(): name for name in all_registered_names}
+    all_registered_lower_names = set(lower_all_registered_names.keys())
+
+    disabled_applied_lower: set[str] = set()
+
+    if enabled:
+        configured_enabled_map = {name.lower(): name for name in enabled}
+        enabled_lower = set(configured_enabled_map)
+        unknown = enabled_lower - all_registered_lower_names
+        if unknown:
+            unknown_enabled_display = sorted(configured_enabled_map[name] for name in unknown)
+            log.warning(
+                'Unknown startup check(s) in `startup_checks.enabled`: %s - ignored',
+                ', '.join(unknown_enabled_display),
+            )
+            if strict_mode:
+                raise StartupCheckError(
+                    'Strict startup checks mode rejected unknown check(s) configured in '
+                    '`startup_checks.enabled`: '
+                    f"{', '.join(unknown_enabled_display)}"
+                )
+        registered_names_lower = {name.lower() for name in registered_names}
+        missing = (enabled_lower - registered_names_lower) - unknown
+        if missing:
+            missing_display = [
+                configured_enabled_map.get(name)
+                or lower_all_registered_names.get(name, name)
+                for name in sorted(missing)
+            ]
+            log.info(
+                'Startup check(s) in `startup_checks.enabled` are not applicable to tags %s - ignored: %s',
+                tags_display,
+                ', '.join(missing_display),
+            )
+            if strict_mode:
+                raise StartupCheckError(
+                    'Strict startup checks mode rejected check(s) that are not applicable to '
+                    f'tags {tags_display}: {", ".join(missing_display)}'
+                )
+        enabled_effective = enabled_lower & registered_names_lower
+        checks = [check for check in checks if check.name.lower() in enabled_effective]
+        if not checks:
+            log.warning(
+                'All configured `startup_checks.enabled` names were unknown or not applicable; '
+                'falling back to default checks for tags %s',
+                tags_display,
+            )
+            checks = list(checks_snapshot)
+
+    if disabled:
+        configured_disabled_map = {name.lower(): name for name in disabled}
+        disabled_lower = set(configured_disabled_map)
+        checks_before_disabled = {check.name.lower() for check in checks}
+        checks = [check for check in checks if check.name.lower() not in disabled_lower]
+        disabled_applied_lower = checks_before_disabled - {check.name.lower() for check in checks}
+        unknown_disabled = disabled_lower - all_registered_lower_names
+        if unknown_disabled:
+            unknown_disabled_display = sorted(configured_disabled_map[name] for name in unknown_disabled)
+            log.warning(
+                'Unknown startup check(s) in `startup_checks.disabled`: %s - ignored',
+                ', '.join(unknown_disabled_display),
+            )
+
+    if disabled_applied_lower and log.isEnabledFor(logging.DEBUG):
+        disabled_applied_display = [
+            lower_all_registered_names.get(name, name)
+            for name in sorted(disabled_applied_lower)
+        ]
+        log.debug('Startup checks disabled by config: %s', ', '.join(disabled_applied_display))
+
+    if not checks:
+        if strict_mode and (enabled or disabled):
+            raise StartupCheckError(
+                'No startup checks remain after applying enabled/disabled filters for tags '
+                f'{tags_display} in strict mode'
+            )
+        level = logging.INFO if (enabled or disabled) else logging.DEBUG
+        log.log(level, 'No startup checks to run for tags %s', tags_display)
+        return
+
+    log.info('Running startup checks%s', f' [{tags_display}]' if normalized_tags else '')
+
+    checks = sorted(checks, key=lambda check: check.name.casefold())
+
+    durations: list[tuple[str, float]] = []
+
+    run_start_time = time.perf_counter()
+    soft_timeout_logged = False
+
+    for check in checks:
+        description = f' ({check.description})' if check.description else ''
+        log.debug('Running startup check %s%s', check.name, description)
+        start_time = time.perf_counter()
+        try:
+            result = check.callback()
+            if inspect.isawaitable(result):
+                if inspect.iscoroutine(result):
+                    result.close()
+                raise StartupCheckError(
+                    f'Startup check "{check.name}" returned an awaitable; asynchronous callbacks are not supported'
+                )
+        except StartupCheckError:
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            log.critical('Startup check %s failed after %.1f ms', check.name, duration_ms, exc_info=True)
+            raise
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            log.critical(
+                'Startup check %s raised an unexpected exception after %.1f ms',
+                check.name,
+                duration_ms,
+                exc_info=True,
+            )
+            raise StartupCheckError(
+                f'Startup check "{check.name}" failed with unexpected error: {error}'
+            ) from error
+        end_time = time.perf_counter()
+        duration_ms = (end_time - start_time) * 1000
+        log.debug('Startup check "%s" passed in %.1f ms', check.name, duration_ms)
+        total_runtime_ms = (end_time - run_start_time) * 1000
+        if soft_timeout_ms is not None and not soft_timeout_logged and total_runtime_ms > soft_timeout_ms:
+            log.warning(
+                'Startup checks exceeded soft timeout after "%s" (%.0f > %d ms)',
+                check.name,
+                total_runtime_ms,
+                soft_timeout_ms,
+            )
+            soft_timeout_logged = True
+        durations.append((check.name, duration_ms))
+
+    disabled_count = len(disabled_applied_lower)
+    if durations:
+        slowest_name, slowest_duration = max(durations, key=lambda item: item[1])
+        log.info(
+            'Startup checks completed successfully: %d ran, %d disabled by config, '
+            'slowest=%s (%.1f ms)',
+            len(durations),
+            disabled_count,
+            slowest_name,
+            slowest_duration,
+        )
+    else:
+        log.info(
+            'Startup checks completed successfully: no checks ran, %d disabled by config',
+            disabled_count,
+        )
+
+
+__all__ = ['register_startup_check', 'run_startup_checks', 'StartupCheck', 'StartupCheckCallback']

--- a/lib/rucio/common/startup_checks_catalog.py
+++ b/lib/rucio/common/startup_checks_catalog.py
@@ -1,0 +1,82 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Runtime startup checks shared by daemons and the REST application."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from rucio.common.startup_checks import register_startup_check
+from rucio.db.sqla.session import get_session
+from rucio.db.sqla.util import oracle_legacy_json_columns
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+logger = logging.getLogger(__name__)
+
+LegacyColumn = tuple[str, str]
+
+__all__ = ['legacy_oracle_json_columns', 'ensure_oracle_json_columns_are_native', 'register_all']
+
+
+def legacy_oracle_json_columns() -> Sequence[LegacyColumn] | None:
+    """Return legacy Oracle JSON columns or ``None`` when not using Oracle."""
+
+    session_scoped = get_session()
+
+    with session_scoped() as session:
+        if session.bind.dialect.name != 'oracle':  # type: ignore[attr-defined]
+            return None
+
+        legacy = oracle_legacy_json_columns(session)
+
+    # Normalise the return type to a tuple to keep a consistent, hashable type.
+    return tuple(legacy)
+
+
+def ensure_oracle_json_columns_are_native() -> None:
+    """Ensure Oracle JSON columns were migrated to native types in 21c+."""
+
+    legacy = legacy_oracle_json_columns()
+
+    if legacy is None:
+        logger.debug('Skipping Oracle JSON column check; database dialect is not Oracle.')
+        return
+
+    if not legacy:
+        logger.info('Oracle JSON column check passed: all JSON columns use native types.')
+        return
+
+    formatted = ', '.join(f"{table}.{column}" for table, column in legacy)
+    message = (
+        'Oracle 21c+ requires native JSON columns. '
+        f'The following columns remain legacy CLOBs: {formatted}'
+    )
+
+    logger.error(message)
+    raise RuntimeError(message)
+
+
+def register_all() -> None:
+    """Register all built-in startup checks."""
+
+    register_startup_check(
+        name='oracle-json-columns',
+        callback=ensure_oracle_json_columns_are_native,
+        description='Ensure Oracle JSON columns are migrated to native types on 21c+',
+        replace=True,
+    )

--- a/lib/rucio/daemons/bb8/bb8.py
+++ b/lib/rucio/daemons/bb8/bb8.py
@@ -26,11 +26,11 @@ from rucio.common.config import config_get_float
 from rucio.common.constants import DEFAULT_VO
 from rucio.common.exception import InvalidRSEExpression
 from rucio.common.logging import setup_logging
-from rucio.core.heartbeat import list_payload_counts, sanity_check
+from rucio.core.heartbeat import list_payload_counts
 from rucio.core.rse import get_rse_usage
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.daemons.bb8.common import get_active_locks, rebalance_rse
-from rucio.daemons.common import HeartbeatHandler, run_daemon
+from rucio.daemons.common import HeartbeatHandler, run_daemon, run_daemon_startup_checks
 
 if TYPE_CHECKING:
     from types import FrameType
@@ -334,7 +334,7 @@ def run(
 
     setup_logging(process_name=DAEMON_NAME)
     hostname = socket.gethostname()
-    sanity_check(executable=DAEMON_NAME, hostname=hostname)
+    run_daemon_startup_checks(executable=DAEMON_NAME, hostname=hostname)
     logging.info("BB8 starting %s threads", str(threads))
     thread_list = [
         threading.Thread(

--- a/lib/rucio/daemons/cache/consumer.py
+++ b/lib/rucio/daemons/cache/consumer.py
@@ -32,6 +32,7 @@ from rucio.common.types import InternalScope, LoggerFunction
 from rucio.core.monitor import MetricManager
 from rucio.core.rse import get_rse_id
 from rucio.core.volatile_replica import add_volatile_replicas, delete_volatile_replicas
+from rucio.daemons.common import run_daemon_startup_checks
 from rucio.db.sqla.constants import DatabaseOperationType
 from rucio.db.sqla.session import db_session
 
@@ -183,6 +184,8 @@ def run(num_thread: int = 1) -> None:
     Starts up the rucio cache consumer thread
     """
     setup_logging(process_name=DAEMON_NAME)
+
+    run_daemon_startup_checks(executable=DAEMON_NAME)
 
     if rucio.db.sqla.util.is_old_db():
         raise exception.DatabaseException('Database was not updated, daemon won\'t start')

--- a/lib/rucio/daemons/common.py
+++ b/lib/rucio/daemons/common.py
@@ -22,6 +22,7 @@ import threading
 import time
 from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union
 
+from rucio.common import startup_checks_catalog
 from rucio.common.logging import formatted_logger
 from rucio.common.startup_checks import run_startup_checks
 from rucio.common.utils import PriorityQueue
@@ -78,6 +79,7 @@ def run_daemon_startup_checks(executable: str, hostname: Optional[str] = None) -
 
     with _daemon_startup_checks_lock:
         if not _daemon_startup_checks_ran:
+            startup_checks_catalog.register_all()
             run_startup_checks(tags={'daemon'}, logger=logger)
             _daemon_startup_checks_ran = True
 

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -25,6 +25,7 @@ from rucio.common import exception
 from rucio.common.config import config_get_bool
 from rucio.common.logging import setup_logging
 from rucio.core.monitor import MetricManager
+from rucio.daemons.common import run_daemon_startup_checks
 from rucio.daemons.conveyor.common import get_conveyor_rses
 from rucio.daemons.conveyor.submitter import submitter
 from rucio.db.sqla.constants import RequestType
@@ -103,6 +104,8 @@ def run(
     """
     activities = activities or []
     setup_logging(process_name=DAEMON_NAME)
+
+    run_daemon_startup_checks(executable=DAEMON_NAME)
 
     if rucio.db.sqla.util.is_old_db():
         raise exception.DatabaseException('Database was not updated, daemon won\'t start')

--- a/lib/rucio/daemons/follower/follower.py
+++ b/lib/rucio/daemons/follower/follower.py
@@ -24,7 +24,8 @@ from rucio.common import exception
 from rucio.common.logging import setup_logging
 from rucio.common.utils import get_thread_with_periodic_running_function
 from rucio.core.did import create_reports
-from rucio.core.heartbeat import die, live, sanity_check
+from rucio.core.heartbeat import die, live
+from rucio.daemons.common import run_daemon_startup_checks
 
 if TYPE_CHECKING:
     from types import FrameType
@@ -84,7 +85,7 @@ def run(
         raise exception.DatabaseException('Database was not updated, daemon won\'t start')
 
     hostname = socket.gethostname()
-    sanity_check(executable=DAEMON_NAME, hostname=hostname)
+    run_daemon_startup_checks(executable=DAEMON_NAME, hostname=hostname)
 
     if once:
         logging.info("executing one follower iteration only")

--- a/lib/rucio/daemons/rsedecommissioner/rse_decommissioner.py
+++ b/lib/rucio/daemons/rsedecommissioner/rse_decommissioner.py
@@ -29,9 +29,8 @@ from rucio.common.config import config_get_int
 from rucio.common.constants import RseAttr
 from rucio.common.exception import RucioException
 from rucio.common.logging import setup_logging
-from rucio.core.heartbeat import sanity_check
 from rucio.core.rse import get_rse_attribute, get_rses_with_attribute
-from rucio.daemons.common import run_daemon
+from rucio.daemons.common import run_daemon, run_daemon_startup_checks
 from rucio.db.sqla.constants import RuleState
 
 from .config import DecommissioningStatus, InvalidStatusName, attr_to_config, set_status
@@ -144,7 +143,7 @@ def run(
     """
     setup_logging(process_name=DAEMON_NAME)
     hostname = socket.gethostname()
-    sanity_check(executable='rucio-rsedecommissioner', hostname=hostname)
+    run_daemon_startup_checks(executable='rucio-rsedecommissioner', hostname=hostname)
 
     logging.info('RSE-Decommissioner starting 1 thread')
 

--- a/lib/rucio/daemons/storage/consistency/actions.py
+++ b/lib/rucio/daemons/storage/consistency/actions.py
@@ -37,11 +37,12 @@ from rucio.common import exception
 from rucio.common.logging import formatted_logger, setup_logging
 from rucio.common.types import InternalAccount, InternalScope, LFNDict
 from rucio.common.utils import daemon_sleep
-from rucio.core.heartbeat import die, live, sanity_check
+from rucio.core.heartbeat import die, live
 from rucio.core.monitor import MetricManager
 from rucio.core.quarantined_replica import add_quarantined_replicas
 from rucio.core.replica import __exist_replicas, update_replicas_states
 from rucio.core.rse import get_rse_id, list_rses
+from rucio.daemons.common import run_daemon_startup_checks
 
 # FIXME: these are needed by local version of declare_bad_file_replicas()
 # TODO: remove after move of this code to core/replica.py - see https://github.com/rucio/rucio/pull/5068
@@ -823,7 +824,7 @@ def run(
            miss_threshold_percent, force_proceed, scanner_files_path))
 
     hostname = socket.gethostname()
-    sanity_check(executable=DAEMON_NAME, hostname=hostname)
+    run_daemon_startup_checks(executable=DAEMON_NAME, hostname=hostname)
 
 # It was decided that for the time being this daemon is best executed in a single thread
 # TODO: If this decicion is reversed in the future, the following line should be removed.

--- a/lib/rucio/web/rest/flaskapi/v1/main.py
+++ b/lib/rucio/web/rest/flaskapi/v1/main.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from flask import Flask
 
+from rucio.common import startup_checks_catalog
 from rucio.common.config import config_get_list
 from rucio.common.exception import ConfigurationError
 from rucio.common.logging import setup_logging
@@ -90,6 +91,7 @@ application = Flask(__name__)
 application.wsgi_app = CORSMiddleware(application.wsgi_app)
 apply_endpoints(application, endpoints)
 setup_logging(application)
+startup_checks_catalog.register_all()
 run_startup_checks(tags={'rest'}, logger=application.logger)
 
 

--- a/lib/rucio/web/rest/flaskapi/v1/main.py
+++ b/lib/rucio/web/rest/flaskapi/v1/main.py
@@ -21,6 +21,7 @@ from flask import Flask
 from rucio.common.config import config_get_list
 from rucio.common.exception import ConfigurationError
 from rucio.common.logging import setup_logging
+from rucio.common.startup_checks import run_startup_checks
 from rucio.web.rest.flaskapi.v1.common import CORSMiddleware
 
 if TYPE_CHECKING:
@@ -89,6 +90,7 @@ application = Flask(__name__)
 application.wsgi_app = CORSMiddleware(application.wsgi_app)
 apply_endpoints(application, endpoints)
 setup_logging(application)
+run_startup_checks(tags={'rest'}, logger=application.logger)
 
 
 if __name__ == '__main__':

--- a/tests/rucio/common/test_setup_logging.py
+++ b/tests/rucio/common/test_setup_logging.py
@@ -1,0 +1,120 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import io
+import logging
+import sys
+
+import pytest
+
+from rucio.common import logging as rucio_logging
+
+
+@pytest.fixture(autouse=True)
+def _reset_root_handlers():
+    """Ensure each test has a clean logging root configuration."""
+    logging.root.handlers = []
+    yield
+    logging.root.handlers = []
+
+
+def _mock_config_get(value_map):
+    def _mock(section, option, raise_exception=False, default=None):
+        return value_map.get(option, default)
+
+    return _mock
+
+
+def _mock_config_get_bool(value_map):
+    def _mock(section, option, raise_exception=False, default=None):
+        return value_map.get(option, default)
+
+    return _mock
+
+
+def test_setup_logging_prefers_env_stream(monkeypatch):
+    monkeypatch.setenv("RUCIO_LOG_STREAM", "stderr")
+    monkeypatch.setattr(rucio_logging, "config_get", _mock_config_get({"loglevel": "INFO", "logstream": "stdout"}))
+    monkeypatch.setattr(rucio_logging, "config_get_bool", _mock_config_get_bool({"redirect_stdout_to_stderr": False}))
+
+    recorded = {}
+    monkeypatch.setattr(logging, "basicConfig", lambda **kwargs: recorded.update(kwargs))
+
+    rucio_logging.setup_logging()
+
+    handler = recorded["handlers"][0]
+    assert handler.stream is sys.stderr
+    assert handler.level == logging.INFO
+
+
+def test_setup_logging_redirects_stdout(monkeypatch):
+    # Ensure global CI env doesn't influence this testcase
+    monkeypatch.delenv("RUCIO_LOG_STREAM", raising=False)
+
+    fake_stdout = io.StringIO()
+    fake_stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", fake_stdout)
+    monkeypatch.setattr(sys, "stderr", fake_stderr)
+    monkeypatch.setenv("RUCIO_LOGGING_REDIRECT_STDOUT_TO_STDERR", "1")
+    monkeypatch.setattr(
+        rucio_logging,
+        "config_get",
+        _mock_config_get({"loglevel": "WARNING", "logstream": "stdout"}),
+    )
+    monkeypatch.setattr(
+        rucio_logging,
+        "config_get_bool",
+        _mock_config_get_bool({"redirect_stdout_to_stderr": False}),
+    )
+
+    recorded = {}
+    monkeypatch.setattr(logging, "basicConfig", lambda **kwargs: recorded.update(kwargs))
+
+    rucio_logging.setup_logging()
+
+    assert sys.stdout is fake_stderr
+    handler = recorded["handlers"][0]
+    assert handler.stream is fake_stdout
+    assert handler.level == logging.WARNING
+
+
+def test_setup_logging_configures_application_logger(monkeypatch):
+    class DummyLogger:
+        def __init__(self):
+            self.handlers = ["original"]
+            self.level = None
+            self.propagate = True
+
+        def addHandler(self, handler):  # noqa: N802
+            self.handlers.append(handler)
+
+        def setLevel(self, level):  # noqa: N802
+            self.level = level
+
+    class DummyApp:
+        def __init__(self):
+            self.logger = DummyLogger()
+
+    monkeypatch.setattr(rucio_logging, "config_get", _mock_config_get({"loglevel": "ERROR", "logstream": "stderr"}))
+    monkeypatch.setattr(rucio_logging, "config_get_bool", _mock_config_get_bool({"redirect_stdout_to_stderr": False}))
+
+    recorded = {}
+    monkeypatch.setattr(logging, "basicConfig", lambda **kwargs: recorded.update(kwargs))
+
+    app = DummyApp()
+    rucio_logging.setup_logging(application=app, process_name="worker")
+
+    handler = recorded["handlers"][0]
+    assert app.logger.handlers == [handler]
+    assert app.logger.level == logging.ERROR
+    assert app.logger.propagate is False

--- a/tests/rucio/common/test_startup_checks.py
+++ b/tests/rucio/common/test_startup_checks.py
@@ -1,0 +1,573 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: UP007, UP045
+"""
+Comprehensive tests for rucio.common.startup_checks
+
+What this suite covers
+----------------------
+1) Registration API
+   - Rejects async functions and async-callable objects
+   - Rejects non-callables, empty/whitespace names
+   - Case-insensitive duplicate protection + replace=True semantics
+   - Tag normalization (whitespace trimming + lower-casing)
+
+2) Selection by tags
+   - Unscoped checks run everywhere
+   - Only checks whose tags intersect the current service tags are executed
+
+3) Configuration overrides
+   - 'enabled' restricts the set of checks to run
+   - 'disabled' excludes checks (global)
+   - Per-tag variants like 'enabled_REST' / 'disabled_daemon' are honored
+   - Option name matching is case-insensitive (e.g., 'EnAbLeD')
+   - Unknown names in config are ignored without crashing
+
+4) Error handling
+   - Exceptions from callbacks are wrapped as StartupCheckError
+   - Callbacks returning an awaitable are rejected at runtime
+   - Callbacks requiring positional arguments cause a wrapped error
+
+Notes
+-----
+- We patch 'startup_checks.config_get_list' to emulate configuration without touching
+  the real config system.
+- We clear the private _registry around each test to ensure isolation.
+- We focus on observable behavior but assert on logging when configuration issues
+  should surface warnings for operators.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Optional
+
+import pytest
+
+from rucio.common import startup_checks
+from rucio.common.exception import StartupCheckError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# ---------------------------
+# Fixtures
+# ---------------------------
+
+@pytest.fixture(autouse=True)
+def clear_registry() -> None:
+    """Ensure the in-memory registry is clean before/after every test."""
+    startup_checks._registry.clear()  # type: ignore[attr-defined]
+    yield
+    startup_checks._registry.clear()  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def config_lists(monkeypatch) -> dict[str, list[str]]:
+    """Patch config_get_list used by startup_checks to read from a local dict.
+
+    Usage inside a test:
+        config_lists['enabled'] = ['check_a']
+        config_lists['disabled_REST'] = ['check_b']
+    """
+    class _CaseInsensitiveDict(dict):  # type: ignore[type-arg]
+        def __setitem__(self, key, value):  # type: ignore[override]
+            super().__setitem__(str(key).lower(), value)
+
+    class _ConfigValues(_CaseInsensitiveDict):
+        def __init__(self) -> None:
+            super().__init__()
+            self.bools = _CaseInsensitiveDict()
+            self.ints = _CaseInsensitiveDict()
+
+    values = _ConfigValues()
+
+    def fake_config_get_list(
+            section: str,
+            option: str,
+            *,
+            raise_exception: bool = True,
+            default=None,
+            **kwargs,
+    ) -> list[str]:
+        assert section == 'startup_checks'
+        key = option.lower()
+        if key in values:
+            return list(values[key])
+        return [] if default is None else default
+
+    monkeypatch.setattr(startup_checks, 'config_get_list', fake_config_get_list)
+
+    def fake_config_get_bool(
+            section: str,
+            option: str,
+            raise_exception: bool = True,
+            default=None,
+            **kwargs,
+    ):
+        assert section == 'startup_checks'
+        key = option.lower()
+        if key in values.bools:
+            return values.bools[key]
+        if raise_exception:
+            raise RuntimeError(f'No boolean config for {option}')
+        return default
+
+    def fake_config_get_int(
+            section: str,
+            option: str,
+            raise_exception: bool = True,
+            default=None,
+            **kwargs,
+    ):
+        assert section == 'startup_checks'
+        key = option.lower()
+        if key in values.ints:
+            return values.ints[key]
+        if raise_exception:
+            raise RuntimeError(f'No integer config for {option}')
+        return default
+
+    monkeypatch.setattr(startup_checks, 'config_get_bool', fake_config_get_bool)
+    monkeypatch.setattr(startup_checks, 'config_get_int', fake_config_get_int)
+    return values
+
+
+# ---------------------------
+# Helper
+# ---------------------------
+
+def _register(name: str, callback: Callable[[], None], *, tags: Optional[set[str]] = None) -> None:
+    startup_checks.register_startup_check(name=name, callback=callback, tags=tags, replace=False)
+
+
+# ---------------------------
+# Registration tests
+# ---------------------------
+
+def test_register_rejects_non_callable() -> None:
+    with pytest.raises(TypeError):
+        startup_checks.register_startup_check(name='bad', callback=42)  # type: ignore[arg-type]
+
+
+def test_register_rejects_whitespace_name() -> None:
+    with pytest.raises(ValueError):
+        startup_checks.register_startup_check(name='   ', callback=lambda: None)
+
+
+def test_register_async_function_rejected() -> None:
+    async def _async_check() -> None:
+        return None
+
+    with pytest.raises(TypeError):
+        startup_checks.register_startup_check(name='async-check', callback=_async_check)
+
+
+def test_register_async_callable_object_rejected() -> None:
+    class _AsyncCallable:
+        async def __call__(self) -> None:
+            return None
+
+    with pytest.raises(TypeError):
+        startup_checks.register_startup_check(name='async-callable', callback=_AsyncCallable())
+
+
+def test_case_insensitive_duplicates_are_rejected() -> None:
+    _register('Example', lambda: None)
+    with pytest.raises(ValueError):
+        _register('example', lambda: None)
+
+
+def test_replace_allows_case_insensitive_overwrite() -> None:
+    executed: list[str] = []
+
+    def _v1() -> None:
+        executed.append('v1')
+
+    def _v2() -> None:
+        executed.append('v2')
+
+    startup_checks.register_startup_check('DB', _v1)
+    # Replace using different case; should not raise and should call new callback
+    startup_checks.register_startup_check('db', _v2, replace=True)
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed == ['v2']
+
+
+# ---------------------------
+# Tag behavior tests
+# ---------------------------
+
+def test_tags_normalized_and_matched_case_insensitively() -> None:
+    executed = False
+
+    def _cb() -> None:
+        nonlocal executed
+        executed = True
+
+    # Mixed-case + whitespace tags at registration
+    _register('network', _cb, tags={' REST ', 'DaeMon'})
+
+    # Run only for 'rest'; the check should run due to tag intersection
+    startup_checks.run_startup_checks(tags={'rest'})
+    assert executed is True
+
+
+def test_unscoped_check_runs_everywhere() -> None:
+    executed = {'global': False, 'daemon': False}
+
+    def _cb_global() -> None:
+        executed['global'] = True
+
+    def _cb_daemon() -> None:
+        executed['daemon'] = True
+
+    _register('global-check', _cb_global, tags=None)  # unscoped
+    _register('daemon-only', _cb_daemon, tags={'daemon'})  # scoped
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed['global'] is True
+    assert executed['daemon'] is True
+
+
+def test_empty_set_of_tags_behaves_like_unscoped() -> None:
+    executed = False
+
+    def _cb() -> None:
+        nonlocal executed
+        executed = True
+
+    _register('global-check', _cb, tags=set())
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed is True
+
+
+def test_only_checks_for_selected_tags_run() -> None:
+    executed: list[str] = []
+
+    _register('daemon-c', lambda: executed.append('daemon'), tags={'daemon'})
+    _register('rest-c', lambda: executed.append('rest'), tags={'rest'})
+    _register('global-c', lambda: executed.append('global'), tags=None)
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert 'daemon' in executed
+    assert 'global' in executed
+    assert 'rest' not in executed
+
+
+# ---------------------------
+# Config override tests
+# ---------------------------
+
+def test_enabled_restricts_set(config_lists) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+    _register('gamma', lambda: executed.append('gamma'), tags={'daemon'})
+
+    config_lists['enabled'] = ['beta']  # only beta should run
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed == ['beta']
+
+
+def test_enabled_option_name_is_case_insensitive(config_lists) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+    config_lists['EnAbLeD'] = ['beta']  # mixed-case key should be honored
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed == ['beta']
+
+
+def test_enabled_check_names_are_case_insensitive(config_lists) -> None:
+    executed: list[str] = []
+
+    _register('NeTwOrK', lambda: executed.append('NeTwOrK'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+
+    config_lists['enabled'] = ['network']  # name lookup should be case-insensitive
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed == ['NeTwOrK']
+
+
+def test_disabled_global_excludes_when_no_enabled(config_lists) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+
+    config_lists['disabled'] = ['beta']
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed == ['alpha']
+
+
+def test_disabled_can_remove_all_checks_and_logs_info(config_lists, caplog) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+
+    config_lists['disabled'] = ['alpha', 'beta']
+
+    with caplog.at_level(logging.INFO, logger='rucio.startup_checks'):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+    assert executed == []
+    info_messages = [record.getMessage() for record in caplog.records if record.levelno >= logging.INFO]
+    assert any('No startup checks to run for tags daemon' in message for message in info_messages)
+
+
+def test_disable_overrides_enable_per_tag(config_lists) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'rest'})
+    _register('beta', lambda: executed.append('beta'), tags={'rest'})
+
+    config_lists['enabled'] = ['alpha', 'beta']
+    config_lists['disabled_REST'] = ['beta']  # per-tag disabled wins over enabled
+
+    startup_checks.run_startup_checks(tags={'rest'})
+    assert executed == ['alpha']
+
+
+def test_enabled_per_tag_suffix_is_honoured(config_lists) -> None:
+    executed = False
+
+    def _cb() -> None:
+        nonlocal executed
+        executed = True
+
+    _register('network', _cb, tags={'rest'})
+    config_lists['enabled_REST'] = ['network']
+
+    startup_checks.run_startup_checks(tags={'rest'})
+    assert executed is True
+
+
+def test_unknown_names_in_config_are_ignored(config_lists, caplog) -> None:
+    executed: list[str] = []
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+
+    config_lists['enabled'] = ['ghost']  # does not exist
+
+    with caplog.at_level(logging.WARNING, logger='rucio.startup_checks'):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+    assert executed == ['alpha']
+    warning_messages = [record.getMessage() for record in caplog.records if record.levelno >= logging.WARNING]
+    assert any('Unknown startup check(s) in `startup_checks.enabled`' in message for message in warning_messages)
+    assert any('falling back to default checks' in message for message in warning_messages)
+
+
+def test_unknown_disabled_names_raise_warning(config_lists, caplog) -> None:
+    executed: list[str] = []
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+
+    config_lists['disabled'] = ['ghost']
+
+    with caplog.at_level(logging.WARNING, logger='rucio.startup_checks'):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+    assert executed == ['alpha']
+    warning_messages = [record.getMessage() for record in caplog.records if record.levelno >= logging.WARNING]
+    assert any('Unknown startup check(s) in `startup_checks.disabled`' in message for message in warning_messages)
+
+
+def test_enabled_not_applicable_names_fall_back_to_defaults(config_lists, caplog) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+    _register('beta', lambda: executed.append('beta'), tags={'rest'})
+
+    config_lists['enabled'] = ['beta']  # valid check but not for daemon tag
+
+    with caplog.at_level(logging.INFO, logger='rucio.startup_checks'):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+    assert executed == ['alpha']
+    info_messages = [record.getMessage() for record in caplog.records if record.levelno >= logging.INFO]
+    assert any('not applicable to tags' in message for message in info_messages)
+    assert any('falling back to default checks' in message for message in info_messages)
+
+
+def test_strict_mode_unknown_names_fail(config_lists) -> None:
+    _register('alpha', lambda: None, tags={'daemon'})
+    config_lists['enabled'] = ['ghost']
+    config_lists.bools['strict'] = True
+
+    with pytest.raises(StartupCheckError):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+
+def test_strict_mode_missing_names_fail(config_lists) -> None:
+    _register('alpha', lambda: None, tags={'rest'})
+    config_lists['enabled'] = ['alpha']
+    config_lists.bools['strict'] = True
+
+    with pytest.raises(StartupCheckError):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+
+def test_strict_mode_filters_removing_all_checks_fail(config_lists) -> None:
+    _register('alpha', lambda: None, tags={'daemon'})
+    config_lists['enabled'] = ['alpha']
+    config_lists['disabled'] = ['alpha']
+    config_lists.bools['strict'] = True
+
+    with pytest.raises(StartupCheckError):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+
+def test_enabled_may_list_names_from_other_tags_but_only_current_tags_run(config_lists) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'rest'})
+    _register('beta', lambda: executed.append('beta'), tags={'daemon'})
+
+    # both listed, but we run with 'rest' only; expect only alpha
+    config_lists['enabled'] = ['alpha', 'beta']
+
+    startup_checks.run_startup_checks(tags={'rest'})
+    assert executed == ['alpha']
+
+
+# ---------------------------
+# Error handling tests
+# ---------------------------
+
+def test_callback_exception_is_wrapped() -> None:
+    def _boom() -> None:
+        raise RuntimeError('boom')
+
+    _register('explodes', _boom, tags={'daemon'})
+    with pytest.raises(StartupCheckError):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+
+def test_callback_requiring_arguments_is_wrapped() -> None:
+    def _needs_arg(x: int) -> None:
+        return None
+
+    _register('bad-sig', _needs_arg, tags={'daemon'})
+    with pytest.raises(StartupCheckError):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+
+def test_async_return_value_is_rejected() -> None:
+    async def _async_inner() -> None:
+        await asyncio.sleep(0)
+
+    def _callback():
+        return _async_inner()
+
+    _register('async-return', _callback)
+    with pytest.raises(StartupCheckError):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+
+# Keep the user-proposed tests that are still valuable (for completeness)
+def test_enable_and_disable_lists_can_coexist(config_lists) -> None:
+    executed: list[str] = []
+
+    def _make_callback(name: str) -> Callable[[], None]:
+        def _callback() -> None:
+            executed.append(name)
+
+        return _callback
+
+    _register('alpha', _make_callback('alpha'), tags={'daemon'})
+    _register('beta', _make_callback('beta'), tags={'daemon'})
+
+    config_lists['enabled'] = ['alpha', 'beta']
+    config_lists['disabled_DAEMON'] = ['beta']
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+    assert executed == ['alpha']
+
+
+def test_tag_suffix_case_is_honoured(config_lists) -> None:
+    executed = False
+
+    def _callback() -> None:
+        nonlocal executed
+        executed = True
+
+    _register('network', _callback, tags={'rest'})
+    config_lists['enabled_REST'] = ['network']
+
+    startup_checks.run_startup_checks(tags={'rest'})
+    assert executed is True
+
+
+def test_duplicate_names_in_config_lists_are_deduplicated(config_lists) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+
+    config_lists['enabled'] = ['alpha', 'ALPHA', 'alpha']
+
+    startup_checks.run_startup_checks(tags={'daemon'})
+
+    assert executed == ['alpha']
+
+
+def test_soft_timeout_logs_warning(config_lists, caplog, monkeypatch) -> None:
+    executed: list[str] = []
+
+    _register('alpha', lambda: executed.append('alpha'), tags={'daemon'})
+
+    config_lists.ints['timeout_ms'] = 150
+
+    times = iter([100.0, 100.2, 100.2])
+    monkeypatch.setattr(startup_checks.time, 'perf_counter', lambda: next(times))
+
+    with caplog.at_level(logging.WARNING, logger='rucio.startup_checks'):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+    assert executed == ['alpha']
+    warning_messages = [record.getMessage() for record in caplog.records if record.levelno >= logging.WARNING]
+    assert any('exceeded soft timeout' in message for message in warning_messages)
+
+
+def test_summary_logs_include_counts(config_lists, caplog) -> None:
+    executed: list[str] = []
+
+    def _make_cb(name: str):
+        def _cb() -> None:
+            executed.append(name)
+
+        return _cb
+
+    _register('alpha', _make_cb('alpha'), tags={'daemon'})
+    _register('beta', _make_cb('beta'), tags={'daemon'})
+
+    config_lists['disabled'] = ['beta']
+
+    with caplog.at_level(logging.INFO, logger='rucio.startup_checks'):
+        startup_checks.run_startup_checks(tags={'daemon'})
+
+    assert executed == ['alpha']
+    info_messages = [record.getMessage() for record in caplog.records if record.levelno == logging.INFO]
+    assert any('Startup checks completed successfully: 1 ran, 1 disabled by config' in message for message in info_messages)

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -25,19 +25,7 @@ from rucio.core import opendata
 from rucio.core.did import add_did, set_status
 from rucio.core.rse import add_rse_attribute
 from rucio.db.sqla.constants import DIDType, OpenDataDIDState
-from rucio.db.sqla.session import get_session
-from rucio.db.sqla.util import json_implemented
 from rucio.tests.common import auth, did_name_generator, headers
-
-skip_unsupported_json = pytest.mark.skipif(
-    not json_implemented(),
-    reason="JSON support is not implemented in this database"
-)
-
-skip_unsupported_dialect = pytest.mark.skipif(
-    get_session().bind.dialect.name in ['oracle', 'sqlite'],
-    reason=f"Unsupported dialect: {get_session().bind.dialect.name}"
-)
 
 OPENDATA_RSE_EXPRESSION = 'OpenData=True'
 
@@ -212,7 +200,6 @@ class TestOpenDataCore:
 
         assert state == OpenDataDIDState.PUBLIC
 
-    @skip_unsupported_dialect
     def test_opendata_dids_meta_update(self, mock_scope, root_account, db_write_session):
         name = did_name_generator(did_type="dataset")
 
@@ -806,7 +793,6 @@ class TestOpenDataCLI:
             f"Expected valid states {valid_states} in error message, got {stderr}"
         )
 
-    @skip_unsupported_dialect
     def test_opendata_cli_update_delete(self, mock_scope, doi_factory):
         name = did_name_generator(did_type="dataset")
 

--- a/tests/test_startup_checks_catalog.py
+++ b/tests/test_startup_checks_catalog.py
@@ -1,0 +1,113 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from contextlib import contextmanager
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def _session_scope(dialect: str):
+    @contextmanager
+    def _scope():
+        yield SimpleNamespace(bind=SimpleNamespace(dialect=SimpleNamespace(name=dialect)))
+
+    return _scope
+
+
+@pytest.fixture
+def catalog(monkeypatch):
+    session_state = {'dialect': 'postgresql', 'legacy': []}
+
+    def _get_session():
+        return _session_scope(session_state['dialect'])
+
+    def _oracle_legacy_json_columns(session):  # pylint: disable=unused-argument
+        return list(session_state['legacy'])
+
+    session_module = ModuleType('rucio.db.sqla.session')
+    session_module.get_session = _get_session
+
+    util_module = ModuleType('rucio.db.sqla.util')
+    util_module.oracle_legacy_json_columns = _oracle_legacy_json_columns
+
+    monkeypatch.setitem(sys.modules, 'rucio.db.sqla.session', session_module)
+    monkeypatch.setitem(sys.modules, 'rucio.db.sqla.util', util_module)
+    monkeypatch.delitem(sys.modules, 'rucio.common.startup_checks_catalog', raising=False)
+
+    module = importlib.import_module('rucio.common.startup_checks_catalog')
+
+    return module, session_state
+
+
+def test_legacy_oracle_json_columns_returns_none_for_non_oracle(catalog):
+    module, state = catalog
+    state['dialect'] = 'postgresql'
+
+    assert module.legacy_oracle_json_columns() is None
+
+
+def test_legacy_oracle_json_columns_returns_tuple(catalog):
+    module, state = catalog
+    state['dialect'] = 'oracle'
+    state['legacy'] = [('t', 'c')]
+
+    assert module.legacy_oracle_json_columns() == (('t', 'c'),)
+
+
+def test_ensure_oracle_json_columns_are_native_logs_success(catalog, monkeypatch, caplog):
+    module, _ = catalog
+    monkeypatch.setattr(module, 'legacy_oracle_json_columns', lambda: ())
+
+    with caplog.at_level(logging.INFO, logger='rucio.common.startup_checks_catalog'):
+        module.ensure_oracle_json_columns_are_native()
+
+    assert 'Oracle JSON column check passed' in caplog.text
+
+
+def test_ensure_oracle_json_columns_are_native_raises(catalog, monkeypatch):
+    module, _ = catalog
+    monkeypatch.setattr(module, 'legacy_oracle_json_columns', lambda: (('table', 'column'),))
+
+    with pytest.raises(RuntimeError) as error:
+        module.ensure_oracle_json_columns_are_native()
+
+    assert 'legacy CLOBs' in str(error.value)
+
+
+def test_register_all_uses_replace(catalog, monkeypatch):
+    module, _ = catalog
+    recorded: dict[str, object] = {}
+
+    def _fake_register(*, name, callback, description=None, tags=None, replace):  # type: ignore[no-untyped-def]
+        recorded.update(
+            name=name,
+            callback=callback,
+            description=description,
+            tags=tags,
+            replace=replace,
+        )
+
+    monkeypatch.setattr(module, 'register_startup_check', _fake_register)
+
+    module.register_all()
+
+    assert recorded['name'] == 'oracle-json-columns'
+    assert recorded['replace'] is True
+    assert callable(recorded['callback'])

--- a/tools/merge_rucio_configs.py
+++ b/tools/merge_rucio_configs.py
@@ -100,7 +100,10 @@ def merge_configs(source_file_paths, dest_file_path, use_env=True, logger=loggin
                         file_config = fix_multi_word_sections(yaml.safe_load(f))
                         parser.read_dict(file_config)
                 elif path.is_file() or file_path.suffix in ['.ini', '.cfg', '.config']:
-                    local_parser = configparser.ConfigParser()
+                    # The merge utility only needs literal values.  Disabling interpolation keeps
+                    # strings that contain percent-based tokens (for example logging formatters)
+                    # from being parsed as references to other options.
+                    local_parser = configparser.ConfigParser(interpolation=None)
                     local_parser.read(file_path)
                     file_config = {section: {option: value for option, value in section_proxy.items()} for section, section_proxy in local_parser.items()}
                 else:


### PR DESCRIPTION
**Draft Notice:** This works but kept frozen until we merge #8207 and #8212.
---

Handles #7648

In this PR, I have already included A) https://github.com/rucio/rucio/pull/8207 and B) https://github.com/rucio/rucio/pull/8212 which need to be merged first (and then I can rebase to reduce current PR-diffs). Therefore, below I am summarising what changes are introduced only by the new commits targeting the #7648 issue specifically. These are:

_- Testing: Comment out unsupported dialect check in `test_opendata.py` (316e932cdfd03fcaaa86e02a946db5d1dac07975)_
_- Core & Internals: Add Oracle JSON column validation and centralized startup checks (f0f3269c3641d692555f3abd1831f19e384ba589)_
_- Metadata: Make JSON type native and database agnostic in Rucio; rucio#7648 (d4c41b6356383fc5a113d30aa35733646dfc3276)_

**Summary of Changes**
- Introduced `rucio.common.startup_checks_catalog` to centralize there our startup checks. Although https://github.com/rucio/rucio/pull/8207 supports check definitions & registrations from everywhere, it might be a good idea to just have all our startup checks at one place.
- Added a global check (which is basically the first one that is using the new startup-check framework introduced by #8207) to enforce native Oracle JSON columns by querying for legacy CLOB-backed JSON fields in Oracle 21c+. Passing this check before a service starts, simplifies many metadata-related issues for us.
- Added the new startup check catalog into both daemon startup and the Flask REST application so these diagnostics run automatically when services launch.
- Updated the SQLAlchemy JSON type to select native JSON storage for Oracle 21c+ while preserving text serialization on earlier versions or other backends (to ensure consistent handling across dialects).
- Switched the `DidMeta` and `DeletedDidMeta` models to use the unified JSON column type and adjusted the JSON metadata plugin to rely on the new capability checks while forcing ORM state changes when updating metadata payloads.

**Also regarding Testing Updates**
- Added unit tests for the startup check catalog to cover Oracle detection.
- Removed the previously hard-coded skip markers from the OpenData integration tests so metadata and CLI workflows execute regardless of database dialect, reflecting broader JSON support.
