### PR TITLE
Testing: upgrade_to_elastic_v9.0.0 #8169

### DIFF
--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -133,9 +133,13 @@ services:
 
   elasticsearch:
     container_name: ${RUCIO_ELASTICSEARCH_CONTAINER_NAME:-dev-elasticsearch-1}
-    image: docker.io/elasticsearch:7.8.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.0
     environment:
       - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+    mem_limit: 2g
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow" ]
       interval: 10s

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -138,6 +138,7 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - xpack.security.enrollment.enabled=false
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
     mem_limit: 2g
     healthcheck:

--- a/tests/test_hermes.py
+++ b/tests/test_hermes.py
@@ -59,7 +59,7 @@ class MyListener:
         {
             "table_content": [
                 ("hermes", "services_list", "influx,activemq,elastic,email"),
-                ("hermes", "elastic_endpoint", "http://elasticsearch:9200/ddm_events/doc/_bulk"),
+                ("hermes", "elastic_endpoint", "http://elasticsearch:9200/ddm_events/_bulk"),
                 ("hermes", "influxdb_endpoint", "http://influxdb:8086/api/v2/write?org=rucio&bucket=rucio"),
                 ("hermes", "influxdb_token", "mytoken"),
                 ("messaging-hermes", "destination", "/queue/events"),
@@ -76,7 +76,7 @@ class MyListener:
         {
             "table_content": [
                 ("hermes", "services_list", "influx,activemq,elastic,email"),
-                ("hermes", "elastic_endpoint", "http://elasticsearch:9200/ddm_events/doc/_bulk"),
+                ("hermes", "elastic_endpoint", "http://elasticsearch:9200/ddm_events/_bulk"),
                 ("hermes", "influxdb_endpoint", "http://influxdb:8086/api/v2/write?org=rucio&bucket=rucio"),
                 ("hermes", "influxdb_token", "mytoken"),
                 ("messaging-hermes", "destination", "/queue/events"),


### PR DESCRIPTION
- upgrade to elasticsearch v9
- add mem limit in elasticsearch.

container starts in forked action. Tests in forked were failing , so will see in upstream.