### PR TITLE
Allow update to scope ownership, listing scopes with owner

### DIFF
--- a/lib/rucio/cli/bin_legacy/rucio.py
+++ b/lib/rucio/cli/bin_legacy/rucio.py
@@ -36,7 +36,7 @@ from tabulate import tabulate
 
 # rucio module has the same name as this executable module, so this rule fails. pylint: disable=no-name-in-module
 from rucio import version
-from rucio.cli.utils import exception_handler, get_client, get_scope, setup_gfal2_logger, signal_handler
+from rucio.cli.utils import exception_handler, get_client, get_scope, scope_exists, setup_gfal2_logger, signal_handler
 from rucio.client.richclient import MAX_TRACEBACK_WIDTH, MIN_CONSOLE_WIDTH, CLITheme, generate_table, get_cli_config, get_pager, print_output, setup_rich_logger
 from rucio.common.client import detect_client_location
 from rucio.common.config import config_get, config_get_float
@@ -48,7 +48,6 @@ from rucio.common.exception import (
     InvalidType,
     RSENotFound,
     RucioException,
-    ScopeNotFound,
     UnsupportedOperation,
 )
 from rucio.common.extra import import_extras
@@ -448,8 +447,7 @@ def list_dids(args, client, logger, console, spinner):
         scope = args.did[0]
         name = '*'
 
-    if scope not in client.list_scopes():
-        raise ScopeNotFound
+    scope_exists(client, scope)
 
     if args.recursive and '*' in name:
         raise InputValidationError('Option recursive cannot be used with wildcards.')
@@ -501,7 +499,7 @@ def list_scopes(args, client, logger, console, spinner):
 
     List scopes.
     """
-    if (cli_config == 'rich') or (not args.csv):
+    if (cli_config == 'rich') and (not args.csv):
         spinner.update(status='Fetching scopes')
         spinner.start()
 
@@ -510,13 +508,29 @@ def list_scopes(args, client, logger, console, spinner):
     else:
         scopes = client.list_scopes()
     if (cli_config == 'rich') and (not args.csv):
-        scopes = [[scope] for scope in sorted(scopes)]
-        table = generate_table(scopes, headers=['SCOPE'], col_alignments=['left'])
-        spinner.stop()
-        print_output(table, console=console, no_pager=args.no_pager)
+        if len(scopes) == 0:
+            spinner.stop()
+        elif isinstance(scopes[0], dict):
+            table = generate_table(scopes, headers=['SCOPE', "ACCOUNT"], col_alignments=['left'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
+        else:
+            scopes = [[scope] for scope in sorted(scopes)]
+            table = generate_table(scopes, headers=['SCOPE'], col_alignments=['left'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
     else:
-        for scope in scopes:
-            print(scope)
+        if len(scopes) == 0:
+            pass
+        elif isinstance(scopes[0], str):  # TODO: Backwards compatibility - remove in v40 issue #8125
+            for scope in scopes:
+                print(scope)
+        elif args.csv:
+            for scope in scopes:
+                print(scope['scope'])
+        else:
+            scopes = [[s['scope'], s['account']] for s in scopes]
+            print(tabulate(scopes, tablefmt=tablefmt, headers=['SCOPE', 'ACCOUNT'], disable_numparse=True))
     return SUCCESS
 
 

--- a/lib/rucio/cli/bin_legacy/rucio_admin.py
+++ b/lib/rucio/cli/bin_legacy/rucio_admin.py
@@ -765,13 +765,29 @@ def list_scopes(args, client, logger, console, spinner):
     else:
         scopes = client.list_scopes()
     if (cli_config == 'rich') and (not args.csv):
-        scopes = [[scope] for scope in sorted(scopes)]
-        table = generate_table(scopes, headers=['SCOPE'], col_alignments=['left'])
-        spinner.stop()
-        print_output(table, console=console, no_pager=args.no_pager)
+        if len(scopes) == 0:
+            spinner.stop()
+        elif isinstance(scopes[0], dict):
+            table = generate_table(scopes, headers=['SCOPE', "ACCOUNT"], col_alignments=['left'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
+        else:
+            scopes = [[scope] for scope in sorted(scopes)]
+            table = generate_table(scopes, headers=['SCOPE'], col_alignments=['left'])
+            spinner.stop()
+            print_output(table, console=console, no_pager=args.no_pager)
     else:
-        for scope in scopes:
-            print(scope)
+        if len(scopes) == 0:
+            pass
+        elif isinstance(scopes[0], str):  # TODO: Backwards compatibility - remove in v40 issue #8125
+            for scope in scopes:
+                print(scope)
+        elif args.csv:
+            for scope in scopes:
+                print(scope['scope'])
+        else:
+            scopes = [[s['scope'], s['account']] for s in scopes]
+            print(tabulate(scopes, tablefmt=tablefmt, headers=['SCOPE', 'ACCOUNT'], disable_numparse=True))
     return SUCCESS
 
 

--- a/lib/rucio/cli/did.py
+++ b/lib/rucio/cli/did.py
@@ -18,10 +18,10 @@ import click
 from rich.text import Text
 from tabulate import tabulate
 
-from rucio.cli.utils import get_scope
+from rucio.cli.utils import get_scope, scope_exists
 from rucio.client.richclient import CLITheme, generate_table, print_output
 from rucio.common.config import config_get
-from rucio.common.exception import InputValidationError, InvalidObject, RucioException, ScopeNotFound
+from rucio.common.exception import InputValidationError, InvalidObject, RucioException
 from rucio.common.utils import chunks, parse_did_filter_from_string_fe
 
 
@@ -83,8 +83,7 @@ def list_(ctx: click.Context, did_pattern: str, recursive: bool, filter_: str, s
             scope = did_pattern
             name = '*'
 
-        if scope not in ctx.obj.client.list_scopes():
-            raise ScopeNotFound
+        scope_exists(ctx.obj.client, scope)
 
         if recursive and '*' in name:
             raise InputValidationError('Option recursive cannot be used with wildcards.')
@@ -94,7 +93,6 @@ def list_(ctx: click.Context, did_pattern: str, recursive: bool, filter_: str, s
                     raise ValueError('Must have a wildcard in did name if filtering by name.')
 
         filters, type_ = parse_did_filter_from_string_fe(filter_, name)
-
         if ctx.obj.use_rich:
             ctx.obj.spinner.update(status='Fetching DIDs')
             ctx.obj.spinner.start()

--- a/lib/rucio/cli/scope.py
+++ b/lib/rucio/cli/scope.py
@@ -39,3 +39,12 @@ def add_(ctx, account, scope_name):
 def list_(ctx: click.Context, account: str, csv: bool):
     """List existing scopes"""
     list_scopes(Arguments({"no_pager": ctx.obj.no_pager, "account": account, "csv": csv}), ctx.obj.client, ctx.obj.logger, ctx.obj.console, ctx.obj.spinner)
+
+
+@scope.command("update")
+@click.argument("scope-name")
+@click.option("--account", help="New account to associate with scope", required=True)
+@click.pass_context
+def update(ctx: click.Context, scope_name: str, account: str) -> None:
+    """Update the owner of the scope [SCOPE-NAME]"""
+    ctx.obj.client.update_scope(account=account, scope=scope_name)

--- a/lib/rucio/cli/utils.py
+++ b/lib/rucio/cli/utils.py
@@ -41,6 +41,7 @@ from rucio.common.exception import (
     RSENotFound,
     RucioException,
     RuleNotFound,
+    ScopeNotFound,
     UnsupportedOperation,
 )
 from rucio.common.utils import extract_scope, setup_logger
@@ -262,11 +263,33 @@ class JSONType(click.ParamType):
             self.fail(f"Invalid JSON: {e}", param, ctx)
 
 
+def scope_exists(client: 'Client', scope: str) -> None:
+    possible_scopes = client.list_scopes()
+    if not len(list(possible_scopes)):
+        raise ScopeNotFound
+    if isinstance(list(possible_scopes)[0], str):  # TODO Backwards Compat - Remove in future releases - #8125
+        scopes = possible_scopes
+    else:
+        scopes = [s['scope'] for s in possible_scopes]  # type: ignore
+
+    if scope not in scopes:  # type: ignore - handled by the if isinstance
+        raise ScopeNotFound
+
+
 def get_scope(did: str, client: Client) -> tuple[str, str]:
     try:
         scope, name = extract_scope(did)
         return scope, name
     except TypeError:
-        scopes = client.list_scopes()
-        scope, name = extract_scope(did, scopes)
+        known_scopes = client.list_scopes()
+        if not len(list(known_scopes)):
+            raise ScopeNotFound
+        if isinstance(known_scopes, dict):
+            scopes = known_scopes.get('scope')  # type: ignore - does not accept 'scope' as a Literal['scope']
+            scope, name = extract_scope(did, scopes)
+        elif isinstance(known_scopes, list):
+            scope, name = extract_scope(did, known_scopes)  # type: ignore - Handled by the isinstance
+        else:
+            raise ScopeNotFound
+
         return scope, name

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -34,7 +34,7 @@ from rucio.common.client import detect_client_location
 from rucio.common.config import config_get
 from rucio.common.constants import DEFAULT_VO
 from rucio.common.didtype import DID
-from rucio.common.exception import InputValidationError, NoFilesDownloaded, NotAllFilesDownloaded, RucioException
+from rucio.common.exception import InputValidationError, NoFilesDownloaded, NotAllFilesDownloaded, RucioException, ScopeNotFound
 from rucio.common.pcache import Pcache
 from rucio.common.utils import execute, extract_scope, generate_uuid, parse_replicas_from_file, parse_replicas_from_string, send_trace, sizefmt
 from rucio.rse import rsemanager as rsemgr
@@ -1856,8 +1856,15 @@ class DownloadClient:
             did_name = did[1]
         elif len(did) == 1:
             if self.extract_scope_convention == 'belleii':
-                scopes = [scope for scope in self.client.list_scopes()]
-                did_scope, did_name = extract_scope(did[0], scopes)
+                listed_scopes = [scope for scope in self.client.list_scopes()]
+                # TODO remove backwards compatiblity check. See #8125
+                if len(listed_scopes) == 0:
+                    raise ScopeNotFound
+                if not isinstance(listed_scopes[0], str):
+                    scopes = [str(s['scope']) for s in listed_scopes]  # type: ignore
+                else:
+                    scopes = listed_scopes
+                did_scope, did_name = extract_scope(did[0], scopes)  # type: ignore
             else:
                 did = did_str.split('.')
                 did_scope = did[0]

--- a/lib/rucio/client/scopeclient.py
+++ b/lib/rucio/client/scopeclient.py
@@ -114,3 +114,38 @@ class ScopeClient(BaseClient):
         else:
             exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
             raise exc_cls(exc_msg)
+
+    def update_scope(self, account: str, scope: str) -> bool:
+        """
+        Change the ownership of a scope
+
+        Parameters
+        ----------
+        account :
+            New account to assign as scope owner
+        scope :
+            Scope to change ownership of
+
+        Returns
+        -------
+        bool
+            True if the operation was successful
+
+        Raises
+        ------
+        AccountNotFound
+            If account doesn't exist.
+        ScopeNotFound
+            If scope doesn't exist.
+        CannotAuthenticate, AccessDenied
+            Insufficient permission/incorrect credentials to change ownership.
+        """
+
+        path = '/'.join(['scopes', account, scope])
+        url = build_url(choice(self.list_hosts), path=path)
+        r = self._send_request(url, method=HTTPMethod.PUT)
+        if r.status_code == codes.created:
+            return True
+        else:
+            exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+            raise exc_cls(exc_msg)

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -47,6 +47,7 @@ def has_permission(issuer: "InternalAccount", action: str, kwargs: dict[str, Any
             'add_rule': perm_add_rule,
             'add_subscription': perm_add_subscription,
             'add_scope': perm_add_scope,
+            'update_scope': perm_update_scope,
             'add_rse': perm_add_rse,
             'update_rse': perm_update_rse,
             'add_protocol': perm_add_protocol,
@@ -284,6 +285,20 @@ def perm_add_scope(issuer: "InternalAccount", kwargs: dict[str, Any], session: "
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+
+
+def perm_update_scope(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:
+    """
+    Checks if an account can update a scop to a account.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
+    :returns: True if account is allowed, otherwise False
+    """
+    return _is_root(issuer) \
+        or has_account_attribute(account=issuer, key='admin', session=session) \
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_get_auth_token_user_pass(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:

--- a/lib/rucio/core/permission/generic_multi_vo.py
+++ b/lib/rucio/core/permission/generic_multi_vo.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import rucio.core.scope
 from rucio.common.constants import RseAttr
@@ -48,6 +48,7 @@ def has_permission(issuer, action, kwargs, session: "Session"):
             'add_rule': perm_add_rule,
             'add_subscription': perm_add_subscription,
             'add_scope': perm_add_scope,
+            'update_scope': perm_update_scope,
             'add_rse': perm_add_rse,
             'update_rse': perm_update_rse,
             'add_protocol': perm_add_protocol,
@@ -283,6 +284,20 @@ def perm_add_scope(issuer, kwargs, session: "Session"):
     :returns: True if account is allowed, otherwise False
     """
     return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+
+
+def perm_update_scope(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:
+    """
+    Checks if an account can update a scop to a account.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
+    :returns: True if account is allowed, otherwise False
+    """
+    return _is_root(issuer) \
+        or has_account_attribute(account=issuer, key='admin', session=session) \
+        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, session: "Session"):

--- a/lib/rucio/core/scope.py
+++ b/lib/rucio/core/scope.py
@@ -14,7 +14,7 @@
 
 from re import match
 from traceback import format_exc
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy import and_, select, update
 from sqlalchemy.exc import IntegrityError
@@ -124,13 +124,13 @@ def list_scopes(session: "Session", filter_: Optional[dict[str, Any]] = None) ->
     return list(session.execute(stmt).scalars().all())
 
 
-def list_scopes_with_account(filter_: Optional[dict[str, Any]] = None, *, session: "Session") -> "Iterable[dict[Literal['scope', 'account'], Any]]":
+def list_scopes_with_account(filter_: Optional[dict[str, Any]] = None, *, session: "Session") -> "Iterable[dict[str, Any]]":
     """
     Lists all scopes.
     :param filter_: Dictionary of attributes by which the input data should be filtered
     :param session: The database session in use.
 
-    :returns: A of dictionaries with the scope and its owner
+    :returns: An iterable of dictionaries with the scope and its owner
     """
     filter_ = filter_ or {}
     stmt = select(

--- a/lib/rucio/gateway/scope.py
+++ b/lib/rucio/gateway/scope.py
@@ -12,16 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import rucio.gateway.permission
 from rucio.common.constants import DEFAULT_VO
 from rucio.common.exception import AccessDenied
 from rucio.common.schema import validate_schema
 from rucio.common.types import InternalAccount, InternalScope
+from rucio.common.utils import gateway_update_return_dict
 from rucio.core import scope as core_scope
 from rucio.db.sqla.constants import DatabaseOperationType
 from rucio.db.sqla.session import db_session
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 def list_scopes(filter_: Optional[dict[str, Any]] = None, vo: str = DEFAULT_VO) -> list[Optional[str]]:
@@ -43,6 +47,28 @@ def list_scopes(filter_: Optional[dict[str, Any]] = None, vo: str = DEFAULT_VO) 
 
     with db_session(DatabaseOperationType.READ) as session:
         return [scope.external for scope in core_scope.list_scopes(filter_=filter_, session=session)]
+
+
+def list_scopes_with_account(filter_: Optional[dict[str, Any]] = None, vo: str = DEFAULT_VO) -> 'Generator[dict[str, Any]]':
+    """
+    Lists all scopes.
+
+    :param filter_: Dictionary of attributes by which the input data should be filtered
+    :param vo: The VO to act on.
+
+    :returns: A list containing all scopes with their owner.
+    """
+    filter_ = filter_ or {}
+
+    if 'scope' in filter_:
+        filter_['scope'] = InternalScope(scope=filter_['scope'], vo=vo)
+    else:
+        filter_['scope'] = InternalScope(scope='*', vo=vo)
+
+    with db_session(DatabaseOperationType.READ) as session:
+        scopes = core_scope.list_scopes_with_account(filter_=filter_, session=session)
+        for scope in scopes:
+            yield gateway_update_return_dict(scope, session=session)
 
 
 def add_scope(

--- a/lib/rucio/web/rest/flaskapi/v1/scopes.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scopes.py
@@ -198,8 +198,14 @@ class ScopeOwnershipList(ErrorHandlingMethodView):
                   description: "All scopes for the account."
                   type: array
                   items:
-                    description: "A scope for the account."
-                    type: string
+                    type: object
+                    properties:
+                      scope:
+                        description: "Name of the scope."
+                        type: str
+                      account:
+                        description: "Account with ownership of the scope."
+                        type: string
           401:
             description: "Invalid Auth Token"
           406:

--- a/lib/rucio/web/rest/flaskapi/v1/scopes.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scopes.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flask import Flask, jsonify, request
+from flask import Flask, Response, jsonify, request
 
 from rucio.common.constants import HTTPMethod
-from rucio.common.exception import AccountNotFound, Duplicate, ScopeNotFound
-from rucio.gateway.scope import add_scope, get_scopes, list_scopes
+from rucio.common.exception import AccountNotFound, Duplicate, ScopeNotFound, VONotFound
+from rucio.gateway.scope import add_scope, get_scopes, list_scopes, update_scope
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
 from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_accept_header_wrapper_flask, generate_http_error_flask, response_headers
 
@@ -93,6 +93,46 @@ class Scope(ErrorHandlingMethodView):
 
         return 'Created', 201
 
+    def put(self, account: str, scope: str) -> Response:
+        """
+        ---
+        summary: Change ownership of a scope.
+        description: "Changes ownership of a scope.."
+        tags:
+          - Scopes
+        parameters:
+        - name: account
+          in: path
+          description: "The new owner account"
+          schema:
+            type: string
+          style: simple
+        - name: scope
+          in: path
+          description: "The name of the scope."
+          schema:
+            type: string
+          style: simple
+        responses:
+          201:
+            description: "OK"
+            content:
+              application/json:
+                schema:
+                  type: string
+                  enum: ['']
+          401:
+            description: "Invalid Auth Token"
+          403:
+            description: "Scope or already exists"
+        """
+        try:
+            update_scope(scope=scope, account=account, issuer=request.environ['issuer'], vo=request.environ['vo'])
+        except (ScopeNotFound, AccountNotFound, VONotFound) as error:
+            return generate_http_error_flask(404, error)
+
+        return Response("", 201)
+
 
 class AccountScopeList(ErrorHandlingMethodView):
 
@@ -145,7 +185,7 @@ def blueprint() -> AuthenticatedBlueprint:
 
     scope_view = Scope.as_view('scope')
     bp.add_url_rule('/', view_func=scope_view, methods=[HTTPMethod.GET.value])
-    bp.add_url_rule('/<account>/<scope>', view_func=scope_view, methods=[HTTPMethod.POST.value])
+    bp.add_url_rule('/<account>/<scope>', view_func=scope_view, methods=[HTTPMethod.POST.value, HTTPMethod.PUT.value])
     account_scope_list_view = AccountScopeList.as_view('account_scope_list')
     bp.add_url_rule('/<account>/scopes', view_func=account_scope_list_view, methods=[HTTPMethod.GET.value])
 

--- a/lib/rucio/web/rest/flaskapi/v1/scopes.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scopes.py
@@ -182,6 +182,29 @@ class AccountScopeList(ErrorHandlingMethodView):
 
 class ScopeOwnershipList(ErrorHandlingMethodView):
     def get(self) -> Response:
+        """
+        ---
+        summary: List Scopes
+        description: "List all scopes and their ownership."
+        tags:
+          - Scopes
+        parameters:
+        responses:
+          200:
+            description: "OK"
+            content:
+              application/json:
+                schema:
+                  description: "All scopes for the account."
+                  type: array
+                  items:
+                    description: "A scope for the account."
+                    type: string
+          401:
+            description: "Invalid Auth Token"
+          406:
+            description: "Not acceptable"
+        """
         scopes = list_scopes_with_account(vo=request.environ['vo'])
         res = []
         for dictionary in scopes:

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -858,7 +858,7 @@ def test_rule(rucio_client, mock_scope):
     assert len(out.split("\n")) == 3  # Creates two rules with independent IDs and one extra line at the end
 
 
-def test_scope():
+def test_scope(random_account):
     new_scope = scope_name_generator()
     cmd = f"rucio scope add {new_scope} --account root"
     exitcode, _, err = execute(cmd)
@@ -871,6 +871,16 @@ def test_scope():
     assert "ERROR" not in err
     # assert new_scope in out
     # See issue https://github.com/rucio/rucio/issues/7316
+
+    # Missing account arguments
+    cmd = f"rucio scope update {new_scope}"
+    exitcode, _, _ = execute(cmd)
+    assert exitcode == 2
+
+    cmd = f"rucio scope update {new_scope} --account {random_account.external}"
+    exitcode, _, err = execute(cmd)
+    assert exitcode == 0
+    assert "ERROR" not in err
 
 
 def test_subscription(rucio_client, mock_scope, random_account, did_factory):

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -858,29 +858,40 @@ def test_rule(rucio_client, mock_scope):
     assert len(out.split("\n")) == 3  # Creates two rules with independent IDs and one extra line at the end
 
 
-def test_scope(random_account):
-    new_scope = scope_name_generator()
-    cmd = f"rucio scope add {new_scope} --account root"
+def test_scope(rucio_client, scope_factory, random_account_factory, jdoe_account, vo):
+    scope = scope_name_generator()
+    account = random_account_factory().external
+    cmd = f"rucio scope add {scope} --account {account}"
     exitcode, _, err = execute(cmd)
     assert exitcode == 0
     assert "ERROR" not in err
 
-    cmd = "rucio scope list --account root"
+    cmd = f"rucio scope list --account {account}"
     exitcode, out, err = execute(cmd)
     assert exitcode == 0
     assert "ERROR" not in err
-    # assert new_scope in out
-    # See issue https://github.com/rucio/rucio/issues/7316
+    assert scope in out
 
-    # Missing account arguments
-    cmd = f"rucio scope update {new_scope}"
-    exitcode, _, _ = execute(cmd)
-    assert exitcode == 2
-
-    cmd = f"rucio scope update {new_scope} --account {random_account.external}"
-    exitcode, _, err = execute(cmd)
+    cmd = f"rucio scope list --account {jdoe_account}"
+    exitcode, out, err = execute(cmd)
     assert exitcode == 0
     assert "ERROR" not in err
+    assert scope not in out
+
+    cmd = "rucio scope list"
+    exitcode, out, err = execute(cmd)
+    assert exitcode == 0
+    assert "ERROR" not in err
+    assert scope in out
+    assert account in out
+
+    new_scope, _ = scope_factory(vos=[vo], account_name=account)
+    new_account = random_account_factory().external
+    cmd = f"rucio scope update {new_scope} --account {new_account}"
+    exitcode, out, err = execute(cmd)
+    assert exitcode == 0
+    assert "ERROR" not in err
+    assert new_scope in rucio_client.list_scopes_for_account(new_account)
 
 
 def test_subscription(rucio_client, mock_scope, random_account, did_factory):

--- a/tests/test_multi_vo.py
+++ b/tests/test_multi_vo.py
@@ -758,7 +758,7 @@ class TestMultiVoClients:
         scope_client.add_scope('root', shr)
         add_scope(new, 'root', 'root', vo=second_vo)
         add_scope(shr, 'root', 'root', vo=second_vo)
-        scope_list_tst = list(scope_client.list_scopes())
+        scope_list_tst = [s['scope'] for s in scope_client.list_scopes()]
         scope_list_new = list(list_scopes(filter_={}, vo=second_vo))
         assert tst in scope_list_tst
         assert new not in scope_list_tst

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -20,7 +20,7 @@ from rucio.common.exception import AccountNotFound, Duplicate, InvalidObject, Sc
 from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.common.utils import generate_uuid as uuid
-from rucio.core.scope import add_scope, get_scopes, is_scope_owner, update_scope
+from rucio.core.scope import add_scope, get_scopes, is_scope_owner, list_scopes_with_account, update_scope
 from rucio.db.sqla.constants import DatabaseOperationType
 from rucio.db.sqla.session import db_session
 from rucio.tests.common import account_name_generator, auth, hdrdict, headers, scope_name_generator
@@ -71,6 +71,21 @@ class TestScopeCoreApi:
         with pytest.raises(ScopeNotFound):
             with db_session(DatabaseOperationType.WRITE) as session:
                 update_scope(scope=scope, account=random_account, session=session)
+
+    def test_list_scope_with_account(self, vo, jdoe_account):
+        scopes = [InternalScope(scope_name_generator(), vo=vo) for _ in range(5)]
+        """ SCOPE (CORE): List scopes """
+        with db_session(DatabaseOperationType.WRITE) as session:
+            for scope in scopes:
+                add_scope(scope=scope, account=jdoe_account, session=session)
+        with db_session(DatabaseOperationType.READ) as session:
+            listed_scopes = list_scopes_with_account(session=session)
+            for scope in listed_scopes:
+                assert set(scope.keys()) == set(["scope", "account"])
+
+            for scope in scopes:
+                assert scope in [s['scope'] for s in listed_scopes]
+                assert jdoe_account == [s['account'] for s in listed_scopes if s['scope'] == scope][0]
 
 
 def test_scope_success(rest_client, auth_token):
@@ -149,6 +164,11 @@ def test_scope_change_ownership(rest_client, auth_token, random_account_factory)
     response = rest_client.put(f"/scopes/{new_owner}/{scope}", headers=headers(auth(auth_token)))
     assert response.status_code == 404
 
+    # try with a scope that doesn't exist
+    fake_scope = generate_uuid()
+    response = rest_client.put(f"/scopes/{random_account_factory()}/{fake_scope}", headers=headers(auth(auth_token)))
+    assert response.status_code == 404
+
 
 def test_list_scope_account_not_found(rest_client, auth_token):
     """ SCOPE (REST): send a GET list all scopes for a not existing account """
@@ -168,6 +188,16 @@ def test_list_scope_no_scopes(rest_client, auth_token):
     response = rest_client.get('/accounts/%s/scopes/' % acntusr, headers=headers(auth(auth_token)))
     assert response.status_code == 404
     assert response.headers.get('ExceptionClass') == 'ScopeNotFound'
+
+
+def test_list_scope_with_owner(rest_client, auth_token, scope_factory, vo, jdoe_account):
+    _, [scope] = scope_factory(vos=[vo], account_name=jdoe_account.external)
+
+    response = rest_client.get("/scopes/owner/", headers=headers(auth(auth_token)))
+    assert response.status_code == 200
+    out = loads(response.get_data(as_text=True))
+    assert scope.external in [s['scope'] for s in out]
+    assert jdoe_account.external in [s['account'] for s in out]
 
 
 class TestScopeClient:
@@ -225,11 +255,11 @@ class TestScopeClient:
             rucio_client.list_scopes_for_account(account)
 
     def test_update_scope(self, rucio_client, scope_factory, random_account_factory, vo):
-        scope, _ = scope_factory(vos=[vo])
+        _, [scope] = scope_factory(vos=[vo])
 
         new_account = random_account_factory()
         with db_session(DatabaseOperationType.READ) as session:
-            is_not_owner = not is_scope_owner(InternalScope(scope), new_account, session)
+            is_not_owner = not is_scope_owner(scope, new_account, session)
         assert is_not_owner
 
         not_real_scope = generate_uuid()
@@ -238,9 +268,19 @@ class TestScopeClient:
 
         not_real_account = generate_uuid()
         with pytest.raises(AccountNotFound):
-            rucio_client.update_scope(account=not_real_account, scope=scope)
+            rucio_client.update_scope(account=not_real_account, scope=scope.external)
 
-        rucio_client.update_scope(account=new_account.external, scope=scope)
+        rucio_client.update_scope(account=new_account.external, scope=scope.external)
         with db_session(DatabaseOperationType.READ) as session:
-            is_owner = is_scope_owner(InternalScope(scope), new_account, session)
+            is_owner = is_scope_owner(scope, new_account, session)
         assert is_owner
+
+    def test_list_scope_with_owner(self, rucio_client, scope_factory, jdoe_account, vo):
+        _, [scope] = scope_factory(vos=[vo], account_name=jdoe_account.external)
+        response = rucio_client.list_scopes()
+
+        assert isinstance(response, list)
+        assert isinstance(response[0], dict)
+
+        assert scope.external in [s['scope'] for s in response]
+        assert jdoe_account.external in [s['account'] for s in response]


### PR DESCRIPTION
Second pass at #8111 Closes #7830 

*Should* be compatible between server and client versions - introduces a new endpoint for the client to call, so old versions of the client will still just get the scope names back for the list. 