### PR TITLE
Add filter and caching to Open Data replica list; Fixes rucio#8215

### DIFF
--- a/etc/docker/test/extra/rucio_autotests_common.cfg
+++ b/etc/docker/test/extra/rucio_autotests_common.cfg
@@ -154,5 +154,8 @@ gcs = /opt/rucio/etc/google-cloud-storage-test.json
 idpsecrets = /opt/rucio/etc/idpsecrets.json
 admin_issuer = wlcg
 
+[opendata]
+rse_expression = OpenData=True
+
 [api]
 endpoints = accountlimits, accounts, archives, auth, config, credentials, dids, dirac, export, heartbeats, identities, import, lifetime_exceptions, locks, meta_conventions, ping, redirect, replicas, requests, rses, rules, scopes, subscriptions, traces, vos, opendata, opendata_public

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -316,8 +316,13 @@ def get_opendata_did_files(
         for file in files
     ]
 
+    rse_expression = config_get("opendata", "rse_expression", raise_exception=True)
+
     for i, file in enumerate(result):
-        replicas = list_replicas(dids=[{"scope": file["scope"], "name": file["name"]}], session=session)
+        replicas = list_replicas(
+            dids=[{"scope": file["scope"], "name": file["name"]}],
+            rse_expression=rse_expression, session=session
+        )
         uris = []
         for replica in replicas:
             pfns = replica["pfns"]

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -722,10 +722,15 @@ def _add_opendata_rule(
 
     rule_asynchronous = config_get_bool("opendata", "rule_asynchronous", raise_exception=False, default=False)
     rule_activity = config_get("opendata", "rule_activity", raise_exception=False, default=None)
-    rule_rse_expression = config_get("opendata", "rule_rse_expression", raise_exception=True)
     rule_account = config_get("opendata", "rule_account", raise_exception=False, default="root")
     rule_vo = config_get("opendata", "rule_vo", raise_exception=False, default=DEFAULT_VO)
     rule_copies = config_get_int("opendata", "rule_copies", raise_exception=False, default=1)
+
+    # The `rse_expression` can be defined either in the more specific `rule_rse_expression` (first choice, override)
+    # or in the more general `rse_expression` (second choice) in the [opendata] section of the config file.
+    rule_rse_expression = config_get("opendata", "rule_rse_expression", raise_exception=False, default=None)
+    if not rule_rse_expression:
+        rule_rse_expression = config_get("opendata", "rse_expression", raise_exception=True)
 
     add_rule_result = add_rule(
         dids=[{"scope": scope, "name": name}],

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -284,7 +284,7 @@ def get_opendata_did_files(
         session: "Session",
 ) -> dict[str, Any]:
     """
-    Retrieve the files associated with an Opendata DID.
+    Retrieve the files and replicas associated with an Opendata DID.
 
     Parameters:
         scope: The scope of the Opendata DID.
@@ -293,7 +293,7 @@ def get_opendata_did_files(
         session: SQLAlchemy session to use for the query.
 
     Returns:
-        A dictionary containing the list of files, cache hit status, and time elapsed in milliseconds.
+        A dictionary containing the list of files including replicas, cache hit status, and time elapsed in milliseconds.
     """
 
     time_start = time.perf_counter()
@@ -443,7 +443,7 @@ def get_opendata_did(
                     extensions.add(filename.split(".")[-1])
 
         result["files_summary"] = {
-            "count": len(result["files"]),
+            "length": len(result["files"]),
             "bytes": bytes_sum,
             "extensions": list(extensions),
             "replicas_missing": replicas_missing,


### PR DESCRIPTION
A new config parameter `rse_expression` has been added to the `opendata` section.

The `rule_rse_expression` used to define the rse expression for the automatic replication rules, will now fallback to the new `rse_expression` parameter when  `rule_rse_expression` is not defined.

The method to fetch file list for open data entries is now filtered on the open data rses according to this config variable and throws if its not defined. This method is now cached and provides additional info such as cache hit status and request elapsed time, which will be useful when assessing the impact of this method.

The tests have been adapted, because of the dependency on `rse_expression` to return files, I added this config parameter to the base config file for tests. Other specific configs such as open data rules are still added via calls.

Related docs PR: 
- https://github.com/rucio/documentation/pull/666