### PR TITLE
Rest&API: Use existing types to define enumerates in docstrings

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -420,7 +420,7 @@ class AccountParameter(ErrorHandlingMethodView):
                   type:
                     description: "The account type."
                     type: string
-                    enum: ["USER", "GROUP", "SERVICE"]
+                    $ref: "#/components/schemas/AccountType"
                   email:
                     description: "The email for the account."
                     type: string

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -128,9 +128,8 @@ class Scope(ErrorHandlingMethodView):
                         type: string
                         description: "The name of the DID."
                       type:
-                        type: string
                         description: "The type of the DID."
-                        enum: ['F', 'D', 'C', 'A', 'X', 'Y', 'Z']
+                        $ref: "#/components/schemas/DIDType"
                       parent:
                         type: string
                         description: "The parent of the DID."
@@ -183,8 +182,7 @@ class Search(ErrorHandlingMethodView):
           in: query
           description: "The DID type to search for."
           schema:
-            type: string
-            enum: ['all', 'collection', 'container', 'dataset', 'file']
+            $ref: "#/components/schemas/KeyType"
             default: 'collection'
         - name: limit
           in: query
@@ -326,8 +324,7 @@ class BulkDIDS(ErrorHandlingMethodView):
                       type: string
                     type:
                       description: "The type of the DID."
-                      type: string
-                      enum: ["F", "D", "C", "A", "X", "Y", "Z"]
+                      $ref: "#/components/schemas/DIDType"
                     account:
                       description: "The account associated with the DID."
                       type: string

--- a/lib/rucio/web/rest/flaskapi/v1/import.py
+++ b/lib/rucio/web/rest/flaskapi/v1/import.py
@@ -46,8 +46,7 @@ class Import(ErrorHandlingMethodView):
                       properties:
                         rse_type:
                           description: "The type of an rse."
-                          type: string
-                          enum: ['DISK', 'TAPE']
+                          $ref: "#/components/schemas/RSEType"
                   distances:
                     description: "Distances data with src rse name as key."
                     type: object
@@ -89,8 +88,7 @@ class Import(ErrorHandlingMethodView):
                             properties:
                               type:
                                 description: "The type of the identity."
-                                type: string
-                                enum: ['X509', 'GSS', 'USERPASS', 'SSH', 'SAML', 'OIDC']
+                                $ref: "#/components/schemas/IdentityType"
                               identity:
                                 description: "Identifier of the identity."
                                 type: string

--- a/lib/rucio/web/rest/flaskapi/v1/locks.py
+++ b/lib/rucio/web/rest/flaskapi/v1/locks.py
@@ -82,8 +82,7 @@ class LockByRSE(ErrorHandlingMethodView):
                         type: string
                       state:
                         description: "The state of the rule."
-                        type: string
-                        enum: ['R', 'O', 'S']
+                        $ref: "#/components/schemas/LockState"
                       length:
                         description: "The length of the rule."
                         type: integer
@@ -179,8 +178,7 @@ class LocksByScopeName(ErrorHandlingMethodView):
                         type: string
                       state:
                         description: "The state of the rule."
-                        type: string
-                        enum: ['R', 'O', 'S']
+                        $ref: "#/components/schemas/LockState"
                       length:
                         description: "The length of the rule."
                         type: integer
@@ -293,7 +291,7 @@ class DatasetLocksForDids(ErrorHandlingMethodView):
                       state:
                         description: "The state of the rule."
                         type: string
-                        enum: ['R', 'O', 'S']
+                        $ref: "#/components/schemas/LockState"
                       length:
                         description: "The length of the rule."
                         type: integer

--- a/lib/rucio/web/rest/flaskapi/v1/opendata.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata.py
@@ -288,9 +288,8 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
                   type: object
                   properties:
                     state:
-                      type: string
                       description: "New state for the DID."
-                      enum: ["draft", "public", "suspended"]
+                      $ref: "#/components/schemas/OpenDataDIDState"
                     meta:
                       type: object
                       description: "New metadata dictionary for the DID. Supports arbitrary JSON objects."

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -69,8 +69,7 @@ class RequestGet(ErrorHandlingMethodView):
                       type: string
                     request_type:
                       description: "The request type."
-                      type: string
-                      enum: ["T", "U", "D", "I", "O"]
+                      $ref: "#/components/schemas/RequestType"
                     scope:
                       description: "The scope of the transfer."
                       type: string
@@ -91,8 +90,7 @@ class RequestGet(ErrorHandlingMethodView):
                       type: string
                     state:
                       description: "The state of the request."
-                      type: string
-                      enum: ["Q", "G", "S", "F", "D", "L", "N", "O", "A", "M", "U", "W", "P"]
+                      $ref: "#/components/schemas/RequestState"
                     external_id:
                       description: "External id of the request."
                       type: string
@@ -234,8 +232,7 @@ class RequestHistoryGet(ErrorHandlingMethodView):
                       type: string
                     request_type:
                       description: "The request type."
-                      type: string
-                      enum: ["T", "U", "D", "I", "O"]
+                      $ref: "#/components/schemas/RequestType"
                     scope:
                       description: "The scope of the transfer."
                       type: string
@@ -256,8 +253,7 @@ class RequestHistoryGet(ErrorHandlingMethodView):
                       type: string
                     state:
                       description: "The state of the request."
-                      type: string
-                      enum: ["Q", "G", "S", "F", "D", "L", "N", "O", "A", "M", "U", "W", "P"]
+                      $ref: "#/components/schemas/RequestState"
                     external_id:
                       description: "External id of the request."
                       type: string
@@ -431,8 +427,7 @@ class RequestList(ErrorHandlingMethodView):
                         type: string
                       request_type:
                         description: "The request type."
-                        type: string
-                        enum: ["T", "U", "D", "I", "O"]
+                        $ref: "#/components/schemas/RequestType"
                       scope:
                         description: "The scope of the transfer."
                         type: string
@@ -453,8 +448,7 @@ class RequestList(ErrorHandlingMethodView):
                         type: string
                       state:
                         description: "The state of the request."
-                        type: string
-                        enum: ["Q", "G", "S", "F", "D", "L", "N", "O", "A", "M", "U", "W", "P"]
+                        $ref: "#/components/schemas/RequestState"
                       external_id:
                         description: "External id of the request."
                         type: string
@@ -670,8 +664,7 @@ class RequestHistoryList(ErrorHandlingMethodView):
                         type: string
                       request_type:
                         description: "The request type."
-                        type: string
-                        enum: ["T", "U", "D", "I", "O"]
+                        $ref: "#/components/schemas/RequestType"
                       scope:
                         description: "The scope of the transfer."
                         type: string
@@ -692,8 +685,7 @@ class RequestHistoryList(ErrorHandlingMethodView):
                         type: string
                       state:
                         description: "The state of the request."
-                        type: string
-                        enum: ["Q", "G", "S", "F", "D", "L", "N", "O", "A", "M", "U", "W", "P"]
+                        $ref: "#/components/schemas/RequestState"
                       external_id:
                         description: "External id of the request."
                         type: string

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -243,8 +243,7 @@ class RSE(ErrorHandlingMethodView):
                     type: string
                   rse_type:
                     description: "The rse type."
-                    type: string
-                    enum: ["DISK", "TAPE"]
+                    $ref: "#/components/schemas/RSEType"
                   latitude:
                     description: "The latitude of the RSE."
                     type: number
@@ -384,8 +383,7 @@ class RSE(ErrorHandlingMethodView):
                     type: string
                   rse_type:
                     description: "The rse type."
-                    type: string
-                    enum: ["DISK", "TAPE"]
+                    $ref: "#/components/schemas/RSEType"
                   latitude:
                     description: "The latitude of the RSE."
                     type: number
@@ -478,8 +476,8 @@ class RSE(ErrorHandlingMethodView):
                       type: string
                     rse_type:
                       description: "The rse type."
-                      type: string
-                      enum: ["DISK", "TAPE"]
+                      $ref: "#/components/schemas/RSEType"
+
                     latitude:
                       description: "The latitude of the RSE."
                       type: number
@@ -728,8 +726,7 @@ class ProtocolList(ErrorHandlingMethodView):
                       type: string
                     rse_type:
                       description: "The rse type."
-                      type: string
-                      enum: ["DISK", "TAPE"]
+                      $ref: "#/components/schemas/RSEType"
                     availability_read:
                       description: "The read availability of the RSE."
                       type: boolean
@@ -1064,8 +1061,8 @@ class Protocol(ErrorHandlingMethodView):
                       type: string
                     rse_type:
                       description: "The rse type."
-                      type: string
-                      enum: ["DISK", "TAPE"]
+                      $ref: "#/components/schemas/RSEType"
+
                     availability_read:
                       description: "The read availability of the RSE."
                       type: boolean
@@ -1228,8 +1225,8 @@ class Protocol(ErrorHandlingMethodView):
                       type: string
                     rse_type:
                       description: "The rse type."
-                      type: string
-                      enum: ["DISK", "TAPE"]
+                      $ref: "#/components/schemas/RSEType"
+
                     availability_read:
                       description: "The read availability of the RSE."
                       type: boolean

--- a/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
+++ b/lib/rucio/web/rest/flaskapi/v1/subscriptions.py
@@ -78,8 +78,7 @@ class Subscription(ErrorHandlingMethodView):
                         type: integer
                       state:
                         description: "The state of the subscription."
-                        type: string
-                        enum: ["A", "I", "N", "U", "B"]
+                        $ref: "#/components/schemas/SubscriptionState"
                       last_processed:
                         description: "The time the subscription was processed last."
                         type: string
@@ -172,8 +171,8 @@ class Subscription(ErrorHandlingMethodView):
                         type: integer
                       state:
                         description: "The state of the subscription. If not supplied, the state will be set to 'U' (updated)."
-                        type: string
-                        enum: ["A", "I", "N", "U", "B"]
+                        $ref: "#/components/schemas/SubscriptionState"
+
         responses:
           201:
             description: "OK"
@@ -371,8 +370,7 @@ class SubscriptionName(ErrorHandlingMethodView):
                         type: integer
                       state:
                         description: "The state of the subscription."
-                        type: string
-                        enum: ["A", "I", "N", "U", "B"]
+                        $ref: "#/components/schemas/SubscriptionState"
                       last_processed:
                         description: "The time the subscription was processed last."
                         type: string
@@ -519,8 +517,7 @@ class States(ErrorHandlingMethodView):
                         type: string
                       state:
                         description: "The state of the rules."
-                        type: string
-                        enum: ["R", "O", "S", "U", "W", "I"]
+                        $ref: "#/components/schemas/RuleState"
                       count:
                         description: "The number of rules with that state."
                         type: integer
@@ -582,8 +579,7 @@ class SubscriptionId(ErrorHandlingMethodView):
                       type: integer
                     state:
                       description: "The state of the subscription."
-                      type: string
-                      enum: ["A", "I", "N", "U", "B"]
+                      $ref: "#/components/schemas/SubscriptionState"
                     last_processed:
                       description: "The time the subscription was processed last."
                       type: string


### PR DESCRIPTION
Closes https://github.com/rucio/documentation/issues/587

Paired with https://github.com/rucio/documentation/pull/665

An example of the rendered documentation: 

<img width="706" height="135" alt="image" src="https://github.com/user-attachments/assets/ebd44225-faaf-4609-aa7a-c6f83c836b68" />
