### PR TITLE
Revert "Common: Change didtype to explicitly use scope extraction policy #7979"

### DIFF
--- a/lib/rucio/common/didtype.py
+++ b/lib/rucio/common/didtype.py
@@ -15,12 +15,10 @@
 """
 DID type to represent a DID and to simplify operations on it
 """
-import logging
-from configparser import NoSectionError
+
 from typing import Any, Union
 
-from rucio.common.exception import ConfigNotFound, DIDError, InvalidAlgorithmName
-from rucio.common.utils import extract_scope
+from rucio.common.exception import DIDError
 
 
 class DID:
@@ -128,20 +126,15 @@ class DID:
         Construct the DID from a string.
         :param did: string containing the DID information
         """
-        try:
-            self.scope, self.name = extract_scope(did)
-        except (ImportError, InvalidAlgorithmName, ConfigNotFound, NoSectionError) as e:  # Only use when the policy can not be found
-            logging.debug("Failure using extract_scope policy for '%s': %s - Using fallback." % (did, type(e).__name__))
-            did_parts = did.split(DID.SCOPE_SEPARATOR, 1)
-            if len(did_parts) == 1:
-                self.name = did
-                self._update_implicit_scope()
-                if not self.has_scope():
-                    error = f"Could not parse scope from did string {did} - fallback policy expects only one '{DID.SCOPE_SEPARATOR}'"
-                    raise DIDError(error)
-            else:
-                self.scope = did_parts[0]
-                self.name = did_parts[1]
+        did_parts = did.split(DID.SCOPE_SEPARATOR, 1)
+        if len(did_parts) == 1:
+            self.name = did
+            self._update_implicit_scope()
+            if not self.has_scope():
+                raise DIDError('Object construction from non-splitable string is ambigious')
+        else:
+            self.scope = did_parts[0]
+            self.name = did_parts[1]
 
     def _did_from_dict(self, did: dict[str, str]) -> None:
         """

--- a/tests/rucio/common/test_didtype.py
+++ b/tests/rucio/common/test_didtype.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import pytest
 
 from rucio.common.didtype import DID
@@ -63,6 +62,10 @@ class TestDIDType:
     def test_did_type_success(self, input_did, expected_scope, expected_name):
         assert input_did.scope == expected_scope
         assert input_did.name == expected_name
+
+    def test_non_implicit_single_string(self):
+        with pytest.raises(DIDError, match='Error using DID type\nDetails: Object construction from non-splitable string is ambigious'):
+            DID('non.implicit.single.string')
 
     def test_copy(self):
         x = DID('test.scope:test.name')


### PR DESCRIPTION
This reverts commit 21310c8b97ad23b4a710aa400aa531e9d0aa165a.

<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->

Fixes #8223 

Re-opens #7979 
