### PR TITLE
Default permission policies: handle sign-url account attribute

### DIFF
--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -1083,7 +1083,7 @@ def perm_get_signed_url(issuer: "InternalAccount", kwargs: dict[str, Any], sessi
     :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='sign-url', session=session)
 
 
 def perm_add_bad_pfns(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:

--- a/lib/rucio/core/permission/generic_multi_vo.py
+++ b/lib/rucio/core/permission/generic_multi_vo.py
@@ -1052,7 +1052,7 @@ def perm_get_signed_url(issuer, kwargs, session: "Session"):
     :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='sign-url', session=session)
 
 
 def perm_add_bad_pfns(issuer, kwargs, session: "Session"):


### PR DESCRIPTION
This PR fixes the default permission policies to take into account the `sign-url` account attribute. As explained in the [issue](#8235), the original name `sign-gcs` doesn't make obvious what it is intended for. As it has never been used into default permission policies (or elsewhere in the standard code), this change is not considered a backward-compatibility issue and will have no impact on existing, non-default, permission policies.

## Checklist
- [x] Created issue: #8235
- [ ] Added tests
- [x] Updated documentation (https://github.com/rucio/documentation/pull/797)
- [ ] Added database migrations - not needed
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>