### PR TITLE
Release management: .gitignore, use *.egg-info so that the webUI egg-info is also matched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ userkey.pem
 
 # ignore MANIFEST file
 MANIFEST
-lib/rucio_clients.egg-info
 
 # build directories
 .coverage
@@ -42,10 +41,10 @@ build/
 covhtml
 dist/
 examples/whip/results/
-lib/rucio.egg-info/
 cache/
 changed_files.txt
 docs/
+*.egg-info
 
 # Backup and temp files
 *.log
@@ -54,7 +53,6 @@ docs/
 *~
 .venv
 lib/rucio/vcsversion.py
-rucio.egg-info
 pylint.out
 
 # Mac OS X Finder


### PR DESCRIPTION
The webUI egg-info is created when building the web UI package via the `build_sdist_wheel.sh` script, but it is not matched by the `.gitignore` right now, though it should.