### PR TITLE
Tooling: Replace Flake8 with Ruff and update related configurations; Fixes rucio#8264

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -55,7 +55,7 @@ jobs:
         id: count_updated
         shell: bash
         run: |
-          pip install flake8 flake8-annotations
+          pip install ruff
           source tools/count_missing_type_annotations_utils.sh
           create_missing_python_type_annotations_report ${{ env.UPDATED_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE }}
           echo "The current number of missing python type annotations: $(wc -l < ${{ env.UPDATED_PYTHON_TYPE_ANNOTATIONS_REPORT_FILE }})"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,6 @@ repos:
   hooks:
   - id: end-of-file-fixer
   - id: trailing-whitespace
-- repo: https://github.com/PyCQA/flake8
-  rev: 7.1.1
-  hooks:
-  - id: flake8
 - repo: local
   hooks:
   - id: add-header

--- a/pyproject.server.toml
+++ b/pyproject.server.toml
@@ -96,7 +96,6 @@ dev = [
     'pytest-xdist',
     'pytest-cov',
     'pyflakes',
-    'flake8',
     'pylint',
     'isort',
     'xmltodict',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ dev = [
     'pytest-xdist',
     'pytest-cov',
     'pyflakes',
-    'flake8',
     'pylint',
     'isort',
     'xmltodict',

--- a/setuputil.py
+++ b/setuputil.py
@@ -48,7 +48,6 @@ dev_requirements = [
     'pytest-xdist',
     'pytest-cov',
     'pyflakes',
-    'flake8',
     'pylint',
     'isort',
     'xmltodict',

--- a/tools/count_missing_type_annotations_utils.sh
+++ b/tools/count_missing_type_annotations_utils.sh
@@ -46,13 +46,17 @@ create_missing_python_type_annotations_report() {
     # This does not include tests, tools, database and bin files.
     # :param $1: The name of the output file.
 
-    flake8 lib/rucio \
-        --ignore=ANN101 \
-        --exclude tools,lib/rucio/db,lib/rucio/client,lib/rucio/common,lib/rucio/rse,bin \
-        --output-file $1 \
-        --select ANN || true
+    ruff check lib/rucio \
+        --select ANN \
+        --output-format concise \
+        --extend-exclude tools \
+        --extend-exclude lib/rucio/db \
+        --extend-exclude lib/rucio/client \
+        --extend-exclude lib/rucio/common \
+        --extend-exclude lib/rucio/rse \
+        --extend-exclude bin \
+        --output-file $1 || true
 }
 
 
-ensure_install "flake8"
-ensure_install "flake8-annotations"
+ensure_install "ruff"


### PR DESCRIPTION
Handles rucio#8264

Since rule `ANN101` is no longer considered (and ignoring it has no effect), I removed it.

With this change, several # NOQA become obsolete so we can remove them. Starting with those maybe: https://github.com/rucio/rucio/issues/8263 