### PR TITLE
Tooling: Update `flake8-type-checking` code to use 'TC' instead of 'TCH' in `pyproject.toml`; rucio#8266

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ select = [
     "I",    # isort
     "N",    # pep8-naming
     "S",    # bandit
-    "TCH",  # flake8-type-checking
+    "TC",   # flake8-type-checking
     "UP",   # pyupgrade
     "TID",  # flake8-tidy-imports
     "PLE",  # pylint


### PR DESCRIPTION
Handles rucio#8266