### PR TITLE
CI: remove unneeded provider from fts3restconfig #8280

### DIFF
--- a/etc/docker/dev/fts/fts3restconfig
+++ b/etc/docker/dev/fts/fts3restconfig
@@ -24,11 +24,6 @@ OAuth2 = True
 pool_timeout=10
 pool_size=10
 
-[providers]
-provider1 = https://indigoiam/
-provider1_ClientId = d6dad80f-11f7-4cf4-a4ef-fbd081ec7f98
-provider1_ClientSecret = AJWL5JZtM6I2iaj7XHYq98kPGo6-8Wde2ScSHJhHNvCLeKppTj9fBmeq2xGWi3RCFlj6cPJFjz-BxXIBva4kDYo
-
 [roles]
 Public = vo:transfer;all:datamanagement
 lcgadmin = all:config


### PR DESCRIPTION
the clientID and client_secret are present in FTS DB: https://github.com/rucio/rucio/blob/master/etc/docker/dev/fts/entrypoint.sh#L26
FTS3 looks into DB directly for those. So remove it from config.


References:
https://fts3-docs.web.cern.ch/fts3-docs/docs/install/token_configuration.html#add-tokenprovider-information-to-the-database
"The FTS Token daemons read the TokenProvider configuration via the database (t_token_provider table)."

