### PR TITLE
Client: Add version markers POC for v38-39 functions #8157

### DIFF
--- a/lib/rucio/client/configclient.py
+++ b/lib/rucio/client/configclient.py
@@ -160,7 +160,13 @@ class ConfigClient(BaseClient):
 
         Returns
         -------
-            True if option was removed successfully.
+            True :
+                if option was removed successfully.
+
+
+        Note:
+        -----
+        Added in version 39.0.0
         """
         path = '/'.join([self.CONFIG_BASEURL, section])
         url = build_url(choice(self.list_hosts), path=path)

--- a/lib/rucio/client/opendataclient.py
+++ b/lib/rucio/client/opendataclient.py
@@ -46,6 +46,10 @@ class OpenDataClient(BaseClient):
 
         Returns:
             The Opendata host URL.
+
+        Note:
+        -----
+        Added in version 38.0.0
         """
 
         if public and self.opendata_host_from_config is not None:
@@ -72,6 +76,10 @@ class OpenDataClient(BaseClient):
         Raises:
             ValueError: If both `state` and `public=True` are provided.
             Exception: If the request fails or the server returns an error.
+
+        Note:
+        -----
+        Added in version 38.0.0
         """
 
         base_url = self.opendata_public_dids_base_url if public else self.opendata_private_dids_base_url
@@ -111,6 +119,10 @@ class OpenDataClient(BaseClient):
 
         Raises:
             Exception: If the request fails or the server returns an error.
+
+        Note:
+        -----
+        Added in version 38.0.0
         """
 
         path = '/'.join([self.opendata_private_dids_base_url, quote_plus(scope), quote_plus(name)])
@@ -142,6 +154,10 @@ class OpenDataClient(BaseClient):
 
         Raises:
             Exception: If the request fails or the server returns an error.
+
+        Note:
+        -----
+        Added in version 38.0.0
         """
 
         path = '/'.join([self.opendata_private_dids_base_url, quote_plus(scope), quote_plus(name)])
@@ -182,6 +198,10 @@ class OpenDataClient(BaseClient):
         Raises:
             ValueError: If none of 'meta', 'state', or 'doi' are provided.
             Exception: If the request fails or the server returns an error.
+
+        Note:
+        -----
+        Added in version 38.0.0
         """
 
         path = '/'.join([self.opendata_private_dids_base_url, quote_plus(scope), quote_plus(name)])
@@ -238,6 +258,10 @@ class OpenDataClient(BaseClient):
         Returns:
             A dictionary containing metadata about the specified DID.
             May include file list, extended metadata, and DOI details depending on the parameters.
+
+        Note:
+        -----
+        Added in version 38.0.0
         """
 
         base_url = self.opendata_public_dids_base_url if public else self.opendata_private_dids_base_url

--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -158,6 +158,10 @@ class RequestClient(BaseClient):
         """Returns all the transfer limits
 
         :returns: transfer limits
+
+        Note:
+        -----
+        Added in version 38.0.0
         """
         path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -194,6 +198,10 @@ class RequestClient(BaseClient):
         :param waitings: Current number of waiting transfers
 
         :returns: True if the transfer limit was deleted
+
+        Note:
+        -----
+        Added in version 38.0.0
         """
         path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
         url = build_url(choice(self.list_hosts), path=path)
@@ -221,6 +229,10 @@ class RequestClient(BaseClient):
         :param direction: The direction in which this limit applies (source/destination)
 
         :returns: True if the transfer limit was deleted
+
+        Note:
+        -----
+        Added in version 38.0.0
         """
         path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
         url = build_url(choice(self.list_hosts), path=path)

--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -198,6 +198,11 @@ class SubscriptionClient(BaseClient):
         ------
         NotFound
             If subscription is not found
+
+
+        Note:
+        -----
+        Added in version 38.0.0
         """
         if not account:
             account = self.account


### PR DESCRIPTION
## Summary
This PR adds numpy-style docstrings with version annotations for client API functions added in v38-39, as described in #8157.

## Approach
Marked 11 functions added in v38-39 using pure numpy-style format:
- Added 'Notes' sections with version information
- Used format compatible with mkdocstrings
- Verified rendering in documentation build system

## Methodology
To ensure accuracy, I used:
1. **`git log -G "def function_name"`** - Traces the exact commit where the function signature was introduced
2. **`git describe --contains --tags`** - Maps the introduction commit to its first official semantic release
3. **Cross-tag validation** - Confirms the function didn't exist in the previous release tag to eliminate false positives from refactors

This approach distinguishes true function additions from refactors or moves.

## Functions Marked

**v38.0.0 (10 functions):**
- `opendataclient.py`: 6 functions (open data management)
  - `get_opendata_host`, `list_opendata_dids`, `add_opendata_did`, `remove_opendata_did`, `update_opendata_did`, `get_opendata_did`
- `requestclient.py`: 3 functions (transfer limits)
  - `list_transfer_limits`, `set_transfer_limit`, `delete_transfer_limit`
- `subscriptionclient.py`: 1 function
  - `deactivate_subscription`

**v39.0.0 (1 function):**
- `configclient.py`: 1 function
  - `delete_config_section`

## Research Notes
- Initially investigated `didclient.py` per mentor suggestion, but found no new functions in v36-39 range (all functions date to v0.1.7 - v1.27.0, stable core module)
- Pivoted to audit entire client library for actual v36-39 additions
- Could not find any public functions added for v37
- Found 11 total new functions in v38-39

## Documentation Format

**Example numpy-style format:**
```python
def function_name():
    """
    Description...
    
    Note
    ----
    Added in version 38.0.0
    """