### PR TITLE
Policies: don't fail silently if policy package doesn't load #7962

### DIFF
--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -57,8 +57,12 @@ if not multivo:
         package_module = importlib.import_module(policy)
         check_policy_module_version(package_module)
         policy = policy + ".permission"
-    except (NoOptionError, NoSectionError, ModuleNotFoundError):
+    except (NoOptionError, NoSectionError):
         policy = 'rucio.core.permission.' + fallback_policy.lower()
+    except ModuleNotFoundError:
+        raise exception.PolicyPackageNotFound(policy)
+    except ImportError:
+        raise exception.ErrorLoadingPolicyPackage(policy)
 
     try:
         module = importlib.import_module(policy)
@@ -91,8 +95,12 @@ def load_permission_for_vo(vo: str) -> None:
         package_module = importlib.import_module(policy)
         check_policy_module_version(package_module)
         policy = policy + ".permission"
-    except (NoOptionError, NoSectionError, ModuleNotFoundError):
+    except (NoOptionError, NoSectionError):
         policy = 'rucio.core.permission.' + generic_fallback.lower()
+    except ModuleNotFoundError:
+        raise exception.PolicyPackageNotFound(policy)
+    except ImportError:
+        raise exception.ErrorLoadingPolicyPackage(policy)
 
     try:
         module = importlib.import_module(policy)


### PR DESCRIPTION
This modifies the code that loads schema and permission modules from policy packages to throw an exception if the configured policy package cannot be loaded. Previously this would silently fail.