### PR TITLE
Testing: Remove Code Coverage Display

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,9 +37,4 @@ jobs:
             run: pip install -r requirements/requirements.dev.txt
 
           - name: Run unit tests
-            run: pytest tests/rucio --cov=lib/rucio
-
-          - name: Upload coverage reports to Codecov
-            uses: codecov/codecov-action@v5.5.2
-            with:
-              token: ${{ secrets.CODECOV_TOKEN }}
+            run: pytest tests/rucio


### PR DESCRIPTION
This removes the code coverage upload within the unit test workflow. Addresses https://github.com/rucio/rucio/issues/6545#issuecomment-3728910317

@maany maybe you can comment on whether we need the unit test workflow. I didn't see any other workflow run tests on Python 3.11 and 3.12. I left the workflow in for now, because it takes about a minute per Python version to complete.