### PR TITLE
gateway: validate SubscriptionState in update_subscription #7820

### DIFF
--- a/lib/rucio/gateway/subscription.py
+++ b/lib/rucio/gateway/subscription.py
@@ -133,7 +133,11 @@ def update_subscription(
                     for rule in metadata['replication_rules']:
                         validate_schema(name='activity', obj=rule.get('activity', 'default'), vo=vo)
             if 'state' in metadata and metadata['state'] is not None:
-                metadata['state'] = SubscriptionState(metadata['state'])
+                try:
+                    metadata['state'] = SubscriptionState(metadata['state'])
+                except ValueError as err:
+                    msg = f"Invalid subscription state: {metadata['state']}"
+                    raise InvalidObject(msg) from err
 
         except ValueError as error:
             raise TypeError(error)

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -187,6 +187,34 @@ class TestSubscriptionCoreGateway:
         with pytest.raises(SubscriptionNotFound):
             update_subscription(name=subscription_name, account='root', metadata={'filter': {'project': ['toto', ]}}, issuer='root', vo=vo)
 
+    def test_update_subscription_invalid_state(self, vo, rse_factory):
+        """ SUBSCRIPTION (Gateway): Invalid subscription state should raise InvalidObject """
+        subscription_name = uuid()
+        rse1, _ = rse_factory.make_mock_rse()
+
+        add_subscription(
+            name=subscription_name,
+            account='root',
+            filter_={'project': self.projects},
+            replication_rules=[{'rse_expression': rse1, 'copies': 1, 'activity': self.activity}],
+            lifetime=100000,
+            retroactive=False,
+            dry_run=False,
+            comments='test',
+            issuer='root',
+            vo=vo
+        )
+
+        # try to update with an invalid state
+        with pytest.raises(InvalidObject):
+            update_subscription(
+                name=subscription_name,
+                account='root',
+                metadata={'state': 'NOT_A_REAL_STATE'},
+                issuer='root',
+                vo=vo
+            )
+
     def test_list_rules_states(self, vo, rse_factory, root_account):
         """ SUBSCRIPTION (Gateway): Test listing of rule states for subscription """
         tmp_scope = InternalScope('mock_' + uuid()[:8], vo=vo)


### PR DESCRIPTION
### Description
Validate the `SubscriptionState` passed in `update_subscription` by catching `ValueError` and returning a proper gateway-level exception instead of letting the raw exception propagate.

### Motivation
The gateway currently assumes that the client always passes a valid `SubscriptionState`. This change makes the validation explicit and improves error handling for invalid input.

Fixes #7820