### PR TITLE
Testing: Fix judge evaluator test flakiness

### DIFF
--- a/tests/test_judge_evaluator.py
+++ b/tests/test_judge_evaluator.py
@@ -387,7 +387,7 @@ class TestJudgeEvaluator:
             assert len(get_replica_locks(scope=file['scope'], name=file['name'])) == 2
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=5)
+@pytest.mark.noparallel(reason="side-effects due to running judge evaluator")
 def test_judge_double_rule_on_container(
     did_factory: "TemporaryDidFactory",
     rse_factory: "TemporaryRSEFactory",
@@ -467,7 +467,7 @@ def test_judge_double_rule_on_container(
         assert all([lock["state"] == LockState.OK for lock in locks])  # all OK
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=5)
+@pytest.mark.noparallel(reason="side-effects due to running judge evaluator")
 def test_judge_double_container_with_existing_rule(
     did_factory: "TemporaryDidFactory",
     rse_factory: "TemporaryRSEFactory",


### PR DESCRIPTION
Replace flaky marking for tests

- test_judge_double_rule_on_container
- test_judge_double_container_with_existing_rule

with noparallel, like all other judge evaluator tests in the file.
I have made 12 test runs on GH actions using this fix without failure.