### PR TITLE
fix(API): Reject invalid GUID with proper error #8341

### DIFF
--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -358,6 +358,15 @@ class TestDIDGateway:
         with pytest.raises(InvalidObject):
             list(did.get_dataset_by_guid('foo', vo=vo))
 
+    def test_list_dids_with_invalid_guid(self, vo):
+    with pytest.raises(InvalidObject):
+        list(did.list_dids(
+            scope='test',
+            filters=[{'guid': 'foo'}],
+            did_type='file',
+            vo=vo
+        ))
+
 
 class TestDIDClients:
 

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 import pytest
 
 from rucio.common import exception
-from rucio.common.exception import DataIdentifierAlreadyExists, DataIdentifierNotFound, DuplicateContent, FileAlreadyExists, FileConsistencyMismatch, InvalidPath, ScopeNotFound, UnsupportedOperation, UnsupportedStatus
+from rucio.common.exception import DataIdentifierAlreadyExists, DataIdentifierNotFound, DuplicateContent, FileAlreadyExists, FileConsistencyMismatch, InvalidPath, ScopeNotFound, UnsupportedOperation, UnsupportedStatus, InvalidObject 
 from rucio.common.types import InternalScope
 from rucio.common.utils import generate_uuid
 from rucio.core.did import (
@@ -353,6 +353,10 @@ class TestDIDGateway:
         assert st
         with pytest.raises(DataIdentifierNotFound):
             did.set_new_dids([{'scope': 'dummyscope', 'name': 'dummyname', 'did_type': DIDType.DATASET}], None, vo=vo)
+
+    def test_get_dataset_by_guid_invalid_guid(self, vo):
+        with pytest.raises(InvalidObject):
+            list(did.get_dataset_by_guid('foo', vo=vo))
 
 
 class TestDIDClients:


### PR DESCRIPTION
Closes: #8341
**Problem**:
When users provide malformed GUID strings to `get_dataset_by_guid()` or `list_dids()`, the API returns a generic 500 error with no useful information instead of a clear validation error.

**Changes**:
Added GUID validation using uuid.UUID() to check format before processing. Raises InvalidObject exception with a clear error message when the GUID is malformed
<!-- Please read https://rucio.cern.ch/documentation/contributing before submitting a pull request -->
