### PR TITLE
Core: account and account_limit, migrate away from session decorators, pass session as required parameter, fix type annotations

### DIFF
--- a/lib/rucio/core/account.py
+++ b/lib/rucio/core/account.py
@@ -29,7 +29,7 @@ from rucio.common.constants import DEFAULT_VO
 from rucio.core.vo import vo_exists
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import AccountStatus, AccountType
-from rucio.db.sqla.session import stream_session, transactional_session
+from rucio.db.sqla.session import stream_session
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
@@ -39,12 +39,10 @@ if TYPE_CHECKING:
     from rucio.common.types import AccountAttributesDict, AccountDict, AccountUsageModelDict, IdentityDict, InternalAccount, UsageDict
 
 
-@transactional_session
 def add_account(
     account: "InternalAccount",
     type_: AccountType,
     email: Optional[str],
-    *,
     session: "Session"
 ) -> None:
     """ Add an account with the given account name and type.
@@ -114,10 +112,8 @@ def get_account(
     return result
 
 
-@transactional_session
 def del_account(
     account: "InternalAccount",
-    *,
     session: "Session"
 ) -> None:
     """ Disable an account with the given account name.
@@ -139,12 +135,10 @@ def del_account(
     query_result.update({'status': AccountStatus.DELETED, 'deleted_at': datetime.utcnow()})
 
 
-@transactional_session
 def update_account(
     account: "InternalAccount",
     key: str,
     value: Any,
-    *,
     session: "Session"
 ) -> None:
     """ Update a property of an account.
@@ -332,12 +326,10 @@ def has_account_attribute(
     return session.execute(query).scalar() is not None
 
 
-@transactional_session
 def add_account_attribute(
     account: "InternalAccount",
     key: str,
     value: Any,
-    *,
     session: "Session"
 ) -> None:
     """
@@ -374,11 +366,9 @@ def add_account_attribute(
         raise exception.RucioException(str(format_exc()))
 
 
-@transactional_session
 def del_account_attribute(
     account: "InternalAccount",
     key: str,
-    *,
     session: "Session"
 ) -> None:
     """

--- a/lib/rucio/core/account.py
+++ b/lib/rucio/core/account.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 def add_account(
     account: "InternalAccount",
     type_: AccountType,
-    email: str,
+    email: Optional[str],
     *,
     session: "Session"
 ) -> None:

--- a/lib/rucio/core/account.py
+++ b/lib/rucio/core/account.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from enum import Enum
 from re import match
 from traceback import format_exc
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from sqlalchemy import and_, select
 from sqlalchemy.exc import IntegrityError
@@ -29,7 +29,7 @@ from rucio.common.constants import DEFAULT_VO
 from rucio.core.vo import vo_exists
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import AccountStatus, AccountType
-from rucio.db.sqla.session import read_session, stream_session, transactional_session
+from rucio.db.sqla.session import stream_session, transactional_session
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
@@ -71,10 +71,8 @@ def add_account(
         raise exception.Duplicate('Account ID \'%s\' already exists!' % account)
 
 
-@read_session
 def account_exists(
     account: "InternalAccount",
-    *,
     session: "Session"
 ) -> bool:
     """ Checks to see if account exists and is active.
@@ -93,10 +91,8 @@ def account_exists(
     return session.execute(query).scalar() is not None
 
 
-@read_session
 def get_account(
-    account: "InternalAccount",
-    *,
+    account: Union["InternalAccount", str],
     session: "Session"
 ) -> models.Account:
     """ Returns an account for the given account name.
@@ -243,10 +239,8 @@ def list_accounts(
         yield {'account': account, 'type': account_type, 'email': email}
 
 
-@read_session
 def list_identities(
     account: "InternalAccount",
-    *,
     session: "Session"
 ) -> list["IdentityDict"]:
     """
@@ -283,10 +277,8 @@ def list_identities(
     return [row._asdict() for row in session.execute(query)]  # type: ignore (pending SQLA2.1: https://github.com/rucio/rucio/discussions/6615)
 
 
-@read_session
 def list_account_attributes(
     account: "InternalAccount",
-    *,
     session: "Session"
 ) -> list["AccountAttributesDict"]:
     """
@@ -317,11 +309,9 @@ def list_account_attributes(
     return [row._asdict() for row in session.execute(query)]  # type: ignore (pending SQLA2.1: https://github.com/rucio/rucio/discussions/6615)
 
 
-@read_session
 def has_account_attribute(
     account: "InternalAccount",
     key: str,
-    *,
     session: "Session"
 ) -> bool:
     """
@@ -410,11 +400,9 @@ def del_account_attribute(
     aid.delete(session=session)
 
 
-@read_session
 def get_usage(
     rse_id: str,
     account: "InternalAccount",
-    *,
     session: "Session"
 ) -> "UsageDict":
     """
@@ -439,10 +427,8 @@ def get_usage(
         return {'bytes': 0, 'files': 0, 'updated_at': None}
 
 
-@read_session
 def get_all_rse_usages_per_account(
     account: "InternalAccount",
-    *,
     session: "Session"
 ) -> list["AccountUsageModelDict"]:
     """
@@ -464,11 +450,9 @@ def get_all_rse_usages_per_account(
         return []
 
 
-@read_session
 def get_usage_history(
     rse_id: str,
     account: "InternalAccount",
-    *,
     session: "Session"
 ) -> list["UsageDict"]:
     """

--- a/lib/rucio/core/account.py
+++ b/lib/rucio/core/account.py
@@ -29,7 +29,6 @@ from rucio.common.constants import DEFAULT_VO
 from rucio.core.vo import vo_exists
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import AccountStatus, AccountType
-from rucio.db.sqla.session import stream_session
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
@@ -168,16 +167,14 @@ def update_account(
         query_result.update({key: value})
 
 
-@stream_session
 def list_accounts(
+    session: "Session",
     filter_: Optional["Mapping[str, Any]"] = None,
-    *,
-    session: "Session"
 ) -> "Iterator[AccountDict]":
     """ Returns a list of all account names.
 
-    :param filter_: Dictionary of attributes by which the input data should be filtered
     :param session: the database session in use.
+    :param filter_: Dictionary of attributes by which the input data should be filtered
 
     returns: a list of all account names.
     """

--- a/lib/rucio/core/account_limit.py
+++ b/lib/rucio/core/account_limit.py
@@ -24,7 +24,7 @@ from rucio.core.account import account_exists, get_all_rse_usages_per_account
 from rucio.core.rse import get_rse_name
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.db.sqla import models
-from rucio.db.sqla.session import read_session, transactional_session
+from rucio.db.sqla.session import transactional_session
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -34,8 +34,7 @@ if TYPE_CHECKING:
     from rucio.common.types import InternalAccount, RSEAccountUsageDict, RSEGlobalAccountUsageDict, RSELocalAccountUsageDict, RSEResolvedGlobalAccountLimitDict
 
 
-@read_session
-def get_rse_account_usage(rse_id: str, *, session: "Session") -> list["RSEAccountUsageDict"]:
+def get_rse_account_usage(rse_id: str, session: "Session") -> list["RSEAccountUsageDict"]:
     """
     Returns the account limit and usage for all accounts on a RSE.
 
@@ -94,12 +93,10 @@ def get_rse_account_usage(rse_id: str, *, session: "Session") -> list["RSEAccoun
     return result
 
 
-@read_session
 def get_global_account_limit(
+    session: "Session",
     account: Optional["InternalAccount"] = None,
-    rse_expression: Optional[str] = None,
-    *,
-    session: "Session"
+    rse_expression: Optional[str] = None
 ) -> Optional[Union[int, float, dict[str, "RSEResolvedGlobalAccountLimitDict"]]]:
     """
     Returns the global account limit for the given account and RSE expression.
@@ -148,12 +145,10 @@ def get_global_account_limit(
     return resolved_global_account_limits
 
 
-@read_session
 def get_local_account_limit(
     account: "InternalAccount",
-    rse_ids: Optional[Union[str, "Iterable[str]"]] = None,
-    *,
-    session: "Session"
+    session: "Session",
+    rse_ids: Optional[Union[str, "Iterable[str]"]] = None
 ) -> Optional[Union[int, float, dict[str, int]]]:
     """
     Returns the local account limit for a given RSE or list of RSEs.

--- a/lib/rucio/core/account_limit.py
+++ b/lib/rucio/core/account_limit.py
@@ -95,8 +95,12 @@ def get_rse_account_usage(rse_id: str, *, session: "Session") -> list["RSEAccoun
 
 
 @read_session
-def get_global_account_limit(account: Optional["InternalAccount"] = None, rse_expression: Optional[str] = None, *,
-                             session: "Session") -> Optional[Union[int, float, dict[str, "RSEResolvedGlobalAccountLimitDict"]]]:
+def get_global_account_limit(
+    account: Optional["InternalAccount"] = None,
+    rse_expression: Optional[str] = None,
+    *,
+    session: "Session"
+) -> Optional[Union[int, float, dict[str, "RSEResolvedGlobalAccountLimitDict"]]]:
     """
     Returns the global account limit for the given account and RSE expression.
     If no RSE expression is provided, returns all limits for the given account.
@@ -145,7 +149,12 @@ def get_global_account_limit(account: Optional["InternalAccount"] = None, rse_ex
 
 
 @read_session
-def get_local_account_limit(account: "InternalAccount", rse_ids: Optional[Union[str, "Iterable[str]"]] = None, *, session: "Session") -> Optional[Union[int, float, dict[str, int]]]:
+def get_local_account_limit(
+    account: "InternalAccount",
+    rse_ids: Optional[Union[str, "Iterable[str]"]] = None,
+    *,
+    session: "Session"
+) -> Optional[Union[int, float, dict[str, int]]]:
     """
     Returns the local account limit for a given RSE or list of RSEs.
 
@@ -350,7 +359,12 @@ def get_local_account_usage(account: "InternalAccount", rse_id: Optional[str] = 
 
 
 @transactional_session
-def get_global_account_usage(account: "InternalAccount", rse_expression: Optional[str] = None, *, session: "Session") -> list["RSEGlobalAccountUsageDict"]:
+def get_global_account_usage(
+    account: "InternalAccount",
+    rse_expression: Optional[str] = None,
+    *,
+    session: "Session"
+) -> list["RSEGlobalAccountUsageDict"]:
     """
     Read the account usage and connect it with the global account limits of the account.
 

--- a/lib/rucio/core/account_limit.py
+++ b/lib/rucio/core/account_limit.py
@@ -332,7 +332,7 @@ def get_local_account_usage(account: "InternalAccount", rse_id: Optional[str] = 
         counters = {c.rse_id: c for c in session.execute(stmt).scalars().all()}
     result_list = []
 
-    for rse_id in set(limits).union(counters):
+    for rse_id in set(limits).union(counters):  # type: ignore (https://github.com/rucio/rucio/issues/8194)
         counter = counters.get(rse_id)
         if counter:
             counter_files = counter.files
@@ -341,14 +341,14 @@ def get_local_account_usage(account: "InternalAccount", rse_id: Optional[str] = 
             counter_files = 0
             counter_bytes = 0
 
-        if counter_bytes > 0 or counter_files > 0 or rse_id in limits.keys():
+        if counter_bytes > 0 or counter_files > 0 or rse_id in limits.keys():  # type: ignore (https://github.com/rucio/rucio/issues/8194)
             result_list.append({
                 'rse_id': rse_id,
                 'rse': get_rse_name(rse_id=rse_id, session=session),
                 'bytes': counter_bytes,
                 'files': counter_files,
-                'bytes_limit': limits.get(rse_id, 0),
-                'bytes_remaining': limits.get(rse_id, 0) - counter_bytes,
+                'bytes_limit': limits.get(rse_id, 0),  # type: ignore (https://github.com/rucio/rucio/issues/8194)
+                'bytes_remaining': limits.get(rse_id, 0) - counter_bytes,  # type: ignore (https://github.com/rucio/rucio/issues/8194)
             })
     return result_list
 
@@ -374,7 +374,7 @@ def get_global_account_usage(
         # All RSE Expressions
         limits = get_global_account_limit(account=account, session=session)
         all_rse_usages = {usage['rse_id']: (usage['bytes'], usage['files']) for usage in get_all_rse_usages_per_account(account=account, session=session)}
-        for rse_expression, limit in limits.items():
+        for rse_expression, limit in limits.items():  # type: ignore
             usage = 0
             files = 0
             for rse in limit['resolved_rse_ids']:

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -361,7 +361,7 @@ def __get_init_oidc_client(token_object: models.Token = None, token_type: str = 
 
 
 @transactional_session
-def get_auth_oidc(account: str, *, session: "Session", **kwargs) -> str:
+def get_auth_oidc(account: "InternalAccount", *, session: "Session", **kwargs) -> str:
     """
     Assembles the authorization request of the Rucio Client tailored to the Rucio user
     & Identity Provider. Saves authentication session parameters in the oauth_requests

--- a/lib/rucio/core/rse_selector.py
+++ b/lib/rucio/core/rse_selector.py
@@ -100,12 +100,12 @@ class RSESelector:
                     if quota_limit is None:
                         local_quota_left = 0
                     else:
-                        local_quota_left = quota_limit - get_usage(rse_id=rse['rse_id'], account=account, session=session)['bytes']
+                        local_quota_left = quota_limit - get_usage(rse_id=rse['rse_id'], account=account, session=session)['bytes']  # type: ignore (https://github.com/rucio/rucio/issues/8194)
 
                     # check global quota
                     rse['global_quota_left'] = {}
                     all_global_quota_enough = True
-                    for rse_expression, limit in global_quota_limit.items():
+                    for rse_expression, limit in global_quota_limit.items():  # type: ignore (https://github.com/rucio/rucio/issues/8194)
                         if rse['rse_id'] in limit['resolved_rse_ids']:
                             quota_limit = limit['limit']
                             global_quota_left = None

--- a/lib/rucio/gateway/account.py
+++ b/lib/rucio/gateway/account.py
@@ -161,7 +161,7 @@ def list_accounts(filter_: Optional[dict[str, Any]] = None, vo: str = DEFAULT_VO
 
     with db_session(DatabaseOperationType.READ) as session:
         for result in account_core.list_accounts(filter_=filter_, session=session):
-            yield gateway_update_return_dict(result, session=session)
+            yield gateway_update_return_dict(result, session=session)  # type: ignore (AccountDict is a valid dict)
 
 
 def account_exists(

--- a/lib/rucio/gateway/account.py
+++ b/lib/rucio/gateway/account.py
@@ -108,7 +108,7 @@ def get_account_info(
 
     with db_session(DatabaseOperationType.READ) as session:
         acc = account_core.get_account(internal_account, session=session)
-        acc.account = acc.account.external
+        acc.account = acc.account.external  # type: ignore (acc.account exists)
         return acc
 
 

--- a/lib/rucio/gateway/account_limit.py
+++ b/lib/rucio/gateway/account_limit.py
@@ -40,7 +40,10 @@ def get_rse_account_usage(
     with db_session(DatabaseOperationType.READ) as session:
         rse_id = get_rse_id(rse=rse, vo=vo, session=session)
 
-        return [gateway_update_return_dict(d, session=session) for d in account_limit_core.get_rse_account_usage(rse_id=rse_id, session=session)]
+        return [
+            gateway_update_return_dict(d, session=session)  # type: ignore (RSEAccountUsageDict is a valid dict)
+            for d in account_limit_core.get_rse_account_usage(rse_id=rse_id, session=session)
+        ]
 
 
 def get_local_account_limit(
@@ -68,11 +71,11 @@ def get_local_account_limit(
         if rse:
             # Single RSE lookup
             rse_id = get_rse_id(rse=rse, vo=vo, session=session)
-            return {rse: account_limit_core.get_local_account_limit(account=internal_account, rse_ids=rse_id, session=session)}
+            return {rse: account_limit_core.get_local_account_limit(account=internal_account, rse_ids=rse_id, session=session)}  # type: ignore (https://github.com/rucio/rucio/issues/8194)
         else:
             # Fetch all RSE limits
             limits = account_limit_core.get_local_account_limit(account=internal_account, rse_ids=None, session=session)
-            return {get_rse_name(rse_id=rse_id, session=session): limit for rse_id, limit in limits.items()}
+            return {get_rse_name(rse_id=rse_id, session=session): limit for rse_id, limit in limits.items()}  # type: ignore (https://github.com/rucio/rucio/issues/8194)
 
 
 def get_global_account_limit(

--- a/lib/rucio/gateway/account_limit.py
+++ b/lib/rucio/gateway/account_limit.py
@@ -272,7 +272,10 @@ def get_local_account_usage(
         if not account_exists(account=internal_account, session=session):
             raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (internal_account))
 
-        return [gateway_update_return_dict(d, session=session) for d in account_limit_core.get_local_account_usage(account=internal_account, rse_id=rse_id, session=session)]
+        return [
+            gateway_update_return_dict(d, session=session)  # type: ignore (RSELocalAccountUsageDict is a valid dict)
+            for d in account_limit_core.get_local_account_usage(account=internal_account, rse_id=rse_id, session=session)
+        ]
 
 
 def get_global_account_usage(
@@ -304,4 +307,11 @@ def get_global_account_usage(
         if not account_exists(account=internal_account, session=session):
             raise rucio.common.exception.AccountNotFound('Account %s does not exist' % (internal_account))
 
-        return [gateway_update_return_dict(d, session=session) for d in account_limit_core.get_global_account_usage(account=internal_account, rse_expression=rse_expression, session=session)]
+        return [
+            gateway_update_return_dict(d, session=session)  # type: ignore (RSEGlobalAccountUsageDict is a valid dict)
+            for d in account_limit_core.get_global_account_usage(
+                account=internal_account,
+                rse_expression=rse_expression,
+                session=session
+                )
+            ]

--- a/lib/rucio/gateway/account_limit.py
+++ b/lib/rucio/gateway/account_limit.py
@@ -82,7 +82,10 @@ def get_global_account_limit(
         account: str,
         rse_expression: Optional[str] = None,
         vo: str = DEFAULT_VO,
-) -> Union[dict[str, RSEResolvedGlobalAccountLimitDict], dict[str, dict[str, RSEResolvedGlobalAccountLimitDict]]]:
+) -> Union[
+    dict[str, Optional[Union[int, float, dict[str, "RSEResolvedGlobalAccountLimitDict"]]]],
+    Optional[Union[int, float, dict[str, "RSEResolvedGlobalAccountLimitDict"]]]
+]:
     """
     Lists the global account limitation names/values for the specified account.
     If an RSE expression is provided, fetches the limit for that expression.

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -611,7 +611,7 @@ class GlobalAccountLimits(ErrorHandlingMethodView):
         except RSENotFound as error:
             return generate_http_error_flask(404, error)
 
-        return Response(render_json(**limits), content_type="application/json")
+        return Response(render_json(**limits), content_type="application/json")  # type: ignore (https://github.com/rucio/rucio/issues/8194)
 
 
 class Identities(ErrorHandlingMethodView):

--- a/tests/test_abacus_account.py
+++ b/tests/test_abacus_account.py
@@ -54,7 +54,8 @@ class TestAbacusAccount2:
         # Update and check the account history with the core method
         with db_session(DatabaseOperationType.WRITE) as session:
             update_account_counter_history(account=root_account, rse_id=rse_id, session=session)
-        usage_history = get_usage_history(rse_id=rse_id, account=root_account)
+        with db_session(DatabaseOperationType.READ) as session:
+            usage_history = get_usage_history(rse_id=rse_id, account=root_account, session=session)
         assert usage_history[-1]['bytes'] == nfiles * file_sizes
         assert usage_history[-1]['files'] == nfiles
 

--- a/tests/test_abacus_account.py
+++ b/tests/test_abacus_account.py
@@ -47,7 +47,8 @@ class TestAbacusAccount2:
         activity = "Staging"
         rucio_client.add_replication_rule([{'scope': mock_scope.external, 'name': dataset}], 1, rse, lifetime=-1, activity=activity)
         account_update(once=True)
-        account_usage = get_local_account_usage(account=root_account, rse_id=rse_id)[0]
+        with db_session(DatabaseOperationType.READ) as session:
+            account_usage = get_local_account_usage(account=root_account, rse_id=rse_id, session=session)[0]
         assert account_usage['bytes'] == nfiles * file_sizes
         assert account_usage['files'] == nfiles
 
@@ -68,8 +69,10 @@ class TestAbacusAccount2:
         cleaner.run(once=True)
         account_update(once=True)
         # set account limit because return value of get_local_account_usage differs if a limit is set or not
-        set_local_account_limit(account=root_account, rse_id=rse_id, bytes_=10)
-        account_usages = get_local_account_usage(account=root_account, rse_id=rse_id)[0]
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(account=root_account, rse_id=rse_id, bytes_=10, session=session)
+        with db_session(DatabaseOperationType.READ) as session:
+            account_usages = get_local_account_usage(account=root_account, rse_id=rse_id, session=session)[0]
         assert account_usages['bytes'] == 0
         assert account_usages['files'] == 0
 

--- a/tests/test_account_limits.py
+++ b/tests/test_account_limits.py
@@ -159,7 +159,8 @@ class TestAccountClient:
         """ ACCOUNT_LIMIT (CLIENTS): Get global account limits """
         rse1, rse1_id = rse_factory.make_mock_rse()
         limit = 10
-        account_limit.set_global_account_limit(account, rse1, limit)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            account_limit.set_global_account_limit(account, rse1, limit, session=session)
         results = rucio_client.get_global_account_limits(account=account.external)
         assert len(results) == 1
         assert results[rse1]['resolved_rses'] == [rse1]
@@ -170,7 +171,8 @@ class TestAccountClient:
         """ ACCOUNT_LIMIT (CLIENTS): Get global account limit. """
         rse1, _ = rse_factory.make_mock_rse()
         limit = 10
-        account_limit.set_global_account_limit(account, rse1, limit)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            account_limit.set_global_account_limit(account, rse1, limit, session=session)
         result = rucio_client.get_global_account_limit(account=account.external, rse_expression=rse1)
         assert result[rse1] == limit
 
@@ -178,27 +180,31 @@ class TestAccountClient:
         """ ACCOUNT_LIMIT (CLIENTS): Get local account limits """
         rse1, rse1_id = rse_factory.make_mock_rse()
         rse2, rse2_id = rse_factory.make_mock_rse()
-        account_limit.set_local_account_limit(account=account, rse_id=rse1_id, bytes_=12345)
-        account_limit.set_local_account_limit(account=account, rse_id=rse2_id, bytes_=12345)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            account_limit.set_local_account_limit(account=account, rse_id=rse1_id, bytes_=12345, session=session)
+            account_limit.set_local_account_limit(account=account, rse_id=rse2_id, bytes_=12345, session=session)
 
         limits = rucio_client.get_local_account_limits(account=account.external)
 
         assert (rse1, 12345) in limits.items()
         assert (rse2, 12345) in limits.items()
 
-        account_limit.delete_local_account_limit(account=account, rse_id=rse1_id)
-        account_limit.delete_local_account_limit(account=account, rse_id=rse2_id)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            account_limit.delete_local_account_limit(account=account, rse_id=rse1_id, session=session)
+            account_limit.delete_local_account_limit(account=account, rse_id=rse2_id, session=session)
 
     def test_get_local_account_limit(self, account, rucio_client, rse_factory):
         """ ACCOUNT_LIMIT (CLIENTS): Get local account limit """
         rse1, rse1_id = rse_factory.make_mock_rse()
-        account_limit.delete_local_account_limit(account=account, rse_id=rse1_id)
-        account_limit.set_local_account_limit(account=account, rse_id=rse1_id, bytes_=333)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            account_limit.delete_local_account_limit(account=account, rse_id=rse1_id, session=session)
+            account_limit.set_local_account_limit(account=account, rse_id=rse1_id, bytes_=333, session=session)
 
         limit = rucio_client.get_local_account_limit(account=account.external, rse=rse1)
 
         assert limit == {rse1: 333}
-        account_limit.delete_local_account_limit(account=account, rse_id=rse1_id)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            account_limit.delete_local_account_limit(account=account, rse_id=rse1_id, session=session)
 
     def test_set_local_account_limit(self, account, rucio_client, rse_factory):
         """ ACCOUNTLIMIT (CLIENTS): Set local account limit """
@@ -208,7 +214,8 @@ class TestAccountClient:
         limit = rucio_client.get_local_account_limit(account=account.external, rse=rse1)
 
         assert limit[rse1] == 987
-        account_limit.delete_local_account_limit(account=account, rse_id=rse1_id)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            account_limit.delete_local_account_limit(account=account, rse_id=rse1_id, session=session)
 
     def test_delete_local_account_limit(self, account, rucio_client, rse_factory):
         """ ACCOUNTLIMIT (CLIENTS): Delete local account limit """
@@ -221,7 +228,8 @@ class TestAccountClient:
         rucio_client.delete_local_account_limit(account=account.external, rse=rse1)
         limit = rucio_client.get_local_account_limit(account=account.external, rse=rse1)
         assert limit[rse1] is None
-        account_limit.delete_local_account_limit(account=account, rse_id=rse1_id)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            account_limit.delete_local_account_limit(account=account, rse_id=rse1_id, session=session)
 
     def test_delete_global_account_limit(self, account, rucio_client, rse_factory):
         """ ACCOUNTLIMIT (CLIENTS): Delete global account limit """

--- a/tests/test_bb8.py
+++ b/tests/test_bb8.py
@@ -30,7 +30,8 @@ from rucio.daemons.bb8.common import rebalance_rule
 from rucio.daemons.judge.cleaner import rule_cleaner
 from rucio.daemons.judge.evaluator import re_evaluator
 from rucio.daemons.undertaker import undertaker
-from rucio.db.sqla.constants import RuleState
+from rucio.db.sqla.constants import DatabaseOperationType, RuleState
+from rucio.db.sqla.session import db_session
 
 from .test_rule import create_files, tag_generator
 
@@ -52,11 +53,12 @@ def test_bb8_rebalance_rule(vo, root_account, jdoe_account, rse_factory, mock_sc
     add_rse_attribute(rse2_id, "fakeweight", 0)
 
     # Add quota
-    set_local_account_limit(jdoe_account, rse1_id, -1)
-    set_local_account_limit(jdoe_account, rse2_id, -1)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        set_local_account_limit(jdoe_account, rse1_id, -1, session=session)
+        set_local_account_limit(jdoe_account, rse2_id, -1, session=session)
 
-    set_local_account_limit(root_account, rse1_id, -1)
-    set_local_account_limit(root_account, rse2_id, -1)
+        set_local_account_limit(root_account, rse1_id, -1, session=session)
+        set_local_account_limit(root_account, rse2_id, -1, session=session)
 
     files = create_files(3, mock_scope, rse1_id)
     dataset = did_factory.make_dataset()
@@ -129,15 +131,16 @@ def test_bb8_full_workflow(vo, root_account, jdoe_account, rse_factory, mock_sco
     add_rse_attribute(rse4_id, "freespace", 1)
 
     # Add quota
-    set_local_account_limit(jdoe_account, rse1_id, -1)
-    set_local_account_limit(jdoe_account, rse2_id, -1)
-    set_local_account_limit(jdoe_account, rse3_id, -1)
-    set_local_account_limit(jdoe_account, rse4_id, -1)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        set_local_account_limit(jdoe_account, rse1_id, -1, session=session)
+        set_local_account_limit(jdoe_account, rse2_id, -1, session=session)
+        set_local_account_limit(jdoe_account, rse3_id, -1, session=session)
+        set_local_account_limit(jdoe_account, rse4_id, -1, session=session)
 
-    set_local_account_limit(root_account, rse1_id, -1)
-    set_local_account_limit(root_account, rse2_id, -1)
-    set_local_account_limit(root_account, rse3_id, -1)
-    set_local_account_limit(root_account, rse4_id, -1)
+        set_local_account_limit(root_account, rse1_id, -1, session=session)
+        set_local_account_limit(root_account, rse2_id, -1, session=session)
+        set_local_account_limit(root_account, rse3_id, -1, session=session)
+        set_local_account_limit(root_account, rse4_id, -1, session=session)
 
     # Invalid the cache because the result of parse_expression is cached
     REGION.invalidate()

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -942,7 +942,8 @@ def test_transfer_to_mas_existing_replica(rse_factory, did_factory, root_account
         assert replica_core.get_replica(rse_id=rse_id, **did)['state'] == ReplicaState.AVAILABLE
 
     # now test a second rule, different account
-    set_local_account_limit(jdoe_account, dst_rse_id, bytes_=-1)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        set_local_account_limit(jdoe_account, dst_rse_id, bytes_=-1, session=session)
     rule2_id = rule_core.add_rule(dids=[did], account=jdoe_account, copies=1, rse_expression=dst_rse, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None, source_replica_expression=dst_rse)[0]
     request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
 
@@ -1003,7 +1004,8 @@ def test_failed_transfers_to_mas_existing_replica(rse_factory, did_factory, root
     assert lock_core.get_replica_locks_for_rule_id(rule_id=rule1_id)[0]['state'] == LockState.STUCK
 
     # now test a second rule, different account
-    set_local_account_limit(jdoe_account, dst_rse_id, bytes_=-1)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        set_local_account_limit(jdoe_account, dst_rse_id, bytes_=-1, session=session)
     rule2_id = rule_core.add_rule(dids=[did], account=jdoe_account, copies=1, rse_expression=dst_rse, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None, source_replica_expression=dst_rse)[0]
     request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
 

--- a/tests/test_gateway_external_representation.py
+++ b/tests/test_gateway_external_representation.py
@@ -149,14 +149,14 @@ class TestGatewayExternalRepresentation:
         assert rse1_id not in out
 
         out = gateway_acc_lim.get_global_account_limit(account_name, vo=vo)
-        assert rse_expr in out
+        assert rse_expr in out  # type: ignore
         if vo2:
-            assert 'vo={}&({})'.format(vo, rse_expr) not in out
+            assert 'vo={}&({})'.format(vo, rse_expr) not in out  # type: ignore
 
         out = gateway_acc_lim.get_global_account_limit(account_name, rse_expr, vo=vo)
-        assert rse_expr in out
+        assert rse_expr in out  # type: ignore
         if vo2:
-            assert 'vo={}&({})'.format(vo, rse_expr) not in out
+            assert 'vo={}&({})'.format(vo, rse_expr) not in out  # type: ignore
 
         out = gateway_acc_lim.get_local_account_usage(account_name, rse1, issuer='root', vo=vo)
         out = list(out)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -24,7 +24,8 @@ from rucio.common.types import InternalAccount
 from rucio.common.utils import generate_uuid as uuid
 from rucio.core.account import add_account, del_account
 from rucio.core.identity import add_account_identity, add_identity, del_account_identity, del_identity, list_identities, verify_identity
-from rucio.db.sqla.constants import AccountType, IdentityType
+from rucio.db.sqla.constants import AccountType, DatabaseOperationType, IdentityType
+from rucio.db.sqla.session import db_session
 from rucio.tests.common import account_name_generator, auth, hdrdict, headers, rfc2253_dn_generator
 from rucio.tests.common_server import get_vo
 
@@ -88,7 +89,8 @@ def test_verify_userpass_identity():
     username = ''.join(random.choice(string.ascii_letters) for i in range(10))
     email = username + '@email.com'
 
-    add_account(account, AccountType.USER, email)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        add_account(account, AccountType.USER, email, session=session)
 
     password = ''.join(random.choice(string.ascii_letters) for i in range(10))
     add_identity(username, IdentityType.USERPASS, email=email, password=password)
@@ -104,7 +106,9 @@ def test_verify_userpass_identity():
 
     del_account_identity(username, IdentityType.USERPASS, account)
     del_identity(username, IdentityType.USERPASS)
-    del_account(account)
+
+    with db_session(DatabaseOperationType.WRITE) as session:
+        del_account(account, session=session)
 
 
 def test_verify_x509_identity():
@@ -118,7 +122,8 @@ def test_verify_x509_identity():
     dn = rfc2253_dn_generator()
     email = 'doesntmatter@email.com'
 
-    add_account(account, AccountType.USER, email)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        add_account(account, AccountType.USER, email, session=session)
 
     add_identity(dn, IdentityType.X509, email=email)
     add_account_identity(dn, IdentityType.X509, account, email=email)
@@ -130,7 +135,8 @@ def test_verify_x509_identity():
 
     del_account_identity(dn, IdentityType.X509, account)
     del_identity(dn, IdentityType.X509)
-    del_account(account)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        del_account(account, session=session)
 
 
 class TestListAccountsByIdentity:

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -175,11 +175,13 @@ def importer_example_data(vo, jdoe_account):
 
     # Account 1 that already exists
     example_data.old_account_1 = InternalAccount(rse_name_generator(), vo=vo)
-    add_account(example_data.old_account_1, AccountType.USER, email='test')
+    with db_session(DatabaseOperationType.WRITE) as session:
+        add_account(example_data.old_account_1, AccountType.USER, email='test', session=session)  # type: ignore (old_account_1 is not None)
 
     # Account 2 that already exists
     example_data.old_account_2 = InternalAccount(rse_name_generator(), vo=vo)
-    add_account(example_data.old_account_2, AccountType.USER, email='test')
+    with db_session(DatabaseOperationType.WRITE) as session:
+        add_account(example_data.old_account_2, AccountType.USER, email='test', session=session)  # type: ignore (old_account_1 is not None)
 
     # Identity that should be removed
     example_data.identity_to_be_removed = rse_name_generator()

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -112,7 +112,8 @@ def importer_example_data(vo, jdoe_account):
             db_identities = list_identities()
             for account in self.data1['accounts']:
                 # check existence
-                db_account = get_account(account=account['account'])
+                with db_session(DatabaseOperationType.READ) as session:
+                    db_account = get_account(account=account['account'], session=session)
                 assert db_account['account'] == account['account']
 
                 # check properties
@@ -132,7 +133,8 @@ def importer_example_data(vo, jdoe_account):
                         assert account['account'] in accounts_for_identity
 
             # check removal of account
-            account = get_account(self.old_account_1)
+            with db_session(DatabaseOperationType.READ) as session:
+                account = get_account(self.old_account_1, session=session)  # type: ignore (old_account_1 should not be None here)
             assert account['status'] == AccountStatus.DELETED
 
             # check removal of identities

--- a/tests/test_judge_cleaner.py
+++ b/tests/test_judge_cleaner.py
@@ -23,7 +23,8 @@ from rucio.core.lock import get_replica_locks
 from rucio.core.rse import add_rse_attribute
 from rucio.core.rule import add_rule, update_rule
 from rucio.daemons.judge.cleaner import rule_cleaner
-from rucio.db.sqla.constants import DIDType
+from rucio.db.sqla.constants import DatabaseOperationType, DIDType
+from rucio.db.sqla.session import db_session
 from rucio.tests.common_server import get_vo
 
 from .test_rule import create_files, tag_generator
@@ -68,15 +69,17 @@ class TestJudgeCleaner:
         # Add quota
         cls.jdoe = InternalAccount('jdoe', **cls.vo)
         cls.root = InternalAccount('root', **cls.vo)
-        set_local_account_limit(cls.jdoe, cls.rse1_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse3_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse4_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse5_id, -1)
 
-        set_local_account_limit(cls.root, cls.rse1_id, -1)
-        set_local_account_limit(cls.root, cls.rse3_id, -1)
-        set_local_account_limit(cls.root, cls.rse4_id, -1)
-        set_local_account_limit(cls.root, cls.rse5_id, -1)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(cls.jdoe, cls.rse1_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse3_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse4_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse5_id, -1, session=session)
+
+            set_local_account_limit(cls.root, cls.rse1_id, -1, session=session)
+            set_local_account_limit(cls.root, cls.rse3_id, -1, session=session)
+            set_local_account_limit(cls.root, cls.rse4_id, -1, session=session)
+            set_local_account_limit(cls.root, cls.rse5_id, -1, session=session)
 
     def test_judge_expire_rule(self):
         """ JUDGE CLEANER: Test the judge when deleting expired rules"""

--- a/tests/test_judge_evaluator.py
+++ b/tests/test_judge_evaluator.py
@@ -211,14 +211,16 @@ class TestJudgeEvaluator:
         # Add a first rule to the DS
         add_rule(dids=[{'scope': scope, 'name': dataset}], account=self.jdoe, copies=1, rse_expression=self.rse1, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
 
-        account_counter_before = get_usage(self.rse1_id, self.jdoe)
+        with db_session(DatabaseOperationType.READ) as session:
+            account_counter_before = get_usage(self.rse1_id, self.jdoe, session=session)
         attach_dids(scope, dataset, files, self.jdoe)
 
         # Fake judge
         re_evaluator(once=True, did_limit=None)
         account_update(once=True)
 
-        account_counter_after = get_usage(self.rse1_id, self.jdoe)
+        with db_session(DatabaseOperationType.READ) as session:
+            account_counter_after = get_usage(self.rse1_id, self.jdoe, session=session)
         assert account_counter_before['bytes'] + 3 * 100 == account_counter_after['bytes']
         assert account_counter_before['files'] + 3 == account_counter_after['files']
 
@@ -239,7 +241,8 @@ class TestJudgeEvaluator:
 
         account_update(once=True)
 
-        account_counter_before = get_usage(self.rse1_id, self.jdoe)
+        with db_session(DatabaseOperationType.READ) as session:
+            account_counter_before = get_usage(self.rse1_id, self.jdoe, session=session)
 
         detach_dids(scope, dataset, [files[0]])
 
@@ -247,7 +250,8 @@ class TestJudgeEvaluator:
         re_evaluator(once=True, did_limit=None)
         account_update(once=True)
 
-        account_counter_after = get_usage(self.rse1_id, self.jdoe)
+        with db_session(DatabaseOperationType.READ) as session:
+            account_counter_after = get_usage(self.rse1_id, self.jdoe, session=session)
         assert account_counter_before['bytes'] - 100 == account_counter_after['bytes']
         assert account_counter_before['files'] - 1 == account_counter_after['files']
 

--- a/tests/test_judge_evaluator.py
+++ b/tests/test_judge_evaluator.py
@@ -87,15 +87,17 @@ class TestJudgeEvaluator:
         # Add quota
         cls.jdoe = InternalAccount('jdoe', **cls.vo)
         cls.root = InternalAccount('root', **cls.vo)
-        set_local_account_limit(cls.jdoe, cls.rse1_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse3_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse4_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse5_id, -1)
 
-        set_local_account_limit(cls.root, cls.rse1_id, -1)
-        set_local_account_limit(cls.root, cls.rse3_id, -1)
-        set_local_account_limit(cls.root, cls.rse4_id, -1)
-        set_local_account_limit(cls.root, cls.rse5_id, -1)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(cls.jdoe, cls.rse1_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse3_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse4_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse5_id, -1, session=session)
+
+            set_local_account_limit(cls.root, cls.rse1_id, -1, session=session)
+            set_local_account_limit(cls.root, cls.rse3_id, -1, session=session)
+            set_local_account_limit(cls.root, cls.rse4_id, -1, session=session)
+            set_local_account_limit(cls.root, cls.rse5_id, -1, session=session)
 
     @pytest.mark.noparallel(reason="uses mock scope and predefined RSEs; runs judge evaluator")
     def test_judge_add_files_to_dataset(self):

--- a/tests/test_judge_injector.py
+++ b/tests/test_judge_injector.py
@@ -74,15 +74,17 @@ class TestJudgeEvaluator:
         # Add quota
         cls.jdoe = InternalAccount('jdoe', **cls.vo)
         cls.root = InternalAccount('root', **cls.vo)
-        set_local_account_limit(cls.jdoe, cls.rse1_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse3_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse4_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse5_id, -1)
 
-        set_local_account_limit(cls.jdoe, cls.rse1_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse3_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse4_id, -1)
-        set_local_account_limit(cls.jdoe, cls.rse5_id, -1)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(cls.jdoe, cls.rse1_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse3_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse4_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse5_id, -1, session=session)
+
+            set_local_account_limit(cls.jdoe, cls.rse1_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse3_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse4_id, -1, session=session)
+            set_local_account_limit(cls.jdoe, cls.rse5_id, -1, session=session)
 
     def test_judge_inject_rule(self):
         """ JUDGE INJECTOR: Test the judge when injecting a rule"""

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -32,8 +32,8 @@ from rucio.core.authentication import redirect_auth_oidc, validate_auth_token
 from rucio.core.identity import add_account_identity
 from rucio.core.oidc import EXPECTED_OIDC_AUDIENCE, EXPECTED_OIDC_SCOPE, _token_cache_get, _token_cache_set, get_auth_oidc, get_token_for_account_operation, get_token_oidc, oidc_identity_string
 from rucio.db.sqla import models
-from rucio.db.sqla.constants import AccountType, IdentityType
-from rucio.db.sqla.session import get_session
+from rucio.db.sqla.constants import AccountType, DatabaseOperationType, IdentityType
+from rucio.db.sqla.session import db_session, get_session
 from rucio.tests.common_server import get_vo
 
 NEW_TOKEN_DICT = {'access_token': 'eyJ3bG...',
@@ -294,11 +294,13 @@ class TestAuthCoreAPIoidc:
         self.adminClientSUB = str('adminclientSUB' + rndstr()).lower()
         self.adminClientSUB_otherISS = str('adminclientSUB_otherISS' + rndstr()).lower()
         try:
-            add_account(self.account, AccountType.USER, 'rucio@email.com', session=self.db_session)
+            with db_session(DatabaseOperationType.WRITE) as session:
+                add_account(self.account, AccountType.USER, 'rucio@email.com', session=session)
         except Duplicate:
             pass
         try:
-            add_account(self.adminaccount, AccountType.SERVICE, 'rucio@email.com', session=self.db_session)
+            with db_session(DatabaseOperationType.WRITE) as session:
+                add_account(self.adminaccount, AccountType.SERVICE, 'rucio@email.com', session=session)
         except Duplicate:
             pass
 

--- a/tests/test_permission.py
+++ b/tests/test_permission.py
@@ -46,14 +46,16 @@ class TestPermissionCoreGateway:
         """ PERMISSION(CORE): Check permission to add scope """
         assert has_permission(issuer='root', action='add_scope', kwargs={'account': 'root'}, vo=vo)
         assert not has_permission(issuer=random_account.external, action='add_scope', kwargs={'account': random_account.external}, vo=vo)
-        add_account_attribute(random_account, 'admin', True)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            add_account_attribute(random_account, 'admin', True, session=session)
         assert has_permission(issuer=random_account.external, action='add_scope', kwargs={'account': random_account.external}, vo=vo)
 
     @skip_non_belleii
     def test_permission_add_scope_admin(self, vo, random_account):
         """ PERMISSION(CORE): Check permission to add scope with scope_admin attribute (Belle II)"""
         assert not has_permission(issuer=random_account.external, action='add_scope', kwargs={'account': random_account.external}, vo=vo)
-        add_account_attribute(random_account, 'scope_admin', True)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            add_account_attribute(random_account, 'scope_admin', True, session=session)
         assert has_permission(issuer=random_account.external, action='add_scope', kwargs={'account': random_account.external}, vo=vo)
 
     def test_permission_get_auth_token_user_pass(self, vo):

--- a/tests/test_rse.py
+++ b/tests/test_rse.py
@@ -1404,7 +1404,8 @@ class TestRSEClient:
         file_sizes = 100
         nfiles = 3
         rse, rse_id = rse_factory.make_posix_rse()
-        set_local_account_limit(account=jdoe_account, rse_id=rse_id, bytes_=10000)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(account=jdoe_account, rse_id=rse_id, bytes_=10000, session=session)
         activity = "Staging"
         files = create_files(nfiles, mock_scope, rse_id, bytes_=file_sizes)
         dataset = did_name_generator('dataset')

--- a/tests/test_rse.py
+++ b/tests/test_rse.py
@@ -45,7 +45,8 @@ from rucio.core.rse import (
 from rucio.core.rule import add_rule
 from rucio.daemons.abacus.account import account_update
 from rucio.db.sqla import models, session
-from rucio.db.sqla.constants import DIDType, RSEType
+from rucio.db.sqla.constants import DatabaseOperationType, DIDType, RSEType
+from rucio.db.sqla.session import db_session
 from rucio.rse import rsemanager as mgr
 from rucio.tests.common import auth, did_name_generator, hdrdict, headers, rse_name_generator
 
@@ -1418,7 +1419,8 @@ class TestRSEClient:
         usages = rucio_client.get_rse_usage(rse=rse)
         for usage in usages:
             assert 'account_usages' not in usage
-        account_usages = {u['account']: u for u in get_rse_account_usage(rse_id)}
+        with db_session(DatabaseOperationType.READ) as session:
+            account_usages = {u['account']: u for u in get_rse_account_usage(rse_id, session=session)}
         assert account_usages[jdoe_account]['quota_bytes'] == 10000
         assert account_usages[jdoe_account]['used_files'] == nfiles
         assert account_usages[jdoe_account]['used_bytes'] == nfiles * file_sizes

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -299,7 +299,8 @@ class TestCore:
         add_account_attribute(
             account, f"{accountgroup}-{rstring}", "admin"
         )
-        email = get_account(account).email
+        with db_session(DatabaseOperationType.READ) as session:
+            email = get_account(account, session=session).email
 
         # import and run relevant function
         from rucio.core.rule import _create_recipients_list
@@ -628,7 +629,8 @@ class TestCore:
         """ REPLICATION RULE (CORE): Test if the account counter is updated correctly when new rule is created"""
 
         account_update(once=True)
-        account_counter_before = get_usage(self.rse1_id, jdoe_account)
+        with db_session(DatabaseOperationType.READ) as session:
+            account_counter_before = get_usage(self.rse1_id, jdoe_account, session=session)  # type: ignore (self.rse1_id is not None)
 
         files = create_files(3, mock_scope, self.rse1_id, bytes_=100)
         dataset = did_factory.random_dataset_did()
@@ -639,7 +641,8 @@ class TestCore:
 
         # Check if the counter has been updated correctly
         account_update(once=True)
-        account_counter_after = get_usage(self.rse1_id, jdoe_account)
+        with db_session(DatabaseOperationType.READ) as session:
+            account_counter_after = get_usage(self.rse1_id, jdoe_account, session=session)  # type: ignore (self.rse1_id is not None)
         assert (account_counter_before['bytes'] + 3 * 100 == account_counter_after['bytes'])
         assert (account_counter_before['files'] + 3 == account_counter_after['files'])
 
@@ -655,13 +658,15 @@ class TestCore:
         rule_id = add_rule(dids=[dataset], account=jdoe_account, copies=1, rse_expression=self.rse1, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)[0]
 
         account_update(once=True)
-        account_counter_before = get_usage(self.rse1_id, jdoe_account)
+        with db_session(DatabaseOperationType.READ) as session:
+            account_counter_before = get_usage(self.rse1_id, jdoe_account, session=session)  # type: ignore (self.rse1_id is not None)
 
         delete_rule(rule_id)
         account_update(once=True)
 
         # Check if the counter has been updated correctly
-        account_counter_after = get_usage(self.rse1_id, jdoe_account)
+        with db_session(DatabaseOperationType.READ) as session:
+            account_counter_after = get_usage(self.rse1_id, jdoe_account, session=session)  # type: ignore (self.rse1_id is not None)
         assert (account_counter_before['bytes'] - 3 * 100 == account_counter_after['bytes'])
         assert (account_counter_before['files'] - 3 == account_counter_after['files'])
 
@@ -677,15 +682,17 @@ class TestCore:
         rule_id = add_rule(dids=[dataset], account=jdoe_account, copies=1, rse_expression=self.rse1, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)[0]
 
         account_update(once=True)
-        account_counter_before_1 = get_usage(self.rse1_id, jdoe_account)
-        account_counter_before_2 = get_usage(self.rse1_id, root_account)
+        with db_session(DatabaseOperationType.READ) as session:
+            account_counter_before_1 = get_usage(self.rse1_id, jdoe_account, session=session)  # type: ignore (self.rse1_id is not None)
+            account_counter_before_2 = get_usage(self.rse1_id, root_account, session=session)  # type: ignore (self.rse1_id is not None)
 
         rucio.gateway.rule.update_replication_rule(rule_id, {'account': 'root'}, issuer='root', vo=vo)
         account_update(once=True)
 
         # Check if the counter has been updated correctly
-        account_counter_after_1 = get_usage(self.rse1_id, jdoe_account)
-        account_counter_after_2 = get_usage(self.rse1_id, root_account)
+        with db_session(DatabaseOperationType.READ) as session:
+            account_counter_after_1 = get_usage(self.rse1_id, jdoe_account, session=session)  # type: ignore (self.rse1_id is not None)
+            account_counter_after_2 = get_usage(self.rse1_id, root_account, session=session)  # type: ignore (self.rse1_id is not None)
         assert (account_counter_before_1['bytes'] - 3 * 100 == account_counter_after_1['bytes'])
         assert (account_counter_before_2['bytes'] + 3 * 100 == account_counter_after_2['bytes'])
 

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -297,9 +297,13 @@ class TestCore:
 
         # create account
         account: InternalAccount = random_account
-        add_account_attribute(
-            account, f"{accountgroup}-{rstring}", "admin"
-        )
+        with db_session(DatabaseOperationType.WRITE) as session:
+            add_account_attribute(
+                account,
+                f"{accountgroup}-{rstring}",
+                "admin",
+                session=session
+            )
         with db_session(DatabaseOperationType.READ) as session:
             email = get_account(account, session=session).email
 
@@ -965,7 +969,8 @@ class TestCore:
         with pytest.raises(AccessDenied):
             rucio.gateway.rule.delete_replication_rule(rule_id=rule_id, purge_replicas=None, issuer=usr, vo=vo)
 
-        add_account_attribute(InternalAccount(usr, vo=vo), 'country-test', 'admin')
+        with db_session(DatabaseOperationType.WRITE) as session:
+            add_account_attribute(InternalAccount(usr, vo=vo), 'country-test', 'admin', session=session)
         rucio.gateway.rule.delete_replication_rule(rule_id=rule_id, purge_replicas=None, issuer=usr, vo=vo)
 
     def test_reduce_rule(self, mock_scope, did_factory, jdoe_account):

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -166,10 +166,11 @@ def setup_class(request, vo, root_account, jdoe_account, rse_factory):
     add_rse_attribute(cls.rse3_id, "fakeweight", 0)
     add_rse_attribute(cls.rse4_id, "fakeweight", 0)
 
-    set_local_account_limit(jdoe_account, cls.rse1_id, -1)
-    set_local_account_limit(jdoe_account, cls.rse2_id, -1)
-    set_local_account_limit(jdoe_account, cls.rse3_id, -1)
-    set_local_account_limit(jdoe_account, cls.rse4_id, -1)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        set_local_account_limit(jdoe_account, cls.rse1_id, -1, session=session)
+        set_local_account_limit(jdoe_account, cls.rse2_id, -1, session=session)
+        set_local_account_limit(jdoe_account, cls.rse3_id, -1, session=session)
+        set_local_account_limit(jdoe_account, cls.rse4_id, -1, session=session)
 
 
 @pytest.mark.usefixtures('setup_class')
@@ -727,10 +728,12 @@ class TestCore:
         add_did(did_type=DIDType.DATASET, account=jdoe_account, **dataset)
         attach_dids(dids=files, account=jdoe_account, **dataset)
 
-        set_local_account_limit(account=jdoe_account, rse_id=self.rse2_id, bytes_=5)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(account=jdoe_account, rse_id=self.rse2_id, bytes_=5, session=session)  # type: ignore
 
         pytest.raises(InsufficientAccountLimit, add_rule, dids=[dataset], account=jdoe_account, copies=1, rse_expression=self.rse2, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
-        set_local_account_limit(account=jdoe_account, rse_id=self.rse2_id, bytes_=-1)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(account=jdoe_account, rse_id=self.rse2_id, bytes_=-1, session=session)  # type: ignore
 
     def test_rule_add_fails_account_global_limit(self, mock_scope, did_factory, random_account, rse_factory):
         """ REPLICATION RULE (CORE): Test if a rule fails correctly when global account limit conflict"""
@@ -742,10 +745,11 @@ class TestCore:
         add_did(did_type=DIDType.DATASET, account=random_account, **dataset)
         attach_dids(dids=files, account=random_account, **dataset)
 
-        set_local_account_limit(account=random_account, rse_id=rse1_id, bytes_=400)
-        # check with two global limits - one breaking limit is enough to let the rule fail
-        set_global_account_limit(rse_expression=f'{rse1}|{rse2}', account=random_account, bytes_=400)
-        set_global_account_limit(rse_expression=f'{rse1}|{rse3}', account=random_account, bytes_=10)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(account=random_account, rse_id=rse1_id, bytes_=400, session=session)
+            # check with two global limits - one breaking limit is enough to let the rule fail
+            set_global_account_limit(rse_expression=f'{rse1}|{rse2}', account=random_account, bytes_=400, session=session)
+            set_global_account_limit(rse_expression=f'{rse1}|{rse3}', account=random_account, bytes_=10, session=session)
         pytest.raises(InsufficientAccountLimit, add_rule, dids=[dataset], account=random_account, copies=1, rse_expression=rse1, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
 
     def test_rule_add_fails_rse_limit(self, mock_scope, did_factory, jdoe_account):
@@ -923,7 +927,8 @@ class TestCore:
         rse = rse_name_generator()
         rse_id = add_rse(rse, vo=vo)
         update_rse(rse_id, {'availability_write': False})
-        set_local_account_limit(jdoe_account, rse_id, -1)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(jdoe_account, rse_id, -1, session=session)
 
         files = create_files(3, mock_scope, self.rse1_id)
         dataset = did_factory.random_dataset_did()
@@ -944,7 +949,8 @@ class TestCore:
         rse = rse_name_generator()
         rse_id = add_rse(rse, vo=vo)
         add_rse_attribute(rse_id, RseAttr.COUNTRY, 'test')
-        set_local_account_limit(jdoe_account, rse_id, -1)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(jdoe_account, rse_id, -1, session=session)
 
         files = create_files(3, mock_scope, self.rse1_id)
         dataset = did_factory.random_dataset_did()
@@ -1037,7 +1043,8 @@ class TestCore:
         rse = rse_name_generator()
         rse_id = add_rse(rse, vo=vo)
         add_rse_attribute(rse_id, RseAttr.TYPE, 'SCRATCHDISK')
-        set_local_account_limit(jdoe_account, rse_id, -1)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(jdoe_account, rse_id, -1, session=session)
 
         files = create_files(3, mock_scope, self.rse1_id)
         dataset = did_factory.random_dataset_did()
@@ -1083,7 +1090,8 @@ class TestCore:
         rse = rse_name_generator()
         rse_id = add_rse(rse, vo=vo)
         add_rse_attribute(rse_id, RseAttr.BLOCK_MANUAL_APPROVAL, '1')
-        set_local_account_limit(jdoe_account, rse_id, -1)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(jdoe_account, rse_id, -1, session=session)
 
         files = create_files(3, mock_scope, self.rse1_id)
         dataset = did_factory.random_dataset_did()
@@ -1335,7 +1343,8 @@ def test_rule_boost(vo, mock_scope, rse_factory, jdoe_account):
     _, tmp_rse_id = rse_factory.make_mock_rse()
     rse, rse_id = rse_factory.make_mock_rse()
     update_rse(rse_id, {'availability_write': False})
-    set_local_account_limit(jdoe_account, rse_id, -1)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        set_local_account_limit(jdoe_account, rse_id, -1, session=session)
     files = create_files(3, mock_scope, tmp_rse_id)
     dataset1 = 'dataset_' + str(uuid())
     add_did(mock_scope, dataset1, DIDType.DATASET, jdoe_account)

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -446,7 +446,8 @@ class TestSubscriptionClient:
         rse2, _ = rse_factory.make_mock_rse()
         rse_expression = '%s|%s' % (rse1, rse2)
         account_name = uuid()[:10]
-        add_account(InternalAccount(account_name, vo=vo), AccountType.USER, 'rucio@email.com')
+        with db_session(DatabaseOperationType.WRITE) as session:
+            add_account(InternalAccount(account_name, vo=vo), AccountType.USER, 'rucio@email.com', session=session)
         subid = rucio_client.add_subscription(name=subscription_name, account=account_name, filter_={'project': self.projects, 'datatype': ['AOD', ], 'excluded_pattern': self.pattern1, 'account': ['tier0', ]},
                                               replication_rules=[{'rse_expression': rse_expression, 'copies': 2, 'activity': self.activity}], lifetime=100000, retroactive=False, dry_run=False, comments='Ni ! Ni!')
         result = [sub['id'] for sub in rucio_client.list_subscriptions(account=account_name)]
@@ -527,7 +528,8 @@ class TestSubscriptionClient:
         rse2, _ = rse_factory.make_mock_rse()
         rse_expression = '%s|%s' % (rse1, rse2)
         account_name = uuid()[:10]
-        add_account(InternalAccount(account_name, vo=vo), AccountType.USER, 'rucio@email.com')
+        with db_session(DatabaseOperationType.WRITE) as session:
+            add_account(InternalAccount(account_name, vo=vo), AccountType.USER, 'rucio@email.com', session=session)
         rucio_client.add_subscription(
             name=subscription_name, account=account_name, filter_={'project': self.projects, 'datatype': ['AOD', ], 'excluded_pattern': self.pattern1, 'account': ['tier0', ]},
             replication_rules=[{'rse_expression': rse_expression, 'copies': 2, 'activity': self.activity}], lifetime=100000, retroactive=False, dry_run=False, comments='Ni ! Ni!')

--- a/tests/test_undertaker.py
+++ b/tests/test_undertaker.py
@@ -26,6 +26,8 @@ from rucio.core.rse import add_rse
 from rucio.core.rule import add_rules, list_rules
 from rucio.daemons.judge.cleaner import rule_cleaner
 from rucio.daemons.undertaker.undertaker import undertaker
+from rucio.db.sqla.constants import DatabaseOperationType
+from rucio.db.sqla.session import db_session
 from rucio.db.sqla.util import json_implemented
 from rucio.tests.common import did_name_generator, rse_name_generator
 
@@ -42,7 +44,8 @@ class TestUndertaker:
         nbfiles = 5
         rse, rse_id = rse_factory.make_rse()
 
-        set_local_account_limit(jdoe_account, rse_id, -1)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(jdoe_account, rse_id, -1, session=session)
 
         dsns1 = [{'name': did_name_generator('dataset'),
                   'scope': mock_scope,
@@ -85,7 +88,8 @@ class TestUndertaker:
 
         # Add quota
         rse, rse_id = rse_factory.make_rse()
-        set_local_account_limit(jdoe_account, rse_id, -1)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(jdoe_account, rse_id, -1, session=session)
 
         dsn = {'name': did_name_generator('dataset'),
                'scope': mock_scope,
@@ -109,7 +113,8 @@ class TestUndertaker:
         rse = 'LOCALGROUPDISK_%s' % rse_name_generator()
         rse_id = add_rse(rse, vo=vo)
 
-        set_local_account_limit(jdoe_account, rse_id, -1)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            set_local_account_limit(jdoe_account, rse_id, -1, session=session)
 
         dsns2 = [{'name': did_name_generator('dataset'),
                   'scope': mock_scope,
@@ -150,8 +155,9 @@ def test_removal_all_replicas2(rse_factory, root_account, mock_scope, core_confi
     rse1, rse1_id = rse_factory.make_posix_rse()
     rse2, rse2_id = rse_factory.make_posix_rse()
 
-    set_local_account_limit(root_account, rse1_id, -1)
-    set_local_account_limit(root_account, rse2_id, -1)
+    with db_session(DatabaseOperationType.WRITE) as session:
+        set_local_account_limit(root_account, rse1_id, -1, session=session)
+        set_local_account_limit(root_account, rse2_id, -1, session=session)
 
     nbdatasets = 1
     nbfiles = 5

--- a/tools/bootstrap_tests.py
+++ b/tools/bootstrap_tests.py
@@ -34,6 +34,8 @@ from rucio.common.types import InternalAccount  # noqa: E402
 from rucio.common.utils import extract_scope  # noqa: E402
 from rucio.core.account import add_account_attribute  # noqa: E402
 from rucio.core.vo import map_vo  # noqa: E402
+from rucio.db.sqla.constants import DatabaseOperationType  # noqa: E402
+from rucio.db.sqla.session import db_session  # noqa: E402
 from rucio.gateway.vo import add_vo  # noqa: E402
 from rucio.tests.common_server import reset_config_table  # noqa: E402
 
@@ -113,13 +115,15 @@ if __name__ == '__main__':
         print('Account jdoe already added')
 
     try:
-        add_account_attribute(account=InternalAccount('root', **vo), key='admin', value=True)  # bypass client as schema validation fails at API level
+        with db_session(DatabaseOperationType.WRITE) as session:
+            add_account_attribute(account=InternalAccount('root', **vo), key='admin', value=True, session=session)  # bypass client as schema validation fails at API level
     except Exception as error:
         print(error)
 
     try:
         client.add_account('panda', 'SERVICE', 'panda@email.com')
-        add_account_attribute(account=InternalAccount('panda', **vo), key='admin', value=True)
+        with db_session(DatabaseOperationType.WRITE) as session:
+            add_account_attribute(account=InternalAccount('panda', **vo), key='admin', value=True, session=session)  # bypass client as schema validation fails at API level
     except Duplicate:
         print('Account panda already added')
 

--- a/tools/convert_database_vo.py
+++ b/tools/convert_database_vo.py
@@ -330,7 +330,7 @@ def convert_to_svo(old_vo, delete_vos=False, commit_changes=False, skip_history=
                 success = remove_vo(vo['vo'], commit_changes=commit_changes, skip_history=skip_history)
                 success_all = success_all and success
         if commit_changes and success_all:
-            del_account(InternalAccount('super_root', vo=DEFAULT_VO), session=s)
+            del_account(InternalAccount('super_root', vo=DEFAULT_VO), session=s)  # type: ignore
     s.close()
 
 


### PR DESCRIPTION
Part of:

- #6989
- #7267

Fixes:

- #8195