### PR TITLE
ci(Testing): run lint hooks via pre-commit in CI

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -11,33 +11,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  add_header:
+  pre_commit:
     if: github.repository_owner == 'rucio' || github.event_name != 'schedule'
-    name: Add header lint
+    name: Lint (pre-commit)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          # We need the history to determine the file creation date.
           fetch-depth: 0
-      - name: Check headers
-        shell: bash
-        run: |
-          python3 tools/add_header --dry-run --disable-progress-bar
-  python_ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Install Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.11"
-      - name: Install dependencies
+      - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
-      - name: Run Ruff
-        run: ruff check --output-format=github .
+          python -m pip install pre-commit
+      - name: Run pre-commit
+        run: |
+          pre-commit run --all-files --show-diff-on-failure
   python_annotations:
     if: |
       !startsWith(github.ref_name, 'release')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
     description: Run the `add_header` script to verify the file headers
     entry: tools/add_header
     language: system
+    args: [--disable-progress-bar]
+    pass_filenames: false
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.14.9
   hooks:


### PR DESCRIPTION
- Consolidate header and Ruff checks into a single pre-commit run in the autotest workflow.
- Disable the add_header progress bar for cleaner CI logs.

Closes: #8245

I think something like this should be fine to have local pre-commit and CI in sync. We could maybe even go on and close #7321 unless we have good reasons to go that way (personally I am in favour of keeping things simpler for the moment).

Keep in mind that with these changes, our CI right now reflects what is happening locally (where there are auto-fixes). But the way we have things setupped now on our CI, I don't see for the moment some problem there. We just need to remember that in case someone did not use pre-commits locally, there is a change that changes are made in the ephemeral workspace for those corresponding jobs. If we need to stick to no --fix, we could add this logic into the `autotest.yml`.