### PR TITLE
refactor(Testing): remove pycodestyle from dev requirements and config

### DIFF
--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,3 +1,0 @@
-[pycodestyle]
-max-line-length=256
-ignore=E731,E722

--- a/pyproject.server.toml
+++ b/pyproject.server.toml
@@ -100,7 +100,6 @@ dev = [
     'isort',
     'xmltodict',
     'pytz',
-    'pycodestyle',
     'pydoc-markdown',
     'docspec_python',
     'sh',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ dev = [
     'isort',
     'xmltodict',
     'pytz',
-    'pycodestyle',
     'pydoc-markdown',
     'docspec_python',
     'sh',

--- a/requirements/requirements.dev.in
+++ b/requirements/requirements.dev.in
@@ -5,7 +5,6 @@ pytest-cov==7.0.0                                           # Test coverage
 pytest-xdist==3.5.0, <3.6                                   # Used for parallel testing; config-related issues >= 3.6 (could be fixed in Python 3.10)
 pytest-rerunfailures==16.0.1                                # Rerun failed tests; 16.1 requires Python 3.10+
 pyflakes==3.1.0                                             # Passive checker of Python programs
-pycodestyle==2.11.0                                         # New package replacing pep8; python_version < '3.9'
 astroid==3.3.11                                             # Version 4+ requires Python 3.10+
 xmltodict==1.0.2                                            # Makes working with XML feel like you are working with JSON
 pytz==2025.2                                                # World timezone definitions, modern and historical

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -323,8 +323,6 @@ pyasn1-modules==0.4.2
     # via
     #   -r requirements.server.txt
     #   google-auth
-pycodestyle==2.11.0
-    # via -r requirements.dev.in
 pycparser==2.23
     # via
     #   -r requirements.server.txt

--- a/setuputil.py
+++ b/setuputil.py
@@ -52,7 +52,6 @@ dev_requirements = [
     'isort',
     'xmltodict',
     'pytz',
-    'pycodestyle',
     'pydoc-markdown',
     'docspec_python',
     'sh',


### PR DESCRIPTION
Remove pycodestyle from dev requirements and config. Should be safe given that we don't use it anymore.

Closes: #8354