### PR TITLE
Testing: address Ruff preview lint issues

### DIFF
--- a/bin/rucio
+++ b/bin/rucio
@@ -102,7 +102,7 @@ def map_legacy_command() -> Optional[list[str]]:
 def run_command(args, use_multi_host_functionality):
     commands = ("account", "config", "did", "replica", "rse", "rule", "scope", "subscription", "ping", "whoami", "test-server", "lifetime-exception", "upload", "download", "opendata")
     if (any(arg in commands for arg in sys.argv)) or args.help or args.version:
-        main(standalone_mode = not use_multi_host_functionality)  # pylint: disable=E1120
+        main(standalone_mode=not use_multi_host_functionality)  # pylint: disable=E1120
 
     else:
         try:
@@ -119,7 +119,7 @@ def run_command(args, use_multi_host_functionality):
             else:
                 sys.argv = ["rucio", "-h"]
 
-                main(standalone_mode = not use_multi_host_functionality)  # pylint: disable=E1120
+                main(standalone_mode=not use_multi_host_functionality)  # pylint: disable=E1120
 
 
 if __name__ == "__main__":

--- a/bin/rucio
+++ b/bin/rucio
@@ -124,7 +124,6 @@ def run_command(args, use_multi_host_functionality):
 
 if __name__ == "__main__":
 
-
     parser = argparse.ArgumentParser(add_help=False)
     # Check for legacy flag
     parser.add_argument("--legacy", action="store_true")

--- a/bin/rucio
+++ b/bin/rucio
@@ -102,7 +102,7 @@ def map_legacy_command() -> Optional[list[str]]:
 def run_command(args, use_multi_host_functionality):
     commands = ("account", "config", "did", "replica", "rse", "rule", "scope", "subscription", "ping", "whoami", "test-server", "lifetime-exception", "upload", "download", "opendata")
     if (any(arg in commands for arg in sys.argv)) or args.help or args.version:
-            main(standalone_mode = not use_multi_host_functionality)  # pylint: disable=E1120
+        main(standalone_mode = not use_multi_host_functionality)  # pylint: disable=E1120
 
     else:
         try:

--- a/bin/rucio
+++ b/bin/rucio
@@ -98,6 +98,7 @@ def map_legacy_command() -> Optional[list[str]]:
 
     return new_command
 
+
 def run_command(args, use_multi_host_functionality):
     commands = ("account", "config", "did", "replica", "rse", "rule", "scope", "subscription", "ping", "whoami", "test-server", "lifetime-exception", "upload", "download", "opendata")
     if (any(arg in commands for arg in sys.argv)) or args.help or args.version:

--- a/lib/rucio/cli/account.py
+++ b/lib/rucio/cli/account.py
@@ -301,7 +301,6 @@ def identity_add(ctx: click.Context, account_name: str, type_: str, id: str, ema
     print('Added new identity to account: %s-%s' % (id, account_name))
 
 
-
 @identity.command("remove")
 @click.argument("account-name", required=True)
 @click.option("--type", "type_", type=click.Choice(["X509", "GSS", "USERPASS", "SSH", "SAML", "OIDC"]), help="Authentication type", required=True)

--- a/lib/rucio/cli/account.py
+++ b/lib/rucio/cli/account.py
@@ -259,6 +259,7 @@ def limit_remove(ctx: click.Context, account_name: str, rse: str, locality: str)
     ctx.obj.client.delete_account_limit(account=account_name, rse=rse, locality=locality)
     print('Deleted account limit for account %s and RSE %s' % (account_name, rse))
 
+
 @account.group("identity")
 def identity():
     """Manage identities for an account - used to login"""

--- a/lib/rucio/cli/utils.py
+++ b/lib/rucio/cli/utils.py
@@ -17,7 +17,7 @@ import json
 import logging
 import os
 import signal
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import sys
 import traceback
 from configparser import NoOptionError, NoSectionError

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -21,7 +21,7 @@ import random
 import secrets
 import shutil
 import signal
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import time
 from queue import Empty, Queue, deque
 from threading import Thread

--- a/lib/rucio/common/dumper/consistency.py
+++ b/lib/rucio/common/dumper/consistency.py
@@ -16,7 +16,7 @@ import datetime
 import logging
 import os
 import re
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import tempfile
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 

--- a/lib/rucio/common/pcache.py
+++ b/lib/rucio/common/pcache.py
@@ -19,7 +19,7 @@ import getopt
 import os
 import re
 import signal
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import sys
 import time
 from socket import gethostname

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -27,7 +27,7 @@ import os.path
 import re
 import signal
 import socket
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import tempfile
 import threading
 import time

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -40,7 +40,7 @@ from itertools import zip_longest
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, cast
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from uuid import uuid4 as uuid
-from xml.etree import ElementTree
+from xml.etree import ElementTree  # noqa: S405 -- trusted XML input
 
 import requests
 from typing_extensions import ParamSpec

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -15,7 +15,7 @@
 import hashlib
 import json
 import logging
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import traceback
 from datetime import datetime, timedelta
 from math import floor

--- a/lib/rucio/daemons/auditor/hdfs.py
+++ b/lib/rucio/daemons/auditor/hdfs.py
@@ -17,7 +17,7 @@ import logging
 import os
 import re
 import shutil
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import tempfile
 from typing import TYPE_CHECKING
 

--- a/lib/rucio/rse/protocols/gfal.py
+++ b/lib/rucio/rse/protocols/gfal.py
@@ -17,7 +17,7 @@ import json
 import logging
 import os
 import re
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import urllib.parse as urlparse
 from threading import Timer
 

--- a/lib/rucio/rse/protocols/posix.py
+++ b/lib/rucio/rse/protocols/posix.py
@@ -16,7 +16,7 @@ import logging
 import os
 import os.path
 import shutil
-from subprocess import call
+from subprocess import call  # noqa: S404 -- subprocess used for external commands
 
 from rucio.common import exception
 from rucio.common.checksum import adler32

--- a/lib/rucio/rse/protocols/srm.py
+++ b/lib/rucio/rse/protocols/srm.py
@@ -15,7 +15,7 @@
 import os
 import re
 import urllib.parse as urlparse
-from subprocess import getstatusoutput
+from subprocess import getstatusoutput  # noqa: S404 -- subprocess used for external commands
 
 from rucio.common import exception
 from rucio.common.utils import execute

--- a/lib/rucio/rse/protocols/storm.py
+++ b/lib/rucio/rse/protocols/storm.py
@@ -14,7 +14,7 @@
 
 import logging
 import os
-from xml.dom import minidom
+from xml.dom import minidom  # noqa: S408 -- trusted XML input
 
 import requests
 

--- a/lib/rucio/rse/protocols/webdav.py
+++ b/lib/rucio/rse/protocols/webdav.py
@@ -18,7 +18,7 @@ import sys
 from dataclasses import dataclass
 from typing import Any, Optional
 from urllib.parse import urlparse
-from xml.etree import ElementTree
+from xml.etree import ElementTree  # noqa: S405 -- trusted XML input
 
 import requests
 from requests.adapters import HTTPAdapter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
+preview = true  # Go to https://docs.astral.sh/ruff/rules/ to see which rules are additionally added
 select = [
     "E",    # All default pycodestyle error families
     "W",    # All default pycodestyle warning families

--- a/setuputil.py
+++ b/setuputil.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import sys
 from typing import Union
 

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 from json import dumps
 from typing import TYPE_CHECKING
 from unittest import mock
-from xml.etree import ElementTree
+from xml.etree import ElementTree  # noqa: S405 -- trusted XML input
 
 import pytest
 import xmltodict

--- a/tools/generate-release-notes.py
+++ b/tools/generate-release-notes.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import json
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import sys
 
 import requests

--- a/tools/generate_version.py
+++ b/tools/generate_version.py
@@ -20,7 +20,7 @@ base_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(base_path)
 os.chdir(base_path)
 
-import subprocess  # noqa: E402
+import subprocess  # noqa: E402,S404 -- subprocess used for external commands
 
 
 def run_git_command(cmd):

--- a/tools/run_pyright/generate.py
+++ b/tools/run_pyright/generate.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import json
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any

--- a/tools/test/run_tests.py
+++ b/tools/test/run_tests.py
@@ -85,7 +85,7 @@ import multiprocessing
 import os
 import pathlib
 import shutil
-import subprocess
+import subprocess  # noqa: S404 -- subprocess used for external commands
 import sys
 import time
 import traceback


### PR DESCRIPTION
## Summary
- Enable Ruff preview rules for Testing.
- Fix Ruff whitespace/indentation warnings (E302, E117, E251, E303).
- Mark trusted XML/subprocess imports with appropriate noqa rules (S404, S405, S408).

Closes: #8362


**Note:**
By enabling `preview` rules, and given our current rule selection, the following rules are being activated:

# [pycodestyle error (E)](https://docs.astral.sh/ruff/rules/#error-e)
| Code | Name | Description |
|---|---|---|
| E111 | <a href="https://docs.astral.sh/ruff/rules/indentation-with-invalid-multiple/" style="color:red;">indentation-with-invalid-multiple</a> | Indentation is not a multiple of {indent_width} |
| E112 | <a href="https://docs.astral.sh/ruff/rules/no-indented-block/" style="color:red;">no-indented-block</a> | Expected an indented block |
| E113 | <a href="https://docs.astral.sh/ruff/rules/unexpected-indentation/" style="color:red;">unexpected-indentation</a> | Unexpected indentation |
| E114 | <a href="https://docs.astral.sh/ruff/rules/indentation-with-invalid-multiple-comment/" style="color:red;">indentation-with-invalid-multiple-comment</a> | Indentation is not a multiple of {indent_width} (comment) |
| E115 | <a href="https://docs.astral.sh/ruff/rules/no-indented-block-comment/" style="color:red;">no-indented-block-comment</a> | Expected an indented block (comment) |
| E116 | <a href="https://docs.astral.sh/ruff/rules/unexpected-indentation-comment/" style="color:red;">unexpected-indentation-comment</a> | Unexpected indentation (comment) |
| E117 | <a href="https://docs.astral.sh/ruff/rules/over-indented/" style="color:red;">over-indented</a> | Over-indented (comment) |
| E201 | <a href="https://docs.astral.sh/ruff/rules/whitespace-after-open-bracket/" style="color:red;">whitespace-after-open-bracket</a> | Whitespace after '{symbol}' |
| E202 | <a href="https://docs.astral.sh/ruff/rules/whitespace-before-close-bracket/" style="color:red;">whitespace-before-close-bracket</a> | Whitespace before '{symbol}' |
| E203 | <a href="https://docs.astral.sh/ruff/rules/whitespace-before-punctuation/" style="color:red;">whitespace-before-punctuation</a> | Whitespace before '{symbol}' |
| E204 | <a href="https://docs.astral.sh/ruff/rules/whitespace-after-decorator/" style="color:red;">whitespace-after-decorator</a> | Whitespace after decorator |
| E211 | <a href="https://docs.astral.sh/ruff/rules/whitespace-before-parameters/" style="color:red;">whitespace-before-parameters</a> | Whitespace before '{bracket}' |
| E221 | <a href="https://docs.astral.sh/ruff/rules/multiple-spaces-before-operator/" style="color:red;">multiple-spaces-before-operator</a> | Multiple spaces before operator |
| E222 | <a href="https://docs.astral.sh/ruff/rules/multiple-spaces-after-operator/" style="color:red;">multiple-spaces-after-operator</a> | Multiple spaces after operator |
| E223 | <a href="https://docs.astral.sh/ruff/rules/tab-before-operator/" style="color:red;">tab-before-operator</a> | Tab before operator |
| E224 | <a href="https://docs.astral.sh/ruff/rules/tab-after-operator/" style="color:red;">tab-after-operator</a> | Tab after operator |
| E225 | <a href="https://docs.astral.sh/ruff/rules/missing-whitespace-around-operator/" style="color:red;">missing-whitespace-around-operator</a> | Missing whitespace around operator |
| E226 | <a href="https://docs.astral.sh/ruff/rules/missing-whitespace-around-arithmetic-operator/" style="color:red;">missing-whitespace-around-arithmetic-operator</a> | Missing whitespace around arithmetic operator |
| E227 | <a href="https://docs.astral.sh/ruff/rules/missing-whitespace-around-bitwise-or-shift-operator/" style="color:red;">missing-whitespace-around-bitwise-or-shift-operator</a> | Missing whitespace around bitwise or shift operator |
| E228 | <a href="https://docs.astral.sh/ruff/rules/missing-whitespace-around-modulo-operator/" style="color:red;">missing-whitespace-around-modulo-operator</a> | Missing whitespace around modulo operator |
| E231 | <a href="https://docs.astral.sh/ruff/rules/missing-whitespace/" style="color:red;">missing-whitespace</a> | Missing whitespace after {} |
| E241 | <a href="https://docs.astral.sh/ruff/rules/multiple-spaces-after-comma/" style="color:red;">multiple-spaces-after-comma</a> | Multiple spaces after comma |
| E242 | <a href="https://docs.astral.sh/ruff/rules/tab-after-comma/" style="color:red;">tab-after-comma</a> | Tab after comma |
| E251 | <a href="https://docs.astral.sh/ruff/rules/unexpected-spaces-around-keyword-parameter-equals/" style="color:red;">unexpected-spaces-around-keyword-parameter-equals</a> | Unexpected spaces around keyword / parameter equals |
| E252 | <a href="https://docs.astral.sh/ruff/rules/missing-whitespace-around-parameter-equals/" style="color:red;">missing-whitespace-around-parameter-equals</a> | Missing whitespace around parameter equals |
| E261 | <a href="https://docs.astral.sh/ruff/rules/too-few-spaces-before-inline-comment/" style="color:red;">too-few-spaces-before-inline-comment</a> | Insert at least two spaces before an inline comment |
| E262 | <a href="https://docs.astral.sh/ruff/rules/no-space-after-inline-comment/" style="color:red;">no-space-after-inline-comment</a> | Inline comment should start with `#` |
| E265 | <a href="https://docs.astral.sh/ruff/rules/no-space-after-block-comment/" style="color:red;">no-space-after-block-comment</a> | Block comment should start with `#` |
| E266 | <a href="https://docs.astral.sh/ruff/rules/multiple-leading-hashes-for-block-comment/" style="color:red;">multiple-leading-hashes-for-block-comment</a> | Too many leading `#` before block comment |
| E271 | <a href="https://docs.astral.sh/ruff/rules/multiple-spaces-after-keyword/" style="color:red;">multiple-spaces-after-keyword</a> | Multiple spaces after keyword |
| E272 | <a href="https://docs.astral.sh/ruff/rules/multiple-spaces-before-keyword/" style="color:red;">multiple-spaces-before-keyword</a> | Multiple spaces before keyword |
| E273 | <a href="https://docs.astral.sh/ruff/rules/tab-after-keyword/" style="color:red;">tab-after-keyword</a> | Tab after keyword |
| E274 | <a href="https://docs.astral.sh/ruff/rules/tab-before-keyword/" style="color:red;">tab-before-keyword</a> | Tab before keyword |
| E275 | <a href="https://docs.astral.sh/ruff/rules/missing-whitespace-after-keyword/" style="color:red;">missing-whitespace-after-keyword</a> | Missing whitespace after keyword |
| E301 | <a href="https://docs.astral.sh/ruff/rules/blank-line-between-methods/" style="color:red;">blank-line-between-methods</a> | Expected {BLANK_LINES_NESTED_LEVEL:?} blank line, found 0 |
| E302 | <a href="https://docs.astral.sh/ruff/rules/blank-lines-top-level/" style="color:red;">blank-lines-top-level</a> | Expected {expected_blank_lines:?} blank lines, found {actual_blank_lines} |
| E303 | <a href="https://docs.astral.sh/ruff/rules/too-many-blank-lines/" style="color:red;">too-many-blank-lines</a> | Too many blank lines ({actual_blank_lines}) |
| E304 | <a href="https://docs.astral.sh/ruff/rules/blank-line-after-decorator/" style="color:red;">blank-line-after-decorator</a> | Blank lines found after function decorator ({lines}) |
| E305 | <a href="https://docs.astral.sh/ruff/rules/blank-lines-after-function-or-class/" style="color:red;">blank-lines-after-function-or-class</a> | Expected 2 blank lines after class or function definition, found ({blank_lines}) |
| E306 | <a href="https://docs.astral.sh/ruff/rules/blank-lines-before-nested-definition/" style="color:red;">blank-lines-before-nested-definition</a> | Expected 1 blank line before a nested definition, found 0 |
| E502 | <a href="https://docs.astral.sh/ruff/rules/redundant-backslash/" style="color:red;">redundant-backslash</a> | Redundant backslash |

# [pycodestyle warning (W)](https://docs.astral.sh/ruff/rules/#warning-w)
| Code | Name | Description |
|---|---|---|
| W391 | <a href="https://docs.astral.sh/ruff/rules/too-many-newlines-at-end-of-file/" style="color:red;">too-many-newlines-at-end-of-file</a> | Too many newlines at end of {domain} |

# [flake8-bandit (S)](https://docs.astral.sh/ruff/rules/#flake8-bandit-s)
| Code | Name | Description |
|---|---|---|
| S401 | <a href="https://docs.astral.sh/ruff/rules/suspicious-telnetlib-import/" style="color:red;">suspicious-telnetlib-import</a> | `telnetlib` and related modules are considered insecure. Use SSH or another encrypted protocol. |
| S402 | <a href="https://docs.astral.sh/ruff/rules/suspicious-ftplib-import/" style="color:red;">suspicious-ftplib-import</a> | `ftplib` and related modules are considered insecure. Use SSH, SFTP, SCP, or another encrypted protocol. |
| S403 | <a href="https://docs.astral.sh/ruff/rules/suspicious-pickle-import/" style="color:red;">suspicious-pickle-import</a> | `pickle`, `cPickle`, `dill`, and `shelve` modules are possibly insecure |
| S404 | <a href="https://docs.astral.sh/ruff/rules/suspicious-subprocess-import/" style="color:red;">suspicious-subprocess-import</a> | `subprocess` module is possibly insecure |
| S405 | <a href="https://docs.astral.sh/ruff/rules/suspicious-xml-etree-import/" style="color:red;">suspicious-xml-etree-import</a> | `xml.etree` methods are vulnerable to XML attacks |
| S406 | <a href="https://docs.astral.sh/ruff/rules/suspicious-xml-sax-import/" style="color:red;">suspicious-xml-sax-import</a> | `xml.sax` methods are vulnerable to XML attacks |
| S407 | <a href="https://docs.astral.sh/ruff/rules/suspicious-xml-expat-import/" style="color:red;">suspicious-xml-expat-import</a> | `xml.dom.expatbuilder` is vulnerable to XML attacks |
| S408 | <a href="https://docs.astral.sh/ruff/rules/suspicious-xml-minidom-import/" style="color:red;">suspicious-xml-minidom-import</a> | `xml.dom.minidom` is vulnerable to XML attacks |
| S409 | <a href="https://docs.astral.sh/ruff/rules/suspicious-xml-pulldom-import/" style="color:red;">suspicious-xml-pulldom-import</a> | `xml.dom.pulldom` is vulnerable to XML attacks |
| S411 | <a href="https://docs.astral.sh/ruff/rules/suspicious-xmlrpc-import/" style="color:red;">suspicious-xmlrpc-import</a> | XMLRPC is vulnerable to remote XML attacks |
| S412 | <a href="https://docs.astral.sh/ruff/rules/suspicious-httpoxy-import/" style="color:red;">suspicious-httpoxy-import</a> | `httpoxy` is a set of vulnerabilities that affect application code running inCGI, or CGI-like environments. The use of CGI for web applications should be avoided |
| S413 | <a href="https://docs.astral.sh/ruff/rules/suspicious-pycrypto-import/" style="color:red;">suspicious-pycrypto-import</a> | `pycrypto` library is known to have publicly disclosed buffer overflow vulnerability |
| S415 | <a href="https://docs.astral.sh/ruff/rules/suspicious-pyghmi-import/" style="color:red;">suspicious-pyghmi-import</a> | An IPMI-related module is being imported. Prefer an encrypted protocol over IPMI. |

# [flake8-type-checking (TC)](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc)
| Code | Name | Description |
|---|---|---|
| TC008 | <a href="https://docs.astral.sh/ruff/rules/quoted-type-alias/" style="color:red;">quoted-type-alias</a> | Remove quotes from type alias |

# [pyupgrade (UP)](https://docs.astral.sh/ruff/rules/#pyupgrade-up)
| Code | Name | Description |
|---|---|---|
| UP042 | <a href="https://docs.astral.sh/ruff/rules/replace-str-enum/" style="color:red;">replace-str-enum</a> | Class {name} inherits from both `str` and `enum.Enum` |

# [pylint error (PLE)](https://docs.astral.sh/ruff/rules/#error-ple)
| Code | Name | Description |
|---|---|---|
| PLE0304 | <a href="https://docs.astral.sh/ruff/rules/invalid-bool-return-type/" style="color:red;">invalid-bool-return-type</a> | `__bool__` does not return `bool` |
| PLE1141 | <a href="https://docs.astral.sh/ruff/rules/dict-iter-missing-items/" style="color:red;">dict-iter-missing-items</a> | Unpacking a dictionary in iteration without calling `.items()` |
| PLE4703 | <a href="https://docs.astral.sh/ruff/rules/modified-iterating-set/" style="color:red;">modified-iterating-set</a> | Iterated set `{name}` is modified within the `for` loop |