### PR TITLE
 fix(WebUI): prevent username enumeration in login endpoint

### DIFF
--- a/lib/rucio/web/ui/flask/common/utils.py
+++ b/lib/rucio/web/ui/flask/common/utils.py
@@ -349,12 +349,12 @@ def x509token_auth(data=None):
 
     if not ui_account:
         if MULTI_VO:
-            msg = "<br><br>Your certificate (%s) is not mapped to (possibly any) rucio account at VO: %s." % (html.escape(dn), html.escape(ui_vo))
+            msg = "<br><br>Your certificate (%s) is not mapped to (possibly any) rucio account at VO: %s." % (html.escape(dn), html.escape(str(ui_vo) if ui_vo else ""))
         else:
             msg = "<br><br>Your certificate (%s) is not mapped to (possibly any) rucio account." % (html.escape(dn))
     else:
         if MULTI_VO:
-            msg = "<br><br>Your certificate (%s) is not mapped to (possibly any) rucio account: %s at VO: %s." % (html.escape(dn), html.escape(ui_account), html.escape(ui_vo))
+            msg = "<br><br>Your certificate (%s) is not mapped to (possibly any) rucio account: %s at VO: %s." % (html.escape(dn), html.escape(ui_account), html.escape(str(ui_vo) if ui_vo else ""))
         else:
             msg = "<br><br>Your certificate (%s) is not mapped to (possibly any) rucio account: %s." % (html.escape(dn), html.escape(ui_account))
 
@@ -415,7 +415,7 @@ def userpass_auth():
 
     if not token:
         if MULTI_VO:
-            return render_template('problem.html', msg='Authentication failed for VO %s. Please check your credentials and try again.' % html.escape(ui_vo))
+            return render_template('problem.html', msg='Authentication failed for VO %s. Please check your credentials and try again.' % html.escape(str(ui_vo) if ui_vo else ""))
         else:
             return render_template('problem.html', msg='Authentication failed. Please check your credentials and try again.')
 
@@ -483,7 +483,7 @@ def saml_auth(method, data=None):
 
         if not token:
             if MULTI_VO:
-                return render_template("problem.html", msg='Authentication failed for VO %s. Please check your credentials and try again.' % html.escape(ui_vo))
+                return render_template("problem.html", msg='Authentication failed for VO %s. Please check your credentials and try again.' % html.escape(str(ui_vo) if ui_vo else ""))
             else:
                 return render_template("problem.html", msg='Authentication failed. Please check your credentials and try again.')
         return finalize_auth(token, 'saml')
@@ -530,7 +530,7 @@ def saml_auth(method, data=None):
 
             if not token:
                 if MULTI_VO:
-                    return render_template("problem.html", msg='Authentication failed for VO %s. Please check your credentials and try again.' % html.escape(ui_vo))
+                    return render_template("problem.html", msg='Authentication failed for VO %s. Please check your credentials and try again.' % html.escape(str(ui_vo) if ui_vo else ""))
                 else:
                     return render_template("problem.html", msg='Authentication failed. Please check your credentials and try again.')
             return finalize_auth(token, 'saml', cookie_extra)

--- a/lib/rucio/web/ui/flask/common/utils.py
+++ b/lib/rucio/web/ui/flask/common/utils.py
@@ -399,7 +399,7 @@ def userpass_auth():
                     valid_vos.append(vo)
 
             if len(valid_vos) == 0:
-                return render_template('problem.html', msg='Cannot find any Rucio account %s associated with identity %s at any VO.' % (html.escape(ui_account), html.escape(username)))
+                return render_template('problem.html', msg='Authentication failed. Please check your credentials and try again.')
             elif len(valid_vos) == 1:
                 ui_vo = valid_vos[0]
             else:
@@ -467,7 +467,7 @@ def saml_auth(method, data=None):
                     if account_exists(ui_account, vo):
                         valid_vos.append(vo)
                 if len(valid_vos) == 0:
-                    return render_template("problem.html", msg=('Cannot find any Rucio account %s associated with identity %s at any VO.' % (html.escape(ui_account), html.escape(saml_nameid))))
+                    return render_template("problem.html", msg='Authentication failed. Please check your credentials and try again.')
                 elif len(valid_vos) == 1:
                     ui_vo = valid_vos[0]
                 else:
@@ -514,7 +514,7 @@ def saml_auth(method, data=None):
                         if account_exists(ui_account, vo):
                             valid_vos.append(vo)
                     if len(valid_vos) == 0:
-                        return render_template("problem.html", msg=('Cannot find any Rucio account %s associated with identity %s at any VO.' % (html.escape(ui_account), html.escape(saml_nameid))))
+                        return render_template("problem.html", msg='Authentication failed. Please check your credentials and try again.')
                     elif len(valid_vos) == 1:
                         ui_vo = valid_vos[0]
                     else:
@@ -559,7 +559,7 @@ def oidc_auth(account, issuer, ui_vo=None):
             if account_exists(account, vo):
                 valid_vos.append(vo)
         if len(valid_vos) == 0:
-            return render_template("problem.html", msg=('Cannot find any Rucio account %s at any VO.' % html.escape(account)))
+            return render_template("problem.html", msg='Authentication failed. Please check your credentials and try again.')
         elif len(valid_vos) == 1:
             ui_vo = valid_vos[0]
         else:

--- a/lib/rucio/web/ui/flask/common/utils.py
+++ b/lib/rucio/web/ui/flask/common/utils.py
@@ -409,17 +409,15 @@ def userpass_auth():
             vos_with_desc = get_vo_descriptions(ui_vo)
             return render_template('login.html', account=None, vo=None, possible_vos=vos_with_desc, userpass_support=USERPASS_SUPPORT)
 
-    if not ui_account:
-        if MULTI_VO:
-            return render_template('problem.html', msg='Cannot get find any account associated with %s identity at VO %s.' % (html.escape(username), html.escape(ui_vo)))
-        else:
-            return render_template('problem.html', msg='Cannot get find any account associated with %s identity.' % (html.escape(username)))
-    token = get_token(auth.get_auth_token_user_pass, acc=ui_account, vo=ui_vo, idt=username, pwd=password)
+    token = None
+    if ui_account:
+        token = get_token(auth.get_auth_token_user_pass, acc=ui_account, vo=ui_vo, idt=username, pwd=password)
+
     if not token:
         if MULTI_VO:
-            return render_template('problem.html', msg='Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s at VO %s.') % (html.escape(username), html.escape(ui_account), html.escape(ui_vo))
+            return render_template('problem.html', msg='Authentication failed for VO %s. Please check your credentials and try again.' % html.escape(ui_vo))
         else:
-            return render_template('problem.html', msg='Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s.') % (html.escape(username), html.escape(ui_account))
+            return render_template('problem.html', msg='Authentication failed. Please check your credentials and try again.')
 
     return finalize_auth(token, 'userpass')
 
@@ -479,17 +477,15 @@ def saml_auth(method, data=None):
                 vos_with_desc = get_vo_descriptions(ui_vo)
                 return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT, possible_vos=vos_with_desc)))
 
-        if not ui_account:
-            if MULTI_VO:
-                return render_template("problem.html", msg='Cannot get find any account associated with %s identity at VO %s.' % (html.escape(saml_nameid), html.escape(ui_vo)))
-            else:
-                return render_template("problem.html", msg='Cannot get find any account associated with %s identity.' % (html.escape(saml_nameid)))
-        token = get_token(auth.get_auth_token_saml, acc=ui_account, vo=ui_vo, idt=saml_nameid)
+        token = None
+        if ui_account:
+            token = get_token(auth.get_auth_token_saml, acc=ui_account, vo=ui_vo, idt=saml_nameid)
+
         if not token:
             if MULTI_VO:
-                return render_template("problem.html", msg=('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s at VO %s.') % (html.escape(saml_nameid), html.escape(ui_account), html.escape(ui_vo)))
+                return render_template("problem.html", msg='Authentication failed for VO %s. Please check your credentials and try again.' % html.escape(ui_vo))
             else:
-                return render_template("problem.html", msg=('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s.') % (html.escape(saml_nameid), html.escape(ui_account)))
+                return render_template("problem.html", msg='Authentication failed. Please check your credentials and try again.')
         return finalize_auth(token, 'saml')
 
     # If method is POST, check the received SAML response and redirect to home if valid
@@ -528,18 +524,15 @@ def saml_auth(method, data=None):
                     vos_with_desc = get_vo_descriptions(ui_vo)
                     return add_cookies(make_response(render_template("select_login_method.html", oidc_issuers=AUTH_ISSUERS, saml_support=SAML_SUPPORT, userpass_support=USERPASS_SUPPORT, possible_vos=vos_with_desc)))
 
-            if not ui_account:
-                if MULTI_VO:
-                    return render_template("problem.html", msg='Cannot get find any account associated with %s identity at VO %s.' % (html.escape(saml_nameid), html.escape(ui_vo)))
-                else:
-                    return render_template("problem.html", msg='Cannot get find any account associated with %s identity.' % (html.escape(saml_nameid)))
-            token = get_token(auth.get_auth_token_saml, acc=ui_account, vo=ui_vo, idt=saml_nameid)
+            token = None
+            if ui_account:
+                token = get_token(auth.get_auth_token_saml, acc=ui_account, vo=ui_vo, idt=saml_nameid)
+
             if not token:
                 if MULTI_VO:
-                    return render_template("problem.html",
-                                           msg=('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s at VO %s.') % (html.escape(saml_nameid), html.escape(ui_account), html.escape(ui_vo)))
+                    return render_template("problem.html", msg='Authentication failed for VO %s. Please check your credentials and try again.' % html.escape(ui_vo))
                 else:
-                    return render_template("problem.html", msg=('Cannot get auth token. It is possible that the presented identity %s is not mapped to any Rucio account %s.') % (html.escape(saml_nameid), html.escape(ui_account)))
+                    return render_template("problem.html", msg='Authentication failed. Please check your credentials and try again.')
             return finalize_auth(token, 'saml', cookie_extra)
 
         return render_template("problem.html", msg="Not authenticated")


### PR DESCRIPTION
Replace distinct error messages in userpass_auth() and saml_auth()  functions with generic authentication failure messages. Previously,  the endpoint returned different errors for non-existent usernames vs. existing usernames with wrong passwords, allowing attackers to enumerate valid usernames.

The fix ensures authentication failures return the same generic  message: "Authentication failed. Please check your credentials and  try again."

Fixes: #8364
