### PR TITLE
Always cancel transfers in conveyor. Closes #6511

### DIFF
--- a/lib/rucio/alembicrevision.py
+++ b/lib/rucio/alembicrevision.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ALEMBIC_REVISION = '3b943000da18'  # the current alembic head revision
+ALEMBIC_REVISION = '3f2b52303b26'  # the current alembic head revision

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -755,7 +755,6 @@ def get_and_mark_next(
         activity: Optional[str] = None,
         total_workers: int = 0,
         worker_number: int = 0,
-        mode_all: bool = False,
         hash_variable: str = 'id',
         activity_shares: Optional[dict[str, Any]] = None,
         include_dependent: bool = True,
@@ -882,21 +881,17 @@ def get_and_mark_next(
             )
         query_result = session.execute(query).scalars()
         if query_result:
-            if mode_all:
-                for res in query_result:
-                    res_dict = res.to_dict()
-                    res_dict['request_id'] = res_dict['id']
-                    res_dict['attributes'] = json.loads(str(res_dict['attributes'] or '{}'))
+            for res in query_result:
+                res_dict = res.to_dict()
+                res_dict['request_id'] = res_dict['id']
+                res_dict['attributes'] = json.loads(str(res_dict['attributes'] or '{}'))
 
-                    dst_id = res_dict['dest_rse_id']
-                    src_id = res_dict['source_rse_id']
-                    res_dict['dst_rse'] = rse_collection[dst_id].ensure_loaded(load_name=True, load_attributes=True)
-                    res_dict['src_rse'] = rse_collection[src_id].ensure_loaded(load_name=True, load_attributes=True) if src_id is not None else None
+                dst_id = res_dict['dest_rse_id']
+                src_id = res_dict['source_rse_id']
+                res_dict['dst_rse'] = rse_collection[dst_id].ensure_loaded(load_name=True, load_attributes=True)
+                res_dict['src_rse'] = rse_collection[src_id].ensure_loaded(load_name=True, load_attributes=True) if src_id is not None else None
 
-                    result.append(res_dict)
-            else:
-                for res in query_result:
-                    result.append({'request_id': res.id, 'external_host': res.external_host, 'external_id': res.external_id})
+                result.append(res_dict)
 
             request_ids = {r['request_id'] for r in result}
             if processed_by and request_ids:

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -3210,3 +3210,42 @@ def reset_stale_waiting_requests(time_limit: Optional[datetime.timedelta] = date
 
     except IntegrityError as error:
         raise RucioException(error.args)
+
+
+@transactional_session
+def delete_orphaned_updated_requests(
+        *,
+        logger: "LoggerFunction" = logging.log,
+        session: "Session",
+) -> None:
+    """
+    Delete updated_requests entries where the referenced request_id
+    no longer exists in the requests table. This handles cleanup during
+    rolling deployments where old daemons may archive requests without
+    knowledge of the updated_requests table.
+
+    # TODO: Remove this function. It's only needed when running rucio <40 and >=40 on the same database.
+    """
+    stmt = select(
+        models.UpdatedRequest.id
+    ).outerjoin(
+        models.Request,
+        models.Request.id == models.UpdatedRequest.request_id
+    ).where(
+        models.Request.id.is_(None)
+    ).with_for_update(
+        skip_locked=True,
+        of=models.UpdatedRequest.id
+    )
+
+    for ids in session.execute(stmt).scalars().partitions(100):
+        del_stmt = delete(
+            models.UpdatedRequest
+        ).where(
+            models.UpdatedRequest.id.in_(ids)
+        ).execution_options(
+            synchronize_session=False
+        )
+        deleted = session.execute(del_stmt).rowcount  # type: ignore
+        if deleted:
+            logger(logging.WARNING, 'Deleted %d orphaned updated_requests entries left by old daemon code', deleted)

--- a/lib/rucio/daemons/conveyor/common.py
+++ b/lib/rucio/daemons/conveyor/common.py
@@ -491,7 +491,7 @@ def _submit_transfers(
                 # Possibility to have a double submission during the next cycle. Try to cancel the external request.
                 try:
                     logger(logging.INFO, 'Cancel transfer %s on %s', eid, transfertool_obj)
-                    transfer_core.cancel_transfer(transfertool_obj, eid)
+                    transfer_core.cancel_transfers(transfertool_obj, [{'external_id': eid}], logger=logger)
                 except Exception:
                     logger(logging.ERROR, 'Failed to cancel transfers %s on %s with error' % (eid, transfertool_obj), exc_info=True)
 

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -93,7 +93,8 @@ def _fetch_requests(
             RequestState.SUBMISSION_FAILED,
             RequestState.NO_SOURCES,
             RequestState.ONLY_TAPE_SOURCES,
-            RequestState.MISMATCH_SCHEME
+            RequestState.MISMATCH_SCHEME,
+            RequestState.CANCELLED,
         ],
     )
     reqs.extend(
@@ -314,6 +315,14 @@ def _finish_requests(
                         replica['archived'] = False
                         replica['error_message'] = req['err_msg'] if req['err_msg'] else request_core.get_transfer_error(req['state'])
                         replicas[req['request_type']][req['rule_id']].append(replica)
+                except RequestNotFound:
+                    logger(logging.WARNING, 'Cannot find request %s anymore', req['request_id'])
+
+            # Cancelled before submission - just archive
+            elif req['state'] == RequestState.CANCELLED:
+                try:
+                    request_core.archive_request(req['request_id'])
+                    logger(logging.INFO, 'CANCELLED DID %s:%s REQUEST %s', req['scope'], req['name'], req['request_id'])
                 except RequestNotFound:
                     logger(logging.WARNING, 'Cannot find request %s anymore', req['request_id'])
 

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -82,7 +82,6 @@ def _fetch_requests(
         limit=db_bulk,
         total_workers=total_workers,
         worker_number=worker_number,
-        mode_all=True,
         include_dependent=False,
         hash_variable='rule_id',
     )

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -123,6 +123,9 @@ def _handle_requests(
     if not reqs:
         return
 
+    # TODO: Remove this line. It's only needed when running rucio <40 and >=40 on the same database.
+    request_core.delete_orphaned_updated_requests(logger=logger)
+
     try:
         logger(logging.DEBUG, 'Updating %i requests', len(reqs))
 

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -345,10 +345,10 @@ def _poll_transfers(
         else:
             return
     except RequestException as error:
-        logger(logging.ERROR, "Failed to contact FTS server: %s" % (str(error)))
+        logger(logging.ERROR, "Failed to contact transfertool server: %s" % (str(error)))
         return
     except Exception:
-        logger(logging.ERROR, "Failed to query FTS info", exc_info=True)
+        logger(logging.ERROR, "Failed to query transfertool", exc_info=True)
         return
 
     tss = time.time()
@@ -368,7 +368,7 @@ def _poll_transfers(
                     transfer_core.mark_transfer_lost(request, logger=logger)
                 METRICS.counter('transfer_lost').inc()
             elif isinstance(transf_resp, Exception):
-                logger(logging.WARNING, "Failed to poll FTS(%s) job (%s): %s" % (transfertool_obj, transfer_id, transf_resp))
+                logger(logging.WARNING, "Failed to poll %s job (%s): %s" % (transfertool_obj, transfer_id, transf_resp))
                 METRICS.counter('query_transfer_exception').inc()
             else:
                 for request_id in request_ids.intersection(transf_resp):

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -384,7 +384,7 @@ def _poll_transfers(
 
             # should touch transfers.
             # Otherwise if one bulk transfer includes many requests and one is not terminated, the transfer will be poll again.
-            transfer_core.touch_transfer(transfertool_obj.external_host, transfer_id)
+            request_core.touch_requests_by_external_id(external_id=transfer_id)
         except (DatabaseException, DatabaseError) as error:
             if (re.match(ORACLE_RESOURCE_BUSY_REGEX, error.args[0])
                     or re.match(ORACLE_DEADLOCK_DETECTED_REGEX, error.args[0])

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -148,6 +148,18 @@ def _handle_requests(
                     timeout=timeout,
                     logger=logger,
                 )
+
+                requests_to_cancel = request_core.get_requests_to_cancel(
+                    state=RequestState.SUBMITTED,
+                    # all request_ids from chunk = {external_id: {request_id: {}}}
+                    request_ids=list(itertools.chain.from_iterable(chunk.values())),
+                )
+                if requests_to_cancel:
+                    transfer_core.cancel_transfers(
+                        transfertool_obj=transfertool_obj,
+                        transfers=requests_to_cancel,
+                        logger=logger,
+                    )
             except Exception:
                 logger(logging.ERROR, 'Exception', exc_info=True)
 

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -84,7 +84,6 @@ def _fetch_requests(
         older_than=datetime.datetime.utcnow() - datetime.timedelta(seconds=older_than) if older_than else None,
         total_workers=total_workers,
         worker_number=worker_number,
-        mode_all=True,
         hash_variable='id',
         activity=activity,
         activity_shares=activity_shares,

--- a/lib/rucio/db/sqla/constants.py
+++ b/lib/rucio/db/sqla/constants.py
@@ -152,6 +152,8 @@ class RequestState(Enum):
     SUSPEND = 'U'
     WAITING = 'W'
     PREPARING = 'P'
+    CANCELLING = 'X'
+    CANCELLED = 'C'
 
 
 class RequestType(Enum):

--- a/lib/rucio/db/sqla/migrate_repo/versions/3f2b52303b26_introduce_request_cancellation.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/3f2b52303b26_introduce_request_cancellation.py
@@ -1,0 +1,161 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Introduce request cancellation"""    # noqa: D400, D415
+
+import datetime
+
+import sqlalchemy as sa
+from alembic import context, op
+from alembic.op import create_check_constraint, create_index, create_primary_key, create_table, drop_table
+from sqlalchemy.exc import DatabaseError
+
+from rucio.db.sqla.types import GUID
+from rucio.db.sqla.util import try_drop_constraint
+
+
+def _mysql_drop_check_constraint_if_exists(schema: str, table: str, constraint: str) -> None:
+    """Drop a check constraint if it exists on MySQL 8+."""
+    try:
+        op.execute('ALTER TABLE %s%s DROP CHECK %s' % (schema, table, constraint))
+    except DatabaseError as e:
+        if e.orig.args[0] != 3821:  # Check constraint not found
+            raise
+
+
+# Alembic revision identifiers
+revision = '3f2b52303b26'
+down_revision = '3b943000da18'
+
+
+def enum_values_str(enumvals):
+    return ', '.join(map(lambda x: x.join(("'", "'")), enumvals))
+
+
+def upgrade():
+    """Upgrade the database to this revision."""
+    schema = context.get_context().version_table_schema + '.' if context.get_context().version_table_schema else ''
+    dialect = context.get_context().dialect.name
+
+    new_enum_values = ['Q', 'G', 'S', 'D', 'F', 'L', 'N', 'O', 'A', 'U', 'W', 'M', 'P', 'X', 'C']
+
+    if dialect in ['oracle', 'mysql', 'postgresql']:
+        # Create updated_requests table
+        create_table(
+            'updated_requests',
+            sa.Column('id', GUID()),
+            sa.Column('request_id', GUID()),
+            sa.Column('state', sa.Enum(*new_enum_values, name='UPDATED_REQUESTS_STATE_CHK', create_constraint=True)),
+            sa.Column('created_at', sa.DateTime, default=datetime.datetime.utcnow),
+            sa.Column('updated_at', sa.DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
+        )
+
+        create_primary_key('UPDATED_REQUESTS_PK', 'updated_requests', ['id'])
+        create_check_constraint('UPDATED_REQUESTS_REQUEST_ID_NN', 'updated_requests', 'request_id is not null')
+        create_index('UPDATED_REQUESTS_REQUEST_ID_IDX', 'updated_requests', ['request_id'])
+
+    # Update state check constraints to include CANCELLING and CANCELLED
+    if dialect == 'oracle':
+        try_drop_constraint('REQUESTS_STATE_CHK', 'requests')
+        op.create_check_constraint(
+            constraint_name='REQUESTS_STATE_CHK',
+            table_name='requests',
+            condition=f'state in ({enum_values_str(new_enum_values)})',
+        )
+        try_drop_constraint('REQUESTS_HIST_STATE_CHK', 'requests_history')
+        op.create_check_constraint(
+            constraint_name='REQUESTS_HIST_STATE_CHK',
+            table_name='requests_history',
+            condition=f'state in ({enum_values_str(new_enum_values)})',
+        )
+    elif dialect == 'postgresql':
+        # Recreate enum types with new values (handles bug in previous migration where type may not exist)
+        op.execute('ALTER TABLE %srequests_history DROP CONSTRAINT IF EXISTS "REQUESTS_HISTORY_STATE_CHK", ALTER COLUMN state TYPE CHAR' % schema)
+        op.execute('DROP TYPE IF EXISTS "REQUESTS_HISTORY_STATE_CHK"')
+        op.execute(f'CREATE TYPE "REQUESTS_HISTORY_STATE_CHK" AS ENUM({enum_values_str(new_enum_values)})')
+        op.execute('ALTER TABLE %srequests_history ALTER COLUMN state TYPE "REQUESTS_HISTORY_STATE_CHK" USING state::"REQUESTS_HISTORY_STATE_CHK"' % schema)
+        op.execute('ALTER TABLE %srequests DROP CONSTRAINT IF EXISTS "REQUESTS_STATE_CHK", ALTER COLUMN state TYPE CHAR' % schema)
+        op.execute('DROP TYPE IF EXISTS "REQUESTS_STATE_CHK"')
+        op.execute(f'CREATE TYPE "REQUESTS_STATE_CHK" AS ENUM({enum_values_str(new_enum_values)})')
+        op.execute('ALTER TABLE %srequests ALTER COLUMN state TYPE "REQUESTS_STATE_CHK" USING state::"REQUESTS_STATE_CHK"' % schema)
+    elif dialect == 'mysql':
+        if context.get_context().dialect.server_version_info[0] >= 8:
+            _mysql_drop_check_constraint_if_exists(schema, 'requests', 'REQUESTS_STATE_CHK')
+            _mysql_drop_check_constraint_if_exists(schema, 'requests_history', 'REQUESTS_HIST_STATE_CHK')
+        op.create_check_constraint(
+            constraint_name='REQUESTS_STATE_CHK',
+            table_name='requests',
+            condition=f'state in ({enum_values_str(new_enum_values)})',
+        )
+        op.create_check_constraint(
+            constraint_name='REQUESTS_HIST_STATE_CHK',
+            table_name='requests_history',
+            condition=f'state in ({enum_values_str(new_enum_values)})',
+        )
+
+
+def downgrade():
+    """Downgrade the database to the previous revision."""
+    schema = context.get_context().version_table_schema + '.' if context.get_context().version_table_schema else ''
+    dialect = context.get_context().dialect.name
+
+    old_enum_values = ['Q', 'G', 'S', 'D', 'F', 'L', 'N', 'O', 'A', 'U', 'W', 'M', 'P']
+
+    if dialect in ['oracle', 'mysql', 'postgresql']:
+        drop_table('updated_requests')
+        if dialect == 'postgresql':
+            op.execute('DROP TYPE IF EXISTS "UPDATED_REQUESTS_STATE_CHK"')
+
+    # Migrate requests in CANCELLING ('X') or CANCELLED ('C') states to FAILED ('F')
+    op.execute("UPDATE %srequests SET state = 'F', err_msg = 'Cancelled by DB downgrade' WHERE state IN ('X', 'C')" % schema)
+
+    # Revert state check constraints
+    if dialect == 'oracle':
+        try_drop_constraint('REQUESTS_STATE_CHK', 'requests')
+        op.create_check_constraint(
+            constraint_name='REQUESTS_STATE_CHK',
+            table_name='requests',
+            condition=f'state in ({enum_values_str(old_enum_values)})',
+        )
+        try_drop_constraint('REQUESTS_HIST_STATE_CHK', 'requests_history')
+        op.create_check_constraint(
+            constraint_name='REQUESTS_HIST_STATE_CHK',
+            table_name='requests_history',
+            condition=f'state in ({enum_values_str(old_enum_values)})',
+        )
+    elif dialect == 'postgresql':
+        # Recreate enum types without X and C values
+        op.execute('ALTER TABLE %srequests_history DROP CONSTRAINT IF EXISTS "REQUESTS_HISTORY_STATE_CHK", ALTER COLUMN state TYPE CHAR' % schema)
+        op.execute('DROP TYPE IF EXISTS "REQUESTS_HISTORY_STATE_CHK"')
+        op.execute(f'CREATE TYPE "REQUESTS_HISTORY_STATE_CHK" AS ENUM({enum_values_str(old_enum_values)})')
+        op.execute('ALTER TABLE %srequests_history ALTER COLUMN state TYPE "REQUESTS_HISTORY_STATE_CHK" USING state::"REQUESTS_HISTORY_STATE_CHK"' % schema)
+        op.execute('ALTER TABLE %srequests DROP CONSTRAINT IF EXISTS "REQUESTS_STATE_CHK", ALTER COLUMN state TYPE CHAR' % schema)
+        op.execute('DROP TYPE IF EXISTS "REQUESTS_STATE_CHK"')
+        op.execute(f'CREATE TYPE "REQUESTS_STATE_CHK" AS ENUM({enum_values_str(old_enum_values)})')
+        op.execute('ALTER TABLE %srequests ALTER COLUMN state TYPE "REQUESTS_STATE_CHK" USING state::"REQUESTS_STATE_CHK"' % schema)
+    elif dialect == 'mysql':
+        if context.get_context().dialect.server_version_info[0] >= 8:
+            _mysql_drop_check_constraint_if_exists(schema, 'requests', 'REQUESTS_STATE_CHK')
+            _mysql_drop_check_constraint_if_exists(schema, 'requests_history', 'REQUESTS_HIST_STATE_CHK')
+        else:
+            op.create_check_constraint(
+                constraint_name='REQUESTS_STATE_CHK',
+                table_name='requests',
+                condition=f'state in ({enum_values_str(old_enum_values)})',
+            )
+            op.create_check_constraint(
+                constraint_name='REQUESTS_HIST_STATE_CHK',
+                table_name='requests_history',
+                condition=f'state in ({enum_values_str(old_enum_values)})',
+            )

--- a/lib/rucio/db/sqla/migrate_repo/versions/d23453595260_extend_request_state_for_preparer.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/d23453595260_extend_request_state_for_preparer.py
@@ -44,7 +44,7 @@ def upgrade():
         )
     elif dialect == 'postgresql':
         op.execute('ALTER TABLE %srequests_history DROP CONSTRAINT IF EXISTS "REQUESTS_HISTORY_STATE_CHK", ALTER COLUMN state TYPE CHAR' % schema)
-        op.execute('DROP TYPE "REQUESTS_HISTORY_STATE_CHK"')
+        op.execute('DROP TYPE IF EXISTS "REQUESTS_HISTORY_STATE_CHK"')
         op.execute(f'CREATE TYPE "REQUESTS_HISTORY_STATE_CHK" AS ENUM({enum_values_str(new_enum_values)})')
         op.execute('ALTER TABLE %srequests_history ALTER COLUMN state TYPE "REQUESTS_HISTORY_STATE_CHK" USING state::"REQUESTS_HISTORY_STATE_CHK"' % schema)
         op.execute('ALTER TABLE %srequests DROP CONSTRAINT IF EXISTS "REQUESTS_STATE_CHK", ALTER COLUMN state TYPE CHAR' % schema)
@@ -82,6 +82,7 @@ def downgrade():
         )
     elif dialect == 'postgresql':
         op.execute('ALTER TABLE %srequests_history DROP CONSTRAINT IF EXISTS "REQUESTS_HISTORY_STATE_CHK", ALTER COLUMN state TYPE CHAR' % schema)
+        op.execute('DROP TYPE "REQUESTS_HISTORY_STATE_CHK"')
         op.execute(f'CREATE TYPE "REQUESTS_HISTORY_STATE_CHK" AS ENUM({enum_values_str(old_enum_values)})')
         op.execute('ALTER TABLE %srequests_history ALTER COLUMN state TYPE "REQUESTS_HISTORY_STATE_CHK" USING state::"REQUESTS_HISTORY_STATE_CHK"' % schema)
         op.execute('ALTER TABLE %srequests DROP CONSTRAINT IF EXISTS "REQUESTS_STATE_CHK", ALTER COLUMN state TYPE CHAR' % schema)

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -1459,6 +1459,19 @@ class Request(BASE, ModelBase):
                    Index('REQUESTS_TYP_STA_TRA_ACT_IDX', 'request_type', 'state', 'transfertool', 'activity'))
 
 
+class UpdatedRequest(BASE, ModelBase):
+    """Represents requests with pending state updates (e.g., cancellation)"""
+    __tablename__ = 'updated_requests'
+    id: Mapped[str] = mapped_column(GUID(), default=utils.generate_uuid)
+    request_id: Mapped[str] = mapped_column(GUID())
+    state: Mapped[Optional[RequestState]] = mapped_column(Enum(RequestState, name='UPDATED_REQUESTS_STATE_CHK',
+                                                               create_constraint=True,
+                                                               values_callable=lambda obj: [e.value for e in obj]))
+    _table_args = (PrimaryKeyConstraint('id', name='UPDATED_REQUESTS_PK'),
+                   CheckConstraint('REQUEST_ID IS NOT NULL', name='UPDATED_REQUESTS_REQUEST_ID_NN'),
+                   Index('UPDATED_REQUESTS_REQUEST_ID_IDX', 'request_id'))
+
+
 class TransferHop(BASE, ModelBase):
     """Represents source files for transfers"""
     __tablename__ = 'transfer_hops'

--- a/lib/rucio/transfertool/bittorrent.py
+++ b/lib/rucio/transfertool/bittorrent.py
@@ -185,7 +185,7 @@ class BittorrentTransfertool(Transfertool):
             for request_id, request in requests.items():
                 driver = self._driver_for_rse(request['dst_rse'])
                 if not driver:
-                    self.logger(f'Cannot instantiate BitTorrent driver for {request["dest_rse"]}')
+                    self.logger(logging.WARNING, f'Cannot instantiate BitTorrent driver for {request["dst_rse"]}')
                     continue
                 response.setdefault(transfer_id, {})[request_id] = driver.get_status(request_id=request_id, torrent_id=transfer_id)
         return response

--- a/tests/test_conveyor.py
+++ b/tests/test_conveyor.py
@@ -448,7 +448,7 @@ def test_multisource(vo, did_factory, root_account, replica_client, caches_mock,
         'rucio_core_request_get_next_requests_total',
         labels={
             'request_type': 'TRANSFER.STAGEIN.STAGEOUT',
-            'state': 'DONE.FAILED.LOST.SUBMISSION_FAILED.NO_SOURCES.ONLY_TAPE_SOURCES.MISMATCH_SCHEME'}
+            'state': 'DONE.FAILED.LOST.SUBMISSION_FAILED.NO_SOURCES.ONLY_TAPE_SOURCES.MISMATCH_SCHEME.CANCELLED'}
     )
 
 
@@ -1079,7 +1079,7 @@ def test_lost_transfers(rse_factory, did_factory, root_account):
 
 
 @skip_rse_tests_with_accounts
-@pytest.mark.noparallel(groups=[NoParallelGroups.SUBMITTER])
+@pytest.mark.noparallel(groups=[NoParallelGroups.SUBMITTER, NoParallelGroups.POLLER, NoParallelGroups.FINISHER])
 def test_cancel_rule(rse_factory, did_factory, root_account):
     """
     Ensure that, when we cancel a rule, the request is cancelled in FTS
@@ -1105,14 +1105,53 @@ def test_cancel_rule(rse_factory, did_factory, root_account):
     with patch('rucio.core.transfer.TRANSFERTOOL_CLASSES_BY_NAME', new={'fts3': _FTSWrapper}):
         submitter(once=True, rses=[{'id': rse_id} for rse_id in all_rses], group_bulk=2, partition_wait_time=0, transfertype='single', filter_transfertool=None)
     request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
+    assert request['state'] == RequestState.SUBMITTED
 
     rule_core.delete_rule(rule_id)
+    request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
+    assert request['state'] == RequestState.SUBMITTED
 
+    poller(once=True, older_than=0, partition_wait_time=0)
+    request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
+    assert request['state'] == RequestState.CANCELLED
+
+    finisher(once=True, partition_wait_time=0)
     with pytest.raises(RequestNotFound):
         request_core.get_request_by_did(rse_id=dst_rse_id, **did)
 
     fts_response = FTS3Transfertool(external_host=TEST_FTS_HOST).bulk_query({request['external_id']: {request['id']: request}})
     assert fts_response[request['external_id']][request['id']].job_response['job_state'] == 'CANCELED'
+
+
+@skip_rse_tests_with_accounts
+@pytest.mark.noparallel(groups=[NoParallelGroups.SUBMITTER, NoParallelGroups.FINISHER])
+def test_cancel_rule_before_submission(rse_factory, did_factory, root_account):
+    """
+    Ensure that cancelling a rule before submission goes directly to CANCELLED state.
+    """
+    src_rse, src_rse_id = rse_factory.make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.posix.Default')
+    dst_rse, dst_rse_id = rse_factory.make_rse(scheme='mock', protocol_impl='rucio.rse.protocols.posix.Default')
+
+    distance_core.add_distance(src_rse_id, dst_rse_id, distance=10)
+    rse_core.add_rse_attribute(dst_rse_id, RseAttr.FTS, TEST_FTS_HOST)
+
+    did = did_factory.upload_test_file(src_rse)
+
+    [rule_id] = rule_core.add_rule(dids=[did], account=root_account, copies=1, rse_expression=dst_rse, grouping='ALL', weight=None, lifetime=None, locked=False, subscription_id=None)
+    request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
+    assert request['state'] == RequestState.QUEUED
+
+    rule_core.delete_rule(rule_id)
+    request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
+    assert request['state'] == RequestState.QUEUED
+
+    submitter(once=True, rses=[{'id': dst_rse_id}], partition_wait_time=0, transfertools=['mock'], transfertype='single', filter_transfertool=None)
+    request = request_core.get_request_by_did(rse_id=dst_rse_id, **did)
+    assert request['state'] == RequestState.CANCELLED
+
+    finisher(once=True, partition_wait_time=0)
+    with pytest.raises(RequestNotFound):
+        request_core.get_request_by_did(rse_id=dst_rse_id, **did)
 
 
 class FTSWrapper(FTS3Transfertool):

--- a/tests/test_judge_repairer.py
+++ b/tests/test_judge_repairer.py
@@ -25,10 +25,9 @@ from rucio.core.account_limit import set_local_account_limit
 from rucio.core.did import add_did, attach_dids
 from rucio.core.lock import failed_transfer, get_replica_locks, successful_transfer
 from rucio.core.replica import get_replica
-from rucio.core.request import cancel_request_did
+from rucio.core.request import queue_request_cancellation
 from rucio.core.rse import add_rse, add_rse_attribute, update_rse
 from rucio.core.rule import add_rule, get_rule
-from rucio.core.transfer import cancel_transfers
 from rucio.daemons.judge.evaluator import re_evaluator
 from rucio.daemons.judge.repairer import rule_repairer
 from rucio.db.sqla import models
@@ -260,10 +259,8 @@ class TestJudgeRepairer:
         successful_transfer(scope=scope, name=files[1]['name'], rse_id=get_replica_locks(scope=files[1]['scope'], name=files[2]['name'])[0].rse_id, nowait=False)
         failed_transfer(scope=scope, name=files[2]['name'], rse_id=get_replica_locks(scope=files[2]['scope'], name=files[2]['name'])[0].rse_id)
         failed_transfer(scope=scope, name=files[3]['name'], rse_id=get_replica_locks(scope=files[3]['scope'], name=files[3]['name'])[0].rse_id)
-        transfs = cancel_request_did(scope=scope, name=files[2]['name'], dest_rse_id=get_replica_locks(scope=files[2]['scope'], name=files[2]['name'])[0].rse_id)
-        cancel_transfers(transfs)
-        transfs = cancel_request_did(scope=scope, name=files[3]['name'], dest_rse_id=get_replica_locks(scope=files[3]['scope'], name=files[2]['name'])[0].rse_id)
-        cancel_transfers(transfs)
+        queue_request_cancellation(scope=scope, name=files[2]['name'], dest_rse_id=get_replica_locks(scope=files[2]['scope'], name=files[2]['name'])[0].rse_id)
+        queue_request_cancellation(scope=scope, name=files[3]['name'], dest_rse_id=get_replica_locks(scope=files[3]['scope'], name=files[2]['name'])[0].rse_id)
 
         assert (rule_id == get_rule(rule_id)['id'].replace('-', '').lower())
         assert (RuleState.STUCK == get_rule(rule_id)['state'])


### PR DESCRIPTION
Completely get rid of FTS calls in core/rule.py . Use a new database work queue table (updated_requests) to communicate between rules and conveyor. Perform cancellation in conveyor. 