### PR TITLE
fix(Policies): make diff-based schemas work fully

### DIFF
--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -24,6 +24,7 @@ from jsonschema import ValidationError, validate
 from rucio.common import config, exception
 from rucio.common.constants import DEFAULT_VO
 from rucio.common.plugins import check_policy_module_version
+from rucio.common.schema.schema_ref import SchemaRef
 from rucio.db.sqla.constants import DatabaseOperationType
 from rucio.db.sqla.session import db_session
 
@@ -146,6 +147,25 @@ def load_schema_for_vo(vo: str) -> None:
     schema_modules[vo] = module
 
 
+def _resolve_references(schema: Any, vo: str = DEFAULT_VO) -> Any:
+    # if this is a schema reference, resolve it
+    if isinstance(schema, SchemaRef):
+        result = schema.resolve(vo)
+    # if this is a list or dictionary, resolve recursively
+    elif isinstance(schema, list):
+        result = []
+        for value in schema:
+            result.append(_resolve_references(value, vo))
+    elif isinstance(schema, dict):
+        result = {}
+        for key in schema:
+            result[key] = _resolve_references(schema[key], vo)
+    else:
+        # for other types (e.g. scalars), return unmodified
+        result = schema
+    return result
+
+
 def validate_schema(name: str, obj: Any, vo: str = DEFAULT_VO) -> None:
     if obj:
         if vo not in schema_modules:
@@ -155,6 +175,7 @@ def validate_schema(name: str, obj: Any, vo: str = DEFAULT_VO) -> None:
         else:
             # if schema not available in VO module, fall back to generic module
             schema = _get_generic_schema_module().SCHEMAS.get(name, {})
+        schema = _resolve_references(schema, vo)
         try:
             validate(obj, schema)
         except ValidationError as error:
@@ -165,8 +186,8 @@ def get_schema_value(key: str, vo: str = DEFAULT_VO) -> Any:
     if vo not in schema_modules:
         load_schema_for_vo(vo)
     if not hasattr(schema_modules[vo], key):
-        return getattr(_get_generic_schema_module(), key)
-    return getattr(schema_modules[vo], key)
+        return _resolve_references(getattr(_get_generic_schema_module(), key), vo)
+    return _resolve_references(getattr(schema_modules[vo], key), vo)
 
 
 def get_scope_name_regexps() -> list[str]:

--- a/lib/rucio/common/schema/generic.py
+++ b/lib/rucio/common/schema/generic.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rucio.common.schema.schema_ref import SchemaRef
 
 ACCOUNT_LENGTH = 25
 
 ACCOUNT = {"description": "Account name",
            "type": "string",
-           "maxLength": ACCOUNT_LENGTH,
+           "maxLength": SchemaRef("ACCOUNT_LENGTH"),
            "pattern": "^[a-z0-9-_]+$"}
 
 ACCOUNTS = {"description": "Array of accounts",
             "type": "array",
-            "items": ACCOUNT,
+            "items": SchemaRef("ACCOUNT"),
             "minItems": 0,
             "maxItems": 1000}
 
@@ -44,7 +45,7 @@ SCOPE_LENGTH = 25
 
 SCOPE = {"description": "Scope name",
          "type": "string",
-         "maxLength": SCOPE_LENGTH,
+         "maxLength": SchemaRef("SCOPE_LENGTH"),
          "pattern": "^[a-zA-Z_\\-.0-9]+$"}
 
 R_SCOPE = {"description": "Scope name",
@@ -55,7 +56,7 @@ NAME_LENGTH = 250
 
 NAME = {"description": "Data Identifier name",
         "type": "string",
-        "maxLength": NAME_LENGTH,
+        "maxLength": SchemaRef("NAME_LENGTH"),
         "pattern": r"^[/A-Za-z0-9][/A-Za-z0-9\.\-_]*$"}
 
 R_NAME = {"description": "Data Identifier name",
@@ -142,7 +143,7 @@ UUID = {"description": "Universally Unique Identifier (UUID)",
 
 META = {"description": "Data Identifier(DID) metadata",
         "type": "object",
-        "properties": {"guid": UUID},
+        "properties": {"guid": SchemaRef("UUID")},
         "additionalProperties": True}
 
 PFN = {"description": "Physical File Name", "type": "string"}
@@ -195,32 +196,32 @@ CLIENT_STATE = {
 RULE = {"description": "Replication rule",
         "type": "object",
         "properties": {"dids": {"type": "array"},
-                       "account": ACCOUNT,
-                       "copies": COPIES,
-                       "rse_expression": RSE_EXPRESSION,
-                       "grouping": GROUPING,
-                       "weight": WEIGHT,
-                       "lifetime": RULE_LIFETIME,
-                       "locked": LOCKED,
-                       "subscription_id": SUBSCRIPTION_ID,
-                       "source_replica_expression": SOURCE_REPLICA_EXPRESSION,
-                       "activity": ACTIVITY,
-                       "notify": NOTIFY,
-                       "purge_replicas": PURGE_REPLICAS,
-                       "ignore_availability": IGNORE_AVAILABILITY,
-                       "comment": COMMENT,
-                       "ask_approval": ASK_APPROVAL,
-                       "asynchronous": ASYNCHRONOUS,
-                       "delay_injection": DELAY_INJECTION,
-                       "priority": PRIORITY,
-                       'split_container': SPLIT_CONTAINER,
-                       'meta': METADATA},
+                       "account": SchemaRef("ACCOUNT"),
+                       "copies": SchemaRef("COPIES"),
+                       "rse_expression": SchemaRef("RSE_EXPRESSION"),
+                       "grouping": SchemaRef("GROUPING"),
+                       "weight": SchemaRef("WEIGHT"),
+                       "lifetime": SchemaRef("RULE_LIFETIME"),
+                       "locked": SchemaRef("LOCKED"),
+                       "subscription_id": SchemaRef("SUBSCRIPTION_ID"),
+                       "source_replica_expression": SchemaRef("SOURCE_REPLICA_EXPRESSION"),
+                       "activity": SchemaRef("ACTIVITY"),
+                       "notify": SchemaRef("NOTIFY"),
+                       "purge_replicas": SchemaRef("PURGE_REPLICAS"),
+                       "ignore_availability": SchemaRef("IGNORE_AVAILABILITY"),
+                       "comment": SchemaRef("COMMENT"),
+                       "ask_approval": SchemaRef("ASK_APPROVAL"),
+                       "asynchronous": SchemaRef("ASYNCHRONOUS"),
+                       "delay_injection": SchemaRef("DELAY_INJECTION"),
+                       "priority": SchemaRef("PRIORITY"),
+                       'split_container': SchemaRef("SPLIT_CONTAINER"),
+                       'meta': SchemaRef("METADATA")},
         "required": ["dids", "copies", "rse_expression"],
         "additionalProperties": False}
 
 RULES = {"description": "Array of replication rules",
          "type": "array",
-         "items": RULE,
+         "items": SchemaRef("RULE"),
          "minItems": 1,
          "maxItems": 1000}
 
@@ -230,32 +231,32 @@ COLLECTION_TYPE = {"description": "Dataset or container type",
 
 COLLECTION = {"description": "Dataset or container",
               "type": "object",
-              "properties": {"scope": SCOPE,
-                             "name": NAME,
-                             "type": COLLECTION_TYPE,
-                             "meta": META,
-                             "rules": RULES},
+              "properties": {"scope": SchemaRef("SCOPE"),
+                             "name": SchemaRef("NAME"),
+                             "type": SchemaRef("COLLECTION_TYPE"),
+                             "meta": SchemaRef("META"),
+                             "rules": SchemaRef("RULES")},
               "required": ["scope", "name", "type"],
               "additionalProperties": False}
 
 COLLECTIONS = {"description": "Array of datasets or containers",
                "type": "array",
-               "items": COLLECTION,
+               "items": SchemaRef("COLLECTION"),
                "minItems": 1,
                "maxItems": 1000}
 
 DID = {"description": "Data Identifier(DID)",
        "type": "object",
-       "properties": {"scope": SCOPE,
-                      "name": NAME,
-                      "type": DID_TYPE,
-                      "meta": META,
-                      "rules": RULES,
-                      "bytes": BYTES,
-                      "adler32": ADLER32,
-                      "md5": MD5,
-                      "state": REPLICA_STATE,
-                      "pfn": PFN},
+       "properties": {"scope": SchemaRef("SCOPE"),
+                      "name": SchemaRef("NAME"),
+                      "type": SchemaRef("DID_TYPE"),
+                      "meta": SchemaRef("META"),
+                      "rules": SchemaRef("RULES"),
+                      "bytes": SchemaRef("BYTES"),
+                      "adler32": SchemaRef("ADLER32"),
+                      "md5": SchemaRef("MD5"),
+                      "state": SchemaRef("REPLICA_STATE"),
+                      "pfn": SchemaRef("PFN")},
        "required": ["scope", "name"],
        "additionalProperties": False}
 
@@ -265,45 +266,45 @@ DID_FILTERS = {"description": "Array to filter DIDs by metadata",
 
 R_DID = {"description": "Data Identifier(DID)",
          "type": "object",
-         "properties": {"scope": R_SCOPE,
-                        "name": R_NAME,
-                        "type": DID_TYPE,
-                        "meta": META,
-                        "rules": RULES,
-                        "bytes": BYTES,
-                        "adler32": ADLER32,
-                        "md5": MD5,
-                        "state": REPLICA_STATE,
-                        "pfn": PFN},
+         "properties": {"scope": SchemaRef("R_SCOPE"),
+                        "name": SchemaRef("R_NAME"),
+                        "type": SchemaRef("DID_TYPE"),
+                        "meta": SchemaRef("META"),
+                        "rules": SchemaRef("RULES"),
+                        "bytes": SchemaRef("BYTES"),
+                        "adler32": SchemaRef("ADLER32"),
+                        "md5": SchemaRef("MD5"),
+                        "state": SchemaRef("REPLICA_STATE"),
+                        "pfn": SchemaRef("PFN")},
          "required": ["scope", "name"],
          "additionalProperties": False}
 
 DIDS = {"description": "Array of Data Identifiers(DIDs)",
         "type": "array",
-        "items": DID,
+        "items": SchemaRef("DID"),
         "minItems": 1,
         "maxItems": 1000}
 
 R_DIDS = {"description": "Array of Data Identifiers(DIDs)",
           "type": "array",
-          "items": R_DID,
+          "items": SchemaRef("R_DID"),
           "minItems": 1,
           "maxItems": 1000}
 
 ATTACHMENT = {"description": "Attachment",
               "type": "object",
-              "properties": {"scope": SCOPE,
-                             "name": NAME,
+              "properties": {"scope": SchemaRef("SCOPE"),
+                             "name": SchemaRef("NAME"),
                              "rse": {"description": "RSE name",
                                      "type": ["string", "null"],
                                      "pattern": "^([A-Z0-9]+([_-][A-Z0-9]+)*)$"},
-                             "dids": DIDS},
+                             "dids": SchemaRef("DIDS")},
               "required": ["dids"],
               "additionalProperties": False}
 
 ATTACHMENTS = {"description": "Array of attachments",
                "type": "array",
-               "items": ATTACHMENT,
+               "items": SchemaRef("ATTACHMENT"),
                "minItems": 1,
                "maxItems": 1000}
 
@@ -317,48 +318,48 @@ SUBSCRIPTION_FILTER = {"type": "object",
                                       "excluded_pattern": {"type": "string"},
                                       "group": {"type": "string"},
                                       "provenance": {"type": "string"},
-                                      "account": ACCOUNTS,
+                                      "account": SchemaRef("ACCOUNTS"),
                                       "grouping": {"type": "string"},
                                       "split_rule": {"type": "boolean"}}}
 
 ADD_REPLICA_FILE = {"description": "add replica file",
                     "type": "object",
-                    "properties": {"scope": SCOPE,
-                                   "name": NAME,
-                                   "bytes": BYTES,
-                                   "adler32": ADLER32},
+                    "properties": {"scope": SchemaRef("SCOPE"),
+                                   "name": SchemaRef("NAME"),
+                                   "bytes": SchemaRef("BYTES"),
+                                   "adler32": SchemaRef("ADLER32")},
                     "required": ["scope", "name", "bytes", "adler32"]}
 
 ADD_REPLICA_FILES = {"description": "add replica files",
                      "type": "array",
-                     "items": ADD_REPLICA_FILE,
+                     "items": SchemaRef("ADD_REPLICA_FILE"),
                      "minItems": 1,
                      "maxItems": 1000}
 
 CACHE_ADD_REPLICAS = {"description": "rucio cache add replicas",
                       "type": "object",
-                      "properties": {"files": ADD_REPLICA_FILES,
-                                     "rse": RSE,
-                                     "lifetime": LIFETIME,
+                      "properties": {"files": SchemaRef("ADD_REPLICA_FILES"),
+                                     "rse": SchemaRef("RSE"),
+                                     "lifetime": SchemaRef("LIFETIME"),
                                      "operation": {"enum": ["add_replicas"]}},
                       "required": ['files', 'rse', 'lifetime', 'operation']}
 
 DELETE_REPLICA_FILE = {"description": "delete replica file",
                        "type": "object",
-                       "properties": {"scope": SCOPE,
-                                      "name": NAME},
+                       "properties": {"scope": SchemaRef("SCOPE"),
+                                      "name": SchemaRef("NAME")},
                        "required": ["scope", "name"]}
 
 DELETE_REPLICA_FILES = {"description": "delete replica files",
                         "type": "array",
-                        "items": DELETE_REPLICA_FILE,
+                        "items": SchemaRef("DELETE_REPLICA_FILE"),
                         "minItems": 1,
                         "maxItems": 1000}
 
 CACHE_DELETE_REPLICAS = {"description": "rucio cache delete replicas",
                          "type": "object",
-                         "properties": {"files": DELETE_REPLICA_FILES,
-                                        "rse": RSE,
+                         "properties": {"files": SchemaRef("DELETE_REPLICA_FILES"),
+                                        "rse": SchemaRef("RSE"),
                                         "operation": {"enum": ["delete_replicas"]}},
                          "required": ['files', 'rse', 'operation']}
 

--- a/lib/rucio/common/schema/generic_multi_vo.py
+++ b/lib/rucio/common/schema/generic_multi_vo.py
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rucio.common.schema.schema_ref import SchemaRef
 
 ACCOUNT_LENGTH = 29
 
 ACCOUNT = {"description": "Account name",
            "type": "string",
-           "maxLength": ACCOUNT_LENGTH - 4,
+           "maxLength": SchemaRef("ACCOUNT_LENGTH", -4),
            "pattern": "^[a-z0-9-_]+$"}
 
 
 ACCOUNTS = {"description": "Array of accounts",
             "type": "array",
-            "items": ACCOUNT,
+            "items": SchemaRef("ACCOUNT"),
             "minItems": 0,
             "maxItems": 1000}
 
@@ -45,7 +46,7 @@ SCOPE_LENGTH = 29
 
 SCOPE = {"description": "Scope name",
          "type": "string",
-         "maxLength": SCOPE_LENGTH - 4,
+         "maxLength": SchemaRef("SCOPE_LENGTH", -4),
          "pattern": "^[a-zA-Z_\\-.0-9]+$"}
 
 R_SCOPE = {"description": "Scope name",
@@ -56,7 +57,7 @@ NAME_LENGTH = 250
 
 NAME = {"description": "Data Identifier name",
         "type": "string",
-        "maxLength": NAME_LENGTH,
+        "maxLength": SchemaRef("NAME_LENGTH"),
         "pattern": r"^[/A-Za-z0-9][/A-Za-z0-9\.\-_]*$"}
 
 R_NAME = {"description": "Data Identifier name",
@@ -143,7 +144,7 @@ UUID = {"description": "Universally Unique Identifier (UUID)",
 
 META = {"description": "Data Identifier(DID) metadata",
         "type": "object",
-        "properties": {"guid": UUID},
+        "properties": {"guid": SchemaRef("UUID")},
         "additionalProperties": True}
 
 PFN = {"description": "Physical File Name", "type": "string"}
@@ -169,32 +170,32 @@ SPLIT_CONTAINER = {"description": "Rule split container mode",
 RULE = {"description": "Replication rule",
         "type": "object",
         "properties": {"dids": {"type": "array"},
-                       "account": ACCOUNT,
-                       "copies": COPIES,
-                       "rse_expression": RSE_EXPRESSION,
-                       "grouping": GROUPING,
-                       "weight": WEIGHT,
-                       "lifetime": RULE_LIFETIME,
-                       "locked": LOCKED,
-                       "subscription_id": SUBSCRIPTION_ID,
-                       "source_replica_expression": SOURCE_REPLICA_EXPRESSION,
-                       "activity": ACTIVITY,
-                       "notify": NOTIFY,
-                       "purge_replicas": PURGE_REPLICAS,
-                       "ignore_availability": IGNORE_AVAILABILITY,
-                       "comment": COMMENT,
-                       "ask_approval": ASK_APPROVAL,
-                       "asynchronous": ASYNCHRONOUS,
-                       "delay_injection": DELAY_INJECTION,
-                       "priority": PRIORITY,
-                       'split_container': SPLIT_CONTAINER,
-                       'meta': METADATA},
+                       "account": SchemaRef("ACCOUNT"),
+                       "copies": SchemaRef("COPIES"),
+                       "rse_expression": SchemaRef("RSE_EXPRESSION"),
+                       "grouping": SchemaRef("GROUPING"),
+                       "weight": SchemaRef("WEIGHT"),
+                       "lifetime": SchemaRef("RULE_LIFETIME"),
+                       "locked": SchemaRef("LOCKED"),
+                       "subscription_id": SchemaRef("SUBSCRIPTION_ID"),
+                       "source_replica_expression": SchemaRef("SOURCE_REPLICA_EXPRESSION"),
+                       "activity": SchemaRef("ACTIVITY"),
+                       "notify": SchemaRef("NOTIFY"),
+                       "purge_replicas": SchemaRef("PURGE_REPLICAS"),
+                       "ignore_availability": SchemaRef("IGNORE_AVAILABILITY"),
+                       "comment": SchemaRef("COMMENT"),
+                       "ask_approval": SchemaRef("ASK_APPROVAL"),
+                       "asynchronous": SchemaRef("ASYNCHRONOUS"),
+                       "delay_injection": SchemaRef("DELAY_INJECTION"),
+                       "priority": SchemaRef("PRIORITY"),
+                       'split_container': SchemaRef("SPLIT_CONTAINER"),
+                       'meta': SchemaRef("METADATA")},
         "required": ["dids", "copies", "rse_expression"],
         "additionalProperties": False}
 
 RULES = {"description": "Array of replication rules",
          "type": "array",
-         "items": RULE,
+         "items": SchemaRef("RULE"),
          "minItems": 1,
          "maxItems": 1000}
 
@@ -204,32 +205,32 @@ COLLECTION_TYPE = {"description": "Dataset or container type",
 
 COLLECTION = {"description": "Dataset or container",
               "type": "object",
-              "properties": {"scope": SCOPE,
-                             "name": NAME,
-                             "type": COLLECTION_TYPE,
-                             "meta": META,
-                             "rules": RULES},
+              "properties": {"scope": SchemaRef("SCOPE"),
+                             "name": SchemaRef("NAME"),
+                             "type": SchemaRef("COLLECTION_TYPE"),
+                             "meta": SchemaRef("META"),
+                             "rules": SchemaRef("RULES")},
               "required": ["scope", "name", "type"],
               "additionalProperties": False}
 
 COLLECTIONS = {"description": "Array of datasets or containers",
                "type": "array",
-               "items": COLLECTION,
+               "items": SchemaRef("COLLECTION"),
                "minItems": 1,
                "maxItems": 1000}
 
 DID = {"description": "Data Identifier(DID)",
        "type": "object",
-       "properties": {"scope": SCOPE,
-                      "name": NAME,
-                      "type": DID_TYPE,
-                      "meta": META,
-                      "rules": RULES,
-                      "bytes": BYTES,
-                      "adler32": ADLER32,
-                      "md5": MD5,
-                      "state": REPLICA_STATE,
-                      "pfn": PFN},
+       "properties": {"scope": SchemaRef("SCOPE"),
+                      "name": SchemaRef("NAME"),
+                      "type": SchemaRef("DID_TYPE"),
+                      "meta": SchemaRef("META"),
+                      "rules": SchemaRef("RULES"),
+                      "bytes": SchemaRef("BYTES"),
+                      "adler32": SchemaRef("ADLER32"),
+                      "md5": SchemaRef("MD5"),
+                      "state": SchemaRef("REPLICA_STATE"),
+                      "pfn": SchemaRef("PFN")},
        "required": ["scope", "name"],
        "additionalProperties": False}
 
@@ -239,45 +240,45 @@ DID_FILTERS = {"description": "Array to filter DIDs by metadata",
 
 R_DID = {"description": "Data Identifier(DID)",
          "type": "object",
-         "properties": {"scope": R_SCOPE,
-                        "name": R_NAME,
-                        "type": DID_TYPE,
-                        "meta": META,
-                        "rules": RULES,
-                        "bytes": BYTES,
-                        "adler32": ADLER32,
-                        "md5": MD5,
-                        "state": REPLICA_STATE,
-                        "pfn": PFN},
+         "properties": {"scope": SchemaRef("R_SCOPE"),
+                        "name": SchemaRef("R_NAME"),
+                        "type": SchemaRef("DID_TYPE"),
+                        "meta": SchemaRef("META"),
+                        "rules": SchemaRef("RULES"),
+                        "bytes": SchemaRef("BYTES"),
+                        "adler32": SchemaRef("ADLER32"),
+                        "md5": SchemaRef("MD5"),
+                        "state": SchemaRef("REPLICA_STATE"),
+                        "pfn": SchemaRef("PFN")},
          "required": ["scope", "name"],
          "additionalProperties": False}
 
 DIDS = {"description": "Array of Data Identifiers(DIDs)",
         "type": "array",
-        "items": DID,
+        "items": SchemaRef("DID"),
         "minItems": 1,
         "maxItems": 1000}
 
 R_DIDS = {"description": "Array of Data Identifiers(DIDs)",
           "type": "array",
-          "items": R_DID,
+          "items": SchemaRef("R_DID"),
           "minItems": 1,
           "maxItems": 1000}
 
 ATTACHMENT = {"description": "Attachement",
               "type": "object",
-              "properties": {"scope": SCOPE,
-                             "name": NAME,
+              "properties": {"scope": SchemaRef("SCOPE"),
+                             "name": SchemaRef("NAME"),
                              "rse": {"description": "RSE name",
                                      "type": ["string", "null"],
                                      "pattern": "^([A-Z0-9]+([_-][A-Z0-9]+)*)$"},
-                             "dids": DIDS},
+                             "dids": SchemaRef("DIDS")},
               "required": ["dids"],
               "additionalProperties": False}
 
 ATTACHMENTS = {"description": "Array of attachments",
                "type": "array",
-               "items": ATTACHMENT,
+               "items": SchemaRef("ATTACHMENT"),
                "minItems": 1,
                "maxItems": 1000}
 
@@ -291,48 +292,48 @@ SUBSCRIPTION_FILTER = {"type": "object",
                                       "excluded_pattern": {"type": "string"},
                                       "group": {"type": "string"},
                                       "provenance": {"type": "string"},
-                                      "account": ACCOUNTS,
+                                      "account": SchemaRef("ACCOUNTS"),
                                       "grouping": {"type": "string"},
                                       "split_rule": {"type": "boolean"}}}
 
 ADD_REPLICA_FILE = {"description": "add replica file",
                     "type": "object",
-                    "properties": {"scope": SCOPE,
-                                   "name": NAME,
-                                   "bytes": BYTES,
-                                   "adler32": ADLER32},
+                    "properties": {"scope": SchemaRef("SCOPE"),
+                                   "name": SchemaRef("NAME"),
+                                   "bytes": SchemaRef("BYTES"),
+                                   "adler32": SchemaRef("ADLER32")},
                     "required": ["scope", "name", "bytes", "adler32"]}
 
 ADD_REPLICA_FILES = {"description": "add replica files",
                      "type": "array",
-                     "items": ADD_REPLICA_FILE,
+                     "items": SchemaRef("ADD_REPLICA_FILE"),
                      "minItems": 1,
                      "maxItems": 1000}
 
 CACHE_ADD_REPLICAS = {"description": "rucio cache add replicas",
                       "type": "object",
-                      "properties": {"files": ADD_REPLICA_FILES,
-                                     "rse": RSE,
-                                     "lifetime": LIFETIME,
+                      "properties": {"files": SchemaRef("ADD_REPLICA_FILES"),
+                                     "rse": SchemaRef("RSE"),
+                                     "lifetime": SchemaRef("LIFETIME"),
                                      "operation": {"enum": ["add_replicas"]}},
                       "required": ['files', 'rse', 'lifetime', 'operation']}
 
 DELETE_REPLICA_FILE = {"description": "delete replica file",
                        "type": "object",
-                       "properties": {"scope": SCOPE,
-                                      "name": NAME},
+                       "properties": {"scope": SchemaRef("SCOPE"),
+                                      "name": SchemaRef("NAME")},
                        "required": ["scope", "name"]}
 
 DELETE_REPLICA_FILES = {"description": "delete replica files",
                         "type": "array",
-                        "items": DELETE_REPLICA_FILE,
+                        "items": SchemaRef("DELETE_REPLICA_FILE"),
                         "minItems": 1,
                         "maxItems": 1000}
 
 CACHE_DELETE_REPLICAS = {"description": "rucio cache delete replicas",
                          "type": "object",
-                         "properties": {"files": DELETE_REPLICA_FILES,
-                                        "rse": RSE,
+                         "properties": {"files": SchemaRef("DELETE_REPLICA_FILES"),
+                                        "rse": SchemaRef("RSE"),
                                         "operation": {"enum": ["delete_replicas"]}},
                          "required": ['files', 'rse', 'operation']}
 

--- a/lib/rucio/common/schema/schema_ref.py
+++ b/lib/rucio/common/schema/schema_ref.py
@@ -1,0 +1,47 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Optional
+
+from rucio.common.constants import DEFAULT_VO
+
+
+class SchemaRef:
+    """
+    Represents a reference from one object in the schema hierarchy to another.
+    This can then be resolved to a value in either the policy package or the
+    generic schema module.
+    Although this is a small class it is in its own module to avoid causing a
+    circular import in __init__.py
+    """
+    def __init__(self, name: str, offset: Optional[int] = None):
+        """
+        Initialize a new SchemaRef containing the name of the item
+        referred to, and an optional integer offset to be added to
+        the item.
+        """
+        self.name = name
+        self.offset = offset
+
+    def resolve(self, vo: str = DEFAULT_VO) -> Any:
+        """
+        Resolves this SchemaRef, returning the actual value of the
+        item referred to.
+        """
+        from rucio.common.schema import get_schema_value
+
+        result = get_schema_value(self.name, vo)
+        if self.offset is not None:
+            result = result + self.offset
+        return result

--- a/tests/mocks/schema_diff.py
+++ b/tests/mocks/schema_diff.py
@@ -14,6 +14,8 @@
 
 # mock schema module that overrides only some values
 
+from rucio.common.schema.schema_ref import SchemaRef
+
 SCOPE_LENGTH = 50
 
 SCOPE = {"description": "Scope name",
@@ -27,3 +29,5 @@ ACCOUNT = {"description": "Account name",
            "pattern": "^[a-z0-9-_]+$"}
 
 SCHEMAS = {'account': ACCOUNT}
+
+TEST_SCHEMA = {"nameLength": SchemaRef("NAME_LENGTH")}

--- a/tests/test_policy_package.py
+++ b/tests/test_policy_package.py
@@ -110,6 +110,12 @@ class TestPolicyPackage:
         # check that schemas not defined in our module fall back to generic
         rucio.common.schema.validate_schema('r_name', 'name_to_validate')
 
+        # check that generic schema references our module correctly
+        assert rucio.common.schema.get_schema_value('ACCOUNTS')['items']['maxLength'] == 1000
+
+        # check that our schema references generic schema correctly
+        assert rucio.common.schema.get_schema_value('TEST_SCHEMA')['nameLength'] == 250
+
         # restore original schema module
         rucio.common.schema.schema_modules['def'] = old_module
 


### PR DESCRIPTION
Closes: #7731

This PR makes "diff-based" schemas in policy packages work correctly so that items not at the top level of the schema hierarchy can be overridden. It does this in a simpler way than my previous attempt, by introducing a new `SchemaRef` class that is used when schema values reference other schema values. These references are then resolved by checking the policy package first and falling back to the generic schema when appropriate.

(The reason `SchemaRef` is in its own file instead of in `__init__.py` is to avoid circular imports).