### PR TITLE
 fix(Clients): Do not overwrite purge-replicas arg in deletion 

### DIFF
--- a/lib/rucio/cli/bin_legacy/rucio.py
+++ b/lib/rucio/cli/bin_legacy/rucio.py
@@ -2532,7 +2532,7 @@ You can filter by key/value, e.g.::
     delete_rule_parser = subparsers.add_parser('delete-rule', help='Delete replication rule.')
     delete_rule_parser.set_defaults(function=delete_rule)
     delete_rule_parser.add_argument(dest='rule_id', action='store', help='Rule id or DID. If DID, the RSE expression is mandatory.')
-    delete_rule_parser.add_argument('--purge-replicas', dest='purge_replicas', action='store_true', help='Purge rule replicas')
+    delete_rule_parser.add_argument('--purge-replicas', dest='purge_replicas', action='store_true', default=None, help='Purge rule replicas')
     delete_rule_parser.add_argument('--all', dest='delete_all', action='store_true', default=False, help='Delete all the rules, even the ones that are not owned by the account')
     delete_rule_parser.add_argument('--rses', dest='rses', action='store', help='The RSE expression. Must be specified if a DID is provided.')
     delete_rule_parser.add_argument('--account', dest='rule_account', action='store', help='The account of the rule that must be deleted')

--- a/lib/rucio/cli/rule.py
+++ b/lib/rucio/cli/rule.py
@@ -68,7 +68,7 @@ def add_(ctx, dids, copies, rses, weight, asynchronous, lifetime, grouping, lock
 
 @rule.command("remove")
 @click.argument("rule-id-dids")
-@click.option("--purge-replicas", is_flag=True, default=False, help="Purge rule replicas")
+@click.option("--purge-replicas", is_flag=True, default=None, help="Purge rule replicas")
 @click.option("--all", "_all", is_flag=True, default=False, help="Delete all the rules, even the ones that are not owned by the account")
 @click.option("--rses", "--rse-exp", help="The RSE expression. Must be specified if a DID is provided.")  # TODO mutual inclusive group
 @click.option("--account", help="The account of the rule that must be deleted")


### PR DESCRIPTION
Closes #8356 

Adds an (already passing) test in `test_rules.py` that verifies this problem is happening purely at the argument specification level in the CLI. This test is not strictly required to show the issue has been fixed, but it's a good sanity check regardless. 