### PR TITLE
Core & Internals: Proper `did_type` handling in recursive `list_dids` rucio#8402

### DIFF
--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -332,10 +332,13 @@ class DidColumnMeta(DidMetaPlugin):
         # required number of times to satisfy all the logical possibilities.
         filters_tmp = []
         for or_group in filters:
-            if 'type' not in or_group:
-                or_group_type = did_type.lower()
-            else:
+            if 'type' in or_group:
                 or_group_type = or_group.pop('type').lower()
+            elif isinstance(or_group.get('did_type'), DIDType):
+                filters_tmp.append(or_group.copy())
+                continue
+            else:
+                or_group_type = did_type.lower()
             if or_group_type not in type_to_did_type_mapping.keys():
                 raise exception.UnsupportedOperation(
                     '{} is not a valid type. Valid types are {}'.format(or_group_type, type_to_did_type_mapping.keys()))

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -180,6 +180,25 @@ class TestDIDCore:
 
         detach_dids(scope=mock_scope, name=parent_name, dids=files)
 
+    def test_list_dids_recursive_preserves_type_filter(self, mock_scope, root_account, rse_factory):
+        """ DATA IDENTIFIERS (CORE): Preserve explicit type filter during recursive DID listing """
+        _, rse_id = rse_factory.make_mock_rse()
+        dataset_name = did_name_generator('dataset')
+        file_name = did_name_generator('file')
+
+        add_did(scope=mock_scope, name=dataset_name, did_type=DIDType.DATASET, account=root_account)
+        attach_dids(
+            scope=mock_scope,
+            name=dataset_name,
+            rse_id=rse_id,
+            dids=[{'scope': mock_scope, 'name': file_name, 'bytes': 1, 'adler32': '0cc737eb'}],
+            account=root_account,
+        )
+
+        listed_dids = set(list_dids(scope=mock_scope, filters={'name': dataset_name, 'type': 'all'}, did_type='collection', recursive=True))
+
+        assert listed_dids == {dataset_name, file_name}
+
     def test_attach_dids_ignore_duplicates(self, vo, mock_scope, root_account, rse_factory):
         """ DATA IDENTIFIERS (CORE): Attach DIDs with the ignore duplicates flag """
         rse, rse_id = rse_factory.make_mock_rse()


### PR DESCRIPTION
This patch fixes #8402 because it makes recursive calls **preserve already-expanded concrete `did_type` filters (including FILE)** instead of re-deriving them from the global `did_type='collection'` fallback after the semantic `type` key has been consumed.

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: rucio#8402
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
