### PR TITLE
Fix(Core): use logging in dirac, replace Belle-II terminology

### DIFF
--- a/lib/rucio/core/dirac.py
+++ b/lib/rucio/core/dirac.py
@@ -69,6 +69,14 @@ def _exists(
         return False, None
 
 
+def _did_parents(name: str) -> list[str]:
+    """Get parents of given did name assuming hierarchical namespace."""
+    parts = name.split('/')
+    parents = ["/".join(parts[:idx]) for idx in range(2, len(parts))]
+    parents.reverse()
+    return parents
+
+
 def add_files(
     lfns: "Iterable[dict[str, Any]]",
     account: str,
@@ -85,7 +93,7 @@ def add_files(
 
     :param lfns: List of lfn (dictionary {'lfn': <lfn>, 'rse': <rse>, 'bytes': <bytes>, 'adler32': <adler32>, 'guid': <guid>, 'pfn': <pfn>}
     :param ignore_availability: A boolean to ignore blocklisted sites.
-    :param parents_metadata: Metadata for selected hierarchy DIDs. (dictionary {'lpn': {key : value}})
+    :param parents_metadata: Metadata for selected hierarchy DIDs. (dictionary {did: {key: value}})
     :param vo: The VO to act on
     :param session: The session used
     """
@@ -123,13 +131,11 @@ def add_files(
             continue
 
         # Get all the ascendants of the file
-        lfn_split = filename.split('/')
-        lpns = ["/".join(lfn_split[:idx]) for idx in range(2, len(lfn_split))]
-        lpns.reverse()
-        LOGGER.info("Ensuring existence of parent collections for did %s: %s", filename, lpns)
+        parents = _did_parents(filename)
+        LOGGER.info("Ensuring existence of parent collections for did %s: %s", filename, parents)
 
         # The parent must be a dataset. Register it as well as the rule
-        dsn_name = lpns[0]
+        dsn_name = parents[0]
         dsn_scope, _ = extract_scope(dsn_name, scopes, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
         dsn_scope = InternalScope(dsn_scope, vo=vo)
         dsn_meta = parents_metadata.get(dsn_name, {})
@@ -162,7 +168,7 @@ def add_files(
                     rse_id=None,
                     session=session)
             exist_lfn.append(dsn_name)
-            parent_name = lpns[1]
+            parent_name = parents[1]
             parent_scope, _ = extract_scope(parent_name, scopes, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
             parent_scope = InternalScope(parent_scope, vo=vo)
             attachments.append({'scope': parent_scope, 'name': parent_name, 'dids': [{'scope': dsn_scope, 'name': dsn_name}]})
@@ -206,18 +212,18 @@ def add_files(
                  session=session)
         attachments.append({'scope': dsn_scope, 'name': dsn_name, 'dids': [{'scope': lfn_scope, 'name': filename}]})
 
-        # Now loop over the ascendants of the dataset and created them
-        for lpn in lpns[1:]:
-            child_scope, _ = extract_scope(lpn, scopes, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
+        # Now loop over the ascendants of the dataset and ensure containers for them
+        for parent in parents[1:]:
+            child_scope, _ = extract_scope(parent, scopes, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
             child_scope = InternalScope(child_scope, vo=vo)
-            exists, did_type = _exists(scope=child_scope, name=lpn, session=session)
-            child_meta = parents_metadata.get(lpn, {})
+            exists, did_type = _exists(scope=child_scope, name=parent, session=session)
+            child_meta = parents_metadata.get(parent, {})
             if exists and did_type == DIDType.DATASET:
-                raise UnsupportedOperation('Cannot create %s as container' % lpn)
-            if (lpn not in exist_lfn) and not exists:
-                LOGGER.info("Will create container %s", lpn)
+                raise UnsupportedOperation('Cannot create %s as container' % parent)
+            if (parent not in exist_lfn) and not exists:
+                LOGGER.info("Will create container %s", parent)
                 add_did(child_scope,
-                        lpn,
+                        parent,
                         DIDType.CONTAINER,
                         account=InternalAccount(account, vo=vo),
                         statuses=None,
@@ -227,11 +233,11 @@ def add_files(
                         dids=None,
                         rse_id=None,
                         session=session)
-                exist_lfn.append(lpn)
-                parent_name = lpns[lpns.index(lpn) + 1]
+                exist_lfn.append(parent)
+                parent_name = parents[parents.index(parent) + 1]
                 parent_scope, _ = extract_scope(parent_name, scopes, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
                 parent_scope = InternalScope(parent_scope, vo=vo)
-                attachments.append({'scope': parent_scope, 'name': parent_name, 'dids': [{'scope': child_scope, 'name': lpn}]})
+                attachments.append({'scope': parent_scope, 'name': parent_name, 'dids': [{'scope': child_scope, 'name': parent}]})
     # Finally attach everything
     attach_dids_to_dids(attachments,
                         account=InternalAccount(account, vo=vo),

--- a/lib/rucio/core/dirac.py
+++ b/lib/rucio/core/dirac.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import re
 from json import loads
 from json.decoder import JSONDecodeError
@@ -35,6 +36,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from sqlalchemy.orm import Session
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _exists(
@@ -122,7 +126,7 @@ def add_files(
         lfn_split = filename.split('/')
         lpns = ["/".join(lfn_split[:idx]) for idx in range(2, len(lfn_split))]
         lpns.reverse()
-        print(lpns)
+        LOGGER.info("Ensuring existence of parent collections for did %s: %s", filename, lpns)
 
         # The parent must be a dataset. Register it as well as the rule
         dsn_name = lpns[0]
@@ -144,7 +148,7 @@ def add_files(
         if exists and did_type == DIDType.CONTAINER:
             raise UnsupportedOperation('Cannot create %s as dataset' % dsn_name)
         if (dsn_name not in exist_lfn) and not exists:
-            print('Will create %s' % dsn_name)
+            LOGGER.info("Will create dataset %s", dsn_name)
             # to maintain a compatibility between master and LTS-1.26 branches remove keywords for first 3 arguments
             add_did(dsn_scope,
                     dsn_name,
@@ -211,7 +215,7 @@ def add_files(
             if exists and did_type == DIDType.DATASET:
                 raise UnsupportedOperation('Cannot create %s as container' % lpn)
             if (lpn not in exist_lfn) and not exists:
-                print('Will create %s' % lpn)
+                LOGGER.info("Will create container %s", lpn)
                 add_did(child_scope,
                         lpn,
                         DIDType.CONTAINER,

--- a/tests/test_dirac.py
+++ b/tests/test_dirac.py
@@ -1,0 +1,21 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def test_did_parents():
+    from rucio.core.dirac import _did_parents
+
+    did_name = "/root/foo/bar/baz"
+    expected = ["/root/foo/bar", "/root/foo", "/root"]
+    assert _did_parents(did_name) == expected


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*


Fixes #8171 

Fixes #7824

## Checklist
- [X] Created issue: #8171, #7824
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [ ] I understand that stale (failing tests, author not answering) PRs will be closed promptly


## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
