### PR TITLE
Fix daemons logging for testing

### DIFF
--- a/lib/rucio/daemons/common.py
+++ b/lib/rucio/daemons/common.py
@@ -56,7 +56,8 @@ class HeartbeatHandler:
         self.pid = os.getpid()
         self.hb_thread = threading.current_thread()
 
-        self.logger = logging.log
+        self.logger_func: "LoggerFunction" = logging.getLogger(executable).log
+        self.logger = self.logger_func
         self.last_heart_beat = None
         self.last_time = None
         self.last_payload = None
@@ -101,7 +102,7 @@ class HeartbeatHandler:
                 self.last_heart_beat = heartbeat_core.live(self.executable, self.hostname, self.pid, self.hb_thread, payload=payload)
 
             prefix = '[%i/%i]: ' % (self.last_heart_beat['assign_thread'], self.last_heart_beat['nr_threads'])
-            self.logger = formatted_logger(logging.log, prefix + '%s')
+            self.logger = formatted_logger(self.logger_func, prefix + '%s')
 
             if not self.last_time:
                 self.logger(logging.DEBUG, 'First heartbeat set')

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -129,7 +129,8 @@ def receiver(
     Main loop to consume messages from the FTS3 producer.
     """
 
-    logging.info('receiver starting')
+    logger = logging.getLogger(DAEMON_NAME).log
+    logger(logging.INFO, 'receiver starting')
 
     brokers_alias = []
     brokers_resolved = []
@@ -138,21 +139,21 @@ def receiver(
     except Exception:
         raise Exception('Could not load brokers from configuration')
 
-    logging.info('resolving broker dns alias: %s' % brokers_alias)
+    logger(logging.INFO, 'resolving broker dns alias: %s' % brokers_alias)
 
     brokers_resolved = []
     for broker in brokers_alias:
         addrinfos = socket.getaddrinfo(broker, 0, socket.AF_INET, 0, socket.IPPROTO_TCP)
         brokers_resolved.extend(ai[4][0] for ai in addrinfos)
 
-    logging.info('brokers resolved to %s', brokers_resolved)
+    logger(logging.INFO, 'brokers resolved to %s', brokers_resolved)
 
-    logging.info('checking authentication method')
+    logger(logging.INFO, 'checking authentication method')
     use_ssl = True
     try:
         use_ssl = config_get_bool('messaging-fts3', 'use_ssl')
     except Exception:
-        logging.info('could not find use_ssl in configuration -- please update your rucio.cfg')
+        logger(logging.INFO, 'could not find use_ssl in configuration -- please update your rucio.cfg')
 
     port = config_get_int('messaging-fts3', 'port')
     vhost = config_get('messaging-fts3', 'broker_virtual_host', raise_exception=False)
@@ -164,9 +165,9 @@ def receiver(
     conns = []
     for broker in brokers_resolved:
         if not use_ssl:
-            logging.info('setting up username/password authentication: %s' % broker)
+            logger(logging.INFO, 'setting up username/password authentication: %s' % broker)
         else:
-            logging.info('setting up ssl cert/key authentication: %s' % broker)
+            logger(logging.INFO, 'setting up ssl cert/key authentication: %s' % broker)
         con = stomp.Connection12(host_and_ports=[(broker, port)],
                                  vhost=vhost,
                                  reconnect_attempts_max=999)
@@ -177,7 +178,7 @@ def receiver(
             )
         conns.append(con)
 
-    logging.info('receiver started')
+    logger(logging.INFO, 'receiver started')
 
     with (HeartbeatHandler(executable=DAEMON_NAME, renewal_interval=30) as heartbeat_handler,
           request_core.TransferStatsManager() as transfer_stats_manager):


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

Fixes #8433

The output in testing will look like the following instead of what is shown in the issue above:

```
2026-03-10T15:19:11.7149570Z DEBUG    conveyor-submitter:logging.py:419 [0/1]: First heartbeat set
2026-03-10T15:19:11.7150304Z INFO     conveyor-submitter:logging.py:419 [0/1]: Daemon started
2026-03-10T15:19:11.7151080Z DEBUG    conveyor-submitter:logging.py:419 [0/1]: Starting next iteration
2026-03-10T15:19:11.7152703Z INFO     conveyor-submitter:logging.py:419 [0/1]: Got 0 transfers for None in 0.023847189999969487 seconds
2026-03-10T15:19:11.7153867Z DEBUG    conveyor-submitter:logging.py:419 [0/1]: Only 0 transfers for None which is less than bulk 100
2026-03-10T15:19:11.7154869Z INFO     conveyor-submitter:logging.py:419 [0/1]: Heartbeat cleaned up
2026-03-10T15:19:11.7156240Z DEBUG    conveyor-preparer:logging.py:419 [0/1]: First heartbeat set
2026-03-10T15:19:11.7156993Z INFO     conveyor-preparer:logging.py:419 [0/1]: Daemon started
2026-03-10T15:19:11.7157798Z DEBUG    conveyor-preparer:logging.py:419 [0/1]: Starting next iteration
2026-03-10T15:19:11.7158810Z DEBUG    conveyor-preparer:logging.py:419 [0/1]: Heartbeat renewed
2026-03-10T15:19:11.7159598Z DEBUG    conveyor-preparer:logging.py:419 [0/1]: Heartbeat renewed
2026-03-10T15:19:11.7160542Z INFO     conveyor-preparer:logging.py:419 [0/1]: Only 3 transfers, which is less than half of the bulk 100
2026-03-10T15:19:11.7161537Z INFO     conveyor-preparer:logging.py:419 [0/1]: Heartbeat cleaned up
```

## Checklist
- [x] Created issue: #8433
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [x] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
