### PR TITLE
feat: make namespace and passphrase configurable in certs / generate.sh

### DIFF
--- a/etc/certs/generate.sh
+++ b/etc/certs/generate.sh
@@ -13,7 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-export PASSPHRASE=123456
+export PASSPHRASE=${PASSPHRASE:-123456}
+export NAMESPACE=${NAMESPACE:-default}
 
 DAYS=9000
 
@@ -31,7 +32,7 @@ cat "ruciouser.pem" "ruciouser.key.pem" > "ruciouser.certkey.pem"
 # The service certificates
 for CN in rucio fts xrd1 xrd2 xrd3 xrd4 xrd5 minio indigoiam keycloak web1
 do
-  SAN="subjectAltName=DNS:$CN,DNS:localhost,DNS:$CN.default.svc.cluster.local"
+  SAN="subjectAltName=DNS:$CN,DNS:localhost,DNS:$CN.$NAMESPACE.svc.cluster.local"
   openssl req -new -newkey rsa:2048 -noenc -keyout "hostcert_$CN.key.pem" -subj "/CN=$CN" > "hostcert_$CN.csr"
   openssl x509 -req -days $DAYS -CAcreateserial -extfile <(printf "%s" "$SAN") -in "hostcert_$CN.csr" -CA rucio_ca.pem -CAkey rucio_ca.key.pem -out "hostcert_$CN.pem" -passin env:PASSPHRASE
 done


### PR DESCRIPTION
The generate_certs.sh script currently hardcodes the Kubernetes namespace and the certificate passphrase.
This limits flexibility for developers who want to run Rucio and related services in different namespaces or with custom passphrases.

This change introduces environment variable overrides with sensible defaults:

  PASSPHRASE=${PASSPHRASE:-123456}
  NAMESPACE=${NAMESPACE:-default}

With this update, users can run the script in arbitrary namespaces or 
set a custom passphrase without modifying the script itself. For example:

  NAMESPACE=rucio-tutorial PASSPHRASE=secret etc/certs/generate.sh

- Fully backward compatible: defaults remain unchanged for current usage.
- Improves developer experience and flexibility.
- No functional changes to certificate generation logic or SANs.

By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).