### PR TITLE
feat(Rules): make time delta for stuck rules updated_at configurable in repairer (float version)

### DIFF
--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -2356,7 +2356,7 @@ def get_injected_rules(
 def get_stuck_rules(
     total_workers: int,
     worker_number: int,
-    delta: int = 600,
+    delta: float = 600.0,
     limit: int = 10,
     blocked_rules: Optional['Sequence[str]'] = None,
     *,

--- a/lib/rucio/daemons/judge/repairer.py
+++ b/lib/rucio/daemons/judge/repairer.py
@@ -30,6 +30,7 @@ from sqlalchemy.exc import DatabaseError
 
 import rucio.db.sqla.util
 from rucio.common import exception
+from rucio.common.config import config_get_float
 from rucio.common.exception import DatabaseException
 from rucio.common.logging import setup_logging
 from rucio.core.monitor import MetricManager
@@ -52,6 +53,11 @@ def rule_repairer(
     """
     Main loop to check for STUCK replication rules
     """
+    if once:
+        delta = -1.0
+    else:
+        delta = config_get_float("repairer", "updated_at_delta", default=1800.0)
+
     paused_rules = {}  # {rule_id: datetime}
     run_daemon(
         once=once,
@@ -62,14 +68,14 @@ def rule_repairer(
         run_once_fnc=functools.partial(
             run_once,
             paused_rules=paused_rules,
-            delta=-1 if once else 1800,
+            delta=delta,
         )
     )
 
 
 def run_once(
         paused_rules: dict[str, datetime],
-        delta: int,
+        delta: float,
         heartbeat_handler: HeartbeatHandler,
         **_kwargs
 ) -> None:


### PR DESCRIPTION
…

Closes #8441

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [X] Created issue: #8441 
- [ ] Added tests
- [X] Updated documentation (https://github.com/rucio/documentation/pull/761)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [X] Picked a reviewer after submission (Leave empty, if unclear)
- [X] I understand that stale (failing tests, author not answering) PRs will be closed promptly

How to best test this?

Documentation update is needed.

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
