### PR TITLE
Change didtype to explicitly use scope extraction policy 

### DIFF
--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -36,7 +36,7 @@ from rucio.common.constants import DEFAULT_VO
 from rucio.common.didtype import DID
 from rucio.common.exception import InputValidationError, NoFilesDownloaded, NotAllFilesDownloaded, RucioException
 from rucio.common.pcache import Pcache
-from rucio.common.utils import execute, extract_scope, generate_uuid, parse_replicas_from_file, parse_replicas_from_string, send_trace, sizefmt
+from rucio.common.utils import execute, extract_scope, generate_uuid, parse_replicas_from_file, send_trace, sizefmt
 from rucio.rse import rsemanager as rsemgr
 
 if TYPE_CHECKING:
@@ -1496,7 +1496,7 @@ class DownloadClient:
             if nrandom:
                 logger(logging.INFO, 'Selecting %d random replicas from DID(s): %s' % (nrandom, [str(did) for did in input_dids]))
 
-            metalink_str = self.client.list_replicas([{'scope': did.scope, 'name': did.name} for did in input_dids],
+            replica_json = self.client.list_replicas([{'scope': did.scope, 'name': did.name} for did in input_dids],
                                                      schemes=schemes,
                                                      ignore_availability=False,
                                                      rse_expression=rse_expression,
@@ -1505,13 +1505,16 @@ class DownloadClient:
                                                      resolve_archives=not item.get('no_resolve_archives'),
                                                      resolve_parents=True,
                                                      nrandom=nrandom,
-                                                     metalink=True)
-            file_items = parse_replicas_from_string(metalink_str)  # type: ignore
+                                                     metalink=False)
+
+            file_items = [i for i in replica_json]
             for file in file_items:
+                file['did'] = DID(scope=file['scope'], name=file['name'])  # file returns a scope and name part
+                file['parent_dids'] = [DID(parent) for parent in file.get('parents', [])]  # parent just has DIDs as strings
                 if impl:
                     file['impl'] = impl
                 elif not item.get('force_scheme'):
-                    file['impl'] = self.preferred_impl(file['sources'])
+                    file['impl'] = self.preferred_impl(file['rses'])
 
             logger(logging.DEBUG, 'num resolved files: %s' % len(file_items))
 
@@ -1524,29 +1527,47 @@ class DownloadClient:
                 for input_did in input_dids:
                     if not any([input_did == f['did'] or str(input_did) in f['parent_dids'] for f in file_items]):
                         logger(logging.ERROR, 'DID does not exist: %s' % input_did)
-                        # TODO: store DID directly as DIDType object
-                        file_items.append({'did': str(input_did), 'adler32': None, 'md5': None, 'sources': [], 'parent_dids': set(), 'impl': impl or None})
+                        file_items.append({'did': input_did, 'adler32': None, 'md5': None, 'rses': {}, 'parent_dids': set(), 'impl': impl or None})
 
             # filtering out tape sources
             if self.is_tape_excluded:
                 for file_item in file_items:
-                    unfiltered_sources = copy.copy(file_item['sources'])
+                    unfiltered_sources = copy.copy([file_item['rses'].keys()])
                     for src in unfiltered_sources:
-                        if src['rse'] in tape_rses:
-                            file_item['sources'].remove(src)
-                    if unfiltered_sources and not file_item['sources']:
+                        if src in tape_rses:
+                            file_item['rses'].remove(src)
+                    if unfiltered_sources and not file_item['rses']:
                         logger(logging.WARNING, 'The requested DID {} only has replicas on tape. Direct download from tape is prohibited. '
                                                 'Please request a transfer to a non-tape endpoint.'.format(file_item['did']))
+
+            def resolve_source_info(sources: dict[str, str]) -> list[dict[str, str]]:
+                resolved_rses = []
+                for src, pfns in sources.items():
+                    for pfn in pfns:
+                        protocols = self.client.get_rse(src).get('protocols', [])
+                        for protocol in protocols:
+                            resolved_rses.append(
+                                {
+                                    "rse": src,
+                                    "pfn": pfn,
+                                    'client_extract': item.get('no_resolve_archives'),
+                                    'priority': protocol.get('priority', 0),
+                                    'domain': protocol.get('domain', 'wan')
+                                }
+                        )
+                return resolved_rses
 
             # Match the file DID back to the DIDs which were provided to list_replicas.
             # Later, this will allow to match the file back to input_items via did_to_input_items
             for file_item in file_items:
-                file_did = DID(file_item['did'])
+                file_did = file_item['did']
 
                 file_input_dids = {DID(did) for did in file_item.get('parent_dids', [])}.intersection(input_dids)
                 if file_did in input_dids:
                     file_input_dids.add(file_did)
                 file_item['input_dids'] = {did: input_dids[did] for did in file_input_dids}
+                # Make sure the sources match the item requirements
+                file_item['sources'] = resolve_source_info(file_item['rses'])
             merged_items_with_sources.extend(file_items)
 
         return did_to_input_items, merged_items_with_sources
@@ -1910,6 +1931,12 @@ class DownloadClient:
         elif not deactivate_file_download_exceptions and num_failed > 0:
             raise NotAllFilesDownloaded()
 
+        # convert DIDs to a string for cleaner outputs
+        for item in output_items:
+            # Check parent and input dids
+            for did_key in ['parent_dids', 'input_dids']:
+                if did_key in item:
+                    item[did_key] = [str(did) for did in item[did_key]]
         return output_items
 
     def _send_trace(self, trace: dict[str, Any]) -> None:

--- a/lib/rucio/common/didtype.py
+++ b/lib/rucio/common/didtype.py
@@ -15,10 +15,12 @@
 """
 DID type to represent a DID and to simplify operations on it
 """
-
+import logging
+from configparser import NoSectionError
 from typing import Any, Union
 
-from rucio.common.exception import DIDError
+from rucio.common.exception import ConfigNotFound, DIDError, InvalidAlgorithmName, PolicyPackageNotFound
+from rucio.common.utils import extract_scope
 
 
 class DID:
@@ -126,15 +128,11 @@ class DID:
         Construct the DID from a string.
         :param did: string containing the DID information
         """
-        did_parts = did.split(DID.SCOPE_SEPARATOR, 1)
-        if len(did_parts) == 1:
-            self.name = did
-            self._update_implicit_scope()
-            if not self.has_scope():
-                raise DIDError('Object construction from non-splitable string is ambigious')
-        else:
-            self.scope = did_parts[0]
-            self.name = did_parts[1]
+        try:
+            self.scope, self.name = extract_scope(did)
+        except (ImportError, InvalidAlgorithmName, ConfigNotFound, NoSectionError) as e:  # Only use when the policy can not be found
+            logging.error("Failure using extract_scope policy for '%s': %s" % (did, type(e).__name__))
+            raise PolicyPackageNotFound('ScopeExtractionAlgorithm')
 
     def _did_from_dict(self, did: dict[str, str]) -> None:
         """

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -33,6 +33,7 @@ import threading
 import time
 import types
 from collections import OrderedDict
+from configparser import NoOptionError, NoSectionError
 from enum import Enum
 from functools import cache, update_wrapper, wraps
 from io import StringIO
@@ -47,7 +48,7 @@ from typing_extensions import ParamSpec
 
 from rucio.common.config import config_get, config_get_bool
 from rucio.common.constants import BASE_SCHEME_MAP, DEFAULT_VO, POLICY_ALGORITHM_TYPES_LITERAL
-from rucio.common.exception import DIDFilterSyntaxError, DuplicateCriteriaInDIDFilter, InputValidationError, InvalidType, MetalinkJsonParsingError, MissingModuleException, RucioException
+from rucio.common.exception import ConfigNotFound, DIDFilterSyntaxError, DuplicateCriteriaInDIDFilter, InputValidationError, InvalidType, MetalinkJsonParsingError, MissingModuleException, RucioException
 from rucio.common.extra import import_extras
 from rucio.common.plugins import PolicyPackageAlgorithms
 from rucio.common.types import InternalAccount, InternalScope, LFNDict, TraceDict
@@ -663,11 +664,16 @@ def extract_scope(
         default_extract: str = 'def',
         vo: str = DEFAULT_VO
 ) -> 'Sequence[str]':
-    scope_extraction_algorithms = ScopeExtractionAlgorithms(vo)
-    extract_scope_convention = config_get('common', 'extract_scope', False, None) or config_get('policy', 'extract_scope', False, None)
-    if extract_scope_convention is None or not ScopeExtractionAlgorithms.supports(extract_scope_convention):
-        extract_scope_convention = default_extract
-    return scope_extraction_algorithms.extract_scope(did, scopes, extract_scope_convention)
+    try:
+        scope_extraction_algorithms = ScopeExtractionAlgorithms(vo)
+        extract_scope_convention = config_get('common', 'extract_scope', False, None) or config_get('policy', 'extract_scope', False, None)
+        if extract_scope_convention is None or not ScopeExtractionAlgorithms.supports(extract_scope_convention):
+            extract_scope_convention = default_extract
+        extracted = scope_extraction_algorithms.extract_scope(did, scopes, extract_scope_convention)
+    except (ConfigNotFound, NoSectionError, NoOptionError):
+        logging.warning("Config option for scope extraction convention not found. Using default convention.")
+        extracted = ScopeExtractionAlgorithms.extract_scope_default(did, scopes)
+    return extracted
 
 
 def pid_exists(pid: int) -> bool:

--- a/tests/rucio/common/test_didtype.py
+++ b/tests/rucio/common/test_didtype.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import pytest
 
 from rucio.common.didtype import DID
@@ -62,10 +63,6 @@ class TestDIDType:
     def test_did_type_success(self, input_did, expected_scope, expected_name):
         assert input_did.scope == expected_scope
         assert input_did.name == expected_name
-
-    def test_non_implicit_single_string(self):
-        with pytest.raises(DIDError, match='Error using DID type\nDetails: Object construction from non-splitable string is ambigious'):
-            DID('non.implicit.single.string')
 
     def test_copy(self):
         x = DID('test.scope:test.name')

--- a/tests/test_policy_package.py
+++ b/tests/test_policy_package.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import importlib
+import logging
 import os
+from unittest import mock
 
 import pytest
 
@@ -21,10 +23,9 @@ import rucio.common.exception
 import rucio.common.schema
 import rucio.core.permission
 from rucio.common.constants import DEFAULT_VO
+from rucio.common.didtype import DID
 from rucio.common.plugins import PolicyPackageAlgorithms
 from rucio.common.types import InternalAccount
-from rucio.db.sqla.constants import DatabaseOperationType
-from rucio.db.sqla.session import db_session
 
 
 class TestPolicyPackageGeneric:
@@ -79,13 +80,11 @@ class TestPolicyPackage:
 
         # check that overridden action works as expected
         root_account = InternalAccount('root')
+        assert not rucio.core.permission.has_permission(root_account, 'add_account', {})
 
-        with db_session(DatabaseOperationType.READ) as session:
-            assert not rucio.core.permission.has_permission(root_account, 'add_account', {}, session=session)
-
-            # check that omitted action falls back to generic module
-            # root should be allowed to add RSE
-            assert rucio.core.permission.has_permission(root_account, 'add_rse', {}, session=session)
+        # check that omitted action falls back to generic module
+        # root should be allowed to add RSE
+        assert rucio.core.permission.has_permission(root_account, 'add_rse', {})
 
         # restore original permission module
         rucio.core.permission.permission_modules['def'] = old_module
@@ -131,3 +130,41 @@ class TestPolicyPackage:
             os.environ['RUCIO_POLICY_PACKAGE'] = old_pp_env
         else:
             del os.environ['RUCIO_POLICY_PACKAGE']
+
+
+@pytest.mark.noparallel(reason='Changes scope extraction policies')
+@pytest.mark.parametrize("file_config_mock", [
+        {"overrides": [("common", "extract_scope", "my_extraction_algo")]},
+    ], indirect=True)
+def test_change_scope_extraction(file_config_mock, did_factory, scope_factory, vo, rse_factory):
+
+    rse, _ = rse_factory.make_posix_rse()
+    mock_scope, _ = scope_factory(vos=[vo])
+
+    def extract_scope(did, scopes, *args, **kwargs):
+        return mock_scope, did.split(":")[-1]
+
+    from rucio.common.utils import ScopeExtractionAlgorithms
+    ScopeExtractionAlgorithms.register("my_extraction_algo", extract_scope)
+
+    n_files = 3
+    did_names = [did['did_name'] for did in did_factory.upload_test_dataset(rse_name=rse, scope=mock_scope, nb_files=n_files)]
+
+    constucted_dids = [f"fake_scope:{did}" for did in did_names]
+
+    for did in constucted_dids:
+        derived_did = DID(did)
+        assert derived_did.scope == mock_scope
+        assert derived_did.name == did.split(':')[-1]
+
+
+def test_scope_extraction_invalid_name(caplog):
+    caplog.set_level(logging.DEBUG)  # Override log level
+    with mock.patch('rucio.common.didtype.extract_scope', side_effect=ImportError()):
+
+        with pytest.raises(rucio.common.exception.PolicyPackageNotFound):
+            DID("scope:name")
+            assert "Failure using extract_scope policy for 'scope:name'" in caplog.text
+
+        with pytest.raises(rucio.common.exception.PolicyPackageNotFound):
+            DID("invalid/scope/name/combo")


### PR DESCRIPTION
Closes #7979 
(To be changed from draft after #8414 is merged)
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: 7979
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
