### PR TITLE
fix(Core): Make sure formatted_logger records have correct callstack info

### DIFF
--- a/lib/rucio/common/logging.py
+++ b/lib/rucio/common/logging.py
@@ -416,5 +416,8 @@ def formatted_logger(innerfunc: 'Callable', formatstr: str = "%s") -> 'Callable'
     """
     @functools.wraps(innerfunc)
     def log_format(level: int, msg: object, *args, **kwargs) -> 'Callable':
-        return innerfunc(level, formatstr % msg, *args, **kwargs)
+        # stacklevel=2 is needed so that the function of the record is correctly reported
+        # allow overriding stacklevel in kwargs by taking passed in stacklevel if given
+        stacklevel = kwargs.pop("stacklevel", 2)
+        return innerfunc(level, formatstr % msg, *args, stacklevel=stacklevel, **kwargs)
     return log_format

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -138,6 +138,24 @@ def test_formatted_logger():
     assert result == (logging.INFO, "a b c")
 
 
+def test_formatted_logger_stacklevel(caplog):
+    logger = logging.getLogger("test_formatted_logger")
+
+    def something_that_logs(logger):
+        logger(logging.INFO, "b")
+
+    new_log_func = formatted_logger(logger.log, "a %s c")
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        something_that_logs(new_log_func)
+
+    # make sure the record points to the the actual function logging and not our internal wrapper
+    records = caplog.records
+    assert len(records) == 1
+    record = records[0]
+    assert record.funcName == "something_that_logs"
+
+
 def test_retrying():
     attempts = []
     start_time = datetime.datetime.now()


### PR DESCRIPTION



*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [X] Created issue:  #8446
- [X] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [ ] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
