### PR TITLE
perf: cache stmt results to avoid duplicate query in recursive list_dids

### DIFF
--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -374,8 +374,16 @@ class DidColumnMeta(DidMetaPlugin):
             from rucio.core.did import list_content
 
             # Get attached DIDs and save in a list because the query has to be finished before starting a new one in the recursion
+            # Cache results locally to avoid executing the same stmt query twice (once here, once at the yield loop below).
+            # NOTE: list() materializes all matching results into memory at once, unlike yield_per() which streams.
+            # This is acceptable here because:
+            #   1. The original code already materializes collections_content as a full list (below).
+            #   2. The `limit` parameter, when provided, bounds the result set size.
+            #   3. The query is scoped + filtered, so unbounded full-scope scans are unlikely in practice.
+            # At extreme scale (thousands of DIDs at one level with no limit), this may increase peak memory usage.
+            current_level_results = list(session.execute(stmt))
             collections_content = []
-            for did in session.execute(stmt).yield_per(100):
+            for did in current_level_results:
                 if did.did_type == DIDType.CONTAINER or did.did_type == DIDType.DATASET:
                     collections_content += [d for d in list_content(scope=did.scope, name=did.name)]
 
@@ -394,8 +402,8 @@ class DidColumnMeta(DidMetaPlugin):
                                              session=session):
                     yield result
 
-        for did in session.execute(stmt).yield_per(
-                5):  # don't unpack this as it makes it dependent on query return order!
+        # When recursive, reuse the cached results instead of re-executing the query
+        for did in (current_level_results if recursive else session.execute(stmt).yield_per(5)):
             if long:
                 did_full = "{}:{}".format(did.scope, did.name)
                 if did_full not in ignore_dids:  # concatenating results of OR clauses may contain duplicate DIDs if the query result sets not mutually exclusive.


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8478
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

When `recursive=True`, the same `FilterEngine` `stmt` query was executed against the database twice per call: once at line 378 to discover containers/datasets for recursion, and again at line 397 to yield results. The second execution is redundant.

This PR caches the first execution's results in a local Python list and reuses them for the yield loop, eliminating one redundant database round-trip per recursion level. The non-recursive path is completely unchanged.

**Benchmark (Docker dev, PostgreSQL):**

| Scale | Before | After | Saved |
|---|---|---|---|
| 61 DIDs | 2.72s | 2.29s | 16% |
| 521 DIDs | 23.64s | 21.32s | 10% |
| 1021 DIDs | 45.41s | 41.48s | 8.7% |

**Memory tradeoff:** `list()` materializes results into memory instead of streaming with `yield_per()`. This is acceptable because the existing code already materializes `collections_content` as a full list in the same block, and the query is scoped + filtered. A `NOTE` comment documents this tradeoff in the code.

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
