### PR TITLE
fix(Auth): hash tokens for cache keys

### DIFF
--- a/lib/rucio/core/authentication.py
+++ b/lib/rucio/core/authentication.py
@@ -81,6 +81,19 @@ def token_key_generator(namespace, fni, **kwargs):
     return generate_key
 
 
+def _hash_token_for_cache(token: str) -> str:
+    """
+    Hash token to create a safe cache key.
+
+    This prevents token exposure in cache and ensures consistent key length
+    (64 chars) that works with both Rucio tokens and long JWT tokens.
+
+    :param token: Authentication token to hash
+    :returns: SHA-256 hash of the token as a hex string (64 characters)
+    """
+    return hashlib.sha256(token.encode('utf-8')).hexdigest()
+
+
 if config_get_bool('cache', 'use_external_cache_for_auth_tokens', default=False):
     TOKENREGION = MemcacheRegion(expiration_time=900, function_key_generator=token_key_generator)
 else:
@@ -498,12 +511,15 @@ def validate_auth_token(token: str, *, session: "Session") -> "TokenValidationDi
 
     # Be gentle with bash variables, there can be whitespace
     token = token.strip()
-    cache_key = token.replace(' ', '')
+
+    # Hash token for cache key to prevent exposure and handle long JWT tokens
+    cache_key = _hash_token_for_cache(token)
 
     # Check if token can be found in cache region
     value: Union[NoValue, "TokenValidationDict"] = TOKENREGION.get(cache_key)
     if value is NO_VALUE:  # no cached entry found
-        value = query_token(token, session=session)
+        # Query database using the original token (not the hash)
+        value = query_token(token)
         if not value:
             # identify JWT access token and validate
             # & save it in Rucio if scope and audience are correct
@@ -513,7 +529,7 @@ def validate_auth_token(token: str, *, session: "Session") -> "TokenValidationDi
                 value = validate_jwt(token, session=session)
             else:
                 raise CannotAuthenticate(traceback.format_exc())
-        # save token in the cache
+        # save token validation result in cache using hashed key
         TOKENREGION.set(cache_key, value)
     lifetime = value.get('lifetime', datetime.datetime(1970, 1, 1))  # type: ignore (value is narrowed to dict, but type-checker doesn't see it)
     if lifetime < datetime.datetime.utcnow():  # check if expired

--- a/lib/rucio/core/authentication.py
+++ b/lib/rucio/core/authentication.py
@@ -81,6 +81,19 @@ def token_key_generator(namespace, fni, **kwargs):
     return generate_key
 
 
+def _hash_token_for_cache(token: str) -> str:
+    """
+    Hash token to create a safe cache key.
+
+    This prevents token exposure in cache and ensures consistent key length
+    (64 chars) that works with both Rucio tokens and long JWT tokens.
+
+    :param token: Authentication token to hash
+    :returns: SHA-256 hash of the token as a hex string (64 characters)
+    """
+    return hashlib.sha256(token.encode('utf-8')).hexdigest()
+
+
 if config_get_bool('cache', 'use_external_cache_for_auth_tokens', default=False):
     TOKENREGION = MemcacheRegion(expiration_time=900, function_key_generator=token_key_generator)
 else:
@@ -498,11 +511,14 @@ def validate_auth_token(token: str, *, session: "Session") -> "TokenValidationDi
 
     # Be gentle with bash variables, there can be whitespace
     token = token.strip()
-    cache_key = token.replace(' ', '')
+
+    # Hash token for cache key to prevent exposure and handle long JWT tokens
+    cache_key = _hash_token_for_cache(token)
 
     # Check if token can be found in cache region
     value: Union[NoValue, "TokenValidationDict"] = TOKENREGION.get(cache_key)
     if value is NO_VALUE:  # no cached entry found
+        # Query database using the original token (not the hash)
         value = query_token(token, session=session)
         if not value:
             # identify JWT access token and validate
@@ -513,7 +529,7 @@ def validate_auth_token(token: str, *, session: "Session") -> "TokenValidationDi
                 value = validate_jwt(token, session=session)
             else:
                 raise CannotAuthenticate(traceback.format_exc())
-        # save token in the cache
+        # save token validation result in cache using hashed key
         TOKENREGION.set(cache_key, value)
     lifetime = value.get('lifetime', datetime.datetime(1970, 1, 1))  # type: ignore (value is narrowed to dict, but type-checker doesn't see it)
     if lifetime < datetime.datetime.utcnow():  # check if expired


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8485
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer
Use SHA-256 to hash authentication tokens before using them as cache keys. This ensures consistent key length (64 chars) that works with both Rucio tokens and long JWT tokens.

This covers Issue #8485. The actual issue is left open to discuss whether we should revisit OIDC tokens and Rucio auth token validation after discussion with @dchristidis.

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>