### PR TITLE
refactor(Transfers): Consolidate and clean up FTS3 receiver config

### DIFF
--- a/etc/docker/test/extra/rucio_autotests_common.cfg
+++ b/etc/docker/test/extra/rucio_autotests_common.cfg
@@ -48,7 +48,6 @@ usercert = /opt/rucio/etc/ruciouser.pem
 
 [messaging-fts3]
 port = 61613
-nonssl_port = 61613
 use_ssl = False
 ssl_key_file = /opt/rucio/etc/usercert.key.pem
 ssl_cert_file = /opt/rucio/etc/usercert.pem

--- a/etc/docker/test/extra/rucio_default.cfg
+++ b/etc/docker/test/extra/rucio_default.cfg
@@ -60,7 +60,6 @@ usercert = /opt/rucio/etc/usercertkey.pem
 
 [messaging-fts3]
 port = 61613
-nonssl_port = 61613
 use_ssl = False
 ssl_key_file = /opt/rucio/etc/userkey.pem
 ssl_cert_file = /opt/rucio/etc/usercert.pem

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -149,33 +149,29 @@ def receiver(
     logger(logging.INFO, 'brokers resolved to %s', brokers_resolved)
 
     logger(logging.INFO, 'checking authentication method')
-    use_ssl = True
-    try:
-        use_ssl = config_get_bool('messaging-fts3', 'use_ssl')
-    except Exception:
-        logger(logging.INFO, 'could not find use_ssl in configuration -- please update your rucio.cfg')
-
-    port = config_get_int('messaging-fts3', 'port')
+    use_ssl = config_get_bool('messaging-fts3', 'use_ssl', default=True)
     vhost = config_get('messaging-fts3', 'broker_virtual_host', raise_exception=False)
-    if not use_ssl:
-        username = config_get('messaging-fts3', 'username')
-        password = config_get('messaging-fts3', 'password')
+    destination = config_get('messaging-fts3', 'destination')
+
+    auth_kwargs = {}
+    if use_ssl:
+        port = config_get_int('messaging-fts3', 'port')
+        cert_file = config_get('messaging-fts3', 'ssl_cert_file')
+        key_file = config_get('messaging-fts3', 'ssl_key_file')
+        logger(logging.INFO, 'using ssl cert/key authentication.')
+    else:
         port = config_get_int('messaging-fts3', 'nonssl_port')
+        auth_kwargs['username'] = config_get('messaging-fts3', 'username')
+        auth_kwargs['password'] = config_get('messaging-fts3', 'password')
+        logger(logging.INFO, 'using username/password authentication.')
 
     conns = []
     for broker in brokers_resolved:
-        if not use_ssl:
-            logger(logging.INFO, 'setting up username/password authentication: %s' % broker)
-        else:
-            logger(logging.INFO, 'setting up ssl cert/key authentication: %s' % broker)
         con = stomp.Connection12(host_and_ports=[(broker, port)],
                                  vhost=vhost,
                                  reconnect_attempts_max=999)
         if use_ssl:
-            con.set_ssl(
-                key_file=config_get('messaging-fts3', 'ssl_key_file'),
-                cert_file=config_get('messaging-fts3', 'ssl_cert_file'),
-            )
+            con.set_ssl(key_file=key_file, cert_file=cert_file)
         conns.append(con)
 
     logger(logging.INFO, 'receiver started')
@@ -201,13 +197,8 @@ def receiver(
                             transfer_stats_manager=transfer_stats_manager,
                             all_vos=all_vos
                         ))
-                    if not use_ssl:
-                        conn.connect(username, password, wait=True)
-                    else:
-                        conn.connect(wait=True)
-                    conn.subscribe(destination=config_get('messaging-fts3', 'destination'),
-                                   id='rucio-messaging-fts3',
-                                   ack='auto')
+                    conn.connect(wait=True, **auth_kwargs)
+                    conn.subscribe(destination=destination, id='rucio-messaging-fts3', ack='auto')
             time.sleep(1)
 
         for conn in conns:

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -152,15 +152,14 @@ def receiver(
     use_ssl = config_get_bool('messaging-fts3', 'use_ssl', default=True)
     vhost = config_get('messaging-fts3', 'broker_virtual_host', raise_exception=False)
     destination = config_get('messaging-fts3', 'destination')
+    port = config_get_int('messaging-fts3', 'port')
 
     auth_kwargs = {}
     if use_ssl:
-        port = config_get_int('messaging-fts3', 'port')
         cert_file = config_get('messaging-fts3', 'ssl_cert_file')
         key_file = config_get('messaging-fts3', 'ssl_key_file')
         logger(logging.INFO, 'using ssl cert/key authentication.')
     else:
-        port = config_get_int('messaging-fts3', 'nonssl_port')
         auth_kwargs['username'] = config_get('messaging-fts3', 'username')
         auth_kwargs['password'] = config_get('messaging-fts3', 'password')
         logger(logging.INFO, 'using username/password authentication.')


### PR DESCRIPTION
Refactor the conveyor-receiver to gather configuration upfront and avoid redundant conditional blocks. Ensure the port is correctly assigned when SSL is disabled (i.e. avoid requiring ssl port for use_ssl false)

Closes: #7833

I explicitly don't understand why ssl `port` in config was required (before this PR) when `use_ssl=False`, as its not used.

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [X] Created issue: #___
- [ ] Added tests
- [X] Updated documentation : links to https://github.com/rucio/documentation/issues/780
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [X] Picked a reviewer after submission (Leave empty, if unclear)
- [X] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
