### PR TITLE
fix(Testing): Disable configuration cache for testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import logging
 import os
 import re
 import traceback
@@ -627,8 +628,10 @@ def core_config_mock(request: pytest.FixtureRequest) -> "Iterator[None]":
     from unittest import mock
 
     from sqlalchemy import Column
+    from sqlalchemy.sql import select
 
     from rucio.common.utils import generate_uuid
+    from rucio.core.config import remove_option
     from rucio.db.sqla.models import PrimaryKeyConstraint, String
     from rucio.db.sqla.session import get_session
 
@@ -654,6 +657,13 @@ def core_config_mock(request: pytest.FixtureRequest) -> "Iterator[None]":
 
     with mock.patch('rucio.core.config.models.Config', new=in_memory_config):
         yield
+
+        # remove temporary options explicitly, so they do not leak via cache after the test
+        stmt = select("*").select_from(in_memory_config)
+        for row in session.execute(stmt).all():
+            remove_option(row.section, row.opt, session=session)
+            logging.log(logging.DEBUG, "core_config_mock removing config option [%s] %s=%s", row.section, row.opt, row.value)
+        session.commit()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Fixes #8490

While this change does fix #8490, it cannot address side effects during parallel test execution.
Please discuss, if patching the configuration cache might be the better option. I have an aversion against patching too many things at once. There might also be another way out of this.

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8490 
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
