### PR TITLE
feat(Clients): Add config option to add/remove specific commands from CLI. 

### DIFF
--- a/etc/docker/test/matrix_policy_package_tests.yml
+++ b/etc/docker/test/matrix_policy_package_tests.yml
@@ -5,6 +5,7 @@ atlas:
     schema: atlas
     lfn2pfn_algorithm_default: "hash"
     package: atlas_rucio_policy_package
+    endpoints_add: lifetime-exception
   tests:
     allow:
       - rucio_tests

--- a/lib/rucio/cli/command.py
+++ b/lib/rucio/cli/command.py
@@ -35,7 +35,7 @@ from rucio.common.utils import setup_logger
 # Taken directly from https://click.palletsprojects.com/en/stable/complex/#defining-the-lazy-group
 class LazyGroup(click.Group):
 
-    DEFAULT_COMMANDS: Final = {"account", "config", "did", "download", "replica", "rse", "rule", "scope", "subscription", "upload", "opendata", "lifetime-exception"}
+    DEFAULT_COMMANDS: Final = {"account", "config", "did", "download", "replica", "rse", "rule", "scope", "subscription", "upload", "opendata"}
     COMMAND_MAP: Final = {
         "account": "rucio.cli.account.account",
         "config": "rucio.cli.config.config",

--- a/lib/rucio/cli/command.py
+++ b/lib/rucio/cli/command.py
@@ -37,7 +37,7 @@ class LazyGroup(click.Group):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.DEFAULT_COMMANDS = {"account", "config", "did", "download", "replica", "rse", "rule", "scope", "subscription", "upload", "opendata", "lifetime-exception"}
+        self.DEFAULT_COMMANDS = {"account", "config", "did", "download", "replica", "rse", "rule", "scope", "subscription", "upload", "opendata"}
         self.command_locs = {
             "account": "rucio.cli.account.account",
             "config": "rucio.cli.config.config",

--- a/lib/rucio/cli/command.py
+++ b/lib/rucio/cli/command.py
@@ -15,7 +15,7 @@ import importlib
 import signal
 import sys
 import time
-from typing import Optional
+from typing import Final, Optional, Union
 
 import click
 from rich.console import Console
@@ -35,8 +35,8 @@ from rucio.common.utils import setup_logger
 # Taken directly from https://click.palletsprojects.com/en/stable/complex/#defining-the-lazy-group
 class LazyGroup(click.Group):
 
-    DEFAULT_COMMANDS = {"account", "config", "did", "download", "replica", "rse", "rule", "scope", "subscription", "upload", "opendata", "lifetime-exception"}
-    COMMAND_MAP = {
+    DEFAULT_COMMANDS: Final = {"account", "config", "did", "download", "replica", "rse", "rule", "scope", "subscription", "upload", "opendata", "lifetime-exception"}
+    COMMAND_MAP: Final = {
         "account": "rucio.cli.account.account",
         "config": "rucio.cli.config.config",
         "did": "rucio.cli.did.did",
@@ -51,12 +51,12 @@ class LazyGroup(click.Group):
         "opendata": "rucio.cli.opendata.opendata",
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self.lazy_subcommands = self.pick_commands()
 
-    def pick_commands(self):
+    def pick_commands(self) -> set[str]:
         commands = set(config_get_list('cli', 'endpoints', raise_exception=False, default=[]))
         commands_add = set(config_get_list('cli', 'endpoints_add', raise_exception=False, default=[]))
         commands_remove = set(config_get_list('cli', 'endpoints_remove', raise_exception=False, default=[]))
@@ -77,17 +77,17 @@ class LazyGroup(click.Group):
 
         return commands
 
-    def list_commands(self, ctx):
+    def list_commands(self, ctx: click.Context) -> list[str]:
         base = super().list_commands(ctx)
         lazy = sorted(self.lazy_subcommands)
         return base + lazy
 
-    def get_command(self, ctx, cmd_name):
+    def get_command(self, ctx: click.Context, cmd_name: str) -> Union[Optional[click.Command], click.BaseCommand]:
         if cmd_name in self.lazy_subcommands:
             return self._lazy_load(cmd_name)
         return super().get_command(ctx, cmd_name)
 
-    def _lazy_load(self, cmd_name):
+    def _lazy_load(self, cmd_name: str) -> click.BaseCommand:
         # lazily loading a command, first get the module name and attribute name
         import_path = self.COMMAND_MAP[cmd_name]
         modname, cmd_object_name = import_path.rsplit(".", 1)
@@ -101,10 +101,10 @@ class LazyGroup(click.Group):
         return cmd_object
 
     @exception_handler
-    def _invoke_with_handler(self, ctx: click.Context):
+    def _invoke_with_handler(self, ctx: click.Context) -> Optional[int]:
         return super().invoke(ctx)
 
-    def invoke(self, ctx: click.Context):
+    def invoke(self, ctx: click.Context) -> Optional[int]:
         result = self._invoke_with_handler(ctx)
         if result not in (None, 0):
             sys.exit(1 if result != 2 else 2)

--- a/lib/rucio/cli/command.py
+++ b/lib/rucio/cli/command.py
@@ -27,22 +27,59 @@ from rucio import version
 from rucio.cli.bin_legacy.rucio import ping, test_server, whoami_account
 from rucio.cli.utils import Arguments, exception_handler, get_client, setup_gfal2_logger, signal_handler
 from rucio.client.richclient import MAX_TRACEBACK_WIDTH, MIN_CONSOLE_WIDTH, CLITheme, get_cli_config, get_pager, setup_rich_logger
+from rucio.common.config import config_get_list
+from rucio.common.exception import ConfigurationError
 from rucio.common.utils import setup_logger
 
 
 # Taken directly from https://click.palletsprojects.com/en/stable/complex/#defining-the-lazy-group
 class LazyGroup(click.Group):
-    def __init__(self, *args, lazy_subcommands=None, **kwargs):
+
+    DEFAULT_COMMANDS = {"account", "config", "did", "download", "replica", "rse", "rule", "scope", "subscription", "upload", "opendata", "lifetime-exception"}
+    COMMAND_MAP = {
+        "account": "rucio.cli.account.account",
+        "config": "rucio.cli.config.config",
+        "did": "rucio.cli.did.did",
+        "download": "rucio.cli.download.download",
+        "lifetime-exception": "rucio.cli.lifetime_exception.lifetime_exception",
+        "replica": "rucio.cli.replica.replica",
+        "rse": "rucio.cli.rse.rse",
+        "rule": "rucio.cli.rule.rule",
+        "scope": "rucio.cli.scope.scope",
+        "subscription": "rucio.cli.subscription.subscription",
+        "upload": "rucio.cli.upload.upload_command",
+        "opendata": "rucio.cli.opendata.opendata",
+    }
+
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # lazy_subcommands is a map of the form:
-        #
-        #   {command-name} -> {module-name}.{command-object-name}
-        #
-        self.lazy_subcommands = lazy_subcommands or {}
+
+        self.lazy_subcommands = self.pick_commands()
+
+    def pick_commands(self):
+        commands = set(config_get_list('cli', 'endpoints', raise_exception=False, default=[]))
+        commands_add = set(config_get_list('cli', 'endpoints_add', raise_exception=False, default=[]))
+        commands_remove = set(config_get_list('cli', 'endpoints_remove', raise_exception=False, default=[]))
+
+        if commands and (commands_add or commands_remove):
+            raise ConfigurationError("Endpoints cannot be set in both 'endpoints' and 'endpoints_add'/'endpoints_remove'")
+
+        if commands_add.intersection(commands_remove):
+            raise ConfigurationError("Endpoints cannot be in both 'endpoints_add' and 'endpoints_remove'")
+
+        for config_setting, name in zip([commands, commands_add, commands_remove], ["endpoints", "endpoints_add", "endpoints_remove"]):
+            if config_setting and not config_setting.issubset(set(self.COMMAND_MAP.keys())):
+                msg = f"Endpoints in '{name}', {config_setting} must be a subset of {list(self.COMMAND_MAP.keys())}"
+                raise ConfigurationError(msg)
+
+        if not commands:
+            commands = self.DEFAULT_COMMANDS - commands_remove | commands_add
+
+        return commands
 
     def list_commands(self, ctx):
         base = super().list_commands(ctx)
-        lazy = sorted(self.lazy_subcommands.keys())
+        lazy = sorted(self.lazy_subcommands)
         return base + lazy
 
     def get_command(self, ctx, cmd_name):
@@ -52,7 +89,7 @@ class LazyGroup(click.Group):
 
     def _lazy_load(self, cmd_name):
         # lazily loading a command, first get the module name and attribute name
-        import_path = self.lazy_subcommands[cmd_name]
+        import_path = self.COMMAND_MAP[cmd_name]
         modname, cmd_object_name = import_path.rsplit(".", 1)
         # do the import
         mod = importlib.import_module(modname)
@@ -76,20 +113,6 @@ class LazyGroup(click.Group):
 
 @click.group(
     cls=LazyGroup,
-    lazy_subcommands={
-        "account": "rucio.cli.account.account",
-        "config": "rucio.cli.config.config",
-        "did": "rucio.cli.did.did",
-        "download": "rucio.cli.download.download",
-        "lifetime-exception": "rucio.cli.lifetime_exception.lifetime_exception",
-        "replica": "rucio.cli.replica.replica",
-        "rse": "rucio.cli.rse.rse",
-        "rule": "rucio.cli.rule.rule",
-        "scope": "rucio.cli.scope.scope",
-        "subscription": "rucio.cli.subscription.subscription",
-        "upload": "rucio.cli.upload.upload_command",
-        "opendata": "rucio.cli.opendata.opendata",
-    },
     context_settings={"help_option_names": ["-h", "--help"]}
 )  # TODO: Implement https://click.palletsprojects.com/en/stable/options/#dynamic-defaults-for-prompts for args from config or os
 @click.option("--account", "--issuer", "issuer", help="Rucio account to use.")

--- a/lib/rucio/cli/command.py
+++ b/lib/rucio/cli/command.py
@@ -27,22 +27,57 @@ from rucio import version
 from rucio.cli.bin_legacy.rucio import ping, test_server, whoami_account
 from rucio.cli.utils import Arguments, exception_handler, get_client, setup_gfal2_logger, signal_handler
 from rucio.client.richclient import MAX_TRACEBACK_WIDTH, MIN_CONSOLE_WIDTH, CLITheme, get_cli_config, get_pager, setup_rich_logger
+from rucio.common.config import config_get_list
+from rucio.common.exception import ConfigurationError
 from rucio.common.utils import setup_logger
 
 
 # Taken directly from https://click.palletsprojects.com/en/stable/complex/#defining-the-lazy-group
 class LazyGroup(click.Group):
-    def __init__(self, *args, lazy_subcommands=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # lazy_subcommands is a map of the form:
-        #
-        #   {command-name} -> {module-name}.{command-object-name}
-        #
-        self.lazy_subcommands = lazy_subcommands or {}
+
+        self.DEFAULT_COMMANDS = {"account", "config", "did", "download", "replica", "rse", "rule", "scope", "subscription", "upload", "opendata", "lifetime-exception"}
+        self.command_locs = {
+            "account": "rucio.cli.account.account",
+            "config": "rucio.cli.config.config",
+            "did": "rucio.cli.did.did",
+            "download": "rucio.cli.download.download",
+            "lifetime-exception": "rucio.cli.lifetime_exception.lifetime_exception",
+            "replica": "rucio.cli.replica.replica",
+            "rse": "rucio.cli.rse.rse",
+            "rule": "rucio.cli.rule.rule",
+            "scope": "rucio.cli.scope.scope",
+            "subscription": "rucio.cli.subscription.subscription",
+            "upload": "rucio.cli.upload.upload_command",
+            "opendata": "rucio.cli.opendata.opendata",
+        }
+        self.lazy_subcommands = self.pick_commands()
+
+    def pick_commands(self):
+        commands = set(config_get_list('cli', 'endpoints', raise_exception=False, default=[]))
+        commands_add = set(config_get_list('cli', 'endpoints_add', raise_exception=False, default=[]))
+        commands_remove = set(config_get_list('cli', 'endpoints_remove', raise_exception=False, default=[]))
+
+        if commands and (commands_add or commands_remove):
+            raise ConfigurationError("Endpoints cannot be set in both 'endpoints' and 'endpoints_add'/'endpoints_remove'")
+
+        if commands_add.intersection(commands_remove):
+            raise ConfigurationError("Endpoints cannot be in both 'endpoints_add' and 'endpoints_remove'")
+
+        for config_setting, name in zip([commands, commands_add, commands_remove], ["endpoints", "endpoints_add", "endpoints_remove"]):
+            if config_setting and not config_setting.issubset(set(self.command_locs.keys())):
+                msg = f"Endpoints in '{name}', {config_setting} must be a subset of {list(self.command_locs.keys())}"
+                raise ConfigurationError(msg)
+
+        if not commands:
+            commands = self.DEFAULT_COMMANDS - commands_remove | commands_add
+
+        return commands
 
     def list_commands(self, ctx):
         base = super().list_commands(ctx)
-        lazy = sorted(self.lazy_subcommands.keys())
+        lazy = sorted(self.lazy_subcommands)
         return base + lazy
 
     def get_command(self, ctx, cmd_name):
@@ -52,7 +87,7 @@ class LazyGroup(click.Group):
 
     def _lazy_load(self, cmd_name):
         # lazily loading a command, first get the module name and attribute name
-        import_path = self.lazy_subcommands[cmd_name]
+        import_path = self.command_locs[cmd_name]
         modname, cmd_object_name = import_path.rsplit(".", 1)
         # do the import
         mod = importlib.import_module(modname)
@@ -76,20 +111,6 @@ class LazyGroup(click.Group):
 
 @click.group(
     cls=LazyGroup,
-    lazy_subcommands={
-        "account": "rucio.cli.account.account",
-        "config": "rucio.cli.config.config",
-        "did": "rucio.cli.did.did",
-        "download": "rucio.cli.download.download",
-        "lifetime-exception": "rucio.cli.lifetime_exception.lifetime_exception",
-        "replica": "rucio.cli.replica.replica",
-        "rse": "rucio.cli.rse.rse",
-        "rule": "rucio.cli.rule.rule",
-        "scope": "rucio.cli.scope.scope",
-        "subscription": "rucio.cli.subscription.subscription",
-        "upload": "rucio.cli.upload.upload_command",
-        "opendata": "rucio.cli.opendata.opendata",
-    },
     context_settings={"help_option_names": ["-h", "--help"]}
 )  # TODO: Implement https://click.palletsprojects.com/en/stable/options/#dynamic-defaults-for-prompts for args from config or os
 @click.option("--account", "--issuer", "issuer", help="Rucio account to use.")

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -539,8 +539,12 @@ def test_upload_download():
     assert exitcode != 2  # Failure is not due to the command structure
 
 
+@pytest.mark.noparallel(reason='Modifies the configuration file')
 def test_lifetime_exception(rucio_client, mock_scope):
     from rucio.client.uploadclient import UploadClient
+
+    # Add the lifetime-exception endpoint
+    rucio_client.set_config_option("cli", "endpoints_add", "lifetime-exception")
 
     input_file = tempfile.NamedTemporaryFile()
     mock_did = tempfile.NamedTemporaryFile()

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -107,6 +107,64 @@ def test_help_menus():
             continue
 
 
+@pytest.mark.skipif(os.environ.get('POLICY') == 'atlas', reason='ATLAS config does not allow for CLI modification')
+@pytest.mark.noparallel(reason='Modifies the configuration file')
+def test_setting_command_options(rucio_client):
+    # Show removing an option does not allow you to use it
+    rucio_client.set_config_option("cli", "endpoints_remove", "account")
+    try:
+        cmd = "rucio account --help"
+        exitcode, _, err = execute(cmd)
+        print(err)
+        assert exitcode == 1
+
+    finally:
+        # teardown
+        rucio_client.delete_config_section("cli")
+
+    # Show adding that option back in lets you use it
+    # lifetime-exception is a non-default option
+    rucio_client.set_config_option("cli", "endpoints_add", "lifetime-exception")
+    try:
+        cmd = "rucio lifetime-exception --help"
+        exitcode, _, _ = execute(cmd)
+        assert exitcode == 0
+    finally:
+        rucio_client.delete_config_section("cli")
+
+    # Show replacing the whole thing only lets you use that option
+    rucio_client.set_config_option("cli", "endpoints", "config")
+    try:
+        cmd = "rucio ping --help"
+        exitcode, _, err = execute(cmd)
+        print(err)
+        assert exitcode == 0
+
+        cmd = "rucio config --help"
+        exitcode, _, err = execute(cmd)
+        print(err)
+        assert exitcode == 0
+
+        cmd = "rucio account --help"
+        exitcode, _, _ = execute(cmd)
+        assert exitcode == 1
+    finally:
+        rucio_client.delete_config_section("cli")
+
+    # Raise a non-implemented when trying to use a command that has no implementation
+    rucio_client.set_config_option("cli", "endpoints_add", "not-a-real-command")
+    try:
+        cmd = "rucio not-a-real-command --help"
+        exitcode, _, err = execute(cmd)
+        assert exitcode == 1
+
+        cmd = "rucio ping --help"
+        exitcode, _, err = execute(cmd)
+        assert exitcode == 1
+    finally:
+        rucio_client.delete_config_section("cli")
+
+
 def test_account(rucio_client):
     new_account = account_name_generator()
     command = f"rucio account add {new_account} USER"


### PR DESCRIPTION
Closes: #8494 

Authored with auto-complete via Qwen3-Coder

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8494 
- [x] Added tests
- [x] Updated documentation https://github.com/rucio/documentation/pull/792
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
