### PR TITLE
permissions/generic: check scopes in upload permissions 

### DIFF
--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -14,13 +14,13 @@
 
 from typing import TYPE_CHECKING, Any
 
-import rucio.core.scope
 from rucio.common.constants import RseAttr
 from rucio.core.account import has_account_attribute, list_account_attributes
 from rucio.core.identity import exist_identity_account
 from rucio.core.lifetime_exception import list_exceptions
 from rucio.core.rse import list_rse_attributes
 from rucio.core.rse_expression_parser import parse_expression
+from rucio.core.scope import is_scope_owner
 from rucio.db.sqla.constants import IdentityType
 
 if TYPE_CHECKING:
@@ -298,7 +298,7 @@ def perm_update_scope(issuer: "InternalAccount", kwargs: dict[str, Any], session
     """
     return _is_root(issuer) \
         or has_account_attribute(account=issuer, key='admin', session=session) \
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
+        or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_get_auth_token_user_pass(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:
@@ -413,7 +413,7 @@ def perm_add_did(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Se
 
     return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin', session=session)\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
+        or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
@@ -441,7 +441,7 @@ def perm_attach_dids(issuer: "InternalAccount", kwargs: dict[str, Any], session:
     """
     return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin', session=session)\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
+        or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
@@ -461,7 +461,7 @@ def perm_attach_dids_to_dids(issuer: "InternalAccount", kwargs: dict[str, Any], 
         scopes = [did['scope'] for did in attachments]
         scopes = list(set(scopes))
         for scope in scopes:
-            if not rucio.core.scope.is_scope_owner(scope, issuer, session=session):
+            if not is_scope_owner(scope, issuer, session=session):
                 return False
         return True
 
@@ -477,7 +477,7 @@ def perm_create_did_sample(issuer: "InternalAccount", kwargs: dict[str, Any], se
     """
     return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin', session=session)\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
+        or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
@@ -587,7 +587,7 @@ def perm_set_metadata_bulk(issuer: "InternalAccount", kwargs: dict[str, Any], se
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_set_metadata(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:
@@ -599,7 +599,7 @@ def perm_set_metadata(issuer: "InternalAccount", kwargs: dict[str, Any], session
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_set_status(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:
@@ -615,7 +615,7 @@ def perm_set_status(issuer: "InternalAccount", kwargs: dict[str, Any], session: 
         if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
             return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_add_protocol(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:
@@ -706,17 +706,31 @@ def perm_add_replicas(issuer: "InternalAccount", kwargs: dict[str, Any], session
     """
     Checks if an account can add replicas.
 
+    If the RSE is not a special one (name terminated by some magic words)
+    or if the account is not an administrator, for each replica scope (passed in kwargs['scopes']
+    for convenience), the ownership is checked: if the account is not owning all of them,
+    permission is denied.
+
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return str(kwargs.get('rse', '')).endswith('SCRATCHDISK')\
-        or str(kwargs.get('rse', '')).endswith('USERDISK')\
-        or str(kwargs.get('rse', '')).endswith('MOCK')\
-        or str(kwargs.get('rse', '')).endswith('LOCALGROUPDISK')\
-        or _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin', session=session)
+
+    special_rse_suffixes = ['LOCALGROUPDISK', 'MOCK', 'SCRATCHDISK', 'USERDISK']
+
+    if _is_root(issuer):
+        return True
+    if has_account_attribute(account=issuer, key='admin', session=session):
+        return True
+    if any(str(kwargs.get('rse', '')).endswith(suffix) for suffix in special_rse_suffixes):
+        return True
+
+    # Also allow if user owns all affected scopes
+    if all(is_scope_owner(scope, account=issuer, session=session) for scope in kwargs["scopes"]):
+        return True
+
+    return False
 
 
 def perm_skip_availability_check(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:
@@ -745,14 +759,28 @@ def perm_delete_replicas(issuer: "InternalAccount", kwargs: dict[str, Any], sess
 
 def perm_update_replicas_states(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:
     """
-    Checks if an account can delete replicas.
+    Checks if an account can add replicas.
+
+    If the account is not an administrator, for each replica scope (passed in kwargs['scopes']
+    for convenience), the ownership is checked: if the account is not owning all of them,
+    permission is denied.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+
+    if _is_root(issuer):
+        return True
+    if has_account_attribute(account=issuer, key='admin', session=session):
+        return True
+
+    # Also allow if user owns all affected scopes
+    if all(is_scope_owner(scope, account=issuer, session=session) for scope in kwargs["scopes"]):
+        return True
+
+    return False
 
 
 def perm_queue_requests(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:

--- a/lib/rucio/core/permission/generic_multi_vo.py
+++ b/lib/rucio/core/permission/generic_multi_vo.py
@@ -14,7 +14,6 @@
 
 from typing import TYPE_CHECKING, Any
 
-import rucio.core.scope
 from rucio.common.constants import RseAttr
 from rucio.core.account import has_account_attribute, list_account_attributes
 from rucio.core.identity import exist_identity_account
@@ -22,6 +21,7 @@ from rucio.core.lifetime_exception import list_exceptions
 from rucio.core.rse import list_rse_attributes
 from rucio.core.rse_expression_parser import parse_expression
 from rucio.core.rule import get_rule
+from rucio.core.scope import is_scope_owner
 from rucio.db.sqla.constants import IdentityType
 
 if TYPE_CHECKING:
@@ -297,7 +297,7 @@ def perm_update_scope(issuer: "InternalAccount", kwargs: dict[str, Any], session
     """
     return _is_root(issuer) \
         or has_account_attribute(account=issuer, key='admin', session=session) \
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
+        or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_get_auth_token_user_pass(issuer, kwargs, session: "Session"):
@@ -412,7 +412,7 @@ def perm_add_did(issuer, kwargs, session: "Session"):
 
     return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin', session=session)\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
+        or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
@@ -440,7 +440,7 @@ def perm_attach_dids(issuer, kwargs, session: "Session"):
     """
     return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin', session=session)\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
+        or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
@@ -460,7 +460,7 @@ def perm_attach_dids_to_dids(issuer, kwargs, session: "Session"):
         scopes = [did['scope'] for did in attachments]
         scopes = list(set(scopes))
         for scope in scopes:
-            if not rucio.core.scope.is_scope_owner(scope, issuer, session=session):
+            if not is_scope_owner(scope, issuer, session=session):
                 return False
         return True
 
@@ -476,7 +476,7 @@ def perm_create_did_sample(issuer, kwargs, session: "Session"):
     """
     return _is_root(issuer)\
         or has_account_attribute(account=issuer, key='admin', session=session)\
-        or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
+        or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)\
         or kwargs['scope'].external == 'mock'
 
 
@@ -586,7 +586,7 @@ def perm_set_metadata(issuer, kwargs, session: "Session"):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_set_status(issuer, kwargs, session: "Session"):
@@ -602,7 +602,7 @@ def perm_set_status(issuer, kwargs, session: "Session"):
         if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
             return False
 
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or rucio.core.scope.is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session) or is_scope_owner(scope=kwargs['scope'], account=issuer, session=session)
 
 
 def perm_add_protocol(issuer, kwargs, session: "Session"):
@@ -669,17 +669,31 @@ def perm_add_replicas(issuer, kwargs, session: "Session"):
     """
     Checks if an account can add replicas.
 
+    If the RSE is not a special one (name terminated by some magic words)
+    or if the account is not an administrator, for each replica scope (passed in kwargs['scopes']
+    for convenience), the ownership is checked: if the account is not owning all of them,
+    permission is denied.
+
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return str(kwargs.get('rse', '')).endswith('SCRATCHDISK')\
-        or str(kwargs.get('rse', '')).endswith('USERDISK')\
-        or str(kwargs.get('rse', '')).endswith('MOCK')\
-        or str(kwargs.get('rse', '')).endswith('LOCALGROUPDISK')\
-        or _is_root(issuer)\
-        or has_account_attribute(account=issuer, key='admin', session=session)
+
+    special_rse_suffixes = ['LOCALGROUPDISK', 'MOCK', 'SCRATCHDISK', 'USERDISK']
+
+    if _is_root(issuer):
+        return True
+    if has_account_attribute(account=issuer, key='admin', session=session):
+        return True
+    if any(str(kwargs.get('rse', '')).endswith(suffix) for suffix in special_rse_suffixes):
+        return True
+
+    # Also allow if user owns all affected scopes
+    if all(is_scope_owner(scope, account=issuer, session=session) for scope in kwargs["scopes"]):
+        return True
+
+    return False
 
 
 def perm_skip_availability_check(issuer, kwargs, session: "Session"):
@@ -708,14 +722,28 @@ def perm_delete_replicas(issuer, kwargs, session: "Session"):
 
 def perm_update_replicas_states(issuer, kwargs, session: "Session"):
     """
-    Checks if an account can delete replicas.
+    Checks if an account can add replicas.
+
+    If the account is not an administrator, for each replica scope (passed in kwargs['scopes']
+    for convenience), the ownership is checked: if the account is not owning all of them,
+    permission is denied.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+
+    if _is_root(issuer):
+        return True
+    if has_account_attribute(account=issuer, key='admin', session=session):
+        return True
+
+    # Also allow if user owns all affected scopes
+    if all(is_scope_owner(scope, account=issuer, session=session) for scope in kwargs["scopes"]):
+        return True
+
+    return False
 
 
 def perm_queue_requests(issuer, kwargs, session: "Session"):

--- a/lib/rucio/gateway/replica.py
+++ b/lib/rucio/gateway/replica.py
@@ -29,6 +29,8 @@ from rucio.gateway import permission
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
+    from sqlalchemy.orm import Session
+
 
 def get_bad_replicas_summary(
         rse_expression: Optional[str] = None,
@@ -297,6 +299,59 @@ def list_replicas(
             yield rep
 
 
+def _check_replicas_permissions(
+        action: str,
+        session: "Session",
+        rse: str,
+        files: "Iterable[dict[str, Any]]",
+        issuer: str,
+        ignore_availability: bool = False,
+        vo: str = DEFAULT_VO
+) -> tuple[str, bool]:
+    """
+    Check permissions to add/delete/update replicas. Helper function for add/delete_replicas()
+    and update_replicas_states().
+
+    :param action: The action that will be performed (must match a has_permission() entry)
+    :param session: database session
+    :param rse: The RSE name.
+    :param files: The list of files.
+    :param issuer: The issuer account.
+    :param ignore_availability: Ignore blocked RSEs.
+    :param vo: The VO to act on.
+    :return: The RSE ID.
+    :return: ignore_availability final value
+    """
+
+    rse_id = get_rse_id(rse=rse, vo=vo, session=session)
+
+    # scopes is a temporary dict where the key is the scope name (str)
+    # and the value is the matching InternalScope object
+    scopes = dict()
+    for f in files:
+        if f['scope'] not in scopes:
+            scopes[f['scope']] = InternalScope(f['scope'], vo=vo)
+        f['scope'] = scopes[f['scope']]
+        f['rse_id'] = rse_id
+        if 'account' in f:
+            f['account'] = InternalAccount(f['account'], vo=vo)
+
+    kwargs = {'rse': rse, 'rse_id': rse_id, 'scopes': list(scopes.values())}
+
+    auth_result = permission.has_permission(
+        issuer=issuer,
+        vo=vo,
+        action=action,
+        kwargs=kwargs,
+        session=session,
+    )
+    if not auth_result.allowed:
+        raise exception.AccessDenied(
+            'Account %s can not add file replicas on %s. %s' % (issuer, rse, auth_result.message))
+
+    return rse_id, ignore_availability
+
+
 def add_replicas(
         rse: str,
         files: "Iterable[dict[str, Any]]",
@@ -318,20 +373,17 @@ def add_replicas(
     validate_schema(name='dids', obj=files, vo=vo)
 
     with db_session(DatabaseOperationType.WRITE) as session:
-        rse_id = get_rse_id(rse=rse, vo=vo, session=session)
-
-        kwargs = {'rse': rse, 'rse_id': rse_id}
-        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='add_replicas', kwargs=kwargs, session=session)
-        if not auth_result.allowed:
-            raise exception.AccessDenied('Account %s can not add file replicas on %s. %s' % (issuer, rse, auth_result.message))
-        if not permission.has_permission(issuer=issuer, vo=vo, action='skip_availability_check', kwargs=kwargs, session=session):
-            ignore_availability = False
+        rse_id, ignore_availability = _check_replicas_permissions(
+            action='add_replicas',
+            session=session,
+            rse=rse,
+            files=files,
+            issuer=issuer,
+            ignore_availability=ignore_availability,
+            vo=vo,
+        )
 
         issuer_account = InternalAccount(issuer, vo=vo)
-        for f in files:
-            f['scope'] = InternalScope(f['scope'], vo=vo)
-            if 'account' in f:
-                f['account'] = InternalAccount(f['account'], vo=vo)
 
         replica.add_replicas(rse_id=rse_id, files=files, account=issuer_account, ignore_availability=ignore_availability, session=session)
 
@@ -355,17 +407,15 @@ def delete_replicas(
     validate_schema(name='r_dids', obj=files, vo=vo)
 
     with db_session(DatabaseOperationType.WRITE) as session:
-        rse_id = get_rse_id(rse=rse, vo=vo, session=session)
-
-        kwargs = {'rse': rse, 'rse_id': rse_id}
-        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='delete_replicas', kwargs=kwargs, session=session)
-        if not auth_result.allowed:
-            raise exception.AccessDenied('Account %s can not delete file replicas on %s. %s' % (issuer, rse, auth_result.message))
-        if not permission.has_permission(issuer=issuer, vo=vo, action='skip_availability_check', kwargs=kwargs, session=session):
-            ignore_availability = False
-
-        for f in files:
-            f['scope'] = InternalScope(f['scope'], vo=vo)
+        rse_id, ignore_availability = _check_replicas_permissions(
+            action='delete_replicas',
+            session=session,
+            rse=rse,
+            files=files,
+            issuer=issuer,
+            ignore_availability=ignore_availability,
+            vo=vo,
+        )
 
         replica.delete_replicas(rse_id=rse_id, files=files, ignore_availability=ignore_availability, session=session)
 
@@ -389,19 +439,16 @@ def update_replicas_states(
     validate_schema(name='dids', obj=files, vo=vo)
 
     with db_session(DatabaseOperationType.WRITE) as session:
-        rse_id = get_rse_id(rse=rse, vo=vo, session=session)
+        _check_replicas_permissions(
+            action='update_replicas_states',
+            session=session,
+            rse=rse,
+            files=files,
+            issuer=issuer,
+            vo=vo,
+        )
 
-        kwargs = {'rse': rse, 'rse_id': rse_id}
-        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='update_replicas_states', kwargs=kwargs, session=session)
-        if not auth_result.allowed:
-            raise exception.AccessDenied('Account %s can not update file replicas state on %s. %s' % (issuer, rse, auth_result.message))
-        replicas = []
-        for file in files:
-            rep = file
-            rep['rse_id'] = rse_id
-            rep['scope'] = InternalScope(rep['scope'], vo=vo)
-            replicas.append(rep)
-        replica.update_replicas_states(replicas=replicas, session=session)
+        replica.update_replicas_states(replicas=files, session=session)
 
 
 def list_dataset_replicas(


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

Fixes #8333

This PR is a new version of #8289 that was closed beause it was inactive and that we didn't manage to reopen. Should be considered as a follow-up, implementing the suggestions by @maxnoe and fixing issues reported by Ruff.

It is my attempt to fix the problem that scopes are not passed to the `has_permission()` function when adding (or deleting) a replica when they are supposed to be the Rucio object on which permissions are applied when uploading or downloading DIDs. 

It is necessary to build the scope list in `gateway/replica.py` and pass it in the `kwargs` argument to the permission module (`core/permission/generic.py` for example). The alternative would be to require the permission module to look in all replicas passed to get the scope and to what is done once in `gateway/replica.py` so IMO it is less optimal. And anyway scopes are not passed at all in `update_replicas_states()` in `gateway/replica.py` so a modification of this module would be necessary anyway...

I am not enough a Rucio expert to ensure that there is no side effect to this modification but it's my feeling: nothing passed previously is modified, just an entry `scopes` is added in the `kwargs` dict so it should be harmless. And the resulting default permission of this PR is a basic configuration that you can use to test your Rucio installation, including upload operations, without writing a permission policy as your first step when configuring a new instance. And production instance probably all have their own policy file so they will not be impacted by the updated `generic.py` or `generic_multi_vo.py`. I think that exposing scopes to replica-related permission functions could also benefit to some production instance that had to work around the absence of scopes with account attributes....

It also requires #8236 to fully address problems with S3 RSEs.


## Checklist
- [x] Created issue: #8333
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>