### PR TITLE
fix(Clients): Unlock a rule 

### DIFF
--- a/lib/rucio/cli/rule.py
+++ b/lib/rucio/cli/rule.py
@@ -339,7 +339,7 @@ def update(
     options = {}
     if lifetime:
         options['lifetime'] = None if lifetime.lower() == "none" else int(lifetime)
-    if locked:
+    if locked is not None:
         options['locked'] = locked
     if comment:
         options['comment'] = comment

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -798,17 +798,17 @@ def test_rule(rucio_client, mock_scope):
     assert exitcode == 0
     assert "ERROR" not in err
 
+    cmd = f"rucio -v rule update {rule_id} --locked True"
+    exitcode, out, err = execute(cmd)
+    assert exitcode == 0
+    assert rucio_client.get_replication_rule(rule_id)['locked']
+
     # Check that you can lock and unlock a rule
     cmd = f"rucio rule update {rule_id} --locked False"
     exitcode, out, err = execute(cmd)
     assert exitcode == 0
     assert "ERROR" not in err
     assert not rucio_client.get_replication_rule(rule_id)['locked']
-
-    cmd = f"rucio -v rule update {rule_id} --locked True"
-    exitcode, out, err = execute(cmd)
-    assert exitcode == 0
-    assert rucio_client.get_replication_rule(rule_id)['locked']
 
     # Testing the two different lifetime type options
     cmd = f"rucio rule update {rule_id} --lifetime 10"


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

Closes: #8513 

## Checklist
- [x] Created issue: #8513 
- [x] Added tests
- [ ] Updated documentation (N/A)
- [ ] Added database migrations (if needed) (N/A)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits (N/A)
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
