### PR TITLE
tests(Clients): Use less exact requirements for rule lifetime setting

### DIFF
--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -756,7 +756,6 @@ def test_rse_qos_policy(rucio_client):
 
 
 @pytest.mark.dirty
-@pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_rule(rucio_client, mock_scope):
     mock_rse = "MOCK-POSIX"
     rule_rse = "MOCK"
@@ -811,13 +810,16 @@ def test_rule(rucio_client, mock_scope):
     assert not rucio_client.get_replication_rule(rule_id)['locked']
 
     # Testing the two different lifetime type options
-    cmd = f"rucio rule update {rule_id} --lifetime 10"
+    cmd = f"rucio rule update {rule_id} --lifetime 30"
     exitcode, out, err = execute(cmd)
     print(out, err)
     assert exitcode == 0
     assert "ERROR" not in err
     rule_info = rucio_client.get_replication_rule(rule_id)
-    assert abs(rule_info["updated_at"] - rule_info["expires_at"]).seconds == 10
+    assert rule_info["expires_at"] is not None
+    # Ensure the expiration date is in the future
+    assert (rule_info["expires_at"] - rule_info['updated_at']).seconds < 60
+    assert rule_info['updated_at'] < rule_info["expires_at"]
 
     cmd = f"rucio rule update {rule_id} --lifetime None"
     exitcode, out, err = execute(cmd)


### PR DESCRIPTION
Closes: #8523

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue:  #8523
- [ ] Added tests N/A
- [ ] Updated documentation (Please link PRs in documentation repository) N/A
- [ ] Added database migrations (if needed) N/A
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits N/A
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
