### PR TITLE
Increase information given in "account show" and "did show" commands

### DIFF
--- a/lib/rucio/cli/account.py
+++ b/lib/rucio/cli/account.py
@@ -82,19 +82,100 @@ def show(ctx: click.Context, account_name: str):
     """
     Show info about a single account
     """
-    info = ctx.obj.client.get_account(account=account_name)
     if ctx.obj.use_rich:
-        keyword_style = {**CLITheme.ACCOUNT_STATUS, **CLITheme.ACCOUNT_TYPE}
-        table_data = [(k, Text(str(v), style=keyword_style.get(str(v), 'default'))) for k, v in sorted(info.items())]
-        table = generate_table(
+        ctx.obj.spinner.update(status='Fetching account info')
+        ctx.obj.spinner.start()
+        keyword_styles = {**CLITheme.BOOLEAN, **CLITheme.DID_TYPE}
+
+    settings = ctx.obj.client.get_account(account=account_name)
+    attributes = next(ctx.obj.client.list_account_attributes(account_name))
+    local_limits = list(ctx.obj.client.get_local_account_usage(account=account_name))
+    global_limits = []
+    for limit_rse in ctx.obj.client.get_global_account_limits(account=account_name).keys():  # Get all the rse expressions with limits
+        # Get the usage for that RSE Expression
+        global_limits += list(ctx.obj.client.get_global_account_usage(account=account_name, rse_expression=limit_rse))
+    identities = ctx.obj.client.list_identities(account=account_name)
+
+    if ctx.obj.use_rich:
+        output = []
+        # Settings
+        # Key and value pairs
+        output.append("[b]Settings:[/]")
+        table_data = [[key, Text(str(item), style=keyword_styles.get(str(item), 'default'))] for key, item in settings.items()]
+        output.append(generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left']))
+
+        # table with "Key" and "Value" for each plugin, with the plugin type as a header
+        output.append("[b]Attributes:[/]\n")
+        table_data = [[attr['key'], Text(str(attr['value']), style=keyword_styles.get(str(attr['value']), 'default'))] for attr in attributes]
+        output.append(generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left']))
+
+        # Local and global limits
+        output.append(Text("Local Limits", style=CLITheme.SUBHEADER_HIGHLIGHT))
+        table_data = [[limit['rse'],
+                Text(sizefmt(limit['bytes'], ctx.obj.human), style=keyword_styles.get(str(limit['bytes']), 'default')),
+                Text(sizefmt(limit['bytes_limit'], ctx.obj.human), style=keyword_styles.get(str(limit['bytes_limit']), 'default')),
+                Text(sizefmt(0 if float(limit['bytes_remaining']) < 0 else float(limit['bytes_remaining']), ctx.obj.human), style=keyword_styles.get(str(limit['bytes_remaining']), 'default'))
+            ] for limit in local_limits]
+        output.append(generate_table(
             table_data,
             row_styles=['none'],
-            col_alignments=['left', 'left']
+            headers=["RSE", "USAGE", "LIMIT", "QUOTA LEFT"],
+            col_alignments=['right', 'left', 'left', 'left'])
         )
-        print_output(table, console=ctx.obj.console, no_pager=ctx.obj.no_pager)
+
+        output.append(Text("Global Limits", style=CLITheme.SUBHEADER_HIGHLIGHT))
+        table_data = [[limit['rse_expression'],
+                       Text(sizefmt(limit['bytes'], ctx.obj.human), style=keyword_styles.get(str(limit['bytes']), 'default')),
+                       Text(sizefmt(limit['bytes_limit'], ctx.obj.human), style=keyword_styles.get(str(limit['bytes_limit']), 'default')),
+                       Text(sizefmt(0 if float(limit['bytes_remaining']) < 0 else float(limit['bytes_remaining']), ctx.obj.human), style=keyword_styles.get(str(limit['bytes_remaining']), 'default'))
+                    ] for limit in global_limits]
+        output.append(generate_table(
+            table_data,
+            row_styles=['none'],
+            headers=["RSE EXPRESSION", "USAGE", "LIMIT", "QUOTA LEFT"],
+            col_alignments=['right', 'left', 'left', 'left'])
+        )
+
+        output.append(Text("Identities", style=CLITheme.SUBHEADER_HIGHLIGHT))
+        table_data = [[identity['identity'], Text(identity['type'], style=keyword_styles.get(str(identity['type']), 'default'))] for identity in identities]
+        output.append(generate_table(table_data, row_styles=['none'], headers=["IDENTITY", "TYPE"], col_alignments=['left', 'left']))
+
+        ctx.obj.spinner.stop()
+        print_output(*output, console=ctx.obj.console, no_pager=ctx.obj.no_pager)
+
     else:
-        for k in info:
-            print(k.ljust(10) + ' : ' + str(info[k]))
+        print("Settings\n===========")
+        for key, value in settings.items():
+            print(f"{ctx.obj.spacing}{key}: {value}")
+
+        print("Attributes\n===========")
+        for attr in attributes:
+            print(f"{ctx.obj.spacing}{attr['key']}: {attr['value']}")
+
+        print("Limits\n===========")
+        if len(list(local_limits)) != 0:
+            print(f"{ctx.obj.spacing}Local limits")
+            table_data = []
+            for limit in local_limits:
+                remaining = 0 if float(limit['bytes_remaining']) < 0 else float(limit['bytes_remaining'])
+                table_data.append([limit['rse'], sizefmt(limit['bytes'], ctx.obj.human), sizefmt(limit['bytes_limit'], ctx.obj.human), sizefmt(remaining, ctx.obj.human)])
+            print(tabulate(table_data, tablefmt=ctx.obj.tablefmt, headers=['RSE', 'USAGE', 'LIMIT', 'QUOTA LEFT']))
+
+        if len(list(global_limits)) != 0:
+            print(f"{ctx.obj.spacing}Global limits")
+            table_data = []
+            for limit in global_limits:
+                remaining = 0 if float(limit['bytes_remaining']) < 0 else float(limit['bytes_remaining'])
+                table_data.append([limit['rse_expression'], sizefmt(limit['bytes'], ctx.obj.human), sizefmt(limit['bytes_limit'], ctx.obj.human), sizefmt(remaining, ctx.obj.human)])
+            print(tabulate(table_data, tablefmt=ctx.obj.tablefmt, headers=['RSE EXPRESSION', 'USAGE', 'LIMIT', 'QUOTA LEFT']))
+
+        print("Identities\n===========")
+        table_data = []
+        for identity in identities:
+            if len(identity['identity']) > 100:
+                identity['identity'] = f"{identity['identity'][:20]} ... {identity['identity'][-20:]} (truncated)"
+            table_data.append([identity['identity'], identity['type']])
+        print(tabulate(table_data, tablefmt=ctx.obj.tablefmt, headers=['IDENTITY', 'TYPE']))
 
 
 @account.command("remove")

--- a/lib/rucio/cli/command.py
+++ b/lib/rucio/cli/command.py
@@ -204,6 +204,7 @@ def main(
     ctx.obj.pager = get_pager()
     ctx.obj.human = not robot
     ctx.obj.tablefmt = 'psql'
+    ctx.obj.spacing = ' ' * 2
 
     if use_rich:
         install(console=console, word_wrap=True, width=min(console.width, MAX_TRACEBACK_WIDTH))  # Make rich exception tracebacks the default.

--- a/lib/rucio/cli/did.py
+++ b/lib/rucio/cli/did.py
@@ -116,36 +116,69 @@ def list_(ctx: click.Context, did_pattern: str, recursive: bool, filter_: str, s
 
 
 @did.command("show")
-@click.argument("dids", nargs=-1)
+@click.argument("did", nargs=1)
 @click.pass_context
-def show(ctx: click.Context, dids: tuple[str, ...]) -> None:
-    """List attributes, statuses, or parents for data identifiers"""
+def show(ctx: click.Context, did: str) -> None:
+    """List attributes, statuses, or parents for a data identifier"""
     if ctx.obj.use_rich:
         ctx.obj.spinner.update(status='Fetching DID stats')
         ctx.obj.spinner.start()
         keyword_styles = {**CLITheme.BOOLEAN, **CLITheme.DID_TYPE}
 
-    output = []
-    for i, did in enumerate(dids):
-        scope, name = get_scope(did, ctx.obj.client)
-        info = ctx.obj.client.get_did(scope=scope, name=name, dynamic_depth='DATASET')
-        if ctx.obj.use_rich:
-            if i > 0:
-                output.append(Text(f'\nDID: {did}', style=CLITheme.TEXT_HIGHLIGHT))
-            elif len(dids) > 1:
-                output.append(Text(f'DID: {did}', style=CLITheme.TEXT_HIGHLIGHT))
-            table_data = [(k, Text(str(v), style=keyword_styles.get(str(v), 'default'))) for (k, v) in sorted(info.items())]
-            table = generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left'])
-            output.append(table)
-        else:
-            if i > 0:
-                print('------')
-            table = [(k + ':', str(v)) for (k, v) in sorted(info.items())]
-            print(tabulate(table, tablefmt='plain', disable_numparse=True))
+    scope, did_name = get_scope(did, ctx.obj.client)
+    settings = ctx.obj.client.get_did(scope=scope, name=did_name, dynamic_depth='DATASET')
+    meta_plugins = config_get("metadata", "plugins", default="DID_COLUMN,JSON").split(",")
+    metadata = {plugin: ctx.obj.client.get_metadata(scope=scope, name=did_name, plugin=plugin) for plugin in meta_plugins}
+    parents = list(ctx.obj.client.list_parent_dids(scope=scope, name=did_name))
 
     if ctx.obj.use_rich:
+        output = []
+        # Settings
+        # Key and value pairs
+        output.append("[b]Settings:[/]")
+        table_data = [[key, Text(str(item), style=keyword_styles.get(str(item), 'default'))] for key, item in settings.items()]
+        output.append(generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left']))
+
+        # Metadata
+        # table with "Key" and "Value" for each plugin, with the plugin type as a header
+        output.append("[b]Metadata:[/]\n")
+        for plugin, meta in metadata.items():
+            if len(meta) != 0:
+                output.append(Text(plugin, style=CLITheme.SUBHEADER_HIGHLIGHT))
+                # TODO protect against non-string-ifiable values
+                table_data = [[key, Text(str(item), style=keyword_styles.get(str(item), 'default'))] for key, item in meta.items()]
+                output.append(generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left']))
+
+        # Parents
+        # table of "SCOPE:NAME" and "TYPE" for parents
+        output.append("[b]Parentage:[/]")
+        table_data = [[
+            f"{parent['scope']}:{parent['name']}",
+            Text(str(parent["type"]), style=CLITheme.DID_TYPE.get(parent["type"], 'default'))
+        ] for parent in parents]
+        output.append(generate_table(table_data, row_styles=['none'], col_alignments=['left', 'left'], headers=['SCOPE:NAME', '[DID TYPE]']))
+
         ctx.obj.spinner.stop()
         print_output(*output, console=ctx.obj.console, no_pager=ctx.obj.no_pager)
+
+    else:
+        # DID Settings
+        print("Settings\n===========")
+        for key, value in settings.items():
+            print(f"{ctx.obj.spacing}{key}: {value}")
+
+        # Metadata for the DID
+        print("Metadata\n===========")
+        for plugin, meta in metadata.items():
+            if len(meta) != 0:
+                print(ctx.obj.spacing, plugin)
+                for key, value in meta.items():
+                    print(f"{ctx.obj.spacing * 2 }{key}: {value}")
+
+        # Parentage
+        print("Parentage\n===========")
+        for parent in parents:
+            print(f"{ctx.obj.spacing}{parent['scope']}:{parent['name']} ({parent['type']})")
 
 
 @did.command("add")

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -107,7 +107,8 @@ def test_help_menus():
             continue
 
 
-def test_account(rucio_client):
+def test_account(rucio_client, rse_factory):
+    rse, _ = rse_factory.make_posix_rse()
     new_account = account_name_generator()
     command = f"rucio account add {new_account} USER"
     exitcode, _, err = execute(command)
@@ -128,11 +129,22 @@ def test_account(rucio_client):
     assert "ERROR" not in err
     assert new_account in out
 
+    rucio_client.add_account_attribute(new_account, "test_key", "test_value")
+    rucio_client.add_identity(new_account, authtype="userpass", identity="test_email@cern.ch", email="test_email@cern.ch", password="123456")
+    rucio_client.set_account_limit(new_account, rse, 10, locality="local")
+    rucio_client.set_account_limit(new_account, rse, 20, locality="global")
+
     command = f"rucio account show {new_account}"
     exitcode, out, err = execute(command)
+
     assert exitcode == 0
     assert "ERROR" not in err
     assert new_account in out
+    assert "test_key" in out
+    assert "test_email" in out
+    assert rse in out
+    assert "20.000 B" in out
+    assert "10.000 B" in out
 
     command = f"rucio account remove {new_account}"
     exitcode, out, err = execute(command)
@@ -341,11 +353,17 @@ def test_did(rucio_client, root_account, file_config_mock):
     assert f"{scope}:{dataset}" in out
     assert "ERROR" not in err
 
+    # Shows settings, metadata, and parents
+    rucio_client.attach_dids(scope=scope, name=container, dids=[{"scope": scope, "name": dataset}])
+    rucio_client.set_metadata(scope=scope, name=dataset, key="campaign", value="test_value")
+
     cmd = f"rucio did show {scope}:{dataset}"
     exitcode, out, err = execute(cmd)
-    assert exitcode == 0
-    assert "ERROR" not in err
+    assert "ERROR" not in err, err
+    assert exitcode == 0, out
     assert dataset in out  # At least list the name properly
+    assert container in out
+    assert "test_value" in out
 
     # Add the collection DIDs
     scope = scope_name_generator()


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

Closes #8502 

## Checklist
- [x] Created issue: #8502
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

For the two added tests, these are what the outputs look like (first using tabular, and then rich CLI outputs)

For account show, IDs that are over 100 characters long break the table even on a very long display, so I have added a "truncated" version. The usual `account id list` command leaves this alone. 

<details><summary>rucio show account</summary>
<p>

```

Settings
===========
  suspended_at: None
  status: ACTIVE
  created_at: 2026-04-30T20:00:52
  email: jdoe@cern.ch
  account: jdoe-b9e42daf8c3348b6
  account_type: USER
  deleted_at: None
  updated_at: 2026-04-30T20:00:53
Attributes
===========
  test_key: test_value
Limits
===========
  Local limits
+--------------------------------------------+---------+----------+--------------+
| RSE                                        | USAGE   | LIMIT    | QUOTA LEFT   |
|--------------------------------------------+---------+----------+--------------|
| QSHRCT-CLI-CLIENT-STRUCTURE-ACCOUNT-SLJBYP | 0.000 B | 10.000 B | 10.000 B     |
+--------------------------------------------+---------+----------+--------------+
  Global limits
+--------------------------------------------+---------+----------+--------------+
| RSE EXPRESSION                             | USAGE   | LIMIT    | QUOTA LEFT   |
|--------------------------------------------+---------+----------+--------------|
| QSHRCT-CLI-CLIENT-STRUCTURE-ACCOUNT-SLJBYP | 0.000 B | 20.000 B | 20.000 B     |
+--------------------------------------------+---------+----------+--------------+
Identities
===========
+--------------------+----------+
| IDENTITY           | TYPE     |
|--------------------+----------|
| test_email@cern.ch | USERPASS |
+--------------------+----------+

```

```

Settings:
┌──────────────┬───────────────────────┐
│ suspended_at │                       │
│ status       │ ACTIVE                │
│ created_at   │ 2026-04-30T20:02:26   │
│ email        │ jdoe@cern.ch          │
│ account      │ jdoe-431275ccac04434f │
│ account_type │ USER                  │
│ deleted_at   │                       │
│ updated_at   │ 2026-04-30T20:02:28   │
└──────────────┴───────────────────────┘
Attributes:

┌──────────┬────────────┐
│ test_key │ test_value │
└──────────┴────────────┘
Local Limits
┌────────────────────────────────────────────┬─────────┬──────────┬────────────┐
│                                        RSE │ USAGE   │ LIMIT    │ QUOTA LEFT │
├────────────────────────────────────────────┼─────────┼──────────┼────────────┤
│ XMPOAL-CLI-CLIENT-STRUCTURE-ACCOUNT-KQDGQV │ 0.000 B │ 10.000 B │ 10.000 B   │
└────────────────────────────────────────────┴─────────┴──────────┴────────────┘
Global Limits
┌────────────────────────────────────────────┬─────────┬──────────┬────────────┐
│                             RSE EXPRESSION │ USAGE   │ LIMIT    │ QUOTA LEFT │
├────────────────────────────────────────────┼─────────┼──────────┼────────────┤
│ XMPOAL-CLI-CLIENT-STRUCTURE-ACCOUNT-KQDGQV │ 0.000 B │ 20.000 B │ 20.000 B   │
└────────────────────────────────────────────┴─────────┴──────────┴────────────┘
Identities
┌────────────────────┬──────────┐
│ IDENTITY           │ TYPE     │
├────────────────────┼──────────┤
│ test_email@cern.ch │ USERPASS │

```


</p>
</details> 



<details><summary>rucio did show</summary>
<p>

```

Settings
===========
  scope: mock_8b14d4c28c98444f
  name: file_RKHGKMLEZZ
  type: DATASET
  account: root
  open: True
  monotonic: False
  expired_at: None
  length: 0
  bytes: 0
Metadata
===========
   DID_COLUMN
    is_open: True
    bytes: None
    events: None
    version: None
    accessed_at: None
    monotonic: False
    length: None
    guid: None
    campaign: None
    closed_at: None
    hidden: False
    md5: None
    project: None
    task_id: None
    eol_at: None
    name: file_RKHGKMLEZZ
    obsolete: False
    adler32: None
    datatype: None
    panda_id: None
    is_archive: None
    scope: mock_8b14d4c28c98444f
    complete: None
    expired_at: None
    run_number: None
    lumiblocknr: None
    constituent: None
    account: root
    is_new: True
    purge_replicas: True
    stream_name: None
    provenance: None
    access_cnt: None
    did_type: DATASET
    availability: AVAILABLE
    deleted_at: None
    phys_group: None
    transient: False
    created_at: 2026-04-30 20:24:27
    suppressed: False
    prod_step: None
    updated_at: 2026-04-30 20:24:27
   JSON
    test_key: test_value
Parentage
===========
  mock_8b14d4c28c98444f:file_BAZVSVBLOQ (CONTAINER)

```

```

Settings:
┌────────────┬───────────────────────┐
│ scope      │ mock_16e0f4bcef0e4a07 │
│ name       │ file_LCWOFFDRWE       │
│ type       │ DATASET               │
│ account    │ root                  │
│ open       │ True                  │
│ monotonic  │ False                 │
│ expired_at │                       │
│ length     │ 0                     │
│ bytes      │ 0                     │
└────────────┴───────────────────────┘
Metadata:
 DID_COLUMN
┌────────────────┬───────────────────────┐
│ is_open        │ True                  │
│ bytes          │                       │
│ events         │                       │
│ version        │                       │
│ accessed_at    │                       │
│ monotonic      │ False                 │
│ length         │                       │
│ guid           │                       │
│ campaign       │                       │
│ closed_at      │                       │
│ hidden         │ False                 │
│ md5            │                       │
│ project        │                       │
│ task_id        │                       │
│ eol_at         │                       │
│ name           │ file_LCWOFFDRWE       │
│ obsolete       │ False                 │
│ adler32        │                       │
│ datatype       │                       │
│ panda_id       │                       │
│ is_archive     │                       │
│ scope          │ mock_16e0f4bcef0e4a07 │
│ complete       │                       │
│ expired_at     │                       │
│ run_number     │                       │
│ lumiblocknr    │                       │
│ constituent    │                       │
│ account        │ root                  │
│ is_new         │ True                  │
│ purge_replicas │ True                  │
│ stream_name    │                       │
│ provenance     │                       │
│ access_cnt     │                       │
│ did_type       │ DATASET               │
│ availability   │ AVAILABLE             │
│ deleted_at     │                       │
│ phys_group     │                       │
│ transient      │ False                 │
│ created_at     │ 2026-04-30 20:23:23   │
│ suppressed     │ False                 │
│ prod_step      │                       │
│ updated_at     │ 2026-04-30 20:23:23   │
└────────────────┴───────────────────────┘
JSON
┌──────────┬────────────┐
│ test_key │ test_value │
└──────────┴────────────┘
Parentage:
┌───────────────────────────────────────┬────────────┐
│ SCOPE:NAME                            │ [DID TYPE] │
├───────────────────────────────────────┼────────────┤
│ mock_16e0f4bcef0e4a07:file_DMEWKRYQXA │ CONTAINER  │
└───────────────────────────────────────┴────────────┘
```

</p>
</details> 


*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
