### PR TITLE
Disable core config cache in testing

### DIFF
--- a/lib/rucio/core/config.py
+++ b/lib/rucio/core/config.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
-from dogpile.cache.api import NoValue
+from dogpile.cache.api import NoValue, NO_VALUE
 from sqlalchemy import and_, delete, func, select, update
 
 from rucio.common.cache import CacheKey, MemcacheRegion
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
 
 
 REGION = MemcacheRegion(expiration_time=900)
+DISABLE_CACHE_READ = os.environ.get('RUCIO_CONFIG_DISABLE_CACHE_READ', "").lower() in ('true', '1')
 
 SECTIONS_CACHE_KEY = 'sections'
 
@@ -413,6 +415,8 @@ def read_from_cache(key: str, expiration_time: int = 900) -> Any:
     :param key: Key that stores the value.
     :param expiration_time: Time in seconds that a value should not be older than.
     """
+    if DISABLE_CACHE_READ:
+        return NO_VALUE
     key = key.replace(' ', '')
     value = REGION.get(key, expiration_time=expiration_time)
     return value

--- a/lib/rucio/core/config.py
+++ b/lib/rucio/core/config.py
@@ -15,7 +15,7 @@
 import os
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
-from dogpile.cache.api import NoValue, NO_VALUE
+from dogpile.cache.api import NO_VALUE
 from sqlalchemy import and_, delete, func, select, update
 
 from rucio.common.cache import CacheKey, MemcacheRegion
@@ -53,11 +53,11 @@ def sections(
     :returns: ['section_name', ...]
     """
 
-    cached_value = NoValue()
+    cached_value = NO_VALUE
     if use_cache:
         cached_value = read_from_cache(SECTIONS_CACHE_KEY, expiration_time)
     sections_list: list[str]
-    if isinstance(cached_value, NoValue):
+    if cached_value is NO_VALUE:
         stmt = select(
             models.Config.section
         ).distinct(
@@ -99,11 +99,11 @@ def has_section(
     :returns: True/False
     """
     has_section_key = 'has_section_%s' % section
-    cached_value = NoValue()
+    cached_value = NO_VALUE
     if use_cache:
         cached_value = read_from_cache(has_section_key, expiration_time)
     _has_section: bool
-    if isinstance(cached_value, NoValue):
+    if cached_value is NO_VALUE:
         stmt = select(
             models.Config
         ).where(
@@ -135,11 +135,11 @@ def options(
     :returns: ['option', ...]
     """
     options_key = CacheKey.options(section)
-    cached_value = NoValue()
+    cached_value = NO_VALUE
     if use_cache:
         cached_value = read_from_cache(options_key, expiration_time)
     options_list: list[str]
-    if isinstance(cached_value, NoValue):
+    if cached_value is NO_VALUE:
         stmt = select(
             models.Config.opt
         ).where(
@@ -173,11 +173,11 @@ def has_option(
     :returns: True/False
     """
     has_option_key = CacheKey.has_option(section, option)
-    cached_value = NoValue()
+    cached_value = NO_VALUE
     if use_cache:
         cached_value = read_from_cache(has_option_key, expiration_time)
     _has_option: bool
-    if isinstance(cached_value, NoValue):
+    if cached_value is NO_VALUE:
         stmt = select(
             models.Config
         ).where(
@@ -219,11 +219,11 @@ def get(
     :returns: The auto-coerced value.
     """
     value_key = CacheKey.value(section, option)
-    cached_value = NoValue()
+    cached_value = NO_VALUE
     if use_cache:
         cached_value = read_from_cache(value_key, expiration_time)
     value: T
-    if isinstance(cached_value, NoValue):
+    if cached_value is NO_VALUE:
         stmt = select(
             models.Config.value
         ).where(
@@ -264,11 +264,11 @@ def items(
     :returns: [('option', auto-coerced value), ...]
     """
     items_key = CacheKey.items(section)
-    cached_value = NoValue()
+    cached_value = NO_VALUE
     if use_cache:
         cached_value = read_from_cache(items_key, expiration_time)
     _items: list[tuple[str, T]]
-    if isinstance(cached_value, NoValue):
+    if cached_value is NO_VALUE:
         stmt = select(
             models.Config.opt,
             models.Config.value

--- a/lib/rucio/core/config.py
+++ b/lib/rucio/core/config.py
@@ -53,18 +53,21 @@ def sections(
     :returns: ['section_name', ...]
     """
 
-    all_sections = NoValue()
+    cached_value = NoValue()
     if use_cache:
-        all_sections = read_from_cache(SECTIONS_CACHE_KEY, expiration_time)
-    if isinstance(all_sections, NoValue):
+        cached_value = read_from_cache(SECTIONS_CACHE_KEY, expiration_time)
+    sections_list: list[str]
+    if isinstance(cached_value, NoValue):
         stmt = select(
             models.Config.section
         ).distinct(
         )
-        all_sections = list(session.execute(stmt).scalars().all())
-        write_to_cache(SECTIONS_CACHE_KEY, all_sections)
+        sections_list = list(session.execute(stmt).scalars().all())
+        write_to_cache(SECTIONS_CACHE_KEY, sections_list)
+    else:
+        sections_list = cached_value  # type: ignore
 
-    return all_sections
+    return sections_list
 
 
 @transactional_session
@@ -96,18 +99,22 @@ def has_section(
     :returns: True/False
     """
     has_section_key = 'has_section_%s' % section
-    has_section = NoValue()
+    cached_value = NoValue()
     if use_cache:
-        has_section = read_from_cache(has_section_key, expiration_time)
-    if isinstance(has_section, NoValue):
+        cached_value = read_from_cache(has_section_key, expiration_time)
+    _has_section: bool
+    if isinstance(cached_value, NoValue):
         stmt = select(
             models.Config
         ).where(
             models.Config.section == section
         )
-        has_section = session.execute(stmt).first() is not None
-        write_to_cache(has_section_key, has_section)
-    return has_section
+        _has_section = session.execute(stmt).first() is not None
+        write_to_cache(has_section_key, _has_section)
+    else:
+        _has_section = cached_value  # type: ignore
+
+    return _has_section
 
 
 @read_session
@@ -128,18 +135,22 @@ def options(
     :returns: ['option', ...]
     """
     options_key = CacheKey.options(section)
-    options = NoValue()
+    cached_value = NoValue()
     if use_cache:
-        options = read_from_cache(options_key, expiration_time)
-    if isinstance(options, NoValue):
+        cached_value = read_from_cache(options_key, expiration_time)
+    options_list: list[str]
+    if isinstance(cached_value, NoValue):
         stmt = select(
             models.Config.opt
         ).where(
             models.Config.section == section
         ).distinct()
-        options = list(session.execute(stmt).scalars().all())
-        write_to_cache(options_key, options)
-    return options
+        options_list = list(session.execute(stmt).scalars().all())
+        write_to_cache(options_key, options_list)
+    else:
+        options_list = cached_value  # type: ignore
+
+    return options_list
 
 
 @read_session
@@ -162,19 +173,23 @@ def has_option(
     :returns: True/False
     """
     has_option_key = CacheKey.has_option(section, option)
-    has_option = NoValue()
+    cached_value = NoValue()
     if use_cache:
-        has_option = read_from_cache(has_option_key, expiration_time)
-    if isinstance(has_option, NoValue):
+        cached_value = read_from_cache(has_option_key, expiration_time)
+    _has_option: bool
+    if isinstance(cached_value, NoValue):
         stmt = select(
             models.Config
         ).where(
             and_(models.Config.section == section,
                  models.Config.opt == option)
         )
-        has_option = session.execute(stmt).first() is not None
-        write_to_cache(has_option_key, has_option)
-    return has_option
+        _has_option = session.execute(stmt).first() is not None
+        write_to_cache(has_option_key, _has_option)
+    else:
+        _has_option = cached_value  # type: ignore
+
+    return _has_option
 
 
 @read_session
@@ -204,10 +219,11 @@ def get(
     :returns: The auto-coerced value.
     """
     value_key = CacheKey.value(section, option)
-    value = NoValue()
+    cached_value = NoValue()
     if use_cache:
-        value = read_from_cache(value_key, expiration_time)
-    if isinstance(value, NoValue):
+        cached_value = read_from_cache(value_key, expiration_time)
+    value: T
+    if isinstance(cached_value, NoValue):
         stmt = select(
             models.Config.value
         ).where(
@@ -224,7 +240,7 @@ def get(
             value = default
             write_to_cache(value_key, value)  # Also write default to cache
     else:
-        value = convert_type_fnc(value)
+        value = convert_type_fnc(cached_value)  # type: ignore
     return value
 
 
@@ -248,19 +264,24 @@ def items(
     :returns: [('option', auto-coerced value), ...]
     """
     items_key = CacheKey.items(section)
-    items = NoValue()
+    cached_value = NoValue()
     if use_cache:
-        items = read_from_cache(items_key, expiration_time)
-    if isinstance(items, NoValue):
+        cached_value = read_from_cache(items_key, expiration_time)
+    _items: list[tuple[str, T]]
+    if isinstance(cached_value, NoValue):
         stmt = select(
             models.Config.opt,
             models.Config.value
         ).where(
             models.Config.section == section
         )
-        items = session.execute(stmt).all()
-        write_to_cache(items_key, items)
-    return [(opt, convert_type_fnc(val)) for opt, val in items]
+        database_result = session.execute(stmt).all()
+        write_to_cache(items_key, database_result)
+        _items = [(opt, convert_type_fnc(val)) for opt, val in database_result]
+    else:
+        _items = [(opt, convert_type_fnc(val)) for opt, val in cached_value]  # type: ignore
+
+    return _items
 
 
 @transactional_session

--- a/lib/rucio/tests/common_server.py
+++ b/lib/rucio/tests/common_server.py
@@ -134,7 +134,8 @@ def cleanup_db_deps(
 def reset_config_table() -> None:
     """ Clear the config table and install any default entries needed for the tests.
     """
-    db_session = get_session()()
+    session_scoped = get_session()
+    db_session = session_scoped()
     db_session.query(models.Config).delete()
     set_config_defaults(session=db_session)
     db_session.commit()

--- a/lib/rucio/tests/common_server.py
+++ b/lib/rucio/tests/common_server.py
@@ -134,11 +134,15 @@ def cleanup_db_deps(
 def reset_config_table() -> None:
     """ Clear the config table and install any default entries needed for the tests.
     """
-    db_session = get_session()
+    db_session = get_session()()
     db_session.query(models.Config).delete()
+    set_config_defaults(session=db_session)
     db_session.commit()
-    core_config.set("vo-map", "testvo1", "tst")
-    core_config.set("vo-map", "testvo2", "ts2")
+
+
+def set_config_defaults(session: "Session") -> None:
+    core_config.set(section="vo-map", option="testvo1", value="tst", session=session)
+    core_config.set(section="vo-map", option="testvo2", value="ts2", session=session)
 
 
 def get_vo() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -651,7 +651,8 @@ def core_config_mock(request: pytest.FixtureRequest) -> "Iterator[None]":
     )
 
     # Fill the table with the requested mock data
-    session = get_session()()
+    session_scoped = get_session()
+    session = session_scoped()
     for section, option, value in (table_content or []):
         in_memory_config(section=section, opt=option, value=value).save(flush=True, session=session)
     session.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,9 @@ def pytest_configure(config: pytest.Config) -> None:
         "flaky(reruns, reruns_delay): mark test as flaky and rerun on failure"
     )
 
+    # disable configuration cache globally. Fixes side effects when using, e.g., core_config_mock
+    os.environ['RUCIO_CONFIG_DISABLE_CACHE_READ'] = 'true'
+
     if config.pluginmanager.hasplugin("xdist"):
         from .ruciopytest import xdist_noparallel_scheduler
         config.pluginmanager.register(xdist_noparallel_scheduler)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -631,6 +631,7 @@ def core_config_mock(request: pytest.FixtureRequest) -> "Iterator[None]":
     from rucio.common.utils import generate_uuid
     from rucio.db.sqla.models import PrimaryKeyConstraint, String
     from rucio.db.sqla.session import get_session
+    from rucio.tests.common_server import set_config_defaults
 
     # Get the fixture parameters
     table_content = []
@@ -653,6 +654,8 @@ def core_config_mock(request: pytest.FixtureRequest) -> "Iterator[None]":
     session.commit()
 
     with mock.patch('rucio.core.config.models.Config', new=in_memory_config):
+        set_config_defaults(session=session)
+        session.commit()
         yield
 
 

--- a/tests/test_automatix.py
+++ b/tests/test_automatix.py
@@ -18,10 +18,8 @@ import tempfile
 from random import choice
 from string import ascii_uppercase
 
-import pytest
-
-from rucio.common.config import config_add_section, config_has_section, config_remove_option, config_set
 from rucio.common.types import InternalScope
+from rucio.core import config as core_config
 from rucio.core.did import get_metadata, list_dids, list_files
 from rucio.core.scope import add_scope
 from rucio.daemons.automatix.automatix import automatix
@@ -31,26 +29,25 @@ from rucio.rse import rsemanager as rsemgr
 from rucio.tests.common import scope_name_generator
 
 
-@pytest.mark.noparallel(reason='changes global configuration value')
-def test_automatix(vo, root_account, rse_factory):
+def test_automatix(vo, root_account, rse_factory, core_config_mock):
     """Automatix: Test the automatix daemon"""
     scope = scope_name_generator()
+    rse, rse_id = rse_factory.make_posix_rse()
     with db_session(DatabaseOperationType.WRITE) as session:
         add_scope(scope=InternalScope(scope, vo), account=root_account, session=session)
-    if not config_has_section("automatix"):
-        config_add_section("automatix")
-    rse, rse_id = rse_factory.make_posix_rse()
-    config_set("automatix", "rses", rse)
-    config_set("automatix", "scope", scope)
-    if os.environ.get("POLICY") == "belleii":
-        config_set(
-            "automatix",
-            "dataset_pattern",
-            "did_prefix/version/project/date/campaign/release/datatype",
-        )
-        config_set("automatix", "file_pattern", "dsn/uuid")
-        config_set("automatix", "did_prefix", "/belle/ddm/tests")
-        config_set("automatix", "separator", "/")
+
+        core_config.set(section="automatix", option="rses", value=rse, session=session)
+        core_config.set(section="automatix", option="scope", value=scope, session=session)
+        if os.environ.get("POLICY") == "belleii":
+            core_config.set(
+                section="automatix",
+                option="dataset_pattern",
+                value="did_prefix/version/project/date/campaign/release/datatype",
+                session=session
+            )
+            core_config.set(section="automatix", option="file_pattern", value="dsn/uuid", session=session)
+            core_config.set(section="automatix", option="did_prefix", value="/belle/ddm/tests", session=session)
+            core_config.set(section="automatix", option="separator", value="/", session=session)
 
     project = ''.join(choice(ascii_uppercase) for _ in range(8))
     test_dict = {
@@ -66,7 +63,7 @@ def test_automatix(vo, root_account, rse_factory):
         file_.flush()
         automatix(
             inputfile=file_.name,
-            sleep_time=10,
+            sleep_time=0,
             once=True,
         )
         dids = [
@@ -90,5 +87,3 @@ def test_automatix(vo, root_account, rse_factory):
         assert status
         for file_ in files:
             assert file_dict["%s:%s" % (file_["scope"], file_["name"])] is True
-    config_remove_option("automatix", "rses")
-    config_remove_option("automatix", "scope")

--- a/tests/test_multi_vo.py
+++ b/tests/test_multi_vo.py
@@ -30,7 +30,7 @@ from rucio.client.client import Client
 from rucio.client.replicaclient import ReplicaClient
 from rucio.client.subscriptionclient import SubscriptionClient
 from rucio.client.uploadclient import UploadClient
-from rucio.common.config import config_add_section, config_has_section, config_remove_option, config_set
+from rucio.common.config import config_remove_option, config_set
 from rucio.common.constants import DEFAULT_VO, RseAttr
 from rucio.common.exception import AccessDenied, Duplicate, InvalidRSEExpression, RucioException, UnsupportedAccountName, UnsupportedOperation
 from rucio.common.types import InternalAccount
@@ -1055,10 +1055,8 @@ class TestMultiVODaemons:
         add_rse_attribute(rse=shr_rse, key=RseAttr.SKIP_UPLOAD_STAT, value=True, issuer='root', vo=second_vo)
         add_protocol(rse=shr_rse, data=mock_protocol, issuer='root', vo=second_vo)
 
-        if not config_has_section("automatix"):
-            config_add_section("automatix")
-        config_set("automatix", "rses", shr_rse)
-        config_set("automatix", "scope", shr_scope)
+        core_config.set("automatix", "rses", shr_rse)
+        core_config.set("automatix", "scope", shr_scope)
 
         automatix(
             inputfile='/opt/rucio/etc/automatix.json',


### PR DESCRIPTION
Fixes #8490

I had to touch the automatix test and add the vo mappings to the core_config_mock, because the multi-VO test was failing due to relying on the vo-map being in the configuration cache.

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8490
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
