### PR TITLE
Rules: Expose split_container in rule client and CLI #8548

### DIFF
--- a/lib/rucio/cli/bin_legacy/rucio.py
+++ b/lib/rucio/cli/bin_legacy/rucio.py
@@ -1226,7 +1226,8 @@ def add_rule(args, client, logger, console, spinner):
                                                comment=args.comment,
                                                ask_approval=args.ask_approval,
                                                asynchronous=args.asynchronous,
-                                               delay_injection=args.delay_injection)
+                                               delay_injection=args.delay_injection,
+                                               split_container=args.split_container)
     except DuplicateRule as error:
         if args.ignore_duplicate:
             for did in dids:
@@ -1245,7 +1246,8 @@ def add_rule(args, client, logger, console, spinner):
                                                           comment=args.comment,
                                                           ask_approval=args.ask_approval,
                                                           asynchronous=args.asynchronous,
-                                                          delay_injection=args.delay_injection)
+                                                          delay_injection=args.delay_injection,
+                                                          split_container=args.split_container)
                     rule_ids.extend(rule_id)
                 except DuplicateRule:
                     print('Duplicate rule for %s:%s found; Skipping.' % (did['scope'], did['name']))
@@ -2547,6 +2549,7 @@ You can filter by key/value, e.g.::
     add_rule_parser.add_argument('--asynchronous', dest='asynchronous', action='store_true', help='Create rule asynchronously')
     add_rule_parser.add_argument('--delay-injection', dest='delay_injection', action='store', type=int, help='Delay (in seconds) to wait before starting applying the rule. This option implies --asynchronous.')
     add_rule_parser.add_argument('--account', dest='rule_account', action='store', help='The account owning the rule')
+    add_rule_parser.add_argument('--split-container', dest='split_container', action='store_true', help='Split a container rule into individual dataset rules')
     add_rule_parser.add_argument('--skip-duplicates', dest='ignore_duplicate', action='store_true', help='Skip duplicate rules')
 
     # Delete replication rule subparser

--- a/lib/rucio/cli/rule.py
+++ b/lib/rucio/cli/rule.py
@@ -46,6 +46,7 @@ def rule():
 @click.option("--asynchronous", is_flag=True, default=False, help="Create rule asynchronously")
 @click.option("--delay-injection", type=int, help="Delay (in seconds) to wait before starting applying the rule. This option implies --asynchronous.")
 @click.option("--account", help="The account owning the rule")
+@click.option("--split-container", is_flag=True, default=False, help="Split a container rule into individual dataset rules")
 @click.option("--skip-duplicates", is_flag=True, default=False, help="Skip duplicate rules")
 @click.pass_context
 def add_(
@@ -65,6 +66,7 @@ def add_(
     ask_approval: bool,
     delay_injection: Optional[int],
     account: Optional[str],
+    split_container: bool,
     skip_duplicates: bool
 ) -> None:
     """Add replication rule to define how replicas of a list of DIDs are created on RSEs."""
@@ -89,7 +91,8 @@ def add_(
             comment=comment,
             ask_approval=ask_approval,
             asynchronous=asynchronous,
-            delay_injection=delay_injection
+            delay_injection=delay_injection,
+            split_container=split_container
     )
     except DuplicateRule as error:
         if skip_duplicates:
@@ -110,7 +113,8 @@ def add_(
                         comment=comment,
                         ask_approval=ask_approval,
                         asynchronous=asynchronous,
-                        delay_injection=delay_injection
+                        delay_injection=delay_injection,
+                        split_container=split_container
                     )
                     rule_ids.extend(rule_id)
                 except DuplicateRule:

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -53,6 +53,7 @@ class RuleClient(BaseClient):
         delay_injection: Optional[int] = None,
         comment: Optional[str] = None,
         weight: Optional[int] = None,
+        split_container: bool = False,
     ) -> Any:
         """
         Add a replication rule.
@@ -100,6 +101,8 @@ class RuleClient(BaseClient):
             Comment about the rule.
         weight :
             If the weighting option of the replication rule is used, the choice of RSEs takes their weight into account.
+        split_container :
+            Should a container rule be split into individual dataset rules. Default is False.
 
         """
         path = self.RULE_BASEURL + '/'
@@ -110,7 +113,8 @@ class RuleClient(BaseClient):
                       'account': account, 'locked': locked, 'source_replica_expression': source_replica_expression,
                       'activity': activity, 'notify': notify, 'purge_replicas': purge_replicas,
                       'ignore_availability': ignore_availability, 'comment': comment, 'ask_approval': ask_approval,
-                      'asynchronous': asynchronous, 'delay_injection': delay_injection, 'priority': priority, 'meta': meta})
+                      'asynchronous': asynchronous, 'delay_injection': delay_injection, 'priority': priority,
+                      'split_container': split_container, 'meta': meta})
         r = self._send_request(url, method=HTTPMethod.POST, data=data)
         if r.status_code == codes.created:
             return loads(r.text)

--- a/tests/test_ruleclient_split_container.py
+++ b/tests/test_ruleclient_split_container.py
@@ -1,0 +1,102 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from json import loads
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from rucio.cli import rule as rule_cli
+from rucio.cli.bin_legacy import rucio as legacy_rucio
+from rucio.client.ruleclient import RuleClient
+from rucio.common.constants import HTTPMethod
+
+
+class _CreatedResponse:
+    status_code = 201
+    text = '["rule-id"]'
+
+
+class _RecordingRuleClient:
+    def __init__(self):
+        self.calls = []
+
+    def add_replication_rule(self, **kwargs):
+        self.calls.append(kwargs)
+        return ["rule-id"]
+
+
+def test_add_replication_rule_serializes_split_container():
+    captured = {}
+    client = RuleClient.__new__(RuleClient)
+    client.list_hosts = ["https://rucio.example"]
+
+    def _send_request(url, method, data):
+        captured["url"] = url
+        captured["method"] = method
+        captured["data"] = loads(data)
+        return _CreatedResponse()
+
+    client._send_request = _send_request
+
+    assert client.add_replication_rule(
+        dids=[{"scope": "mock", "name": "container"}],
+        copies=1,
+        rse_expression="MOCK",
+        split_container=True,
+    ) == ["rule-id"]
+    assert captured["url"] == "https://rucio.example/rules/"
+    assert captured["method"] == HTTPMethod.POST
+    assert captured["data"]["split_container"] is True
+
+
+def test_rule_click_add_forwards_split_container(monkeypatch):
+    client = _RecordingRuleClient()
+    monkeypatch.setattr(rule_cli, "get_scope", lambda did, _client: tuple(did.split(":", 1)))
+
+    result = CliRunner().invoke(
+        rule_cli.rule,
+        ["add", "mock:container", "--copies", "1", "--rses", "MOCK", "--split-container"],
+        obj=SimpleNamespace(client=client),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert client.calls[0]["split_container"] is True
+
+
+def test_legacy_add_rule_forwards_split_container(monkeypatch):
+    client = _RecordingRuleClient()
+    monkeypatch.setattr(legacy_rucio, "get_scope", lambda did, _client: tuple(did.split(":", 1)))
+    args = SimpleNamespace(
+        dids=["mock:container"],
+        copies=1,
+        rse_expression="MOCK",
+        weight=None,
+        lifetime=None,
+        grouping=None,
+        rule_account=None,
+        locked=False,
+        source_replica_expression=None,
+        notify=None,
+        activity=None,
+        comment=None,
+        ask_approval=False,
+        asynchronous=False,
+        delay_injection=None,
+        split_container=True,
+        ignore_duplicate=False,
+    )
+
+    assert legacy_rucio.add_rule(args, client, None, None, None) == legacy_rucio.SUCCESS
+    assert client.calls[0]["split_container"] is True


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8548
- [x] Added tests
- [ ] Updated documentation (not required; server REST docs already describe `split_container`)
- [ ] Added database migrations (not needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits (not applicable)
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

Closes #8548.

This exposes the existing `split_container` rule parameter through the client-facing add-rule paths:

- adds `split_container` to `RuleClient.add_replication_rule()` and serializes it in the POST payload
- adds `--split-container` to `rucio rule add`
- adds `--split-container` to the legacy `rucio add-rule`
- covers client serialization plus both CLI forwarding paths, including the legacy/new CLI entry points

Validation:

- `uv run --with-editable . --with pytest python -m pytest tests/test_ruleclient_split_container.py -q` -> 3 passed
- `uv run --with ruff ruff check lib/rucio/client/ruleclient.py lib/rucio/cli/rule.py lib/rucio/cli/bin_legacy/rucio.py tests/test_ruleclient_split_container.py` -> All checks passed
- `uv run python -m py_compile lib/rucio/client/ruleclient.py lib/rucio/cli/rule.py lib/rucio/cli/bin_legacy/rucio.py tests/test_ruleclient_split_container.py` -> passed
- `git diff origin/master...HEAD --check` -> passed

Secret scan:

- `git diff origin/master...HEAD | gitleaks stdin --no-banner --redact --timeout 30` -> no leaks found

No full service-stack integration test was run locally; this patch only forwards an already-supported REST/gateway/core parameter.

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High, Medium, Low*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High, Medium, Low*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree, Disagree*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree, Disagree*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree*]

```
- **Confidence in review**: High Medium Low
- **Confidence in scope**: High Medium Low
- **Quality**: Agree
- **Security**: Agree Disagree
- **Backwards compatibility**: Agree Disagree
- **Testing**: Agree
- **Documentation**: Agree

# Notes for merger

```
</details>
