### PR TITLE
Clients: Add local checksum utility #6510

### DIFF
--- a/MANIFEST.client.in
+++ b/MANIFEST.client.in
@@ -19,6 +19,7 @@ include tools/reset_database.py
 include tools/merge_rucio_configs.py
 include bin/rucio
 include bin/rucio-admin
+include bin/rucio-checksum
 prune lib/rucio/web/ui
 prune dist
 prune examples

--- a/bin/rucio-checksum
+++ b/bin/rucio-checksum
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+from typing import Optional
+
+from rucio.common.checksum import CHECKSUM_ALGO_DICT, GLOBALLY_SUPPORTED_CHECKSUMS, PREFERRED_CHECKSUM
+from rucio.common.exception import ChecksumCalculationError
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Print checksums for local files.")
+    parser.add_argument(
+        "-a",
+        "--algorithm",
+        choices=sorted(GLOBALLY_SUPPORTED_CHECKSUMS),
+        default=PREFERRED_CHECKSUM,
+        help=f"Checksum algorithm to use. Default: {PREFERRED_CHECKSUM}.",
+    )
+    parser.add_argument("files", metavar="FILE", nargs="+", help="Local file(s) to checksum.")
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = get_parser().parse_args(argv)
+    checksum = CHECKSUM_ALGO_DICT[args.algorithm]
+    exit_code = 0
+
+    for filepath in args.files:
+        try:
+            print(f"{checksum(filepath)}  {filepath}")
+        except ChecksumCalculationError as error:
+            print(error, file=sys.stderr)
+            exit_code = 1
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.client.toml
+++ b/pyproject.client.toml
@@ -90,6 +90,7 @@ script-files = [
   "bin/rucio-bb8",
   "bin/rucio-cache-client",
   "bin/rucio-cache-consumer",
+  "bin/rucio-checksum",
   "bin/rucio-conveyor-finisher",
   "bin/rucio-conveyor-poller",
   "bin/rucio-conveyor-preparer",

--- a/pyproject.server.toml
+++ b/pyproject.server.toml
@@ -128,6 +128,7 @@ script-files = [
   "bin/rucio-bb8",
   "bin/rucio-cache-client",
   "bin/rucio-cache-consumer",
+  "bin/rucio-checksum",
   "bin/rucio-conveyor-finisher",
   "bin/rucio-conveyor-poller",
   "bin/rucio-conveyor-preparer",

--- a/tests/rucio/common/test_checksum.py
+++ b/tests/rucio/common/test_checksum.py
@@ -12,12 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from importlib.machinery import SourceFileLoader
+from types import ModuleType
 from unittest.mock import Mock
 
 import pytest
 
 from rucio.common.checksum import GLOBALLY_SUPPORTED_CHECKSUMS, adler32, crc32, is_checksum_valid, md5, set_preferred_checksum, sha256
 from rucio.common.exception import ChecksumCalculationError
+
+
+def test_rucio_checksum_utility(tmp_path, capsys):
+    test_file = tmp_path / 'file.txt'
+    test_file.write_text('hello test\n')
+
+    loader = SourceFileLoader('rucio_checksum', 'bin/rucio-checksum')
+    checksum_utility = ModuleType(loader.name)
+    loader.exec_module(checksum_utility)
+
+    assert checksum_utility.main([str(test_file)]) == 0
+    captured = capsys.readouterr()
+    assert captured.err == ''
+    assert captured.out == f'198d03ff  {test_file}\n'
+
+    assert checksum_utility.main(['--algorithm', 'md5', str(test_file)]) == 0
+    captured = capsys.readouterr()
+    assert captured.err == ''
+    assert captured.out == f'31d50dd6285b9ff9f8611d0762265d04  {test_file}\n'
+
+    assert checksum_utility.main(['--algorithm', 'md5', str(tmp_path / 'missing-file'), str(test_file)]) == 1
+    captured = capsys.readouterr()
+    assert f'An error occurred while calculating the md5 checksum of file {tmp_path / "missing-file"}.' in captured.err
+    assert captured.out == f'31d50dd6285b9ff9f8611d0762265d04  {test_file}\n'
 
 
 class TestChecksumUtils:


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #6510
- [x] Added tests
- [ ] Updated documentation (not required; command help and tests cover the new local utility)
- [ ] Added database migrations (not needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits (not applicable)
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

Closes #6510.

This adds `bin/rucio-checksum` for local file checksum calculation without initializing a Rucio client connection:

- defaults to the globally preferred checksum
- supports the current globally supported algorithms, `adler32` and `md5`
- continues processing later files when one file cannot be checksummed, while returning a nonzero exit code
- includes the new script in the client/server script lists and client manifest

Validation:

- `PYTHONPATH=lib:. python3 -m pytest tests/rucio/common/test_checksum.py` -> 11 passed
- `/Users/brucewayne/Money/tools/bin/uv tool run ruff check bin/rucio-checksum tests/rucio/common/test_checksum.py` -> All checks passed
- `python3 -m py_compile bin/rucio-checksum` -> passed
- `python3` TOML parse for `pyproject.client.toml` and `pyproject.server.toml` -> ok
- `git diff --check` -> passed
- `git diff --binary | gitleaks stdin --redact --no-banner` -> no leaks found
- Direct checks: default `adler32` returned `198d03ff`; `--algorithm md5` returned `31d50dd6285b9ff9f8611d0762265d04`; a missing file returned exit code 1 and continued to the next file.

Scope note:

- The command advertises `GLOBALLY_SUPPORTED_CHECKSUMS` rather than every internal checksum helper, so unsupported/internal algorithms are rejected by argument parsing.

<details>
<summary>Reviewer template</summary>

Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High, Medium, Low*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High, Medium, Low*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree, Disagree*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree, Disagree*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree*]

```text
- **Confidence in review**: High Medium Low
- **Confidence in scope**: High Medium Low
- **Quality**: Agree
- **Security**: Agree Disagree
- **Backwards compatibility**: Agree Disagree
- **Testing**: Agree
- **Documentation**: Agree

# Notes for merger
```
</details>