### PR TITLE
fix(Clients): Do not overwrite 'purge-replicas' after deleting rule

### DIFF
--- a/lib/rucio/cli/bin_legacy/rucio.py
+++ b/lib/rucio/cli/bin_legacy/rucio.py
@@ -2553,7 +2553,7 @@ You can filter by key/value, e.g.::
     delete_rule_parser = subparsers.add_parser('delete-rule', help='Delete replication rule.')
     delete_rule_parser.set_defaults(function=delete_rule)
     delete_rule_parser.add_argument(dest='rule_id', action='store', help='Rule id or DID. If DID, the RSE expression is mandatory.')
-    delete_rule_parser.add_argument('--purge-replicas', dest='purge_replicas', action='store_true', help='Purge rule replicas')
+    delete_rule_parser.add_argument('--purge-replicas', dest='purge_replicas', action='store_true', default=None, help='Purge rule replicas')
     delete_rule_parser.add_argument('--all', dest='delete_all', action='store_true', default=False, help='Delete all the rules, even the ones that are not owned by the account')
     delete_rule_parser.add_argument('--rses', dest='rses', action='store', help='The RSE expression. Must be specified if a DID is provided.')
     delete_rule_parser.add_argument('--account', dest='rule_account', action='store', help='The account of the rule that must be deleted')

--- a/lib/rucio/cli/rule.py
+++ b/lib/rucio/cli/rule.py
@@ -124,7 +124,7 @@ def add_(
 
 @rule.command("remove")
 @click.argument("rule-id-dids")
-@click.option("--purge-replicas", is_flag=True, default=False, help="Purge rule replicas")
+@click.option("--purge-replicas", is_flag=True, default=None, help="Purge rule replicas")
 @click.option("--all", "_all", is_flag=True, default=False, help="Delete all the rules, even the ones that are not owned by the account")
 @click.option("--rses", "--rse-exp", help="The RSE expression. Must be specified if a DID is provided.")  # TODO mutual inclusive group
 @click.option("--account", help="The account of the rule that must be deleted")

--- a/tests/test_bin_rucio.py
+++ b/tests/test_bin_rucio.py
@@ -560,6 +560,41 @@ def test_delete_rule(did_factory, rse_factory, rucio_client):
     assert temp_rse not in rses
 
 
+@pytest.mark.parametrize(
+        "cmd",
+        [lambda r: f"rucio delete-rule {r}", lambda r: f"rucio rule remove {r}"],
+        ids=["Legacy CLI", "Current CLI"]
+)
+def test_delete_rule_purge_replicas(cmd, did_factory, rse_factory, rucio_client):
+    """CLIENT(USER): Remove rule and purge replicas"""
+    base_rse, _ = rse_factory.make_posix_rse()
+    temp_file1 = did_factory.upload_test_file(rse_name=base_rse)
+    temp_file1['scope'] = temp_file1['scope'].external
+
+    # remove limit and set attributes
+    account = rucio_client.whoami()['account']
+    temp_rse, _ = rse_factory.make_posix_rse()
+    rucio_client.set_local_account_limit(account, temp_rse, -1)
+
+    # Add the rule
+    rule_id = rucio_client.add_replication_rule(
+        dids=[temp_file1],
+        copies=1,
+        rse_expression=temp_rse,
+        purge_replicas=True
+    )[0]
+
+    rule = rucio_client.get_replication_rule(rule_id)
+    assert rule['purge_replicas'] is True
+
+    exit, out, err = execute(cmd(rule_id))
+    assert exit == 0
+    assert "ERROR" not in err
+
+    rule = rucio_client.get_replication_rule(rule_id)
+    assert rule['purge_replicas'] is True
+
+
 @pytest.mark.dirty(reason="Cleanup can fail to complete because of child rules in client tests")
 def test_move_rule(did_factory, rse_factory, rucio_client):
     """CLIENT(USER): Rucio move rule"""

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1499,6 +1499,26 @@ class TestClient:
         assert rule['state'] == RuleState.INJECT.name
 
 
+def test_purge_replicas(rucio_client, rse_factory, did_factory, root_account):
+    activity = "Staging"
+    upload_rse, _ = rse_factory.make_posix_rse()
+    file = did_factory.upload_test_file(upload_rse)
+    dataset = did_factory.make_dataset()
+
+    rule_rse, _ = rse_factory.make_posix_rse()
+
+    file, dataset = ({'scope': did['scope'].external, 'name': did['name']} for did in (file, dataset))
+    rucio_client.add_files_to_dataset(files=[file], **dataset)
+
+    rule_id = rucio_client.add_replication_rule(dids=[file], account=root_account.external, copies=1, rse_expression=rule_rse, purge_replicas=True, activity=activity)[0]
+    rule = rucio_client.get_replication_rule(rule_id)
+    assert rule['purge_replicas'] is True
+
+    rucio_client.delete_replication_rule(rule_id)
+    rule = rucio_client.get_replication_rule(rule_id)
+    assert rule['purge_replicas'] is True  # Should not change behavior
+
+
 def test_add_rule_with_0_copies(did_client, did_factory, root_account, rse_factory):
     """ REPLICATION RULE (CLIENT): Add a replication rule and list full history """
     rse, rse_id = rse_factory.make_posix_rse()


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

Re-submission of #8386 after it was caught in a revert crossfire

## Checklist
- [x] Created issue: #8356 
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
