### PR TITLE
fix(Clients): Add split-container rule option

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -72,6 +72,7 @@ Individual contributors to the source code
 - Vimalan S <vimalan.github@gmail.com>, 2025
 - Riccardo Di Maio <riccardodimaio11@gmail.com>, 2024-2025
 - Karanjot Singh <karanjot.singh@cern.ch>, 2025-2026
+- Mauro Marques Filho <eu@resolvicomai.app>, 2026
 
 Organisations employing contributors
 ------------------------------------

--- a/lib/rucio/cli/bin_legacy/rucio.py
+++ b/lib/rucio/cli/bin_legacy/rucio.py
@@ -1226,7 +1226,8 @@ def add_rule(args, client, logger, console, spinner):
                                                comment=args.comment,
                                                ask_approval=args.ask_approval,
                                                asynchronous=args.asynchronous,
-                                               delay_injection=args.delay_injection)
+                                               delay_injection=args.delay_injection,
+                                               split_container=args.split_container)
     except DuplicateRule as error:
         if args.ignore_duplicate:
             for did in dids:
@@ -1245,7 +1246,8 @@ def add_rule(args, client, logger, console, spinner):
                                                           comment=args.comment,
                                                           ask_approval=args.ask_approval,
                                                           asynchronous=args.asynchronous,
-                                                          delay_injection=args.delay_injection)
+                                                          delay_injection=args.delay_injection,
+                                                          split_container=args.split_container)
                     rule_ids.extend(rule_id)
                 except DuplicateRule:
                     print('Duplicate rule for %s:%s found; Skipping.' % (did['scope'], did['name']))
@@ -2547,6 +2549,7 @@ You can filter by key/value, e.g.::
     add_rule_parser.add_argument('--asynchronous', dest='asynchronous', action='store_true', help='Create rule asynchronously')
     add_rule_parser.add_argument('--delay-injection', dest='delay_injection', action='store', type=int, help='Delay (in seconds) to wait before starting applying the rule. This option implies --asynchronous.')
     add_rule_parser.add_argument('--account', dest='rule_account', action='store', help='The account owning the rule')
+    add_rule_parser.add_argument('--split-container', dest='split_container', action='store_true', help='Split a container rule into individual dataset rules')
     add_rule_parser.add_argument('--skip-duplicates', dest='ignore_duplicate', action='store_true', help='Skip duplicate rules')
 
     # Delete replication rule subparser

--- a/lib/rucio/cli/rule.py
+++ b/lib/rucio/cli/rule.py
@@ -46,6 +46,7 @@ def rule():
 @click.option("--asynchronous", is_flag=True, default=False, help="Create rule asynchronously")
 @click.option("--delay-injection", type=int, help="Delay (in seconds) to wait before starting applying the rule. This option implies --asynchronous.")
 @click.option("--account", help="The account owning the rule")
+@click.option("--split-container", is_flag=True, default=False, help="Split a container rule into individual dataset rules")
 @click.option("--skip-duplicates", is_flag=True, default=False, help="Skip duplicate rules")
 @click.pass_context
 def add_(
@@ -65,6 +66,7 @@ def add_(
     ask_approval: bool,
     delay_injection: Optional[int],
     account: Optional[str],
+    split_container: bool,
     skip_duplicates: bool
 ) -> None:
     """Add replication rule to define how replicas of a list of DIDs are created on RSEs."""
@@ -89,7 +91,8 @@ def add_(
             comment=comment,
             ask_approval=ask_approval,
             asynchronous=asynchronous,
-            delay_injection=delay_injection
+            delay_injection=delay_injection,
+            split_container=split_container
     )
     except DuplicateRule as error:
         if skip_duplicates:
@@ -110,7 +113,8 @@ def add_(
                         comment=comment,
                         ask_approval=ask_approval,
                         asynchronous=asynchronous,
-                        delay_injection=delay_injection
+                        delay_injection=delay_injection,
+                        split_container=split_container
                     )
                     rule_ids.extend(rule_id)
                 except DuplicateRule:

--- a/lib/rucio/client/ruleclient.py
+++ b/lib/rucio/client/ruleclient.py
@@ -53,6 +53,7 @@ class RuleClient(BaseClient):
         delay_injection: Optional[int] = None,
         comment: Optional[str] = None,
         weight: Optional[int] = None,
+        split_container: bool = False,
     ) -> Any:
         """
         Add a replication rule.
@@ -100,6 +101,8 @@ class RuleClient(BaseClient):
             Comment about the rule.
         weight :
             If the weighting option of the replication rule is used, the choice of RSEs takes their weight into account.
+        split_container :
+            Split a container rule into individual dataset rules. Default is False.
 
         """
         path = self.RULE_BASEURL + '/'
@@ -110,7 +113,8 @@ class RuleClient(BaseClient):
                       'account': account, 'locked': locked, 'source_replica_expression': source_replica_expression,
                       'activity': activity, 'notify': notify, 'purge_replicas': purge_replicas,
                       'ignore_availability': ignore_availability, 'comment': comment, 'ask_approval': ask_approval,
-                      'asynchronous': asynchronous, 'delay_injection': delay_injection, 'priority': priority, 'meta': meta})
+                      'asynchronous': asynchronous, 'delay_injection': delay_injection, 'priority': priority, 'meta': meta,
+                      'split_container': split_container})
         r = self._send_request(url, method=HTTPMethod.POST, data=data)
         if r.status_code == codes.created:
             return loads(r.text)

--- a/tests/test_rule_split_container_client.py
+++ b/tests/test_rule_split_container_client.py
@@ -1,0 +1,114 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from argparse import Namespace
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from rucio.cli.bin_legacy.rucio import add_rule, get_parser
+from rucio.cli.rule import rule
+from rucio.client.ruleclient import RuleClient
+from rucio.common.constants import HTTPMethod
+
+
+class _CreatedResponse:
+    status_code = 201
+    text = '["rule-id"]'
+    headers = {}
+    content = b''
+
+
+class _RecordingRuleClient:
+    account = 'root'
+
+    def __init__(self):
+        self.calls = []
+
+    def add_replication_rule(self, **kwargs):
+        self.calls.append(kwargs)
+        return ['rule-id']
+
+
+def test_rule_client_add_replication_rule_sends_split_container():
+    captured = {}
+    client = RuleClient.__new__(RuleClient)
+    client.list_hosts = ['http://rucio.example']
+
+    def send_request(url, method, data):
+        captured['url'] = url
+        captured['method'] = method
+        captured['data'] = data
+        return _CreatedResponse()
+
+    client._send_request = send_request
+
+    result = client.add_replication_rule(
+        dids=[{'scope': 'mock', 'name': 'dataset'}],
+        copies=1,
+        rse_expression='MOCK',
+        split_container=True,
+    )
+
+    assert result == ['rule-id']
+    assert captured['method'] == HTTPMethod.POST
+    assert json.loads(captured['data'])['split_container'] is True
+
+
+def test_rule_add_cli_passes_split_container_to_client():
+    client = _RecordingRuleClient()
+    with patch('rucio.cli.rule.get_scope', return_value=('mock', 'dataset')):
+        result = CliRunner().invoke(
+            rule,
+            ['add', 'mock:dataset', '--copies', '1', '--rses', 'MOCK', '--split-container'],
+            obj=SimpleNamespace(client=client),
+        )
+
+    assert result.exit_code == 0, result.output
+    assert client.calls[0]['split_container'] is True
+
+
+def test_legacy_add_rule_parser_accepts_split_container():
+    args = get_parser().parse_args(['add-rule', 'mock:dataset', '1', 'MOCK', '--split-container'])
+
+    assert args.split_container is True
+
+
+def test_legacy_add_rule_passes_split_container_to_client():
+    client = _RecordingRuleClient()
+    args = Namespace(
+        dids=['mock:dataset'],
+        copies=1,
+        rse_expression='MOCK',
+        weight=None,
+        lifetime=None,
+        grouping=None,
+        rule_account=None,
+        locked=False,
+        source_replica_expression=None,
+        notify=None,
+        activity=None,
+        comment=None,
+        ask_approval=False,
+        asynchronous=False,
+        delay_injection=None,
+        split_container=True,
+        ignore_duplicate=False,
+    )
+
+    with patch('rucio.cli.bin_legacy.rucio.get_scope', return_value=('mock', 'dataset')):
+        assert add_rule(args, client, None, None, None) == 0
+    assert client.calls[0]['split_container'] is True


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8548
- [x] Added tests
- [ ] Updated documentation (not required: REST docs already include `split_container`; this exposes the existing option in clients)
- [ ] Added database migrations (not needed)
- [x] For backwards compatibility breaking changes, leave additional description, follow conventional commits (not breaking)
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Summary
- Add `split_container` to `RuleClient.add_replication_rule` and include it in the JSON payload.
- Add `--split-container` to the click-based `rucio rule add` command.
- Add `--split-container` to the legacy `rucio add-rule` parser and pass it to the client.

## Validation
- `.venv/bin/python -m pytest tests/test_rule_split_container_client.py -q`
- `.venv/bin/ruff check lib/rucio/client/ruleclient.py lib/rucio/cli/rule.py lib/rucio/cli/bin_legacy/rucio.py tests/test_rule_split_container_client.py`
- `git diff --check`

## AI assistance disclosure
AI assistance was used in preparing this PR. This was omitted from the initial PR body and is now disclosed here in line with the project AI policy. I take responsibility for the submitted changes and understand that normal human review is still required before merge.

## Additional description for reviewer
This keeps the server/API behavior unchanged and only exposes the already-supported `split_container` option through the Python client and both CLI entrypoints.