### PR TITLE
fix(Clients): Render rich boolean values

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -72,6 +72,7 @@ Individual contributors to the source code
 - Vimalan S <vimalan.github@gmail.com>, 2025
 - Riccardo Di Maio <riccardodimaio11@gmail.com>, 2024-2025
 - Karanjot Singh <karanjot.singh@cern.ch>, 2025-2026
+- Mauro Marques Filho <eu@resolvicomai.app>, 2026
 
 Organisations employing contributors
 ------------------------------------

--- a/lib/rucio/client/richclient.py
+++ b/lib/rucio/client/richclient.py
@@ -218,7 +218,7 @@ def _format_value(value: Optional[Union[RenderableType, int, float, bool, dateti
     if value is None or str(value) == 'None':
         return ''
     if isinstance(value, bool):
-        return CLITheme.BOOLEAN[str(value)]
+        return Text(str(value), style=CLITheme.BOOLEAN[str(value)])
     if isinstance(value, (int, float, datetime)):
         return str(value)
     return value

--- a/tests/test_richclient.py
+++ b/tests/test_richclient.py
@@ -1,0 +1,29 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rich.console import Console
+
+from rucio.client.richclient import generate_table
+
+
+def test_generate_table_renders_boolean_values() -> None:
+    console = Console(record=True, color_system=None, width=80)
+
+    console.print(generate_table([['admin', True], ['suspended', False]], headers=['Key', 'Value']))
+
+    output = console.export_text()
+    assert 'True' in output
+    assert 'False' in output
+    assert 'green' not in output
+    assert 'red' not in output


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #7222
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

Fixes #7222.

`generate_table()` used to convert boolean values into `CLITheme.BOOLEAN` style names (`green`/`red`) as plain strings. Rich then rendered those literal strings in table cells. This returns a `Text("True"/"False", style=...)` renderable instead, so account attribute and other Rich tables display boolean values while keeping the intended colors.

Validation:
- `.venv/bin/python -m pytest -p no:xdist tests/test_richclient.py -q`
- `.venv/bin/ruff check lib/rucio/client/richclient.py tests/test_richclient.py`
- `.venv/bin/python -m py_compile lib/rucio/client/richclient.py tests/test_richclient.py`
- `git diff --check`

Note: `tests/test_cli_client_structure.py::test_account_attribute` could not run locally because this checkout has no Rucio config file (`ConfigNotFound`, looked for `/opt/rucio/etc/rucio.cfg`).

## AI assistance disclosure
AI assistance was used in preparing this PR. This was omitted from the initial PR body and is now disclosed here in line with the project AI policy. I take responsibility for the submitted changes and understand that normal human review is still required before merge.