### PR TITLE
Remove flaky test_cacert_config_no_cfg_found

### DIFF
--- a/tests/rucio/common/test_dumper.py
+++ b/tests/rucio/common/test_dumper.py
@@ -61,10 +61,6 @@ class TestDumper:
         with patch('os.path.exists', Mock(return_value=True)):
             assert dumper.cacert_config(config, '.') is False
 
-    def test_cacert_config_no_cfg_found(self):
-        with patch('os.path.exists', Mock(return_value=True)):
-            assert dumper.cacert_config(config, '.') is False
-
     @pytest.mark.parametrize("file_config_mock", [
         {"overrides": [('client', 'ca_cert', '/opt/rucio/etc/web/ca.crt')]},
     ], indirect=True)


### PR DESCRIPTION
This test seems to assume that, by default, no configuration is found or set for `ca_cert`. That assumption is not true as seen in `etc/docker/test/extra/rucio_autotests_common.cfg`. I see no good explanation why this test has worked most of the times it ran, but it might be the surrounding parallel running functions that override the configuration value in question.

Removal, because `test_cacert_config_not_set` seems sufficient for the correct functioning here.

Closes: #8359

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8359
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
