### PR TITLE
fix: add --split-container option to `rucio rule add` CLI command (closes #8548)

### DIFF
--- a/lib/rucio/cli/rule.py
+++ b/lib/rucio/cli/rule.py
@@ -47,6 +47,7 @@ def rule():
 @click.option("--delay-injection", type=int, help="Delay (in seconds) to wait before starting applying the rule. This option implies --asynchronous.")
 @click.option("--account", help="The account owning the rule")
 @click.option("--skip-duplicates", is_flag=True, default=False, help="Skip duplicate rules")
+@click.option("--split-container", is_flag=True, default=False, help="Split the container into individual datasets when adding the rule")
 @click.pass_context
 def add_(
     ctx: click.Context,
@@ -65,7 +66,8 @@ def add_(
     ask_approval: bool,
     delay_injection: Optional[int],
     account: Optional[str],
-    skip_duplicates: bool
+    skip_duplicates: bool,
+    split_container: bool
 ) -> None:
     """Add replication rule to define how replicas of a list of DIDs are created on RSEs."""
     did_list = []


### PR DESCRIPTION
## What

The `split_container` parameter is supported by `add_replication_rule` in the core, gateway, and REST API layers, but was missing from the CLI (`rucio rule add`) and the corresponding Python client call.

## Fix

- Add `--split-container` flag to the `rule add` Click command.
- Add `split_container` parameter to the `add_` function signature.
- Pass `split_container=split_container` to `ctx.obj.client.add_replication_rule(...)`.

Closes #8548