### PR TITLE
Auth: Set HttpOnly flag on SAML authentication cookie

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -1409,7 +1409,7 @@ class SAML(ErrorHandlingMethodView):
         if not errors:
             if auth.is_authenticated():
                 response = Response()
-                response.set_cookie('saml-nameid', value=auth.get_nameid(), path='/')
+                response.set_cookie('saml-nameid', value=auth.get_nameid(), path='/', httponly=True)
                 return response
         return '', 200
 


### PR DESCRIPTION
Closes #8475 

By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).

### Checklist

- [x]  Created issue: [Authentication cookie missing HttpOnly flag #8475](https://github.com/rucio/rucio/issues/8475)
- [ ]  Added tests
- [ ]  Updated documentation (Please link PRs in documentation repository)
- [ ]  Added database migrations (if needed)
- [ ]  For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ]  Picked a reviewer after submission (Leave empty, if unclear)
- [x]  I understand that stale (failing tests, author not answering) PRs will be closed promptly

### Additional description for reviewer
This PR originally targeted the x-rucio-auth-token cookie in the OIDC flow, but that code was removed in #8318. The same issue exists on the saml-nameid cookie which is still present.
Added httponly=True to the saml-nameid cookie in the SAML post handler. Confirmed via git grep that this cookie is only read server-side via request.cookies.get() — no JS accesses it anywhere in the codebase, so this change is safe.