### PR TITLE
Correct bug in `config list` command

### DIFF
--- a/lib/rucio/cli/config.py
+++ b/lib/rucio/cli/config.py
@@ -40,7 +40,7 @@ def list_(ctx: click.Context, section: Optional[str], key: Optional[str]):
                 else:
                     print(f'[{config_section}]')
             if not isinstance(option, dict):
-                print(f'{section}={option}')
+                print(f'{config_section}={option}')
                 print_header = False
             else:
                 for config_key, value in option.items():

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -265,7 +265,8 @@ def test_config():
     exitcode, out, err = execute(f"rucio config list --section {section} --key {option}")
     assert exitcode == 0
     assert "ERROR" not in err
-    assert value in out
+    assert f"[{section}]" in out
+    assert f"{option}={value}" in out
 
     cmd = f"rucio config remove --section {section} --key {option}"
     exitcode, _, err = execute(cmd)
@@ -299,7 +300,12 @@ def test_config():
 
     exitcode, out, err = execute(f"rucio config list --section {section}")
     assert exitcode == 0
-    assert new_value in out
+    assert f"{option}={new_value}" in out
+
+    exitcode, out, err = execute("rucio config list")
+    assert exitcode == 0
+    assert f'[{section}]' in out
+    assert f"{option}={new_value}" in out
 
 
 @pytest.mark.parametrize("file_config_mock", [


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8573
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)-N/A
- [ ] Added database migrations (if needed)-N/A
- [x] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer
Closes #8573 

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
