### PR TITLE
fix(auth): add HttpOnly and Secure flags to authentication cookies

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -701,8 +701,8 @@ class TokenOIDC(ErrorHandlingMethodView):
             domain = '.'.join(urlparse(webhome).netloc.split('.')[1:])
             response = redirect(webhome, code=303)
             response.headers.extend(headers)
-            response.set_cookie('x-rucio-auth-token', value=result['token']['token'], domain=domain, path='/')
-            response.set_cookie('rucio-auth-token-created-at', value=str(time.time()), domain=domain, path='/')
+            response.set_cookie('x-rucio-auth-token', value=result['token']['token'], domain=domain, path='/', httponly=True, secure=True)
+            response.set_cookie('rucio-auth-token-created-at', value=str(time.time()), domain=domain, path='/', httponly=True, secure=True)
             # response.set_cookie('x-rucio-auth-token', value=result['token']['token'])
             # response.set_cookie('rucio-auth-token-created-at', value=str(time.time()))
             return response
@@ -1531,7 +1531,7 @@ class SAML(ErrorHandlingMethodView):
         if not errors:
             if auth.is_authenticated():
                 response = Response()
-                response.set_cookie('saml-nameid', value=auth.get_nameid(), path='/')
+                response.set_cookie('saml-nameid', value=auth.get_nameid(), path='/', httponly=True, secure=True)
                 return response
         return '', 200
 


### PR DESCRIPTION
## Summary

Fixes #8475 — CWE-1004: authentication cookies missing HttpOnly and Secure flags.

## Changes

Added `httponly=True, secure=True` to all three authentication cookie `set_cookie()` calls in `lib/rucio/web/rest/flaskapi/v1/auth.py`:

| Cookie | Line |
|--------|------|
| `x-rucio-auth-token` | 704 |
| `rucio-auth-token-created-at` | 705 |
| `saml-nameid` | 1534 |

This prevents client-side JavaScript from accessing the auth token (mitigating XSS-based token theft) and enforces HTTPS-only cookie transmission.

Closes #8475