### PR TITLE
Testing: Skip throttler daemon waits in tests #8576

### DIFF
--- a/tests/test_throttler.py
+++ b/tests/test_throttler.py
@@ -191,7 +191,7 @@ class TestSimpleLimits:
         attach_dids(mock_scope, dataset_1_name, [{'name': name1, 'scope': mock_scope}], root_account)
         attach_dids(mock_scope, dataset_1_name, [{'name': name2, 'scope': mock_scope}], root_account)
 
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
 
         request_1 = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request_1['state'] == RequestState.WAITING
@@ -204,7 +204,7 @@ class TestSimpleLimits:
 
         delete_transfer_limit(dest_rse, activity=self.all_activities)
 
-        throttler(once=True)
+        throttler(once=True, partition_wait_time=0)
 
         request_1 = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request_1['state'] == RequestState.QUEUED
@@ -229,8 +229,8 @@ class TestSimpleLimits:
         attach_dids(mock_scope, dataset_1_name, [{'name': name1, 'scope': mock_scope}], root_account)
         attach_dids(mock_scope, dataset_1_name, [{'name': name2, 'scope': mock_scope}], root_account)
 
-        preparer(once=True, transfertools=['mock'])
-        throttler(once=True)
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
+        throttler(once=True, partition_wait_time=0)
         request_1 = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request_1['state'] == RequestState.WAITING
         request_2 = get_request_by_did(mock_scope, name2, dest_rse_id)
@@ -252,8 +252,8 @@ class TestSimpleLimits:
         attach_dids(mock_scope, dataset_1_name, [{'name': name1, 'scope': mock_scope}], root_account)
         attach_dids(mock_scope, dataset_1_name, [{'name': name2, 'scope': mock_scope}], root_account)
 
-        preparer(once=True, transfertools=['mock'])
-        throttler(once=True)
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
+        throttler(once=True, partition_wait_time=0)
         # released because it got requested first
         request_1 = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request_1['state'] == RequestState.QUEUED
@@ -284,8 +284,8 @@ class TestSimpleLimits:
                 {'source_rse_id': source_rse_id, 'dest_rse_id': dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
-        preparer(once=True, transfertools=['mock'])
-        throttler(once=True)
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
+        throttler(once=True, partition_wait_time=0)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
         request2 = get_request_by_did(mock_scope, name2, dest_rse_id)
@@ -302,8 +302,8 @@ class TestSimpleLimits:
                 {'source_rse_id': source_rse_id, 'dest_rse_id': dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2018)},
             ]
         )
-        preparer(once=True, transfertools=['mock'])
-        throttler(once=True)
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
+        throttler(once=True, partition_wait_time=0)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
 
@@ -325,8 +325,8 @@ class TestSimpleLimits:
                 {'source_rse_id': source_rse_id, 'dest_rse_id': dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
-        preparer(once=True, transfertools=['mock'])
-        throttler(once=True)
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
+        throttler(once=True, partition_wait_time=0)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.WAITING
         request2 = get_request_by_did(mock_scope, name2, dest_rse_id)
@@ -348,8 +348,8 @@ class TestSimpleLimits:
                 {'source_rse_id': source_rse_id, 'dest_rse_id': dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
-        preparer(once=True, transfertools=['mock'])
-        throttler(once=True)
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
+        throttler(once=True, partition_wait_time=0)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
         request2 = get_request_by_did(mock_scope, name2, dest_rse_id)
@@ -393,8 +393,8 @@ class TestSimpleLimits:
             ]
         )
 
-        preparer(once=True, transfertools=['mock'])
-        throttler(once=True)
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
+        throttler(once=True, partition_wait_time=0)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
         request2 = get_request_by_did(mock_scope, name2, dest_rse_id2)
@@ -418,8 +418,8 @@ class TestSimpleLimits:
                 {'source_rse_id': source_rse_id, 'dest_rse_id': dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
-        preparer(once=True, transfertools=['mock'])
-        throttler(once=True)
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
+        throttler(once=True, partition_wait_time=0)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
         request2 = get_request_by_did(mock_scope, name2, dest_rse_id)
@@ -463,8 +463,8 @@ class TestSimpleLimits:
                 },
             ]
         )
-        preparer(once=True, transfertools=['mock'])
-        throttler(once=True)
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
+        throttler(once=True, partition_wait_time=0)
         # release because max_transfers=1
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
@@ -517,7 +517,7 @@ class TestSimpleLimits:
         attach_dids(mock_scope, dataset_1_name, [{'name': name1, 'scope': mock_scope}], root_account)
         attach_dids(mock_scope, dataset_1_name, [{'name': name2, 'scope': mock_scope}], root_account)
 
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         request_1 = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request_1['state'] == RequestState.WAITING
         request_2 = get_request_by_did(mock_scope, name2, dest_rse_id2)
@@ -527,7 +527,7 @@ class TestSimpleLimits:
         request_4 = get_request_by_did(mock_scope, name4, dest_rse_id2)
         assert request_4['state'] == RequestState.WAITING
 
-        throttler(once=True)
+        throttler(once=True, partition_wait_time=0)
         # released because it got requested first
         request_1 = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request_1['state'] == RequestState.QUEUED
@@ -604,8 +604,8 @@ class TestOverlappingLimits:
             ]
         )
 
-        preparer(once=True, transfertools=['mock'])
-        throttler(once=True)
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
+        throttler(once=True, partition_wait_time=0)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
         request2 = get_request_by_did(mock_scope, name2, dest_rse_id)
@@ -661,7 +661,7 @@ class TestRequestCoreRelease:
                 },
             ]
         )
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_per_free_volume(dest_rse_id, volume=volume)
         # released because small enough
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
@@ -710,7 +710,7 @@ class TestRequestCoreRelease:
         dataset2_name = generate_uuid()
         add_did(mock_scope, dataset2_name, DIDType.DATASET, root_account)
         attach_dids(mock_scope, dataset2_name, [{'name': name2, 'scope': mock_scope}, {'name': name3, 'scope': mock_scope}], root_account)
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_per_free_volume(dest_rse_id, volume=volume)
         # released because dataset fits in volume
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
@@ -733,7 +733,7 @@ class TestRequestCoreRelease:
                 {'source_rse_id': source_rse_id, 'dest_rse_id': dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2015)},
             ]
         )
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_per_free_volume(dest_rse_id, volume=volume)
         # waiting because no available volume
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
@@ -757,7 +757,7 @@ class TestRequestCoreRelease:
             ]
         )
 
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_grouped_fifo(dest_rse_id, count=1, volume=0, deadline=0)
         request = get_request_by_did(mock_scope, name, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
@@ -773,7 +773,7 @@ class TestRequestCoreRelease:
         dataset_name = generate_uuid()
         add_did(mock_scope, dataset_name, DIDType.DATASET, root_account)
         attach_dids(mock_scope, dataset_name, [{'name': name, 'scope': mock_scope}], root_account)
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_grouped_fifo(dest_rse_id, count=1, volume=0, deadline=0)
         request = get_request_by_did(mock_scope, name, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
@@ -797,7 +797,7 @@ class TestRequestCoreRelease:
         attach_dids(mock_scope, dataset_1_name, [{'name': name1, 'scope': mock_scope}, {'name': name2, 'scope': mock_scope}], root_account)
         attach_dids(mock_scope, dataset_2_name, [{'name': name3, 'scope': mock_scope}, {'name': name4, 'scope': mock_scope}], root_account)
 
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_grouped_fifo(dest_rse_id, count=1, deadline=0, volume=0)
         request_1 = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request_1['state'] == RequestState.QUEUED
@@ -828,7 +828,7 @@ class TestRequestCoreRelease:
         attach_dids(mock_scope, dataset_1_name, [{'name': name2, 'scope': mock_scope}], root_account)
         transfer_limit_factory(dest_rse, self.all_activities, volume=10, max_transfers=1)
 
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         amount_updated_requests = release_waiting_requests_grouped_fifo(dest_rse_id, count=1, deadline=0, volume=10)
         assert amount_updated_requests == 3
         # released because it got requested first
@@ -861,7 +861,7 @@ class TestRequestCoreRelease:
         attach_dids(mock_scope, dataset_1_name, [{'name': name1, 'scope': mock_scope}], root_account)
         attach_dids(mock_scope, dataset_1_name, [{'name': name2, 'scope': mock_scope}], root_account)
         transfer_limit_factory(dest_rse, self.all_activities, volume=5, max_transfers=1)
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_grouped_fifo(dest_rse_id, count=1, deadline=0, volume=5)
         # released because it got requested first
         request_1 = get_request_by_did(mock_scope, name1, dest_rse_id)
@@ -885,7 +885,7 @@ class TestRequestCoreRelease:
             ]
         )
 
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_grouped_fifo(source_rse_id=source_rse_id, count=0, deadline=1, volume=0)
         # queued because of deadline
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
@@ -910,7 +910,7 @@ class TestRequestCoreRelease:
                 {'source_rse_id': source_rse_id, 'dest_rse_id': dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_fifo(dest_rse_id, count=1)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
@@ -944,7 +944,7 @@ class TestRequestCoreRelease:
                 },
             ]
         )
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_fifo(dest_rse_id, count=2, account=root_account, activity=self.user_activity)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
@@ -968,7 +968,7 @@ class TestRequestCoreRelease:
                 {'source_rse_id': source_rse_id, 'dest_rse_id': dest_rse_id, 'requested_at': datetime.utcnow().replace(year=2020)},
             ]
         )
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_all_waiting_requests(dest_rse_id)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
@@ -991,7 +991,7 @@ class TestRequestCoreRelease:
                 {'source_rse_id': source_rse_id, 'dest_rse_id': dest_rse_id, 'requested_at': datetime.utcnow()},
             ]
         )
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_per_deadline(source_rse_id=source_rse_id, deadline=1)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED
@@ -1010,7 +1010,7 @@ class TestRequestCoreRelease:
         dataset_name = generate_uuid()
         add_did(mock_scope, dataset_name, DIDType.DATASET, root_account)
         attach_dids(mock_scope, dataset_name, [{'name': name1, 'scope': mock_scope}, {'name': name2, 'scope': mock_scope}], root_account)
-        preparer(once=True, transfertools=['mock'])
+        preparer(once=True, partition_wait_time=0, transfertools=['mock'])
         release_waiting_requests_per_deadline(source_rse_id=source_rse_id, deadline=1)
         request = get_request_by_did(mock_scope, name1, dest_rse_id)
         assert request['state'] == RequestState.QUEUED


### PR DESCRIPTION
This updates the one-shot `preparer` and `throttler` calls in `tests/test_throttler.py` to pass `partition_wait_time=0`removing unnecessary fixed sleeps.

With this change, I estimate that the total aggregate runner time reduction is going to be roughly -77mins, which translates to a practical time-saving of around 10minutes (since these run in parallel).

Indeed after this PR I see those time changes:

```text
saved    before   after    job
12.2m    45.0m    32.7m    autotest py3.9 multi_vo postgres14
11.9m    44.5m    32.7m    autotest py3.10 multi_vo postgres14
 8.5m    24.6m    16.1m    autotest py3.9 remote_dbs postgres14
 7.9m    33.1m    25.2m    autotest py3.10 sqlite
 7.0m    37.3m    30.3m    autotest py3.9 remote_dbs oracle
 6.6m    14.2m     7.6m    VO-specific belleii
 6.3m    24.6m    18.4m    autotest py3.10 remote_dbs postgres14
 6.1m    38.5m    32.4m    autotest py3.10 remote_dbs mysql8
 6.1m    38.2m    32.1m    autotest py3.10 remote_dbs oracle
 3.8m    32.0m    28.3m    autotest py3.9 sqlite
-1.6m    33.7m    35.3m    autotest py3.9 remote_dbs mysql8
```

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: rucio#8576
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
