### PR TITLE
Metadata: Fix bulk metadata plugin handling; rucio#7323

### DIFF
--- a/lib/rucio/client/didclient.py
+++ b/lib/rucio/client/didclient.py
@@ -655,7 +655,7 @@ class DIDClient(BaseClient):
             self,
             dids: "Sequence[Mapping[str, Any]]",
             inherit: bool = False,
-            plugin: str = "JSON",
+            plugin: str = "DID_COLUMN",
     ) -> "Iterator[dict[str, Any]]":
         """
         Bulk get data identifier metadata

--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -2089,7 +2089,7 @@ def list_parent_dids_bulk(
 def get_metadata_bulk(
     dids: list["Mapping[Any, Any]"],
     inherit: bool = False,
-    plugin: str = 'JSON',
+    plugin: str = 'DID_COLUMN',
     *,
     session: "Session"
 ) -> "Iterator[dict[str, Any]]":

--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -2136,9 +2136,9 @@ def get_metadata_bulk(
         for dids in parent_list:
             result = {'scope': dids[0][0], 'name': dids[0][1]}
             for did in dids:
-                for key in meta_dict[did]:
+                for key, value in meta_dict[did].items():
                     if key not in result:
-                        result[key] = meta_dict[did][key]
+                        result[key] = value
             yield result
     else:
         condition = []
@@ -2157,7 +2157,15 @@ def get_metadata_bulk(
                     or_(*chunk)
                 )
                 for row in session.execute(stmt).scalars():
-                    yield row.to_dict()
+                    if plugin.casefold() == 'did_column':
+                        yield row.to_dict()
+                    else:
+                        meta = get_metadata(row.scope, row.name, plugin=plugin, session=session)
+                        result = {'scope': row.scope, 'name': row.name}
+                        for key, value in meta.items():
+                            if key not in result:
+                                result[key] = value
+                        yield result
         except NoResultFound:
             raise exception.DataIdentifierNotFound('No Data Identifiers found')
 

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -1778,7 +1778,7 @@ class BulkDIDsMeta(ErrorHandlingMethodView):
                       - scope: "user"
                         name: "dataset_002"
                     inherit: true
-                    plugin: "JSON"
+                    plugin: "DID_COLUMN"
 
         responses:
           200:

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -1765,9 +1765,9 @@ class BulkDIDsMeta(ErrorHandlingMethodView):
                   plugin:
                     description: >
                       Which metadata plug‑in to query
-                      (`"JSON"`, `"DID_COLUMN"`, `"ALL"`, etc.; default: `"JSON"`).
+                      (`"JSON"`, `"DID_COLUMN"`, `"ALL"`, etc.; default: `"DID_COLUMN"`).
                     type: string
-                    default: "JSON"
+                    default: "DID_COLUMN"
               examples:
                 defaultQuery:
                   summary: "Query two DIDs with inheritance"
@@ -1909,7 +1909,7 @@ class BulkDIDsMeta(ErrorHandlingMethodView):
         params = json_parameters()
         dids = param_get(params, "dids")
         inherit = param_get_bool(params, "inherit", default=False)
-        plugin = param_get(params, "plugin", default="JSON")
+        plugin = param_get(params, "plugin", default="DID_COLUMN")
 
         try:
             def generate(vo):

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -1243,7 +1243,7 @@ def test_bulk_get_meta_inheritance(vo, rse_factory, mock_scope, did_factory, ruc
         rucio_client.attach_dids_to_dids([{'scope': scope, 'name': container['name'], 'dids': [{'scope': scope, 'name': datasets[idx]['name']}]}])
         meta_mapping['%s:%s' % (scope, files[idx]['name'])][ckey] = 'cnt_%s' % idx
 
-    list_meta = [meta for meta in rucio_client.get_metadata_bulk(list_dids, inherit=True)]
+    list_meta = [meta for meta in rucio_client.get_metadata_bulk(list_dids, inherit=True, plugin='JSON')]
 
     for meta in list_meta:
         did = '%s:%s' % (meta['scope'], meta['name'])

--- a/tests/test_did_meta_plugins.py
+++ b/tests/test_did_meta_plugins.py
@@ -19,7 +19,7 @@ import pytest
 from rucio.client.didclient import DIDClient
 from rucio.common.exception import KeyNotFound
 from rucio.common.utils import generate_uuid
-from rucio.core.did import add_did, delete_dids, get_metadata_bulk, set_dids_metadata_bulk, set_metadata_bulk
+from rucio.core.did import add_did, attach_dids, delete_dids, get_metadata_bulk, set_dids_metadata_bulk, set_metadata_bulk
 from rucio.core.did_meta_plugins import get_metadata, list_dids, set_metadata
 from rucio.core.did_meta_plugins.elasticsearch_meta import ElasticDidMeta
 from rucio.core.did_meta_plugins.mongo_meta import MongoDidMeta
@@ -128,19 +128,47 @@ class TestDidMetaJSON:
         skip_without_json()
 
         dids = []
-        expected_meta = []
+        expected_metadata_by_name = {}
 
-        meta_key = 'data_product_id'
+        json_key = 'data_product_id'
         for _ in range(5):
             did_name = did_name_generator('dataset')
-            meta_value = generate_uuid()
-            add_did(scope=mock_scope, name=did_name, did_type='DATASET', account=root_account)
-            set_metadata(scope=mock_scope, name=did_name, key=meta_key, value=meta_value)
+            project = 'data12_8TeV'
+            json_value = generate_uuid()
+            add_did(scope=mock_scope, name=did_name, did_type='DATASET', account=root_account, meta={'project': project})
+            set_metadata(scope=mock_scope, name=did_name, key=json_key, value=json_value)
             dids.append({'scope': mock_scope, 'name': did_name})
-            expected_meta.append({'scope': mock_scope, 'name': did_name, meta_key: meta_value})
+            expected_metadata_by_name[did_name] = {'project': project, json_key: json_value}
 
-        meta = list(get_metadata_bulk(dids, plugin="JSON", inherit=True))
-        assert meta == expected_meta
+        column_metadata_by_name = {meta['name']: meta for meta in get_metadata_bulk(dids)}
+        json_metadata_by_name = {meta['name']: meta for meta in get_metadata_bulk(dids, plugin='JSON')}
+        all_metadata_by_name = {meta['name']: meta for meta in get_metadata_bulk(dids, plugin='ALL')}
+
+        # Check first the DIDs (names only) match before comparing plugin-specific metadata.
+        assert set(column_metadata_by_name) == set(json_metadata_by_name) == set(all_metadata_by_name) == set(expected_metadata_by_name)
+
+        for name, expected in expected_metadata_by_name.items():
+            assert column_metadata_by_name[name]['project'] == expected['project']
+            assert json_key not in column_metadata_by_name[name]
+            assert json_metadata_by_name[name][json_key] == expected[json_key]
+            assert 'project' not in json_metadata_by_name[name]
+            assert all_metadata_by_name[name]['project'] == expected['project']
+            assert all_metadata_by_name[name][json_key] == expected[json_key]
+
+        parent_name = did_name_generator('container')
+        parent_json_key = 'parent_data_product_id'
+        parent_json_value = generate_uuid()
+        add_did(scope=mock_scope, name=parent_name, did_type='CONTAINER', account=root_account)
+        set_metadata(scope=mock_scope, name=parent_name, key=parent_json_key, value=parent_json_value)
+        attach_dids(scope=mock_scope, name=parent_name, dids=[dids[0]], account=root_account)
+
+        inherited_meta = list(get_metadata_bulk(dids, plugin='JSON', inherit=True))
+        expected_inherited_meta = [
+            {'scope': mock_scope, 'name': did['name'], json_key: expected_metadata_by_name[did['name']][json_key]}
+            for did in dids
+        ]
+        expected_inherited_meta[0][parent_json_key] = parent_json_value
+        assert inherited_meta == expected_inherited_meta
 
     @pytest.mark.dirty
     def test_get_metadata(self, mock_scope, root_account):


### PR DESCRIPTION
Fixes `get_metadata_bulk` so `plugin` is respected when `inherit=False`.

Also aligns bulk metadata defaults to `DID_COLUMN` across core, client, and REST to preserve the existing default output for non-inherited calls.

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: rucio#7323
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [x] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
