### PR TITLE
Fix formatting of boolean values in the rich client to show colored text values

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -72,6 +72,7 @@ Individual contributors to the source code
 - Vimalan S <vimalan.github@gmail.com>, 2025
 - Riccardo Di Maio <riccardodimaio11@gmail.com>, 2024-2025
 - Karanjot Singh <karanjot.singh@cern.ch>, 2025-2026
+- Vlad Galuska <vlad.galuska21@gmail.com>, 2026
 
 Organisations employing contributors
 ------------------------------------

--- a/lib/rucio/client/richclient.py
+++ b/lib/rucio/client/richclient.py
@@ -218,7 +218,7 @@ def _format_value(value: Optional[Union[RenderableType, int, float, bool, dateti
     if value is None or str(value) == 'None':
         return ''
     if isinstance(value, bool):
-        return CLITheme.BOOLEAN[str(value)]
+        return Text(str(value), style=CLITheme.BOOLEAN[str(value)])
     if isinstance(value, (int, float, datetime)):
         return str(value)
     return value

--- a/tests/rucio/common/test_richclient_format_value.py
+++ b/tests/rucio/common/test_richclient_format_value.py
@@ -1,0 +1,53 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timezone
+
+import pytest
+from rich.text import Text
+from rich.tree import Tree
+
+from rucio.client.richclient import CLITheme, _format_value
+
+
+class TestRichClientFormatValue:
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_format_value_when_boolean_should_return_styled_text(self, value):
+        cell = _format_value(value)
+        assert isinstance(cell, Text)
+        assert str(cell) == str(value)
+        assert cell.style == CLITheme.BOOLEAN[str(value)]
+
+    @pytest.mark.parametrize("value", [None, "None"])
+    def test_format_value_when_none_should_not_fail(self, value):
+        assert _format_value(value) == ''
+
+    def test_format_value_when_empty_should_return_empty(self):
+        assert _format_value("") == ""
+
+    @pytest.mark.parametrize("value", [Text("blah"), Tree("blah")])
+    def test_format_value_when_renderable_type_should_return_it(self, value):
+        assert _format_value(value) is value
+
+    @pytest.mark.parametrize("value", [3, 3.14])
+    def test_format_value_when_number_should_return_string(self, value):
+        assert _format_value(value) == str(value)
+
+    def test_format_value_when_various_dates_should_return_string(self):
+        assert _format_value(datetime(2012, 1, 1)) == "2012-01-01 00:00:00"
+        assert _format_value(datetime(2012, 1, 1, 12, 30, 30, 123456)) == "2012-01-01 12:30:30.123456"
+        assert _format_value(
+            datetime(2012, 1, 1, 12, 30, 30, 123456, tzinfo=timezone.utc)
+        ) == "2012-01-01 12:30:30.123456+00:00"


### PR DESCRIPTION
Rich boolean properties were displayed as "green" and "red" in the tables,  and (as correctly stated in the issue description), the rows were not populated as "Text" properties or "str", but "CLITheme.BOOLEAN[str(value)]" was used instead which provided the color that should be used for the text.

Additionally, I've added a new unit test suite for the "_format_value" function that covers all the other fields as well. I wanted to also extend the e2e tests, but have found some issues with how the "file_config_mock" works for commands that I will open an issue for. 

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## AI usage disclosure
Claude Code assisted with research and drafting; I reproduced, verified, reviewed, understand and stand by all changes (as described in the Rucio AI Policy).

## Checklist
- [x] Created issue: #7222
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
