### PR TITLE
fix(Monitoring): update monitoring stack to Elastic Stack 9.0.0

### DIFF
--- a/etc/docker/dev/README.rst
+++ b/etc/docker/dev/README.rst
@@ -99,17 +99,17 @@ To create some events and write them to Elasticsearch first run again the tests 
     tools/run_tests.sh -ir
 
 
-Then you will have to run the transfer daemons (conveyor-\*) and messaging daemon (hermes) to send the events to ActiveMQ. There a script for that which repeats these daemons in single execution mode from the section in a loop::
+Then you will have to run the transfer daemons (conveyor-\*) and messaging daemon (hermes) to send the events to ActiveMQ. There's a script for that which repeats these daemons in single execution mode from the section in a loop::
 
     run_daemons
 
 
-When all the daemons ran you will be able to find the events in Kibana. If you run the docker environment on you local machine you can access Kibana at http://localhost:5601. The necessary index pattern will be added automatically. There is also one dashboard available in Kibana. If it is running on remote machine you can SSH forward it::
+When all the daemons ran you will be able to find the events in Kibana. If you run the docker environment on you local machine you can access Kibana at http://localhost:5601. To see the events, create a data view in Kibana with the index pattern "rucio-events-*" and "@timestamp" as the timestamp field. If it is running on a remote machine you can SSH forward it::
 
     ssh -L 5601:127.0.0.1:5601 <hostname>
 
 
-Additionally, there is also a Grafana server running with one simple dashboard. You can access it at http://localhost:3000. The default credentials are "admin/admin". Also ActiveMQ web console can be accessed at http://localhost:8161.
+Additionally, there is also a Grafana server running with one simple dashboard. You can access it at http://localhost:3000. The default credentials are "admin/admin". Also ActiveMQ web console can be accessed at http://localhost:8161 (credentials are also "admin/admin").
 
 If you would like to continuously create some transfers and events there are scripts available for that. Open two different shells and in one run::
 

--- a/etc/docker/dev/docker-compose.yml
+++ b/etc/docker/dev/docker-compose.yml
@@ -147,16 +147,14 @@ services:
       timeout: 5s
       retries: 10
 
+  # Web portal credentials are admin/admin
   activemq:
     container_name: ${RUCIO_ACTIVEMQ_CONTAINER_NAME:-dev-activemq-1}
+    # When bumping this image tag, also update ACTIVEMQ_VERSION on the logstash service
     image: docker.io/apache/activemq-classic:5.18.7
     platform: linux/amd64
     volumes:
       - ./activemq/users.properties:/opt/apache-activemq/conf/users.properties
-    environment:
-      # web portal access, helpful for debugging
-      ACTIVEMQ_WEB_USER: activemq
-      ACTIVEMQ_WEB_PASSWORD: supersecret
 
   postgres14:
     container_name: ${RUCIO_POSTGRES14_CONTAINER_NAME:-dev-postgres14-1}
@@ -445,17 +443,22 @@ services:
   # ------------------------------------------------------------------
   logstash:
     container_name: dev-logstash-1
-    image: docker.elastic.co/logstash/logstash-oss:7.3.2
-    platform: linux/amd64
+    image: docker.elastic.co/logstash/logstash:9.0.0
+    entrypoint: ["/docker-entrypoint.sh"]
+    environment:
+      # Must match the activemq service image tag (and stay on 5.x, see logstash/entrypoint.sh)
+      - ACTIVEMQ_VERSION=5.18.7
     profiles:
       - monitoring
-    command: bash -c "logstash-plugin install logstash-input-stomp ; /usr/local/bin/docker-entrypoint"
     volumes:
-      - ./pipeline.conf:/usr/share/logstash/pipeline/pipeline.conf:Z
+      - ./logstash/entrypoint.sh:/docker-entrypoint.sh:ro
+      - ./pipeline.conf:/usr/share/logstash/pipeline/logstash.conf:Z
+      # Cache the activemq jar downloaded on startup
+      - vol-logstash-data:/usr/share/logstash/data
 
   kibana:
     container_name: dev-kibana-1
-    image: docker.io/kibana:7.4.0
+    image: docker.elastic.co/kibana/kibana:9.0.0
     profiles:
       - monitoring
 
@@ -584,6 +587,7 @@ volumes:
   vol-iam-db-mysql:
   vol-mysql8-mysql:
   vol-postgres-data:
+  vol-logstash-data:
 
 networks:
   default:

--- a/etc/docker/dev/logstash/entrypoint.sh
+++ b/etc/docker/dev/logstash/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# The logstash jms input plugin needs the ActiveMQ client jar (see require_jars in pipeline.conf).
+# The jar must stay on 5.x even if the broker moves to 6+: the plugin imports javax.jms, renamed in ActiveMQ 6.
+ACTIVEMQ_VERSION=${ACTIVEMQ_VERSION:?must be set in docker-compose.yml}
+
+JAR_LOCATION=/usr/share/logstash/data/jars/activemq-all-${ACTIVEMQ_VERSION}.jar
+
+if [ ! -f "$JAR_LOCATION" ]; then
+    echo "Downloading activemq-all-${ACTIVEMQ_VERSION}.jar from Maven Central to ${JAR_LOCATION}"
+    curl -fsSL --create-dirs -o "$JAR_LOCATION" \
+        "https://repo1.maven.org/maven2/org/apache/activemq/activemq-all/${ACTIVEMQ_VERSION}/activemq-all-${ACTIVEMQ_VERSION}.jar"
+    echo "Download complete"
+else
+    echo "Using cached ${JAR_LOCATION}"
+fi
+
+exec /usr/local/bin/docker-entrypoint "$@"

--- a/etc/docker/dev/pipeline.conf
+++ b/etc/docker/dev/pipeline.conf
@@ -1,20 +1,18 @@
 input {
-  stomp {
-    host => "activemq"
-    port => 61613
-    destination => "/queue/events"
-    codec => "json"
-    user => "logstash"
-    password => "supersecret"
+  jms {
+    broker_url => "tcp://activemq:61616"
+    destination => "events"
+    factory => "org.apache.activemq.ActiveMQConnectionFactory"
     type => "rucio-event"
-    debug => true
+    codec => "json"
+    # Needs to match the download path in logstash/entrypoint.sh
+    require_jars => ["/usr/share/logstash/data/jars/activemq-all-${ACTIVEMQ_VERSION}.jar"]
   }
 }
 
 output {
   elasticsearch {
     hosts => "elasticsearch"
-    index => 'rucio-events-%{+YYYY.MM.dd}'
-    document_type => "doc"
+    index => "rucio-events-%{+YYYY.MM.dd}"
   }
 }


### PR DESCRIPTION
The monitoring stack (Kibana 7.4.0/Logstash 7.3.2/ElasticSearch 9.0.0) was out of sync and the monitoring profile no longer worked. Additionally, the Logstash stomp plugin is unmaintained and doesn't work on 9.0.0 so we had to migrate to consume from ActiveMQ via JMS which requires the ActiveMQ client JAR. This jar is downloaded on container startup.

During testing I found out that the ActiveMQ credentials setting wasn't working and it was using the default "admin"/"admin", so I removed the old ones and left a comment.

The Logstash credentials were also not working (the logstash user was referenced in pipeline.conf but never defined in users.properties). I think the rest of the `users.properties` can be dropped as well because the dev broker has no authentication plugin. I didn't want to do it in this PR though, so I'll create a follow-up issue to discuss if the authentication should be enabled or the users should be dropped altogether.

I went for the `docker-entrypoint.sh` approach in the logstash jar downloading as the new line was rather long and I wanted to keep it consistent with how the fts/xrd*/web1 services mount their entrypoint scripts.

Please let me know if the jar caching is overkill (I was on the fence about that).

For testing, I checked ActiveMQ:
<img width="965" height="99" alt="image" src="https://github.com/user-attachments/assets/4ba60b76-6a64-4e14-94dc-7b54ea0db369" />

Elasticsearch:
<img width="1642" height="356" alt="image" src="https://github.com/user-attachments/assets/909ceae2-ac52-47d5-a2c4-026301701a4e" />

And Kibana (for which I found that the readme was stale and updated it):
<img width="2406" height="712" alt="image" src="https://github.com/user-attachments/assets/f45f53dc-b763-4645-b711-036db13ee7f3" />

Closes: #8585

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## AI usage disclosure
Claude Code assisted with research and drafting; I reproduced, verified, reviewed, understand and stand by all changes (as described in the Rucio AI Policy).

## Checklist
- [x] Created issue: #8585
- [ ] Added tests
- [x] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
