### PR TITLE
Use native XRootD Python bindings

### DIFF
--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -1950,16 +1950,18 @@ class DownloadClient:
             self.logger(logging.INFO, 'No preferred protocol impl in rucio.cfg: %s' % (error))
             return supported_impl
         else:
-            preferred_impls = list(preferred_impls.split(', '))
-            i = 0
-            while i < len(preferred_impls):
-                impl = preferred_impls[i]
-                impl_split = impl.split('.')
-                if len(impl_split) == 1:
-                    preferred_impls[i] = 'rucio.rse.protocols.' + impl + '.Default'
+            configured_impls = preferred_impls
+            preferred_impls = []
+            for impl in configured_impls.split(','):
+                impl = impl.strip()
+                if not impl:
+                    continue
+                if impl.startswith('rucio.'):
+                    preferred_impls.append(impl)
+                elif '.' in impl:
+                    preferred_impls.append('rucio.rse.protocols.' + impl)
                 else:
-                    preferred_impls[i] = 'rucio.rse.protocols.' + impl
-                i += 1
+                    preferred_impls.append('rucio.rse.protocols.' + impl + '.Default')
 
         for source in sources:
             if source['rse'] in checked_rses:
@@ -1971,13 +1973,18 @@ class DownloadClient:
                 self.logger(logging.DEBUG, 'Could not get info of RSE %s: %s' % (source['source'], error))
                 continue
 
-            preferred_protocols = [protocol for protocol in reversed(rse_settings['protocols']) if protocol['impl'] in preferred_impls]
+            preferred_protocols = []
+            for preferred_impl in preferred_impls:
+                preferred_protocols.extend([
+                    protocol for protocol in rse_settings['protocols']
+                    if protocol['impl'] == preferred_impl and protocol not in preferred_protocols
+                ])
 
             if len(preferred_protocols) == 0:
                 continue
 
             for protocol in preferred_protocols:
-                if not protocol['domains']['wan'].get("read"):
+                if protocol['domains']['wan'].get("read") is None:
                     self.logger(logging.WARNING, 'Unsuitable protocol "%s": "WAN Read" operation is not supported' % (protocol['impl']))
                     continue
                 try:

--- a/lib/rucio/client/uploadclient.py
+++ b/lib/rucio/client/uploadclient.py
@@ -426,11 +426,8 @@ class UploadClient:
                     domain = 'lan'
             logger(logging.DEBUG, '{} domain is used for the upload'.format(domain))
 
-            # FIXME:
-            # Rewrite preferred_impl selection - also check test_upload.py/test_download.py and fix impl order (see FIXME there)
-            #
-            # if not impl and not force_scheme:
-            #    impl = self.preferred_impl(rse_settings, domain)
+            if not impl and not force_scheme:
+                impl = self.preferred_impl(rse_settings, domain)
 
             if not no_register and not register_after_upload:
                 self._register_file(file,
@@ -1466,32 +1463,37 @@ class UploadClient:
             self.logger(logging.INFO, 'No preferred protocol impl in rucio.cfg: %s' % (error))
             pass
         else:
-            preferred_impls = list(preferred_impls.split(', '))
-            i = 0
-            while i < len(preferred_impls):
-                impl = preferred_impls[i]
-                impl_split = impl.split('.')
-                if len(impl_split) == 1:
-                    preferred_impls[i] = 'rucio.rse.protocols.' + impl + '.Default'
+            configured_impls = preferred_impls
+            preferred_impls = []
+            for impl in configured_impls.split(','):
+                impl = impl.strip()
+                if not impl:
+                    continue
+                if impl.startswith('rucio.'):
+                    preferred_impls.append(impl)
+                elif '.' in impl:
+                    preferred_impls.append('rucio.rse.protocols.' + impl)
                 else:
-                    preferred_impls[i] = 'rucio.rse.protocols.' + impl
-                i += 1
+                    preferred_impls.append('rucio.rse.protocols.' + impl + '.Default')
 
-            preferred_protocols = [protocol for protocol in reversed(rse_settings['protocols']) if
-                                   protocol['impl'] in preferred_impls]
+            for preferred_impl in preferred_impls:
+                preferred_protocols.extend([
+                    protocol for protocol in rse_settings['protocols']
+                    if protocol['impl'] == preferred_impl and protocol not in preferred_protocols
+                ])
 
         if len(preferred_protocols) > 0:
-            preferred_protocols += [protocol for protocol in reversed(rse_settings['protocols']) if
+            preferred_protocols += [protocol for protocol in rse_settings['protocols'] if
                                     protocol not in preferred_protocols]
         else:
-            preferred_protocols = reversed(rse_settings['protocols'])
+            preferred_protocols = rse_settings['protocols']
 
         for protocol in preferred_protocols:
             if domain not in list(protocol['domains'].keys()):
                 self.logger(logging.DEBUG,
                             'Unsuitable protocol "%s": Domain %s not supported' % (protocol['impl'], domain))
                 continue
-            if not all(operations in protocol['domains'][domain] for operations in ("read", "write", "delete")):
+            if not all(protocol['domains'][domain].get(operation) is not None for operation in ("read", "write", "delete")):
                 self.logger(logging.DEBUG,
                             'Unsuitable protocol "%s": All operations are not supported' % (protocol['impl']))
                 continue

--- a/lib/rucio/rse/protocols/xrootd.py
+++ b/lib/rucio/rse/protocols/xrootd.py
@@ -12,26 +12,76 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 import os
+from contextlib import contextmanager
+from importlib import import_module, metadata
+from threading import RLock
+from typing import TYPE_CHECKING, Any, cast
+
+from packaging.version import InvalidVersion, Version
 
 from rucio.common import exception
 from rucio.common.checksum import PREFERRED_CHECKSUM
-from rucio.common.utils import execute
+from rucio.common.config import config_get
 from rucio.rse.protocols import protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import ModuleType
+
+    from rucio.common.types import LoggerFunction, RSESettingsDict
+
+_MIN_XROOTD_VERSION = Version('6.0.0')
+_XROOTD_AUTH_ENV_KEYS = ('XrdSecPROTOCOL', 'BEARER_TOKEN', 'X509_USER_PROXY')
+_XROOTD_ENV_LOCK = RLock()
+
+
+def _is_supported_xrootd_version(xrootd_client: ModuleType) -> bool:
+    version = getattr(xrootd_client, '__version__', None)
+    if version is None:
+        try:
+            version = metadata.version('xrootd')
+        except metadata.PackageNotFoundError:
+            return False
+    try:
+        return Version(str(version).lstrip('v')) >= _MIN_XROOTD_VERSION
+    except InvalidVersion:
+        return False
+
+
+try:
+    _xrootd_client: ModuleType | None = import_module('XRootD.client')
+    _xrootd_flags: ModuleType | None = import_module('XRootD.client.flags')
+
+    if not _is_supported_xrootd_version(_xrootd_client):
+        _xrootd_client = None
+        _xrootd_flags = None
+except Exception:
+    _xrootd_client = None
+    _xrootd_flags = None
+
+
+def _client() -> ModuleType:
+    if _xrootd_client is None:
+        raise exception.MissingDependency('Missing dependency : xrootd')
+    return _xrootd_client
+
+
+def _flags() -> ModuleType:
+    if _xrootd_flags is None:
+        raise exception.MissingDependency('Missing dependency : xrootd')
+    return _xrootd_flags
 
 
 class Default(protocol.RSEProtocol):
-    """ Implementing access to RSEs using the XRootD protocol using GSI authentication."""
+    """Implement access to RSEs using the native XRootD Python bindings."""
 
-    @property
-    def _auth_env(self):
-        if self.auth_token:
-            return f"XrdSecPROTOCOL=ztn BEARER_TOKEN='{self.auth_token}'"
-        else:
-            return 'XrdSecPROTOCOL=gsi'
+    _COPY_DEFAULT_TIMEOUT = 0
 
-    def __init__(self, protocol_attr, rse_settings, logger=logging.log):
+    def __init__(self, protocol_attr: dict[str, Any], rse_settings: RSESettingsDict, logger: LoggerFunction = logging.log) -> None:
         """ Initializes the object with information about the referred RSE.
 
             :param props: Properties derived from the RSE Repository
@@ -42,6 +92,160 @@ class Default(protocol.RSEProtocol):
         self.hostname = self.attributes['hostname']
         self.port = str(self.attributes['port'])
         self.logger = logger
+        self.__fs: Any | None = None
+
+    @property
+    def _endpoint(self) -> str:
+        return '{}://{}:{}'.format(self.scheme, self.hostname, self.port)
+
+    @staticmethod
+    def _status_ok(status: Any) -> bool:
+        return bool(getattr(status, 'ok', False))
+
+    @staticmethod
+    def _status_message(status: Any) -> Any:
+        return getattr(status, 'message', status)
+
+    @staticmethod
+    def _response_text(response: Any) -> Any:
+        if isinstance(response, bytes):
+            return response.decode()
+        return response
+
+    def _valid_x509_proxy(self) -> str | None:
+        for proxy in (
+            os.environ.get('RUCIO_CLIENT_PROXY'),
+            os.environ.get('X509_USER_PROXY'),
+            self._configured_x509_proxy(),
+            self._default_x509_proxy(),
+        ):
+            expanded_proxy = self._expand_x509_proxy(proxy)
+            if expanded_proxy:
+                return expanded_proxy
+        return None
+
+    def _configured_x509_proxy(self) -> str | None:
+        try:
+            return config_get('client', 'client_x509_proxy', default=None, raise_exception=False)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _default_x509_proxy() -> str | None:
+        if hasattr(os, 'geteuid'):
+            return '/tmp/x509up_u%d' % os.geteuid()
+        return None
+
+    @staticmethod
+    def _expand_x509_proxy(proxy: str | None) -> str | None:
+        if not proxy:
+            return None
+        expanded_proxy = os.path.expanduser(os.path.expandvars(proxy))
+        if '$' in expanded_proxy:
+            return None
+        if os.path.isfile(expanded_proxy):
+            return expanded_proxy
+        return None
+
+    def _clear_unexpanded_x509_proxy(self) -> None:
+        proxy = os.environ.get('X509_USER_PROXY')
+        if proxy and '$' in os.path.expandvars(proxy):
+            os.environ.pop('X509_USER_PROXY', None)
+
+    @staticmethod
+    def _auth_env_snapshot() -> dict[str, str | None]:
+        return {
+            key: os.environ.get(key)
+            for key in _XROOTD_AUTH_ENV_KEYS
+        }
+
+    @staticmethod
+    def _restore_auth_env(xrootd_client: Any, snapshot: dict[str, str | None]) -> None:
+        for key, value in snapshot.items():
+            if value is None:
+                os.environ.pop(key, None)
+                xrootd_client.EnvPutString(key, '')
+            else:
+                os.environ[key] = value
+                xrootd_client.EnvPutString(key, value)
+
+    def _configure_auth(self, xrootd_client: Any) -> None:
+        if self.auth_token:
+            os.environ['XrdSecPROTOCOL'] = 'ztn'
+            os.environ['BEARER_TOKEN'] = self.auth_token
+            xrootd_client.EnvPutString('XrdSecPROTOCOL', 'ztn')
+            xrootd_client.EnvPutString('BEARER_TOKEN', self.auth_token)
+            return
+
+        os.environ['XrdSecPROTOCOL'] = 'gsi'
+        xrootd_client.EnvPutString('XrdSecPROTOCOL', 'gsi')
+
+        proxy = self._valid_x509_proxy()
+        if proxy:
+            os.environ['X509_USER_PROXY'] = proxy
+            xrootd_client.EnvPutString('X509_USER_PROXY', proxy)
+        else:
+            self._clear_unexpanded_x509_proxy()
+
+    @contextmanager
+    def _xrootd_operation(self) -> Iterator[None]:
+        # XRootD Python bindings expose security settings through process-wide
+        # environment state; serialize native calls which mutate and consume it.
+        with _XROOTD_ENV_LOCK:
+            xrootd_client = cast('Any', _client())
+            auth_env = self._auth_env_snapshot()
+            try:
+                self._configure_auth(xrootd_client)
+                yield
+            finally:
+                self._restore_auth_env(xrootd_client, auth_env)
+
+    def _filesystem(self) -> Any:
+        xrootd_client = cast('Any', _client())
+        if self.__fs is None:
+            self.__fs = xrootd_client.FileSystem(self._endpoint)
+        return cast('Any', self.__fs)
+
+    def _is_not_found(self, status: Any) -> bool:
+        if status is None:
+            return False
+        return (
+            getattr(status, 'code', None) == getattr(status, 'errNotFound', None)
+            or getattr(status, 'shellcode', None) == 54
+            or 'No such file' in getattr(status, 'message', '')
+        )
+
+    def _is_file_exists(self, status: Any) -> bool:
+        if status is None:
+            return False
+        return 'file exists' in str(self._status_message(status)).lower()
+
+    def _ensure_ok(self, status: Any, source_not_found: bool = False) -> None:
+        if status is not None and self._status_ok(status):
+            return
+        if source_not_found and self._is_not_found(status):
+            raise exception.SourceNotFound(self._status_message(status))
+        raise exception.RucioException(self._status_message(status))
+
+    def _copy(self, source: str, target: str, transfer_timeout: int | None = None) -> None:
+        xrootd_client = cast('Any', _client())
+        timeout = int(transfer_timeout or self._COPY_DEFAULT_TIMEOUT)
+        with self._xrootd_operation():
+            copy_process = xrootd_client.CopyProcess()
+            copy_process.add_job(
+                source,
+                target,
+                force=True,
+                mkdir=True,
+                cptimeout=timeout,
+                inittimeout=timeout or 600,
+            )
+            prepare_status = copy_process.prepare()
+            self._ensure_ok(prepare_status)
+            copy_status, copy_results = copy_process.run()
+        if not self._status_ok(copy_status) and copy_results:
+            copy_status = copy_results[0].get('status', copy_status)
+        self._ensure_ok(copy_status, source_not_found=True)
 
     def path2pfn(self, path):
         """
@@ -73,11 +277,12 @@ class Default(protocol.RSEProtocol):
         self.logger(logging.DEBUG, 'xrootd.exists: pfn: {}'.format(pfn))
         try:
             path = self.pfn2path(pfn)
-            cmd = f'{self._auth_env} xrdfs {self.hostname}:{self.port} stat {path}'
-            self.logger(logging.DEBUG, 'xrootd.exists: cmd: {}'.format(cmd))
-            status, out, err = execute(cmd)
-            if status != 0:
+            with self._xrootd_operation():
+                status, _ = self._filesystem().stat(path)
+            if not self._status_ok(status):
                 return False
+        except exception.RucioException:
+            raise
         except Exception as e:
             raise exception.ServiceUnavailable(e)
 
@@ -100,26 +305,23 @@ class Default(protocol.RSEProtocol):
             path = self.pfn2path(path)
 
         try:
-            # xrdfs stat for getting filesize
-            cmd = f'{self._auth_env} xrdfs {self.hostname}:{self.port} stat {path}'
-            self.logger(logging.DEBUG, 'xrootd.stat: filesize cmd: {}'.format(cmd))
-            status_stat, out, err = execute(cmd)
-            if status_stat == 0:
-                for line in out.split('\n'):
-                    if line and ':' in line:
-                        k, v = line.split(':', maxsplit=1)
-                        if k.strip().lower() == 'size':
-                            ret['filesize'] = v.strip()
-                            break
+            with self._xrootd_operation():
+                status, stat_info = self._filesystem().stat(path)
+                self._ensure_ok(status, source_not_found=True)
+                ret['filesize'] = str(getattr(stat_info, 'size'))
 
-            # xrdfs query checksum for getting checksum
-            cmd = f'{self._auth_env} xrdfs {self.hostname}:{self.port} query checksum {path}'
-            self.logger(logging.DEBUG, 'xrootd.stat: checksum cmd: {}'.format(cmd))
-            status_query, out, err = execute(cmd)
-            if status_query == 0:
-                chsum, value = out.strip('\n').split()
-                ret[chsum] = value
+                if not self.rse.get('verify_checksum', True):
+                    return ret
 
+                flags = cast('Any', _flags())
+                status, checksum = self._filesystem().query(flags.QueryCode.CHECKSUM, path)
+                if self._status_ok(status):
+                    checksum = self._response_text(checksum)
+                    chsum, value = checksum.strip('\n\0').split()
+                    ret[chsum] = value
+
+        except exception.RucioException:
+            raise
         except Exception as e:
             raise exception.ServiceUnavailable(e)
 
@@ -188,13 +390,13 @@ class Default(protocol.RSEProtocol):
         """
         self.logger(logging.DEBUG, 'xrootd.connect: port: {}, hostname {}'.format(self.port, self.hostname))
         try:
-            # The query stats call is not implemented on some xroot doors.
-            # Workaround: fail, if server does not reply within 10 seconds for static config query
-            cmd = f'{self._auth_env} XRD_REQUESTTIMEOUT=10 xrdfs {self.hostname}:{self.port} query config {self.hostname}:{self.port}'
-            self.logger(logging.DEBUG, 'xrootd.connect: cmd: {}'.format(cmd))
-            status, out, err = execute(cmd)
-            if status != 0:
-                raise exception.RSEAccessDenied(err)
+            flags = cast('Any', _flags())
+            with self._xrootd_operation():
+                status, _ = self._filesystem().query(flags.QueryCode.CONFIG, '{}:{}'.format(self.hostname, self.port), timeout=10)
+            if not self._status_ok(status):
+                raise exception.RSEAccessDenied(self._status_message(status))
+        except exception.RucioException:
+            raise
         except Exception as e:
             raise exception.RSEAccessDenied(e)
 
@@ -213,13 +415,9 @@ class Default(protocol.RSEProtocol):
         """
         self.logger(logging.DEBUG, 'xrootd.get: pfn: {}'.format(pfn))
         try:
-            cmd = f'{self._auth_env} xrdcp -f {pfn} {dest}'
-            self.logger(logging.DEBUG, 'xrootd.get: cmd: {}'.format(cmd))
-            status, out, err = execute(cmd)
-            if status == 54:
-                raise exception.SourceNotFound()
-            elif status != 0:
-                raise exception.RucioException(err)
+            self._copy(pfn, dest, transfer_timeout=transfer_timeout)
+        except exception.RucioException:
+            raise
         except Exception as e:
             raise exception.ServiceUnavailable(e)
 
@@ -244,11 +442,9 @@ class Default(protocol.RSEProtocol):
         if not os.path.exists(source_url):
             raise exception.SourceNotFound()
         try:
-            cmd = f'{self._auth_env} xrdcp -f {source_url} {path}'
-            self.logger(logging.DEBUG, 'xrootd.put: cmd: {}'.format(cmd))
-            status, out, err = execute(cmd)
-            if status != 0:
-                raise exception.RucioException(err)
+            self._copy(os.path.abspath(source_url), path, transfer_timeout=transfer_timeout)
+        except exception.RucioException:
+            raise
         except Exception as e:
             raise exception.ServiceUnavailable(e)
 
@@ -266,11 +462,11 @@ class Default(protocol.RSEProtocol):
             raise exception.SourceNotFound()
         try:
             path = self.pfn2path(pfn)
-            cmd = f'{self._auth_env} xrdfs {self.hostname}:{self.port} rm {path}'
-            self.logger(logging.DEBUG, 'xrootd.delete: cmd: {}'.format(cmd))
-            status, out, err = execute(cmd)
-            if status != 0:
-                raise exception.RucioException(err)
+            with self._xrootd_operation():
+                status, _ = self._filesystem().rm(path)
+            self._ensure_ok(status, source_not_found=True)
+        except exception.RucioException:
+            raise
         except Exception as e:
             raise exception.ServiceUnavailable(e)
 
@@ -290,13 +486,14 @@ class Default(protocol.RSEProtocol):
             path = self.pfn2path(pfn)
             new_path = self.pfn2path(new_pfn)
             new_dir = new_path[:new_path.rindex('/') + 1]
-            cmd = f'{self._auth_env} xrdfs {self.hostname}:{self.port} mkdir -p {new_dir}'
-            self.logger(logging.DEBUG, 'xrootd.stat: mkdir cmd: {}'.format(cmd))
-            status, out, err = execute(cmd)
-            cmd = f'{self._auth_env} xrdfs {self.hostname}:{self.port} mv {path} {new_path}'
-            self.logger(logging.DEBUG, 'xrootd.stat: rename cmd: {}'.format(cmd))
-            status, out, err = execute(cmd)
-            if status != 0:
-                raise exception.RucioException(err)
+            flags = cast('Any', _flags())
+            with self._xrootd_operation():
+                status, _ = self._filesystem().mkdir(new_dir, flags.MkDirFlags.MAKEPATH)
+                if not self._is_file_exists(status):
+                    self._ensure_ok(status)
+                status, _ = self._filesystem().mv(path, new_path)
+            self._ensure_ok(status, source_not_found=True)
+        except exception.RucioException:
+            raise
         except Exception as e:
             raise exception.ServiceUnavailable(e)

--- a/requirements/requirements.dev.in
+++ b/requirements/requirements.dev.in
@@ -16,3 +16,4 @@ pip-tools==7.5.3                                            # Generate requireme
 atlas-rucio-policy-package==0.8.3
 belleii-rucio-policy-package @ git+https://github.com/rucio/temporary-belle2-policy-package@v0.1.1
 ruff==0.15.20                                               # Linter
+xrootd>=6.1.0                                               # Native XRootD bindings used by integration tests

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -530,6 +530,8 @@ xmlsec==1.3.17
     # via -r requirements.server.txt
 xmltodict==1.0.4
     # via -r requirements.dev.in
+xrootd>=6.1.0
+    # via -r requirements.dev.in
 yapf==0.43.0
     # via pydoc-markdown
 yarl==1.22.0

--- a/tests/test_rse_protocol_xrootd.py
+++ b/tests/test_rse_protocol_xrootd.py
@@ -13,14 +13,134 @@
 # limitations under the License.
 
 import os
+from contextlib import nullcontext
 
 import pytest
 
 from rucio.common.utils import execute
 from rucio.rse import rsemanager
+from rucio.rse.protocols import xrootd
 from rucio.tests.common import load_test_conf_file, skip_rse_tests_with_accounts
 
 from .rsemgr_api_test import MgrTestCases
+
+
+class _Status:
+    def __init__(self, ok=True, message=''):
+        self.ok = ok
+        self.message = message
+
+
+class _StatInfo:
+    size = 1234
+
+
+class _QueryCode:
+    CHECKSUM = 'checksum'
+
+
+class _MkDirFlags:
+    MAKEPATH = 'makepath'
+
+
+class _Flags:
+    QueryCode = _QueryCode
+    MkDirFlags = _MkDirFlags
+
+
+class _FileSystem:
+    def __init__(self):
+        self.renamed = False
+
+    def stat(self, path):
+        return _Status(), _StatInfo()
+
+    def query(self, query_code, path):
+        return _Status(), b'adler32 deadbeef\n\0'
+
+    def mkdir(self, path, flags):
+        return _Status(ok=False, message='[ERROR] Unable to mkdir {}; file exists'.format(path)), None
+
+    def mv(self, path, new_path):
+        self.renamed = True
+        return _Status(), None
+
+
+class _XRootDClient:
+    def __init__(self, version='6.0.0'):
+        self.__version__ = version
+        self.env = []
+
+    def EnvPutString(self, key, value):  # noqa: N802 - match XRootD client API
+        self.env.append((key, value))
+
+
+def test_native_xrootd_requires_version_6_or_newer():
+    assert not xrootd._is_supported_xrootd_version(_XRootDClient('5.8.4'))
+    assert xrootd._is_supported_xrootd_version(_XRootDClient('6.0.0'))
+    assert xrootd._is_supported_xrootd_version(_XRootDClient('6.0.3'))
+    assert xrootd._is_supported_xrootd_version(_XRootDClient('6.1.0'))
+    assert xrootd._is_supported_xrootd_version(_XRootDClient('v6.1.0'))
+
+
+def test_native_xrootd_clears_unexpanded_proxy_from_env(monkeypatch):
+    protocol = xrootd.Default.__new__(xrootd.Default)
+
+    monkeypatch.setenv('X509_USER_PROXY', '$RUCIO_CLIENT_PROXY')
+
+    protocol._clear_unexpanded_x509_proxy()
+
+    assert 'X509_USER_PROXY' not in os.environ
+
+
+def test_native_xrootd_operation_restores_auth_environment(monkeypatch):
+    client = _XRootDClient()
+    protocol = xrootd.Default.__new__(xrootd.Default)
+    protocol.auth_token = 'new-token'
+
+    monkeypatch.setattr(xrootd, '_xrootd_client', client)
+    monkeypatch.setenv('XrdSecPROTOCOL', 'gsi')
+    monkeypatch.setenv('BEARER_TOKEN', 'old-token')
+    monkeypatch.delenv('X509_USER_PROXY', raising=False)
+
+    with protocol._xrootd_operation():
+        assert os.environ['XrdSecPROTOCOL'] == 'ztn'
+        assert os.environ['BEARER_TOKEN'] == 'new-token'
+
+    assert os.environ['XrdSecPROTOCOL'] == 'gsi'
+    assert os.environ['BEARER_TOKEN'] == 'old-token'
+    assert 'X509_USER_PROXY' not in os.environ
+    assert ('XrdSecPROTOCOL', 'gsi') in client.env
+    assert ('BEARER_TOKEN', 'old-token') in client.env
+    assert ('X509_USER_PROXY', '') in client.env
+
+
+def test_native_xrootd_stat_accepts_bytes_checksum(monkeypatch):
+    protocol = xrootd.Default.__new__(xrootd.Default)
+    protocol.logger = lambda *args, **kwargs: None
+    protocol.rse = {'verify_checksum': True}
+    protocol._filesystem = lambda: _FileSystem()
+    protocol._xrootd_operation = nullcontext
+
+    monkeypatch.setattr(xrootd, '_xrootd_flags', _Flags)
+
+    assert protocol.stat('/tmp/file') == {'filesize': '1234', 'adler32': 'deadbeef'}
+
+
+def test_native_xrootd_rename_ignores_existing_directory(monkeypatch):
+    fs = _FileSystem()
+    protocol = xrootd.Default.__new__(xrootd.Default)
+    protocol.logger = lambda *args, **kwargs: None
+    protocol._filesystem = lambda: fs
+    protocol._xrootd_operation = nullcontext
+    protocol.exists = lambda pfn: True
+    protocol.pfn2path = lambda pfn: pfn
+
+    monkeypatch.setattr(xrootd, '_xrootd_flags', _Flags)
+
+    protocol.rename('/tmp/file.rucio.upload', '/tmp/file')
+
+    assert fs.renamed
 
 
 @pytest.mark.noparallel(reason='creates and removes a test directory with a fixed name')


### PR DESCRIPTION
## Summary

- refactor upload/download `preferred_impl` handling so configured protocol order is respected and protocol priority `0` is treated as supported
- replace the XRootD RSE protocol implementation shell calls with optional native `XRootD.client` Python bindings when `xrootd` is importable and version-supported
- keep GFAL and other protocol implementations available as fallback choices through the existing RSE protocol selection
- add `xrootd>=6.1.0` to dev requirements so test/development environments include the native bindings without making them a mandatory runtime dependency for Rucio installs

## Motivation

The existing `rucio.rse.protocols.xrootd.Default` implementation required local XRootD command-line tools for `root://` operations. The native Python bindings let this protocol avoid `xrdcp`/`xrdfs` subprocess calls while preserving the existing plugin/fallback model for deployments that continue to prefer GFAL or other implementations.

`xrootd` remains an optional runtime dependency. If the bindings are missing or unsupported, the native protocol reports the missing dependency through the normal Rucio protocol path rather than making XRootD a mandatory Rucio install dependency.

## Implementation notes

- native operations use `XRootD.client.FileSystem` and `CopyProcess`
- auth setup uses the current XRootD process-wide environment hooks, so native calls are serialized and previous auth environment values are restored after each operation
- X.509 proxy discovery handles explicit Rucio/client env values, configured proxy paths, and the default `/tmp/x509up_u<uid>` location
- tests cover version gating, proxy cleanup, auth environment restoration, byte checksum decoding, and rename behavior when parent directories already exist

## Validation

- `pre-commit run --files lib/rucio/rse/protocols/xrootd.py requirements/requirements.dev.in requirements/requirements.dev.txt tests/test_rse_protocol_xrootd.py`
- `python3 -m pytest tests/test_rse_protocol_xrootd.py::test_native_xrootd_requires_version_6_or_newer tests/test_rse_protocol_xrootd.py::test_native_xrootd_clears_unexpanded_proxy_from_env tests/test_rse_protocol_xrootd.py::test_native_xrootd_operation_restores_auth_environment tests/test_rse_protocol_xrootd.py::test_native_xrootd_stat_accepts_bytes_checksum tests/test_rse_protocol_xrootd.py::test_native_xrootd_rename_ignores_existing_directory -q`
- `PYTHONPATH=lib npx pyright --pythonpath .venv/bin/python lib/rucio/rse/protocols/xrootd.py`
- `npx commitlint --from origin/master --to HEAD --verbose`