### PR TITLE
fix(Clients): Ensure token directory exists for OIDC browser-based authentication

### DIFF
--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -686,16 +686,19 @@ class BaseClient:
 
         self.auth_token = result.headers['x-rucio-auth-token']
         if self.auth_oidc_refresh_active:
-            self.logger.debug("Resetting the token expiration epoch file content.")
-            # reset the token expiration epoch file content
-            # at new CLI OIDC authentication
-            self.token_exp_epoch = None
-            file_d, file_n = mkstemp(dir=self.token_path)
-            with fdopen(file_d, "w") as f_exp_epoch:
-                f_exp_epoch.write(str(self.token_exp_epoch))
-            move(file_n, self.token_exp_epoch_file)
-            self.__refresh_token_oidc()
+            self.__initialize_oidc_token_refresh()
         return True
+
+    def __initialize_oidc_token_refresh(self) -> None:
+        """
+        A freshly issued OIDC token carries no expiration, so reset the stored epoch
+        and refresh to get one the auto-refresh mechanism can track.
+        """
+        self.logger.debug("Resetting the token expiration epoch file content.")
+        self.token_exp_epoch = None
+        self.__ensure_token_directory_exists()
+        self.__atomic_write_to_file(self.token_exp_epoch_file, str(self.token_exp_epoch))
+        self.__refresh_token_oidc()
 
     def __get_token_x509(self) -> bool:
         """
@@ -930,32 +933,29 @@ class BaseClient:
         """
         Write the current auth_token to the local token file.
         """
-        # check if rucio temp directory is there. If not create it with permissions only for the current user
-        if not os.path.isdir(self.token_path):
-            try:
-                self.logger.debug('rucio token folder \'%s\' not found. Create it.' % self.token_path)
-                try:
-                    makedirs(self.token_path, 0o700)
-                except FileExistsError:
-                    msg = f'Token directory already exists at {self.token_path} - skipping'
-                    self.logger.debug(msg)
-            except Exception:
-                raise
+        self.__ensure_token_directory_exists()
 
         try:
-            file_d, file_n = mkstemp(dir=self.token_path)
-            with fdopen(file_d, "w") as f_token:
-                f_token.write(self.auth_token)
-            move(file_n, self.token_file)
+            self.__atomic_write_to_file(self.token_file, self.auth_token)
             if self.auth_type == 'oidc' and self.token_exp_epoch and self.auth_oidc_refresh_active:
-                file_d, file_n = mkstemp(dir=self.token_path)
-                with fdopen(file_d, "w") as f_exp_epoch:
-                    f_exp_epoch.write(str(self.token_exp_epoch))
-                move(file_n, self.token_exp_epoch_file)
+                self.__atomic_write_to_file(self.token_exp_epoch_file, str(self.token_exp_epoch))
         except OSError as error:
             print("I/O error({0}): {1}".format(error.errno, error.strerror))
-        except Exception:
-            raise
+
+    def __atomic_write_to_file(self, path: str, data: str) -> None:
+        file_d, file_n = mkstemp(dir=self.token_path)
+        with fdopen(file_d, "w") as temp_file:
+            temp_file.write(data)
+        move(file_n, path)
+
+    def __ensure_token_directory_exists(self) -> None:
+        if not os.path.isdir(self.token_path):
+            self.logger.debug(f'Rucio token directory \'{self.token_path}\' not found. Creating it...')
+            try:
+                # permissions here are only for the current user
+                makedirs(self.token_path, 0o700)
+            except FileExistsError:
+                self.logger.debug(f'Token directory already exists at {self.token_path} - skipping.')
 
     def __authenticate(self) -> None:
         """

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -23,6 +23,31 @@ from rucio.tests.common import remove_config, skip_outside_gh_actions
 from tests.mocks.mock_http_server import MockServer
 
 
+def _create_oidc_base_client(vo):
+    from rucio.client.baseclient import BaseClient
+
+    class OIDCMockHandler(MockServer.Handler):
+        def do_GET(self):
+            host, port = self.server.server_address
+            poll_url = f'http://{host}:{port}/poll_for_token'
+            if 'oidc_refresh' in self.path:
+                self.send_code_and_message(200, {}, '')
+            elif 'auth/oidc' in self.path:
+                self.send_code_and_message(200, {'X-Rucio-OIDC-Auth-URL': poll_url}, '')
+            else:
+                self.send_code_and_message(200, {'X-Rucio-Auth-Token': 'fake-oidc-token-for-test'}, '')
+
+    with MockServer(OIDCMockHandler) as server:
+        return BaseClient(
+            rucio_host=server.base_url,
+            auth_host=server.base_url,
+            account='root',
+            auth_type='oidc',
+            creds={'oidc_polling': True},
+            vo=vo,
+        )
+
+
 @pytest.fixture
 def client_token_path_override(file_config_mock, function_scope_prefix, tmp_path):
     """
@@ -30,6 +55,21 @@ def client_token_path_override(file_config_mock, function_scope_prefix, tmp_path
     """
     from rucio.common.config import config_set
     config_set('client', 'auth_token_file_path', str(tmp_path / f'{function_scope_prefix}token'))
+
+
+@pytest.fixture
+def setup_oidc_config(tmp_path, monkeypatch):
+    from rucio.common.config import config_set
+
+    def _setup(refresh_active=True):
+        token_dir = tmp_path / 'rucio_tokens'
+        token_file = token_dir / 'token'
+        config_set('client', 'auth_token_file_path', str(token_file))
+        config_set('client', 'auth_oidc_refresh_active', str(refresh_active))
+        monkeypatch.setattr('rucio.client.baseclient.wlcg_token_discovery', lambda: None)
+        return token_dir, token_file
+
+    return _setup
 
 
 @pytest.mark.usefixtures("client_token_path_override")
@@ -156,6 +196,37 @@ class TestBaseClient:
                 creds = {'client_cert': self.usercert,
                          'client_key': self.userkey}
                 BaseClient(rucio_host=server.base_url, auth_host=server.base_url, account='root', ca_cert=self.cacert, auth_type='x509', creds=creds, vo=vo)
+
+    def test_oidc_auth_creates_token_directory_when_no_directory_exists(self, vo, setup_oidc_config):
+        """ CLIENTS (BASECLIENT): OIDC auth creates the token dir when absent """
+        token_dir, token_file = setup_oidc_config()
+
+        _create_oidc_base_client(vo)
+
+        assert token_dir.is_dir()
+        assert (token_dir.stat().st_mode & 0o777) == 0o700
+        assert token_file.read_text() == 'fake-oidc-token-for-test'
+
+    def test_oidc_auth_uses_existing_token_directory_when_directory_exists(self, vo, setup_oidc_config):
+        """ CLIENTS (BASECLIENT): OIDC auth reuses an existing token dir without replacing it """
+        token_dir, token_file = setup_oidc_config()
+
+        token_dir.mkdir(mode=0o700)
+        (token_dir / 'fake').write_text('keep me')
+
+        _create_oidc_base_client(vo)
+
+        assert (token_dir / 'fake').read_text() == 'keep me'
+        assert token_file.read_text() == 'fake-oidc-token-for-test'
+
+    def test_oidc_auth_without_refresh_active(self, vo, setup_oidc_config):
+        """ CLIENTS (BASECLIENT): OIDC auth creates the token dir when absent and refresh inactive"""
+        token_dir, token_file = setup_oidc_config(refresh_active=False)
+
+        _create_oidc_base_client(vo)
+
+        assert token_dir.is_dir()
+        assert token_file.read_text() == 'fake-oidc-token-for-test'
 
     def test_retry_on_502_succeeds_eventually(self, vo):
         """ CLIENTS (BASECLIENT): Ensure client retries on 502 error codes"""


### PR DESCRIPTION
Browser-based OIDC authentication was writing the token-expiration file into the token directory before it existed, leading to an error on a fresh client (when auth_oidc_refresh_active was enabled). Create the directory before any token file is written, and route token writes through an atomic file writer helper.

Also extended tests to cover this bug and added two additional tests for existing directory and for when refresh is disabled.

I initially wanted to extract the directory generation and file writing into a helper file, but I realised it's done in multiple places and it's best to extract them from those at the same time, so I'll eventually create a follow-up issue for that and for extending the tests to cover the new utils functions.

Additionally, credit to the original author @roelj in the PR https://github.com/rucio/rucio/pull/8211 . I took the fix there, made a few modifications and mostly focused on extending the tests.

Besides testing via tests I also booted up a oidc backend and verified it via the cli:
<img width="1345" height="846" alt="image" src="https://github.com/user-attachments/assets/180b8075-d020-40e4-973e-7fe2e9a55e7c" />

Closes: #8210 

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## AI usage disclosure
Claude Code assisted with research and drafting; I reproduced, verified, reviewed, understand and stand by all changes (as described in the Rucio AI Policy).

## Checklist
- [x] Created issue: #8210
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
