### PR TITLE
fix(Auth): Fix timestamp calculation

### DIFF
--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -17,7 +17,7 @@ import json
 import logging
 import subprocess  # noqa: S404 -- subprocess used for external commands
 import traceback
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from math import floor
 from secrets import choice
 from typing import TYPE_CHECKING, Any, Final, Optional, Union
@@ -102,7 +102,7 @@ def _token_cache_get(
         METRICS.counter('token_cache.invalid').inc()
         return None
 
-    now = datetime.utcnow().timestamp()
+    now = datetime.now(tz=timezone.utc).timestamp()
     expiration = payload.get('exp', 0)    # type: ignore
     if now + min_lifetime > expiration:
         METRICS.counter('token_cache.expired').inc()

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -15,7 +15,7 @@
 import time
 import traceback
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
@@ -775,7 +775,7 @@ def test_token_cache() -> None:
     assert _token_cache_get(key) is None
 
     valid_token = JWT().pack([{
-        'exp': int((datetime.utcnow() + timedelta(hours=1)).timestamp())
+        'exp': int((datetime.now(tz=timezone.utc) + timedelta(hours=1)).timestamp())
     }])
     _token_cache_set(key, valid_token)
     assert _token_cache_get(key) == valid_token
@@ -785,13 +785,13 @@ def test_token_cache() -> None:
     assert _token_cache_get(key) is None
 
     below_min_lifetime_token = JWT().pack([{
-        'exp': int((datetime.utcnow() + timedelta(minutes=1)).timestamp())
+        'exp': int((datetime.now(tz=timezone.utc) + timedelta(minutes=1)).timestamp())
     }])
     _token_cache_set(key, below_min_lifetime_token)
     assert _token_cache_get(key) is None
 
     expired_token = JWT().pack([{
-        'exp': int((datetime.utcnow() - timedelta(minutes=1)).timestamp())
+        'exp': int((datetime.now(tz=timezone.utc) - timedelta(minutes=1)).timestamp())
     }])
     _token_cache_set(key, expired_token)
     assert _token_cache_get(key) is None


### PR DESCRIPTION
To test this properly one would need to run them in systems with different time zones. Monkey-patching that defeats the purpose of the test.

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8579
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
