### PR TITLE
Remove X-Requested-Host HTTP header support in /accounts/whoami

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -330,10 +330,7 @@ class AccountParameter(ErrorHandlingMethodView):
             description: "Not acceptable"
         """
         if account == 'whoami':
-            # Redirect to the account uri
-            frontend = request.headers.get('X-Requested-Host', default=None)
-            if frontend:
-                return redirect(f'{frontend}/accounts/{request.environ.get("issuer")}', code=302)
+            # Relative redirect to the account uri
             return redirect(request.environ['issuer'], code=303)
 
         try:

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -322,6 +322,13 @@ class AccountParameter(ErrorHandlingMethodView):
                     deleted_at:
                       description: "Datetime if the account was deleted."
                       type: string
+          303:
+            description: "See other redirect for special account value whoami."
+            headers:
+              Location:
+                description: "Account identifier of the authenticated requestor. Intended for a relative redirect."
+                schema:
+                  type: string
           401:
             description: "Invalid Auth Token"
           404:


### PR DESCRIPTION
Closes #8474

Rendered documentation change from 38656bcebed2c8c5849305170d5ed67d55aea0c7:

<img width="861" height="307" alt="Screenshot 2026-06-22 at 16 25 57" src="https://github.com/user-attachments/assets/da7297cd-b647-41aa-af49-104b8476e6af" />

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8474
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
