### PR TITLE
fix(Core): Handle unmatched QoS write errors; Fix rucio#8625

### DIFF
--- a/lib/rucio/core/rse.py
+++ b/lib/rucio/core/rse.py
@@ -1943,6 +1943,7 @@ def add_qos_policy(
            or match('.*UniqueViolation.*duplicate key value violates unique constraint.*', error.args[0])\
            or match('.*IntegrityError.*columns.*are not unique.*', error.args[0]):
             raise exception.Duplicate('QoS policy %s already exists!' % qos_policy)
+        raise exception.RucioException(error.args)
     except DatabaseError as error:
         raise exception.RucioException(error.args)
 


### PR DESCRIPTION
Added a general `RucioException` in `add_qos_policy` to avoid missing the unmatched errors.

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8625
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
