### PR TITLE
doc(Clients): Update docstrings with return values and exceptions

### DIFF
--- a/lib/rucio/client/configclient.py
+++ b/lib/rucio/client/configclient.py
@@ -42,6 +42,23 @@ class ConfigClient(BaseClient):
             The name of the section.
         option :
             The option within the section.
+
+        Raises
+        ----------
+        ConfigNotFound
+            The section or option are not present in the configuration
+        ValueError
+            Section is not specified when option is
+
+        Returns
+        ----------
+            Dictionary containing configuration details.
+            * When no options are specified, the entire configuration is returned in the format
+            ```{"sectionA": {"option1": "value1", "option2": "value2"}, "sectionb": {"option1": "value1"}}```.
+            * When the section is supplied:
+            ```{"option1": "value1", "option2": "value2"}```
+            * When section and options are supplied:
+            ```"value1"```
         """
 
         if section is None and option is not None:
@@ -134,8 +151,16 @@ class ConfigClient(BaseClient):
 
         Returns
         -------
-
             True if option was removed successfully.
+
+        Raises
+        -------
+        ConfigNotFound
+            The section or option does not exist.
+
+        Note:
+        ------
+        If the last option in a section is deleted, the section is also deleted.
         """
 
         path = '/'.join([self.CONFIG_BASEURL, section, option])
@@ -161,6 +186,12 @@ class ConfigClient(BaseClient):
         Returns
         -------
             True if option was removed successfully.
+
+        Raises
+        -------
+        ConfigNotFound
+            The section or option does not exist.
+
         """
         path = '/'.join([self.CONFIG_BASEURL, section])
         url = build_url(choice(self.list_hosts), path=path)


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue  Closes: #8612
- [ ] Added tests - N/A
- [ ] Updated documentation (Please link PRs in documentation repository) - N/A
- [ ] Added database migrations (if needed) - N/A
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits - N/A
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
