### PR TITLE
Core: Added overloads for account limit functions

### DIFF
--- a/lib/rucio/core/account_limit.py
+++ b/lib/rucio/core/account_limit.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union, overload
 
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.sql import func, literal, select
@@ -92,9 +92,14 @@ def get_rse_account_usage(rse_id: str, session: "Session") -> list["RSEAccountUs
     return result
 
 
-def get_global_account_limit(
-    session: "Session",
-    account: Optional["InternalAccount"] = None,
+@overload
+def get_global_account_limit(session: "Session", account: "InternalAccount", rse_expression: str) -> Optional[Union[int, float]]: ...
+
+@overload
+def get_global_account_limit(session: "Session", account: Optional["InternalAccount"] = None, rse_expression: Optional[str] = None) -> dict[str, "RSEResolvedGlobalAccountLimitDict"]: ...
+
+
+def get_global_account_limit(session: "Session", account: Optional["InternalAccount"] = None,
     rse_expression: Optional[str] = None
 ) -> Optional[Union[int, float, dict[str, "RSEResolvedGlobalAccountLimitDict"]]]:
     """
@@ -144,11 +149,15 @@ def get_global_account_limit(
     return resolved_global_account_limits
 
 
-def get_local_account_limit(
-    account: "InternalAccount",
-    session: "Session",
-    rse_ids: Optional[Union[str, "Iterable[str]"]] = None
-) -> Optional[Union[int, float, dict[str, int]]]:
+@overload
+def get_local_account_limit(account: "InternalAccount", session: "Session", rse_ids: str) -> Optional[Union[int, float]]: ...
+
+@overload
+def get_local_account_limit(account: "InternalAccount", session: "Session", rse_ids: Optional["Iterable[str]"] = None) -> dict[str, Union[int, float]]: ...
+
+
+def get_local_account_limit(account: "InternalAccount", session: "Session", rse_ids: Optional[Union[str, "Iterable[str]"]] = None
+) -> Optional[Union[int, float, dict[str, Union[int, float]]]]:
     """
     Returns the local account limit for a given RSE or list of RSEs.
 
@@ -326,7 +335,7 @@ def get_local_account_usage(account: "InternalAccount", session: "Session", rse_
         counters = {c.rse_id: c for c in session.execute(stmt).scalars().all()}
     result_list = []
 
-    for rse_id in set(limits).union(counters):  # type: ignore (https://github.com/rucio/rucio/issues/8194)
+    for rse_id in set(limits).union(counters):
         counter = counters.get(rse_id)
         if counter:
             counter_files = counter.files
@@ -335,14 +344,14 @@ def get_local_account_usage(account: "InternalAccount", session: "Session", rse_
             counter_files = 0
             counter_bytes = 0
 
-        if counter_bytes > 0 or counter_files > 0 or rse_id in limits.keys():  # type: ignore (https://github.com/rucio/rucio/issues/8194)
+        if counter_bytes > 0 or counter_files > 0 or rse_id in limits.keys():
             result_list.append({
                 'rse_id': rse_id,
                 'rse': get_rse_name(rse_id=rse_id, session=session),
                 'bytes': counter_bytes,
                 'files': counter_files,
-                'bytes_limit': limits.get(rse_id, 0),  # type: ignore (https://github.com/rucio/rucio/issues/8194)
-                'bytes_remaining': limits.get(rse_id, 0) - counter_bytes,  # type: ignore (https://github.com/rucio/rucio/issues/8194)
+                'bytes_limit': limits.get(rse_id, 0),
+                'bytes_remaining': limits.get(rse_id, 0) - counter_bytes,
             })
     return result_list
 
@@ -366,7 +375,7 @@ def get_global_account_usage(
         # All RSE Expressions
         limits = get_global_account_limit(account=account, session=session)
         all_rse_usages = {usage['rse_id']: (usage['bytes'], usage['files']) for usage in get_all_rse_usages_per_account(account=account, session=session)}
-        for rse_expression, limit in limits.items():  # type: ignore
+        for rse_expression, limit in limits.items():
             usage = 0
             files = 0
             for rse in limit['resolved_rse_ids']:
@@ -399,6 +408,6 @@ def get_global_account_usage(
             'rse_expression': rse_expression,
             'bytes': usage[0], 'files': usage[1],
             'bytes_limit': limit,
-            'bytes_remaining': limit - usage[0]  # type: ignore (https://github.com/rucio/rucio/issues/8194)
+            'bytes_remaining': limit - usage[0]
         })
     return result_list

--- a/lib/rucio/core/rse_selector.py
+++ b/lib/rucio/core/rse_selector.py
@@ -100,12 +100,12 @@ class RSESelector:
                     if quota_limit is None:
                         local_quota_left = 0
                     else:
-                        local_quota_left = quota_limit - get_usage(rse_id=rse['rse_id'], account=account, session=session)['bytes']  # type: ignore (https://github.com/rucio/rucio/issues/8194)
+                        local_quota_left = quota_limit - get_usage(rse_id=rse['rse_id'], account=account, session=session)['bytes']
 
                     # check global quota
                     rse['global_quota_left'] = {}
                     all_global_quota_enough = True
-                    for rse_expression, limit in global_quota_limit.items():  # type: ignore (https://github.com/rucio/rucio/issues/8194)
+                    for rse_expression, limit in global_quota_limit.items():
                         if rse['rse_id'] in limit['resolved_rse_ids']:
                             quota_limit = limit['limit']
                             global_quota_left = None

--- a/lib/rucio/gateway/account_limit.py
+++ b/lib/rucio/gateway/account_limit.py
@@ -71,21 +71,18 @@ def get_local_account_limit(
         if rse:
             # Single RSE lookup
             rse_id = get_rse_id(rse=rse, vo=vo, session=session)
-            return {rse: account_limit_core.get_local_account_limit(account=internal_account, rse_ids=rse_id, session=session)}  # type: ignore (https://github.com/rucio/rucio/issues/8194)
+            return {rse: account_limit_core.get_local_account_limit(account=internal_account, rse_ids=rse_id, session=session)}
         else:
             # Fetch all RSE limits
             limits = account_limit_core.get_local_account_limit(account=internal_account, rse_ids=None, session=session)
-            return {get_rse_name(rse_id=rse_id, session=session): limit for rse_id, limit in limits.items()}  # type: ignore (https://github.com/rucio/rucio/issues/8194)
+            return {get_rse_name(rse_id=rse_id, session=session): limit for rse_id, limit in limits.items()}
 
 
 def get_global_account_limit(
         account: str,
         rse_expression: Optional[str] = None,
         vo: str = DEFAULT_VO,
-) -> Union[
-    dict[str, Optional[Union[int, float, dict[str, "RSEResolvedGlobalAccountLimitDict"]]]],
-    Optional[Union[int, float, dict[str, "RSEResolvedGlobalAccountLimitDict"]]]
-]:
+) -> Union[dict[str, Optional[Union[float, int]]], dict[str, RSEResolvedGlobalAccountLimitDict]]:
     """
     Lists the global account limitation names/values for the specified account.
     If an RSE expression is provided, fetches the limit for that expression.

--- a/lib/rucio/web/rest/flaskapi/v1/accounts.py
+++ b/lib/rucio/web/rest/flaskapi/v1/accounts.py
@@ -705,7 +705,7 @@ class GlobalAccountLimits(ErrorHandlingMethodView):
         except RSENotFound as error:
             return generate_http_error_flask(404, error)
 
-        return Response(render_json(**limits), content_type="application/json")  # type: ignore (https://github.com/rucio/rucio/issues/8194)
+        return Response(render_json(**limits), content_type="application/json")
 
     def post(self, account: str, rse_expression: str) -> 'ResponseReturnValue':
         """


### PR DESCRIPTION
Closes: #8194 
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8194 
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer
This PR adds overloads for `get_global_account_limit` and `get_local_account_limit` to provide more precise return types based on the input arguments. It also updates the corresponding gateway type annotations to reflect the expected return types.
There is no runtime behavior change, verified by pyright clean run.
While working on this, I noticed two related issues. (1) get_global_account_limit(account=None) in core/account_limit.py can silently collapse limits from different accounts into the same dict key if they share an rse_expression — not fixed in this PR, flagging for a separate discussion/issue since it's a behavioral question, not a typing one. (2) The gateway's get_global_account_limit had a stale return-type annotation that didn't match either of its actual branches — likely invisible to mypy/pyright before, since the old blanket Union on the core function made the mismatch unprovable. Fixed in this PR as a necessary consequence of correcting the core function's types.
cc @rdimaio — opened this per the approach you outlined in #8194.

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
