### PR TITLE
Core: Fix flake8-logging-format violations

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -73,6 +73,7 @@ Individual contributors to the source code
 - Riccardo Di Maio <riccardodimaio11@gmail.com>, 2024-2025
 - Karanjot Singh <karanjot.singh@cern.ch>, 2025-2026
 - Vlad Galuska <vlad.galuska21@gmail.com>, 2026
+- Ashish Tomer <ashish0817tomer@gmail.com>, 2026
 
 Organisations employing contributors
 ------------------------------------

--- a/bin/rucio
+++ b/bin/rucio
@@ -112,7 +112,7 @@ def run_command(args, use_multi_host_functionality):
 
         # Make a custom warning - show the new help menu when invalid commands are called.
         except argparse.ArgumentError:
-            logger.error("Invalid argument(s) - %s " % sys.argv[1:])
+            logger.error("Invalid argument(s) - %s ", sys.argv[1:])
             command = map_legacy_command()
             if command is not None:
                 sys.argv = ["rucio"] + command + ["-h"]

--- a/lib/rucio/cli/account.py
+++ b/lib/rucio/cli/account.py
@@ -160,7 +160,7 @@ def attribute_list(ctx: click.Context, account_name: str):
 def attribute_set(ctx: click.Context, account_name: str, key: str, value: str):
     """Add or update an attribute [key] to an account"""
     if key in [attr['key'] for attr in next(ctx.obj.client.list_account_attributes(account_name))]:
-        ctx.obj.logger.debug("key %s already exists for account %s! Overwriting..." % (key, account_name))
+        ctx.obj.logger.debug("key %s already exists for account %s! Overwriting...", key, account_name)
         ctx.obj.client.delete_account_attribute(account=account_name, key=key)
     ctx.obj.client.add_account_attribute(account=account_name, key=key, value=value)
 

--- a/lib/rucio/cli/bin_legacy/rucio.py
+++ b/lib/rucio/cli/bin_legacy/rucio.py
@@ -385,7 +385,7 @@ def attach(args, client, logger, console, spinner):
             f = open(dids[0], 'r')
             dids = [did.rstrip() for did in f.readlines()]
         except OSError as error:
-            logger.error("Can't open file '" + dids[0] + "'.")
+            logger.error("Can't open file '%s'.", dids[0])
             raise OSError from error
 
     dids = [{'scope': get_scope(did, client)[0], 'name': get_scope(did, client)[1]} for did in dids]
@@ -395,7 +395,7 @@ def attach(args, client, logger, console, spinner):
         logger.warning("You are trying to attach too much DIDs. Therefore they will be chunked and attached in multiple commands.")
         missing_dids = []
         for i, chunk in enumerate(chunks(dids, limit)):
-            logger.info("Try to attach chunk {0}/{1}".format(i, int(math.ceil(float(len(dids)) / float(limit)))))
+            logger.info('Try to attach chunk %s/%s', i, int(math.ceil(float(len(dids)) / float(limit))))
             try:
                 client.attach_dids(scope=scope, name=name, dids=chunk)
             except Exception:
@@ -816,22 +816,22 @@ def erase(args, client, logger, console, spinner):
 
     for did in args.dids:
         if '*' in did:
-            logger.warning("This command doesn't support wildcards! Skipping DID: %s" % did)
+            logger.warning("This command doesn't support wildcards! Skipping DID: %s", did)
             continue
         try:
             scope, name = get_scope(did, client)
         except RucioException as error:
-            logger.warning('DID is in wrong format: %s' % did)
-            logger.debug('Error: %s' % error)
+            logger.warning('DID is in wrong format: %s', did)
+            logger.debug('Error: %s', error)
             continue
 
         if args.undo:
             try:
                 client.set_metadata(scope=scope, name=name, key='lifetime', value=None)
-                logger.info('Erase undo for DID: {0}:{1}'.format(scope, name))
+                logger.info('Erase undo for DID: %s:%s', scope, name)
             except Exception:
                 logger.warning('Cannot undo erase operation on DID. DID not existent or grace period of 24 hours already expired.')
-                logger.warning('    DID: {0}:{1}'.format(scope, name))
+                logger.warning('    DID: %s:%s', scope, name)
         else:
             try:
                 # set lifetime to expire in 24 hours (value is in seconds).
@@ -839,8 +839,8 @@ def erase(args, client, logger, console, spinner):
                 logger.info('CAUTION! erase operation is irreversible after 24 hours. To cancel this operation you can run the following command:')
                 print("rucio erase --undo {0}:{1}".format(scope, name))
             except RucioException as error:
-                logger.warning('Failed to erase DID: %s' % did)
-                logger.debug('Error: %s' % error)
+                logger.warning('Failed to erase DID: %s', did)
+                logger.debug('Error: %s', error)
     return SUCCESS
 
 
@@ -868,7 +868,7 @@ def upload(args, client, logger, console, spinner):
             dsscope = did[0]
             dsname = did[1]
         elif len(did) == 2:
-            logger.warning('Ignoring input {} because dataset DID is already set {}:{}'.format(arg, dsscope, dsname))
+            logger.warning('Ignoring input %s because dataset DID is already set %s:%s', arg, dsscope, dsname)
 
     items: list[FileToUploadDict] = []
     for arg in args.args:
@@ -1044,7 +1044,7 @@ def download(args, client, logger, console, spinner):
         num_dids = len(args.dids)
         did_str = args.dids[0]
         if num_dids > 1:
-            logger.warning('Download with --pfn option only supports one DID but {} DIDs were given. Considering only first DID: {}'.format(num_dids, did_str))
+            logger.warning('Download with --pfn option only supports one DID but %s DIDs were given. Considering only first DID: %s', num_dids, did_str)
             logger.debug(args.dids)
         item_defaults['pfn'] = args.pfn
         item_defaults['did'] = did_str
@@ -1940,39 +1940,39 @@ def add_lifetime_exception(args, client, logger, console, spinner):
             scope, name = meta['scope'], meta['name']
             dids_list.remove({'scope': scope, 'name': name})
             if meta['did_type'] == 'FILE':
-                logger.warning('%s:%s is a file. Will be ignored' % (scope, name))
+                logger.warning('%s:%s is a file. Will be ignored', scope, name)
                 error_summary["files_ignored"]["count"] += 1
             elif meta['did_type'] == 'CONTAINER':
-                logger.warning('%s:%s is a container. It needs to be resolved' % (scope, name))
+                logger.warning('%s:%s is a container. It needs to be resolved', scope, name)
                 containers.append({'scope': scope, 'name': name})
                 error_summary["containers_resolved"]["count"] += 1
             elif not meta['eol_at']:
-                logger.warning('%s:%s is not affected by the lifetime model' % (scope, name))
+                logger.warning('%s:%s is not affected by the lifetime model', scope, name)
                 error_summary["not_in_lifetime_model"]["count"] += 1
             else:
-                logger.info('%s:%s will be declared' % (scope, name))
+                logger.info('%s:%s will be declared', scope, name)
                 datasets.append({'scope': scope, 'name': name})
                 error_summary["successfully_submitted"]["count"] += 1
 
     for did in dids_list:
         scope = did['scope']
         name = did['name']
-        logger.warning('%s:%s does not exist' % (scope, name))
+        logger.warning('%s:%s does not exist', scope, name)
 
     if containers:
         logger.warning('One or more DIDs are containers. They will be resolved into a list of datasets to request exception. Full list below')
         for container in containers:
-            logger.info('Resolving %s:%s into datasets :' % (container['scope'], container['name']))
+            logger.info('Resolving %s:%s into datasets :', container['scope'], container['name'])
             list_datasets = __resolve_containers_to_datasets(container['scope'], container['name'], client)
             for chunk in chunks(list_datasets, chunk_limit):
                 for meta in client.get_metadata_bulk(chunk):
                     scope, name = meta['scope'], meta['name']
-                    logger.debug('%s:%s' % (scope, name))
+                    logger.debug('%s:%s', scope, name)
                     if not meta['eol_at']:
-                        logger.warning('%s:%s is not affected by the lifetime model' % (scope, name))
+                        logger.warning('%s:%s is not affected by the lifetime model', scope, name)
                         error_summary["not_in_lifetime_model"]["count"] += 1
                     else:
-                        logger.info('%s:%s will be declared' % (scope, name))
+                        logger.info('%s:%s will be declared', scope, name)
                         datasets.append({'scope': scope, 'name': name})
                         error_summary["successfully_submitted"]["count"] += 1
     if not datasets:

--- a/lib/rucio/cli/bin_legacy/rucio_admin.py
+++ b/lib/rucio/cli/bin_legacy/rucio_admin.py
@@ -703,7 +703,7 @@ def set_limit_rse(args, client, logger, console, spinner):
     try:
         args.value = int(args.value)
         if client.set_rse_limits(args.rse, args.name, args.value):
-            logger.info('Set RSE limit successfully for %s: %s = %s' % (args.rse, args.name, args.value))
+            logger.info('Set RSE limit successfully for %s: %s = %s', args.rse, args.name, args.value)
     except ValueError:
         logger.error('The RSE limit value must be an integer')
 
@@ -719,10 +719,10 @@ def delete_limit_rse(args, client, logger, console, spinner):
     """
     limits = client.get_rse_limits(args.rse)
     if args.name not in limits.keys():
-        logger.error('Limit %s not defined in RSE %s' % (args.name, args.rse))
+        logger.error('Limit %s not defined in RSE %s', args.name, args.rse)
     else:
         if client.delete_rse_limits(args.rse, args.name):
-            logger.info('Deleted RSE limit successfully for %s: %s' % (args.rse, args.name))
+            logger.info('Deleted RSE limit successfully for %s: %s', args.rse, args.name)
 
     return SUCCESS
 
@@ -1370,7 +1370,7 @@ def set_tombstone(args, client, logger, console, spinner):
         scope, name = get_scope(did, client)
         replicas.append({'scope': scope, 'name': name, 'rse': rse})
     client.set_tombstone(replicas)
-    logger.info('Set tombstone successfully on: %s' % args.dids)
+    logger.info('Set tombstone successfully on: %s', args.dids)
     return SUCCESS
 
 

--- a/lib/rucio/cli/config.py
+++ b/lib/rucio/cli/config.py
@@ -60,7 +60,7 @@ def set(ctx: click.Context, section: str, key: str, value: str):
         $ rucio config set --section my-section --key key --value value
     """
     if ctx.obj.client.get_config().get(section, {}).get(key, None) is not None:
-        ctx.obj.logger.debug("%s.%s already exists. Overwriting..." % (section, key))
+        ctx.obj.logger.debug("%s.%s already exists. Overwriting...", section, key)
 
     ctx.obj.client.set_config_option(section=section, option=key, value=value)
     print(f'Set configuration: {section}.{key}={value}')

--- a/lib/rucio/cli/did.py
+++ b/lib/rucio/cli/did.py
@@ -204,22 +204,22 @@ def remove(ctx: click.Context, dids: tuple[str, ...], undo: bool) -> None:
     """
     for did in dids:
         if '*' in did:
-            ctx.obj.logger.warning("This command doesn't support wildcards! Skipping DID: %s" % did)
+            ctx.obj.logger.warning("This command doesn't support wildcards! Skipping DID: %s", did)
             continue
         try:
             scope, name = get_scope(did, ctx.obj.client)
         except RucioException as error:
-            ctx.obj.logger.warning('DID is in wrong format: %s' % did)
-            ctx.obj.logger.debug('Error: %s' % error)
+            ctx.obj.logger.warning('DID is in wrong format: %s', did)
+            ctx.obj.logger.debug('Error: %s', error)
             continue
 
         if undo:
             try:
                 ctx.obj.client.set_metadata(scope=scope, name=name, key='lifetime', value=None)
-                ctx.obj.logger.info('Erase undo for DID: {0}:{1}'.format(scope, name))
+                ctx.obj.logger.info('Erase undo for DID: %s:%s', scope, name)
             except Exception:
                 ctx.obj.logger.warning('Cannot undo erase operation on DID. DID not existent or grace period of 24 hours already expired.')
-                ctx.obj.logger.warning('    DID: {0}:{1}'.format(scope, name))
+                ctx.obj.logger.warning('    DID: %s:%s', scope, name)
         else:
             try:
                 # set lifetime to expire in 24 hours (value is in seconds).
@@ -227,8 +227,8 @@ def remove(ctx: click.Context, dids: tuple[str, ...], undo: bool) -> None:
                 ctx.obj.logger.info('CAUTION! erase operation is irreversible after 24 hours. To cancel this operation you can run the following command:')
                 print("rucio erase --undo {0}:{1}".format(scope, name))  # TODO: replace with f-strings
             except RucioException as error:
-                ctx.obj.logger.warning('Failed to erase DID: %s' % did)
-                ctx.obj.logger.debug('Error: %s' % error)
+                ctx.obj.logger.warning('Failed to erase DID: %s', did)
+                ctx.obj.logger.debug('Error: %s', error)
 
 
 @did.group()
@@ -279,7 +279,7 @@ def content_add_(ctx: click.Context, to_did: str, from_file: bool, dids: tuple[s
             f = open(dids[0], 'r')
             dids_list = [did.rstrip() for did in f.readlines()]
         except OSError as error:
-            ctx.obj.logger.error("Can't open file '" + dids[0] + "'.")
+            ctx.obj.logger.error("Can't open file '%s'.", dids[0])
             raise OSError from error
     else:
         dids_list = list(dids)
@@ -291,7 +291,7 @@ def content_add_(ctx: click.Context, to_did: str, from_file: bool, dids: tuple[s
         ctx.obj.logger.warning("You are trying to attach too much DIDs. Therefore they will be chunked and attached in multiple commands.")
         missing_dids = []
         for i, chunk in enumerate(chunks(did_objs, limit)):
-            ctx.obj.logger.info("Try to attach chunk {0}/{1}".format(i, int(math.ceil(float(len(did_objs)) / float(limit)))))
+            ctx.obj.logger.info('Try to attach chunk %s/%s', i, int(math.ceil(float(len(did_objs)) / float(limit))))
             try:
                 ctx.obj.client.attach_dids(scope=scope, name=name, dids=chunk)
             except Exception:

--- a/lib/rucio/cli/rse.py
+++ b/lib/rucio/cli/rse.py
@@ -362,7 +362,7 @@ def attribute_set(ctx: click.Context, rse_name: str, key: str, value: str) -> No
         $ rucio rse attribute set my-rse --key My-Attribute  --value True
     """
     if ctx.obj.client.list_rse_attributes(rse_name).get(key, None) is not None:
-        ctx.obj.logger.debug("RSE %s already has attribute %s. Overwritting..." % (rse_name, key))
+        ctx.obj.logger.debug("RSE %s already has attribute %s. Overwritting...", rse_name, key)
 
     ctx.obj.client.add_rse_attribute(rse=rse_name, key=key, value=value)
     print(f'Added new RSE attribute for {rse_name}: {key}-{value} ')

--- a/lib/rucio/cli/utils.py
+++ b/lib/rucio/cli/utils.py
@@ -89,7 +89,7 @@ def exception_handler(function: "Callable") -> "Callable":
             logger.debug("This means that one you provided an invalid combination of parameters, or incorrect types. Please check the command help (-h/--help).")
             return FAILURE
         except NotImplementedError as error:
-            logger.error(f"Cannot run that operation/command combination {error}")
+            logger.error('Cannot run that operation/command combination %s', error)
             return FAILURE
         except DataIdentifierNotFound as error:
             logger.error(error)
@@ -146,13 +146,13 @@ def exception_handler(function: "Callable") -> "Callable":
                     used_account = "%s (from RUCIO_ACCOUNT)" % os.environ["RUCIO_ACCOUNT"]
                 except Exception:
                     pass
-                logger.error("Specified account %s does not have an associated identity." % used_account)
+                logger.error('Specified account %s does not have an associated identity.', used_account)
 
             else:
                 logger.debug(traceback.format_exc())
                 contact = config_get("policy", "support", raise_exception=False)
                 support = ("Please follow up with all relevant information at: " + contact) if contact else ""
-                logger.error("\nThe object is missing this property: %s\n" 'This should never happen. Please rerun the last command with the "-v" option to gather more information.\n' "%s" % (str(error), support))
+                logger.error('\nThe object is missing this property: %s\nThis should never happen. Please rerun the last command with the "-v" option to gather more information.\n%s', error, support)
             return FAILURE
         except RucioException as error:
             logger.error(error)
@@ -173,7 +173,7 @@ def exception_handler(function: "Callable") -> "Callable":
             support = ("If it's a problem concerning your experiment or if you're unsure what to do, please follow up at: %s\n" % contact) if contact else ""
             contact = config_get("policy", "support_rucio", default="https://github.com/rucio/rucio/issues")
             support += "If you're sure there is a problem with Rucio itself, please follow up at: " + contact
-            logger.error("\nRucio exited with an unexpected/unknown error.\n" 'Please rerun the last command with the "-v" option to gather more information.\n' "%s" % support)
+            logger.error('\nRucio exited with an unexpected/unknown error.\nPlease rerun the last command with the "-v" option to gather more information.\n%s', support)
             return FAILURE
 
     return new_funct

--- a/lib/rucio/client/baseclient.py
+++ b/lib/rucio/client/baseclient.py
@@ -433,7 +433,7 @@ class BaseClient:
         :param reason: the reason to backoff which will be shown to the user
         """
         sleep_time = min(MAX_RETRY_BACK_OFF_SECONDS, 0.25 * 2 ** retry_number)
-        self.logger.warning("Waiting {}s due to reason: {} ".format(sleep_time, reason))
+        self.logger.warning('Waiting %ss due to reason: %s ', sleep_time, reason)
         time.sleep(sleep_time)
 
     def _send_request(self, url, method, headers=None, data=None, params=None, stream=False, get_token=False,
@@ -465,14 +465,14 @@ class BaseClient:
         if verify is None:
             verify = self.ca_cert or False  # Maybe unnecessary but make sure to convert "" -> False
 
-        self.logger.debug("HTTP request: %s %s" % (method.value, url))
+        self.logger.debug('HTTP request: %s %s', method.value, url)
         for h, v in hds.items():
             if h == 'X-Rucio-Auth-Token':
                 v = "[hidden]"
-            self.logger.debug("HTTP header:  %s: %s" % (h, v))
+            self.logger.debug('HTTP header:  %s: %s', h, v)
         if method != HTTPMethod.GET and data:
             text = self._reduce_data(data)
-            self.logger.debug("Request data (length=%d): [%s]" % (len(data), text))
+            self.logger.debug('Request data (length=%d): [%s]', len(data), text)
 
         result = None
         for retry in range(self.AUTH_RETRIES + 1):
@@ -486,17 +486,17 @@ class BaseClient:
                 elif method == HTTPMethod.DELETE:
                     result = self.session.delete(url, headers=hds, data=data, verify=verify, timeout=self.timeout)
                 else:
-                    self.logger.debug("Unknown request type %s. Request was not sent" % (method,))
+                    self.logger.debug('Unknown request type %s. Request was not sent', method)
                     return None
-                self.logger.debug("HTTP Response: %s %s" % (result.status_code, result.reason))
+                self.logger.debug('HTTP Response: %s %s', result.status_code, result.reason)
                 if result.status_code in STATUS_CODES_TO_RETRY:
                     self._back_off(retry, 'server returned {}'.format(result.status_code))
                     continue
                 if result.status_code // 100 != 2 and result.text:
                     # do not do this for successful requests because the caller may be expecting streamed response
-                    self.logger.debug("Response text (length=%d): [%s]" % (len(result.text), result.text))
+                    self.logger.debug('Response text (length=%d): [%s]', len(result.text), result.text)
             except ConnectionError as error:
-                self.logger.error('ConnectionError: ' + str(error))
+                self.logger.error('ConnectionError: %s', error)
                 if retry > self.request_retries:
                     raise
                 continue
@@ -505,7 +505,7 @@ class BaseClient:
                 # While in python3 we can directly catch 'BrokenPipeError', in python2 it doesn't exist.
                 if getattr(error, 'errno') != errno.EPIPE:
                     raise
-                self.logger.error('BrokenPipe: ' + str(error))
+                self.logger.error('BrokenPipe: %s', error)
                 if retry > self.request_retries:
                     raise
                 continue
@@ -596,7 +596,7 @@ class BaseClient:
                 new_token = refresh_result.headers['X-Rucio-Auth-Token']
                 new_exp_epoch = refresh_result.headers['X-Rucio-Auth-Token-Expires']
                 if new_token and new_exp_epoch:
-                    self.logger.debug("Saving token %s and expiration epoch %s to files" % (str(new_token), str(new_exp_epoch)))
+                    self.logger.debug('Saving token %s and expiration epoch %s to files', new_token, new_exp_epoch)
                     # save to the file
                     self.auth_token = new_token
                     self.token_exp_epoch = new_exp_epoch
@@ -635,9 +635,9 @@ class BaseClient:
         result = None
         request_auth_url = build_url(self.auth_host, path='auth/oidc')
         # requesting authorization URL specific to the user & Rucio OIDC Client
-        self.logger.debug("Initial auth URL request headers %s to files" % str(headers))
+        self.logger.debug('Initial auth URL request headers %s to files', headers)
         oidc_auth_res = self._send_request(request_auth_url, method=HTTPMethod.GET, headers=headers, get_token=True)
-        self.logger.debug("Response headers %s and text %s" % (str(oidc_auth_res.headers), str(oidc_auth_res.text)))
+        self.logger.debug('Response headers %s and text %s', oidc_auth_res.headers, oidc_auth_res.text)
         # with the obtained authorization URL we will contact the Identity Provider to get to the login page
         if 'X-Rucio-OIDC-Auth-URL' not in oidc_auth_res.headers:
             print("Rucio Client did not succeed to get AuthN/Z URL from the Rucio Auth Server. \
@@ -718,10 +718,10 @@ class BaseClient:
             client_cert = self.creds['client_proxy']
 
         if (client_cert is not None) and not (os.path.exists(client_cert)):
-            self.logger.error('given client cert (%s) doesn\'t exist' % client_cert)
+            self.logger.error("given client cert (%s) doesn't exist", client_cert)
             return False
         if client_key is not None and not os.path.exists(client_key):
-            self.logger.error('given client key (%s) doesn\'t exist' % client_key)
+            self.logger.error("given client key (%s) doesn't exist", client_key)
 
         if client_key is None:
             cert = client_cert
@@ -755,10 +755,10 @@ class BaseClient:
 
         private_key_path = self.creds['ssh_private_key']
         if not os.path.exists(private_key_path):
-            self.logger.error('given private key (%s) doesn\'t exist' % private_key_path)
+            self.logger.error("given private key (%s) doesn't exist", private_key_path)
             return False
         if private_key_path is not None and not os.path.exists(private_key_path):
-            self.logger.error('given private key (%s) doesn\'t exist' % private_key_path)
+            self.logger.error("given private key (%s) doesn't exist", private_key_path)
             return False
 
         url = build_url(self.auth_host, path='auth/ssh_challenge_token')
@@ -776,7 +776,7 @@ class BaseClient:
             raise exc_cls(exc_msg)
 
         self.ssh_challenge_token = result.headers['x-rucio-ssh-challenge-token']
-        self.logger.debug('got new ssh challenge token \'%s\'' % self.ssh_challenge_token)
+        self.logger.debug("got new ssh challenge token '%s'", self.ssh_challenge_token)
 
         # sign the challenge token with the private key
         with open(private_key_path, 'r') as fd_private_key_path:
@@ -916,12 +916,12 @@ class BaseClient:
 
     def __ensure_token_directory_exists(self) -> None:
         if not os.path.isdir(self.token_path):
-            self.logger.debug(f'Rucio token directory \'{self.token_path}\' not found. Creating it...')
+            self.logger.debug("Rucio token directory '%s' not found. Creating it...", self.token_path)
             try:
                 # permissions here are only for the current user
                 makedirs(self.token_path, 0o700)
             except FileExistsError:
-                self.logger.debug(f'Token directory already exists at {self.token_path} - skipping.')
+                self.logger.debug('Token directory already exists at %s - skipping.', self.token_path)
 
     def __authenticate(self) -> None:
         """

--- a/lib/rucio/common/plugins.py
+++ b/lib/rucio/common/plugins.py
@@ -109,16 +109,16 @@ class PolicyPackageAlgorithms:
             return default_algorithm
 
         module_name = package + "." + algorithm_type
-        LOGGER.info('Attempting to find algorithm %s in default location %s...' % (algorithm_type, module_name))
+        LOGGER.info('Attempting to find algorithm %s in default location %s...', algorithm_type, module_name)
         try:
             module = importlib.import_module(module_name)
 
             if hasattr(module, algorithm_type):
                 default_algorithm = getattr(module, algorithm_type)
         except ModuleNotFoundError:
-            LOGGER.info('Algorithm %s not found in default location %s' % (algorithm_type, module_name))
+            LOGGER.info('Algorithm %s not found in default location %s', algorithm_type, module_name)
         except ImportError:
-            LOGGER.info('Algorithm %s found in default location %s, but could not be loaded' % (algorithm_type, module_name))
+            LOGGER.info('Algorithm %s found in default location %s, but could not be loaded', algorithm_type, module_name)
         # if the default algorithm is not present, this will store None and we will
         # not attempt to load the same algorithm again
         cls._default_algorithms[type_for_vo] = default_algorithm

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -76,7 +76,7 @@ if not _is_multivo():
         if config.is_client():
             # policy package may not be required/installed on client, but client may
             # share config file with server, so only a warning for this case
-            LOGGER.warning('Unable to find policy package %s' % policy)
+            LOGGER.warning('Unable to find policy package %s', policy)
             policy = 'rucio.common.schema.' + GENERIC_FALLBACK.lower()
         else:
             raise exception.PolicyPackageNotFound(policy)
@@ -89,8 +89,8 @@ if not _is_multivo():
         # if policy package does not contain schema module, load fallback module instead
         # this allows a policy package to omit modules that do not need customisation
         try:
-            LOGGER.warning('Unable to load schema module %s from policy package, falling back to %s'
-                           % (policy, GENERIC_FALLBACK))
+            LOGGER.warning('Unable to load schema module %s from policy package, falling back to %s',
+                           policy, GENERIC_FALLBACK)
             policy = 'rucio.common.schema.' + GENERIC_FALLBACK.lower()
             module = importlib.import_module(policy)
         except ModuleNotFoundError:
@@ -120,7 +120,7 @@ def load_schema_for_vo(vo: str) -> None:
         policy = 'rucio.common.schema.' + generic_fallback.lower()
     except ModuleNotFoundError:
         if config.is_client():
-            LOGGER.warning('Unable to find policy package %s' % policy)
+            LOGGER.warning('Unable to find policy package %s', policy)
             policy = 'rucio.common.schema.' + generic_fallback.lower()
         else:
             raise exception.PolicyPackageNotFound(policy)
@@ -133,8 +133,8 @@ def load_schema_for_vo(vo: str) -> None:
         # if policy package does not contain schema module, load fallback module instead
         # this allows a policy package to omit modules that do not need customisation
         try:
-            LOGGER.warning('Unable to load schema module %s from policy package, falling back to %s'
-                           % (policy, generic_fallback))
+            LOGGER.warning('Unable to load schema module %s from policy package, falling back to %s',
+                           policy, generic_fallback)
             policy = 'rucio.common.schema.' + generic_fallback.lower()
             module = importlib.import_module(policy)
         except ModuleNotFoundError:

--- a/lib/rucio/core/nongrid_trace.py
+++ b/lib/rucio/core/nongrid_trace.py
@@ -115,15 +115,15 @@ def trace(payload: dict[str, Any]) -> None:
             try:
                 conn = random.sample(t_conns, 1)[0]
                 if not conn.is_connected():
-                    LOGGER.info('reconnect to ' + conn.transport._Transport__host_and_ports[0][0])
+                    LOGGER.info('reconnect to %s', conn.transport._Transport__host_and_ports[0][0])
                     conn.connect(USERNAME, PASSWORD)
             except stomp.exception.NotConnectedException:
-                LOGGER.warning('Could not connect to broker %s, try another one' %
+                LOGGER.warning('Could not connect to broker %s, try another one',
                                conn.transport._Transport__host_and_ports[0][0])
                 t_conns.remove(conn)
                 continue
             except stomp.exception.ConnectFailedException:
-                LOGGER.warning('Could not connect to broker %s, try another one' %
+                LOGGER.warning('Could not connect to broker %s, try another one',
                                conn.transport._Transport__host_and_ports[0][0])
                 t_conns.remove(conn)
                 continue
@@ -131,6 +131,6 @@ def trace(payload: dict[str, Any]) -> None:
         if conn.is_connected:
             conn.send(body=report, destination=TOPIC, headers={'persistent': 'true', 'appversion': 'rucio'})
         else:
-            LOGGER.error("Unable to connect to broker. Could not send trace: %s" % report)
+            LOGGER.error('Unable to connect to broker. Could not send trace: %s', report)
     except Exception as error:
         LOGGER.error(error)

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -246,8 +246,7 @@ def __load_oidc_configuration() -> bool:
             OIDC_CLIENT_SECRET = data[ADMIN_ISSUER_ID]['client_secret']
             issuer = data[ADMIN_ISSUER_ID]['issuer']
     except Exception:
-        logging.error('Failed to parse configuration file "%s"', IDPSECRETS,
-                      exc_info=True)
+        logging.exception('Failed to parse configuration file "%s"', IDPSECRETS)
         return False
     try:
         oidc_discover_url = urljoin(issuer, '.well-known/openid-configuration')
@@ -256,7 +255,7 @@ def __load_oidc_configuration() -> bool:
         payload = response.json()
         OIDC_PROVIDER_ENDPOINT = payload['token_endpoint']
     except (requests.HTTPError, requests.JSONDecodeError, KeyError):
-        logging.error('Failed to discover token endpoint', exc_info=True)
+        logging.exception('Failed to discover token endpoint')
         return False
 
     return True
@@ -856,7 +855,7 @@ def __get_rucio_jwt_dict(jwt: str, account=None, *, session: "Session"):
         identity_string = oidc_identity_string(token_payload['sub'], token_payload['iss'])
         expiry_date = datetime.utcfromtimestamp(float(token_payload['exp']))
         if expiry_date < datetime.utcnow():  # check if expired
-            logging.debug("Token has already expired since: %s", str(expiry_date))
+            logging.debug("Token has already expired since: %s", expiry_date)
             return None
         scope = None
         audience = None
@@ -870,7 +869,7 @@ def __get_rucio_jwt_dict(jwt: str, account=None, *, session: "Session"):
             account = get_default_account(identity_string, IdentityType.OIDC, True, session=session)
         else:
             if not exist_identity_account(identity_string, IdentityType.OIDC, account, session=session):
-                logging.debug("No OIDC identity exists for account: %s", str(account))
+                logging.debug("No OIDC identity exists for account: %s", account)
                 return None
         value = {'account': account,
                  'identity': identity_string,

--- a/lib/rucio/core/permission/__init__.py
+++ b/lib/rucio/core/permission/__init__.py
@@ -70,8 +70,8 @@ if not multivo:
         # if policy package does not contain permission module, load fallback module instead
         # this allows a policy package to omit modules that do not need customisation
         try:
-            LOGGER.warning('Unable to load permission module %s from policy package, falling back to %s'
-                           % (policy, fallback_policy))
+            LOGGER.warning('Unable to load permission module %s from policy package, falling back to %s',
+                           policy, fallback_policy)
             policy = 'rucio.core.permission.' + fallback_policy.lower()
             module = importlib.import_module(policy)
         except ModuleNotFoundError:
@@ -108,8 +108,8 @@ def load_permission_for_vo(vo: str) -> None:
         # if policy package does not contain permission module, load fallback module instead
         # this allows a policy package to omit modules that do not need customisation
         try:
-            LOGGER.warning('Unable to load permission module %s from policy package, falling back to %s'
-                           % (policy, generic_fallback))
+            LOGGER.warning('Unable to load permission module %s from policy package, falling back to %s',
+                           policy, generic_fallback)
             policy = 'rucio.core.permission.' + generic_fallback.lower()
             module = importlib.import_module(policy)
         except ModuleNotFoundError:

--- a/lib/rucio/core/trace.py
+++ b/lib/rucio/core/trace.py
@@ -272,7 +272,7 @@ def ip_format_checker(value: str) -> bool:
     try:
         ipaddress.ip_address(value)
     except ValueError:
-        LOGGER.debug(f"{value} is not a valid IPv4 or IPv6 address and raises an errors upon validation.")
+        LOGGER.debug('%s is not a valid IPv4 or IPv6 address and raises an errors upon validation.', value)
         result = False
     else:
         result = True
@@ -324,23 +324,23 @@ def trace(payload: dict[str, Any]) -> None:
     try:
         validate_schema(report)
     except InvalidObject as error:
-        ROTATING_LOGGER.warning("Problem validating schema: %s" % error)
-        LOGGER.warning("Problem validating schema: %s" % error)
+        ROTATING_LOGGER.warning('Problem validating schema: %s', error)
+        LOGGER.warning('Problem validating schema: %s', error)
 
     try:
         for i in range(len(t_conns)):
             try:
                 conn = random.sample(t_conns, 1)[0]
                 if not conn.is_connected():
-                    LOGGER.info('reconnect to ' + conn.transport._Transport__host_and_ports[0][0])
+                    LOGGER.info('reconnect to %s', conn.transport._Transport__host_and_ports[0][0])
                     conn.connect(USERNAME, PASSWORD)
             except stomp.exception.NotConnectedException:
-                LOGGER.warning('Could not connect to broker %s, try another one' %
+                LOGGER.warning('Could not connect to broker %s, try another one',
                                conn.transport._Transport__host_and_ports[0][0])
                 t_conns.remove(conn)
                 continue
             except stomp.exception.ConnectFailedException:
-                LOGGER.warning('Could not connect to broker %s, try another one' %
+                LOGGER.warning('Could not connect to broker %s, try another one',
                                conn.transport._Transport__host_and_ports[0][0])
                 t_conns.remove(conn)
                 continue
@@ -348,7 +348,7 @@ def trace(payload: dict[str, Any]) -> None:
         if conn.is_connected:
             conn.send(body=report, destination=TOPIC, headers={'persistent': 'true', 'appversion': 'rucio'})
         else:
-            LOGGER.error("Unable to connect to broker. Could not send trace: %s" % report)
+            LOGGER.error('Unable to connect to broker. Could not send trace: %s', report)
     except Exception as error:
         LOGGER.error(error)
 

--- a/lib/rucio/daemons/auditor/__init__.py
+++ b/lib/rucio/daemons/auditor/__init__.py
@@ -249,7 +249,7 @@ def check(
                 process_output(output)
         except Exception:
             elapsed = (datetime.now() - start).total_seconds() / 60
-            logger.error('Check of "%s" failed in %d minutes, %d remaining attempts', rse, elapsed, attempts, exc_info=True)
+            logger.exception('Check of "%s" failed in %d minutes, %d remaining attempts', rse, elapsed, attempts)
             success = False
         else:
             elapsed = (datetime.now() - start).total_seconds() / 60

--- a/lib/rucio/daemons/bb8/bb8.py
+++ b/lib/rucio/daemons/bb8/bb8.py
@@ -173,7 +173,7 @@ def run_once(
             total_total += float(rse["total"])
             rse["receive_volume"] = 0  # Already rebalanced volume in this run
             global_ratio = float(total_primary) / float(total_total)
-            logger(logging.INFO, "Global ratio: %f" % (global_ratio))
+            logger(logging.INFO, "Global ratio: %f", global_ratio)
 
         for rse in sorted(rses, key=lambda k: k["ratio"]):
             logger(

--- a/lib/rucio/daemons/conveyor/finisher.py
+++ b/lib/rucio/daemons/conveyor/finisher.py
@@ -165,7 +165,7 @@ def finisher(
     # Get suspicious patterns
     suspicious_patterns = config_get_list('conveyor', 'suspicious_pattern', default=[])
     suspicious_patterns = [re.compile(pat.strip()) for pat in suspicious_patterns]
-    logging.log(logging.DEBUG, "Suspicious patterns: %s" % [pat.pattern for pat in suspicious_patterns])
+    logging.log(logging.DEBUG, "Suspicious patterns: %s", [pat.pattern for pat in suspicious_patterns])
 
     retry_protocol_mismatches = config_get_bool('conveyor', 'retry_protocol_mismatches', default=False)
 

--- a/lib/rucio/daemons/conveyor/poller.py
+++ b/lib/rucio/daemons/conveyor/poller.py
@@ -267,14 +267,14 @@ def run(
 
         try:
             if round(sum(parsed_activity_shares.values()), 2) != 1:
-                logging.critical('activity shares do not sum up to 1, got %s - aborting' % round(sum(parsed_activity_shares.values()), 2))
+                logging.critical('activity shares do not sum up to 1, got %s - aborting', round(sum(parsed_activity_shares.values()), 2))
                 return
         except Exception:
             logging.critical('activity shares are not numbers? - aborting')
             return
 
         parsed_activity_shares.update((share, int(percentage * db_bulk)) for share, percentage in parsed_activity_shares.items())
-        logging.info('activity shares enabled: %s' % parsed_activity_shares)
+        logging.info('activity shares enabled: %s', parsed_activity_shares)
 
     cached_topology = ExpiringObjectCache(ttl=300, new_obj_fnc=lambda: Topology())
     poller(

--- a/lib/rucio/daemons/conveyor/receiver.py
+++ b/lib/rucio/daemons/conveyor/receiver.py
@@ -73,7 +73,7 @@ class Receiver:
 
     @METRICS.count_it
     def on_error(self, frame: "Frame") -> None:
-        logging.error('[%s] %s' % (self.__broker, frame.body))
+        logging.error('[%s] %s', self.__broker, frame.body)
 
     @METRICS.count_it
     def on_message(self, frame: "Frame") -> None:

--- a/lib/rucio/daemons/conveyor/stager.py
+++ b/lib/rucio/daemons/conveyor/stager.py
@@ -111,9 +111,8 @@ def run(
     working_rses = None
     if rses or include_rses or exclude_rses:
         working_rses = get_conveyor_rses(rses, include_rses, exclude_rses, vos)
-        logging.info("RSE selection: RSEs: %s, Include: %s, Exclude: %s" % (rses,
-                                                                            include_rses,
-                                                                            exclude_rses))
+        logging.info("RSE selection: RSEs: %s, Include: %s, Exclude: %s", rses,
+                     include_rses, exclude_rses)
     elif multi_vo:
         working_rses = get_conveyor_rses(rses, include_rses, exclude_rses, vos)
         logging.info("RSE selection: automatic for relevant VOs")

--- a/lib/rucio/daemons/conveyor/submitter.py
+++ b/lib/rucio/daemons/conveyor/submitter.py
@@ -231,17 +231,19 @@ def submitter(
     failover_schemes = config_failover_schemes.intersection(schemes_supported_by_tt)
 
     if config_schemes and not schemes:
-        logging.critical(f'None of the configured schemes ({list(config_schemes)}) is supported '
-                         f'by any configured transfertool ({transfertools}). This configuration is invalid. Aborting')
+        logging.critical('None of the configured schemes (%s) is supported '
+                         'by any configured transfertool (%s). This configuration is invalid. Aborting',
+                         list(config_schemes), transfertools)
         return
     if config_failover_schemes and not failover_schemes:
-        logging.critical(f'None of the configured failover schemes ({list(config_failover_schemes)}) is supported '
-                         f'by any configured transfertool ({transfertools}). This configuration is invalid. Aborting')
+        logging.critical('None of the configured failover schemes (%s) is supported '
+                         'by any configured transfertool (%s). This configuration is invalid. Aborting',
+                         list(config_failover_schemes), transfertools)
         return
     if config_schemes.difference(schemes):
-        logging.info(f'Following schemes filtered out: {list(config_schemes.difference(schemes))}')
+        logging.info('Following schemes filtered out: %s', list(config_schemes.difference(schemes)))
     if config_failover_schemes.difference(failover_schemes):
-        logging.info(f'Following failover schemes filtered out: {list(config_failover_schemes.difference(failover_schemes))}')
+        logging.info('Following failover schemes filtered out: %s', list(config_failover_schemes.difference(failover_schemes)))
 
     timeout = config_get_float('conveyor', 'submit_timeout', default=None, raise_exception=False)
 

--- a/lib/rucio/daemons/follower/follower.py
+++ b/lib/rucio/daemons/follower/follower.py
@@ -54,7 +54,7 @@ def aggregate_events(
         start_time = time.time()
         create_reports(total_workers=heartbeat['nr_threads'] - 1,
                        worker_number=heartbeat['assign_thread'])
-        logging.info('worker[%s/%s] took %s for creating reports' % (heartbeat['assign_thread'], heartbeat['nr_threads'] - 1, time.time() - start_time))
+        logging.info('worker[%s/%s] took %s for creating reports', heartbeat['assign_thread'], heartbeat['nr_threads'] - 1, time.time() - start_time)
 
         if once:
             break

--- a/lib/rucio/daemons/judge/cleaner.py
+++ b/lib/rucio/daemons/judge/cleaner.py
@@ -150,7 +150,7 @@ def run(
     if once:
         rule_cleaner(once)
     else:
-        logging.info('Cleaner starting %s threads' % str(threads))
+        logging.info('Cleaner starting %s threads', threads)
         thread_list = [threading.Thread(target=rule_cleaner, kwargs={'once': once,
                                                                      'sleep_time': sleep_time}) for i in range(0, threads)]
         [t.start() for t in thread_list]

--- a/lib/rucio/daemons/judge/evaluator.py
+++ b/lib/rucio/daemons/judge/evaluator.py
@@ -175,7 +175,7 @@ def run(
     if once:
         re_evaluator(once=once, did_limit=did_limit)
     else:
-        logging.info('Evaluator starting %s threads' % str(threads))
+        logging.info('Evaluator starting %s threads', threads)
         thread_list = [threading.Thread(target=re_evaluator, kwargs={'once': once,
                                                                      'sleep_time': sleep_time,
                                                                      'did_limit': did_limit}) for i in range(0, threads)]

--- a/lib/rucio/daemons/judge/injector.py
+++ b/lib/rucio/daemons/judge/injector.py
@@ -154,7 +154,7 @@ def run(
     if once:
         rule_injector(once)
     else:
-        logging.info('Injector starting %s threads' % str(threads))
+        logging.info('Injector starting %s threads', threads)
         thread_list = [threading.Thread(target=rule_injector, kwargs={'once': once,
                                                                       'sleep_time': sleep_time}) for i in range(0, threads)]
         [t.start() for t in thread_list]

--- a/lib/rucio/daemons/judge/repairer.py
+++ b/lib/rucio/daemons/judge/repairer.py
@@ -151,7 +151,7 @@ def run(
     if once:
         rule_repairer(once)
     else:
-        logging.info('Repairer starting %s threads' % str(threads))
+        logging.info('Repairer starting %s threads', threads)
         thread_list = [threading.Thread(target=rule_repairer, kwargs={'once': once,
                                                                       'sleep_time': sleep_time}) for i in range(0, threads)]
         [t.start() for t in thread_list]

--- a/lib/rucio/daemons/reaper/dark_reaper.py
+++ b/lib/rucio/daemons/reaper/dark_reaper.py
@@ -243,8 +243,8 @@ def run(
                     raise VONotFound(msg)
             else:
                 vos = [v['vo'] for v in list_vos(session=session)]
-        logging.info('Dark Reaper: This instance will work on VO%s: %s'
-                     % ('s' if len(vos) > 1 else '', ', '.join([v for v in vos])))
+        logging.info('Dark Reaper: This instance will work on VO%s: %s',
+                     's' if len(vos) > 1 else '', ', '.join([v for v in vos]))
 
     all_rses = []
     for vo in vos:

--- a/lib/rucio/daemons/reaper/reaper.py
+++ b/lib/rucio/daemons/reaper/reaper.py
@@ -101,7 +101,7 @@ def get_rses_to_process(
                     raise VONotFound(msg)
             else:
                 vos = [v['vo'] for v in list_vos(session=session)]
-        logging.log(logging.INFO, 'Reaper: This instance will work on VO%s: %s' % ('s' if len(vos) > 1 else '', ', '.join([v for v in vos])))
+        logging.log(logging.INFO, 'Reaper: This instance will work on VO%s: %s', 's' if len(vos) > 1 else '', ', '.join([v for v in vos]))
 
     cache_key = 'rses_to_process_1%s2%s3%s' % (str(rses), str(include_rses), str(exclude_rses))
     if multi_vo:

--- a/lib/rucio/daemons/storage/consistency/actions.py
+++ b/lib/rucio/daemons/storage/consistency/actions.py
@@ -816,7 +816,7 @@ def run(
 # Could limit it only to Tier-2s:
 #        rses = [rse['rse'] for rse in list_rses({'tier': 2, 'availability_write': True})]
 
-    logging.info('\n RSEs: %s' % rses)
+    logging.info('\n RSEs: %s', rses)
     logger(logging.INFO, '\n RSEs: %s  \n run once: %r \n Sleep time: %d  \n Dark min age (days): %d\
      \n Dark files threshold %%: %f  \n Missing files threshold %%: %f  \n Force proceed: %r\
      \n Scanner files path: %s ' % (rses, once, sleep_time, dark_min_age, dark_threshold_percent,
@@ -833,7 +833,7 @@ def run(
         actions_loop(once, scope, rses, sleep_time, dark_min_age, dark_threshold_percent,  # type: ignore (scope and rses might be None)
                      miss_threshold_percent, force_proceed, scanner_files_path)
     else:
-        logging.info('Consistency Actions starting %s threads' % str(threads))
+        logging.info('Consistency Actions starting %s threads', threads)
         thread_list = [threading.Thread(target=actions_loop,
                                         kwargs={'once': once, 'scope': scope, 'rses': rses, 'sleep_time': sleep_time,
                                                 'dark_min_age': dark_min_age,

--- a/lib/rucio/daemons/tracer/kronos.py
+++ b/lib/rucio/daemons/tracer/kronos.py
@@ -357,7 +357,7 @@ def run_once_kronos_file(heartbeat_handler: HeartbeatHandler, stomp_conn_mngr: S
     except (NoOptionError, NoSectionError, RuntimeError):
         bad_files_patterns = []
     except Exception as error:
-        logger.error(f'Failed to get bad_file_patterns {str(error)}')
+        logger(logging.ERROR, 'Failed to get bad_file_patterns %s', error)
         bad_files_patterns = []
 
     use_ssl = config_get_bool('tracer-kronos', 'use_ssl', default=True, raise_exception=False)

--- a/lib/rucio/db/sqla/migrate_repo/env.py
+++ b/lib/rucio/db/sqla/migrate_repo/env.py
@@ -71,7 +71,7 @@ def _log_version_details(
     except ValueError:
         relative_path = script_path
 
-    log.info(f"Executing {operation} {source} -> {destination} using {relative_path}::{operation}")
+    log.info('Executing %s %s -> %s using %s::%s', operation, source, destination, relative_path, operation)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/lib/rucio/gateway/lock.py
+++ b/lib/rucio/gateway/lock.py
@@ -136,6 +136,6 @@ def get_replica_locks_for_rule_id(
 
         for lock_object in locks:
             if lock_object['scope'].vo != vo:  # rule is on a different VO, so don't return any locks
-                LOGGER.debug('rule id %s is not present on VO %s' % (rule_id, vo))
+                LOGGER.debug('rule id %s is not present on VO %s', rule_id, vo)
                 break
             yield gateway_update_return_dict(lock_object, session=session)

--- a/lib/rucio/transfertool/bittorrent_driver_qbittorrent.py
+++ b/lib/rucio/transfertool/bittorrent_driver_qbittorrent.py
@@ -80,7 +80,7 @@ class QBittorrentDriver(BittorrentDriver):
         if url.scheme.lower() == 'https':
             token = request_token(audience=url.hostname, scope='qbittorrent_admin')
         else:
-            logging.debug(f'{cls.external_name} will not try token authentication. Requires HTTPS.')
+            logging.debug('%s will not try token authentication. Requires HTTPS.', cls.external_name)
 
         rse_cred = get_rse_credentials().get(rse.id, {})
         username = rse_cred.get('qbittorrent_username')

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -351,7 +351,7 @@ def generate_http_error_flask(
             response=render_json(**data),
         )
     except Exception:
-        logging.exception(f'Cannot create generate_http_error_flask response with {data}')
+        logging.exception('Cannot create generate_http_error_flask response with %s', data)
         raise
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ select = [
     "UP",   # pyupgrade
     "TID",  # flake8-tidy-imports
     "PLE",  # pylint
+    "G",     # flake8-logging-format
 ]
 
 extend-select = [

--- a/tools/test/votest_helper.py
+++ b/tools/test/votest_helper.py
@@ -36,20 +36,20 @@ def validate(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         if 'data' not in kwargs:
-            logger.error(f"Please specify a kwarg data for {func.__name__}")
+            logger.error('Please specify a kwarg data for %s', func.__name__)
             sys.exit(1)
         if 'vo' not in kwargs:
-            logger.error(f"Please specify a kwarg vo for {func.__name__}")
+            logger.error('Please specify a kwarg vo for %s', func.__name__)
         if 'section' not in kwargs:
-            logger.error(f"Please specify a kwarg section for {func.__name__}")
+            logger.error('Please specify a kwarg section for %s', func.__name__)
         data = kwargs['data']
         vo = kwargs['vo']
         section = kwargs['section']
         if vo not in data:
-            logger.error(f"{vo} is not defined in the matrix configuration file.")
+            logger.error('%s is not defined in the matrix configuration file.', vo)
             sys.exit(1)
         if section not in data[vo]:
-            logger.error(f"No {section} found for installing policy packages for vo {vo}")
+            logger.error('No %s found for installing policy packages for vo %s', section, vo)
             sys.exit(1)
         output = func(*args, **kwargs)
         return output
@@ -64,7 +64,7 @@ def get_config(data: dict, vo: str, section: str):
 def get_installation_cmd(data: dict, vo: str):
     installation_cmd = get_config(data=data, vo=vo, section="installation_cmd")
     if installation_cmd == '':
-        logger.warning(f"No Installation command specified for {vo}")
+        logger.warning('No Installation command specified for %s', vo)
         sys.exit(1)
     return installation_cmd
 
@@ -72,11 +72,11 @@ def get_installation_cmd(data: dict, vo: str):
 def persist_config_overrides(data: dict, vo: str, rucio_cfg: Path):
     config_overrides = get_config(data=data, vo=vo, section="config_overrides")
     if len(config_overrides) == 0:
-        logger.warning(f"No config overrides specified for policy {vo}. Rucio Configuration will not be modified.")
+        logger.warning('No config overrides specified for policy %s. Rucio Configuration will not be modified.', vo)
         sys.exit(1)
 
     if not rucio_cfg.is_file():
-        logger.warning(f"Rucio Configuration File not found at {rucio_cfg}. Please use --rucio-cfg option to specify a valid path.")
+        logger.warning('Rucio Configuration File not found at %s. Please use --rucio-cfg option to specify a valid path.', rucio_cfg)
         sys.exit(1)
     rucio_config = configparser.ConfigParser()
     rucio_config.read(rucio_cfg)
@@ -87,7 +87,7 @@ def persist_config_overrides(data: dict, vo: str, rucio_cfg: Path):
     for key, val in config_overrides.items():
         policy_section[key] = val
     with open(rucio_cfg, 'w') as rucio:
-        logger.warning(f"Overriding policy section in {rucio_cfg}")
+        logger.warning('Overriding policy section in %s', rucio_cfg)
         rucio_config.write(rucio)
     return config_overrides
 
@@ -132,7 +132,7 @@ def build_config(input_conf):
             for python_ver in input_conf[policy_package]['python']
         ]
     except KeyError as e:
-        logger.warning(f"Key not found for policy package. Check YAML schema. Details: {e}")
+        logger.warning('Key not found for policy package. Check YAML schema. Details: %s', e)
         sys.exit(1)
     return json.dumps(build_matrix)
 


### PR DESCRIPTION
Closes: #7985

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #7985 
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer
This PR addresses #7985 by fixing all existing flake8-logging-format (G) violations reported by Ruff across the codebase.

Summary
Logging calls were updated to use lazy %-style formatting instead of f-strings or % string concatenation inside logger.*() calls. This follows the [flake8-logging-format](https://docs.astral.sh/ruff/rules/#flake8-logging-format-g) convention: arguments are passed to the logger so formatting only runs when the log level is enabled.

Examples of changes:
logger.error(f"Something failed: {err}") → logger.error("Something failed: %s", err) (G004)
logger.error("Invalid argument(s) - %s " % sys.argv[1:]) → logger.error("Invalid argument(s) - %s ", sys.argv[1:]) (G002)
Scope
~30 files touched across bin/, lib/rucio/ (CLI, core, daemons, gateway, web), and tools/test/
All G rule checks pass locally:

ruff check --select=G .
Pre-commit ruff hook also passes. No new tests were added; existing behavior is unchanged.

## AI usage disclosure
Cursor assisted with review fixes and commit cleanup guidance; I reviewed and understand all changes (per the Rucio AI Policy).

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
