### PR TITLE
fix(Clients): sign SSH auth challenge with rsa-sha2-256 #8566

### DIFF
--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -798,6 +798,9 @@ def ssh_sign(private_key: str, message: str) -> str:
     """
     Sign a string message using the private key.
 
+    The message is signed with rsa-sha2-256: paramiko's implicit default,
+    ssh-rsa (SHA-1), was removed in paramiko 5.
+
     :param private_key: The SSH RSA private key as a string.
     :param message: The message to sign as a string.
     :return: Base64 encoded signature as a string.
@@ -808,7 +811,7 @@ def ssh_sign(private_key: str, message: str) -> str:
     sio_private_key = StringIO(private_key)
     priv_k = RSAKey.from_private_key(sio_private_key)
     sio_private_key.close()
-    signature_stream = priv_k.sign_ssh_data(encoded_message)
+    signature_stream = priv_k.sign_ssh_data(encoded_message, algorithm='rsa-sha2-256')
     signature_stream.rewind()
     base64_encoded = base64.b64encode(signature_stream.get_remainder())
     base64_encoded = base64_encoded.decode()

--- a/pyproject.server.toml
+++ b/pyproject.server.toml
@@ -32,7 +32,7 @@ dependencies = [
   'argcomplete<=3.7.0',
   'boto',  # no upper limit is set in .in or .txt req files
   'python-magic<=0.4.27',
-  'paramiko<=4.0.0',
+  'paramiko<=5.0.0',
   'boto3<=1.42.97',
   'sqlalchemy<=2.0.51',
   'alembic<=1.16.5',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   'argcomplete<=3.7.0',
   'boto',  # no upper limit is set in .in or .txt req files
   'python-magic<=0.4.27',
-  'paramiko<=4.0.0',
+  'paramiko<=5.0.0',
   'boto3<=1.42.97',
   'sqlalchemy<=2.0.51',
   'alembic<=1.16.5',

--- a/requirements/requirements.client.txt
+++ b/requirements/requirements.client.txt
@@ -10,7 +10,7 @@ typing-extensions>=4.16.0                                   # Type annotations t
 click>=8.1.8                                                # CLI engine
 
 # All dependencies needed in extras for rucio client should be defined here
-paramiko>=4.0.0                                             # ssh_extras; SSH2 protocol library (also needed in the server)
+paramiko>=5.0.0                                             # ssh_extras; SSH2 protocol library (also needed in the server)
 kerberos>=1.3.1                                             # kerberos_extras for client and server
 pykerberos>=1.2.4                                           # kerberos_extras for client and server
 requests-kerberos>=0.15.0                                   # kerberos_extras for client and server

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -285,7 +285,7 @@ packaging==26.2
     #   pytest-rerunfailures
     #   qbittorrent-api
     #   wheel
-paramiko==4.0.0
+paramiko==5.0.0
     # via -r requirements.server.txt
 pathspec==1.1.1
     # via black

--- a/requirements/requirements.server.in
+++ b/requirements/requirements.server.in
@@ -22,7 +22,7 @@ xmlsec==1.3.17                                              # Required to instal
 packaging==26.2                                             # Packaging utilities
 
 # All dependencies needed in extras for rucio server/daemons should be defined here
-paramiko==4.0.0                                             # ssh_extras; SSH2 protocol library (also needed in the server)
+paramiko==5.0.0                                             # ssh_extras; SSH2 protocol library (also needed in the server)
 kerberos==1.3.1                                             # kerberos_extras for client and server
 pykerberos==1.2.4                                           # kerberos_extras for client and server
 requests-kerberos==0.15.0                                   # kerberos_extras for client and server

--- a/requirements/requirements.server.txt
+++ b/requirements/requirements.server.txt
@@ -151,7 +151,7 @@ packaging==26.2
     # via
     #   -r requirements.server.in
     #   qbittorrent-api
-paramiko==4.0.0
+paramiko==5.0.0
     # via -r requirements.server.in
 prometheus-client==0.25.0
     # via -r requirements.server.in

--- a/setuputil.py
+++ b/setuputil.py
@@ -71,7 +71,7 @@ server_requirements_table = {
         'argcomplete<=3.7.0',
         'boto',  # no upper limit is set in .in or .txt req files
         'python-magic<=0.4.27',
-        'paramiko<=4.0.0',
+        'paramiko<=5.0.0',
         'boto3<=1.42.97',
         'sqlalchemy<=2.0.51',
         'alembic<=1.16.5',

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -14,8 +14,10 @@
 
 import datetime
 import time
+from base64 import b64decode
 
 import pytest
+from paramiko import Message
 from requests import session
 
 from rucio.common.exception import AccessDenied, CannotAuthenticate, Duplicate
@@ -96,6 +98,14 @@ VPEtp2ruk2N7rv0DixwcEQlD/DqsfmR2/QWDeDd1xxoTXPhIXQ==
 def test_strip_x509_proxy_attributes(vo, dn, stripped_dn):
     """ AUTHENTICATION (CORE): Test the stripping of X509-proxy attributes"""
     assert strip_x509_proxy_attributes(dn) == stripped_dn
+
+
+def test_ssh_sign_uses_rsa_sha2_256():
+    """AUTHENTICATION (COMMON): ssh_sign must sign with rsa-sha2-256, not the removed ssh-rsa (SHA-1)."""
+    signature = ssh_sign(PRIVATE_KEY, 'challenge-0123456789abcdef')
+    # the algorithm name is the first field of the signature blob
+    algorithm = Message(b64decode(signature)).get_text()
+    assert algorithm == 'rsa-sha2-256'
 
 
 @pytest.mark.noparallel(reason='changes identities of the same account')


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

Note: Slightly assisted-by: Claude Fable 5

## Checklist
- [X] Created issue: #8566
- [X] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [X] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [X] Picked a reviewer after submission (Leave empty, if unclear)
- [X] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
