### PR TITLE
Metadata: Fix created_at DID filtering; rucio#8409

### DIFF
--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -230,6 +230,11 @@ def list_dids(scope=None, filters=None, did_type='collection', ignore_case=False
                 continue
             key_nooperator = key.split('.')[0]      # remove operator attribute from key if suffixed
 
+            # `created_at` is filterable but not mutable metadata, so route it to the DID-column plugin.
+            if key_nooperator == 'created_at':
+                required_unique_plugins.add(METADATA_PLUGIN_MODULES[0])
+                continue
+
             # Iterate through the list of metadata plugins, checking which (if any) manages this particular key
             # and appending the corresponding plugin to the set, required_unique_plugins.
             is_this_key_managed = False

--- a/lib/rucio/core/did_meta_plugins/filter_engine.py
+++ b/lib/rucio/core/did_meta_plugins/filter_engine.py
@@ -144,7 +144,7 @@ class FilterEngine:
         for or_group in filters:
             if 'created_after' in or_group:
                 or_group['created_at.gte'] = or_group.pop('created_after')
-            elif 'created_before' in or_group:
+            if 'created_before' in or_group:
                 or_group['created_at.lte'] = or_group.pop('created_before')
         return filters
 

--- a/tests/test_did_meta_plugins.py
+++ b/tests/test_did_meta_plugins.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 from copy import deepcopy
+from datetime import datetime
 
 import pytest
+from sqlalchemy import update
 
 from rucio.client.didclient import DIDClient
 from rucio.common.exception import KeyNotFound
@@ -24,6 +26,7 @@ from rucio.core.did_meta_plugins import get_metadata, list_dids, set_metadata
 from rucio.core.did_meta_plugins.elasticsearch_meta import ElasticDidMeta
 from rucio.core.did_meta_plugins.mongo_meta import MongoDidMeta
 from rucio.core.did_meta_plugins.postgres_meta import ExternalPostgresJSONDidMeta
+from rucio.db.sqla import models
 from rucio.db.sqla.util import json_implemented
 from rucio.tests.common import did_name_generator, skip_rse_tests_with_accounts
 
@@ -105,6 +108,67 @@ class TestDidMetaDidColumn:
 
         # with pytest.raises(KeyNotFound):
         #     list_dids(tmp_scope, {'NotReallyAKey': 'NotReallyAValue'})
+
+    @pytest.mark.dirty
+    def test_list_dids_created_at_filters_use_did_table_timestamps(self, mock_scope, did_factory, db_write_session):
+        """ Check whether created_at filters use DID table timestamps """
+        # Cover one DID before, inside, and at the exclusive upper bound.
+        timestamps = {
+            did_factory.make_dataset(session=db_write_session)['name']: datetime(2025, 1, 1, 0, 0),
+            did_factory.make_dataset(session=db_write_session)['name']: datetime(2025, 1, 15, 0, 0),
+            did_factory.make_dataset(session=db_write_session)['name']: datetime(2025, 2, 1, 0, 0),
+        }
+        expected_names = {
+            name for name, created_at in timestamps.items()
+            if datetime(2025, 1, 10) <= created_at < datetime(2025, 2, 1)
+        }
+
+        # JSON metadata must not make created_at route through the JSON plugin.
+        if json_implemented(session=db_write_session):
+            set_metadata(
+                scope=mock_scope,
+                name=next(iter(timestamps)),
+                key='issue8409_%s' % generate_uuid(),
+                value='x',
+                session=db_write_session,
+            )
+
+        for name, created_at in timestamps.items():
+            db_write_session.execute(
+                update(models.DataIdentifier)
+                .where(models.DataIdentifier.scope == mock_scope)
+                .where(models.DataIdentifier.name == name)
+                .values(created_at=created_at)
+            )
+        # list_dids opens its own session, so commit the fixed timestamps first.
+        db_write_session.commit()
+
+        dids = list(list_dids(
+            mock_scope,
+            [{
+                'name': name,  # Limit results to DIDs created by this test
+                'created_at.gte': '2025-01-10T00:00:00',
+                'created_at.lt': '2025-02-01T00:00:00',
+            } for name in timestamps],
+            did_type='collection',
+            long=True,
+        ))
+
+        assert {did['name'] for did in dids} == expected_names
+        assert {did['did_type'] for did in dids} == {'DATASET'}
+
+        # Legacy bounds must both survive compatibility conversion.
+        legacy_dids = list_dids(
+            mock_scope,
+            [{
+                'name': name,
+                'created_after': '2025-01-10T00:00:00',
+                'created_before': '2025-01-31T23:59:59',
+            } for name in timestamps],
+            did_type='collection',
+        )
+
+        assert set(legacy_dids) == expected_names
 
 
 class TestDidMetaJSON:

--- a/tests/test_filter_engine.py
+++ b/tests/test_filter_engine.py
@@ -109,6 +109,21 @@ class TestFilterEngineDummy:
             filters = FilterEngine(input_datetime_expression, strict_coerce=False).filters
             assert filters == filters_expected
 
+    def test_backwards_compatibility_created_after_and_before(self):
+        filters = FilterEngine(
+            [{
+                'created_after': '1900-01-01T00:00:00',
+                'created_before': '1900-01-02T00:00:00',
+            }],
+            model_class=models.DataIdentifier,
+        ).filters
+
+        translated = {(clause[0].key, clause[1], clause[2]) for clause in filters[0]}
+        assert translated == {
+            ('created_at', operator.ge, datetime(1900, 1, 1, 0, 0)),
+            ('created_at', operator.le, datetime(1900, 1, 2, 0, 0)),
+        }
+
     def test_backwards_compatibility_length(self):
         test_expressions = {
             'length > 0': [[('length', operator.gt, 0)]],


### PR DESCRIPTION
`created_at.*` is now routed to the DID-column metadata plugin, so it filters on `dids.created_at` instead of being treated as custom metadata.

The legacy `created_after` and `created_before` filters are also both translated when used together.

**Compatibility risk**: users who had custom metadata also named `created_at` and relied on generic `list_dids` searches filtering that custom field may see different results. After this change, `created_at.*` always means the core DID timestamp. This is intentional, but it is the main behavior change.

**Also, mixed-plugin filters remain unsupported.** A query combining `created_at.*` with a custom metadata-only key may now fail with the existing single-plugin limitation instead of accidentally routing through a custom metadata plugin.

_AI Disclaimer: GPT 5.5 pro xhigh has been used to assist in the preparation of this PR._

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8409
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [x] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
