### PR TITLE
fix(Clients): Use correct attribute in replica list dataset

### DIFF
--- a/lib/rucio/cli/replica.py
+++ b/lib/rucio/cli/replica.py
@@ -327,7 +327,7 @@ def list_dataset(
             if ctx.obj.use_rich:
                 table = generate_table([[dsn] for dsn in dsns], headers=['SCOPE:NAME'])
                 ctx.obj.spinner.stop()
-                print_output(table, console=ctx.obj.console, no_pager=ctx.obj.args.no_pager)
+                print_output(table, console=ctx.obj.console, no_pager=ctx.obj.no_pager)
             else:
                 print("SCOPE:NAME")
                 print('----------')


### PR DESCRIPTION
`rucio replica list dataset --rse <RSE>` crashes in the rich renderer when called due to an extra 'args' when trying to access 'no_pager' which results in an exit code 1.

This got caught in my other PR #8588 which enables the rich renderer CLI in the tests, that's why there is no test coverage here, it's all there.

I verified locally however, as described in the ticket.
Before the fix:
<img width="961" height="150" alt="image" src="https://github.com/user-attachments/assets/5fdef2b2-be60-4c9f-b927-fb1eeff8608b" />

After the fix:
<img width="587" height="105" alt="image" src="https://github.com/user-attachments/assets/347860e1-40e2-4420-974a-da250fabc742" />

Closes: #8641

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## AI usage disclosure
Claude Code assisted with research and drafting; I reproduced, verified, reviewed, understand and stand by all changes (as described in the Rucio AI Policy).

## Checklist
- [x] Created issue: #8641
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
