### PR TITLE
build(deps): bump actions/checkout to 7.0.0 in checkout_ancestor_commit

### DIFF
--- a/.github/actions/checkout_ancestor_commit/action.yaml
+++ b/.github/actions/checkout_ancestor_commit/action.yaml
@@ -28,7 +28,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
     - name: Checkout Ancestor Commit


### PR DESCRIPTION
Quick fix to unblock dependabot