### PR TITLE
fix(Clients): Render non-list subscription filter values in rich CLI

### DIFF
--- a/lib/rucio/cli/bin_legacy/rucio_admin.py
+++ b/lib/rucio/cli/bin_legacy/rucio_admin.py
@@ -900,7 +900,7 @@ def list_subscriptions(args, client, logger, console, spinner):
                     if k == 'filter':
                         filter_tree = Tree('')
                         for filter, values in json.loads(sub['filter']).items():
-                            values_str = ', '.join(values)
+                            values_str = __format_filter_values(values)
                             filter_tree.add(f'[{CLITheme.JSON_STR}]{filter}[/]: {values_str}')
                         table_data.append(['filter', filter_tree])
                     elif k == 'replication_rules':
@@ -921,7 +921,7 @@ def list_subscriptions(args, client, logger, console, spinner):
                 table_data.append(['comments', sub.get('comments', '')])
                 filter_tree = Tree('')
                 for filter, values in json.loads(sub['filter']).items():
-                    values_str = ', '.join(values)
+                    values_str = __format_filter_values(values)
                     filter_tree.add(f'[green]{filter}[/]: {values_str}')
                 table_data.append(['filter', filter_tree])
                 table_data.append(['name', sub['name']])
@@ -941,6 +941,12 @@ def list_subscriptions(args, client, logger, console, spinner):
             spinner.stop()
             print_output(table, console=console, no_pager=args.no_pager)
     return SUCCESS
+
+
+def __format_filter_values(values: object) -> str:
+    if isinstance(values, (list, tuple)):
+        return ', '.join(map(str, values))
+    return str(values)
 
 
 @exception_handler


### PR DESCRIPTION
When using the rich renderer, `rucio subscription list` built the filter with `', '.join(values)`, assuming every filter value is a list of strings. Allowed filter values also include booleans (`split_rule`) and plain strings (`pattern`). Instead now, they will join list values and render everything else with str() in both the default and --long rich paths.

We can't add tests for this due to the rich cli renderer not working in tests which I have a PR for #8588 . I did verify it manually via the CLI and will extend 8588 with tests for this once it's merged:

<img width="525" height="309" alt="image" src="https://github.com/user-attachments/assets/a9d0af90-843d-4183-bcae-31e530ba8e4c" />

Closes: #8661

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## AI usage disclosure
Claude Code assisted with research and drafting; I reproduced, verified, reviewed, understand and stand by all changes (as described in the Rucio AI Policy).

## Checklist
- [x] Created issue: #8661 
- [ ] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [x] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
