### PR TITLE
fix(Clients): Allow bidirection distance updates when one RSE does not have a distance

### DIFF
--- a/lib/rucio/cli/rse.py
+++ b/lib/rucio/cli/rse.py
@@ -282,16 +282,25 @@ def distance_set(
     """Create a link from SOURCE-RSE to DESTINATION-RSE with a distance"""
     params = {'distance': distance}
 
-    if ctx.obj.client.get_distance(source_rse, destination_rse):
-        ctx.obj.client.update_distance(source_rse, destination_rse, params, bidirectional)
+    src_exists = bool(ctx.obj.client.get_distance(source_rse, destination_rse))
+    dest_exists = bool(ctx.obj.client.get_distance(destination_rse, source_rse))
 
+    if bidirectional:
+        if src_exists and dest_exists:
+            ctx.obj.client.update_distance(source_rse, destination_rse, params, True)
+        elif src_exists:
+            ctx.obj.client.add_distance(destination_rse, source_rse, parameters=params, bidirectional=False)
+            ctx.obj.client.update_distance(source_rse, destination_rse, params, False)
+        elif dest_exists:
+            ctx.obj.client.add_distance(source_rse, destination_rse, parameters=params, bidirectional=False)
+            ctx.obj.client.update_distance(destination_rse, source_rse, params, False)
+        else:
+            ctx.obj.client.add_distance(source_rse, destination_rse, parameters=params, bidirectional=True)
     else:
-        ctx.obj.client.add_distance(
-            source_rse,
-            destination_rse,
-            parameters=params,
-            bidirectional=bidirectional
-        )
+        if src_exists:
+            ctx.obj.client.update_distance(source_rse, destination_rse, params, False)
+        else:
+            ctx.obj.client.add_distance(source_rse, destination_rse, parameters=params, bidirectional=False)
 
     if bidirectional:
         print(f"Set distances between {source_rse} <-> {destination_rse} to {distance}")

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -1067,3 +1067,35 @@ def test_rse_distance_bidirectional(rucio_client, rse_factory):
     exitcode, out, err = execute(cmd)
     assert exitcode == 0
     assert f"Deleted distances between {rse_name_1} <-> {rse_name_2}" in out
+
+    # Ensure bidirectional updates work when only one RSE is present
+    rse_name_3, _ = rse_factory.make_posix_rse()
+    rse_name_4, _ = rse_factory.make_posix_rse()
+    distance = 1
+
+    cmd = f'rucio rse distance set --distance {distance} {rse_name_3} {rse_name_4}'
+    exitcode, out, err = execute(cmd)
+    assert exitcode == 0
+    assert rucio_client.get_distance(rse_name_3, rse_name_4)[0]['distance'] == distance
+
+    distance = 10
+    cmd = f'rucio rse distance set --bidirectional --distance {distance} {rse_name_3} {rse_name_4}'
+    exitcode, out, err = execute(cmd)
+    assert exitcode == 0
+    assert rucio_client.get_distance(rse_name_3, rse_name_4)[0]['distance'] == distance
+    assert rucio_client.get_distance(rse_name_4, rse_name_3)[0]['distance'] == distance
+
+    rse_name_5, _ = rse_factory.make_posix_rse()
+    rse_name_6, _ = rse_factory.make_posix_rse()
+    distance = 1
+
+    cmd = f'rucio rse distance set --distance {distance} {rse_name_5} {rse_name_6}'
+    exitcode, out, err = execute(cmd)
+    assert exitcode == 0
+
+    distance = 10
+    cmd = f'rucio rse distance set --bidirectional --distance {distance} {rse_name_6} {rse_name_5}'
+    exitcode, out, err = execute(cmd)
+    assert exitcode == 0
+    assert rucio_client.get_distance(rse_name_6, rse_name_5)[0]['distance'] == distance
+    assert rucio_client.get_distance(rse_name_5, rse_name_6)[0]['distance'] == distance


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Closes #8665 
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository) -N/A
- [ ] Added database migrations (if needed)
- [x] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

Minor cleanup was provided by qwen3-coder-next. 

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
