### PR TITLE
feat(Transfers): Add the possibility to overide WEBDAV_TRANSFER_MODE for transfer using FTS3 through RSE attribute

### DIFF
--- a/lib/rucio/common/constants.py
+++ b/lib/rucio/common/constants.py
@@ -159,6 +159,7 @@ class RseAttr:
     TYPE = 'type'
     USE_IPV4 = 'use_ipv4'
     VERIFY_CHECKSUM = 'verify_checksum'
+    WEBDAV_TRANSFER_MODE = 'webdav_transfer_mode'
 
     # The following RSE attributes are exclusively used in the permission layer
     # and are likely VO-specific.
@@ -201,7 +202,8 @@ RSE_ATTRS_STR = Literal[
     'source_for_used_space',
     'staging_buffer',
     'tombstone_delay',
-    'type'
+    'type',
+    'webdav_transfer_mode'
 ]
 
 RSE_ATTRS_BOOL = Literal[

--- a/lib/rucio/core/transfer.py
+++ b/lib/rucio/core/transfer.py
@@ -157,7 +157,7 @@ class DirectTransferImplementation(DirectTransfer):
         return self.protocol_factory.protocol(source.rse, source.scheme, self.operation_src)
 
     @staticmethod
-    def __rewrite_source_url(source_url, source_sign_url, dest_sign_url, source_scheme):
+    def __rewrite_source_url(source_url, source_sign_url, dest_sign_url, source_scheme, dest_rse: "RseData"):
         """
         Parametrize source url for some special cases of source and destination schemes
         """
@@ -167,9 +167,11 @@ class DirectTransferImplementation(DirectTransfer):
         elif dest_sign_url == 's3':
             if source_scheme in ['davs', 'https']:
                 source_url += '?copy_mode=push'
-        elif WEBDAV_TRANSFER_MODE:
-            if source_scheme in ['davs', 'https']:
-                source_url += '?copy_mode=%s' % WEBDAV_TRANSFER_MODE
+        elif source_scheme in ['davs', 'https']:
+            # RSE attribute on destination takes precedence over global config
+            transfer_mode = dest_rse.attributes.get(RseAttr.WEBDAV_TRANSFER_MODE) or WEBDAV_TRANSFER_MODE
+            if transfer_mode:
+                source_url += '?copy_mode=%s' % transfer_mode
 
         source_sign_url_map = {'gcs': 'gclouds', 's3': 's3s'}
         if source_sign_url in source_sign_url_map:
@@ -215,7 +217,7 @@ class DirectTransferImplementation(DirectTransfer):
             'path': src.file_path
         }
         source_url = list(protocol.lfns2pfns(lfns=lfn).values())[0]
-        source_url = cls.__rewrite_source_url(source_url, source_sign_url=source_sign_url, dest_sign_url=dest_sign_url, source_scheme=src.scheme)
+        source_url = cls.__rewrite_source_url(source_url, source_sign_url=source_sign_url, dest_sign_url=dest_sign_url, source_scheme=src.scheme, dest_rse=dst.rse)
         return source_url
 
     @classmethod

--- a/tests/test_transfer_plugins.py
+++ b/tests/test_transfer_plugins.py
@@ -393,3 +393,235 @@ def test_no_staging_metadata_if_src_is_not_tape(did_factory, rse_factory, root_a
     job_params = fts3_tool._file_from_transfer(transfer_params, job_params)
 
     assert "staging_metadata" not in job_params
+
+
+class TestWebdavTransferMode:
+    """Tests for the webdav_transfer_mode RSE attribute."""
+
+    def _make_transfer_path_with_scheme(
+            self,
+            did,
+            rse_factory,
+            root_account,
+            src_scheme: str = 'davs',
+            dst_scheme: str = 'davs',
+            dst_rse_attributes: dict = None,
+    ):
+        """Helper to create a transfer path with specific schemes and RSE attributes."""
+        from rucio.core.rse import add_rse_attribute
+
+        src_rse, src_rse_id = rse_factory.make_rse(
+            scheme=src_scheme,
+            protocol_impl='rucio.rse.protocols.gfal.Default'
+        )
+        dst_rse, dst_rse_id = rse_factory.make_rse(
+            scheme=dst_scheme,
+            protocol_impl='rucio.rse.protocols.gfal.Default'
+        )
+
+        if dst_rse_attributes:
+            for key, value in dst_rse_attributes.items():
+                add_rse_attribute(dst_rse_id, key, value)
+
+        all_rses = [src_rse_id, dst_rse_id]
+        distance_core.add_distance(src_rse_id, dst_rse_id, distance=1)
+
+        topology = Topology(rse_ids=all_rses)
+        file = {"scope": did["scope"], "name": did["name"], "bytes": 1}
+        replica_core.add_replicas(rse_id=src_rse_id, files=[file], account=root_account)
+        rule_core.add_rule(
+            dids=[did],
+            account=root_account,
+            copies=1,
+            rse_expression=dst_rse,
+            grouping="ALL",
+            weight=None,
+            lifetime=None,
+            locked=False,
+            subscription_id=None,
+        )
+
+        requests_by_id = list_and_mark_transfer_requests_and_source_replicas(
+            rse_collection=topology, rses=[src_rse_id, dst_rse_id]
+        )
+        requests, *_ = build_transfer_paths(
+            topology=topology,
+            protocol_factory=ProtocolFactory(),
+            requests_with_sources=requests_by_id.values(),
+        )
+        _, [transfer_path] = next(iter(requests.items()))
+
+        return transfer_path
+
+    def test_webdav_transfer_mode_rse_attribute_push(self, monkeypatch, did_factory, rse_factory, root_account):
+        """Test that webdav_transfer_mode RSE attribute on destination sets copy_mode=push in source URL."""
+        from rucio.common.constants import RseAttr
+        from rucio.core import transfer as transfer_module
+        monkeypatch.setattr(transfer_module, 'WEBDAV_TRANSFER_MODE', None)
+
+        mock_did = did_factory.random_file_did()
+        transfer_path = self._make_transfer_path_with_scheme(
+            mock_did,
+            rse_factory,
+            root_account,
+            src_scheme='davs',
+            dst_scheme='davs',
+            dst_rse_attributes={RseAttr.WEBDAV_TRANSFER_MODE: 'push'},
+        )
+
+        transfer = transfer_path[0]
+        source_url = transfer.source_url(transfer.src)
+
+        assert '?copy_mode=push' in source_url
+
+    def test_webdav_transfer_mode_rse_attribute_pull(self, monkeypatch, did_factory, rse_factory, root_account):
+        """Test that webdav_transfer_mode RSE attribute on destination sets copy_mode=pull in source URL."""
+        from rucio.common.constants import RseAttr
+        from rucio.core import transfer as transfer_module
+        monkeypatch.setattr(transfer_module, 'WEBDAV_TRANSFER_MODE', None)
+
+        mock_did = did_factory.random_file_did()
+        transfer_path = self._make_transfer_path_with_scheme(
+            mock_did,
+            rse_factory,
+            root_account,
+            src_scheme='davs',
+            dst_scheme='davs',
+            dst_rse_attributes={RseAttr.WEBDAV_TRANSFER_MODE: 'pull'},
+        )
+
+        transfer = transfer_path[0]
+        source_url = transfer.source_url(transfer.src)
+
+        assert '?copy_mode=pull' in source_url
+
+    def test_webdav_transfer_mode_no_attribute_no_config(self, monkeypatch, did_factory, rse_factory, root_account):
+        """Test that without RSE attribute or global config, no copy_mode is added."""
+        from rucio.core import transfer as transfer_module
+        monkeypatch.setattr(transfer_module, 'WEBDAV_TRANSFER_MODE', None)
+
+        mock_did = did_factory.random_file_did()
+        transfer_path = self._make_transfer_path_with_scheme(
+            mock_did,
+            rse_factory,
+            root_account,
+            src_scheme='davs',
+            dst_scheme='davs',
+            dst_rse_attributes=None,
+        )
+
+        transfer = transfer_path[0]
+        source_url = transfer.source_url(transfer.src)
+
+        assert 'copy_mode' not in source_url
+
+    def test_webdav_transfer_mode_rse_attribute_overrides_config(self, monkeypatch, did_factory, rse_factory, root_account):
+        """Test that RSE attribute takes precedence over global config."""
+        from rucio.common.constants import RseAttr
+        from rucio.core import transfer as transfer_module
+        monkeypatch.setattr(transfer_module, 'WEBDAV_TRANSFER_MODE', 'pull')
+
+        mock_did = did_factory.random_file_did()
+        transfer_path = self._make_transfer_path_with_scheme(
+            mock_did,
+            rse_factory,
+            root_account,
+            src_scheme='davs',
+            dst_scheme='davs',
+            dst_rse_attributes={RseAttr.WEBDAV_TRANSFER_MODE: 'push'},
+        )
+
+        transfer = transfer_path[0]
+        source_url = transfer.source_url(transfer.src)
+
+        assert '?copy_mode=push' in source_url
+
+    def test_webdav_transfer_mode_global_config_used_when_no_attribute(self, monkeypatch, did_factory, rse_factory, root_account):
+        """Test that global config is used when RSE attribute is not set."""
+        from rucio.core import transfer as transfer_module
+        monkeypatch.setattr(transfer_module, 'WEBDAV_TRANSFER_MODE', 'push')
+
+        mock_did = did_factory.random_file_did()
+        transfer_path = self._make_transfer_path_with_scheme(
+            mock_did,
+            rse_factory,
+            root_account,
+            src_scheme='davs',
+            dst_scheme='davs',
+            dst_rse_attributes=None,
+        )
+
+        transfer = transfer_path[0]
+        source_url = transfer.source_url(transfer.src)
+
+        assert '?copy_mode=push' in source_url
+
+    def test_webdav_transfer_mode_https_scheme(self, monkeypatch, did_factory, rse_factory, root_account):
+        """Test that webdav_transfer_mode also works with https scheme."""
+        from rucio.common.constants import RseAttr
+        from rucio.core import transfer as transfer_module
+        monkeypatch.setattr(transfer_module, 'WEBDAV_TRANSFER_MODE', None)
+
+        mock_did = did_factory.random_file_did()
+        transfer_path = self._make_transfer_path_with_scheme(
+            mock_did,
+            rse_factory,
+            root_account,
+            src_scheme='https',
+            dst_scheme='https',
+            dst_rse_attributes={RseAttr.WEBDAV_TRANSFER_MODE: 'push'},
+        )
+
+        transfer = transfer_path[0]
+        source_url = transfer.source_url(transfer.src)
+
+        assert '?copy_mode=push' in source_url
+
+    def test_webdav_transfer_mode_not_applied_to_other_schemes(self, monkeypatch, did_factory, rse_factory, root_account):
+        """Test that webdav_transfer_mode is not applied to non-davs/https schemes."""
+        from rucio.common.constants import RseAttr
+        from rucio.core import transfer as transfer_module
+        from rucio.core.rse import add_rse_attribute
+
+        monkeypatch.setattr(transfer_module, 'WEBDAV_TRANSFER_MODE', None)
+
+        mock_did = did_factory.random_file_did()
+
+        # Use xrootd protocol for this test
+        src_rse, src_rse_id = rse_factory.make_xroot_rse()
+        dst_rse, dst_rse_id = rse_factory.make_xroot_rse()
+
+        add_rse_attribute(dst_rse_id, RseAttr.WEBDAV_TRANSFER_MODE, 'push')
+
+        all_rses = [src_rse_id, dst_rse_id]
+        distance_core.add_distance(src_rse_id, dst_rse_id, distance=1)
+
+        topology = Topology(rse_ids=all_rses)
+        file = {"scope": mock_did["scope"], "name": mock_did["name"], "bytes": 1}
+        replica_core.add_replicas(rse_id=src_rse_id, files=[file], account=root_account)
+        rule_core.add_rule(
+            dids=[mock_did],
+            account=root_account,
+            copies=1,
+            rse_expression=dst_rse,
+            grouping="ALL",
+            weight=None,
+            lifetime=None,
+            locked=False,
+            subscription_id=None,
+        )
+
+        requests_by_id = list_and_mark_transfer_requests_and_source_replicas(
+            rse_collection=topology, rses=[src_rse_id, dst_rse_id]
+        )
+        requests, *_ = build_transfer_paths(
+            topology=topology,
+            protocol_factory=ProtocolFactory(),
+            requests_with_sources=requests_by_id.values(),
+        )
+        _, [transfer_path] = next(iter(requests.items()))
+
+        transfer = transfer_path[0]
+        source_url = transfer.source_url(transfer.src)
+
+        assert 'copy_mode' not in source_url


### PR DESCRIPTION


Closes: #8695

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Checklist
- [x] Created issue: #8695 
- [x] Added tests
- [ ] Updated documentation (Please link PRs in documentation repository)
- [ ] Added database migrations (if needed)
- [ ] For backwards compatibility breaking changes, leave additional description, follow conventional commits
- [ ] Picked a reviewer after submission (Leave empty, if unclear)
- [x] I understand that stale (failing tests, author not answering) PRs will be closed promptly

## Additional description for reviewer

*Note: This OPTIONAL is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
