### PR TITLE
fix(Core): allow OIDC login without a pre-declared account

### DIFF
--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -37,7 +37,7 @@ from sqlalchemy.sql.expression import true
 
 from rucio.common.cache import MemcacheRegion
 from rucio.common.config import config_get, config_get_bool, config_get_int
-from rucio.common.exception import CannotAuthenticate, CannotAuthorize, RucioException
+from rucio.common.exception import CannotAuthenticate, CannotAuthorize, IdentityError, RucioException
 from rucio.common.stopwatch import Stopwatch
 from rucio.common.utils import all_oidc_req_claims_present, build_url, chunks, val_to_space_sep_str
 from rucio.core.account import account_exists
@@ -367,7 +367,9 @@ def get_auth_oidc(account: "InternalAccount", *, session: "Session", **kwargs) -
     Returns authorization URL as a string or a redirection url to
     be used in user's browser for authentication.
 
-    :param account: Rucio Account identifier as a string.
+    :param account: Rucio Account identifier as a string. The 'webui' sentinel
+                    account defers the account selection to get_token_oidc,
+                    where the default account of the identity is used.
     :param auth_scope: space separated list of scope names. Scope parameter
                        defines which user's info the user allows to provide
                        to the Rucio Client.
@@ -401,10 +403,13 @@ def get_auth_oidc(account: "InternalAccount", *, session: "Session", **kwargs) -
     polling = kwargs.get('polling', False)
     refresh_lifetime = kwargs.get('refresh_lifetime', REFRESH_LIFETIME_H)
     ip = kwargs.get('ip', None)
-    # Make sure the account exists
-    if not account_exists(account, session=session):
-        logging.debug("Account %s does not exist.", account)
-        return None
+    # 'webui' is a sentinel for requests without an account; the default account
+    # of the identity will be assigned during get_token_oidc
+    if account.external != 'webui':
+        # Make sure the account exists
+        if not account_exists(account, session=session):
+            logging.debug("Account %s does not exist.", account)
+            return None
 
     try:
         stopwatch = Stopwatch()
@@ -514,12 +519,21 @@ def get_token_oidc(
         if oidc_tokens['id_token']['nonce'] != nonce:
             raise CannotAuthenticate("ID token could not be associated with the Rucio OIDC Client"
                                      + " session. This points to possible replay attack !")
-        account = oauth_req_params.account
         # starting to fill dictionary with parameters for token DB row
         jwt_row_dict, extra_dict = {}, {}
         jwt_row_dict['identity'] = oidc_identity_string(oidc_tokens['id_token']['sub'],
                                                         oidc_tokens['id_token']['iss'])
         jwt_row_dict['account'] = oauth_req_params.account
+
+        # the 'webui' sentinel means no account was specified at /auth/oidc;
+        # assign the default account of the now authenticated identity instead
+        if jwt_row_dict['account'].external == 'webui':
+            try:
+                jwt_row_dict['account'] = get_default_account(jwt_row_dict['identity'], IdentityType.OIDC, True, session=session)
+            except IdentityError as error:
+                raise CannotAuthenticate("OIDC identity '%s' is not mapped to any Rucio account."
+                                         % jwt_row_dict['identity']) from error
+        account = jwt_row_dict['account']
 
         # check if given account has the identity registered
         if not exist_identity_account(jwt_row_dict['identity'], IdentityType.OIDC, jwt_row_dict['account'], session=session):

--- a/lib/rucio/gateway/authentication.py
+++ b/lib/rucio/gateway/authentication.py
@@ -66,7 +66,7 @@ def redirect_auth_oidc(
 
 
 def get_auth_oidc(
-    account: str,
+    account: Optional[str],
     vo: str = DEFAULT_VO,
     **kwargs
 ) -> str:
@@ -78,7 +78,8 @@ def get_auth_oidc(
     Returns authorization URL as a string or a redirection url to
     be used in user's browser for authentication.
 
-    :param account: Rucio Account identifier as a string.
+    :param account: Rucio Account identifier as a string, or None if the account
+                    should be derived from the identity during get_token_oidc.
     :param vo: The VO to act on.
     :param auth_scope: space separated list of scope names. Scope parameter
                        defines which user's info the user allows to provide
@@ -97,7 +98,9 @@ def get_auth_oidc(
     """
     # no permission layer for the moment !
 
-    internal_account = InternalAccount(account, vo=vo)
+    # 'webui' is a sentinel for requests without an account; the default account
+    # of the identity will be assigned during get_token_oidc
+    internal_account = InternalAccount(account if account else 'webui', vo=vo)
     with db_session(DatabaseOperationType.WRITE) as session:
         return oidc.get_auth_oidc(internal_account, session=session, **kwargs)
 

--- a/lib/rucio/web/rest/flaskapi/v1/auth.py
+++ b/lib/rucio/web/rest/flaskapi/v1/auth.py
@@ -275,7 +275,8 @@ class OIDC(ErrorHandlingMethodView):
         parameters:
         - name: HTTP_X_RUCIO_ACCOUNT
           in: header
-          description: "Account identifier as a string."
+          description: "Account identifier as a string. If not given, the default
+                        account of the authenticated identity is used."
           schema:
             type: string
         - name: HTTP_X_RUCIO_CLIENT_AUTHORIZE_SCOPE
@@ -321,7 +322,9 @@ class OIDC(ErrorHandlingMethodView):
         headers.set('Pragma', 'no-cache')
 
         vo = extract_vo(request.headers)
-        account = request.environ.get('HTTP_X_RUCIO_ACCOUNT', 'webui')
+        # if no account is given, it will be derived from the identity
+        # once the user has authenticated at the Identity Provider
+        account = request.environ.get('HTTP_X_RUCIO_ACCOUNT', None)
         auth_scope = request.environ.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_SCOPE', "")
         audience = request.environ.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_AUDIENCE', "")
         issuer = request.environ.get('HTTP_X_RUCIO_CLIENT_AUTHORIZE_ISSUER', None)

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -552,6 +552,70 @@ class TestAuthCoreAPIoidc:
 
     @patch('rucio.core.oidc.__get_init_oidc_client')
     @patch('rucio.core.oidc.__get_rucio_oidc_clients')
+    def test_get_access_token_oidc_account_less_polling_success(self, mock_clients, mock_oidc_client):
+        """ OIDC Request for access token without a pre-declared account - success
+
+            Runs the Test:
+
+            - initialising the auth flow with the 'webui' sentinel account,
+              i.e. without specifying a Rucio account up front
+            - filling the right identity into the token (mocking the IdP response)
+            - calling the get_token_oidc core function
+
+            End:
+
+            - checking that the token is in the DB and got assigned
+              to the default account of the identity
+        """
+        mock_oidc_client.side_effect = get_mock_oidc_client
+        sentinel_account = InternalAccount('webui', **self.vo)
+        auth_init_response = self.get_auth_init_and_mock_response(code_response=rndstr(), account=sentinel_account, polling=True, session=self.db_session)
+        oauth_session_row = get_oauth_session_row(sentinel_account, state=auth_init_response['state'], session=self.db_session)
+        assert oauth_session_row
+        # mocking the token response
+        access_token = rndstr()
+        NEW_TOKEN_DICT['access_token'] = access_token
+        NEW_TOKEN_DICT['id_token'] = {'sub': 'knownsub', 'iss': 'https://test_issuer/', 'nonce': auth_init_response['nonce']}
+        token_dict = get_token_oidc(auth_init_response['auth_query_string'], session=self.db_session)
+        assert token_dict
+        assert token_dict['polling'] is True
+        assert 'token' not in token_dict
+        # the token must have been assigned to the default account
+        # of the identity, not to the sentinel account
+        db_token = get_token_row(access_token, session=self.db_session)
+        assert db_token
+        # not asserting == self.accountstring: 'knownsub' is remapped to a fresh
+        # account each setup_method, so the oldest mapping may be an earlier test's
+        assert db_token.account.external != 'webui'
+
+    @patch('rucio.core.oidc.__get_init_oidc_client')
+    @patch('rucio.core.oidc.__get_rucio_oidc_clients')
+    def test_get_access_token_oidc_account_less_unknown_identity(self, mock_clients, mock_oidc_client):
+        """ OIDC Request for access token without a pre-declared account, identity unknown - failure
+
+            Runs the Test:
+
+            - initialising the auth flow with the 'webui' sentinel account
+            - filling an identity unknown to Rucio into the token (mocking the IdP response)
+            - calling the get_token_oidc core function
+
+            End:
+
+            - checking that no token was issued
+        """
+        mock_oidc_client.side_effect = get_mock_oidc_client
+        sentinel_account = InternalAccount('webui', **self.vo)
+        auth_init_response = self.get_auth_init_and_mock_response(code_response=rndstr(), account=sentinel_account, polling=True, session=self.db_session)
+        access_token = rndstr()
+        NEW_TOKEN_DICT['access_token'] = access_token
+        NEW_TOKEN_DICT['id_token'] = {'sub': 'unknownsub', 'iss': 'https://test_issuer/', 'nonce': auth_init_response['nonce']}
+        token_dict = get_token_oidc(auth_init_response['auth_query_string'], session=self.db_session)
+        assert token_dict is None
+        db_token = get_token_row(access_token, session=self.db_session)
+        assert not db_token
+
+    @patch('rucio.core.oidc.__get_init_oidc_client')
+    @patch('rucio.core.oidc.__get_rucio_oidc_clients')
     def test_get_access_token_oidc_cli_fetchcode_success(self, mock_clients, mock_oidc_client):
         """ OIDC Request for access token, client receives fetchcode - success
 


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
Restore the pre-41.0.0 account-less /auth/oidc flow removed by eb3aa6297: requests without X-Rucio-Account skip the account existence check, and get_token_oidc assigns the default account of the authenticated identity.

Tests were assisted by AI

<!-- Required. Summarise WHAT this PR changes. The WHY should already be
     covered by the linked issue and its discussion. A sufficiently detailed
     commit message may be reused here. If a checklist item below does not
     apply to this PR, briefly say why here. -->


## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [X] This PR closes #8689 
      <!-- Every PR requires an issue; if none exists yet, please create one
           first. GitHub links the PR to the issue and closes it on merge.
           In the rare case the issue should remain open after the merge,
           write "Related to #____" here instead and briefly say why in the
           description. -->
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [X] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
