### PR TITLE
fix(Clients): correct subscription parameter annotations

### DIFF
--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -56,7 +56,7 @@ class SubscriptionClient(BaseClient):
             Dictionary of attributes by which the input data should be filtered
             Example: `{'dsn': 'data11_hi*.express_express.*,data11_hi*physics_MinBiasOverlay*', 'account': 'tzero'}`
         replication_rules :
-            Replication rules to be set. Dictionary with keys copies, rse_expression, weight, rse_expression
+            Replication rules to be set. List of dictionaries with keys copies, rse_expression, weight
         comments :
             Comments for the subscription
         lifetime :
@@ -150,7 +150,7 @@ class SubscriptionClient(BaseClient):
         account : Account identifier
         filter_ : Dictionary of attributes by which the input data should be filtered
             Example: `{'dsn': 'data11_hi*.express_express.*,data11_hi*physics_MinBiasOverlay*', 'account': 'tzero'}`
-        replication_rules : Replication rules to be set. Dictionary with keys copies, rse_expression, weight, rse_expression
+        replication_rules : Replication rules to be set. List of dictionaries with keys copies, rse_expression, weight
         comments : Comments for the subscription
         lifetime : Subscription's lifetime (days); False if subscription has no lifetime
         retroactive : Flag to know if the subscription should be applied on previous data

--- a/lib/rucio/client/subscriptionclient.py
+++ b/lib/rucio/client/subscriptionclient.py
@@ -36,7 +36,7 @@ class SubscriptionClient(BaseClient):
             name: str,
             account: str,
             filter_: dict[str, Any],
-            replication_rules: dict[str, Any],
+            replication_rules: list[dict[str, Any]],
             comments: str,
             lifetime: Union[int, Literal[False]],
             retroactive: bool,
@@ -89,7 +89,7 @@ class SubscriptionClient(BaseClient):
     def list_subscriptions(
             self,
             name: Optional[str] = None,
-            account: Optional[dict[str, Any]] = None
+            account: Optional[str] = None
     ) -> Union["Iterator[dict[str, Any]]", list]:
         """
         Returns a dictionary with the subscription information :
@@ -131,10 +131,10 @@ class SubscriptionClient(BaseClient):
 
     def update_subscription(
             self,
-            name,
+            name: str,
             account: Optional[str] = None,
             filter_: Optional[dict[str, Any]] = None,
-            replication_rules: Optional[dict[str, Any]] = None,
+            replication_rules: Optional[list[dict[str, Any]]] = None,
             comments: Optional[str] = None,
             lifetime: Optional[Union[int, Literal[False]]] = None,
             retroactive: Optional[bool] = None,


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description

Closes #8709. Corrects `SubscriptionClient` parameter annotations to match the list and string values accepted by the implementation, and updates the corresponding docstrings. Annotation correctness is additionally enforced by the project's pipeline.

## Checklist

- [x] This PR closes #8709
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]

```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
## AI usage disclosure

AI tools assisted with research, drafting, and preparing this PR; I reproduced, verified, reviewed, understand and stand by all changes (as described in the Rucio AI Policy).
