### PR TITLE
refactor(Clients): Use 'distance' as arg when setting RSE distances instead of 'parameters' dictionary

### DIFF
--- a/lib/rucio/cli/bin_legacy/rucio_admin.py
+++ b/lib/rucio/cli/bin_legacy/rucio_admin.py
@@ -548,8 +548,7 @@ def add_distance_rses(args, client, logger, console, spinner):
 
     Set the distance between two RSEs.
     """
-    params = {'distance': args.distance}
-    client.add_distance(args.source, args.destination, params)
+    client.add_distance(args.source, args.destination, args.distance)
     print('Set distance from %s to %s to %d' % (args.source, args.destination, args.distance))
     return SUCCESS
 
@@ -584,15 +583,9 @@ def update_distance_rses(args, client, logger, console, spinner):
 
     Update the existing distance entry between two RSEs.
     """
-    params = {}
-    if args.distance is not None:
-        params['distance'] = args.distance
-    elif args.ranking is not None:
-        params['distance'] = args.ranking
-    client.update_distance(args.source, args.destination, params)
+    client.update_distance(args.source, args.destination, distance=args.distance)
     print('Update distance information from %s to %s:' % (args.source, args.destination))
-    if params.get('distance') is not None:
-        print("- Distance set to %d" % params['distance'])
+    print("- Distance set to %d" % args.distance)
     return SUCCESS
 
 

--- a/lib/rucio/cli/rse.py
+++ b/lib/rucio/cli/rse.py
@@ -280,27 +280,26 @@ def distance_set(
     bidirectional: bool
 ) -> None:
     """Create a link from SOURCE-RSE to DESTINATION-RSE with a distance"""
-    params = {'distance': distance}
 
     src_exists = bool(ctx.obj.client.get_distance(source_rse, destination_rse))
     dest_exists = bool(ctx.obj.client.get_distance(destination_rse, source_rse))
 
     if bidirectional:
         if src_exists and dest_exists:
-            ctx.obj.client.update_distance(source_rse, destination_rse, params, True)
+            ctx.obj.client.update_distance(source_rse, destination_rse, distance, True)
         elif src_exists:
-            ctx.obj.client.add_distance(destination_rse, source_rse, parameters=params, bidirectional=False)
-            ctx.obj.client.update_distance(source_rse, destination_rse, params, False)
+            ctx.obj.client.add_distance(destination_rse, source_rse, distance=distance, bidirectional=False)
+            ctx.obj.client.update_distance(source_rse, destination_rse, distance, False)
         elif dest_exists:
-            ctx.obj.client.add_distance(source_rse, destination_rse, parameters=params, bidirectional=False)
-            ctx.obj.client.update_distance(destination_rse, source_rse, params, False)
+            ctx.obj.client.add_distance(source_rse, destination_rse, distance=distance, bidirectional=False)
+            ctx.obj.client.update_distance(destination_rse, source_rse, distance, False)
         else:
-            ctx.obj.client.add_distance(source_rse, destination_rse, parameters=params, bidirectional=True)
+            ctx.obj.client.add_distance(source_rse, destination_rse, distance=distance, bidirectional=True)
     else:
         if src_exists:
-            ctx.obj.client.update_distance(source_rse, destination_rse, params, False)
+            ctx.obj.client.update_distance(source_rse, destination_rse, distance, False)
         else:
-            ctx.obj.client.add_distance(source_rse, destination_rse, parameters=params, bidirectional=False)
+            ctx.obj.client.add_distance(source_rse, destination_rse, distance=distance, bidirectional=False)
 
     if bidirectional:
         print(f"Set distances between {source_rse} <-> {destination_rse} to {distance}")

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -1388,7 +1388,7 @@ class RSEClient(BaseClient):
         self,
         source: str,
         destination: str,
-        parameters: dict[str, int],
+        distance: int,
         bidirectional: bool = False
     ) -> Literal[True]:
         """
@@ -1432,7 +1432,10 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        parameters["bidirectional"] = bidirectional
+        parameters = {
+            "distance": distance,
+            "bidirectional": bidirectional
+        }
         r = self._send_request(url, method=HTTPMethod.POST, data=dumps(parameters))
         if r.status_code == codes.created:
             return True
@@ -1445,7 +1448,7 @@ class RSEClient(BaseClient):
         self,
         source: str,
         destination: str,
-        parameters: dict[str, int],
+        distance: int,
         bidirectional: bool = False
     ) -> Literal[True]:
         """
@@ -1486,7 +1489,10 @@ class RSEClient(BaseClient):
         path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
-        parameters["bidirectional"] = bidirectional
+        parameters = {
+            "distance": distance,
+            "bidirectional": bidirectional
+        }
         r = self._send_request(url, method=HTTPMethod.PUT, data=dumps(parameters))
         if r.status_code == codes.ok:
             return True

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -1403,8 +1403,8 @@ class RSEClient(BaseClient):
             The source RSE name.
         destination :
             The destination RSE name.
-        parameters :
-            Dicionary in the format {"distance": int}.
+        distance :
+            Distance between RSEs.
         bidirectional:
             If True, also adds the distance from dest to src.
 
@@ -1426,7 +1426,7 @@ class RSEClient(BaseClient):
             ```python
             from rucio.client.client import Client
             rse_client = Client()
-            rse_client.add_distance(source="RSE1", destination="RSE2", parameters={"distance": 10})
+            rse_client.add_distance(source="RSE1", destination="RSE2", distance=10)
             ```
         """
         path = [self.RSE_BASEURL, source, 'distances', destination]
@@ -1462,8 +1462,8 @@ class RSEClient(BaseClient):
             The source RSE.
         destination :
             The destination RSE.
-        parameters :
-            Updated distance in the form {"distance": int}.
+        distance :
+            New distance between RSEs.
         bidirectional :
             If True, also updates the distance from dest to src.
 
@@ -1478,8 +1478,8 @@ class RSEClient(BaseClient):
             ```python
             from rucio.client.client import Client
             rse_client = Client()
-            rse_client.add_distance(source="RSE1", destination="RSE2", parameters={"distance": 10})
-            rse_client.update_distance(source="RSE1", destination="RSE2", parameters={"distance": 20})  # Update the distance to 20
+            rse_client.add_distance(source="RSE1", destination="RSE2", distance=10)
+            rse_client.update_distance(source="RSE1", destination="RSE2", distance=20)  # Update the distance to 20
             ```
 
         See Also

--- a/tests/test_bin_rucio.py
+++ b/tests/test_bin_rucio.py
@@ -273,7 +273,7 @@ def test_rse_delete_distance(rse_factory, rucio_client):
     rse_name_2, _ = rse_factory.make_posix_rse()
 
     # add distance between the RSEs
-    rucio_client.add_distance(rse_name_1, rse_name_2, parameters={'distance': 1, 'ranking': 1})
+    rucio_client.add_distance(rse_name_1, rse_name_2, distance=1)
 
     # delete distance OK
     cmd = f'rucio-admin rse delete-distance {rse_name_1} {rse_name_2}'

--- a/tests/test_rse.py
+++ b/tests/test_rse.py
@@ -1559,14 +1559,14 @@ class TestRSEClient:
         rucio_client.add_rse(destination)
         rucio_client.add_distance(source=source,
                                   destination=destination,
-                                  parameters={'distance': 1})
+                                  distance=1)
 
         for distance in rucio_client.get_distance(source=source, destination=destination):
             assert distance['distance'] == 1
 
         rucio_client.update_distance(source=source,
                                      destination=destination,
-                                     parameters={'distance': 0})
+                                     distance=0)
 
     @pytest.mark.dirty
     def test_add_distance_bidirectional(self, rucio_client):
@@ -1576,7 +1576,7 @@ class TestRSEClient:
         rucio_client.add_rse(destination)
         rucio_client.add_distance(source=source,
                                   destination=destination,
-                                  parameters={'distance': 1},
+                                  distance=1,
                                   bidirectional=True)
 
         for distance in rucio_client.get_distance(source=source, destination=destination):
@@ -1587,7 +1587,7 @@ class TestRSEClient:
 
         rucio_client.update_distance(source=source,
                                      destination=destination,
-                                     parameters={'distance': 5},
+                                     distance=5,
                                      bidirectional=True)
 
         assert rucio_client.get_distance(source=source, destination=destination)[0]['distance'] == 5


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
Replaces the `client.add_distance` and `update_distance` `parameters` argument with `distance`. No new tests are needed, this is a refactor change. 


## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [x] This PR closes #8521 
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
