### PR TITLE
feat(Clients): add rucio rse distance list command

### DIFF
--- a/lib/rucio/cli/rse.py
+++ b/lib/rucio/cli/rse.py
@@ -18,6 +18,7 @@ import click
 from rich.padding import Padding
 from rich.text import Text
 from rich.tree import Tree
+from tabulate import tabulate
 
 from rucio.cli.utils import RichCLITheme, RichUtils
 from rucio.common.exception import InputValidationError
@@ -254,6 +255,27 @@ def distance_show(ctx: click.Context, source_rse: str, destination_rse: str) -> 
             print(f'Distance information from {source_rse} to {destination_rse}: distance={distance}')
         else:
             print(f"No distance set from {source_rse} to {destination_rse}")
+
+
+@distance.command("list")
+@click.argument("source-rse")
+@click.pass_context
+def distance_list(ctx: click.Context, source_rse: str) -> None:
+    """Display all destinations and distances for SOURCE-RSE"""
+    distances = ctx.obj.client.get_distance(source_rse)
+    if not distances:
+        print(f"No distances found for source RSE '{source_rse}'.")
+        return
+    table_rows = [[row['dest_rse'], row['distance']] for row in distances]
+    if ctx.obj.use_rich:
+        table = RichUtils.generate_table(
+            table_rows,
+            headers=['DESTINATION', 'DISTANCE'],
+            col_alignments=['left', 'right']
+        )
+        RichUtils.print_output(table, console=ctx.obj.console, no_pager=ctx.obj.no_pager)
+    else:
+        print(tabulate(table_rows, tablefmt=ctx.obj.tablefmt, headers=['DESTINATION', 'DISTANCE']))
 
 
 @distance.command("set")

--- a/lib/rucio/client/rseclient.py
+++ b/lib/rucio/client/rseclient.py
@@ -1504,17 +1504,17 @@ class RSEClient(BaseClient):
     def get_distance(
             self,
             source: str,
-            destination: str
+            destination: Optional[str] = None
     ) -> list[dict[str, Union[str, int]]]:
         """
         Get distances between rses.
 
-        Param
+        Parameters
         ----------
         source :
             The source RSE.
         destination :
-            The destination RSE.
+            The destination RSE. If None, returns all distances from source RSE.
 
         Returns
         -------
@@ -1530,7 +1530,10 @@ class RSEClient(BaseClient):
             ** ranking ** [int]: Legacy name for distance, same value as distance.
 
         """
-        path = [self.RSE_BASEURL, source, 'distances', destination]
+        if destination is None:
+            path = [self.RSE_BASEURL, source, 'distances']
+        else:
+            path = [self.RSE_BASEURL, source, 'distances', destination]
         path = '/'.join(path)
         url = build_url(choice(self.list_hosts), path=path)
         r = self._send_request(url, method=HTTPMethod.GET)

--- a/lib/rucio/gateway/rse.py
+++ b/lib/rucio/gateway/rse.py
@@ -520,21 +520,24 @@ def update_distance(
                                                 distance=distance, bidirectional=bidirectional, session=session)
 
 
-def get_distance(source, destination, issuer, vo=DEFAULT_VO):
+def get_distance(source: str, issuer: str, destination: "Optional[str]" = None, vo: str = DEFAULT_VO):
     """
-    Get distances between rses.
+    Get distances between RSEs.
 
     :param source: The source RSE.
-    :param destination: The destination RSE.
+    :param destination: The destination RSE. If None, return all distances from source.
     :param issuer: The issuer account.
     :param vo: The VO to act on.
 
-    :returns distance: List of dictionaries.
+    :returns distance: List of dictionaries with distance information.
     """
     with db_session(DatabaseOperationType.READ) as session:
-        distances = distance_module.get_distances(src_rse_id=rse_module.get_rse_id(source, vo=vo, session=session),
-                                                  dest_rse_id=rse_module.get_rse_id(destination, vo=vo, session=session),
-                                                  session=session)
+        kwargs = {
+            'src_rse_id': rse_module.get_rse_id(source, vo=vo, session=session)
+        }
+        if destination is not None:
+            kwargs['dest_rse_id'] = rse_module.get_rse_id(destination, vo=vo, session=session)
+        distances = distance_module.get_distances(session=session, **kwargs)
 
         return [gateway_update_return_dict(d, session=session) for d in distances]
 

--- a/lib/rucio/web/rest/flaskapi/v1/rses.py
+++ b/lib/rucio/web/rest/flaskapi/v1/rses.py
@@ -1827,7 +1827,7 @@ class Distance(ErrorHandlingMethodView):
     """ Create/Update and read distances between RSEs. """
 
     @check_accept_header_wrapper_flask(['application/json'])
-    def get(self, source, destination):
+    def get(self, source, destination=None):
         """
         ---
         summary: Get Rse Distances
@@ -2232,6 +2232,8 @@ def blueprint() -> AuthenticatedBlueprint:
     distance_view = Distance.as_view('distance')
     bp.add_url_rule('/<source>/distances/<destination>', view_func=distance_view,
                     methods=[HTTPMethod.GET.value, HTTPMethod.POST.value, HTTPMethod.PUT.value, HTTPMethod.DELETE.value])
+    bp.add_url_rule('/<source>/distances', view_func=distance_view,
+                    methods=[HTTPMethod.GET.value])
     protocol_view = Protocol.as_view('protocol')
     bp.add_url_rule('/<rse>/protocols/<scheme>/<hostname>/<port>', view_func=protocol_view,
                     methods=[HTTPMethod.DELETE.value, HTTPMethod.PUT.value])

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -760,9 +760,9 @@ def test_rse_protocol(file_config_mock):
 
 
 @with_each_cli_renderer
-def test_rse_distance(file_config_mock):
-    source_rse = "MOCK"
-    dest_rse = "MOCK2"
+def test_rse_distance(file_config_mock, rse_factory):
+    source_rse, _ = rse_factory.make_posix_rse()
+    dest_rse, _ = rse_factory.make_posix_rse()
 
     cmd = f"rucio rse distance unset {source_rse} {dest_rse}"
     exitcode, out, err = execute(cmd)
@@ -798,6 +798,32 @@ def test_rse_distance(file_config_mock):
     exitcode, out, err = execute(cmd)
     assert exitcode == 0
     assert "ERROR" not in err
+
+
+@with_each_cli_renderer
+def test_rse_distance_list(file_config_mock, rse_factory):
+    source_rse, _ = rse_factory.make_posix_rse()
+    dest_rse, _ = rse_factory.make_posix_rse()
+    distance = 3
+
+    cmd = f"rucio rse distance set {source_rse} {dest_rse} --distance {distance}"
+    exitcode, out, err = execute(cmd)
+    assert exitcode == 0
+    assert "ERROR" not in err
+
+    cmd = f"rucio rse distance list {source_rse}"
+    exitcode, out, err = execute(cmd)
+    assert exitcode == 0
+    assert "ERROR" not in err
+    assert dest_rse in out
+    assert 'DESTINATION' in out
+    assert 'DISTANCE' in out
+    assert str(distance) in out
+
+    # The pipe check verifies tabulate (psql) output from the non-Rich path, since Rich
+    # uses box-drawing characters instead of '|'.
+    if file_config_mock.get('experimental', 'cli') == 'tabulate':
+        assert '|' in out
 
 
 @with_each_cli_renderer

--- a/tests/test_rse.py
+++ b/tests/test_rse.py
@@ -1600,6 +1600,25 @@ class TestRSEClient:
         assert len(rucio_client.get_distance(source=source, destination=destination)) == 0
         assert len(rucio_client.get_distance(source=destination, destination=source)) == 0
 
+    @pytest.mark.dirty
+    def test_get_distance_without_destination(self, rucio_client, rse_factory):
+        """ RSE (CLIENTS): List RSE distance from source."""
+        source, _ = rse_factory.make_posix_rse()
+        dest1, _ = rse_factory.make_posix_rse()
+        dest2, _ = rse_factory.make_posix_rse()
+        rucio_client.add_distance(source=source, destination=dest1, distance=1)
+        rucio_client.add_distance(source=source, destination=dest2, distance=2)
+
+        distances = rucio_client.get_distance(source=source)
+        assert len(distances) == 2
+        dest_distances = {d['dest_rse']: d['distance'] for d in distances}
+        assert dest_distances[dest1] == 1
+        assert dest_distances[dest2] == 2
+
+        pair = rucio_client.get_distance(source=source, destination=dest1)
+        assert len(pair) == 1
+        assert pair[0]['distance'] == 1
+
     def test_get_rse_protocols_includes_verify_checksum(self, vo):
         """ RSE (CORE): Test validate_checksum in RSEs info"""
         rse = rse_name_generator()


### PR DESCRIPTION
Closes: #8630

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description

Add `rucio rse distance list source-rse` The command prints a DESTINATION /
DISTANCE table for matching RSE pairs.

Make `destination` optional in the client, REST, and gateway `get_distance`
paths so callers can list all distances from a source RSE via
`GET /rses/<source>/distances`. Pair lookup and existing `distance show`,
`set`, and `unset` behaviour are unchanged.

## Checklist

- [x] This PR closes #8630
- [x] Tests cover the change, or no tests are needed (explain why in the description)
      — Added `TestRSEClient::test_get_distance_without_destination` and
      `test_rse_distance_list`; existing `test_add_distance` and
      `test_rse_distance` cover regression.
- [ ] Documentation is updated (link the docs PR here), or no documentation change is needed
      — CLI `--help` on `distance list` is sufficient; no separate docs change.
- [ ] Database migrations are included, or the change touches no database schema
      — Uses existing distance tables; no schema change.
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits
      — `distance show` and pair `get_distance(source, destination)` unchanged.

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Quality**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]