### PR TITLE
Transfers: Return latest request history by DID #8722

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -73,6 +73,7 @@ Individual contributors to the source code
 - Riccardo Di Maio <riccardodimaio11@gmail.com>, 2024-2025
 - Karanjot Singh <karanjot.singh@cern.ch>, 2025-2026
 - Vlad Galuska <vlad.galuska21@gmail.com>, 2026
+- Divyanshu Mishra <23F2001496@ds.study.iitm.ac.in>, 2026
 
 Organisations employing contributors
 ------------------------------------
@@ -92,6 +93,7 @@ Organisations employing contributors
 - University of Edinburgh (UK)
 - Birla Institute of Technology, Mesra (India)
 - Indian Institute of Technology, Kharagpur (India)
+- Indian Institute of Technology Madras (India)
 - Stockholm University, Stockholm (Sweden)
 - Dwarkadas J. Sanghvi College of Engineering (India)
 - Science and Technology Facilities Council (UK)

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -1192,7 +1192,7 @@ def get_request_history_by_did(
     session: "Session"
 ) -> dict[str, Any]:
     """
-    Retrieve a historical request by its DID for a destination RSE.
+    Retrieve the latest historical request by its DID for a destination RSE.
 
     :param scope:          The scope of the data identifier.
     :param name:           The name of the data identifier.
@@ -1214,6 +1214,11 @@ def get_request_history_by_did(
             stmt = stmt.where(
                 models.RequestHistory.request_type == request_type
             )
+
+        stmt = stmt.order_by(
+            models.RequestHistory.created_at.desc(),
+            models.RequestHistory.retry_count.desc(),
+        ).limit(1)
 
         tmp = session.execute(stmt).scalar()
         if not tmp:

--- a/lib/rucio/gateway/request.py
+++ b/lib/rucio/gateway/request.py
@@ -73,7 +73,7 @@ def get_request_history_by_did(
     vo: str = DEFAULT_VO,
 ) -> dict[str, Any]:
     """
-    Retrieve a historical request by its DID for a destination RSE.
+    Retrieve the latest historical request by its DID for a destination RSE.
 
     :param scope: The scope of the data identifier as a string.
     :param name: The name of the data identifier as a string.

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Union
 
 import pytest
@@ -23,7 +23,7 @@ from rucio.common.constants import RseAttr
 from rucio.common.utils import generate_uuid, parse_response
 from rucio.core.distance import add_distance
 from rucio.core.replica import add_replica
-from rucio.core.request import TransferStatsManager, get_request_by_did, list_requests, list_requests_history, queue_requests, set_transfer_limit
+from rucio.core.request import TransferStatsManager, get_request_by_did, get_request_history_by_did, list_requests, list_requests_history, queue_requests, requeue_and_archive, set_transfer_limit, transition_request_state
 from rucio.core.rse import add_rse_attribute
 from rucio.db.sqla import constants, models
 from rucio.db.sqla.constants import RequestState, RequestType
@@ -123,6 +123,106 @@ def test_queue_requests_state(vo, file_config_mock, rse_factory, mock_scope, roo
     assert request['state'] == target_state
     request = get_request_by_did(mock_scope, name3, dest_rse_id2, session=db_session)
     assert request['state'] == target_state
+
+
+@pytest.mark.parametrize('newer_first', [False, True])
+def test_get_request_history_by_did_returns_latest(newer_first, rse_factory, mock_scope, db_session):
+    """REQUEST (CORE): Retrieve the most recent matching request history row."""
+    _, source_rse_id = rse_factory.make_mock_rse(session=db_session)
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = generate_uuid()
+    now = datetime.utcnow()
+    common = {
+        'request_type': RequestType.TRANSFER,
+        'scope': mock_scope,
+        'name': name,
+        'dest_rse_id': dest_rse_id,
+        'source_rse_id': source_rse_id,
+        'state': RequestState.FAILED,
+    }
+    latest_id = generate_uuid()
+    rows = [
+        models.RequestHistory(
+            id=generate_uuid(),
+            retry_count=0,
+            created_at=now - timedelta(minutes=1),
+            **common,
+        ),
+        models.RequestHistory(
+            id=latest_id,
+            retry_count=3,
+            created_at=now,
+            **common,
+        ),
+    ]
+    if newer_first:
+        rows.reverse()
+    for row in rows:
+        row.save(session=db_session)
+
+    request = get_request_history_by_did(mock_scope, name, dest_rse_id, session=db_session)
+
+    assert request['id'] == latest_id
+    assert request['retry_count'] == 3
+
+
+def test_get_request_history_by_did_uses_retry_count_as_tiebreaker(rse_factory, mock_scope, db_session):
+    """REQUEST (CORE): Break identical creation timestamp ties by retry count."""
+    _, source_rse_id = rse_factory.make_mock_rse(session=db_session)
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = generate_uuid()
+    created_at = datetime.utcnow()
+    common = {
+        'request_type': RequestType.TRANSFER,
+        'scope': mock_scope,
+        'name': name,
+        'dest_rse_id': dest_rse_id,
+        'source_rse_id': source_rse_id,
+        'state': RequestState.FAILED,
+        'created_at': created_at,
+    }
+    latest_id = generate_uuid()
+    models.RequestHistory(id=generate_uuid(), retry_count=1, **common).save(session=db_session)
+    models.RequestHistory(id=latest_id, retry_count=3, **common).save(session=db_session)
+
+    request = get_request_history_by_did(mock_scope, name, dest_rse_id, session=db_session)
+
+    assert request['id'] == latest_id
+    assert request['retry_count'] == 3
+
+
+def test_get_request_history_by_did_returns_latest_real_workflow(rse_factory, mock_scope, root_account, db_session):
+    """REQUEST (CORE): Retrieve the latest attempt after retries are archived."""
+    _, source_rse_id = rse_factory.make_mock_rse(session=db_session)
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = generate_uuid()
+    add_replica(source_rse_id, mock_scope, name, 1, root_account, session=db_session)
+
+    queue_requests([{
+        'dest_rse_id': dest_rse_id,
+        'src_rse_id': source_rse_id,
+        'request_type': RequestType.TRANSFER,
+        'request_id': generate_uuid(),
+        'name': name,
+        'scope': mock_scope,
+        'rule_id': generate_uuid(),
+        'retry_count': 0,
+        'attributes': {
+            'activity': 'User Subscription',
+            'bytes': 1,
+            'md5': '',
+            'adler32': '',
+        },
+    }], session=db_session)
+
+    for _ in range(4):
+        request = get_request_by_did(mock_scope, name, dest_rse_id, session=db_session)
+        transition_request_state(request['id'], state=RequestState.FAILED, session=db_session)
+        requeue_and_archive({'request_id': request['id']}, source_ranking_update=False, session=db_session)
+
+    request = get_request_history_by_did(mock_scope, name, dest_rse_id, session=db_session)
+
+    assert request['retry_count'] == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description

Orders matching `RequestHistory` rows by descending creation time before selecting one, so `get_request_history_by_did` consistently returns the latest retry instead of a database-dependent row. The core and gateway docstrings now state this contract, and a deterministic regression test inserts two matching histories and verifies the newest retry is returned.

No user-facing documentation or database migration is needed: this corrects an existing retrieval contract without changing the schema or public signature.

## Checklist

- [x] This PR closes #8722
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described

## Validation

- `ruff check lib/rucio/core/request.py lib/rucio/gateway/request.py tests/test_request.py`
- Linux / Python 3.13 / SQLite: focused regression test (`1 passed`)
- Linux / Python 3.13 / SQLite: affected core request tests (`5 passed`)

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template</summary>

```text
- **Confidence in review**: High / Medium / Low
- **Confidence in scope**: High / Medium / Low
- **Quality**: Agree
- **Security**: Agree / Disagree
- **Backwards compatibility**: Agree / Disagree
- **Testing**: Agree
- **Documentation**: Agree

# Notes for merger
```
</details>