### PR TITLE
feat(Clients): add --state filter to rucio rule list

### DIFF
--- a/lib/rucio/cli/rule.py
+++ b/lib/rucio/cli/rule.py
@@ -373,10 +373,20 @@ def update(
 @click.option("--csv", is_flag=True, default=False, help="Comma Separated Value output")
 @click.option("--file", help="Filter by file")
 @click.option("--account", help="Filter by account")
+@click.option("--state", type=click.Choice(["STUCK", "OK", "REPLICATING", "SUSPENDED", "WAITING_APPROVAL", "INJECT"]), help="Filter by rule state (only with --account)")
 @click.option("--subscription", help="Filter by subscription name")
 @click.pass_context
-def list_(ctx: click.Context, did: Optional[str], traverse: bool, csv: bool, file: Optional[str], account: Optional[str], subscription: Optional[str]) -> None:
-    """List all rules impacting a given DID"""
+def list_(
+    ctx: click.Context,
+    did: Optional[str],
+    traverse: bool,
+    csv: bool,
+    file: Optional[str],
+    account: Optional[str],
+    state: Optional[Literal["STUCK", "OK", "REPLICATING", "SUSPENDED", "WAITING_APPROVAL", "INJECT"]],
+    subscription: Optional[str],
+) -> None:
+    """List rules by DID, file, account or subscription."""
     # Done here to raise error==2
     if not (did or file or account or subscription):
         raise InputValidationError("At least one option has to be given. Use -h to list the options.")
@@ -416,7 +426,10 @@ def list_(ctx: click.Context, did: Optional[str], traverse: bool, csv: bool, fil
                 if rules:
                     print('No rules found, listing rules for parents')
     elif account:
-        rules = ctx.obj.client.list_account_rules(account=account)
+        if state:
+            rules = ctx.obj.client.list_replication_rules({"account": account, "state": state})
+        else:
+            rules = ctx.obj.client.list_account_rules(account=account)
     elif subscription:
         if account is None:
             account = ctx.obj.client.account

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -972,7 +972,7 @@ def list_rules(
 
     :param filters: dictionary of attributes by which the results should be filtered.
     :param session: The database session in use.
-    :raises:        RucioException
+    :raises:        InputValidationError, RucioException
     """
 
     stmt = select(
@@ -1007,12 +1007,13 @@ def list_rules(
                 continue
             elif key == 'state':
                 if isinstance(value, str):
-                    value = RuleState(value)
-                else:
                     try:
                         value = RuleState[value]
-                    except ValueError:
-                        pass
+                    except KeyError:
+                        try:
+                            value = RuleState(value)
+                        except ValueError as exc:
+                            raise InputValidationError('Invalid rule state: %s' % value) from exc
             elif key == 'did_type' and isinstance(value, str):
                 value = DIDType(value)
             elif key == 'grouping' and isinstance(value, str):

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -880,6 +880,89 @@ def test_rule(rucio_client, mock_scope, file_config_mock):
     assert exitcode == 0
     assert rule_id in out
 
+    stuck_name = generate_uuid()
+    rucio_client.add_replica(rse=mock_rse, scope=scope, name=stuck_name, bytes_=4, adler32="deadbeef")
+    ok_name = generate_uuid()
+    rucio_client.add_replica(rse=mock_rse, scope=scope, name=ok_name, bytes_=4, adler32="deadbeef")
+    replicating_name = generate_uuid()
+    rucio_client.add_replica(rse=mock_rse, scope=scope, name=replicating_name, bytes_=4, adler32="deadbeef")
+    suspended_name = generate_uuid()
+    rucio_client.add_replica(rse=mock_rse, scope=scope, name=suspended_name, bytes_=4, adler32="deadbeef")
+    waiting_approval_name = generate_uuid()
+    rucio_client.add_replica(rse=mock_rse, scope=scope, name=waiting_approval_name, bytes_=4, adler32="deadbeef")
+    inject_name = generate_uuid()
+    rucio_client.add_replica(rse=mock_rse, scope=scope, name=inject_name, bytes_=4, adler32="deadbeef")
+
+    rule_ids = rucio_client.add_replication_rule(
+        dids=[
+            {"scope": scope, "name": stuck_name},
+            {"scope": scope, "name": replicating_name},
+            {"scope": scope, "name": suspended_name},
+        ],
+        copies=1,
+        rse_expression=rule_rse,
+    )
+    waiting_approval_rule_id = rucio_client.add_replication_rule(
+        dids=[
+            {"scope": scope, "name": waiting_approval_name},
+        ],
+        copies=1,
+        rse_expression=rule_rse,
+        ask_approval=True
+    )[0]
+    inject_rule_id = rucio_client.add_replication_rule(
+        dids=[
+            {"scope": scope, "name": inject_name},
+        ],
+        copies=1,
+        rse_expression=rule_rse,
+        asynchronous=True
+    )[0]
+
+    ok_rule_id = rucio_client.add_replication_rule(
+        dids=[{"scope": scope, "name": ok_name}],
+        copies=1,
+        rse_expression=mock_rse
+    )[0]
+
+    stuck_rule_id = rule_ids[0]
+    replicating_rule_id = rule_ids[1]
+    suspended_rule_id = rule_ids[2]
+    rucio_client.update_replication_rule(stuck_rule_id, options={"state": "STUCK"})
+    rucio_client.update_replication_rule(suspended_rule_id, options={"state": "SUSPENDED"})
+
+    assert rucio_client.get_replication_rule(stuck_rule_id)["state"] == "STUCK"
+    assert rucio_client.get_replication_rule(ok_rule_id)["state"] == "OK"
+    assert rucio_client.get_replication_rule(replicating_rule_id)["state"] == "REPLICATING"
+    assert rucio_client.get_replication_rule(suspended_rule_id)["state"] == "SUSPENDED"
+    assert rucio_client.get_replication_rule(waiting_approval_rule_id)["state"] == "WAITING_APPROVAL"
+    assert rucio_client.get_replication_rule(inject_rule_id)["state"] == "INJECT"
+
+    state_rules = {
+        "STUCK": stuck_rule_id,
+        "OK": ok_rule_id,
+        "REPLICATING": replicating_rule_id,
+        "SUSPENDED": suspended_rule_id,
+        "WAITING_APPROVAL": waiting_approval_rule_id,
+        "INJECT": inject_rule_id,
+    }
+
+    for state, state_rule_id in state_rules.items():
+        cmd = f"rucio rule list --account {rucio_client.account} --state {state}"
+        exitcode, out, err = execute(cmd)
+        assert exitcode == 0
+        assert "ERROR" not in err
+        assert state_rule_id in out
+        for other_id in state_rules.values():
+            if other_id != state_rule_id:
+                assert other_id not in out
+
+    cmd = f"rucio rule list --account {rucio_client.account} --state FOO"
+    exitcode, out, err = execute(cmd)
+    assert exitcode != 0
+    assert "not one of" in err
+    assert "FOO" in err
+
     cmd = "rucio rule list"
     exitcode, out, err = execute(cmd)
     assert exitcode != 0


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
Add a --state option to rucio rule list so rules can be filtered by state when listing by account, e.g.:

`rucio rule list --account root --state STUCK`
When --account and --state are both provided, the CLI uses the existing list_replication_rules client API with account and state filters. Without --state, behavior is unchanged (list_account_rules).

Closes #8120.

## Changes
**CLI (lib/rucio/cli/rule.py)**

Added --state to rucio rule list (documented values: STUCK, OK, REPLICATING).
When --account and --state are set, calls list_replication_rules({"account": account, "state": state.upper()}).
The CLI passes human-readable state names (e.g. STUCK), consistent with rucio rule update --stuck and the help text. No single-letter codes are exposed to users.

**Core (lib/rucio/core/rule.py)**

Fixed state filtering in `list_rules()` so string filters resolve by enum name first (`RuleState[value]`), then fall back to enum value (`RuleState(value)`). Invalid strings raise `RucioException`.

Why this core change was needed: `RuleState` stores single-character DB values (`STUCK = 'S'`, `OK = 'O'`, `REPLICATING = 'R'`). The old code used `RuleState(value)`, which only accepts those one-character values. Callers (CLI, REST `GET /rules/?state=STUCK`) pass full names, which caused filtering to fail. Lookup by enum name matches how `update_rule` already handles state and what users expect from the CLI.

The fallback keeps existing callers that already filter by the DB character (`S`, `O`, `R`) working.

The client layer is unchanged beyond using the existing `list_replication_rules` API; the fix belongs in core so REST and CLI callers both work with full state names.

**Tests (tests/test_cli_client_structure.py)**

Extended test_rule to cover --state STUCK and --state OK when listing by account.
Why a separate rule is used in the test: The test needs a rule in STUCK state to verify the filter, but test_rule continues to use the original rule_id for later steps (move, update, lock, lifetime, suspend, etc.). Marking that main rule as STUCK would interfere with those steps. A dedicated rule is created and marked STUCK only for the state-filter assertions, so the rest of the test stays unchanged.
## Checklist

- [x] This PR closes #8120 
- [x] Tests cover the change, or no tests are needed (explain why in the description)
--- Integration tests in `test_cli_client_structure.py`: a rule is set to STUCK via rucio rule update --stuck, then --state STUCK includes it and --state OK excludes it.
- [ ] Documentation is updated (link the docs PR here), or no documentation change is needed
- [ ] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Additional notes for reviewer

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
