### PR TITLE
fix(Testing): Point trace config to the ActiveMQ STOMP port

### DIFF
--- a/etc/docker/test/extra/rucio_autotests_common.cfg
+++ b/etc/docker/test/extra/rucio_autotests_common.cfg
@@ -81,14 +81,14 @@ special_accounts = panda, tier0
 [trace]
 tracedir = /var/log/rucio/trace
 brokers=activemq
-port=61013
+port=61613
 username = username
 password = password
 topic = /topic/rucio.tracer
 
 [tracer-kronos]
 brokers=activemq
-port=61013
+port=61613
 ssl_key_file = /opt/rucio/etc/usercert.key.pem
 ssl_cert_file = /opt/rucio/etc/usercert.pem
 queue = /queue/Consumer.kronos.rucio.tracer

--- a/etc/docker/test/extra/rucio_default.cfg
+++ b/etc/docker/test/extra/rucio_default.cfg
@@ -93,7 +93,7 @@ special_accounts = panda, tier0
 [trace]
 tracedir = /var/log/rucio/trace
 brokers=activemq
-port=61013
+port=61613
 username = username
 password = password
 topic = /topic/rucio.tracer
@@ -101,14 +101,14 @@ topic = /topic/rucio.tracer
 [nongrid-trace]
 tracedir = /var/log/rucio/trace
 brokers=activemq
-port=61013
+port=61613
 username = username
 password = password
 topic = /topic/rucio.tracer
 
 [tracer-kronos]
 brokers=activemq
-port=61013
+port=61613
 ssl_key_file = /opt/rucio/etc/userkey.pem
 ssl_cert_file = /opt/rucio/etc/usercert.pem
 queue = /queue/Consumer.kronos.rucio.tracer


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
The `[trace]` section used port `61013`, but ActiveMQ only exposes STOMP on `61613`. Since `POST /traces/` connects to the broker synchronously, every upload and download waited on a connection attempt against a dead port. `test_overlapping_containers_and_wildcards` emits 54 traces and dropped from 33.7s to 10.0s locally, with broker failures going from 58 to 0. 

Also fixes the same stale port in `[nongrid-trace]` and `[tracer-kronos]`. 

## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [x] This PR closes #8723
      <!-- Every PR requires an issue; if none exists yet, please create one
           first. GitHub links the PR to the issue and closes it on merge.
           In the rare case the issue should remain open after the merge,
           write "Related to #____" here instead and briefly say why in the
           description. -->
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
