### PR TITLE
fix(Testing): Use non-empty file for upload in test_lifetime_exception

### DIFF
--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -543,12 +543,13 @@ def test_lifetime_exception(rucio_client, mock_scope, file_config_mock):
     rucio_client.set_config_option("cli", "endpoints_add", "lifetime-exception")
 
     input_file = tempfile.NamedTemporaryFile()
-    mock_did = tempfile.NamedTemporaryFile()
+    # Upload file needs to be non-empty to avoid UploadClient treating it as a storage race and retrying
+    mock_did = file_generator()
     mock_rse = "MOCK-POSIX"
     upload_client = UploadClient(rucio_client)
 
     item: FileToUploadDict = {
-        'path': mock_did.name,
+        'path': mock_did,
         'rse': mock_rse,
         'did_scope': mock_scope.external,
     }
@@ -556,7 +557,7 @@ def test_lifetime_exception(rucio_client, mock_scope, file_config_mock):
     upload_client.upload(items=[item])
 
     with open(input_file.name, "w") as f:
-        f.write(f"{mock_scope}:{mock_did.name.split('/')[-1]}")
+        f.write(f"{mock_scope}:{mock_did.split('/')[-1]}")
 
     cmd = f"rucio lifetime-exception add -f {input_file.name} --reason mock_test -x 2100-12-30"
     exitcode, _, err = execute(cmd)

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -536,7 +536,7 @@ def test_upload_download(file_config_mock):
 
 @pytest.mark.noparallel(reason='Modifies the configuration file')
 @with_each_cli_renderer
-def test_lifetime_exception(rucio_client, mock_scope, file_config_mock):
+def test_lifetime_exception(rucio_client, mock_scope, file_config_mock, file_factory):
     from rucio.client.uploadclient import UploadClient
 
     # Add the lifetime-exception endpoint
@@ -544,7 +544,7 @@ def test_lifetime_exception(rucio_client, mock_scope, file_config_mock):
 
     input_file = tempfile.NamedTemporaryFile()
     # Upload file needs to be non-empty to avoid UploadClient treating it as a storage race and retrying
-    mock_did = file_generator()
+    mock_did = file_factory.file_generator()
     mock_rse = "MOCK-POSIX"
     upload_client = UploadClient(rucio_client)
 
@@ -557,7 +557,7 @@ def test_lifetime_exception(rucio_client, mock_scope, file_config_mock):
     upload_client.upload(items=[item])
 
     with open(input_file.name, "w") as f:
-        f.write(f"{mock_scope}:{mock_did.split('/')[-1]}")
+        f.write(f"{mock_scope}:{mock_did.name}")
 
     cmd = f"rucio lifetime-exception add -f {input_file.name} --reason mock_test -x 2100-12-30"
     exitcode, _, err = execute(cmd)


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description

UploadClient treats filesize 0 as a storage race and retries with exponential backoff (~63s). Use file_generator() for the uploaded DID so the protocol-stat path does not false-positive.

Reduces the test runtime from ~66s to ~3s

## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [x] This PR closes #8740
      <!-- Every PR requires an issue; if none exists yet, please create one
           first. GitHub links the PR to the issue and closes it on merge.
           In the rare case the issue should remain open after the merge,
           write "Related to #____" here instead and briefly say why in the
           description. -->
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
