### PR TITLE
Fix generation of opendata download urls

### DIFF
--- a/lib/rucio/client/opendataclient.py
+++ b/lib/rucio/client/opendataclient.py
@@ -241,6 +241,7 @@ class OpenDataClient(BaseClient):
             A dictionary containing metadata about the specified DID.
             May include file list, extended metadata, and DOI details depending on the parameters.
         Raises:
+            OpenDataDataIdentifierNotFound: If the OpenData DID does not exist.
             InvalidRequest: If download URLs are requested without including files.
             ReplicaNotFound: If download URLs are requested but no suitable
                 replica is available.

--- a/lib/rucio/client/opendataclient.py
+++ b/lib/rucio/client/opendataclient.py
@@ -240,6 +240,14 @@ class OpenDataClient(BaseClient):
         Returns:
             A dictionary containing metadata about the specified DID.
             May include file list, extended metadata, and DOI details depending on the parameters.
+        Raises:
+            InvalidRequest: If download URLs are requested without including files.
+            ReplicaNotFound: If download URLs are requested but no suitable
+                replica is available.
+            OpenDataError: If download URL generation fails due to a
+                non-temporary EOS backend error.
+            ResourceTemporaryUnavailable: If download URL generation cannot
+                complete because an EOS backend operation failed temporarily.
         """
 
         base_url = self.opendata_public_dids_base_url if public else self.opendata_private_dids_base_url

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -454,14 +454,15 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
         host = parsed.hostname
         if host and parsed.port:
             host = f"{host}:{parsed.port}"
-        if not host or not _is_eos_host(host):
-            continue
 
-        if parsed.scheme not in {"http", "https"}:
+        if not (
+            parsed.scheme in {"http", "https"}
+            and host
+            and _is_eos_host(host)
+        ):
             logger.info(
-                "Skipping EOS replica URI '%s': unsupported scheme '%s'.",
+                "Skipping replica URI '%s': only HTTP(S) replicas hosted on EOS are supported.",
                 uri,
-                parsed.scheme,
             )
             continue
 

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -452,6 +452,8 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
             continue
 
         host = parsed.hostname
+        if host and parsed.port:
+            host = f"{host}:{parsed.port}"
         if not host or not _is_eos_host(host):
             continue
 

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -17,7 +17,7 @@ import logging
 import time
 from re import match, search
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 import requests
 from dogpile.cache.api import NoValue
@@ -31,7 +31,6 @@ from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.constants import DEFAULT_VO
 from rucio.common.exception import OpenDataError, OpenDataInvalidStateUpdate
 from rucio.common.types import InternalAccount
-from rucio.common.utils import add_url_query
 from rucio.core.did import list_files
 from rucio.core.monitor import MetricManager
 from rucio.core.replica import list_replicas
@@ -442,6 +441,24 @@ def _format_url_authority(host: str, port: Optional[int]) -> str:
     return host
 
 
+def _append_authz_query_parameter(uri: str, token: str) -> str:
+    """
+    Append an authz parameter without reparsing or rebuilding the existing query.
+
+    The original query string is preserved verbatim so repeated parameters,
+    valueless flags, ordering, and existing percent-encoding are not changed.
+    """
+    parsed = urlparse(uri)
+    authz_query = urlencode({"authz": token})
+
+    if parsed.query:
+        query = f"{parsed.query}&{authz_query}"
+    else:
+        query = authz_query
+
+    return parsed._replace(query=query).geturl()
+
+
 def _generate_download_urls(uris: list[str]) -> list[str]:
     """
     Build tokenized download URLs for the given replica URIs.
@@ -499,7 +516,7 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
         if not token:
             continue
 
-        download_urls.append(add_url_query(uri, {"authz": token}))
+        download_urls.append(_append_authz_query_parameter(uri, token))
 
     return download_urls
 

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -429,7 +429,7 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
     """
     Build tokenized download URLs for the given replica URIs.
 
-    Only valid HTTP(S) URIs whose host exposes an EOS REST gateway are
+    Only valid HTTP(S) or DAV(S) URIs whose host exposes an EOS REST gateway are
     considered. For each eligible URI, a read-only EOS token scoped to the
     file path is requested and appended as an ``authz`` query parameter.
 
@@ -456,9 +456,9 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
             logger.warning("Skipping malformed replica URI '%s'.", uri)
             continue
 
-        if parsed.scheme not in {"http", "https"} or not host:
+        if parsed.scheme not in {"http", "https", "dav", "davs"} or not host:
             logger.debug(
-                "Skipping replica URI '%s': only HTTP(S) replicas are supported.",
+                "Skipping replica URI '%s': only HTTP(S) and DAV(S) replicas are supported.",
                 uri,
             )
             continue
@@ -523,7 +523,7 @@ def get_opendata_did_files(
     """
     Retrieve the files and replicas associated with an OpenData DID.
 
-    When ``include_download_urls`` is enabled, HTTP(S) replicas are retrieved
+    When ``include_download_urls`` is enabled, HTTP(S) and DAV(S) replicas are retrieved
     separately and used to generate tokenized EOS download URLs.
 
     Parameters:
@@ -616,7 +616,7 @@ def get_opendata_did_files(
             download_replicas = list_replicas(
                 dids=dids,
                 rse_expression=rse_expression,
-                schemes=["http", "https"],
+                schemes=["http", "https", "dav", "davs"],
                 session=session,
             )
 
@@ -624,12 +624,12 @@ def get_opendata_did_files(
 
             if not download_uris:
                 logger.error(
-                    "No HTTP(S) DISK replica URI available for OpenData file %s:%s.",
+                    "No HTTP(S) or DAV(S) DISK replica URI available for OpenData file %s:%s.",
                     file["scope"],
                     file["name"],
                 )
                 raise OpenDataError(
-                    f"Failed to retrieve HTTP(S) replica URI for OpenData file "
+                    f"Failed to retrieve HTTP(S) or DAV(S) replica URI for OpenData file "
                     f"{file['scope']}:{file['name']}."
                 )
 

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -482,6 +482,8 @@ def _eos_grpc_gateway_token_command(
         ResourceTemporaryUnavailable: If the EOS token service cannot be
             contacted, returns a temporary HTTP failure, an invalid response,
             or reports a failed token-generation command.
+        OpenDataError: If the EOS token service returns a non-temporary HTTP
+            error.
     """
     expires_at = int(time.time()) + lifetime_seconds
 
@@ -817,6 +819,8 @@ def get_opendata_did_files(
         OpenDataDataIdentifierNotFound: If the OpenData DID does not exist.
         OpenDataError: If a required replica URI or requested download URL
             cannot be obtained.
+        ResourceTemporaryUnavailable: If download URL generation cannot complete
+            because an EOS backend operation failed temporarily.
     """
 
     time_start = time.perf_counter()
@@ -989,6 +993,9 @@ def get_opendata_did(
 
     Returns:
         A dictionary containing info about the specified DID which include "scope", "name", "state", "meta" (if requested), etc.
+    Raises:
+    ResourceTemporaryUnavailable: If download URLs are requested and an EOS
+        backend failure prevents them from being generated.
     """
 
     query = select(

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -384,7 +384,7 @@ def _is_eos_host(host: str) -> bool:
             timeout=timeout,
             allow_redirects=False,
         )
-    except requests.exceptions.RequestException as error:
+    except (requests.exceptions.RequestException, OSError) as error:
         logger.warning(
             "Failed to probe host %s for EOS REST gateway support: %s",
             host,
@@ -529,7 +529,7 @@ def _eos_grpc_gateway_token_command(
             verify=ca_bundle,
             timeout=timeout,
         )
-    except requests.exceptions.RequestException as error:
+    except (requests.exceptions.RequestException, OSError) as error:
         logger.warning(
             "Failed to request EOS token for '%s' on %s: %s",
             filename,

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -724,7 +724,11 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
 
             if temporary_error is None:
                 temporary_error = error
-
+            continue
+        except OpenDataError:
+            # A non-retryable failure for one replica must not prevent
+            # trying other independent replicas.
+            token_cache[token_scope] = None
             continue
 
         token = token_cache[token_scope]

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -31,6 +31,7 @@ from rucio.common.config import config_get, config_get_bool, config_get_int
 from rucio.common.constants import DEFAULT_VO
 from rucio.common.exception import OpenDataError, OpenDataInvalidStateUpdate
 from rucio.common.types import InternalAccount
+from rucio.common.utils import add_url_query
 from rucio.core.did import list_files
 from rucio.core.monitor import MetricManager
 from rucio.core.replica import list_replicas
@@ -482,8 +483,7 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
         if not token:
             continue
 
-        separator = "&" if "?" in uri else "?"
-        download_urls.append(f"{uri}{separator}authz={token}")
+        download_urls.append(add_url_query(uri, {"authz": token}))
 
     return download_urls
 

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -431,7 +431,7 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
 
     Only URIs whose host answers the EOS REST gateway probe are considered;
     for those, a read-only EOS token scoped to the file path is requested and
-    appended to the URI as a ``token`` query parameter. URIs on non-EOS hosts
+    appended to the URI as a ``authz`` query parameter. URIs on non-EOS hosts
     or for which no token could be obtained are skipped.
 
     Args:

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 import json
 import logging
 import time
@@ -790,6 +791,31 @@ def _index_disk_uris_by_did(
     return result
 
 
+def _make_opendata_did_files_cache_key(
+    scope: "InternalScope",
+    name: str,
+    include_download_urls: bool,
+) -> str:
+    """
+    Build a bounded cache key for Open Data DID file listings.
+
+    The variable part of the key is hashed to avoid exceeding Memcached's
+    250-byte key limit while still keeping cache entries distinct by scope,
+    name, download URL inclusion, and cache version.
+    """
+    cache_identity = (
+        f"{scope}_{name}_dl_{include_download_urls}"
+    )
+    digest = hashlib.sha256(
+        cache_identity.encode("utf-8")
+    ).hexdigest()
+
+    return (
+        f"opendata_did_files_v"
+        f"{OPENDATA_DID_FILES_CACHE_VERSION}_{digest}"
+    )
+
+
 def get_opendata_did_files(
         *,
         scope: "InternalScope",
@@ -826,9 +852,10 @@ def get_opendata_did_files(
     time_start = time.perf_counter()
 
     # Append the include_download_urls flag to the cache key so we don't mix up responses
-    cache_key = (
-        f"opendata_did_files_v{OPENDATA_DID_FILES_CACHE_VERSION}_"
-        f"{scope}_{name}_dl_{include_download_urls}"
+    cache_key = _make_opendata_did_files_cache_key(
+        scope,
+        name,
+        include_download_urls,
     )
 
     if use_cache:

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -429,16 +429,19 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
     """
     Build tokenized download URLs for the given replica URIs.
 
-    Only URIs whose host answers the EOS REST gateway probe are considered;
-    for those, a read-only EOS token scoped to the file path is requested and
-    appended to the URI as a ``authz`` query parameter. URIs on non-EOS hosts
-    or for which no token could be obtained are skipped.
+    Only valid HTTP(S) URIs whose host exposes an EOS REST gateway are
+    considered. For each eligible URI, a read-only EOS token scoped to the
+    file path is requested and appended as an ``authz`` query parameter.
+
+    Malformed URIs, unsupported schemes, non-EOS hosts, and URIs for which
+    a token cannot be obtained are skipped.
 
     Args:
-        uris: The replica URIs (e.g. 'https://eos.example:8444//eos/path/file.root').
+        uris: Replica URIs to process.
 
     Returns:
-        The list of download URLs, possibly empty.
+        The successfully generated tokenized download URLs. The list may be
+        empty if none of the provided URIs can be used.
     """
     lifetime = config_get_int("opendata", "eos_token_lifetime", raise_exception=False,
                               default=DEFAULT_EOS_TOKEN_LIFETIME_SECONDS)
@@ -447,23 +450,23 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
     for uri in uris:
         try:
             parsed = urlparse(uri)
+            host = parsed.hostname
+            port = parsed.port
         except ValueError:
-            logger.debug("Skipping malformed replica URI '%s'.", uri)
+            logger.warning("Skipping malformed replica URI '%s'.", uri)
             continue
 
-        host = parsed.hostname
-        if host and parsed.port:
-            host = f"{host}:{parsed.port}"
-
-        if not (
-            parsed.scheme in {"http", "https"}
-            and host
-            and _is_eos_host(host)
-        ):
-            logger.info(
-                "Skipping replica URI '%s': only HTTP(S) replicas hosted on EOS are supported.",
+        if parsed.scheme not in {"http", "https"} or not host:
+            logger.debug(
+                "Skipping replica URI '%s': only HTTP(S) replicas are supported.",
                 uri,
             )
+            continue
+
+        if port:
+            host = f"{host}:{port}"
+
+        if not _is_eos_host(host):
             continue
 
         path = parsed.path
@@ -477,11 +480,34 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
             lifetime_seconds=lifetime,
         )
 
-        if token:
-            separator = "&" if "?" in uri else "?"
-            download_urls.append(f"{uri}{separator}authz={token}")
+        if not token:
+            continue
+
+        separator = "&" if "?" in uri else "?"
+        download_urls.append(f"{uri}{separator}authz={token}")
 
     return download_urls
+
+
+def _extract_disk_uris(replicas) -> list[str]:
+    """
+    Extract DISK replica URIs from ``list_replicas`` results.
+
+    Args:
+        replicas: Replica entries returned by ``list_replicas``.
+
+    Returns:
+        The PFN URIs whose replica type is ``DISK``.
+    """
+    uris = []
+
+    for replica in replicas:
+        for uri, data in replica["pfns"].items():
+            if data["type"] != "DISK":
+                continue
+            uris.append(uri)
+
+    return uris
 
 
 def get_opendata_did_files(
@@ -493,17 +519,26 @@ def get_opendata_did_files(
         session: "Session",
 ) -> dict[str, Any]:
     """
-    Retrieve the files and replicas associated with an Opendata DID.
+    Retrieve the files and replicas associated with an OpenData DID.
+
+    When ``include_download_urls`` is enabled, HTTP(S) replicas are retrieved
+    separately and used to generate tokenized EOS download URLs.
 
     Parameters:
-        scope: The scope of the Opendata DID.
-        name: The name of the Opendata DID.
+        scope: The scope of the OpenData DID.
+        name: The name of the OpenData DID.
         use_cache: If True, use caching to store/retrieve the result. Defaults to False.
-        include_download_urls: If True, include download URLs for the files. Defaults to False.
+        include_download_urls: If True, include tokenized download URLs for the files.
         session: SQLAlchemy session to use for the query.
 
     Returns:
-        A dictionary containing the list of files including replicas, cache hit status, and time elapsed in milliseconds.
+        A dictionary containing the files and their replica URIs, together
+        with cache-hit information and elapsed request time.
+
+    Raises:
+        OpenDataDataIdentifierNotFound: If the OpenData DID does not exist.
+        OpenDataError: If a required replica URI or requested download URL
+            cannot be obtained.
     """
 
     time_start = time.perf_counter()
@@ -551,24 +586,65 @@ def get_opendata_did_files(
     rse_expression = config_get("opendata", "rse_expression", raise_exception=True)
 
     for i, file in enumerate(file_list):
+        dids = [{"scope": file["scope"], "name": file["name"]}]
+
+        # Retrieve replicas using the standard Rucio protocol selection.
         replicas = list_replicas(
-            dids=[{"scope": file["scope"], "name": file["name"]}],
-            rse_expression=rse_expression, session=session
-        )
-        uris = []
-        for replica in replicas:
-            pfns = replica["pfns"]
-            for uri, data in pfns.items():
-                if data["type"] != "DISK":
-                    continue
-                uris.append(uri)
+        dids=dids,
+        rse_expression=rse_expression,
+        session=session,
+    )
+
+        uris = _extract_disk_uris(replicas)
+
+        if not uris:
+            logger.error(
+                "No DISK replica URI available for OpenData file %s:%s.",
+                file["scope"],
+                file["name"],
+            )
+            raise OpenDataError(
+                f"Failed to retrieve replica URI for OpenData file "
+                f"{file['scope']}:{file['name']}."
+            )
 
         file_list[i]["uris"] = uris
 
-    # Process download URLs before we cache the result
-    if include_download_urls:
-        for file in file_list:
-            file["download_urls"] = _generate_download_urls(file.get("uris", []))
+        if include_download_urls:
+            download_replicas = list_replicas(
+                dids=dids,
+                rse_expression=rse_expression,
+                schemes=["http", "https"],
+                session=session,
+            )
+
+            download_uris = _extract_disk_uris(download_replicas)
+
+            if not download_uris:
+                logger.error(
+                    "No HTTP(S) DISK replica URI available for OpenData file %s:%s.",
+                    file["scope"],
+                    file["name"],
+                )
+                raise OpenDataError(
+                    f"Failed to retrieve HTTP(S) replica URI for OpenData file "
+                    f"{file['scope']}:{file['name']}."
+                )
+
+            download_urls = _generate_download_urls(download_uris)
+
+            if not download_urls:
+                logger.error(
+                    "Failed to generate download URL for OpenData file %s:%s.",
+                    file["scope"],
+                    file["name"],
+                )
+                raise OpenDataError(
+                    f"Failed to generate download URL for OpenData file "
+                    f"{file['scope']}:{file['name']}."
+                )
+
+            file_list[i]["download_urls"] = download_urls
 
     # Now that the file_list is fully built (with or without download URLs), cache it
     if use_cache:

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -797,15 +797,22 @@ def _make_opendata_did_files_cache_key(
     include_download_urls: bool,
 ) -> str:
     """
-    Build a bounded cache key for Open Data DID file listings.
+    Build a bounded and unambiguous cache key for Open Data DID file listings.
 
-    The variable part of the key is hashed to avoid exceeding Memcached's
-    250-byte key limit while still keeping cache entries distinct by scope,
-    name, download URL inclusion, and cache version.
+    The complete internal scope is included so cache entries remain isolated
+    between VOs. The structured identity is hashed to avoid ambiguous field
+    concatenation and Memcached's 250-byte key limit.
     """
-    cache_identity = (
-        f"{scope}_{name}_dl_{include_download_urls}"
+    cache_identity = json.dumps(
+        {
+            "scope": scope.internal,
+            "name": name,
+            "include_download_urls": include_download_urls,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
     )
+
     digest = hashlib.sha256(
         cache_identity.encode("utf-8")
     ).hexdigest()
@@ -843,15 +850,16 @@ def get_opendata_did_files(
 
     Raises:
         OpenDataDataIdentifierNotFound: If the OpenData DID does not exist.
-        OpenDataError: If a required replica URI or requested download URL
-            cannot be obtained.
+        OpenDataError: If download URLs are requested but a suitable replica
+            URI or tokenized download URL cannot be obtained.
         ResourceTemporaryUnavailable: If download URL generation cannot complete
             because an EOS backend operation failed temporarily.
     """
 
     time_start = time.perf_counter()
 
-    # Append the include_download_urls flag to the cache key so we don't mix up responses
+    # Build a cache key which uniquely identifies the DID, VO, and
+    # download URL inclusion mode.
     cache_key = _make_opendata_did_files_cache_key(
         scope,
         name,
@@ -923,26 +931,14 @@ def get_opendata_did_files(
                     dids=dids,
                     rse_expression=rse_expression,
                     schemes=["http", "https", "dav", "davs"],
+                    resolve_archives=False,
                     session=session,
                 )
             )
 
     for file in file_list:
         did_key = (file["scope"], file["name"])
-
         uris = regular_uris_by_did.get(did_key, [])
-
-        if not uris:
-            logger.error(
-                "No DISK replica URI available for OpenData file %s:%s.",
-                file["scope"],
-                file["name"],
-            )
-            raise OpenDataError(
-                f"Failed to retrieve replica URI for OpenData file "
-                f"{file['scope']}:{file['name']}."
-            )
-
         file["uris"] = uris
 
         if not include_download_urls:

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -1001,6 +1001,9 @@ def get_opendata_did_files(
 
     for file in file_list:
         did_key = (file["scope"], file["name"])
+
+        # Missing regular replicas are represented by an empty URI list.
+        # A suitable replica is required only when download URLs are requested.
         uris = regular_uris_by_did.get(did_key, [])
         file["uris"] = uris
 

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -58,6 +58,7 @@ EOS_PROBE_NEGATIVE_REGION = MemcacheRegion(expiration_time=300)
 # expiration time of the file listing cache (REGION above) so that download
 # URLs served from the cache always carry a still-valid token.
 DEFAULT_EOS_TOKEN_LIFETIME_SECONDS = 4 * 3600
+OPENDATA_DID_FILES_CACHE_VERSION = 2
 
 
 def is_valid_opendata_did_state(state: str) -> bool:
@@ -560,7 +561,10 @@ def get_opendata_did_files(
     time_start = time.perf_counter()
 
     # Append the include_download_urls flag to the cache key so we don't mix up responses
-    cache_key = f"opendata_did_files_{scope}_{name}_dl_{include_download_urls}"
+    cache_key = (
+        f"opendata_did_files_v{OPENDATA_DID_FILES_CACHE_VERSION}_"
+        f"{scope}_{name}_dl_{include_download_urls}"
+    )
 
     if use_cache:
         file_list = REGION.get(cache_key)

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -481,10 +481,11 @@ def _eos_grpc_gateway_token_command(
 
     Raises:
         ResourceTemporaryUnavailable: If the EOS token service cannot be
-            contacted, returns a temporary HTTP failure, an invalid response,
-            or reports a failed token-generation command.
+            contacted, returns a temporary HTTP failure, or returns an invalid
+            response.
         OpenDataError: If the EOS token service returns a non-temporary HTTP
-            error.
+            error, rejects the token-generation command, or returns unexpected
+            token output.
     """
     expires_at = int(time.time()) + lifetime_seconds
 
@@ -585,21 +586,34 @@ def _eos_grpc_gateway_token_command(
             f"EOS token service returned an invalid response for {eos_host}."
         )
 
-    if str(response_data.get("retc")) != "0":
+    try:
+        retc = int(response_data["retc"])
+    except (KeyError, TypeError, ValueError) as error:
+        logger.warning(
+            "EOS token service returned an invalid return code "
+            "for '%s' on %s.",
+            filename,
+            eos_host,
+        )
+        raise exception.ResourceTemporaryUnavailable(
+            f"EOS token service returned an invalid response for {eos_host}."
+        ) from error
+
+    if retc != 0:
         logger.warning(
             "EOS token command failed for '%s' on %s: retc=%s, stderr=%s",
             filename,
             eos_host,
-            response_data.get("retc"),
+            retc,
             response_data.get("stdErr", ""),
         )
-        raise exception.ResourceTemporaryUnavailable(
-            f"EOS token generation failed for {eos_host}."
+        raise OpenDataError(
+            f"EOS token generation failed for {eos_host}: retc={retc}."
         )
 
-    token = response_data.get("stdOut", "")
+    token_output = response_data.get("stdOut", "")
 
-    if not isinstance(token, str) or not token.strip():
+    if not isinstance(token_output, str) or not token_output.strip():
         logger.warning(
             "EOS token service returned an empty token for '%s' on %s.",
             filename,
@@ -609,7 +623,29 @@ def _eos_grpc_gateway_token_command(
             f"EOS token generation failed for {eos_host}."
         )
 
-    return token.strip()
+    token_lines = [
+        line.strip()
+        for line in token_output.splitlines()
+        if line.strip()
+    ]
+
+    token = token_lines[0] if len(token_lines) == 1 else ""
+
+    if (
+        not token.startswith("zteos64:")
+        or len(token) <= len("zteos64:")
+    ):
+        logger.warning(
+            "EOS token service returned unexpected token output "
+            "for '%s' on %s.",
+            filename,
+            eos_host,
+        )
+        raise OpenDataError(
+            f"EOS token generation returned unexpected output for {eos_host}."
+        )
+
+    return token
 
 
 def _format_url_authority(host: str, port: Optional[int]) -> str:
@@ -667,7 +703,9 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
 
     Raises:
         ResourceTemporaryUnavailable: If no download URL can be generated
-        and at least one EOS backend operation failed temporarily.
+            and at least one EOS backend operation failed temporarily.
+        OpenDataError: If no download URL can be generated and at least one
+            EOS backend operation failed permanently.
     """
     lifetime = config_get_int("opendata", "eos_token_lifetime", raise_exception=False,
                               default=DEFAULT_EOS_TOKEN_LIFETIME_SECONDS)
@@ -681,6 +719,7 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
     temporary_error: Optional[
         exception.ResourceTemporaryUnavailable
     ] = None
+    permanent_error: Optional[OpenDataError] = None
 
     for uri in uris:
         try:
@@ -728,10 +767,12 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
             if temporary_error is None:
                 temporary_error = error
             continue
-        except OpenDataError:
+        except OpenDataError as error:
             # A non-retryable failure for one replica must not prevent
             # trying other independent replicas.
             token_cache[token_scope] = None
+            if permanent_error is None:
+                permanent_error = error
             continue
 
         token = token_cache[token_scope]
@@ -745,8 +786,12 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
 
     # If at least one independent replica worked, return it. Otherwise,
     # preserve the temporary nature of any EOS backend outage.
-    if not download_urls and temporary_error is not None:
-        raise temporary_error
+    if not download_urls:
+        if temporary_error is not None:
+            raise temporary_error
+
+        if permanent_error is not None:
+            raise permanent_error
 
     return download_urls
 
@@ -936,6 +981,24 @@ def get_opendata_did_files(
                 )
             )
 
+    if include_download_urls:
+        for file in file_list:
+            did_key = (file["scope"], file["name"])
+            download_uris = download_uris_by_did.get(did_key, [])
+
+            if not download_uris:
+                logger.error(
+                    "No HTTP(S) or DAV(S) DISK replica URI available "
+                    "for OpenData file %s:%s.",
+                    file["scope"],
+                    file["name"],
+                )
+
+                raise OpenDataError(
+                    f"Failed to retrieve HTTP(S) or DAV(S) replica URI "
+                    f"for OpenData file {file['scope']}:{file['name']}."
+                )
+
     for file in file_list:
         did_key = (file["scope"], file["name"])
         uris = regular_uris_by_did.get(did_key, [])
@@ -944,20 +1007,7 @@ def get_opendata_did_files(
         if not include_download_urls:
             continue
 
-        download_uris = download_uris_by_did.get(did_key, [])
-
-        if not download_uris:
-            logger.error(
-                "No HTTP(S) or DAV(S) DISK replica URI available "
-                "for OpenData file %s:%s.",
-                file["scope"],
-                file["name"],
-            )
-            raise OpenDataError(
-                f"Failed to retrieve HTTP(S) or DAV(S) replica URI "
-                f"for OpenData file {file['scope']}:{file['name']}."
-            )
-
+        download_uris = download_uris_by_did[did_key]
         download_urls = _generate_download_urls(download_uris)
 
         if not download_urls:
@@ -966,6 +1016,7 @@ def get_opendata_did_files(
                 file["scope"],
                 file["name"],
             )
+
             raise OpenDataError(
                 f"Failed to generate download URL for OpenData file "
                 f"{file['scope']}:{file['name']}."

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -895,10 +895,12 @@ def get_opendata_did_files(
 
     Raises:
         OpenDataDataIdentifierNotFound: If the OpenData DID does not exist.
-        OpenDataError: If download URLs are requested but a suitable replica
-            URI or tokenized download URL cannot be obtained.
-        ResourceTemporaryUnavailable: If download URL generation cannot complete
-            because an EOS backend operation failed temporarily.
+        ReplicaNotFound: If download URLs are requested but no suitable
+            replica is available.
+        OpenDataError: If download URL generation fails due to a
+            non-temporary EOS backend error.
+        ResourceTemporaryUnavailable: If download URL generation cannot
+            complete because an EOS backend operation failed temporarily.
     """
 
     time_start = time.perf_counter()
@@ -994,8 +996,8 @@ def get_opendata_did_files(
                     file["name"],
                 )
 
-                raise OpenDataError(
-                    f"Failed to retrieve HTTP(S) or DAV(S) replica URI "
+                raise exception.ReplicaNotFound(
+                    f"No HTTP(S) or DAV(S) DISK replica URI available "
                     f"for OpenData file {file['scope']}:{file['name']}."
                 )
 
@@ -1020,9 +1022,9 @@ def get_opendata_did_files(
                 file["name"],
             )
 
-            raise OpenDataError(
-                f"Failed to generate download URL for OpenData file "
-                f"{file['scope']}:{file['name']}."
+            raise exception.ReplicaNotFound(
+                f"No suitable EOS download replica available "
+                f"for OpenData file {file['scope']}:{file['name']}."
             )
 
         file["download_urls"] = download_urls
@@ -1071,9 +1073,19 @@ def get_opendata_did(
     Returns:
         A dictionary containing info about the specified DID which include "scope", "name", "state", "meta" (if requested), etc.
     Raises:
-    ResourceTemporaryUnavailable: If download URLs are requested and an EOS
-        backend failure prevents them from being generated.
+        InvalidRequest: If download URLs are requested without including files.
+        ReplicaNotFound: If download URLs are requested but no suitable
+            replica is available.
+        OpenDataError: If download URL generation fails due to a
+            non-temporary EOS backend error.
+        ResourceTemporaryUnavailable: If download URL generation cannot
+            complete because an EOS backend operation failed temporarily.
     """
+
+    if include_download_urls and not include_files:
+        raise exception.InvalidRequest(
+            "Download URLs require files to be included."
+        )
 
     query = select(
         models.OpenDataDid.scope,

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -481,6 +481,15 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
                               default=DEFAULT_EOS_TOKEN_LIFETIME_SECONDS)
 
     download_urls = []
+
+    # The token lifetime and permission are constant within this invocation.
+    # Therefore, authority and normalized path identify the authorization scope.
+    token_cache: dict[tuple[str, str], Optional[str]] = {}
+
+    temporary_error: Optional[
+        exception.ResourceTemporaryUnavailable
+    ] = None
+
     for uri in uris:
         try:
             parsed = urlparse(uri)
@@ -499,24 +508,49 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
 
         eos_authority = _format_url_authority(host, port)
 
-        if not _is_eos_host(eos_authority):
-            continue
-
         path = parsed.path
-        # PFNs such as 'https://host:8444//eos/path' carry a double slash before the path
+
+        # PFNs such as https://host:8444//eos/path contain a double
+        # slash between the authority and EOS path.
         if path.startswith("//"):
             path = path[1:]
 
-        token = _eos_grpc_gateway_token_command(
-            eos_host=eos_authority,
-            filename=path,
-            lifetime_seconds=lifetime,
-        )
+        token_scope = (eos_authority, path)
+
+        try:
+            if token_scope not in token_cache:
+                if not _is_eos_host(eos_authority):
+                    token_cache[token_scope] = None
+                else:
+                    token_cache[token_scope] = (
+                        _eos_grpc_gateway_token_command(
+                            eos_host=eos_authority,
+                            filename=path,
+                            lifetime_seconds=lifetime,
+                        )
+                    )
+        except exception.ResourceTemporaryUnavailable as error:
+            # Do not immediately fail: another independent replica may work.
+            token_cache[token_scope] = None
+
+            if temporary_error is None:
+                temporary_error = error
+
+            continue
+
+        token = token_cache[token_scope]
 
         if not token:
             continue
 
-        download_urls.append(_append_authz_query_parameter(uri, token))
+        download_urls.append(
+            _append_authz_query_parameter(uri, token)
+        )
+
+    # If at least one independent replica worked, return it. Otherwise,
+    # preserve the temporary nature of any EOS backend outage.
+    if not download_urls and temporary_error is not None:
+        raise temporary_error
 
     return download_urls
 

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -435,7 +435,7 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
     or for which no token could be obtained are skipped.
 
     Args:
-        uris: The replica URIs (e.g. 'root://eos.example:1094//eos/path/file.root').
+        uris: The replica URIs (e.g. 'https://eos.example:8444//eos/path/file.root').
 
     Returns:
         The list of download URLs, possibly empty.
@@ -457,8 +457,16 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
         if not host or not _is_eos_host(host):
             continue
 
+        if parsed.scheme not in {"http", "https"}:
+            logger.info(
+                "Skipping EOS replica URI '%s': unsupported scheme '%s'.",
+                uri,
+                parsed.scheme,
+            )
+            continue
+
         path = parsed.path
-        # PFNs such as 'root://host:1094//eos/path' carry a double slash before the path
+        # PFNs such as 'https://host:8444//eos/path' carry a double slash before the path
         if path.startswith("//"):
             path = path[1:]
 

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -532,6 +532,7 @@ def _eos_grpc_gateway_token_command(
             cert=(cert, key),
             verify=ca_bundle,
             timeout=timeout,
+            allow_redirects=False,
         )
     except (requests.exceptions.RequestException, OSError) as error:
         logger.warning(

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -293,92 +293,198 @@ def get_opendata_record_id(
         return int(result["record_id"])
 
 
+def _raise_on_temporary_http_error(
+    response: requests.Response,
+    *,
+    operation: str,
+    host: str,
+) -> None:
+    """
+    Raise an exception when an HTTP response represents a temporary failure.
+
+    HTTP 408 (Request Timeout), 429 (Too Many Requests), and all 5xx responses
+    are considered temporary failures and are reported as
+    ``ResourceTemporaryUnavailable``.
+
+    Args:
+        response: HTTP response to inspect.
+        operation: Description of the operation being performed.
+        host: Host against which the operation was performed.
+
+    Raises:
+        ResourceTemporaryUnavailable: If the response status code indicates
+            a temporary HTTP failure.
+    """
+    if response.status_code in {408, 429} or response.status_code >= 500:
+        raise exception.ResourceTemporaryUnavailable(
+            f"{operation} is temporarily unavailable for {host}."
+        )
+
+
 def _is_eos_host(host: str) -> bool:
     """
     Probe ``host`` to determine whether it exposes the EOS REST gateway.
 
-    Calls the documented ``version_cmd`` endpoint of the EOS REST gateway
-    (defined in ``proto/eos_rest_gateway/eos_rest_gateway_service.proto`` in
-    the cern-eos/eos repository). A genuine EOS instance returns its
-    standard command envelope ``{"retc": "0", "stdOut": "...", "stdErr": ""}``
-    where ``stdOut`` carries an ``EOS_SERVER_VERSION=`` line. The probe is
-    read-only and does not require client-cert auth.
+    Calls the documented ``version_cmd`` endpoint of the EOS REST gateway.
+    A genuine EOS instance returns its standard command envelope
+    ``{"retc": "0", "stdOut": "...", "stdErr": ""}``, where ``stdOut``
+    contains an ``EOS_SERVER_VERSION=`` line.
 
-    Positive results are cached for a long time; negative results for a short
-    window so transient probe failures (network blips, gateway restarts) do
-    not lock a host out indefinitely.
+    Positive and confirmed negative results are cached. Transient transport,
+    server, or response-decoding failures are propagated as
+    ``ResourceTemporaryUnavailable`` and are not negative-cached.
+
+    Args:
+        host: Host authority to probe, including the port if present
+            (e.g. ``eospilot.cern.ch:8444``).
+
+    Returns:
+        True if the host is confirmed to expose an EOS REST gateway,
+        False if it is confirmed not to expose one.
+
+    Raises:
+        ResourceTemporaryUnavailable: If the probe cannot be completed due
+            to a temporary transport or server failure, an invalid response,
+            or a failed EOS probe command.
     """
     cached = EOS_PROBE_REGION.get(host)
     if not isinstance(cached, NoValue):
         return bool(cached)
+
     cached_neg = EOS_PROBE_NEGATIVE_REGION.get(host)
     if not isinstance(cached_neg, NoValue):
         return bool(cached_neg)
 
-    ca_bundle = config_get("opendata", "eos_ca_bundle", raise_exception=False, default="/etc/grid-security/ca.pem")
-    timeout = config_get_int("opendata", "eos_probe_timeout", raise_exception=False, default=3)
-    # The EOS REST gateway is always exposed over HTTPS. This is independent from the replica PFN scheme.
+    ca_bundle = config_get(
+        "opendata",
+        "eos_ca_bundle",
+        raise_exception=False,
+        default="/etc/grid-security/ca.pem",
+    )
+    timeout = config_get_int(
+        "opendata",
+        "eos_probe_timeout",
+        raise_exception=False,
+        default=3,
+    )
+
+    # The EOS REST gateway is always exposed over HTTPS. This is independent
+    # from the replica PFN scheme.
     url = f"https://{host}/v1/eos/rest/gateway/version_cmd"
 
-    is_eos = False
     try:
         response = requests.post(
             url,
             json={},
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
             verify=ca_bundle,
             timeout=timeout,
             allow_redirects=False,
         )
-        if response.status_code == 200:
-            try:
-                payload = response.json()
-            except ValueError:
-                payload = None
-            if (
-                isinstance(payload, dict)
-                and str(payload.get("retc")) == "0"
-                and "EOS_SERVER_VERSION=" in payload.get("stdOut", "")
-            ):
-                is_eos = True
-        if not is_eos:
-            logger.info(
-                "Host %s did not respond as an EOS REST gateway (status=%s).",
-                host, response.status_code,
-            )
-    except Exception as e:
-        logger.warning("EOS probe failed for %s: %s", host, e)
+    except requests.exceptions.RequestException as error:
+        logger.warning(
+            "Failed to probe host %s for EOS REST gateway support: %s",
+            host,
+            error,
+        )
+        raise exception.ResourceTemporaryUnavailable(
+            f"Unable to probe {host} for EOS REST gateway support."
+        ) from error
+
+    _raise_on_temporary_http_error(
+        response,
+        operation="REST gateway probe",
+        host=host,
+    )
+
+    if response.status_code != 200:
+        logger.info(
+            "Host %s did not respond as an EOS REST gateway "
+            "(status=%s).",
+            host,
+            response.status_code,
+        )
+        EOS_PROBE_NEGATIVE_REGION.set(host, False)
+        return False
+
+    try:
+        payload = response.json()
+    except ValueError as error:
+        logger.warning(
+            "Failed to decode REST gateway probe response from %s: %s",
+            host,
+            error,
+        )
+        raise exception.ResourceTemporaryUnavailable(
+            f"REST gateway probe returned an invalid response for {host}."
+        ) from error
+
+    if not isinstance(payload, dict):
+        logger.warning(
+            "REST gateway probe for %s returned an unexpected response type.",
+            host,
+        )
+        raise exception.ResourceTemporaryUnavailable(
+            f"REST gateway probe returned an invalid response for {host}."
+        )
+
+    if "retc" in payload and str(payload["retc"]) != "0":
+        logger.warning(
+            "EOS probe command failed for %s: retc=%s, stderr=%s",
+            host,
+            payload.get("retc"),
+            payload.get("stdErr", ""),
+        )
+        raise exception.ResourceTemporaryUnavailable(
+            f"REST gateway probe command failed for {host}."
+        )
+
+    std_out = payload.get("stdOut", "")
+
+    is_eos = (
+        str(payload.get("retc")) == "0"
+        and isinstance(std_out, str)
+        and "EOS_SERVER_VERSION=" in std_out
+    )
 
     if is_eos:
         EOS_PROBE_REGION.set(host, True)
     else:
         EOS_PROBE_NEGATIVE_REGION.set(host, False)
+
     return is_eos
 
 
 def _eos_grpc_gateway_token_command(
-        eos_host: str,
-        filename: str,
-        lifetime_seconds: int,
-) -> Optional[str]:
+    eos_host: str,
+    filename: str,
+    lifetime_seconds: int,
+) -> str:
     """
-    Sends a POST request to the EOS GRPC REST Gateway to generate an access token.
-    The following environment configuration may need to be set on the target EOS instance: `EOS_MGM_ENABLE_REST_API=1`
+    Send a POST request to the EOS GRPC REST gateway to generate an access token.
+
+    The EOS REST gateway is always contacted over HTTPS, independently of the
+    replica PFN scheme.
 
     Args:
-        eos_host: EOS REST gateway authority, including the port if present (e.g. 'eospilot.cern.ch:8444').
-        filename: The path the token should grant access to.
-        lifetime_seconds: How many seconds the token should be valid for.
+        eos_host: EOS REST gateway authority, including the port if present
+            (e.g. ``eospilot.cern.ch:8444``).
+        filename: Path the token should grant read access to.
+        lifetime_seconds: Number of seconds the token should remain valid.
 
     Returns:
-        Optional[str]: The raw token string if successful, or None if the token could not be fetched.
+        The raw token string when token generation succeeds.
+
+    Raises:
+        ResourceTemporaryUnavailable: If the EOS token service cannot be
+            contacted, returns a temporary HTTP failure, an invalid response,
+            or reports a failed token-generation command.
     """
-    # Calculate the exact expiration Unix timestamp
     expires_at = int(time.time()) + lifetime_seconds
 
-    # The EOS REST gateway is always accessed over HTTPS, independently
-    # of the replica PFN scheme. All supported replica protocols are expected
-    # to use the same configured port.
     eos_host = eos_host.rstrip("/")
     url = f"https://{eos_host}/v1/eos/rest/gateway/token_cmd"
 
@@ -390,16 +496,29 @@ def _eos_grpc_gateway_token_command(
 
     headers = {
         "Content-Type": "application/json",
-        "Accept": "application/json"
+        "Accept": "application/json",
     }
 
-    # This is the default location the FTS renewal daemon uses to store the proxy.
-    cert = key = config_get("opendata", "eos_proxy_path", raise_exception=False, default="/opt/proxy/x509up")
+    cert = key = config_get(
+        "opendata",
+        "eos_proxy_path",
+        raise_exception=False,
+        default="/opt/proxy/x509up",
+    )
 
-    # Grid CA bundle for SSL verification
-    ca_bundle = config_get("opendata", "eos_ca_bundle", raise_exception=False, default="/etc/grid-security/ca.pem")
+    ca_bundle = config_get(
+        "opendata",
+        "eos_ca_bundle",
+        raise_exception=False,
+        default="/etc/grid-security/ca.pem",
+    )
 
-    timeout = config_get_int("opendata", "eos_token_request_timeout", raise_exception=False, default=5)
+    timeout = config_get_int(
+        "opendata",
+        "eos_token_request_timeout",
+        raise_exception=False,
+        default=5,
+    )
 
     try:
         response = requests.post(
@@ -410,19 +529,84 @@ def _eos_grpc_gateway_token_command(
             verify=ca_bundle,
             timeout=timeout,
         )
-        response.raise_for_status()
+    except requests.exceptions.RequestException as error:
+        logger.warning(
+            "Failed to request EOS token for '%s' on %s: %s",
+            filename,
+            eos_host,
+            error,
+        )
+        raise exception.ResourceTemporaryUnavailable(
+            f"EOS token request could not be completed for {eos_host}."
+        ) from error
+
+    _raise_on_temporary_http_error(
+        response,
+        operation="EOS token service",
+        host=eos_host,
+    )
+
+    if response.status_code != 200:
+        logger.warning(
+            "EOS token service returned HTTP %s for '%s' on %s.",
+            response.status_code,
+            filename,
+            eos_host,
+        )
+        raise exception.OpenDataError(
+            f"EOS token generation failed for {eos_host}: "
+            f"HTTP {response.status_code}."
+        )
+
+    try:
         response_data = response.json()
+    except ValueError as error:
+        logger.warning(
+            "Failed to decode EOS token response for '%s' on %s: %s",
+            filename,
+            eos_host,
+            error,
+        )
+        raise exception.ResourceTemporaryUnavailable(
+            f"EOS token service returned an invalid response for {eos_host}."
+        ) from error
 
-        token = response_data.get("stdOut", "").strip()
+    if not isinstance(response_data, dict):
+        logger.warning(
+            "EOS token service returned an unexpected response type "
+            "for '%s' on %s.",
+            filename,
+            eos_host,
+        )
+        raise exception.ResourceTemporaryUnavailable(
+            f"EOS token service returned an invalid response for {eos_host}."
+        )
 
-        if not token:
-            logger.warning("EOS GRPC Gateway returned an empty token for '%s' on %s.", filename, eos_host)
-            return None
+    if str(response_data.get("retc")) != "0":
+        logger.warning(
+            "EOS token command failed for '%s' on %s: retc=%s, stderr=%s",
+            filename,
+            eos_host,
+            response_data.get("retc"),
+            response_data.get("stdErr", ""),
+        )
+        raise exception.ResourceTemporaryUnavailable(
+            f"EOS token generation failed for {eos_host}."
+        )
 
-        return token
-    except Exception as e:
-        logger.warning("Error fetching EOS GRPC token for '%s' on %s: %s", filename, eos_host, e)
-        return None
+    token = response_data.get("stdOut", "")
+
+    if not isinstance(token, str) or not token.strip():
+        logger.warning(
+            "EOS token service returned an empty token for '%s' on %s.",
+            filename,
+            eos_host,
+        )
+        raise exception.ResourceTemporaryUnavailable(
+            f"EOS token generation failed for {eos_host}."
+        )
+
+    return token.strip()
 
 
 def _format_url_authority(host: str, port: Optional[int]) -> str:
@@ -467,8 +651,9 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
     considered. For each eligible URI, a read-only EOS token scoped to the
     file path is requested and appended as an ``authz`` query parameter.
 
-    Malformed URIs, unsupported schemes, non-EOS hosts, and URIs for which
-    a token cannot be obtained are skipped.
+    Malformed URIs, unsupported schemes, and confirmed non-EOS hosts are
+    skipped. Temporary EOS failures are tolerated while other independent
+    replicas are tried and are propagated if no download URL can be generated.
 
     Args:
         uris: Replica URIs to process.
@@ -476,6 +661,10 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
     Returns:
         The successfully generated tokenized download URLs. The list may be
         empty if none of the provided URIs can be used.
+
+    Raises:
+        ResourceTemporaryUnavailable: If no download URL can be generated
+        and at least one EOS backend operation failed temporarily.
     """
     lifetime = config_get_int("opendata", "eos_token_lifetime", raise_exception=False,
                               default=DEFAULT_EOS_TOKEN_LIFETIME_SECONDS)

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -527,6 +527,23 @@ def _extract_disk_uris(
     return uris
 
 
+def _index_disk_uris_by_did(
+    replicas: "Iterable[dict[str, Any]]",
+) -> dict[tuple["InternalScope", str], list[str]]:
+    """
+    Index DISK PFNs by DID.
+    """
+    result: dict[tuple["InternalScope", str], list[str]] = {}
+
+    for replica in replicas:
+        key = (replica["scope"], replica["name"])
+        result.setdefault(key, []).extend(
+            _extract_disk_uris([replica])
+        )
+
+    return result
+
+
 def get_opendata_did_files(
         *,
         scope: "InternalScope",
@@ -605,17 +622,40 @@ def get_opendata_did_files(
 
     rse_expression = config_get("opendata", "rse_expression", raise_exception=True)
 
-    for i, file in enumerate(file_list):
-        dids = [{"scope": file["scope"], "name": file["name"]}]
+    dids = [
+        {
+            "scope": file["scope"],
+            "name": file["name"],
+        }
+        for file in file_list
+    ]
 
-        # Retrieve replicas using the standard Rucio protocol selection.
-        replicas = list_replicas(
-        dids=dids,
-        rse_expression=rse_expression,
-        session=session,
-    )
+    regular_uris_by_did: dict[tuple["InternalScope", str], list[str]] = {}
+    download_uris_by_did: dict[tuple["InternalScope", str], list[str]] = {}
 
-        uris = _extract_disk_uris(replicas)
+    if dids:
+        regular_uris_by_did = _index_disk_uris_by_did(
+            list_replicas(
+                dids=dids,
+                rse_expression=rse_expression,
+                session=session,
+            )
+        )
+
+        if include_download_urls:
+            download_uris_by_did = _index_disk_uris_by_did(
+                list_replicas(
+                    dids=dids,
+                    rse_expression=rse_expression,
+                    schemes=["http", "https", "dav", "davs"],
+                    session=session,
+                )
+            )
+
+    for file in file_list:
+        did_key = (file["scope"], file["name"])
+
+        uris = regular_uris_by_did.get(did_key, [])
 
         if not uris:
             logger.error(
@@ -628,43 +668,39 @@ def get_opendata_did_files(
                 f"{file['scope']}:{file['name']}."
             )
 
-        file_list[i]["uris"] = uris
+        file["uris"] = uris
 
-        if include_download_urls:
-            download_replicas = list_replicas(
-                dids=dids,
-                rse_expression=rse_expression,
-                schemes=["http", "https", "dav", "davs"],
-                session=session,
+        if not include_download_urls:
+            continue
+
+        download_uris = download_uris_by_did.get(did_key, [])
+
+        if not download_uris:
+            logger.error(
+                "No HTTP(S) or DAV(S) DISK replica URI available "
+                "for OpenData file %s:%s.",
+                file["scope"],
+                file["name"],
+            )
+            raise OpenDataError(
+                f"Failed to retrieve HTTP(S) or DAV(S) replica URI "
+                f"for OpenData file {file['scope']}:{file['name']}."
             )
 
-            download_uris = _extract_disk_uris(download_replicas)
+        download_urls = _generate_download_urls(download_uris)
 
-            if not download_uris:
-                logger.error(
-                    "No HTTP(S) or DAV(S) DISK replica URI available for OpenData file %s:%s.",
-                    file["scope"],
-                    file["name"],
-                )
-                raise OpenDataError(
-                    f"Failed to retrieve HTTP(S) or DAV(S) replica URI for OpenData file "
-                    f"{file['scope']}:{file['name']}."
-                )
+        if not download_urls:
+            logger.error(
+                "Failed to generate download URL for OpenData file %s:%s.",
+                file["scope"],
+                file["name"],
+            )
+            raise OpenDataError(
+                f"Failed to generate download URL for OpenData file "
+                f"{file['scope']}:{file['name']}."
+            )
 
-            download_urls = _generate_download_urls(download_uris)
-
-            if not download_urls:
-                logger.error(
-                    "Failed to generate download URL for OpenData file %s:%s.",
-                    file["scope"],
-                    file["name"],
-                )
-                raise OpenDataError(
-                    f"Failed to generate download URL for OpenData file "
-                    f"{file['scope']}:{file['name']}."
-                )
-
-            file_list[i]["download_urls"] = download_urls
+        file["download_urls"] = download_urls
 
     # Now that the file_list is fully built (with or without download URLs), cache it
     if use_cache:

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -316,6 +316,7 @@ def _is_eos_host(host: str) -> bool:
 
     ca_bundle = config_get("opendata", "eos_ca_bundle", raise_exception=False, default="/etc/grid-security/ca.pem")
     timeout = config_get_int("opendata", "eos_probe_timeout", raise_exception=False, default=3)
+    # The EOS REST gateway is always exposed over HTTPS. This is independent from the replica PFN scheme.
     url = f"https://{host}/v1/eos/rest/gateway/version_cmd"
 
     is_eos = False
@@ -364,7 +365,7 @@ def _eos_grpc_gateway_token_command(
     The following environment configuration may need to be set on the target EOS instance: `EOS_MGM_ENABLE_REST_API=1`
 
     Args:
-        eos_host: The hostname/URL of the EOS instance (e.g., 'https://eospilot.cern.ch' or just 'eospilot.cern.ch').
+        eos_host: EOS REST gateway authority, including the port if present (e.g. 'eospilot.cern.ch:8444').
         filename: The path the token should grant access to.
         lifetime_seconds: How many seconds the token should be valid for.
 
@@ -374,13 +375,11 @@ def _eos_grpc_gateway_token_command(
     # Calculate the exact expiration Unix timestamp
     expires_at = int(time.time()) + lifetime_seconds
 
-    # Ensure the host has a valid HTTP scheme before we construct the URL
-    if not eos_host.startswith("http://") and not eos_host.startswith("https://"):
-        eos_host = f"https://{eos_host}"
-
-    # Construct the endpoint URL
-    eos_host = eos_host.rstrip('/')
-    url = f"{eos_host}/v1/eos/rest/gateway/token_cmd"
+    # The EOS REST gateway is always accessed over HTTPS, independently
+    # of the replica PFN scheme. All supported replica protocols are expected
+    # to use the same configured port.
+    eos_host = eos_host.rstrip("/")
+    url = f"https://{eos_host}/v1/eos/rest/gateway/token_cmd"
 
     payload = {
         "path": filename,

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -425,6 +425,22 @@ def _eos_grpc_gateway_token_command(
         return None
 
 
+def _format_url_authority(host: str, port: Optional[int]) -> str:
+    """
+    Format a hostname and optional port as a valid URL authority.
+
+    IPv6 hostnames returned by urlparse().hostname do not contain the
+    brackets required when used inside a URL.
+    """
+    if ":" in host:
+        host = f"[{host}]"
+
+    if port is not None:
+        return f"{host}:{port}"
+
+    return host
+
+
 def _generate_download_urls(uris: list[str]) -> list[str]:
     """
     Build tokenized download URLs for the given replica URIs.
@@ -463,10 +479,9 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
             )
             continue
 
-        if port:
-            host = f"{host}:{port}"
+        eos_authority = _format_url_authority(host, port)
 
-        if not _is_eos_host(host):
+        if not _is_eos_host(eos_authority):
             continue
 
         path = parsed.path
@@ -475,7 +490,7 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
             path = path[1:]
 
         token = _eos_grpc_gateway_token_command(
-            eos_host=host,
+            eos_host=eos_authority,
             filename=path,
             lifetime_seconds=lifetime,
         )

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -468,7 +468,7 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
 
         if token:
             separator = "&" if "?" in uri else "?"
-            download_urls.append(f"{uri}{separator}token={token}")
+            download_urls.append(f"{uri}{separator}authz={token}")
 
     return download_urls
 

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -1073,6 +1073,7 @@ def get_opendata_did(
     Returns:
         A dictionary containing info about the specified DID which include "scope", "name", "state", "meta" (if requested), etc.
     Raises:
+        OpenDataDataIdentifierNotFound: If the OpenData DID does not exist.
         InvalidRequest: If download URLs are requested without including files.
         ReplicaNotFound: If download URLs are requested but no suitable
             replica is available.

--- a/lib/rucio/core/opendata.py
+++ b/lib/rucio/core/opendata.py
@@ -39,7 +39,7 @@ from rucio.db.sqla import models
 from rucio.db.sqla.constants import DIDType, OpenDataDIDState
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
     from sqlalchemy.orm import Session
 
@@ -489,7 +489,9 @@ def _generate_download_urls(uris: list[str]) -> list[str]:
     return download_urls
 
 
-def _extract_disk_uris(replicas) -> list[str]:
+def _extract_disk_uris(
+    replicas: "Iterable[dict[str, Any]]",
+) -> list[str]:
     """
     Extract DISK replica URIs from ``list_replicas`` results.
 

--- a/lib/rucio/gateway/opendata.py
+++ b/lib/rucio/gateway/opendata.py
@@ -83,11 +83,12 @@ def get_opendata_did(
     Returns:
         A dictionary containing the details of the requested DID.
     Raises:
+        OpenDataDataIdentifierNotFound: If the OpenData DID does not exist.
         InvalidRequest: If download URLs are requested without including files.
         ReplicaNotFound: If download URLs are requested but no suitable
             replica is available.
-        OpenDataError: If download URL generation fails due to a
-            non-temporary EOS backend error.
+        OpenDataError: If the requested state is invalid or download URL
+            generation fails due to a non-temporary EOS backend error.
         ResourceTemporaryUnavailable: If download URL generation cannot
             complete because an EOS backend operation failed temporarily.
     """

--- a/lib/rucio/gateway/opendata.py
+++ b/lib/rucio/gateway/opendata.py
@@ -82,6 +82,14 @@ def get_opendata_did(
 
     Returns:
         A dictionary containing the details of the requested DID.
+    Raises:
+        InvalidRequest: If download URLs are requested without including files.
+        ReplicaNotFound: If download URLs are requested but no suitable
+            replica is available.
+        OpenDataError: If download URL generation fails due to a
+            non-temporary EOS backend error.
+        ResourceTemporaryUnavailable: If download URL generation cannot
+            complete because an EOS backend operation failed temporarily.
     """
 
     internal_scope = InternalScope(scope, vo=vo)

--- a/lib/rucio/web/rest/flaskapi/v1/opendata.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata.py
@@ -15,7 +15,15 @@
 from flask import Blueprint, Flask, Response, request
 
 from rucio.common.constants import DEFAULT_VO, HTTPMethod
-from rucio.common.exception import AccessDenied, DataIdentifierNotFound, OpenDataDataIdentifierAlreadyExists, OpenDataDataIdentifierNotFound, ResourceTemporaryUnavailable
+from rucio.common.exception import (
+    AccessDenied,
+    DataIdentifierNotFound,
+    OpenDataDataIdentifierAlreadyExists,
+    OpenDataDataIdentifierNotFound,
+    OpenDataError,
+    ReplicaNotFound,
+    ResourceTemporaryUnavailable,
+)
 from rucio.common.utils import render_json
 from rucio.core.opendata import validate_opendata_did_state
 from rucio.gateway import opendata
@@ -108,20 +116,26 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
             include_doi = request.args.get("doi", default="1").lower() == "1"
             include_record_id = request.args.get("record_id", default="1").lower() == "1"
             include_download_urls = request.args.get("download_urls", default="0").lower() == "1"
-            result = opendata.get_opendata_did(scope=scope, name=name, vo=vo,
-                                               state=state,
-                                               include_files=include_files,
-                                               include_metadata=include_metadata,
-                                               include_doi=include_doi,
-                                               include_record_id=include_record_id,
-                                               include_download_urls=include_download_urls,
-                                               )
+            try:
+                result = opendata.get_opendata_did(
+                    scope=scope,
+                    name=name,
+                    vo=vo,
+                    state=state,
+                    include_files=include_files,
+                    include_metadata=include_metadata,
+                    include_doi=include_doi,
+                    include_record_id=include_record_id,
+                    include_download_urls=include_download_urls,
+                )
+            except OpenDataError as error:
+                return generate_http_error_flask(500, error)
 
             result = render_json(**result)
             return Response(result, status=200, mimetype='application/json')
         except AccessDenied as error:
             return generate_http_error_flask(401, error)
-        except OpenDataDataIdentifierNotFound as error:
+        except (OpenDataDataIdentifierNotFound, ReplicaNotFound) as error:
             return generate_http_error_flask(404, error)
         except ResourceTemporaryUnavailable as error:
             return generate_http_error_flask(503, error)
@@ -185,7 +199,7 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
             style: form
           - name: download_urls
             in: query
-            description: "Whether to include download URLs for the files. '1' to include, '0' to exclude. Default is '0'."
+            description: "Whether to include download URLs for the files. Requires 'files=1'. '1' to include, '0' to exclude. Default is '0'."
             schema:
               type: string
               enum: ['0', '1']
@@ -208,9 +222,11 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
           401:
             description: "Access denied: Invalid authentication."
           404:
-            description: "Data Identifier not found."
+            description: "Data Identifier or suitable download replica not found."
           400:
             description: "Invalid request or input parameters."
+          500:
+            description: "EOS backend failed while generating download URLs."
           503:
             description: "EOS backend temporarily unavailable while generating download URLs."
         """

--- a/lib/rucio/web/rest/flaskapi/v1/opendata.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata.py
@@ -211,6 +211,8 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
             description: "Data Identifier not found."
           400:
             description: "Invalid request or input parameters."
+          503:
+            description: "EOS backend temporarily unavailable while generating download URLs."
         """
         return self.get_helper(scope=scope, name=name, public=False)
 

--- a/lib/rucio/web/rest/flaskapi/v1/opendata.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata.py
@@ -15,7 +15,7 @@
 from flask import Blueprint, Flask, Response, request
 
 from rucio.common.constants import DEFAULT_VO, HTTPMethod
-from rucio.common.exception import AccessDenied, DataIdentifierNotFound, OpenDataDataIdentifierAlreadyExists, OpenDataDataIdentifierNotFound
+from rucio.common.exception import AccessDenied, DataIdentifierNotFound, OpenDataDataIdentifierAlreadyExists, OpenDataDataIdentifierNotFound, ResourceTemporaryUnavailable
 from rucio.common.utils import render_json
 from rucio.core.opendata import validate_opendata_did_state
 from rucio.gateway import opendata
@@ -123,6 +123,8 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
             return generate_http_error_flask(401, error)
         except OpenDataDataIdentifierNotFound as error:
             return generate_http_error_flask(404, error)
+        except ResourceTemporaryUnavailable as error:
+            return generate_http_error_flask(503, error)
         except Exception as error:
             return generate_http_error_flask(400, error)
 

--- a/lib/rucio/web/rest/flaskapi/v1/opendata.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata.py
@@ -128,6 +128,8 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
                     include_record_id=include_record_id,
                     include_download_urls=include_download_urls,
                 )
+            except OpenDataDataIdentifierNotFound as error:
+                return generate_http_error_flask(404, error)
             except OpenDataError as error:
                 return generate_http_error_flask(500, error)
 
@@ -135,7 +137,7 @@ class OpenDataDIDsView(ErrorHandlingMethodView):
             return Response(result, status=200, mimetype='application/json')
         except AccessDenied as error:
             return generate_http_error_flask(401, error)
-        except (OpenDataDataIdentifierNotFound, ReplicaNotFound) as error:
+        except ReplicaNotFound as error:
             return generate_http_error_flask(404, error)
         except ResourceTemporaryUnavailable as error:
             return generate_http_error_flask(503, error)

--- a/lib/rucio/web/rest/flaskapi/v1/opendata_public.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata_public.py
@@ -118,7 +118,7 @@ class OpenDataPublicDIDsView(ErrorHandlingMethodView):
             style: form
           - name: download_urls
             in: query
-            description: "Whether to include download URLs for the files. '1' to include, '0' to exclude. Default is '0'."
+            description: "Whether to include download URLs for the files. Requires 'files=1'. '1' to include, '0' to exclude. Default is '0'."
             schema:
               type: string
               enum: ['0', '1']
@@ -134,9 +134,11 @@ class OpenDataPublicDIDsView(ErrorHandlingMethodView):
           401:
             description: "Access denied: Invalid authentication."
           404:
-            description: "Data Identifier not found."
+            description: "Data Identifier or suitable download replica not found."
           400:
             description: "Invalid request or input parameters."
+          500:
+            description: "EOS backend failed while generating download URLs."
           503:
             description: "EOS backend temporarily unavailable while generating download URLs."
         """

--- a/lib/rucio/web/rest/flaskapi/v1/opendata_public.py
+++ b/lib/rucio/web/rest/flaskapi/v1/opendata_public.py
@@ -137,6 +137,8 @@ class OpenDataPublicDIDsView(ErrorHandlingMethodView):
             description: "Data Identifier not found."
           400:
             description: "Invalid request or input parameters."
+          503:
+            description: "EOS backend temporarily unavailable while generating download URLs."
         """
 
         return OpenDataDIDsView.get_helper(scope=scope, name=name, public=True)

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -666,11 +666,7 @@ class TestOpenDataEOS:
 
     def test_generate_download_urls_no_token(self, monkeypatch):
         monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
-        monkeypatch.setattr(
-            opendata,
-            "_eos_grpc_gateway_token_command",
-            lambda **kwargs: None,
-        )
+        monkeypatch.setattr(opendata, "_eos_grpc_gateway_token_command", lambda **kwargs: None)
 
         eos_uri = f"https://{self.eos_host}:8444/eos/file.root"
 

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -808,25 +808,24 @@ class TestOpenDataEOS:
     def test_get_opendata_did_files_download_url_generation_failure(
         self,
         mock_scope,
-        root_account,
         monkeypatch,
+        did_factory,
         db_write_session,
-):
-        name = did_name_generator(did_type="dataset")
-        file_name = did_name_generator(did_type="file")
-
-        add_did(
+    ):
+        dataset = did_factory.make_dataset(
             scope=mock_scope,
-            name=name,
-            account=root_account,
-            did_type=DIDType.DATASET,
             session=db_write_session,
         )
+
+        name = dataset["name"]
+        file_name = did_name_generator(did_type="file")
+
         opendata.add_opendata_did(
             scope=mock_scope,
             name=name,
             session=db_write_session,
         )
+
         db_write_session.commit()
 
         https_uri = (
@@ -891,25 +890,24 @@ class TestOpenDataEOS:
     def test_get_opendata_did_files_download_urls_only_root(
         self,
         mock_scope,
-        root_account,
         monkeypatch,
+        did_factory,
         db_write_session,
-):
-        name = did_name_generator(did_type="dataset")
-        file_name = did_name_generator(did_type="file")
-
-        add_did(
+    ):
+        dataset = did_factory.make_dataset(
             scope=mock_scope,
-            name=name,
-            account=root_account,
-            did_type=DIDType.DATASET,
             session=db_write_session,
         )
+
+        name = dataset["name"]
+        file_name = did_name_generator(did_type="file")
+
         opendata.add_opendata_did(
             scope=mock_scope,
             name=name,
             session=db_write_session,
         )
+
         db_write_session.commit()
 
         root_uri = f"root://{self.eos_host}:1094//eos/opendata/file.root"
@@ -955,25 +953,24 @@ class TestOpenDataEOS:
     def test_get_opendata_did_files_download_urls(
         self,
         mock_scope,
-        root_account,
         monkeypatch,
+        did_factory,
         db_write_session,
-):
-        name = did_name_generator(did_type="dataset")
-        file_name = did_name_generator(did_type="file")
-
-        add_did(
+    ):
+        dataset = did_factory.make_dataset(
             scope=mock_scope,
-            name=name,
-            account=root_account,
-            did_type=DIDType.DATASET,
             session=db_write_session,
         )
+
+        name = dataset["name"]
+        file_name = did_name_generator(did_type="file")
+
         opendata.add_opendata_did(
             scope=mock_scope,
             name=name,
             session=db_write_session,
         )
+
         db_write_session.commit()
 
         root_uri = f"root://{self.eos_host}:1094//eos/opendata/experiment/file.root"
@@ -1052,28 +1049,27 @@ class TestOpenDataEOS:
     def test_get_opendata_did_files_batches_replica_resolution(
         self,
         mock_scope,
-        root_account,
         monkeypatch,
+        did_factory,
         db_write_session,
     ):
-        name = did_name_generator(did_type="dataset")
+        dataset = did_factory.make_dataset(
+            scope=mock_scope,
+            session=db_write_session,
+        )
+
+        name = dataset["name"]
         file_names = [
             did_name_generator(did_type="file")
             for _ in range(3)
         ]
 
-        add_did(
-            scope=mock_scope,
-            name=name,
-            account=root_account,
-            did_type=DIDType.DATASET,
-            session=db_write_session,
-        )
         opendata.add_opendata_did(
             scope=mock_scope,
             name=name,
             session=db_write_session,
         )
+
         db_write_session.commit()
 
         def fake_list_files(*args, **kwargs):
@@ -1200,26 +1196,25 @@ class TestOpenDataEOS:
 
     def test_get_opendata_did_files_no_disk_uri(
             self,
-            mock_scope,
-            root_account,
-            monkeypatch,
-            db_write_session,
+        mock_scope,
+        monkeypatch,
+        did_factory,
+        db_write_session,
     ):
-        name = did_name_generator(did_type="dataset")
-        file_name = did_name_generator(did_type="file")
-
-        add_did(
+        dataset = did_factory.make_dataset(
             scope=mock_scope,
-            name=name,
-            account=root_account,
-            did_type=DIDType.DATASET,
             session=db_write_session,
         )
+
+        name = dataset["name"]
+        file_name = did_name_generator(did_type="file")
+
         opendata.add_opendata_did(
             scope=mock_scope,
             name=name,
             session=db_write_session,
         )
+
         db_write_session.commit()
 
         def fake_list_files(*args, **kwargs):
@@ -1253,22 +1248,19 @@ class TestOpenDataEOS:
     def test_get_opendata_did_files_ignores_legacy_cache(
         self,
         mock_scope,
-        root_account,
         monkeypatch,
+        did_factory,
         db_write_session,
     ):
         cache = _FakeCacheRegion()
 
-        name = did_name_generator(did_type="dataset")
-        file_name = did_name_generator(did_type="file")
-
-        add_did(
+        dataset = did_factory.make_dataset(
             scope=mock_scope,
-            name=name,
-            account=root_account,
-            did_type=DIDType.DATASET,
             session=db_write_session,
         )
+
+        name = dataset["name"]
+        file_name = did_name_generator(did_type="file")
 
         opendata.add_opendata_did(
             scope=mock_scope,

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -2240,6 +2240,7 @@ class TestOpenDataAPI:
     @pytest.mark.parametrize(
         "error_class, expected_status",
         [
+            (OpenDataDataIdentifierNotFound, 404),
             (ReplicaNotFound, 404),
             (OpenDataError, 500),
         ],

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -666,9 +666,15 @@ class TestOpenDataEOS:
 
     def test_generate_download_urls_no_token(self, monkeypatch):
         monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
-        monkeypatch.setattr(opendata, "_eos_grpc_gateway_token_command", lambda **kwargs: None)
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            lambda **kwargs: None,
+        )
 
-        assert opendata._generate_download_urls([f"root://{self.eos_host}:1094//eos/file.root"]) == []
+        eos_uri = f"https://{self.eos_host}:8444/eos/file.root"
+
+        assert opendata._generate_download_urls([eos_uri]) == []
 
     def test_generate_download_urls_skips_root_eos_uri(self, monkeypatch):
         eos_uri = f"root://{self.eos_host}:1094//eos/opendata/file.root"

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -249,6 +249,25 @@ class TestOpenDataCore:
 
         assert meta == meta_new, "'meta' should be updated"
 
+    def test_opendata_did_files_cache_key_length(self, mock_scope):
+        cache_key = opendata._make_opendata_did_files_cache_key(
+            mock_scope,
+            "n" * 250,
+            True,
+        )
+
+        assert len(cache_key.encode("utf-8")) <= 250
+
+        without_download_urls = (
+            opendata._make_opendata_did_files_cache_key(
+                mock_scope,
+                "n" * 250,
+                False,
+            )
+        )
+
+        assert cache_key != without_download_urls
+
     def test_opendata_doi_update(self, mock_scope, root_account, doi_factory, db_write_session):
         name = did_name_generator(did_type="dataset")
 

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -1009,8 +1009,8 @@ class TestOpenDataCLI:
         exitcode, stdout, stderr = execute("rucio opendata did list --short")
         assert exitcode == 0, f"Failed to list opendata with short option: {stderr.strip()}"
         lines = [line.strip() for line in stdout.split("\n") if line.strip()]
-        pattern = re.compile(rf"^{mock_scope}:.+$")
-        assert all(pattern.match(line) for line in lines), f"All lines should follow the {mock_scope}:name pattern"
+        pattern = re.compile(r"^[^:]+:.+$")
+        assert all(pattern.match(line) for line in lines), "All lines should follow the scope:name pattern"
         assert f"{mock_scope}:{name}" in lines, f"Expected {mock_scope}:{name} in opendata list with short option"
 
         exitcode, stdout, stderr = execute("rucio opendata did list --state draft")

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -1218,19 +1218,30 @@ class TestOpenDataEOS:
     def test_generate_download_urls_skips_root_eos_uri(self, monkeypatch):
         eos_uri = f"root://{self.eos_host}:1094//eos/opendata/file.root"
 
-        requested_paths = []
+        def unexpected_eos_probe(host):
+            pytest.fail(
+                "EOS probing must not run for unsupported root:// replicas"
+            )
 
-        def fake_token_command(*, eos_host, filename, lifetime_seconds):
-            requested_paths.append(filename)
-            return self.eos_token
+        def unexpected_token_request(**kwargs):
+            pytest.fail(
+                "EOS token generation must not run for unsupported root:// replicas"
+            )
 
-        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
-        monkeypatch.setattr(opendata, "_eos_grpc_gateway_token_command", fake_token_command)
+        monkeypatch.setattr(
+            opendata,
+            "_is_eos_host",
+            unexpected_eos_probe,
+        )
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            unexpected_token_request,
+        )
 
         download_urls = opendata._generate_download_urls([eos_uri])
 
-        assert download_urls == [], "Root EOS URI should not generate a download URL"
-        assert requested_paths == [], "Token command should not be called for root EOS URIs"
+        assert download_urls == []
 
     def test_get_opendata_did_files_download_urls_only_root(
         self,

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -629,8 +629,8 @@ class TestOpenDataEOS:
                                                             lifetime_seconds=3600) is None
 
     def test_generate_download_urls(self, monkeypatch):
-        expected_eos_host = f"{self.eos_host}:1094"
-        eos_uri = f"root://{self.eos_host}:1094//eos/opendata/experiment/file.root"
+        expected_eos_host = f"{self.eos_host}:8444"
+        eos_uri = f"https://{self.eos_host}:8444//eos/opendata/experiment/file.root"
         uris = [
             eos_uri,
             "https://not-eos.example.org:443/other/path/file.root",
@@ -640,7 +640,7 @@ class TestOpenDataEOS:
         requested_paths = []
 
         def fake_token_command(*, eos_host, filename, lifetime_seconds):
-            assert eos_host == f"{self.eos_host}:1094"
+            assert eos_host == f"{self.eos_host}:8444"
             requested_paths.append(filename)
             return self.eos_token
 
@@ -654,7 +654,7 @@ class TestOpenDataEOS:
         assert requested_paths == ["/eos/opendata/experiment/file.root"]
 
     def test_generate_download_urls_uri_with_query(self, monkeypatch):
-        eos_uri = f"root://{self.eos_host}:1094//eos/opendata/file.root?xrd.wantprot=unix"
+        eos_uri = f"https://{self.eos_host}:8444//eos/opendata/file.root?xrd.wantprot=unix"
 
         monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
         monkeypatch.setattr(opendata, "_eos_grpc_gateway_token_command",
@@ -679,9 +679,9 @@ class TestOpenDataEOS:
         opendata.add_opendata_did(scope=mock_scope, name=name, session=db_write_session)
         db_write_session.commit()
 
-        eos_uri = f"root://{self.eos_host}:1094//eos/opendata/experiment/file.root"
+        eos_uri = f"https://{self.eos_host}:8444//eos/opendata/experiment/file.root"
         tape_uri = "root://tape.example.org:1094//tape/file.root"
-        expected_eos_host = f"{self.eos_host}:1094"
+        expected_eos_host = f"{self.eos_host}:8444"
 
         def fake_list_files(*args, **kwargs):
             yield {"scope": mock_scope, "name": file_name, "bytes": 42, "adler32": "deadbeef"}

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -58,13 +58,20 @@ skip_unsupported_dialect = pytest.mark.skipif(
 OPENDATA_RSE_EXPRESSION = 'OpenData=True'
 
 
-@pytest.fixture(scope="module", autouse=True)
-def module_setup():
-    # Set OpenData RSE expression for tests
+def _configure_opendata_rse_expression():
     if not config_has_section('opendata'):
         config_add_section('opendata')
 
-    config_set('opendata', 'rse_expression', OPENDATA_RSE_EXPRESSION)
+    config_set(
+        'opendata',
+        'rse_expression',
+        OPENDATA_RSE_EXPRESSION,
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def module_setup():
+    _configure_opendata_rse_expression()
 
 
 class TestOpenDataCommon:
@@ -666,6 +673,7 @@ class TestOpenDataEOS:
         assert token == self.eos_token
 
         assert mock_post.call_args[0][0] == f"https://{self.eos_host}/v1/eos/rest/gateway/token_cmd"
+        assert mock_post.call_args[1]["allow_redirects"] is False
         body = mock_post.call_args[1]["json"]
         assert body["path"] == "/eos/opendata/experiment/file.root"
         assert body["permission"] == "r"
@@ -1257,6 +1265,7 @@ class TestOpenDataEOS:
         did_factory,
         db_write_session,
     ):
+        _configure_opendata_rse_expression()
         dataset = did_factory.make_dataset(
             scope=mock_scope,
             session=db_write_session,
@@ -1364,6 +1373,7 @@ class TestOpenDataEOS:
         did_factory,
         db_write_session,
     ):
+        _configure_opendata_rse_expression()
         dataset = did_factory.make_dataset(
             scope=mock_scope,
             session=db_write_session,
@@ -1427,6 +1437,7 @@ class TestOpenDataEOS:
         did_factory,
         db_write_session,
     ):
+        _configure_opendata_rse_expression()
         dataset = did_factory.make_dataset(
             scope=mock_scope,
             session=db_write_session,
@@ -1523,6 +1534,7 @@ class TestOpenDataEOS:
         did_factory,
         db_write_session,
     ):
+        _configure_opendata_rse_expression()
         dataset = did_factory.make_dataset(
             scope=mock_scope,
             session=db_write_session,
@@ -1618,6 +1630,7 @@ class TestOpenDataEOS:
         did_factory,
         db_write_session,
     ):
+        _configure_opendata_rse_expression()
         dataset = did_factory.make_dataset(
             scope=mock_scope,
             session=db_write_session,
@@ -1768,6 +1781,7 @@ class TestOpenDataEOS:
         did_factory,
         db_write_session,
     ):
+        _configure_opendata_rse_expression()
         dataset = did_factory.make_dataset(
             scope=mock_scope,
             session=db_write_session,
@@ -1830,7 +1844,7 @@ class TestOpenDataEOS:
         db_write_session,
     ):
         cache = _FakeCacheRegion()
-
+        _configure_opendata_rse_expression()
         dataset = did_factory.make_dataset(
             scope=mock_scope,
             session=db_write_session,
@@ -1930,6 +1944,7 @@ class TestOpenDataEOS:
         did_factory,
         db_write_session,
     ):
+        _configure_opendata_rse_expression()
         dataset = did_factory.make_dataset(
             scope=mock_scope,
             session=db_write_session,
@@ -2204,7 +2219,7 @@ class TestOpenDataAPI:
     def test_opendata_api_temporary_failure_returns_503(
         self,
         rest_client,
-        auth_token,
+        request,
         mock_scope,
         public,
     ):
@@ -2221,7 +2236,9 @@ class TestOpenDataAPI:
 
         request_kwargs = {}
         if not public:
-            request_kwargs["headers"] = headers(auth(auth_token))
+            request_kwargs["headers"] = headers(
+                auth(request.getfixturevalue("auth_token"))
+            )
 
         with patch(
             "rucio.gateway.opendata.get_opendata_did",
@@ -2248,7 +2265,7 @@ class TestOpenDataAPI:
     def test_opendata_api_download_failure_status(
         self,
         rest_client,
-        auth_token,
+        request,
         mock_scope,
         public,
         error_class,
@@ -2267,7 +2284,9 @@ class TestOpenDataAPI:
 
         request_kwargs = {}
         if not public:
-            request_kwargs["headers"] = headers(auth(auth_token))
+            request_kwargs["headers"] = headers(
+                auth(request.getfixturevalue("auth_token"))
+            )
 
         with patch(
             "rucio.gateway.opendata.get_opendata_did",

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -558,14 +558,20 @@ class TestOpenDataEOS:
         monkeypatch.setattr(opendata, "EOS_PROBE_NEGATIVE_REGION", _FakeCacheRegion())
 
     def test_is_eos_host_positive(self):
-        with patch("rucio.core.opendata.requests.post",
-                   return_value=_mock_eos_response(json_data=self.eos_version_payload)) as mock_post:
-            assert opendata._is_eos_host(self.eos_host) is True
-            # The positive result is cached: a second call must not probe again
-            assert opendata._is_eos_host(self.eos_host) is True
+        eos_host = f"{self.eos_host}:8444"
 
-        assert mock_post.call_count == 1, "Positive probe result should be cached"
-        assert mock_post.call_args[0][0] == f"https://{self.eos_host}/v1/eos/rest/gateway/version_cmd"
+        with patch(
+            "rucio.core.opendata.requests.post",
+            return_value=_mock_eos_response(json_data=self.eos_version_payload),
+        ) as mock_post:
+            assert opendata._is_eos_host(eos_host) is True
+            assert opendata._is_eos_host(eos_host) is True
+
+        assert mock_post.call_count == 1
+        assert mock_post.call_args[0][0] == (
+            f"https://{self.eos_host}:8444"
+            "/v1/eos/rest/gateway/version_cmd"
+        )
 
     def test_is_eos_host_positive_integer_retc(self):
         payload = {"retc": 0, "stdOut": "EOS_SERVER_VERSION=5.2.31", "stdErr": ""}
@@ -608,16 +614,30 @@ class TestOpenDataEOS:
         assert body["permission"] == "r"
         assert time_before + lifetime_seconds <= int(body["expires"]) <= time_after + lifetime_seconds
 
-    def test_eos_token_command_host_with_scheme(self):
-        payload = {"retc": "0", "stdOut": self.eos_token, "stdErr": ""}
-        with patch("rucio.core.opendata.requests.post",
-                   return_value=_mock_eos_response(json_data=payload)) as mock_post:
-            token = opendata._eos_grpc_gateway_token_command(eos_host=f"https://{self.eos_host}/",
-                                                             filename="/eos/opendata/file.root",
-                                                             lifetime_seconds=3600)
+    def test_eos_token_command_host_with_port(self):
+        eos_host = f"{self.eos_host}:8444"
+        payload = {
+            "retc": "0",
+            "stdOut": self.eos_token,
+            "stdErr": "",
+        }
+
+        with patch(
+            "rucio.core.opendata.requests.post",
+            return_value=_mock_eos_response(json_data=payload),
+        ) as mock_post:
+            token = opendata._eos_grpc_gateway_token_command(
+                eos_host=eos_host,
+                filename="/eos/opendata/file.root",
+                lifetime_seconds=3600,
+            )
 
         assert token == self.eos_token
-        assert mock_post.call_args[0][0] == f"https://{self.eos_host}/v1/eos/rest/gateway/token_cmd"
+
+        assert mock_post.call_args[0][0] == (
+            f"https://{self.eos_host}:8444"
+            "/v1/eos/rest/gateway/token_cmd"
+        )
 
     def test_eos_token_command_empty_token(self):
         payload = {"retc": "0", "stdOut": "  \n", "stdErr": ""}
@@ -668,17 +688,42 @@ class TestOpenDataEOS:
             f"//eos/opendata/experiment/file.root"
         )
 
-        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
+        probed_hosts = []
+        token_requests = []
+
+        def fake_is_eos_host(host):
+            probed_hosts.append(host)
+            return True
+
+        def fake_token_command(*, eos_host, filename, lifetime_seconds):
+            token_requests.append({
+                "eos_host": eos_host,
+                "filename": filename,
+            })
+            return self.eos_token
+
+        monkeypatch.setattr(opendata, "_is_eos_host", fake_is_eos_host)
         monkeypatch.setattr(
             opendata,
             "_eos_grpc_gateway_token_command",
-            lambda **kwargs: self.eos_token,
+            fake_token_command,
         )
 
         download_urls = opendata._generate_download_urls([eos_uri])
 
         assert download_urls == [
             f"{eos_uri}?authz={self.eos_token}"
+        ]
+
+        assert probed_hosts == [
+            f"{self.eos_host}:8444"
+        ]
+
+        assert token_requests == [
+            {
+                "eos_host": f"{self.eos_host}:8444",
+                "filename": "/eos/opendata/experiment/file.root",
+            }
         ]
 
     def test_generate_download_urls_uri_with_query(self, monkeypatch):

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -16,7 +16,7 @@ import re
 import time
 from configparser import NoOptionError
 from unittest.mock import MagicMock, patch
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, parse_qsl, urlparse
 
 import pytest
 import requests
@@ -773,17 +773,26 @@ class TestOpenDataEOS:
             }
         ]
 
-    def test_generate_download_urls_uri_with_query_and_fragment(self, monkeypatch):
+    def test_generate_download_urls_preserves_query_and_fragment(
+        self,
+        monkeypatch,
+    ):
+        token = "token+value"
         eos_uri = (
             f"https://{self.eos_host}:8444"
-            "//eos/opendata/file.root?xrd.wantprot=unix#multirange"
+            "/eos/opendata/file.root"
+            "?source=a&source=b&flag#part"
         )
 
-        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
+        monkeypatch.setattr(
+            opendata,
+            "_is_eos_host",
+            lambda host: True,
+        )
         monkeypatch.setattr(
             opendata,
             "_eos_grpc_gateway_token_command",
-            lambda **kwargs: self.eos_token,
+            lambda **kwargs: token,
         )
 
         download_urls = opendata._generate_download_urls([eos_uri])
@@ -791,11 +800,24 @@ class TestOpenDataEOS:
         assert len(download_urls) == 1
 
         parsed = urlparse(download_urls[0])
-        query = parse_qs(parsed.query)
 
-        assert query["xrd.wantprot"] == ["unix"]
-        assert query["authz"] == [self.eos_token]
-        assert parsed.fragment == "multirange"
+        # Verify that the existing query is preserved verbatim.
+        assert parsed.query.startswith(
+            "source=a&source=b&flag&authz="
+        )
+
+        # Verify its decoded semantics as well.
+        assert parse_qsl(
+            parsed.query,
+            keep_blank_values=True,
+        ) == [
+            ("source", "a"),
+            ("source", "b"),
+            ("flag", ""),
+            ("authz", token),
+        ]
+
+        assert parsed.fragment == "part"
 
     def test_generate_download_urls_no_token(self, monkeypatch):
         monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -691,6 +691,37 @@ class TestOpenDataEOS:
         # The double slash of the PFN must be collapsed in the path sent to EOS.
         assert requested_paths == ["/eos/opendata/experiment/file.root"]
 
+    def test_generate_download_urls_preserves_ipv6_authority(self, monkeypatch):
+        eos_uri = "https://[2001:db8::1]:8444//eos/opendata/file.root"
+
+        probed_hosts = []
+        token_hosts = []
+
+        def fake_is_eos_host(host):
+            probed_hosts.append(host)
+            return True
+
+        def fake_token_command(*, eos_host, filename, lifetime_seconds):
+            token_hosts.append(eos_host)
+            return self.eos_token
+
+        monkeypatch.setattr(opendata, "_is_eos_host", fake_is_eos_host)
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            fake_token_command,
+        )
+
+        download_urls = opendata._generate_download_urls([eos_uri])
+
+        assert probed_hosts == ["[2001:db8::1]:8444"]
+        assert token_hosts == ["[2001:db8::1]:8444"]
+
+        parsed = urlparse(download_urls[0])
+        assert parsed.hostname == "2001:db8::1"
+        assert parsed.port == 8444
+        assert parse_qs(parsed.query)["authz"] == [self.eos_token]
+
     @pytest.mark.parametrize("scheme", ["http", "https", "dav", "davs"])
     def test_generate_download_urls_supported_schemes(self, scheme, monkeypatch):
         eos_uri = (

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -34,6 +34,7 @@ from rucio.common.exception import (
     OpenDataInvalidStateUpdate,
     ResourceTemporaryUnavailable,
 )
+from rucio.common.types import InternalScope
 from rucio.common.utils import execute
 from rucio.core import opendata
 from rucio.core.did import add_did, set_status
@@ -267,6 +268,37 @@ class TestOpenDataCore:
         )
 
         assert cache_key != without_download_urls
+
+    def test_opendata_did_files_cache_key_is_vo_aware(self):
+        scope_vo1 = InternalScope("shared", vo="vo1")
+        scope_vo2 = InternalScope("shared", vo="vo2")
+
+        key_vo1 = opendata._make_opendata_did_files_cache_key(
+            scope_vo1,
+            "dataset",
+            True,
+        )
+        key_vo2 = opendata._make_opendata_did_files_cache_key(
+            scope_vo2,
+            "dataset",
+            True,
+        )
+
+        assert key_vo1 != key_vo2
+
+    def test_opendata_did_files_cache_key_is_unambiguous(self):
+        key_first = opendata._make_opendata_did_files_cache_key(
+            InternalScope("a_b"),
+            "c",
+            True,
+        )
+        key_second = opendata._make_opendata_did_files_cache_key(
+            InternalScope("a"),
+            "b_c",
+            True,
+        )
+
+        assert key_first != key_second
 
     def test_opendata_doi_update(self, mock_scope, root_account, doi_factory, db_write_session):
         name = did_name_generator(did_type="dataset")
@@ -1541,6 +1573,7 @@ class TestOpenDataEOS:
             list_replicas_calls.append({
                 "dids": list(dids),
                 "schemes": schemes,
+                "resolve_archives": kwargs.get("resolve_archives"),
             })
 
             for did in dids:
@@ -1597,6 +1630,7 @@ class TestOpenDataEOS:
 
         assert len(regular_call["dids"]) == 3
         assert len(download_call["dids"]) == 3
+        assert download_call["resolve_archives"] is False
 
         assert {
             did["name"] for did in regular_call["dids"]
@@ -1646,7 +1680,7 @@ class TestOpenDataEOS:
         assert token_called is False
 
     def test_get_opendata_did_files_no_disk_uri(
-            self,
+        self,
         mock_scope,
         monkeypatch,
         did_factory,
@@ -1683,18 +1717,26 @@ class TestOpenDataEOS:
                 "pfns": {},
             }
 
-        monkeypatch.setattr(opendata, "list_files", fake_list_files)
-        monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
+        monkeypatch.setattr(
+            opendata,
+            "list_files",
+            fake_list_files,
+        )
+        monkeypatch.setattr(
+            opendata,
+            "list_replicas",
+            fake_list_replicas,
+        )
 
-        with pytest.raises(
-            OpenDataError,
-            match="Failed to retrieve replica URI",
-        ):
-            opendata.get_opendata_did_files(
-                scope=mock_scope,
-                name=name,
-                session=db_write_session,
-            )
+        result = opendata.get_opendata_did_files(
+            scope=mock_scope,
+            name=name,
+            session=db_write_session,
+        )
+
+        assert len(result["files"]) == 1
+        assert result["files"][0]["uris"] == []
+        assert "download_urls" not in result["files"][0]
 
     def test_get_opendata_did_files_ignores_legacy_cache(
         self,

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -32,6 +32,7 @@ from rucio.common.exception import (
     OpenDataDuplicateRecordID,
     OpenDataError,
     OpenDataInvalidStateUpdate,
+    ResourceTemporaryUnavailable,
 )
 from rucio.common.utils import execute
 from rucio.core import opendata
@@ -591,10 +592,13 @@ class TestOpenDataEOS:
         with patch("rucio.core.opendata.requests.post", return_value=_mock_eos_response(json_data=payload)):
             assert opendata._is_eos_host(self.eos_host) is False
 
-    def test_is_eos_host_negative_unreachable(self):
-        with patch("rucio.core.opendata.requests.post",
-                   side_effect=requests.exceptions.ConnectionError("connection refused")):
-            assert opendata._is_eos_host(self.eos_host) is False
+    def test_is_eos_host_unreachable(self):
+        with patch(
+            "rucio.core.opendata.requests.post",
+            side_effect=requests.exceptions.ConnectionError("connection refused"),
+        ):
+            with pytest.raises(ResourceTemporaryUnavailable):
+                opendata._is_eos_host(self.eos_host)
 
     def test_eos_token_command(self):
         lifetime_seconds = 3600
@@ -641,21 +645,92 @@ class TestOpenDataEOS:
         )
 
     def test_eos_token_command_empty_token(self):
-        payload = {"retc": "0", "stdOut": "  \n", "stdErr": ""}
-        with patch("rucio.core.opendata.requests.post", return_value=_mock_eos_response(json_data=payload)):
-            assert opendata._eos_grpc_gateway_token_command(eos_host=self.eos_host, filename="/eos/file.root",
-                                                            lifetime_seconds=3600) is None
+        payload = {
+            "retc": "0",
+            "stdOut": "  \n",
+            "stdErr": "",
+        }
+
+        with patch(
+            "rucio.core.opendata.requests.post",
+            return_value=_mock_eos_response(json_data=payload),
+        ):
+            with pytest.raises(ResourceTemporaryUnavailable):
+                opendata._eos_grpc_gateway_token_command(
+                    eos_host=self.eos_host,
+                    filename="/eos/file.root",
+                    lifetime_seconds=3600,
+                )
 
     def test_eos_token_command_http_error(self):
-        with patch("rucio.core.opendata.requests.post", return_value=_mock_eos_response(status_code=500)):
-            assert opendata._eos_grpc_gateway_token_command(eos_host=self.eos_host, filename="/eos/file.root",
-                                                            lifetime_seconds=3600) is None
+        with patch(
+            "rucio.core.opendata.requests.post",
+            return_value=_mock_eos_response(status_code=500),
+        ):
+            with pytest.raises(ResourceTemporaryUnavailable):
+                opendata._eos_grpc_gateway_token_command(
+                    eos_host=self.eos_host,
+                    filename="/eos/file.root",
+                    lifetime_seconds=3600,
+                )
 
     def test_eos_token_command_unreachable(self):
-        with patch("rucio.core.opendata.requests.post",
-                   side_effect=requests.exceptions.ConnectionError("connection refused")):
-            assert opendata._eos_grpc_gateway_token_command(eos_host=self.eos_host, filename="/eos/file.root",
-                                                            lifetime_seconds=3600) is None
+        with patch(
+            "rucio.core.opendata.requests.post",
+            side_effect=requests.exceptions.ConnectionError("connection refused"),
+        ):
+            with pytest.raises(ResourceTemporaryUnavailable):
+                opendata._eos_grpc_gateway_token_command(
+                    eos_host=self.eos_host,
+                    filename="/eos/file.root",
+                    lifetime_seconds=3600,
+                )
+
+    def test_eos_token_command_nonzero_retc(self):
+        payload = {
+            "retc": -5,
+            "stdOut": "zteos64:invalid-after-command-failure",
+            "stdErr": "error: could not store token",
+        }
+
+        with patch(
+            "rucio.core.opendata.requests.post",
+            return_value=_mock_eos_response(json_data=payload),
+        ):
+            with pytest.raises(ResourceTemporaryUnavailable):
+                opendata._eos_grpc_gateway_token_command(
+                    eos_host=self.eos_host,
+                    filename="/eos/file.root",
+                    lifetime_seconds=3600,
+                )
+
+    def test_is_eos_host_temporary_http_error(self):
+        with patch(
+            "rucio.core.opendata.requests.post",
+            return_value=_mock_eos_response(status_code=503),
+        ):
+            with pytest.raises(ResourceTemporaryUnavailable):
+                opendata._is_eos_host(self.eos_host)
+
+    def test_eos_token_command_non_temporary_http_error(self):
+        with patch(
+            "rucio.core.opendata.requests.post",
+            return_value=_mock_eos_response(status_code=404),
+        ):
+            with pytest.raises(OpenDataError):
+                opendata._eos_grpc_gateway_token_command(
+                    eos_host=self.eos_host,
+                    filename="/eos/file.root",
+                    lifetime_seconds=3600,
+                )
+
+    def test_is_eos_host_invalid_json(self):
+        with patch(
+            "rucio.core.opendata.requests.post",
+            return_value=_mock_eos_response(status_code=200),
+        ):
+            with pytest.raises(ResourceTemporaryUnavailable):
+                opendata._is_eos_host(self.eos_host)
 
     def test_generate_download_urls(self, monkeypatch):
         expected_eos_host = f"{self.eos_host}:8444"
@@ -690,6 +765,47 @@ class TestOpenDataEOS:
 
         # The double slash of the PFN must be collapsed in the path sent to EOS.
         assert requested_paths == ["/eos/opendata/experiment/file.root"]
+
+    def test_generate_download_urls_uses_other_replica_after_temporary_failure(
+        self,
+        monkeypatch,
+    ):
+        first_uri = (
+            f"https://first.{self.eos_host}:8444"
+            "/eos/opendata/file.root"
+        )
+        second_uri = (
+            f"https://second.{self.eos_host}:8444"
+            "/eos/opendata/file.root"
+        )
+
+        monkeypatch.setattr(
+            opendata,
+            "_is_eos_host",
+            lambda host: True,
+        )
+
+        def fake_token_command(*, eos_host, filename, lifetime_seconds):
+            if eos_host == f"first.{self.eos_host}:8444":
+                raise ResourceTemporaryUnavailable(
+                    "temporary EOS failure"
+                )
+            return self.eos_token
+
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            fake_token_command,
+        )
+
+        download_urls = opendata._generate_download_urls(
+            [first_uri, second_uri]
+        )
+
+        assert len(download_urls) == 1
+        assert urlparse(download_urls[0]).hostname == (
+            f"second.{self.eos_host}"
+        )
 
     def test_generate_download_urls_preserves_ipv6_authority(self, monkeypatch):
         eos_uri = "https://[2001:db8::1]:8444//eos/opendata/file.root"
@@ -819,13 +935,26 @@ class TestOpenDataEOS:
 
         assert parsed.fragment == "part"
 
-    def test_generate_download_urls_no_token(self, monkeypatch):
-        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
-        monkeypatch.setattr(opendata, "_eos_grpc_gateway_token_command", lambda **kwargs: None)
+    def test_generate_download_urls_temporary_token_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            opendata,
+            "_is_eos_host",
+            lambda host: True,
+        )
+
+        def fail_token_command(**kwargs):
+            raise ResourceTemporaryUnavailable("temporary EOS failure")
+
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            fail_token_command,
+        )
 
         eos_uri = f"https://{self.eos_host}:8444/eos/file.root"
 
-        assert opendata._generate_download_urls([eos_uri]) == []
+        with pytest.raises(ResourceTemporaryUnavailable):
+            opendata._generate_download_urls([eos_uri])
 
     def test_generate_download_urls_reuses_equivalent_eos_token(
         self,
@@ -948,7 +1077,7 @@ class TestOpenDataEOS:
 
         https_uri = (
             f"https://{self.eos_host}:8444"
-            f"//eos/opendata/experiment/file.root"
+            "//eos/opendata/experiment/file.root"
         )
 
         def fake_list_files(*args, **kwargs):
@@ -968,19 +1097,33 @@ class TestOpenDataEOS:
                 },
             }
 
-        monkeypatch.setattr(opendata, "list_files", fake_list_files)
-        monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
-        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
+        def fail_token_command(**kwargs):
+            raise ResourceTemporaryUnavailable(
+                "temporary EOS token failure"
+            )
+
+        monkeypatch.setattr(
+            opendata,
+            "list_files",
+            fake_list_files,
+        )
+        monkeypatch.setattr(
+            opendata,
+            "list_replicas",
+            fake_list_replicas,
+        )
+        monkeypatch.setattr(
+            opendata,
+            "_is_eos_host",
+            lambda host: True,
+        )
         monkeypatch.setattr(
             opendata,
             "_eos_grpc_gateway_token_command",
-            lambda **kwargs: None,
+            fail_token_command,
         )
 
-        with pytest.raises(
-            OpenDataError,
-            match="Failed to generate download URL",
-        ):
+        with pytest.raises(ResourceTemporaryUnavailable):
             opendata.get_opendata_did_files(
                 scope=mock_scope,
                 name=name,

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -32,6 +32,7 @@ from rucio.common.exception import (
     OpenDataDuplicateRecordID,
     OpenDataError,
     OpenDataInvalidStateUpdate,
+    ReplicaNotFound,
     ResourceTemporaryUnavailable,
 )
 from rucio.common.types import InternalScope
@@ -1409,8 +1410,8 @@ class TestOpenDataEOS:
         monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
 
         with pytest.raises(
-            OpenDataError,
-            match="Failed to retrieve HTTP\\(S\\) or DAV\\(S\\) replica URI",
+            ReplicaNotFound,
+            match="No HTTP\\(S\\) or DAV\\(S\\) DISK replica URI available",
         ):
             opendata.get_opendata_did_files(
                 scope=mock_scope,
@@ -1991,8 +1992,8 @@ class TestOpenDataEOS:
         )
 
         with pytest.raises(
-            OpenDataError,
-            match="Failed to retrieve HTTP\\(S\\) or DAV\\(S\\) replica URI",
+            ReplicaNotFound,
+            match="No HTTP\\(S\\) or DAV\\(S\\) DISK replica URI available",
         ):
             opendata.get_opendata_did_files(
                 scope=mock_scope,
@@ -2187,12 +2188,12 @@ class TestOpenDataAPI:
             assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
             assert "files" in response.json, "Files should be present in the response"
 
-            # The parameter is also accepted without requesting the files
+            # Download URLs require the file list to be requested.
             response = rest_client.get(
                 f"{endpoint}?download_urls=1",
                 headers=request_headers,
             )
-            assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
+            assert response.status_code == 400, f"Expected 400 Bad Request, got {response.status_code}"
         finally:
             rest_client.delete(
                 endpoint,
@@ -2234,6 +2235,49 @@ class TestOpenDataAPI:
             )
 
         assert response.status_code == 503
+
+    @pytest.mark.parametrize("public", [False, True])
+    @pytest.mark.parametrize(
+        "error_class, expected_status",
+        [
+            (ReplicaNotFound, 404),
+            (OpenDataError, 500),
+        ],
+    )
+    def test_opendata_api_download_failure_status(
+        self,
+        rest_client,
+        auth_token,
+        mock_scope,
+        public,
+        error_class,
+        expected_status,
+    ):
+        base_endpoint = (
+            self.api_endpoint_public
+            if public
+            else self.api_endpoint
+        )
+
+        endpoint = (
+            f"{base_endpoint}/{mock_scope}/test"
+            "?files=1&download_urls=1"
+        )
+
+        request_kwargs = {}
+        if not public:
+            request_kwargs["headers"] = headers(auth(auth_token))
+
+        with patch(
+            "rucio.gateway.opendata.get_opendata_did",
+            side_effect=error_class("download failure"),
+        ):
+            response = rest_client.get(
+                endpoint,
+                **request_kwargs,
+            )
+
+        assert response.status_code == expected_status
 
 
 @pytest.mark.noparallel(reason="Changes in configuration values and race conditions")

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -807,6 +807,51 @@ class TestOpenDataEOS:
             f"second.{self.eos_host}"
         )
 
+    @pytest.mark.parametrize("failing_first", [True, False])
+    def test_generate_download_urls_uses_healthy_replica_after_non_temporary_failure(
+        self,
+        monkeypatch,
+        failing_first,
+    ):
+        failing_uri = (
+            f"https://bad.{self.eos_host}:8444"
+            "/eos/opendata/file.root"
+        )
+        working_uri = (
+            f"https://good.{self.eos_host}:8444"
+            "/eos/opendata/file.root"
+        )
+
+        uris = (
+            [failing_uri, working_uri]
+            if failing_first
+            else [working_uri, failing_uri]
+        )
+
+        monkeypatch.setattr(
+            opendata,
+            "_is_eos_host",
+            lambda host: True,
+        )
+
+        def fake_token_command(*, eos_host, filename, lifetime_seconds):
+            if eos_host == f"bad.{self.eos_host}:8444":
+                raise OpenDataError("non-retryable token failure")
+            return self.eos_token
+
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            fake_token_command,
+        )
+
+        download_urls = opendata._generate_download_urls(uris)
+
+        assert len(download_urls) == 1
+        assert urlparse(download_urls[0]).hostname == (
+            f"good.{self.eos_host}"
+        )
+
     def test_generate_download_urls_preserves_ipv6_authority(self, monkeypatch):
         eos_uri = "https://[2001:db8::1]:8444//eos/opendata/file.root"
 

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -768,7 +768,7 @@ class TestOpenDataEOS:
             "rucio.core.opendata.requests.post",
             return_value=_mock_eos_response(json_data=payload),
         ):
-            with pytest.raises(ResourceTemporaryUnavailable):
+            with pytest.raises(OpenDataError, match="retc=-5"):
                 opendata._eos_grpc_gateway_token_command(
                     eos_host=self.eos_host,
                     filename="/eos/file.root",
@@ -789,6 +789,63 @@ class TestOpenDataEOS:
             return_value=_mock_eos_response(status_code=404),
         ):
             with pytest.raises(OpenDataError):
+                opendata._eos_grpc_gateway_token_command(
+                    eos_host=self.eos_host,
+                    filename="/eos/file.root",
+                    lifetime_seconds=3600,
+                )
+
+    def test_eos_token_command_rejects_diagnostic_output(self):
+        payload = {
+            "retc": "0",
+            "stdOut": (
+                f"{self.eos_token}\n"
+                "warning: token requires approval"
+            ),
+            "stdErr": "",
+        }
+
+        with patch(
+            "rucio.core.opendata.requests.post",
+            return_value=_mock_eos_response(json_data=payload),
+        ):
+            with pytest.raises(OpenDataError):
+                opendata._eos_grpc_gateway_token_command(
+                    eos_host=self.eos_host,
+                    filename="/eos/file.root",
+                    lifetime_seconds=3600,
+                )
+
+    @pytest.mark.parametrize("retc", [None, "invalid"])
+    def test_eos_token_command_invalid_retc(self, retc):
+        payload = {
+            "retc": retc,
+            "stdOut": self.eos_token,
+            "stdErr": "",
+        }
+
+        with patch(
+            "rucio.core.opendata.requests.post",
+            return_value=_mock_eos_response(json_data=payload),
+        ):
+            with pytest.raises(ResourceTemporaryUnavailable):
+                opendata._eos_grpc_gateway_token_command(
+                    eos_host=self.eos_host,
+                    filename="/eos/file.root",
+                    lifetime_seconds=3600,
+                )
+
+    def test_eos_token_command_missing_retc(self):
+        payload = {
+            "stdOut": self.eos_token,
+            "stdErr": "",
+        }
+
+        with patch(
+            "rucio.core.opendata.requests.post",
+            return_value=_mock_eos_response(json_data=payload),
+        ):
+            with pytest.raises(ResourceTemporaryUnavailable):
                 opendata._eos_grpc_gateway_token_command(
                     eos_host=self.eos_host,
                     filename="/eos/file.root",
@@ -1135,6 +1192,30 @@ class TestOpenDataEOS:
             assert parse_qs(urlparse(url).query)["authz"] == [
                 self.eos_token
             ]
+
+    def test_generate_download_urls_propagates_non_temporary_failure(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            opendata,
+            "_is_eos_host",
+            lambda host: True,
+        )
+
+        def fail_token_command(**kwargs):
+            raise OpenDataError("EOS command rejected")
+
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            fail_token_command,
+        )
+
+        uri = f"https://{self.eos_host}:8444/eos/file.root"
+
+        with pytest.raises(OpenDataError, match="EOS command rejected"):
+            opendata._generate_download_urls([uri])
 
     def test_extract_disk_uris_filters_non_disk_replicas(self):
         disk_uri = (
@@ -1838,6 +1919,85 @@ class TestOpenDataEOS:
 
         assert query["authz"] == [self.eos_token]
         assert "token" not in query
+
+    def test_get_opendata_did_files_validates_all_download_uris_before_token_generation(
+        self,
+        mock_scope,
+        monkeypatch,
+        did_factory,
+        db_write_session,
+    ):
+        dataset = did_factory.make_dataset(
+            scope=mock_scope,
+            session=db_write_session,
+        )
+
+        name = dataset["name"]
+        first_file = did_name_generator(did_type="file")
+        second_file = did_name_generator(did_type="file")
+
+        opendata.add_opendata_did(
+            scope=mock_scope,
+            name=name,
+            session=db_write_session,
+        )
+        db_write_session.commit()
+
+        def fake_list_files(*args, **kwargs):
+            for file_name in [first_file, second_file]:
+                yield {
+                    "scope": mock_scope,
+                    "name": file_name,
+                    "bytes": 42,
+                    "adler32": "deadbeef",
+                }
+
+        def fake_list_replicas(*args, **kwargs):
+            download_lookup = kwargs.get("schemes") is not None
+
+            for did in kwargs["dids"]:
+                if download_lookup:
+                    pfns = (
+                        {
+                            f"https://{self.eos_host}:8444"
+                            f"/eos/{did['name']}": {"type": "DISK"}
+                        }
+                        if did["name"] == first_file
+                        else {}
+                    )
+                else:
+                    pfns = {}
+
+                yield {
+                    "scope": did["scope"],
+                    "name": did["name"],
+                    "pfns": pfns,
+                }
+
+        def unexpected_download_generation(uris):
+            pytest.fail(
+                "Download URLs must not be generated before "
+                "all files have been validated"
+            )
+
+        monkeypatch.setattr(opendata, "list_files", fake_list_files)
+        monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
+        monkeypatch.setattr(
+            opendata,
+            "_generate_download_urls",
+            unexpected_download_generation,
+        )
+
+        with pytest.raises(
+            OpenDataError,
+            match="Failed to retrieve HTTP\\(S\\) or DAV\\(S\\) replica URI",
+        ):
+            opendata.get_opendata_did_files(
+                scope=mock_scope,
+                name=name,
+                include_download_urls=True,
+                session=db_write_session,
+            )
 
 
 @pytest.mark.noparallel(reason="Changes in configuration values and race conditions")

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -827,6 +827,70 @@ class TestOpenDataEOS:
 
         assert opendata._generate_download_urls([eos_uri]) == []
 
+    def test_generate_download_urls_reuses_equivalent_eos_token(
+        self,
+        monkeypatch,
+    ):
+        uris = [
+            (
+                f"{scheme}://{self.eos_host}:8444"
+                "//eos/opendata/file.root"
+            )
+            for scheme in ["http", "https", "dav", "davs"]
+        ]
+
+        probed_hosts = []
+        token_requests = []
+
+        def fake_is_eos_host(host):
+            probed_hosts.append(host)
+            return True
+
+        def fake_token_command(
+            *,
+            eos_host,
+            filename,
+            lifetime_seconds,
+        ):
+            token_requests.append((eos_host, filename))
+            return self.eos_token
+
+        monkeypatch.setattr(
+            opendata,
+            "_is_eos_host",
+            fake_is_eos_host,
+        )
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            fake_token_command,
+        )
+
+        download_urls = opendata._generate_download_urls(uris)
+
+        # Preserve all supported protocol alternatives.
+        assert len(download_urls) == 4
+        assert {
+            urlparse(url).scheme
+            for url in download_urls
+        } == {"http", "https", "dav", "davs"}
+
+        # Probe and token generation happen once for the common scope.
+        assert probed_hosts == [
+            f"{self.eos_host}:8444"
+        ]
+        assert token_requests == [
+            (
+                f"{self.eos_host}:8444",
+                "/eos/opendata/file.root",
+            )
+        ]
+
+        for url in download_urls:
+            assert parse_qs(urlparse(url).query)["authz"] == [
+                self.eos_token
+            ]
+
     def test_get_opendata_did_files_download_url_generation_failure(
         self,
         mock_scope,

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -891,6 +891,38 @@ class TestOpenDataEOS:
                 self.eos_token
             ]
 
+    def test_extract_disk_uris_filters_non_disk_replicas(self):
+        disk_uri = (
+            "https://disk.example.org:8444"
+            "//eos/file.root"
+        )
+        tape_uri = (
+            "https://tape.example.org:8444"
+            "//eos/file.root"
+        )
+
+        replicas = [
+            {
+                "pfns": {
+                    disk_uri: {"type": "DISK"},
+                    tape_uri: {"type": "TAPE"},
+                }
+            }
+        ]
+
+        assert opendata._extract_disk_uris(replicas) == [
+            disk_uri
+        ]
+        assert opendata._extract_disk_uris(
+            [
+                {
+                    "pfns": {
+                        tape_uri: {"type": "TAPE"},
+                    }
+                }
+            ]
+        ) == []
+
     def test_get_opendata_did_files_download_url_generation_failure(
         self,
         mock_scope,
@@ -1131,6 +1163,101 @@ class TestOpenDataEOS:
         assert parse_qs(parsed.query)["authz"] == [self.eos_token]
 
         assert ["http", "https", "dav", "davs"] in requested_schemes
+
+    def test_get_opendata_did_files_without_download_urls(
+        self,
+        mock_scope,
+        monkeypatch,
+        did_factory,
+        db_write_session,
+    ):
+        dataset = did_factory.make_dataset(
+            scope=mock_scope,
+            session=db_write_session,
+        )
+
+        name = dataset["name"]
+        file_name = did_name_generator(did_type="file")
+
+        opendata.add_opendata_did(
+            scope=mock_scope,
+            name=name,
+            session=db_write_session,
+        )
+        db_write_session.commit()
+
+        root_uri = (
+            f"root://{self.eos_host}:1094"
+            f"//eos/opendata/{file_name}"
+        )
+
+        list_replicas_calls = []
+
+        def fake_list_files(*args, **kwargs):
+            yield {
+                "scope": mock_scope,
+                "name": file_name,
+                "bytes": 42,
+                "adler32": "deadbeef",
+            }
+
+        def fake_list_replicas(*args, **kwargs):
+            list_replicas_calls.append(kwargs)
+
+            for did in kwargs["dids"]:
+                yield {
+                    "scope": did["scope"],
+                    "name": did["name"],
+                    "pfns": {
+                        root_uri: {"type": "DISK"},
+                    },
+                }
+
+        def unexpected_eos_probe(host):
+            pytest.fail(
+                "EOS probing must not run when "
+                "include_download_urls=False"
+            )
+
+        def unexpected_token_request(**kwargs):
+            pytest.fail(
+                "EOS token generation must not run when "
+                "include_download_urls=False"
+            )
+
+        monkeypatch.setattr(
+            opendata,
+            "list_files",
+            fake_list_files,
+        )
+        monkeypatch.setattr(
+            opendata,
+            "list_replicas",
+            fake_list_replicas,
+        )
+        monkeypatch.setattr(
+            opendata,
+            "_is_eos_host",
+            unexpected_eos_probe,
+        )
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            unexpected_token_request,
+        )
+
+        result = opendata.get_opendata_did_files(
+            scope=mock_scope,
+            name=name,
+            include_download_urls=False,
+            session=db_write_session,
+        )
+
+        assert len(list_replicas_calls) == 1
+        assert list_replicas_calls[0].get("schemes") is None
+
+        assert result["files"][0]["uris"] == [root_uri]
+        assert "download_urls" not in result["files"][0]
 
     def test_get_opendata_did_files_batches_replica_resolution(
         self,

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -674,6 +674,26 @@ class TestOpenDataEOS:
                     lifetime_seconds=3600,
                 )
 
+    def test_is_eos_host_tls_file_error(self):
+        with patch(
+            "rucio.core.opendata.requests.post",
+            side_effect=OSError("CA file not found"),
+        ):
+            with pytest.raises(ResourceTemporaryUnavailable):
+                opendata._is_eos_host(self.eos_host)
+
+    def test_eos_token_command_tls_file_error(self):
+        with patch(
+            "rucio.core.opendata.requests.post",
+            side_effect=OSError("certificate file not found"),
+        ):
+            with pytest.raises(ResourceTemporaryUnavailable):
+                opendata._eos_grpc_gateway_token_command(
+                    eos_host=self.eos_host,
+                    filename="/eos/file.root",
+                    lifetime_seconds=3600,
+                )
+
     def test_eos_token_command_unreachable(self):
         with patch(
             "rucio.core.opendata.requests.post",

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -661,6 +661,26 @@ class TestOpenDataEOS:
         # The double slash of the PFN must be collapsed in the path sent to EOS
         assert requested_paths == ["/eos/opendata/experiment/file.root"]
 
+    @pytest.mark.parametrize("scheme", ["http", "https", "dav", "davs"])
+    def test_generate_download_urls_supported_schemes(self, scheme, monkeypatch):
+        eos_uri = (
+            f"{scheme}://{self.eos_host}:8444"
+            f"//eos/opendata/experiment/file.root"
+        )
+
+        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            lambda **kwargs: self.eos_token,
+        )
+
+        download_urls = opendata._generate_download_urls([eos_uri])
+
+        assert download_urls == [
+            f"{eos_uri}?authz={self.eos_token}"
+        ]
+
     def test_generate_download_urls_uri_with_query(self, monkeypatch):
         eos_uri = f"https://{self.eos_host}:8444//eos/opendata/file.root?xrd.wantprot=unix"
 
@@ -796,7 +816,7 @@ class TestOpenDataEOS:
             }
 
         def fake_list_replicas(*args, **kwargs):
-            if kwargs.get("schemes") == ["http", "https"]:
+            if kwargs.get("schemes") == ["http", "https", "dav", "davs"]:
                 yield {"pfns": {}}
             else:
                 yield {
@@ -810,7 +830,7 @@ class TestOpenDataEOS:
 
         with pytest.raises(
             OpenDataError,
-            match="Failed to retrieve HTTP\\(S\\) replica URI",
+            match="Failed to retrieve HTTP\\(S\\) or DAV\\(S\\) replica URI",
         ):
             opendata.get_opendata_did_files(
                 scope=mock_scope,
@@ -861,7 +881,7 @@ class TestOpenDataEOS:
             schemes = kwargs.get("schemes")
             requested_schemes.append(schemes)
 
-            if schemes == ["http", "https"]:
+            if schemes == ["http", "https", "dav", "davs"]:
                 yield {
                     "pfns": {
                         https_uri: {"type": "DISK"},
@@ -903,7 +923,7 @@ class TestOpenDataEOS:
             f"{https_uri}?authz={self.eos_token}"
         ]
 
-        assert ["http", "https"] in requested_schemes
+        assert ["http", "https", "dav", "davs"] in requested_schemes
 
     @pytest.mark.parametrize(
         "uri",

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -23,7 +23,15 @@ from dogpile.cache.api import NoValue
 
 from rucio.common.config import config_add_section, config_get, config_get_bool, config_has_section, config_remove_option, config_set
 from rucio.common.constants import OPENDATA_DID_STATE_LITERAL
-from rucio.common.exception import DataIdentifierNotFound, OpenDataDataIdentifierAlreadyExists, OpenDataDataIdentifierNotFound, OpenDataDuplicateDOI, OpenDataDuplicateRecordID, OpenDataInvalidStateUpdate
+from rucio.common.exception import (
+    DataIdentifierNotFound,
+    OpenDataDataIdentifierAlreadyExists,
+    OpenDataDataIdentifierNotFound,
+    OpenDataDuplicateDOI,
+    OpenDataDuplicateRecordID,
+    OpenDataError,
+    OpenDataInvalidStateUpdate,
+)
 from rucio.common.utils import execute
 from rucio.core import opendata
 from rucio.core.did import add_did, set_status
@@ -672,6 +680,70 @@ class TestOpenDataEOS:
 
         assert opendata._generate_download_urls([eos_uri]) == []
 
+    def test_get_opendata_did_files_download_url_generation_failure(
+        self,
+        mock_scope,
+        root_account,
+        monkeypatch,
+        db_write_session,
+):
+        name = did_name_generator(did_type="dataset")
+        file_name = did_name_generator(did_type="file")
+
+        add_did(
+            scope=mock_scope,
+            name=name,
+            account=root_account,
+            did_type=DIDType.DATASET,
+            session=db_write_session,
+        )
+        opendata.add_opendata_did(
+            scope=mock_scope,
+            name=name,
+            session=db_write_session,
+        )
+        db_write_session.commit()
+
+        https_uri = (
+            f"https://{self.eos_host}:8444"
+            f"//eos/opendata/experiment/file.root"
+        )
+
+        def fake_list_files(*args, **kwargs):
+            yield {
+                "scope": mock_scope,
+                "name": file_name,
+                "bytes": 42,
+                "adler32": "deadbeef",
+            }
+
+        def fake_list_replicas(*args, **kwargs):
+            yield {
+                "pfns": {
+                    https_uri: {"type": "DISK"},
+                }
+            }
+
+        monkeypatch.setattr(opendata, "list_files", fake_list_files)
+        monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
+        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            lambda **kwargs: None,
+        )
+
+        with pytest.raises(
+            OpenDataError,
+            match="Failed to generate download URL",
+        ):
+            opendata.get_opendata_did_files(
+                scope=mock_scope,
+                name=name,
+                include_download_urls=True,
+                session=db_write_session,
+            )
+
     def test_generate_download_urls_skips_root_eos_uri(self, monkeypatch):
         eos_uri = f"root://{self.eos_host}:1094//eos/opendata/file.root"
 
@@ -689,42 +761,223 @@ class TestOpenDataEOS:
         assert download_urls == [], "Root EOS URI should not generate a download URL"
         assert requested_paths == [], "Token command should not be called for root EOS URIs"
 
-    def test_get_opendata_did_files_download_urls(self, mock_scope, root_account, monkeypatch, db_write_session):
+    def test_get_opendata_did_files_download_urls_only_root(
+        self,
+        mock_scope,
+        root_account,
+        monkeypatch,
+        db_write_session,
+):
         name = did_name_generator(did_type="dataset")
         file_name = did_name_generator(did_type="file")
 
-        add_did(scope=mock_scope, name=name, account=root_account, did_type=DIDType.DATASET,
-                session=db_write_session)
-        opendata.add_opendata_did(scope=mock_scope, name=name, session=db_write_session)
+        add_did(
+            scope=mock_scope,
+            name=name,
+            account=root_account,
+            did_type=DIDType.DATASET,
+            session=db_write_session,
+        )
+        opendata.add_opendata_did(
+            scope=mock_scope,
+            name=name,
+            session=db_write_session,
+        )
         db_write_session.commit()
 
-        eos_uri = f"https://{self.eos_host}:8444//eos/opendata/experiment/file.root"
-        tape_uri = "root://tape.example.org:1094//tape/file.root"
-        expected_eos_host = f"{self.eos_host}:8444"
+        root_uri = f"root://{self.eos_host}:1094//eos/opendata/file.root"
 
         def fake_list_files(*args, **kwargs):
-            yield {"scope": mock_scope, "name": file_name, "bytes": 42, "adler32": "deadbeef"}
+            yield {
+                "scope": mock_scope,
+                "name": file_name,
+                "bytes": 42,
+                "adler32": "deadbeef",
+            }
 
         def fake_list_replicas(*args, **kwargs):
-            yield {"pfns": {eos_uri: {"type": "DISK"}, tape_uri: {"type": "TAPE"}}}
+            if kwargs.get("schemes") == ["http", "https"]:
+                yield {"pfns": {}}
+            else:
+                yield {
+                    "pfns": {
+                        root_uri: {"type": "DISK"},
+                    }
+                }
 
         monkeypatch.setattr(opendata, "list_files", fake_list_files)
         monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
-        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: host == expected_eos_host)
-        monkeypatch.setattr(opendata, "_eos_grpc_gateway_token_command", lambda **kwargs: self.eos_token)
 
-        result = opendata.get_opendata_did_files(scope=mock_scope, name=name, include_download_urls=True,
-                                                 session=db_write_session)
+        with pytest.raises(
+            OpenDataError,
+            match="Failed to retrieve HTTP\\(S\\) replica URI",
+        ):
+            opendata.get_opendata_did_files(
+                scope=mock_scope,
+                name=name,
+                include_download_urls=True,
+                session=db_write_session,
+            )
+
+    def test_get_opendata_did_files_download_urls(
+        self,
+        mock_scope,
+        root_account,
+        monkeypatch,
+        db_write_session,
+):
+        name = did_name_generator(did_type="dataset")
+        file_name = did_name_generator(did_type="file")
+
+        add_did(
+            scope=mock_scope,
+            name=name,
+            account=root_account,
+            did_type=DIDType.DATASET,
+            session=db_write_session,
+        )
+        opendata.add_opendata_did(
+            scope=mock_scope,
+            name=name,
+            session=db_write_session,
+        )
+        db_write_session.commit()
+
+        root_uri = f"root://{self.eos_host}:1094//eos/opendata/experiment/file.root"
+        https_uri = f"https://{self.eos_host}:8444//eos/opendata/experiment/file.root"
+        expected_eos_host = f"{self.eos_host}:8444"
+
+        requested_schemes = []
+
+        def fake_list_files(*args, **kwargs):
+            yield {
+                "scope": mock_scope,
+                "name": file_name,
+                "bytes": 42,
+                "adler32": "deadbeef",
+            }
+
+        def fake_list_replicas(*args, **kwargs):
+            schemes = kwargs.get("schemes")
+            requested_schemes.append(schemes)
+
+            if schemes == ["http", "https"]:
+                yield {
+                    "pfns": {
+                        https_uri: {"type": "DISK"},
+                    }
+                }
+            else:
+                yield {
+                    "pfns": {
+                        root_uri: {"type": "DISK"},
+                    }
+                }
+
+        monkeypatch.setattr(opendata, "list_files", fake_list_files)
+        monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
+        monkeypatch.setattr(
+            opendata,
+            "_is_eos_host",
+            lambda host: host == expected_eos_host,
+        )
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            lambda **kwargs: self.eos_token,
+        )
+
+        result = opendata.get_opendata_did_files(
+            scope=mock_scope,
+            name=name,
+            include_download_urls=True,
+            session=db_write_session,
+        )
 
         assert len(result["files"]) == 1
-        file = result["files"][0]
-        assert file["uris"] == [eos_uri], "Only DISK replicas should be exposed"
-        assert file["download_urls"] == [f"{eos_uri}?authz={self.eos_token}"]
 
-        # Without the flag, no download URLs should be computed
-        result = opendata.get_opendata_did_files(scope=mock_scope, name=name, include_download_urls=False,
-                                                 session=db_write_session)
-        assert "download_urls" not in result["files"][0]
+        file = result["files"][0]
+
+        assert file["uris"] == [root_uri]
+        assert file["download_urls"] == [
+            f"{https_uri}?authz={self.eos_token}"
+        ]
+
+        assert ["http", "https"] in requested_schemes
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "https://eos.example.org:notaport/eos/file.root",
+            "https://eos.example.org:99999/eos/file.root",
+        ],
+    )
+    def test_generate_download_urls_skips_invalid_port(self, uri, monkeypatch):
+        token_called = False
+
+        def fake_token_command(**kwargs):
+            nonlocal token_called
+            token_called = True
+            return self.eos_token
+
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            fake_token_command,
+        )
+
+        download_urls = opendata._generate_download_urls([uri])
+
+        assert download_urls == []
+        assert token_called is False
+
+    def test_get_opendata_did_files_no_disk_uri(
+            self,
+            mock_scope,
+            root_account,
+            monkeypatch,
+            db_write_session,
+    ):
+        name = did_name_generator(did_type="dataset")
+        file_name = did_name_generator(did_type="file")
+
+        add_did(
+            scope=mock_scope,
+            name=name,
+            account=root_account,
+            did_type=DIDType.DATASET,
+            session=db_write_session,
+        )
+        opendata.add_opendata_did(
+            scope=mock_scope,
+            name=name,
+            session=db_write_session,
+        )
+        db_write_session.commit()
+
+        def fake_list_files(*args, **kwargs):
+            yield {
+                "scope": mock_scope,
+                "name": file_name,
+                "bytes": 42,
+                "adler32": "deadbeef",
+            }
+
+        def fake_list_replicas(*args, **kwargs):
+            yield {"pfns": {}}
+
+        monkeypatch.setattr(opendata, "list_files", fake_list_files)
+        monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
+
+        with pytest.raises(
+            OpenDataError,
+            match="Failed to retrieve replica URI",
+        ):
+            opendata.get_opendata_did_files(
+                scope=mock_scope,
+                name=name,
+                session=db_write_session,
+            )
 
 
 @pytest.mark.noparallel(reason="Changes in configuration values and race conditions")

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -16,6 +16,7 @@ import re
 import time
 from configparser import NoOptionError
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 import requests
@@ -677,8 +678,17 @@ class TestOpenDataEOS:
 
         download_urls = opendata._generate_download_urls(uris)
 
-        assert download_urls == [f"{eos_uri}?authz={self.eos_token}"]
-        # The double slash of the PFN must be collapsed in the path sent to EOS
+        assert len(download_urls) == 1
+
+        parsed = urlparse(download_urls[0])
+
+        assert parsed.scheme == "https"
+        assert parsed.hostname == self.eos_host
+        assert parsed.port == 8444
+        assert parsed.path == "//eos/opendata/experiment/file.root"
+        assert parse_qs(parsed.query)["authz"] == [self.eos_token]
+
+        # The double slash of the PFN must be collapsed in the path sent to EOS.
         assert requested_paths == ["/eos/opendata/experiment/file.root"]
 
     @pytest.mark.parametrize("scheme", ["http", "https", "dav", "davs"])
@@ -711,9 +721,15 @@ class TestOpenDataEOS:
 
         download_urls = opendata._generate_download_urls([eos_uri])
 
-        assert download_urls == [
-            f"{eos_uri}?authz={self.eos_token}"
-        ]
+        assert len(download_urls) == 1
+
+        parsed = urlparse(download_urls[0])
+
+        assert parsed.scheme == scheme
+        assert parsed.hostname == self.eos_host
+        assert parsed.port == 8444
+        assert parsed.path == "//eos/opendata/experiment/file.root"
+        assert parse_qs(parsed.query)["authz"] == [self.eos_token]
 
         assert probed_hosts == [
             f"{self.eos_host}:8444"
@@ -726,16 +742,29 @@ class TestOpenDataEOS:
             }
         ]
 
-    def test_generate_download_urls_uri_with_query(self, monkeypatch):
-        eos_uri = f"https://{self.eos_host}:8444//eos/opendata/file.root?xrd.wantprot=unix"
+    def test_generate_download_urls_uri_with_query_and_fragment(self, monkeypatch):
+        eos_uri = (
+            f"https://{self.eos_host}:8444"
+            "//eos/opendata/file.root?xrd.wantprot=unix#multirange"
+        )
 
         monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
-        monkeypatch.setattr(opendata, "_eos_grpc_gateway_token_command",
-                            lambda **kwargs: self.eos_token)
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            lambda **kwargs: self.eos_token,
+        )
 
         download_urls = opendata._generate_download_urls([eos_uri])
 
-        assert download_urls == [f"{eos_uri}&authz={self.eos_token}"]
+        assert len(download_urls) == 1
+
+        parsed = urlparse(download_urls[0])
+        query = parse_qs(parsed.query)
+
+        assert query["xrd.wantprot"] == ["unix"]
+        assert query["authz"] == [self.eos_token]
+        assert parsed.fragment == "multirange"
 
     def test_generate_download_urls_no_token(self, monkeypatch):
         monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
@@ -964,9 +993,16 @@ class TestOpenDataEOS:
         file = result["files"][0]
 
         assert file["uris"] == [root_uri]
-        assert file["download_urls"] == [
-            f"{https_uri}?authz={self.eos_token}"
-        ]
+
+        assert len(file["download_urls"]) == 1
+
+        parsed = urlparse(file["download_urls"][0])
+
+        assert parsed.scheme == "https"
+        assert parsed.hostname == self.eos_host
+        assert parsed.port == 8444
+        assert parsed.path == "//eos/opendata/experiment/file.root"
+        assert parse_qs(parsed.query)["authz"] == [self.eos_token]
 
         assert ["http", "https", "dav", "davs"] in requested_schemes
 

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -844,9 +844,11 @@ class TestOpenDataEOS:
 
         def fake_list_replicas(*args, **kwargs):
             yield {
+                "scope": mock_scope,
+                "name": file_name,
                 "pfns": {
                     https_uri: {"type": "DISK"},
-                }
+                },
             }
 
         monkeypatch.setattr(opendata, "list_files", fake_list_files)
@@ -922,12 +924,18 @@ class TestOpenDataEOS:
 
         def fake_list_replicas(*args, **kwargs):
             if kwargs.get("schemes") == ["http", "https", "dav", "davs"]:
-                yield {"pfns": {}}
+                yield {
+                    "scope": mock_scope,
+                    "name": file_name,
+                    "pfns": {},
+                }
             else:
                 yield {
+                    "scope": mock_scope,
+                    "name": file_name,
                     "pfns": {
                         root_uri: {"type": "DISK"},
-                    }
+                    },
                 }
 
         monkeypatch.setattr(opendata, "list_files", fake_list_files)
@@ -988,15 +996,19 @@ class TestOpenDataEOS:
 
             if schemes == ["http", "https", "dav", "davs"]:
                 yield {
+                    "scope": mock_scope,
+                    "name": file_name,
                     "pfns": {
                         https_uri: {"type": "DISK"},
-                    }
+                    },
                 }
             else:
                 yield {
+                    "scope": mock_scope,
+                    "name": file_name,
                     "pfns": {
                         root_uri: {"type": "DISK"},
-                    }
+                    },
                 }
 
         monkeypatch.setattr(opendata, "list_files", fake_list_files)
@@ -1036,6 +1048,129 @@ class TestOpenDataEOS:
         assert parse_qs(parsed.query)["authz"] == [self.eos_token]
 
         assert ["http", "https", "dav", "davs"] in requested_schemes
+
+    def test_get_opendata_did_files_batches_replica_resolution(
+        self,
+        mock_scope,
+        root_account,
+        monkeypatch,
+        db_write_session,
+    ):
+        name = did_name_generator(did_type="dataset")
+        file_names = [
+            did_name_generator(did_type="file")
+            for _ in range(3)
+        ]
+
+        add_did(
+            scope=mock_scope,
+            name=name,
+            account=root_account,
+            did_type=DIDType.DATASET,
+            session=db_write_session,
+        )
+        opendata.add_opendata_did(
+            scope=mock_scope,
+            name=name,
+            session=db_write_session,
+        )
+        db_write_session.commit()
+
+        def fake_list_files(*args, **kwargs):
+            for file_name in file_names:
+                yield {
+                    "scope": mock_scope,
+                    "name": file_name,
+                    "bytes": 42,
+                    "adler32": "deadbeef",
+                }
+
+        list_replicas_calls = []
+
+        def fake_list_replicas(*args, **kwargs):
+            dids = kwargs["dids"]
+            schemes = kwargs.get("schemes")
+
+            list_replicas_calls.append({
+                "dids": list(dids),
+                "schemes": schemes,
+            })
+
+            for did in dids:
+                if schemes == ["http", "https", "dav", "davs"]:
+                    uri = (
+                        f"https://{self.eos_host}:8444"
+                        f"//eos/opendata/{did['name']}"
+                    )
+                else:
+                    uri = (
+                        f"root://{self.eos_host}:1094"
+                        f"//eos/opendata/{did['name']}"
+                    )
+
+                yield {
+                    "scope": did["scope"],
+                    "name": did["name"],
+                    "pfns": {
+                        uri: {"type": "DISK"},
+                    },
+                }
+
+        monkeypatch.setattr(opendata, "list_files", fake_list_files)
+        monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
+        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            lambda **kwargs: self.eos_token,
+        )
+
+        result = opendata.get_opendata_did_files(
+            scope=mock_scope,
+            name=name,
+            include_download_urls=True,
+            session=db_write_session,
+        )
+
+        assert len(result["files"]) == 3
+
+        # Exactly one batch for regular replicas and one for download replicas.
+        assert len(list_replicas_calls) == 2
+
+        regular_call = list_replicas_calls[0]
+        download_call = list_replicas_calls[1]
+
+        assert regular_call["schemes"] is None
+        assert download_call["schemes"] == [
+            "http",
+            "https",
+            "dav",
+            "davs",
+        ]
+
+        assert len(regular_call["dids"]) == 3
+        assert len(download_call["dids"]) == 3
+
+        assert {
+            did["name"] for did in regular_call["dids"]
+        } == set(file_names)
+
+        assert {
+            did["name"] for did in download_call["dids"]
+        } == set(file_names)
+
+        for file in result["files"]:
+            assert file["uris"] == [
+                f"root://{self.eos_host}:1094"
+                f"//eos/opendata/{file['name']}"
+            ]
+
+            assert len(file["download_urls"]) == 1
+
+            parsed = urlparse(file["download_urls"][0])
+
+            assert parsed.path == f"//eos/opendata/{file['name']}"
+            assert parse_qs(parsed.query)["authz"] == [self.eos_token]
 
     @pytest.mark.parametrize(
         "uri",
@@ -1096,7 +1231,11 @@ class TestOpenDataEOS:
             }
 
         def fake_list_replicas(*args, **kwargs):
-            yield {"pfns": {}}
+            yield {
+                "scope": mock_scope,
+                "name": file_name,
+                "pfns": {},
+            }
 
         monkeypatch.setattr(opendata, "list_files", fake_list_files)
         monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
@@ -1170,11 +1309,11 @@ class TestOpenDataEOS:
 
         def fake_list_replicas(*args, **kwargs):
             yield {
+                "scope": mock_scope,
+                "name": file_name,
                 "pfns": {
-                    https_uri: {
-                        "type": "DISK",
-                    }
-                }
+                    https_uri: {"type": "DISK"},
+                },
             }
 
         monkeypatch.setattr(opendata, "REGION", cache)

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -629,6 +629,7 @@ class TestOpenDataEOS:
                                                             lifetime_seconds=3600) is None
 
     def test_generate_download_urls(self, monkeypatch):
+        expected_eos_host = f"{self.eos_host}:1094"
         eos_uri = f"root://{self.eos_host}:1094//eos/opendata/experiment/file.root"
         uris = [
             eos_uri,
@@ -639,16 +640,16 @@ class TestOpenDataEOS:
         requested_paths = []
 
         def fake_token_command(*, eos_host, filename, lifetime_seconds):
-            assert eos_host == self.eos_host
+            assert eos_host == f"{self.eos_host}:1094"
             requested_paths.append(filename)
             return self.eos_token
 
-        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: host == self.eos_host)
+        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: host == expected_eos_host)
         monkeypatch.setattr(opendata, "_eos_grpc_gateway_token_command", fake_token_command)
 
         download_urls = opendata._generate_download_urls(uris)
 
-        assert download_urls == [f"{eos_uri}?token={self.eos_token}"]
+        assert download_urls == [f"{eos_uri}?authz={self.eos_token}"]
         # The double slash of the PFN must be collapsed in the path sent to EOS
         assert requested_paths == ["/eos/opendata/experiment/file.root"]
 
@@ -661,7 +662,7 @@ class TestOpenDataEOS:
 
         download_urls = opendata._generate_download_urls([eos_uri])
 
-        assert download_urls == [f"{eos_uri}&token={self.eos_token}"]
+        assert download_urls == [f"{eos_uri}&authz={self.eos_token}"]
 
     def test_generate_download_urls_no_token(self, monkeypatch):
         monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
@@ -680,6 +681,7 @@ class TestOpenDataEOS:
 
         eos_uri = f"root://{self.eos_host}:1094//eos/opendata/experiment/file.root"
         tape_uri = "root://tape.example.org:1094//tape/file.root"
+        expected_eos_host = f"{self.eos_host}:1094"
 
         def fake_list_files(*args, **kwargs):
             yield {"scope": mock_scope, "name": file_name, "bytes": 42, "adler32": "deadbeef"}
@@ -689,7 +691,7 @@ class TestOpenDataEOS:
 
         monkeypatch.setattr(opendata, "list_files", fake_list_files)
         monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
-        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: host == self.eos_host)
+        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: host == expected_eos_host)
         monkeypatch.setattr(opendata, "_eos_grpc_gateway_token_command", lambda **kwargs: self.eos_token)
 
         result = opendata.get_opendata_did_files(scope=mock_scope, name=name, include_download_urls=True,
@@ -698,7 +700,7 @@ class TestOpenDataEOS:
         assert len(result["files"]) == 1
         file = result["files"][0]
         assert file["uris"] == [eos_uri], "Only DISK replicas should be exposed"
-        assert file["download_urls"] == [f"{eos_uri}?token={self.eos_token}"]
+        assert file["download_urls"] == [f"{eos_uri}?authz={self.eos_token}"]
 
         # Without the flag, no download URLs should be computed
         result = opendata.get_opendata_did_files(scope=mock_scope, name=name, include_download_urls=False,

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -670,6 +670,23 @@ class TestOpenDataEOS:
 
         assert opendata._generate_download_urls([f"root://{self.eos_host}:1094//eos/file.root"]) == []
 
+    def test_generate_download_urls_skips_root_eos_uri(self, monkeypatch):
+        eos_uri = f"root://{self.eos_host}:1094//eos/opendata/file.root"
+
+        requested_paths = []
+
+        def fake_token_command(*, eos_host, filename, lifetime_seconds):
+            requested_paths.append(filename)
+            return self.eos_token
+
+        monkeypatch.setattr(opendata, "_is_eos_host", lambda host: True)
+        monkeypatch.setattr(opendata, "_eos_grpc_gateway_token_command", fake_token_command)
+
+        download_urls = opendata._generate_download_urls([eos_uri])
+
+        assert download_urls == [], "Root EOS URI should not generate a download URL"
+        assert requested_paths == [], "Token command should not be called for root EOS URIs"
+
     def test_get_opendata_did_files_download_urls(self, mock_scope, root_account, monkeypatch, db_write_session):
         name = did_name_generator(did_type="dataset")
         file_name = did_name_generator(did_type="file")

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -1111,6 +1111,110 @@ class TestOpenDataEOS:
                 session=db_write_session,
             )
 
+    def test_get_opendata_did_files_ignores_legacy_cache(
+        self,
+        mock_scope,
+        root_account,
+        monkeypatch,
+        db_write_session,
+    ):
+        cache = _FakeCacheRegion()
+
+        name = did_name_generator(did_type="dataset")
+        file_name = did_name_generator(did_type="file")
+
+        add_did(
+            scope=mock_scope,
+            name=name,
+            account=root_account,
+            did_type=DIDType.DATASET,
+            session=db_write_session,
+        )
+
+        opendata.add_opendata_did(
+            scope=mock_scope,
+            name=name,
+            session=db_write_session,
+        )
+
+        db_write_session.commit()
+
+        legacy_key = f"opendata_did_files_{mock_scope}_{name}_dl_True"
+
+        cache.set(
+            legacy_key,
+            [
+                {
+                    "scope": mock_scope,
+                    "name": file_name,
+                    "uris": [],
+                    "download_urls": [
+                        "https://old.example/file?token=legacy"
+                    ],
+                }
+            ],
+        )
+
+        https_uri = (
+            f"https://{self.eos_host}:8444"
+            "//eos/opendata/file.root"
+        )
+
+        def fake_list_files(*args, **kwargs):
+            yield {
+                "scope": mock_scope,
+                "name": file_name,
+                "bytes": 42,
+                "adler32": "deadbeef",
+            }
+
+        def fake_list_replicas(*args, **kwargs):
+            yield {
+                "pfns": {
+                    https_uri: {
+                        "type": "DISK",
+                    }
+                }
+            }
+
+        monkeypatch.setattr(opendata, "REGION", cache)
+        monkeypatch.setattr(opendata, "list_files", fake_list_files)
+        monkeypatch.setattr(opendata, "list_replicas", fake_list_replicas)
+        monkeypatch.setattr(
+            opendata,
+            "_is_eos_host",
+            lambda host: True,
+        )
+        monkeypatch.setattr(
+            opendata,
+            "_eos_grpc_gateway_token_command",
+            lambda **kwargs: self.eos_token,
+        )
+
+        result = opendata.get_opendata_did_files(
+            scope=mock_scope,
+            name=name,
+            use_cache=True,
+            include_download_urls=True,
+            session=db_write_session,
+        )
+
+        assert result["cache_hit"] is False
+
+        assert len(result["files"]) == 1
+
+        file = result["files"][0]
+
+        assert file["uris"] == [https_uri]
+
+        assert len(file["download_urls"]) == 1
+
+        parsed = urlparse(file["download_urls"][0])
+        query = parse_qs(parsed.query)
+
+        assert query["authz"] == [self.eos_token]
+        assert "token" not in query
+
 
 @pytest.mark.noparallel(reason="Changes in configuration values and race conditions")
 class TestOpenDataClient:

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -1965,6 +1965,42 @@ class TestOpenDataAPI:
                 headers=request_headers,
             )
 
+    @pytest.mark.parametrize("public", [False, True])
+    def test_opendata_api_temporary_failure_returns_503(
+        self,
+        rest_client,
+        auth_token,
+        mock_scope,
+        public,
+    ):
+        name = did_name_generator(did_type="dataset")
+        base_endpoint = (
+            self.api_endpoint_public
+            if public
+            else self.api_endpoint
+        )
+        endpoint = (
+            f"{base_endpoint}/{mock_scope}/{name}"
+            "?files=1&download_urls=1"
+        )
+
+        request_kwargs = {}
+        if not public:
+            request_kwargs["headers"] = headers(auth(auth_token))
+
+        with patch(
+            "rucio.gateway.opendata.get_opendata_did",
+            side_effect=ResourceTemporaryUnavailable(
+                "temporary EOS failure"
+            ),
+        ):
+            response = rest_client.get(
+                endpoint,
+                **request_kwargs,
+            )
+
+        assert response.status_code == 503
+
 
 @pytest.mark.noparallel(reason="Changes in configuration values and race conditions")
 class TestOpenDataCLI:

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -1760,7 +1760,7 @@ class TestOpenDataEOS:
         assert download_urls == []
         assert token_called is False
 
-    def test_get_opendata_did_files_no_disk_uri(
+    def test_get_opendata_did_files_no_disk_uri_without_download_urls(
         self,
         mock_scope,
         monkeypatch,
@@ -1816,6 +1816,8 @@ class TestOpenDataEOS:
         )
 
         assert len(result["files"]) == 1
+        # Missing regular replicas must not fail a file listing when
+        # tokenized download URLs were not requested.
         assert result["files"][0]["uris"] == []
         assert "download_urls" not in result["files"][0]
 


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
<!-- Required. Summarise WHAT this PR changes. The WHY should already be
     covered by the linked issue and its discussion. A sufficiently detailed
     commit message may be reused here. If a checklist item below does not
     apply to this PR, briefly say why here. -->

This PR fixes OpenData EOS download URL generation and improves replica validation.

- Use the `authz` query parameter instead of `token` when appending EOS access tokens.
- Generate tokenized download URLs only for HTTP(S) and DAV(S) DISK replicas hosted on EOS.
- Preserve explicit ports for HTTP(S) and DAV(S) replica URIs.
- Supported replica schemes for tokenized download URL generation are HTTP, HTTPS, DAV, and DAVS.
- Skip replicas using unsupported schemes, such as `root://`, before probing the EOS gateway.
- Keep regular replica URI selection independent from download URL generation.
- Fail the request if no DISK replica URI is available for an OpenData file.
- Fail download URL requests if no suitable HTTP(S) and DAV(S) DISK replica is available.
- Fail download URL requests if no tokenized EOS download URL can be generated.
- Update the related tests to cover HTTP(S) and DAV(S) EOS replicas, explicit ports, existing query parameters, unsupported schemes, missing DISK replicas, and download URL generation failures.


## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [x] This PR closes #8744 
      <!-- Every PR requires an issue; if none exists yet, please create one
           first. GitHub links the PR to the issue and closes it on merge.
           In the rare case the issue should remain open after the merge,
           write "Related to #____" here instead and briefly say why in the
           description. -->
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
