### PR TITLE
add is_opendata field to get_metadata

### DIFF
--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -2195,15 +2195,39 @@ def get_metadata_bulk(
                 ).where(
                     or_(*chunk)
                 )
-                for row in session.execute(stmt).scalars():
-                    if plugin.casefold() == 'did_column':
-                        yield row.to_dict()
-                    else:
+                if plugin.casefold() == 'did_column':
+                    opendata_subquery = select(
+                        models.OpenDataDid.scope,
+                        models.OpenDataDid.name
+                    ).subquery()
+
+                    stmt = stmt.add_columns(
+                        case(
+                            (opendata_subquery.c.scope.isnot(null()), true()),
+                            else_=false()
+                        ).label("is_opendata")
+                    ).outerjoin(
+                        opendata_subquery,
+                        and_(
+                            models.DataIdentifier.scope == opendata_subquery.c.scope,
+                            models.DataIdentifier.name == opendata_subquery.c.name
+                        )
+                    )
+
+                    for row, is_opendata in session.execute(stmt):
+                        result = row.to_dict()
+                        result["is_opendata"] = is_opendata
+                        yield result
+
+                else:
+                    for row in session.execute(stmt).scalars():
                         meta = get_metadata(row.scope, row.name, plugin=plugin, session=session)
+
                         result = {'scope': row.scope, 'name': row.name}
                         for key, value in meta.items():
                             if key not in result:
                                 result[key] = value
+
                         yield result
         except NoResultFound:
             raise exception.DataIdentifierNotFound('No Data Identifiers found')

--- a/lib/rucio/core/did.py
+++ b/lib/rucio/core/did.py
@@ -31,6 +31,7 @@ from rucio.common.config import config_get_bool, config_get_int
 from rucio.common.constants import DEFAULT_VO
 from rucio.common.utils import chunks, is_archive
 from rucio.core import did_meta_plugins
+from rucio.core.did_meta_plugins.opendata_meta import add_is_opendata_column
 from rucio.core.message import add_message, add_messages
 from rucio.core.monitor import MetricManager
 from rucio.core.naming_convention import validate_name
@@ -2196,23 +2197,7 @@ def get_metadata_bulk(
                     or_(*chunk)
                 )
                 if plugin.casefold() == 'did_column':
-                    opendata_subquery = select(
-                        models.OpenDataDid.scope,
-                        models.OpenDataDid.name
-                    ).subquery()
-
-                    stmt = stmt.add_columns(
-                        case(
-                            (opendata_subquery.c.scope.isnot(null()), true()),
-                            else_=false()
-                        ).label("is_opendata")
-                    ).outerjoin(
-                        opendata_subquery,
-                        and_(
-                            models.DataIdentifier.scope == opendata_subquery.c.scope,
-                            models.DataIdentifier.name == opendata_subquery.c.name
-                        )
-                    )
+                    stmt = add_is_opendata_column(stmt)
 
                     for row, is_opendata in session.execute(stmt):
                         result = row.to_dict()
@@ -2222,12 +2207,10 @@ def get_metadata_bulk(
                 else:
                     for row in session.execute(stmt).scalars():
                         meta = get_metadata(row.scope, row.name, plugin=plugin, session=session)
-
                         result = {'scope': row.scope, 'name': row.name}
                         for key, value in meta.items():
                             if key not in result:
                                 result[key] = value
-
                         yield result
         except NoResultFound:
             raise exception.DataIdentifierNotFound('No Data Identifiers found')

--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -72,6 +72,10 @@ RESTRICTED_CHARACTERS = {
     '.': "Used as a delimiter for key and operator (<key>.<operator>) in filtering engine."
 }
 
+READ_ONLY_METADATA_KEYS = {
+    'is_opendata',
+}
+
 
 @read_session
 def get_metadata(scope, name, plugin="DID_COLUMN", *, session: "Session"):
@@ -90,14 +94,26 @@ def get_metadata(scope, name, plugin="DID_COLUMN", *, session: "Session"):
     """
     if plugin.lower() == "all":
         all_metadata = {}
+        read_only_metadata = {}
         for metadata_plugin in METADATA_PLUGIN_MODULES:
             metadata = metadata_plugin.get_metadata(scope, name, session=session)
             all_metadata.update(metadata)
+
+            if metadata_plugin is METADATA_PLUGIN_MODULES[0]:
+                read_only_metadata = {
+                    key: metadata[key]
+                    for key in READ_ONLY_METADATA_KEYS
+                    if key in metadata
+                }
+
+        # Read-only metadata derived from Rucio's internal state must take
+        # precedence over values returned by other metadata plugins.
+        all_metadata.update(read_only_metadata)
         return all_metadata
-    else:
-        for metadata_plugin in METADATA_PLUGIN_MODULES:
-            if metadata_plugin.is_named(plugin):
-                return metadata_plugin.get_metadata(scope, name, session=session)
+
+    for metadata_plugin in METADATA_PLUGIN_MODULES:
+        if metadata_plugin.is_named(plugin):
+            return metadata_plugin.get_metadata(scope, name, session=session)
 
     raise exception.UnsupportedMetadataPlugin(f'Metadata plugin "{plugin}" is not enabled on the server.')
 
@@ -115,6 +131,13 @@ def set_metadata(scope, name, key, value, recursive=False, *, session: "Session"
     :param session: (optional) The database session in use.
     :raises: InvalidMetadata
     """
+    # Prevent explicit updates to metadata fields whose values are derived
+    # from Rucio's internal state rather than stored as user metadata.
+    if key in READ_ONLY_METADATA_KEYS:
+        raise exception.UnsupportedOperation(
+            f"'{key}' is a read-only metadata field"
+        )
+
     # Check for forbidden characters in key.
     for char in RESTRICTED_CHARACTERS:
         if char in key:
@@ -149,10 +172,18 @@ def set_metadata_bulk(scope, name, meta, recursive=False, *, session: "Session")
     :raises: InvalidMetadata
     """
     metadata = meta
-
-    unmanaged_keys = list()
     if not isinstance(metadata, dict):
         metadata = dict(metadata)
+
+    # Prevent updates to read-only metadata fields whose values are derived
+    # from Rucio's internal state rather than stored as user metadata.
+    read_only_keys = READ_ONLY_METADATA_KEYS.intersection(metadata)
+    if read_only_keys:
+        raise exception.UnsupportedOperation(
+            f"Metadata field(s) {sorted(read_only_keys)} are read-only"
+        )
+
+    unmanaged_keys = list()
     metadata_plugin_keys = {metadata_plugin: [] for metadata_plugin in METADATA_PLUGIN_MODULES}
 
     # Iterate through all keys, sequentially checking if each metadata plugin manages the considered key. If it

--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -72,10 +72,6 @@ RESTRICTED_CHARACTERS = {
     '.': "Used as a delimiter for key and operator (<key>.<operator>) in filtering engine."
 }
 
-READ_ONLY_METADATA_KEYS = {
-    'is_opendata',
-}
-
 
 @read_session
 def get_metadata(scope, name, plugin="DID_COLUMN", *, session: "Session"):
@@ -94,21 +90,14 @@ def get_metadata(scope, name, plugin="DID_COLUMN", *, session: "Session"):
     """
     if plugin.lower() == "all":
         all_metadata = {}
-        read_only_metadata = {}
         for metadata_plugin in METADATA_PLUGIN_MODULES:
             metadata = metadata_plugin.get_metadata(scope, name, session=session)
-            all_metadata.update(metadata)
 
             if metadata_plugin is METADATA_PLUGIN_MODULES[0]:
-                read_only_metadata = {
-                    key: metadata[key]
-                    for key in READ_ONLY_METADATA_KEYS
-                    if key in metadata
-                }
+                metadata.pop("is_opendata", None)
 
-        # Read-only metadata derived from Rucio's internal state must take
-        # precedence over values returned by other metadata plugins.
-        all_metadata.update(read_only_metadata)
+            all_metadata.update(metadata)
+
         return all_metadata
 
     for metadata_plugin in METADATA_PLUGIN_MODULES:
@@ -131,13 +120,6 @@ def set_metadata(scope, name, key, value, recursive=False, *, session: "Session"
     :param session: (optional) The database session in use.
     :raises: InvalidMetadata
     """
-    # Prevent explicit updates to metadata fields whose values are derived
-    # from Rucio's internal state rather than stored as user metadata.
-    if key in READ_ONLY_METADATA_KEYS:
-        raise exception.UnsupportedOperation(
-            f"'{key}' is a read-only metadata field"
-        )
-
     # Check for forbidden characters in key.
     for char in RESTRICTED_CHARACTERS:
         if char in key:
@@ -174,15 +156,6 @@ def set_metadata_bulk(scope, name, meta, recursive=False, *, session: "Session")
     metadata = meta
     if not isinstance(metadata, dict):
         metadata = dict(metadata)
-
-    # Prevent updates to read-only metadata fields whose values are derived
-    # from Rucio's internal state rather than stored as user metadata.
-    read_only_keys = READ_ONLY_METADATA_KEYS.intersection(metadata)
-    if read_only_keys:
-        raise exception.UnsupportedOperation(
-            f"Metadata field(s) {sorted(read_only_keys)} are read-only"
-        )
-
     unmanaged_keys = list()
     metadata_plugin_keys = {metadata_plugin: [] for metadata_plugin in METADATA_PLUGIN_MODULES}
 

--- a/lib/rucio/core/did_meta_plugins/__init__.py
+++ b/lib/rucio/core/did_meta_plugins/__init__.py
@@ -72,6 +72,10 @@ RESTRICTED_CHARACTERS = {
     '.': "Used as a delimiter for key and operator (<key>.<operator>) in filtering engine."
 }
 
+READ_ONLY_METADATA_KEYS = {
+    'is_opendata',
+}
+
 
 @read_session
 def get_metadata(scope, name, plugin="DID_COLUMN", *, session: "Session"):
@@ -90,14 +94,22 @@ def get_metadata(scope, name, plugin="DID_COLUMN", *, session: "Session"):
     """
     if plugin.lower() == "all":
         all_metadata = {}
+        read_only_metadata = {}
+
         for metadata_plugin in METADATA_PLUGIN_MODULES:
             metadata = metadata_plugin.get_metadata(scope, name, session=session)
-
-            if metadata_plugin is METADATA_PLUGIN_MODULES[0]:
-                metadata.pop("is_opendata", None)
-
             all_metadata.update(metadata)
 
+            if metadata_plugin is METADATA_PLUGIN_MODULES[0]:
+                read_only_metadata = {
+                    key: metadata[key]
+                    for key in READ_ONLY_METADATA_KEYS
+                    if key in metadata
+                }
+
+        # Read-only metadata derived from Rucio's internal state must take
+        # precedence over values returned by other metadata plugins.
+        all_metadata.update(read_only_metadata)
         return all_metadata
 
     for metadata_plugin in METADATA_PLUGIN_MODULES:
@@ -120,6 +132,10 @@ def set_metadata(scope, name, key, value, recursive=False, *, session: "Session"
     :param session: (optional) The database session in use.
     :raises: InvalidMetadata
     """
+    if key in READ_ONLY_METADATA_KEYS:
+        raise exception.InvalidMetadata(
+            f"'{key}' is a read-only metadata field"
+        )
     # Check for forbidden characters in key.
     for char in RESTRICTED_CHARACTERS:
         if char in key:
@@ -156,6 +172,11 @@ def set_metadata_bulk(scope, name, meta, recursive=False, *, session: "Session")
     metadata = meta
     if not isinstance(metadata, dict):
         metadata = dict(metadata)
+    read_only_keys = READ_ONLY_METADATA_KEYS.intersection(metadata)
+    if read_only_keys:
+        raise exception.InvalidMetadata(
+            f"Metadata field(s) {sorted(read_only_keys)} are read-only"
+        )
     unmanaged_keys = list()
     metadata_plugin_keys = {metadata_plugin: [] for metadata_plugin in METADATA_PLUGIN_MODULES}
 

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -16,15 +16,16 @@ import operator
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import and_, false, inspect, null, update
+from sqlalchemy import inspect, update
 from sqlalchemy.exc import CompileError, InvalidRequestError, NoResultFound
 from sqlalchemy.sql import func
-from sqlalchemy.sql.expression import case, select, true
+from sqlalchemy.sql.expression import select, true
 
 from rucio.common import exception
 from rucio.core import account_counter, rse_counter
 from rucio.core.did_meta_plugins.did_meta_plugin_interface import DidMetaPlugin
 from rucio.core.did_meta_plugins.filter_engine import FilterEngine
+from rucio.core.did_meta_plugins.opendata_meta import add_is_opendata_column
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import DIDType
 from rucio.db.sqla.session import read_session, stream_session, transactional_session
@@ -66,20 +67,12 @@ class DidColumnMeta(DidMetaPlugin):
         :returns: DID metadata as a dictionary.
         """
         try:
-            opendata_subquery = select(
-                models.OpenDataDid.scope,
-                models.OpenDataDid.name
-            ).subquery()
-
-            stmt = select(
+            stmt = add_is_opendata_column(
+                select(models.DataIdentifier)
+            ).with_hint(
                 models.DataIdentifier,
-                case((opendata_subquery.c.scope.isnot(null()), true()), else_=false()).label("is_opendata")
-            ).outerjoin(
-                opendata_subquery,
-                and_(
-                    models.DataIdentifier.scope == opendata_subquery.c.scope,
-                    models.DataIdentifier.name == opendata_subquery.c.name
-                )
+                'INDEX(DIDS DIDS_PK)',
+                'oracle'
             ).where(
                 models.DataIdentifier.scope == scope,
                 models.DataIdentifier.name == name

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -142,6 +142,11 @@ class DidColumnMeta(DidMetaPlugin):
         if did_query.one_or_none() is None:
             raise exception.DataIdentifierNotFound("Data identifier '%s:%s' not found" % (scope, name))
 
+        if 'is_opendata' in metadata:
+            raise exception.UnsupportedOperation(
+                "'is_opendata' is a read-only metadata field"
+    )
+
         remainder: dict[Any, Any] = {}
         for key, value in metadata.items():
             if key == 'eol_at' and isinstance(value, str):
@@ -506,7 +511,8 @@ class DidColumnMeta(DidMetaPlugin):
             'length.lt',
             'length.gte',
             'length.lte',
-            'type'
+            'type',
+            'is_opendata',
         ]
 
         hardcoded_keys = list(set(all_did_table_columns) - set(exclude_did_table_columns)) + additional_keys

--- a/lib/rucio/core/did_meta_plugins/did_column_meta.py
+++ b/lib/rucio/core/did_meta_plugins/did_column_meta.py
@@ -142,11 +142,6 @@ class DidColumnMeta(DidMetaPlugin):
         if did_query.one_or_none() is None:
             raise exception.DataIdentifierNotFound("Data identifier '%s:%s' not found" % (scope, name))
 
-        if 'is_opendata' in metadata:
-            raise exception.UnsupportedOperation(
-                "'is_opendata' is a read-only metadata field"
-    )
-
         remainder: dict[Any, Any] = {}
         for key, value in metadata.items():
             if key == 'eol_at' and isinstance(value, str):
@@ -512,7 +507,6 @@ class DidColumnMeta(DidMetaPlugin):
             'length.gte',
             'length.lte',
             'type',
-            'is_opendata',
         ]
 
         hardcoded_keys = list(set(all_did_table_columns) - set(exclude_did_table_columns)) + additional_keys

--- a/lib/rucio/core/did_meta_plugins/opendata_meta.py
+++ b/lib/rucio/core/did_meta_plugins/opendata_meta.py
@@ -1,0 +1,38 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sqlalchemy import and_, false, null
+from sqlalchemy.sql.expression import case, select, true
+
+from rucio.db.sqla import models
+
+
+def add_is_opendata_column(stmt):
+    opendata_subquery = select(
+        models.OpenDataDid.scope,
+        models.OpenDataDid.name
+    ).subquery()
+
+    return stmt.add_columns(
+        case(
+            (opendata_subquery.c.scope.isnot(null()), true()),
+            else_=false()
+        ).label("is_opendata")
+    ).outerjoin(
+        opendata_subquery,
+        and_(
+            models.DataIdentifier.scope == opendata_subquery.c.scope,
+            models.DataIdentifier.name == opendata_subquery.c.name
+        )
+    )

--- a/lib/rucio/core/did_meta_plugins/opendata_meta.py
+++ b/lib/rucio/core/did_meta_plugins/opendata_meta.py
@@ -12,13 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import and_, false, null
 from sqlalchemy.sql.expression import case, select, true
 
 from rucio.db.sqla import models
 
+if TYPE_CHECKING:
+    from sqlalchemy.sql.selectable import Select
 
-def add_is_opendata_column(stmt):
+
+def add_is_opendata_column(stmt: "Select") -> "Select":
     opendata_subquery = select(
         models.OpenDataDid.scope,
         models.OpenDataDid.name

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -342,6 +342,8 @@ class BulkDIDS(ErrorHandlingMethodView):
                 schema:
                   type: string
                   enum: ["Created"]
+          400:
+            description: "Bad Request - invalid metadata."
           401:
             description: "Invalid Auth Token"
           406:
@@ -352,6 +354,8 @@ class BulkDIDS(ErrorHandlingMethodView):
         dids = json_list()
         try:
             add_dids(dids=dids, issuer=request.environ['issuer'], vo=request.environ['vo'])
+        except InvalidMetadata as error:
+            return generate_http_error_flask(400, error)
         except DataIdentifierNotFound as error:
             return generate_http_error_flask(404, error)
         except (DuplicateContent, DataIdentifierAlreadyExists, UnsupportedOperation) as error:
@@ -456,6 +460,8 @@ class Attachments(ErrorHandlingMethodView):
                 schema:
                   type: string
                   enum: ["Created"]
+          400:
+            description: "Bad Request - invalid metadata."
           401:
             description: "Invalid Auth Token"
           404:
@@ -478,6 +484,8 @@ class Attachments(ErrorHandlingMethodView):
                                 ignore_duplicate=ignore_duplicate,
                                 issuer=request.environ['issuer'],
                                 vo=request.environ['vo'])
+        except InvalidMetadata as error:
+            return generate_http_error_flask(400, error)
         except DataIdentifierNotFound as error:
             return generate_http_error_flask(404, error)
         except (DuplicateContent, DataIdentifierAlreadyExists, UnsupportedOperation, FileAlreadyExists) as error:
@@ -675,6 +683,8 @@ class DIDs(ErrorHandlingMethodView):
                 schema:
                   type: string
                   enum: ['Created']
+          400:
+            description: "Bad Request - invalid request path, object, or metadata."
           401:
             description: "Invalid Auth Token"
           404:
@@ -704,7 +714,7 @@ class DIDs(ErrorHandlingMethodView):
                 issuer=request.environ['issuer'],
                 vo=request.environ['vo'],
             )
-        except (InvalidObject, InvalidPath) as error:
+        except (InvalidObject, InvalidPath, InvalidMetadata) as error:
             return generate_http_error_flask(400, error)
         except (DataIdentifierNotFound, ScopeNotFound) as error:
             return generate_http_error_flask(404, error)
@@ -898,6 +908,8 @@ class Attachment(ErrorHandlingMethodView):
                 schema:
                   type: string
                   enum: ["Created"]
+          400:
+            description: "Bad Request - invalid path or metadata."
           401:
             description: "Invalid Auth Token"
           404:
@@ -920,7 +932,7 @@ class Attachment(ErrorHandlingMethodView):
                         attachment=attachments,
                         issuer=request.environ['issuer'],
                         vo=request.environ['vo'])
-        except InvalidPath as error:
+        except (InvalidPath, InvalidMetadata) as error:
             return generate_http_error_flask(400, error)
         except (DataIdentifierNotFound, RSENotFound) as error:
             return generate_http_error_flask(404, error)
@@ -1685,10 +1697,7 @@ class BulkDIDsMeta(ErrorHandlingMethodView):
                   type: string
                   enum: ["Created"]
           400:
-            description: |
-              Bad Request – malformed JSON or missing/invalid `dids` structure.
-              (Raised by the generic JSON‑parameter parser before reaching the
-              business logic.)
+            description: "Bad Request – malformed request structure or invalid metadata."
           401:
             description: |
               Unauthorized – invalid Auth Token or insufficient privileges to
@@ -1880,6 +1889,8 @@ class BulkDIDsMeta(ErrorHandlingMethodView):
                 issuer=request.environ["issuer"],
                 vo=request.environ["vo"],
             )
+        except InvalidMetadata as err:
+            return generate_http_error_flask(400, err)
         except DataIdentifierNotFound as err:
             return generate_http_error_flask(404, err)
         except UnsupportedOperation as err:

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -1511,6 +1511,8 @@ class Meta(ErrorHandlingMethodView):
                 )
             except DataIdentifierNotFound as error:
                 return generate_http_error_flask(404, error)
+            except UnsupportedOperation as error:
+                return generate_http_error_flask(409, error)
             except (KeyNotFound, InvalidMetadata, InvalidValueForKey) as error:
                 return generate_http_error_flask(400, error)
             return 'Created', 201
@@ -1528,6 +1530,8 @@ class Meta(ErrorHandlingMethodView):
                 )
             except DataIdentifierNotFound as error:
                 return generate_http_error_flask(404, error)
+            except UnsupportedOperation as error:
+                return generate_http_error_flask(409, error)
             except (KeyNotFound, InvalidMetadata, InvalidValueForKey) as error:
                 return generate_http_error_flask(400, error)
             return "Created", 201

--- a/lib/rucio/web/rest/flaskapi/v1/dids.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dids.py
@@ -1511,8 +1511,6 @@ class Meta(ErrorHandlingMethodView):
                 )
             except DataIdentifierNotFound as error:
                 return generate_http_error_flask(404, error)
-            except UnsupportedOperation as error:
-                return generate_http_error_flask(409, error)
             except (KeyNotFound, InvalidMetadata, InvalidValueForKey) as error:
                 return generate_http_error_flask(400, error)
             return 'Created', 201
@@ -1530,8 +1528,6 @@ class Meta(ErrorHandlingMethodView):
                 )
             except DataIdentifierNotFound as error:
                 return generate_http_error_flask(404, error)
-            except UnsupportedOperation as error:
-                return generate_http_error_flask(409, error)
             except (KeyNotFound, InvalidMetadata, InvalidValueForKey) as error:
                 return generate_http_error_flask(400, error)
             return "Created", 201

--- a/lib/rucio/web/rest/flaskapi/v1/dirac.py
+++ b/lib/rucio/web/rest/flaskapi/v1/dirac.py
@@ -15,7 +15,7 @@
 from flask import Flask, request
 
 from rucio.common.constants import HTTPMethod
-from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifierAlreadyExists, Duplicate, InvalidPath, ResourceTemporaryUnavailable, RSENotFound, UnsupportedOperation
+from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifierAlreadyExists, Duplicate, InvalidMetadata, InvalidPath, ResourceTemporaryUnavailable, RSENotFound, UnsupportedOperation
 from rucio.common.utils import parse_response
 from rucio.gateway.dirac import add_files
 from rucio.web.rest.flaskapi.authenticated_bp import AuthenticatedBlueprint
@@ -64,7 +64,7 @@ class AddFiles(ErrorHandlingMethodView):
                   type: string
                   enum: ["Created"]
           400:
-            description: "Cannot decode json parameter list."
+            description: "Bad Request - invalid request parameters, path, or metadata."
           401:
             description: "Invalid Auth Token"
           404:
@@ -83,7 +83,7 @@ class AddFiles(ErrorHandlingMethodView):
         try:
             add_files(lfns=lfns, issuer=request.environ['issuer'], ignore_availability=ignore_availability,
                       parents_metadata=parents_metadata, vo=request.environ['vo'])
-        except InvalidPath as error:
+        except (InvalidPath, InvalidMetadata) as error:
             return generate_http_error_flask(400, error)
         except AccessDenied as error:
             return generate_http_error_flask(401, error)

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -28,6 +28,7 @@ from rucio.common.exception import (
     DataIdentifierAlreadyExists,
     DataIdentifierNotFound,
     Duplicate,
+    InvalidMetadata,
     InvalidObject,
     InvalidPath,
     InvalidType,
@@ -341,7 +342,7 @@ class Replicas(ErrorHandlingMethodView):
                   type: string
                   enum: ["Created"]
           400:
-            description: "Invalid Path"
+            description: "Invalid Path or metadata"
           401:
             description: "Invalid Auth Token"
           404:
@@ -363,7 +364,7 @@ class Replicas(ErrorHandlingMethodView):
                 vo=request.environ['vo'],
                 ignore_availability=param_get_bool(parameters, 'ignore_availability', default=False),
             )
-        except InvalidPath as error:
+        except (InvalidPath, InvalidMetadata) as error:
             return generate_http_error_flask(400, error)
         except AccessDenied as error:
             return generate_http_error_flask(401, error)

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -37,6 +37,7 @@ from rucio.common.exception import (
     RSENotFound,
     ScopeNotFound,
     SortingAlgorithmNotSupported,
+    UnsupportedOperation,
 )
 from rucio.common.utils import APIEncoder, parse_response, render_json
 from rucio.core.replica_sorter import sort_replicas
@@ -367,7 +368,7 @@ class Replicas(ErrorHandlingMethodView):
             return generate_http_error_flask(400, error)
         except AccessDenied as error:
             return generate_http_error_flask(401, error)
-        except (Duplicate, DataIdentifierAlreadyExists) as error:
+        except (Duplicate, DataIdentifierAlreadyExists, UnsupportedOperation) as error:
             return generate_http_error_flask(409, error)
         except (RSENotFound, ScopeNotFound) as error:
             return generate_http_error_flask(404, error)

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -37,7 +37,6 @@ from rucio.common.exception import (
     RSENotFound,
     ScopeNotFound,
     SortingAlgorithmNotSupported,
-    UnsupportedOperation,
 )
 from rucio.common.utils import APIEncoder, parse_response, render_json
 from rucio.core.replica_sorter import sort_replicas
@@ -368,7 +367,7 @@ class Replicas(ErrorHandlingMethodView):
             return generate_http_error_flask(400, error)
         except AccessDenied as error:
             return generate_http_error_flask(401, error)
-        except (Duplicate, DataIdentifierAlreadyExists, UnsupportedOperation) as error:
+        except (Duplicate, DataIdentifierAlreadyExists) as error:
             return generate_http_error_flask(409, error)
         except (RSENotFound, ScopeNotFound) as error:
             return generate_http_error_flask(404, error)

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import re
 import time
 from configparser import NoOptionError
@@ -38,10 +39,17 @@ skip_unsupported_json = pytest.mark.skipif(
     reason="JSON support is not implemented in this database"
 )
 
-skip_unsupported_dialect = pytest.mark.skipif(
-    get_session().bind.dialect.name in ['oracle', 'sqlite'],
-    reason=f"Unsupported dialect: {get_session().bind.dialect.name}"
-)
+
+def skip_unsupported_dialect(*unsupported_dialects):
+    session = get_session()
+    if not session.bind:
+        return pytest.mark.skipif(False, reason="Database not bound")
+
+    dialect: str = session.bind.dialect.name
+    should_skip = dialect in unsupported_dialects
+    reason = f"Unsupported dialect: {dialect}" if should_skip else "Dialect supported"
+    return pytest.mark.skipif(should_skip, reason=reason)
+
 
 OPENDATA_RSE_EXPRESSION = 'OpenData=True'
 
@@ -216,7 +224,7 @@ class TestOpenDataCore:
 
         assert state == OpenDataDIDState.PUBLIC
 
-    @skip_unsupported_dialect
+    @skip_unsupported_dialect("oracle", "sqlite")
     def test_opendata_dids_meta_update(self, mock_scope, root_account, db_write_session):
         name = did_name_generator(did_type="dataset")
 
@@ -808,9 +816,11 @@ class TestOpenDataAPI:
     api_endpoint_public = '/opendata/public/dids'
 
     def test_opendata_api_list(self, rest_client, auth_token, root_account):
+        request_headers = headers(auth(auth_token))
+
         response = rest_client.get(
             self.api_endpoint,
-            headers=headers(auth(auth_token)),
+            headers=request_headers,
         )
         assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
 
@@ -847,7 +857,7 @@ class TestOpenDataAPI:
             endpoint,
             headers=request_headers,
         )
-        assert response.status_code == 201, f"Expected 200 OK, got {response.status_code}"
+        assert response.status_code == 201, f"Expected 201 OK, got {response.status_code}"
 
         # Add it again, should fail because it already exists
         response = rest_client.post(
@@ -902,6 +912,62 @@ class TestOpenDataAPI:
                 endpoint,
                 headers=request_headers,
             )
+
+    @skip_unsupported_dialect("postgresql")
+    def test_is_opendata(self, rest_client, auth_token, root_account, mock_scope):
+        # More details why this is skipped: https://github.com/rucio/rucio/pull/7903#issuecomment-3144608087
+
+        name = did_name_generator(did_type="dataset")
+        opendata_endpoint = f"{self.api_endpoint}/{mock_scope}/{name}"
+        meta_endpoint = f"/dids/{mock_scope}/{name}/meta"
+        request_headers = headers(auth(auth_token))
+
+        # Add it as a DID
+        add_did(scope=mock_scope, name=name, account=root_account, did_type=DIDType.DATASET)
+
+        # Check `is_opendata` returns False for a regular DID
+        response = rest_client.get(
+            meta_endpoint,
+            headers=request_headers,
+        )
+        assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
+        response_data = json.loads(response.get_data(as_text=True))
+        is_opendata: bool = response_data["is_opendata"]
+        assert not is_opendata, "Expected is_opendata to be False for a regular DID"
+
+        # Register as Opendata
+        response = rest_client.post(
+            opendata_endpoint,
+            headers=request_headers,
+        )
+        assert response.status_code == 201, f"Expected 201 OK, got {response.status_code}"
+
+        # Check `is_opendata` returns True for an Opendata DID
+        response = rest_client.get(
+            meta_endpoint,
+            headers=request_headers,
+        )
+        assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
+        response_data = json.loads(response.get_data(as_text=True))
+        is_opendata: bool = response_data["is_opendata"]
+        assert is_opendata, "Expected is_opendata to be True for an Opendata DID"
+
+        # Remove it from Opendata
+        response = rest_client.delete(
+            opendata_endpoint,
+            headers=request_headers,
+        )
+        assert response.status_code == 204, f"Expected 204 OK, got {response.status_code}"
+
+        # Check `is_opendata` returns False again after removal
+        response = rest_client.get(
+            meta_endpoint,
+            headers=request_headers,
+        )
+        assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
+        response_data = json.loads(response.get_data(as_text=True))
+        is_opendata: bool = response_data["is_opendata"]
+        assert not is_opendata, "Expected is_opendata to be False after removal from Opendata"
 
 
 @pytest.mark.noparallel(reason="Changes in configuration values and race conditions")
@@ -1045,7 +1111,7 @@ class TestOpenDataCLI:
             f"Expected valid states {valid_states} in error message, got {stderr}"
         )
 
-    @skip_unsupported_dialect
+    @skip_unsupported_dialect("oracle", "sqlite")
     def test_opendata_cli_update_delete(self, mock_scope, doi_factory):
         name = did_name_generator(did_type="dataset")
 

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -27,7 +27,7 @@ from rucio.common.constants import OPENDATA_DID_STATE_LITERAL
 from rucio.common.exception import DataIdentifierNotFound, OpenDataDataIdentifierAlreadyExists, OpenDataDataIdentifierNotFound, OpenDataDuplicateDOI, OpenDataDuplicateRecordID, OpenDataInvalidStateUpdate
 from rucio.common.utils import execute
 from rucio.core import opendata
-from rucio.core.did import add_did, delete_dids, set_status
+from rucio.core.did import add_did, delete_dids, get_metadata_bulk, set_status
 from rucio.core.rse import add_rse_attribute
 from rucio.db.sqla.constants import DIDType, OpenDataDIDState
 from rucio.db.sqla.session import get_session
@@ -514,6 +514,48 @@ class TestOpenDataCore:
 
         finally:
             config_set('opendata', 'rse_expression', OPENDATA_RSE_EXPRESSION)
+
+    def test_get_metadata_bulk_includes_is_opendata(
+        self,
+        mock_scope,
+        root_account,
+        db_write_session,
+    ):
+        regular_name = did_name_generator(did_type="dataset")
+        opendata_name = did_name_generator(did_type="dataset")
+
+        dids = [
+            {"scope": mock_scope, "name": regular_name},
+            {"scope": mock_scope, "name": opendata_name},
+        ]
+
+        for did in dids:
+            add_did(
+                scope=did["scope"],
+                name=did["name"],
+                account=root_account,
+                did_type=DIDType.DATASET,
+                session=db_write_session,
+            )
+
+        opendata.add_opendata_did(
+            scope=mock_scope,
+            name=opendata_name,
+            session=db_write_session,
+        )
+
+        db_write_session.commit()
+
+        metadata = {
+            item["name"]: item
+            for item in get_metadata_bulk(
+                dids=dids,
+                session=db_write_session,
+            )
+        }
+
+        assert metadata[regular_name]["is_opendata"] is False
+        assert metadata[opendata_name]["is_opendata"] is True
 
 
 class _FakeCacheRegion:

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -523,7 +523,6 @@ class TestOpenDataCore:
     ):
         regular_name = did_name_generator(did_type="dataset")
         opendata_name = did_name_generator(did_type="dataset")
-
         dids = [
             {"scope": mock_scope, "name": regular_name},
             {"scope": mock_scope, "name": opendata_name},
@@ -544,7 +543,6 @@ class TestOpenDataCore:
                 name=opendata_name,
                 session=db_write_session,
             )
-
             db_write_session.flush()
 
             metadata = {
@@ -558,35 +556,6 @@ class TestOpenDataCore:
             assert metadata[regular_name]["is_opendata"] is False
             assert metadata[opendata_name]["is_opendata"] is True
 
-            single_metadata = get_metadata(
-                scope=mock_scope,
-                name=opendata_name,
-                plugin="ALL",
-                session=db_write_session,
-            )
-
-            assert single_metadata["is_opendata"] is True
-
-            regular_single_metadata = get_metadata(
-                scope=mock_scope,
-                name=regular_name,
-                plugin="ALL",
-                session=db_write_session,
-            )
-
-            assert regular_single_metadata["is_opendata"] is False
-
-            all_metadata = {
-                item["name"]: item
-                for item in get_metadata_bulk(
-                    dids=dids,
-                    plugin="ALL",
-                    session=db_write_session,
-                )
-            }
-
-            assert all_metadata[regular_name]["is_opendata"] is False
-            assert all_metadata[opendata_name]["is_opendata"] is True
         finally:
             db_write_session.rollback()
 
@@ -625,6 +594,68 @@ class TestOpenDataCore:
                     meta={"is_opendata": False},
                     session=db_write_session,
                 )
+        finally:
+            db_write_session.rollback()
+
+    @skip_unsupported_json
+    def test_get_metadata_all_includes_is_opendata(
+        self,
+        mock_scope,
+        root_account,
+        db_write_session,
+    ):
+        regular_name = did_name_generator(did_type="dataset")
+        opendata_name = did_name_generator(did_type="dataset")
+        dids = [
+            {"scope": mock_scope, "name": regular_name},
+            {"scope": mock_scope, "name": opendata_name},
+        ]
+
+        for did in dids:
+            add_did(
+                scope=did["scope"],
+                name=did["name"],
+                account=root_account,
+                did_type=DIDType.DATASET,
+                session=db_write_session,
+            )
+
+        try:
+            opendata.add_opendata_did(
+                scope=mock_scope,
+                name=opendata_name,
+                session=db_write_session,
+            )
+            db_write_session.flush()
+
+            opendata_metadata = get_metadata(
+                scope=mock_scope,
+                name=opendata_name,
+                plugin="ALL",
+                session=db_write_session,
+            )
+            assert opendata_metadata["is_opendata"] is True
+
+            regular_metadata = get_metadata(
+                scope=mock_scope,
+                name=regular_name,
+                plugin="ALL",
+                session=db_write_session,
+            )
+            assert regular_metadata["is_opendata"] is False
+
+            bulk_metadata = {
+                item["name"]: item
+                for item in get_metadata_bulk(
+                    dids=dids,
+                    plugin="ALL",
+                    session=db_write_session,
+                )
+            }
+
+            assert bulk_metadata[regular_name]["is_opendata"] is False
+            assert bulk_metadata[opendata_name]["is_opendata"] is True
+
         finally:
             db_write_session.rollback()
 

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -913,9 +913,7 @@ class TestOpenDataAPI:
                 headers=request_headers,
             )
 
-    @skip_unsupported_dialect("postgresql")
     def test_is_opendata(self, rest_client, auth_token, root_account, mock_scope):
-        # More details why this is skipped: https://github.com/rucio/rucio/pull/7903#issuecomment-3144608087
 
         name = did_name_generator(did_type="dataset")
         opendata_endpoint = f"{self.api_endpoint}/{mock_scope}/{name}"

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -538,24 +538,27 @@ class TestOpenDataCore:
                 session=db_write_session,
             )
 
-        opendata.add_opendata_did(
-            scope=mock_scope,
-            name=opendata_name,
-            session=db_write_session,
-        )
-
-        db_write_session.commit()
-
-        metadata = {
-            item["name"]: item
-            for item in get_metadata_bulk(
-                dids=dids,
+        try:
+            opendata.add_opendata_did(
+                scope=mock_scope,
+                name=opendata_name,
                 session=db_write_session,
             )
-        }
 
-        assert metadata[regular_name]["is_opendata"] is False
-        assert metadata[opendata_name]["is_opendata"] is True
+            db_write_session.flush()
+
+            metadata = {
+                item["name"]: item
+                for item in get_metadata_bulk(
+                    dids=dids,
+                    session=db_write_session,
+                )
+            }
+
+            assert metadata[regular_name]["is_opendata"] is False
+            assert metadata[opendata_name]["is_opendata"] is True
+        finally:
+            db_write_session.rollback()
 
 
 class _FakeCacheRegion:

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -27,7 +27,7 @@ from rucio.common.constants import OPENDATA_DID_STATE_LITERAL
 from rucio.common.exception import DataIdentifierNotFound, OpenDataDataIdentifierAlreadyExists, OpenDataDataIdentifierNotFound, OpenDataDuplicateDOI, OpenDataDuplicateRecordID, OpenDataInvalidStateUpdate
 from rucio.common.utils import execute
 from rucio.core import opendata
-from rucio.core.did import add_did, set_status
+from rucio.core.did import add_did, delete_dids, set_status
 from rucio.core.rse import add_rse_attribute
 from rucio.db.sqla.constants import DIDType, OpenDataDIDState
 from rucio.db.sqla.session import get_session
@@ -914,58 +914,76 @@ class TestOpenDataAPI:
             )
 
     def test_is_opendata(self, rest_client, auth_token, root_account, mock_scope):
-
         name = did_name_generator(did_type="dataset")
         opendata_endpoint = f"{self.api_endpoint}/{mock_scope}/{name}"
         meta_endpoint = f"/dids/{mock_scope}/{name}/meta"
         request_headers = headers(auth(auth_token))
 
-        # Add it as a DID
-        add_did(scope=mock_scope, name=name, account=root_account, did_type=DIDType.DATASET)
-
-        # Check `is_opendata` returns False for a regular DID
-        response = rest_client.get(
-            meta_endpoint,
-            headers=request_headers,
+        add_did(
+            scope=mock_scope,
+            name=name,
+            account=root_account,
+            did_type=DIDType.DATASET,
         )
-        assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
-        response_data = json.loads(response.get_data(as_text=True))
-        is_opendata: bool = response_data["is_opendata"]
-        assert not is_opendata, "Expected is_opendata to be False for a regular DID"
 
-        # Register as Opendata
-        response = rest_client.post(
-            opendata_endpoint,
-            headers=request_headers,
-        )
-        assert response.status_code == 201, f"Expected 201 OK, got {response.status_code}"
+        try:
+            # Check `is_opendata` returns False for a regular DID
+            response = rest_client.get(
+                meta_endpoint,
+                headers=request_headers,
+            )
+            assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
 
-        # Check `is_opendata` returns True for an Opendata DID
-        response = rest_client.get(
-            meta_endpoint,
-            headers=request_headers,
-        )
-        assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
-        response_data = json.loads(response.get_data(as_text=True))
-        is_opendata: bool = response_data["is_opendata"]
-        assert is_opendata, "Expected is_opendata to be True for an Opendata DID"
+            response_data = json.loads(response.get_data(as_text=True))
+            assert response_data["is_opendata"] is False, \
+                "Expected is_opendata to be False for a regular DID"
 
-        # Remove it from Opendata
-        response = rest_client.delete(
-            opendata_endpoint,
-            headers=request_headers,
-        )
-        assert response.status_code == 204, f"Expected 204 OK, got {response.status_code}"
+            # Register as OpenData
+            response = rest_client.post(
+                opendata_endpoint,
+                headers=request_headers,
+            )
+            assert response.status_code == 201, f"Expected 201 Created, got {response.status_code}"
 
-        # Check `is_opendata` returns False again after removal
-        response = rest_client.get(
-            meta_endpoint,
-            headers=request_headers,
-        )
-        assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
-        response_data = json.loads(response.get_data(as_text=True))
-        is_opendata: bool = response_data["is_opendata"]
-        assert not is_opendata, "Expected is_opendata to be False after removal from Opendata"
+            # Check `is_opendata` returns True for an OpenData DID
+            response = rest_client.get(
+                meta_endpoint,
+                headers=request_headers,
+            )
+            assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
+
+            response_data = json.loads(response.get_data(as_text=True))
+            assert response_data["is_opendata"] is True, \
+                "Expected is_opendata to be True for an OpenData DID"
+
+            # Remove it from OpenData
+            response = rest_client.delete(
+                opendata_endpoint,
+                headers=request_headers,
+            )
+            assert response.status_code == 204, f"Expected 204 No Content, got {response.status_code}"
+
+            # Check `is_opendata` returns False again after removal
+            response = rest_client.get(
+                meta_endpoint,
+                headers=request_headers,
+            )
+            assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
+
+            response_data = json.loads(response.get_data(as_text=True))
+            assert response_data["is_opendata"] is False, \
+                "Expected is_opendata to be False after removal from OpenData"
+
+        finally:
+            delete_dids(
+                dids=[{
+                    "scope": mock_scope,
+                    "name": name,
+                    "did_type": DIDType.DATASET,
+                    "purge_replicas": True,
+                }],
+                account=root_account,
+            )
 
 
 @pytest.mark.noparallel(reason="Changes in configuration values and race conditions")

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -28,6 +28,7 @@ from rucio.common.exception import DataIdentifierNotFound, InvalidMetadata, Open
 from rucio.common.utils import execute
 from rucio.core import opendata
 from rucio.core.did import add_did, delete_dids, get_metadata, get_metadata_bulk, set_metadata, set_metadata_bulk, set_status
+from rucio.core.did_meta_plugins.json_meta import JSONDidMeta
 from rucio.core.rse import add_rse_attribute
 from rucio.db.sqla.constants import DIDType, OpenDataDIDState
 from rucio.db.sqla.session import get_session
@@ -606,15 +607,16 @@ class TestOpenDataCore:
     ):
         regular_name = did_name_generator(did_type="dataset")
         opendata_name = did_name_generator(did_type="dataset")
+
         dids = [
             {"scope": mock_scope, "name": regular_name},
             {"scope": mock_scope, "name": opendata_name},
         ]
 
-        for did in dids:
+        for did_data in dids:
             add_did(
-                scope=did["scope"],
-                name=did["name"],
+                scope=did_data["scope"],
+                name=did_data["name"],
                 account=root_account,
                 did_type=DIDType.DATASET,
                 session=db_write_session,
@@ -626,25 +628,44 @@ class TestOpenDataCore:
                 name=opendata_name,
                 session=db_write_session,
             )
+
+            # Simulate legacy custom metadata created before `is_opendata`
+            # became a read-only derived metadata field.
+            JSONDidMeta().set_metadata(
+                scope=mock_scope,
+                name=opendata_name,
+                key="is_opendata",
+                value=False,
+                session=db_write_session,
+            )
+
             db_write_session.flush()
 
-            opendata_metadata = get_metadata(
+            json_metadata = get_metadata(
+                scope=mock_scope,
+                name=opendata_name,
+                plugin="JSON",
+                session=db_write_session,
+            )
+            assert json_metadata["is_opendata"] is False
+
+            single_metadata = get_metadata(
                 scope=mock_scope,
                 name=opendata_name,
                 plugin="ALL",
                 session=db_write_session,
             )
-            assert opendata_metadata["is_opendata"] is True
+            assert single_metadata["is_opendata"] is True
 
-            regular_metadata = get_metadata(
+            regular_single_metadata = get_metadata(
                 scope=mock_scope,
                 name=regular_name,
                 plugin="ALL",
                 session=db_write_session,
             )
-            assert regular_metadata["is_opendata"] is False
+            assert regular_single_metadata["is_opendata"] is False
 
-            bulk_metadata = {
+            all_metadata = {
                 item["name"]: item
                 for item in get_metadata_bulk(
                     dids=dids,
@@ -653,8 +674,8 @@ class TestOpenDataCore:
                 )
             }
 
-            assert bulk_metadata[regular_name]["is_opendata"] is False
-            assert bulk_metadata[opendata_name]["is_opendata"] is True
+            assert all_metadata[regular_name]["is_opendata"] is False
+            assert all_metadata[opendata_name]["is_opendata"] is True
 
         finally:
             db_write_session.rollback()
@@ -1057,7 +1078,8 @@ class TestOpenDataAPI:
                 headers=request_headers,
             )
 
-    def test_is_opendata(self, rest_client, auth_token, root_account, mock_scope, message_mock):
+    def test_is_opendata(self, rest_client, auth_token, root_account, mock_scope, monkeypatch):
+        monkeypatch.setattr("rucio.core.did.add_message", lambda *args, **kwargs: None)
         name = did_name_generator(did_type="dataset")
         opendata_endpoint = f"{self.api_endpoint}/{mock_scope}/{name}"
         meta_endpoint = f"/dids/{mock_scope}/{name}/meta"

--- a/tests/test_opendata.py
+++ b/tests/test_opendata.py
@@ -24,10 +24,10 @@ from dogpile.cache.api import NoValue
 
 from rucio.common.config import config_add_section, config_get, config_get_bool, config_has_section, config_remove_option, config_set
 from rucio.common.constants import OPENDATA_DID_STATE_LITERAL
-from rucio.common.exception import DataIdentifierNotFound, OpenDataDataIdentifierAlreadyExists, OpenDataDataIdentifierNotFound, OpenDataDuplicateDOI, OpenDataDuplicateRecordID, OpenDataInvalidStateUpdate
+from rucio.common.exception import DataIdentifierNotFound, InvalidMetadata, OpenDataDataIdentifierAlreadyExists, OpenDataDataIdentifierNotFound, OpenDataDuplicateDOI, OpenDataDuplicateRecordID, OpenDataInvalidStateUpdate
 from rucio.common.utils import execute
 from rucio.core import opendata
-from rucio.core.did import add_did, delete_dids, get_metadata_bulk, set_status
+from rucio.core.did import add_did, delete_dids, get_metadata, get_metadata_bulk, set_metadata, set_metadata_bulk, set_status
 from rucio.core.rse import add_rse_attribute
 from rucio.db.sqla.constants import DIDType, OpenDataDIDState
 from rucio.db.sqla.session import get_session
@@ -557,6 +557,74 @@ class TestOpenDataCore:
 
             assert metadata[regular_name]["is_opendata"] is False
             assert metadata[opendata_name]["is_opendata"] is True
+
+            single_metadata = get_metadata(
+                scope=mock_scope,
+                name=opendata_name,
+                plugin="ALL",
+                session=db_write_session,
+            )
+
+            assert single_metadata["is_opendata"] is True
+
+            regular_single_metadata = get_metadata(
+                scope=mock_scope,
+                name=regular_name,
+                plugin="ALL",
+                session=db_write_session,
+            )
+
+            assert regular_single_metadata["is_opendata"] is False
+
+            all_metadata = {
+                item["name"]: item
+                for item in get_metadata_bulk(
+                    dids=dids,
+                    plugin="ALL",
+                    session=db_write_session,
+                )
+            }
+
+            assert all_metadata[regular_name]["is_opendata"] is False
+            assert all_metadata[opendata_name]["is_opendata"] is True
+        finally:
+            db_write_session.rollback()
+
+    def test_is_opendata_metadata_is_read_only(
+        self,
+        mock_scope,
+        root_account,
+        db_write_session,
+    ):
+        name = did_name_generator(did_type="dataset")
+
+        add_did(
+            scope=mock_scope,
+            name=name,
+            account=root_account,
+            did_type=DIDType.DATASET,
+            session=db_write_session,
+        )
+
+        try:
+            db_write_session.flush()
+
+            with pytest.raises(InvalidMetadata):
+                set_metadata(
+                    scope=mock_scope,
+                    name=name,
+                    key="is_opendata",
+                    value=False,
+                    session=db_write_session,
+                )
+
+            with pytest.raises(InvalidMetadata):
+                set_metadata_bulk(
+                    scope=mock_scope,
+                    name=name,
+                    meta={"is_opendata": False},
+                    session=db_write_session,
+                )
         finally:
             db_write_session.rollback()
 
@@ -958,7 +1026,7 @@ class TestOpenDataAPI:
                 headers=request_headers,
             )
 
-    def test_is_opendata(self, rest_client, auth_token, root_account, mock_scope):
+    def test_is_opendata(self, rest_client, auth_token, root_account, mock_scope, message_mock):
         name = did_name_generator(did_type="dataset")
         opendata_endpoint = f"{self.api_endpoint}/{mock_scope}/{name}"
         meta_endpoint = f"/dids/{mock_scope}/{name}/meta"


### PR DESCRIPTION
Issue: #7901

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
<!-- Required. Summarise WHAT this PR changes. The WHY should already be
     covered by the linked issue and its discussion. A sufficiently detailed
     commit message may be reused here. If a checklist item below does not
     apply to this PR, briefly say why here. -->
This PR resumes the closed PR #7903 


## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [x] This PR closes #7901 
      <!-- Every PR requires an issue; if none exists yet, please create one
           first. GitHub links the PR to the issue and closes it on merge.
           In the rare case the issue should remain open after the merge,
           write "Related to #____" here instead and briefly say why in the
           description. -->
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

Treat `is_opendata` as a reserved, read-only metadata key. Its value is derived from the OpenData catalog and cannot be overridden through custom metadata.

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
