### PR TITLE
fix(Testing): use CliRunner instead of subprocess in test_help_menus

### DIFF
--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -19,7 +19,9 @@ import tempfile
 from typing import TYPE_CHECKING
 
 import pytest
+from click.testing import CliRunner
 
+from rucio.cli.command import main as rucio_cli
 from rucio.common.exception import RucioException
 from rucio.common.utils import generate_uuid
 from rucio.tests.common import account_name_generator, execute, file_generator, rse_name_generator, scope_name_generator, with_each_cli_renderer
@@ -77,33 +79,34 @@ def test_main_args(file_config_mock):
 @with_each_cli_renderer
 def test_help_menus(file_config_mock):
     """Verify help menus"""
-    exitcode, out, err = execute("rucio --help")
-    assert exitcode == 0
-    assert "ERROR" not in err
-    out = out.split("\n")
+    runner = CliRunner()
+    result = runner.invoke(rucio_cli, ["--help"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "ERROR" not in result.output
+    out = result.output.split("\n")
     commands = [cmd.split(" ") for cmd in out[out.index("Commands:") + 1:] if len(cmd) > 3]  # command has two spaces in front of it
     commands = [cmd[2] for cmd in commands]
 
     for command in commands:
-        exitcode, out, err = execute(f"rucio {command} --help")
-        assert exitcode == 0, f"Command {command} --help failed"  # Included for debugging purposes
+        result = runner.invoke(rucio_cli, [command, "--help"], catch_exceptions=False)
+        assert result.exit_code == 0, f"Command {command} --help failed"  # Included for debugging purposes
 
-        exitcode, out, err = execute(f"rucio {command} -h")
-        assert exitcode == 0, f"Command {command} -h failed"
+        result = runner.invoke(rucio_cli, [command, "-h"], catch_exceptions=False)
+        assert result.exit_code == 0, f"Command {command} -h failed"
 
         # test the subcommands/operations as well
-        out = out.split("\n")
+        out = result.output.split("\n")
         try:
             subcommands = [cmd.split(" ") for cmd in out[out.index("Commands:") + 1:] if len(cmd) > 3]
             subcommands = [cmd[2] for cmd in subcommands]
             for subcommand in subcommands:
                 menu = f"rucio {command} {subcommand} --help"
-                exitcode, out, err = execute(menu)
-                assert exitcode == 0, f"Command {menu} failed"  # Included for debugging purposes
+                result = runner.invoke(rucio_cli, [command, subcommand, "--help"], catch_exceptions=False)
+                assert result.exit_code == 0, f"Command {menu} failed"  # Included for debugging purposes
 
                 menu = f"rucio {command} {subcommand} -h"
-                exitcode, out, err = execute(menu)
-                assert exitcode == 0, f"Command {menu} -h failed"
+                result = runner.invoke(rucio_cli, [command, subcommand, "-h"], catch_exceptions=False)
+                assert result.exit_code == 0, f"Command {menu} -h failed"
 
         except ValueError:  # "Commands:" not in list
             continue


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description

`test_help_menus` spawned a new process for every  invocation, which made it one of the slowest tests (~95s). Invoke the CLI in-process with Click's CliRunner instead.

The CLI is already a Click application (`rucio.cli.command.main`), so using to invoke in-process with Click's CliRunner instead of `execute()`. This avoids subprocess startup, shell parsing, and interpreter init on each call, while still capturing exit code and output the same way.

## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [x] This PR closes #8752
      <!-- Every PR requires an issue; if none exists yet, please create one
           first. GitHub links the PR to the issue and closes it on merge.
           In the rare case the issue should remain open after the merge,
           write "Related to #____" here instead and briefly say why in the
           description. -->
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
