### PR TITLE
fix(API): Pass error message when replica is incorrectly supplied

### DIFF
--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -435,6 +435,8 @@ class Replicas(ErrorHandlingMethodView):
             update_replicas_states(rse=rse, files=files, issuer=request.environ['issuer'], vo=request.environ['vo'])
         except AccessDenied as error:
             return generate_http_error_flask(401, error)
+        except (ValueError, AttributeError) as error:
+            return generate_http_error_flask(400, ValueError.__name__, exc_msg=str(error))
 
         return '', 200
 

--- a/lib/rucio/web/rest/flaskapi/v1/replicas.py
+++ b/lib/rucio/web/rest/flaskapi/v1/replicas.py
@@ -435,6 +435,8 @@ class Replicas(ErrorHandlingMethodView):
             update_replicas_states(rse=rse, files=files, issuer=request.environ['issuer'], vo=request.environ['vo'])
         except AccessDenied as error:
             return generate_http_error_flask(401, error)
+        except (ValueError, AttributeError) as error:
+            return generate_http_error_flask(400, error)
 
         return '', 200
 

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -29,7 +29,7 @@ from werkzeug.datastructures import Headers, MultiDict
 import rucio.core.permission
 from rucio.client.ruleclient import RuleClient
 from rucio.common.constants import RseAttr
-from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifierNotFound, InputValidationError, ReplicaIsLocked, ReplicaNotFound, RucioException, ScopeNotFound
+from rucio.common.exception import AccessDenied, DatabaseException, DataIdentifierNotFound, InputValidationError, InvalidObject, ReplicaIsLocked, ReplicaNotFound, RucioException, ScopeNotFound
 from rucio.common.utils import clean_pfns, generate_uuid, parse_response
 from rucio.core.config import set as cconfig_set
 from rucio.core.did import add_did, attach_dids, get_did, get_did_access_cnt, get_did_atime, list_files, set_status
@@ -837,6 +837,19 @@ def test_client_add_list_replicas(rse_factory, replica_client, mock_scope):
     assert len(replicas) == 5
     for i in range(nbfiles):
         assert rse2 in replicas[i]['rses']
+
+    # A list raises an attribute error
+    with pytest.raises(RucioException) as err:
+        replica_client.update_replicas_states(rse2, files=files1[0])
+        assert "Details: no error information passed" not in err.args[0]
+
+    # A non-real state type raises a value error
+    fake_files = [f for f in files1]
+    for file in fake_files:
+        file['state'] = "FAKE"
+    with pytest.raises(InvalidObject) as err:
+        replica_client.update_replicas_states(rse2, files=fake_files)
+        assert "Details: no error information passed" not in err.args[0]
 
 
 def test_client_add_replica_scope_not_found(rse_factory, replica_client):


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
Adds a 400 exception to replace the 500 error passed when a Value or Attribute error is raised by `update_replicas_states`


## Checklist

- [x] This PR closes #8121 
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
