### PR TITLE
feat(Transfers): List request history by did

### DIFF
--- a/lib/rucio/client/requestclient.py
+++ b/lib/rucio/client/requestclient.py
@@ -24,11 +24,19 @@ from rucio.common.utils import build_url
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
+    from datetime import datetime
 
 
 class RequestClient(BaseClient):
 
     REQUEST_BASEURL = 'requests'
+
+    def _send_get_request(self, url: str, params: Optional[dict[str, Any]] = None) -> 'Iterator[dict[str, Any]]':
+        r = self._send_request(url, method=HTTPMethod.GET, params=params)
+        if r.status_code == codes.ok:
+            return self._load_json_data(r)
+        exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
+        raise exc_cls(exc_msg)
 
     def list_requests(
             self,
@@ -45,13 +53,7 @@ class RequestClient(BaseClient):
         path = '/'.join([self.REQUEST_BASEURL, 'list']) + '?' + '&'.join(['src_rse={}'.format(src_rse), 'dst_rse={}'.format(
             dst_rse), 'request_states={}'.format(request_states)])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, method=HTTPMethod.GET)
-
-        if r.status_code == codes.ok:
-            return self._load_json_data(r)
-        else:
-            exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
-            raise exc_cls(exc_msg)
+        return self._send_get_request(url)
 
     def list_requests_history(
             self,
@@ -70,20 +72,14 @@ class RequestClient(BaseClient):
         path = '/'.join([self.REQUEST_BASEURL, 'history', 'list']) + '?' + '&'.join(['src_rse={}'.format(src_rse), 'dst_rse={}'.format(
             dst_rse), 'request_states={}'.format(request_states), 'offset={}'.format(offset), 'limit={}'.format(limit)])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, method=HTTPMethod.GET)
-
-        if r.status_code == codes.ok:
-            return self._load_json_data(r)
-        else:
-            exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
-            raise exc_cls(exc_msg)
+        return self._send_get_request(url)
 
     def list_request_by_did(
             self,
             name: str,
             rse: str,
             scope: Optional[str] = None
-    ) -> 'Iterator[dict[str, Any]]':
+    ) -> dict[str, Any]:
         """Return latest request details for a DID
         Parameters
         ----------
@@ -106,20 +102,14 @@ class RequestClient(BaseClient):
         if scope is not None:
             path = '/'.join([self.REQUEST_BASEURL, quote_plus(scope), quote_plus(name), rse])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, method=HTTPMethod.GET)
-
-        if r.status_code == codes.ok:
-            return next(self._load_json_data(r))
-        else:
-            exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
-            raise exc_cls(exc_msg)
+        return next(self._send_get_request(url))
 
     def list_request_history_by_did(
             self,
             name: str,
             rse: str,
             scope: Optional[str] = None
-    ) -> 'Iterator[dict[str, Any]]':
+    ) -> dict[str, Any]:
         """
         Return latest request details for a DID
 
@@ -144,13 +134,75 @@ class RequestClient(BaseClient):
         if scope is not None:
             path = '/'.join([self.REQUEST_BASEURL, 'history', quote_plus(scope), quote_plus(name), rse])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, method=HTTPMethod.GET)
+        return next(self._send_get_request(url))
 
-        if r.status_code == codes.ok:
-            return next(self._load_json_data(r))
-        else:
-            exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
-            raise exc_cls(exc_msg)
+    def list_requests_history_by_did(
+            self,
+            name: str,
+            rse: str,
+            scope: str,
+            rule_id: Optional[str] = None,
+            request_states: Optional['Sequence[str]'] = None,
+            created_after: Optional['datetime'] = None,
+            created_before: Optional['datetime'] = None,
+            offset: Optional[int] = None,
+            limit: int = 10
+    ) -> 'Iterator[dict[str, Any]]':
+        """
+        Return the latest historical requests for a DID, newest first.
+
+        Unlike `list_request_history_by_did`, which returns a single request, this returns up to `limit` requests, so
+        several transfer attempts of the same DID can be inspected at once. This call can be very slow on large servers,
+        so it is for debugging purposes. Narrowing the window with `created_after` and `created_before` can help if the
+         database partitions by those.
+
+        Parameters
+        ----------
+        name :
+            DID name.
+        rse :
+            Destination RSE name.
+        scope :
+            Scope of the DID.
+        rule_id :
+            Only return requests belonging to this replication rule.
+        request_states :
+            Only return requests in one of these states, given as state *values* such as 'F'
+            rather than the names such as 'FAILED' that appear in the responses. Defaults to all.
+        created_after :
+            Only return requests created at or after this time.
+        created_before :
+            Only return requests created at or before this time.
+        offset :
+            Number of requests to skip.
+        limit :
+            Maximum number of requests to return. Defaults to 10.
+
+        Raises
+        ------
+        exc_cls
+            From BaseClient._get_exception.
+
+        Returns
+        -------
+            An iterator over the matching historical requests.
+        """
+        path = '/'.join([self.REQUEST_BASEURL, 'history', 'list', quote_plus(scope), quote_plus(name), rse])
+        url = build_url(choice(self.list_hosts), path=path)
+
+        params: dict[str, Any] = {'limit': limit}
+        if rule_id:
+            params['rule_id'] = rule_id
+        if request_states:
+            params['request_states'] = ','.join(request_states)
+        if created_after:
+            params['created_after'] = created_after.strftime('%Y-%m-%dT%H:%M:%S')
+        if created_before:
+            params['created_before'] = created_before.strftime('%Y-%m-%dT%H:%M:%S')
+        if offset:
+            params['offset'] = offset
+
+        return self._send_get_request(url, params=params)
 
     def list_transfer_limits(
             self
@@ -161,13 +213,7 @@ class RequestClient(BaseClient):
         """
         path = '/'.join([self.REQUEST_BASEURL, 'transfer_limits'])
         url = build_url(choice(self.list_hosts), path=path)
-        r = self._send_request(url, method=HTTPMethod.GET)
-
-        if r.status_code == codes.ok:
-            return self._load_json_data(r)
-        else:
-            exc_cls, exc_msg = self._get_exception(headers=r.headers, status_code=r.status_code, data=r.content)
-            raise exc_cls(exc_msg)
+        return self._send_get_request(url)
 
     def set_transfer_limit(
             self,

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -90,6 +90,7 @@ def has_permission(issuer: "InternalAccount", action: str, kwargs: dict[str, Any
             'list_requests_history': perm_list_requests_history,
             'get_request_by_did': perm_get_request_by_did,
             'get_request_history_by_did': perm_get_request_history_by_did,
+            'list_requests_history_by_did': perm_list_requests_history_by_did,
             'cancel_request': perm_cancel_request,
             'get_next': perm_get_next,
             'set_local_account_limit': perm_set_local_account_limit,
@@ -791,6 +792,18 @@ def perm_get_request_by_did(issuer: "InternalAccount", kwargs: dict[str, Any], s
 def perm_get_request_history_by_did(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:
     """
     Checks if an account can get a historical request by DID.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
+    :returns: True if account is allowed, otherwise False
+    """
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+
+
+def perm_list_requests_history_by_did(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:
+    """
+    Checks if an account can list historical requests by DID.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/core/permission/generic_multi_vo.py
+++ b/lib/rucio/core/permission/generic_multi_vo.py
@@ -88,6 +88,7 @@ def has_permission(issuer, action, kwargs, session: "Session"):
             'list_requests_history': perm_list_requests_history,
             'get_request_by_did': perm_get_request_by_did,
             'get_request_history_by_did': perm_get_request_history_by_did,
+            'list_requests_history_by_did': perm_list_requests_history_by_did,
             'cancel_request': perm_cancel_request,
             'get_next': perm_get_next,
             'set_local_account_limit': perm_set_local_account_limit,
@@ -754,6 +755,18 @@ def perm_get_request_by_did(issuer, kwargs, session: "Session"):
 def perm_get_request_history_by_did(issuer, kwargs, session: "Session"):
     """
     Checks if an account can get a historical request by DID.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :param session: The DB session to use
+    :returns: True if account is allowed, otherwise False
+    """
+    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+
+
+def perm_list_requests_history_by_did(issuer: "InternalAccount", kwargs: dict[str, Any], session: "Session") -> bool:
+    """
+    Checks if an account can list historical requests by DID.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/core/request.py
+++ b/lib/rucio/core/request.py
@@ -3064,6 +3064,83 @@ def list_requests_history(
         yield request
 
 
+@stream_session
+def list_requests_history_by_did(
+    scope: InternalScope,
+    name: str,
+    rse_id: str,
+    rule_id: Optional[str] = None,
+    states: Optional['Sequence[RequestState]'] = None,
+    created_after: Optional[datetime.datetime] = None,
+    created_before: Optional[datetime.datetime] = None,
+    offset: Optional[int] = None,
+    limit: int = 10,
+    *,
+    session: "Session"
+) -> 'Iterator[models.RequestHistory]':
+    """
+    List the latest historical requests for a DID towards a destination RSE, newest first.
+
+    Unlike `get_request_history_by_did`, which returns a single row, this returns up to
+    `limit` rows so that several transfer attempts of the same DID can be inspected at once.
+
+    Parameters
+    ----------
+    scope :
+        The scope of the data identifier.
+    name :
+        The name of the data identifier.
+    rse_id :
+        The destination RSE ID of the requests.
+    rule_id :
+        Only return requests associated with this replication rule.
+    states :
+        Only return requests in one of these states. Defaults to all.
+    created_after :
+        Only return requests created at or after this time.
+    created_before :
+        Only return requests created at or before this time.
+    offset :
+        Number of rows to skip.
+    limit :
+        Maximum number of requests to return.
+    session :
+        The database session in use.
+
+    Returns
+    -------
+        An iterator over the matching historical requests, ordered by creation time descending.
+    """
+    stmt = select(
+        models.RequestHistory
+    ).where(
+        and_(
+            models.RequestHistory.scope == scope,
+            models.RequestHistory.name == name,
+            models.RequestHistory.dest_rse_id == rse_id
+        )
+    )
+    if rule_id:
+        stmt = stmt.where(models.RequestHistory.rule_id == rule_id)
+    if states:
+        stmt = stmt.where(models.RequestHistory.state.in_(states))
+    if created_after:
+        stmt = stmt.where(models.RequestHistory.created_at >= created_after)
+    if created_before:
+        stmt = stmt.where(models.RequestHistory.created_at <= created_before)
+
+    stmt = stmt.order_by(
+        models.RequestHistory.created_at.desc(),
+        models.RequestHistory.id.desc()
+    )
+    if offset:
+        stmt = stmt.offset(offset)
+    stmt = stmt.limit(limit)
+
+    for request in session.execute(stmt).yield_per(500).scalars():
+        yield request
+
+
 @transactional_session
 def reset_stale_waiting_requests(time_limit: Optional[datetime.timedelta] = datetime.timedelta(days=1), *, session: "Session") -> None:
     """

--- a/lib/rucio/gateway/request.py
+++ b/lib/rucio/gateway/request.py
@@ -29,9 +29,31 @@ from rucio.db.sqla.session import db_session
 from rucio.gateway import permission
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Iterable, Iterator, Sequence
 
+    from sqlalchemy.orm import Session
+
     from rucio.db.sqla.constants import RequestState
+
+
+def _resolve_and_authorize_did_request(
+    scope: str,
+    name: str,
+    rse: str,
+    issuer: str,
+    action: str,
+    vo: str,
+    session: "Session",
+) -> tuple[str, InternalScope]:
+    rse_id = get_rse_id(rse=rse, vo=vo, session=session)
+
+    kwargs = {'scope': scope, 'name': name, 'rse': rse, 'rse_id': rse_id, 'issuer': issuer}
+    auth_result = permission.has_permission(issuer=issuer, vo=vo, action=action, kwargs=kwargs, session=session)
+    if not auth_result.allowed:
+        raise exception.AccessDenied(f'{issuer} cannot retrieve the request DID {scope}:{name} to RSE {rse}. {auth_result.message}')
+
+    return rse_id, InternalScope(scope, vo=vo)
 
 
 def get_request_by_did(
@@ -52,14 +74,9 @@ def get_request_by_did(
     :returns: Request as a dictionary.
     """
     with db_session(DatabaseOperationType.READ) as session:
-        rse_id = get_rse_id(rse=rse, vo=vo, session=session)
-
-        kwargs = {'scope': scope, 'name': name, 'rse': rse, 'rse_id': rse_id, 'issuer': issuer}
-        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='get_request_by_did', kwargs=kwargs, session=session)
-        if not auth_result.allowed:
-            raise exception.AccessDenied(f'{issuer} cannot retrieve the request DID {scope}:{name} to RSE {rse}. {auth_result.message}')
-
-        internal_scope = InternalScope(scope, vo=vo)
+        rse_id, internal_scope = _resolve_and_authorize_did_request(
+            scope, name, rse, issuer, 'get_request_by_did', vo, session
+        )
         req = request.get_request_by_did(internal_scope, name, rse_id, session=session)
 
         return gateway_update_return_dict(req, session=session)
@@ -83,17 +100,78 @@ def get_request_history_by_did(
     :returns: Request as a dictionary.
     """
     with db_session(DatabaseOperationType.READ) as session:
-        rse_id = get_rse_id(rse=rse, vo=vo, session=session)
-
-        kwargs = {'scope': scope, 'name': name, 'rse': rse, 'rse_id': rse_id, 'issuer': issuer}
-        auth_result = permission.has_permission(issuer=issuer, vo=vo, action='get_request_history_by_did', kwargs=kwargs, session=session)
-        if not auth_result.allowed:
-            raise exception.AccessDenied(f'{issuer} cannot retrieve the request DID {scope}:{name} to RSE {rse}. {auth_result.message}')
-
-        internal_scope = InternalScope(scope, vo=vo)
+        rse_id, internal_scope = _resolve_and_authorize_did_request(
+            scope, name, rse, issuer, 'get_request_history_by_did', vo, session
+        )
         req = request.get_request_history_by_did(internal_scope, name, rse_id, session=session)
 
         return gateway_update_return_dict(req, session=session)
+
+
+def list_requests_history_by_did(
+    scope: str,
+    name: str,
+    rse: str,
+    issuer: str,
+    vo: str = DEFAULT_VO,
+    rule_id: Optional[str] = None,
+    states: Optional["Sequence[RequestState]"] = None,
+    created_after: Optional["datetime.datetime"] = None,
+    created_before: Optional["datetime.datetime"] = None,
+    offset: Optional[int] = None,
+    limit: int = 10,
+) -> "Iterator[dict[str, Any]]":
+    """
+    List the latest historical requests for a DID towards a destination RSE, newest first.
+
+    Unlike `get_request_history_by_did`, which returns a single request, this returns up to `limit`. This can get
+    quite slow on large servers, so it's only intended for debugging purposes.
+
+    Parameters
+    ----------
+    scope :
+        The scope of the data identifier as a string.
+    name :
+        The name of the data identifier as a string.
+    rse :
+        The destination RSE of the requests as a string.
+    issuer :
+        Issuing account as a string.
+    vo :
+        The VO to act on.
+    rule_id :
+        Only return requests associated with this replication rule.
+    states :
+        Only return requests in one of these states. All states when omitted.
+    created_after :
+        Only return requests created at or after this time.
+    created_before :
+        Only return requests created at or before this time.
+    offset :
+        Number of requests to skip, for paging.
+    limit :
+        Maximum number of requests to return.
+
+    Returns
+    -------
+        An iterator over the matching historical requests as dictionaries.
+
+    Raises
+    ------
+    AccessDenied
+        If the issuer is not allowed to retrieve the historical requests.
+    RSENotFound
+        If the destination RSE does not exist.
+    """
+    with db_session(DatabaseOperationType.READ) as session:
+        rse_id, internal_scope = _resolve_and_authorize_did_request(
+            scope, name, rse, issuer, 'list_requests_history_by_did', vo, session
+        )
+        for req in request.list_requests_history_by_did(
+                scope=internal_scope, name=name, rse_id=rse_id, rule_id=rule_id, states=states,
+                created_after=created_after, created_before=created_before, offset=offset, limit=limit, session=session
+        ):
+            yield gateway_update_return_dict(req.to_dict(), session=session)
 
 
 def list_requests(

--- a/lib/rucio/web/rest/flaskapi/v1/requests.py
+++ b/lib/rucio/web/rest/flaskapi/v1/requests.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import json
-from typing import TYPE_CHECKING, Union, cast
+import uuid
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 import flask
 from flask import Flask, Response
 
 from rucio.common.constants import HTTPMethod, TransferLimitDirection
-from rucio.common.exception import AccessDenied, RequestNotFound
+from rucio.common.exception import AccessDenied, RequestNotFound, RSENotFound
 from rucio.common.utils import APIEncoder, render_json
 from rucio.core.rse import get_rses_with_attribute_value
 from rucio.db.sqla.constants import RequestState
@@ -29,6 +31,52 @@ from rucio.web.rest.flaskapi.v1.common import ErrorHandlingMethodView, check_acc
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+# smallest maximum allowed value across the supported databases
+MAX_BIGINT = 2 ** 63 - 1
+
+
+def _parse_request_states_param(request_states: Optional[str]) -> Optional[list[RequestState]]:
+    if not request_states:
+        return None
+    try:
+        return [RequestState(state) for state in request_states.split(',')]
+    except ValueError as error:
+        raise ValueError('Request state value is invalid') from error
+
+
+def _parse_datetime_param(value: Optional[str], name: str) -> Optional[datetime.datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.datetime.strptime(value, '%Y-%m-%dT%H:%M:%S')
+    except ValueError as error:
+        raise ValueError(f'Cannot decode {name}, must be of the form %Y-%m-%dT%H:%M:%S') from error
+
+
+# not using `flask.request.args.get(type=int)` because it fails silently on non-number values, whereas we want to throw a 400
+def _parse_int_param(value: Optional[str], name: str, default: int) -> int:
+    if not value:
+        return default
+    try:
+        return int(value)
+    except ValueError as error:
+        raise ValueError(f'Cannot decode {name}, must be an integer') from error
+
+
+def _validate_paging_param(name: str, value: int, minimum: int) -> int:
+    if value < minimum or value > MAX_BIGINT:
+        raise ValueError(f'The {name} must be between {minimum} and {MAX_BIGINT}')
+    return value
+
+
+def _validate_and_normalize_rule_id_param(rule_id: Optional[str]) -> Optional[str]:
+    if not rule_id:
+        return None
+    try:
+        return str(uuid.UUID(rule_id))
+    except ValueError as error:
+        raise ValueError('The rule_id is not a valid UUID') from error
 
 
 class RequestGet(ErrorHandlingMethodView):
@@ -821,6 +869,234 @@ class RequestHistoryList(ErrorHandlingMethodView):
         return try_stream(generate(issuer=flask.request.environ['issuer'], vo=flask.request.environ['vo']))
 
 
+class RequestHistoryListByDid(ErrorHandlingMethodView):
+    """ REST API to list the latest historical requests for a DID. """
+
+    @check_accept_header_wrapper_flask(['application/x-json-stream'])
+    def get(self, scope_name: str, rse: str) -> "Response":
+        """
+        ---
+        summary: List Historic Requests By DID
+        description: |
+          List the latest historical requests for a given DID to a destination RSE, newest first.
+
+          Warning: this call can be very slow on large instances, it is meant for operator debugging. Restricting the
+          time window with `created_after`/`created_before` also improves performance if the table is partitioned on that.
+
+        tags:
+          - Requests
+        parameters:
+        - name: scope_name
+          in: path
+          description: "Data identifier (scope)/(name)."
+          schema:
+            type: string
+          style: simple
+        - name: rse
+          in: path
+          description: "Destination rse."
+          schema:
+            type: string
+          style: simple
+        - name: rule_id
+          in: query
+          description: "Only return requests belonging to this replication rule."
+          schema:
+            type: string
+        - name: request_states
+          in: query
+          description: "The accepted request states. Delimited by comma, defaults to all."
+          schema:
+            type: string
+        - name: created_after
+          in: query
+          description: "Only return requests created at or after this time, as %Y-%m-%dT%H:%M:%S."
+          schema:
+            type: string
+        - name: created_before
+          in: query
+          description: "Only return requests created at or before this time, as %Y-%m-%dT%H:%M:%S."
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description: "The offset of the list. Must be between 0 and 2^63 - 1."
+          schema:
+            type: integer
+            default: 0
+        - name: limit
+          in: query
+          description: "The maximum number of items to return. Must be between 1 and 2^63 - 1."
+          schema:
+            type: integer
+            default: 10
+        responses:
+          200:
+            description: "OK"
+            content:
+              application/x-json-stream:
+                schema:
+                  description: "All historical requests matching the arguments, newest first."
+                  type: array
+                  items:
+                    description: "A historical request."
+                    type: object
+                    properties:
+                      id:
+                        description: "The id of the request."
+                        type: string
+                      request_type:
+                        description: "The request type."
+                        $ref: "#/components/schemas/RequestType"
+                      scope:
+                        description: "The scope of the transfer."
+                        type: string
+                      name:
+                        description: "The name of the transfer."
+                        type: string
+                      did_type:
+                        description: "The DID type."
+                        type: string
+                      dest_rse_id:
+                        description: "The destination RSE id."
+                        type: string
+                      source_rse_id:
+                        description: "The source RSE id."
+                        type: string
+                      attributes:
+                        description: "All attributes associated with the request, as a raw JSON string."
+                        type: string
+                      state:
+                        description: "The state of the request."
+                        $ref: "#/components/schemas/RequestState"
+                      external_id:
+                        description: "External id of the request."
+                        type: string
+                      external_host:
+                        description: "External host of the request."
+                        type: string
+                      retry_count:
+                        description: "The numbers of attempted retries."
+                        type: integer
+                      err_msg:
+                        description: "An error message if one occurred."
+                        type: string
+                      previous_attempt_id:
+                        description: "The id of the previous attempt."
+                        type: string
+                      rule_id:
+                        description: "The id of the associated replication rule."
+                        type: string
+                      activity:
+                        description: "The activity of the request."
+                        type: string
+                      bytes:
+                        description: "The size of the DID in bytes."
+                        type: integer
+                      md5:
+                        description: "The md5 checksum of the DID to transfer."
+                        type: string
+                      adler32:
+                        description: "The adler32 checksum of the DID to transfer."
+                        type: string
+                      dest_url:
+                        description: "The destination url."
+                        type: string
+                      created_at:
+                        description: "The time the request got created. The results are ordered by this value, newest first."
+                        type: string
+                      submitted_at:
+                        description: "The time the request got submitted."
+                        type: string
+                      started_at:
+                        description: "The time the request got started."
+                        type: string
+                      transferred_at:
+                        description: "The time the request got transferred."
+                        type: string
+                      estimated_at:
+                        description: "The time the request got estimated."
+                        type: string
+                      submitter_id:
+                        description: "The id of the submitter."
+                        type: string
+                      estimated_stated_at:
+                        description: "The estimation of the started at value."
+                        type: string
+                      estimated_transferred_at:
+                        description: "The estimation of the transferred at value."
+                        type: string
+                      staging_started_at:
+                        description: "The time the staging got started."
+                        type: string
+                      staging_finished_at:
+                        description: "The time the staging got finished."
+                        type: string
+                      account:
+                        description: "The account which issued the request."
+                        type: string
+                      requested_at:
+                        description: "The time the request got requested."
+                        type: string
+                      priority:
+                        description: "The priority of the request."
+                        type: integer
+                      transfertool:
+                        description: "The transfertool used."
+                        type: string
+                      source_rse:
+                        description: "The name of the source RSE."
+                        type: string
+                      dest_rse:
+                        description: "The name of the destination RSE."
+                        type: string
+          400:
+            description: "Invalid parameter"
+          401:
+            description: "Invalid Auth Token"
+          404:
+            description: "Not found"
+          406:
+            description: "Not acceptable"
+        """
+        try:
+            scope, name = parse_scope_name(scope_name, flask.request.environ['vo'])
+        except ValueError as error:
+            return generate_http_error_flask(400, error)
+
+        try:
+            states = _parse_request_states_param(flask.request.args.get('request_states', default=None))
+            created_after = _parse_datetime_param(
+                flask.request.args.get('created_after', default=None), 'created_after'
+            )
+            created_before = _parse_datetime_param(
+                flask.request.args.get('created_before', default=None), 'created_before'
+            )
+            limit = _validate_paging_param(
+                'limit', _parse_int_param(flask.request.args.get('limit'), 'limit', default=10), minimum=1
+            )
+            offset = _validate_paging_param(
+                'offset', _parse_int_param(flask.request.args.get('offset'), 'offset', default=0), minimum=0
+            )
+            rule_id = _validate_and_normalize_rule_id_param(flask.request.args.get('rule_id', default=None))
+        except ValueError as error:
+            return generate_http_error_flask(400, 'Invalid', str(error))
+
+        def generate(issuer: str, vo: str) -> "Iterator[str]":
+            for result in request.list_requests_history_by_did(
+                    scope=scope, name=name, rse=rse, issuer=issuer, vo=vo, rule_id=rule_id, states=states,
+                    created_after=created_after, created_before=created_before, offset=offset, limit=limit
+            ):
+                yield render_json(**result) + '\n'
+
+        try:
+            return try_stream(generate(issuer=flask.request.environ['issuer'], vo=flask.request.environ['vo']))
+        except RSENotFound as error:
+            return generate_http_error_flask(404, error)
+        except AccessDenied as error:
+            return generate_http_error_flask(401, error)
+
+
 class RequestMetricsGet(ErrorHandlingMethodView):
     """ REST API to get request stats. """
 
@@ -1169,6 +1445,8 @@ def blueprint() -> AuthenticatedBlueprint:
     bp.add_url_rule('/list', view_func=request_list_view, methods=[HTTPMethod.GET.value])
     request_history_list_view = RequestHistoryList.as_view('request_history_list')
     bp.add_url_rule('/history/list', view_func=request_history_list_view, methods=[HTTPMethod.GET.value])
+    request_history_list_by_did_view = RequestHistoryListByDid.as_view('request_history_list_by_did')
+    bp.add_url_rule('/history/list/<path:scope_name>/<rse>', view_func=request_history_list_by_did_view, methods=[HTTPMethod.GET.value])
     request_metrics_view = RequestMetricsGet.as_view('request_metrics_get')
     bp.add_url_rule('/metrics', view_func=request_metrics_view, methods=[HTTPMethod.GET.value])
     transfer_limits_view = TransferLimits.as_view('transfer_limits_get')

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -12,22 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import json
+import uuid
 from datetime import datetime
 from typing import Union
 
 import pytest
 
+import rucio.common.schema
 from rucio.common.config import config_get_bool
 from rucio.common.constants import RseAttr
+from rucio.common.exception import AccessDenied, RSENotFound
+from rucio.common.types import InternalScope
 from rucio.common.utils import generate_uuid, parse_response
 from rucio.core.distance import add_distance
 from rucio.core.replica import add_replica
-from rucio.core.request import TransferStatsManager, get_request_by_did, list_requests, list_requests_history, queue_requests, set_transfer_limit
+from rucio.core.request import TransferStatsManager, get_request_by_did, list_requests, list_requests_history, list_requests_history_by_did, queue_requests, set_transfer_limit
 from rucio.core.rse import add_rse_attribute
 from rucio.db.sqla import constants, models
 from rucio.db.sqla.constants import RequestState, RequestType
-from rucio.tests.common import auth, hdrdict, headers, vohdr
+from rucio.gateway import request as request_gateway
+from rucio.tests.common import Mime, accept, auth, did_name_generator, hdrdict, headers, rse_name_generator, vohdr
 
 
 @pytest.mark.parametrize("file_config_mock", [
@@ -371,3 +377,522 @@ def test_api_metrics(vo, rest_client, auth_token, rse_factory, did_factory, root
     response = json.loads(response.get_data(as_text=True))
     metric = response.get(f'{src_rse}:{dst_rse}')
     assert metric is not None
+
+
+def _add_request_history(
+        dest_rse_id,
+        scope=None,
+        name=None,
+        rule_id=None,
+        state=RequestState.SUBMITTED,
+        created_at=None,
+        *,
+        session
+):
+    row = models.RequestHistory(
+        scope=scope,
+        name=name if name is not None else did_name_generator(),
+        dest_rse_id=dest_rse_id,
+        rule_id=rule_id,
+        state=state,
+        created_at=created_at if created_at is not None else datetime.utcnow(),
+    )
+    row.save(session=session)
+    return row
+
+
+def test_list_history_by_did_returns_latest_first(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    older = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 1), session=db_session
+    )
+    newer = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 2), session=db_session
+    )
+
+    rows = list(list_requests_history_by_did(mock_scope, name, dest_rse_id, session=db_session))
+    assert [row.id for row in rows] == [newer.id, older.id]
+
+
+def test_list_history_by_did_orders_ties_by_id(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    same_time = datetime(2024, 1, 1)
+    rows = [_add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=same_time, session=db_session
+    ) for _ in range(5)]
+    expected = sorted([row.id for row in rows], key=lambda row_id: uuid.UUID(row_id).int, reverse=True)
+
+    result = list(list_requests_history_by_did(mock_scope, name, dest_rse_id, session=db_session))
+    assert [row.id for row in result] == expected
+
+
+def test_list_history_by_did_respects_limit(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    rows = [_add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, i + 1), session=db_session
+    ) for i in range(5)]
+
+    result = list(list_requests_history_by_did(mock_scope, name, dest_rse_id, limit=2, session=db_session))
+    assert [row.id for row in result] == [rows[4].id, rows[3].id]
+
+
+def test_list_history_by_did_default_limit_is_10(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    for i in range(11):
+        _add_request_history(
+            dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, i + 1), session=db_session
+        )
+
+    result = list(list_requests_history_by_did(mock_scope, name, dest_rse_id, session=db_session))
+    assert len(result) == 10
+
+
+def test_list_history_by_did_offset_pages_without_overlap(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    rows = [_add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, i + 1), session=db_session
+    ) for i in range(4)]
+
+    page1 = list(list_requests_history_by_did(mock_scope, name, dest_rse_id, limit=2, session=db_session))
+    page2 = list(list_requests_history_by_did(mock_scope, name, dest_rse_id, offset=2, limit=2, session=db_session))
+
+    assert [row.id for row in page1 + page2] == [rows[3].id, rows[2].id, rows[1].id, rows[0].id]
+
+
+def test_list_history_by_did_filters_by_rule_id(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    rule_id = generate_uuid()
+    matching = _add_request_history(dest_rse_id, scope=mock_scope, name=name, rule_id=rule_id, session=db_session)
+    _add_request_history(dest_rse_id, scope=mock_scope, name=name, rule_id=generate_uuid(), session=db_session)
+
+    result = list(list_requests_history_by_did(mock_scope, name, dest_rse_id, rule_id=rule_id, session=db_session))
+    assert [row.id for row in result] == [matching.id]
+
+
+def test_list_history_by_did_filters_by_states(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    failed = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, state=RequestState.FAILED, session=db_session
+    )
+    waiting = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, state=RequestState.WAITING, session=db_session
+    )
+
+    result = list(
+        list_requests_history_by_did(mock_scope, name, dest_rse_id, states=[RequestState.FAILED], session=db_session)
+    )
+    assert [row.id for row in result] == [failed.id]
+
+    result = list(list_requests_history_by_did(mock_scope, name, dest_rse_id, session=db_session))
+    assert {row.id for row in result} == {failed.id, waiting.id}
+
+
+def test_list_history_by_did_created_window_inclusive(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    before = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 1), session=db_session
+    )
+    lower_bound = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 2), session=db_session
+    )
+    upper_bound = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 3), session=db_session
+    )
+    after = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 4), session=db_session
+    )
+
+    result = list(list_requests_history_by_did(
+        mock_scope, name, dest_rse_id,
+        created_after=lower_bound.created_at, created_before=upper_bound.created_at,
+        session=db_session,
+    ))
+    result_ids = {row.id for row in result}
+    assert result_ids == {lower_bound.id, upper_bound.id}
+    assert before.id not in result_ids
+    assert after.id not in result_ids
+
+
+def test_list_history_by_did_created_after_only(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    _add_request_history(dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 1), session=db_session)
+    later = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 2), session=db_session
+    )
+    midpoint = datetime(2024, 1, 1, 12)
+
+    result = list(
+        list_requests_history_by_did(mock_scope, name, dest_rse_id, created_after=midpoint, session=db_session)
+    )
+    assert [row.id for row in result] == [later.id]
+
+
+def test_list_history_by_did_created_before_only(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    earlier = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 1), session=db_session
+    )
+    _add_request_history(dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 2), session=db_session)
+    midpoint = datetime(2024, 1, 1, 12)
+
+    result = list(
+        list_requests_history_by_did(mock_scope, name, dest_rse_id, created_before=midpoint, session=db_session)
+    )
+    assert [row.id for row in result] == [earlier.id]
+
+
+def test_list_history_by_did_missing_did_returns_empty(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+
+    result = list(list_requests_history_by_did(mock_scope, did_name_generator(), dest_rse_id, session=db_session))
+    assert result == []
+
+
+def test_list_history_by_did_scoped_to_did_and_rse(mock_scope, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    _, other_dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    other_name = did_name_generator()
+    matching = _add_request_history(dest_rse_id, scope=mock_scope, name=name, session=db_session)
+    _add_request_history(other_dest_rse_id, scope=mock_scope, name=name, session=db_session)
+    _add_request_history(dest_rse_id, scope=mock_scope, name=other_name, session=db_session)
+
+    result = list(list_requests_history_by_did(mock_scope, name, dest_rse_id, session=db_session))
+    assert [row.id for row in result] == [matching.id]
+
+
+def test_list_history_by_did_vo_isolation(vo, second_vo, rse_factory, db_session):
+    _, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    same_vo_scope = InternalScope('mock', vo=vo)
+    other_vo_scope = InternalScope('mock', vo=second_vo)
+    matching = _add_request_history(dest_rse_id, scope=same_vo_scope, name=name, session=db_session)
+    _add_request_history(dest_rse_id, scope=other_vo_scope, name=name, session=db_session)
+
+    result = list(list_requests_history_by_did(same_vo_scope, name, dest_rse_id, session=db_session))
+    assert [row.id for row in result] == [matching.id]
+
+
+def test_gateway_list_history_by_did_denied_for_plain_account(vo, jdoe_account, rse_factory, mock_scope, db_session):
+    dest_rse, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    _add_request_history(dest_rse_id, scope=mock_scope, name=name, session=db_session)
+    db_session.commit()
+
+    with pytest.raises(AccessDenied):
+        list(request_gateway.list_requests_history_by_did(
+            scope=mock_scope.external, name=name, rse=dest_rse, issuer=jdoe_account.external, vo=vo,
+        ))
+
+
+def _list_history_by_did_url(scope, name, rse):
+    return f'/requests/history/list/{scope}/{name.lstrip("/")}/{rse}'
+
+
+def _get_list_history_by_did(rest_client, auth_token, vo, scope, name, rse, params=None, mime=Mime.JSON_STREAM):
+    return rest_client.get(
+        _list_history_by_did_url(scope, name, rse),
+        query_string=params or {},
+        headers=headers(auth(auth_token), vohdr(vo), accept(mime)),
+    )
+
+
+def _parse_stream(response):
+    text = response.get_data(as_text=True)
+    if not text:
+        return []
+    return [parse_response(line) for line in text.split('\n')[:-1]]
+
+
+def test_api_list_history_by_did_streams_latest_first(vo, rest_client, auth_token, rse_factory, mock_scope, db_session):
+    dest_rse, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    _add_request_history(dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 1), session=db_session)
+    _add_request_history(dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 2), session=db_session)
+    db_session.commit()
+
+    response = _get_list_history_by_did(rest_client, auth_token, vo, mock_scope.external, name, dest_rse)
+    assert response.status_code == 200
+    assert response.content_type == Mime.JSON_STREAM
+    rows = _parse_stream(response)
+    assert len(rows) == 2
+    assert rows[0]['created_at'] > rows[1]['created_at']
+    for row in rows:
+        assert row['name'] == name
+        assert row['dest_rse'] == dest_rse
+
+
+def test_api_list_history_by_did_default_limit(vo, rest_client, auth_token, rse_factory, mock_scope, db_session):
+    dest_rse, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    for i in range(11):
+        _add_request_history(
+            dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, i + 1), session=db_session
+        )
+    db_session.commit()
+
+    response = _get_list_history_by_did(rest_client, auth_token, vo, mock_scope.external, name, dest_rse)
+    assert response.status_code == 200
+    assert len(_parse_stream(response)) == 10
+
+
+def test_api_list_history_by_did_limit_offset_params(vo, rest_client, auth_token, rse_factory, mock_scope, db_session):
+    dest_rse, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    seeded = [_add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, i + 1), session=db_session
+    ) for i in range(5)]
+    db_session.commit()
+    newest_first = [row.id for row in reversed(seeded)]
+
+    page1 = _parse_stream(
+        _get_list_history_by_did(rest_client, auth_token, vo, mock_scope.external, name, dest_rse, params={'limit': 2})
+    )
+    assert [row['id'] for row in page1] == newest_first[0:2]
+
+    page2 = _parse_stream(
+        _get_list_history_by_did(
+            rest_client, auth_token, vo, mock_scope.external, name, dest_rse, params={'limit': 2, 'offset': 2}
+        )
+    )
+    assert [row['id'] for row in page2] == newest_first[2:4]
+
+
+def test_api_list_history_by_did_rule_id_filter(vo, rest_client, auth_token, rse_factory, mock_scope, db_session):
+    dest_rse, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    rule_id = generate_uuid()
+    matching = _add_request_history(dest_rse_id, scope=mock_scope, name=name, rule_id=rule_id, session=db_session)
+    _add_request_history(dest_rse_id, scope=mock_scope, name=name, rule_id=generate_uuid(), session=db_session)
+    db_session.commit()
+
+    response = _get_list_history_by_did(
+        rest_client, auth_token, vo, mock_scope.external, name, dest_rse, params={'rule_id': rule_id}
+    )
+    rows = _parse_stream(response)
+    assert [row['id'] for row in rows] == [matching.id]
+
+
+def test_api_list_history_by_did_states_filter(vo, rest_client, auth_token, rse_factory, mock_scope, db_session):
+    dest_rse, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    failed = _add_request_history(dest_rse_id, scope=mock_scope, name=name, state=RequestState.FAILED, session=db_session)
+    waiting = _add_request_history(dest_rse_id, scope=mock_scope, name=name, state=RequestState.WAITING, session=db_session)
+    submitted = _add_request_history(dest_rse_id, scope=mock_scope, name=name, state=RequestState.SUBMITTED, session=db_session)
+    db_session.commit()
+
+    rows = _parse_stream(
+        _get_list_history_by_did(
+            rest_client, auth_token, vo, mock_scope.external, name, dest_rse, params={'request_states': 'F'}
+        )
+    )
+    assert [row['id'] for row in rows] == [failed.id]
+
+    rows = _parse_stream(
+        _get_list_history_by_did(
+            rest_client, auth_token, vo, mock_scope.external, name, dest_rse, params={'request_states': 'F,S'}
+        )
+    )
+    assert {row['id'] for row in rows} == {failed.id, submitted.id}
+
+    response = _get_list_history_by_did(
+        rest_client, auth_token, vo, mock_scope.external, name, dest_rse, params={'request_states': 'F,unknown'}
+    )
+    assert response.status_code == 400
+    body = parse_response(response.get_data(as_text=True))
+    assert body['ExceptionClass'] == 'Invalid'
+
+    rows = _parse_stream(_get_list_history_by_did(rest_client, auth_token, vo, mock_scope.external, name, dest_rse))
+    assert {row['id'] for row in rows} == {failed.id, waiting.id, submitted.id}
+
+
+def test_api_list_history_by_did_bad_state_returns_400(vo, rest_client, auth_token, mock_scope):
+    response = _get_list_history_by_did(
+        rest_client, auth_token, vo, mock_scope.external, did_name_generator(), rse_name_generator(),
+        params={'request_states': 'unknown'}
+    )
+    assert response.status_code == 400
+    body = parse_response(response.get_data(as_text=True))
+    assert body['ExceptionClass'] == 'Invalid'
+
+
+def test_api_list_history_by_did_created_window(vo, rest_client, auth_token, rse_factory, mock_scope, db_session):
+    dest_rse, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    earlier = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 1), session=db_session
+    )
+    later = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 2), session=db_session
+    )
+    db_session.commit()
+    midpoint = datetime(2024, 1, 1, 12).strftime('%Y-%m-%dT%H:%M:%S')
+
+    rows = _parse_stream(
+        _get_list_history_by_did(
+            rest_client, auth_token, vo, mock_scope.external, name, dest_rse, params={'created_after': midpoint}
+        )
+    )
+    assert [row['id'] for row in rows] == [later.id]
+
+    rows = _parse_stream(
+        _get_list_history_by_did(
+            rest_client, auth_token, vo, mock_scope.external, name, dest_rse, params={'created_before': midpoint}
+        )
+    )
+    assert [row['id'] for row in rows] == [earlier.id]
+
+
+def test_api_list_history_by_did_bad_date_returns_400(vo, rest_client, auth_token, mock_scope):
+    response = _get_list_history_by_did(
+        rest_client, auth_token, vo, mock_scope.external, did_name_generator(), rse_name_generator(),
+        params={'created_after': 'not-a-date'}
+    )
+    assert response.status_code == 400
+    body = parse_response(response.get_data(as_text=True))
+    assert body['ExceptionClass'] == 'Invalid'
+
+
+def test_api_list_history_by_did_bad_rule_id_returns_400(vo, rest_client, auth_token, mock_scope):
+    response = _get_list_history_by_did(
+        rest_client, auth_token, vo, mock_scope.external, did_name_generator(), rse_name_generator(),
+        params={'rule_id': 'not-a-uuid'}
+    )
+    assert response.status_code == 400
+    body = parse_response(response.get_data(as_text=True))
+    assert body['ExceptionClass'] == 'Invalid'
+
+
+@pytest.mark.parametrize(
+    "params",
+    [{'limit': 0}, {'limit': -1}, {'offset': -1}, {'limit': 2 ** 63}, {'offset': 2 ** 63}, {'limit': 'abc'}, {'offset': 'abc'}]
+)
+def test_api_list_history_by_did_invalid_limit_offset_returns_400(params, vo, rest_client, auth_token, mock_scope):
+    response = _get_list_history_by_did(
+        rest_client, auth_token, vo, mock_scope.external, did_name_generator(), rse_name_generator(), params=params
+    )
+    assert response.status_code == 400
+    body = parse_response(response.get_data(as_text=True))
+    assert body['ExceptionClass'] == 'Invalid'
+
+
+def test_api_list_history_by_did_empty_limit_offset_use_defaults(vo, rest_client, auth_token, rse_factory, mock_scope, db_session):
+    dest_rse, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    for i in range(11):
+        _add_request_history(
+            dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, i + 1), session=db_session
+        )
+    db_session.commit()
+
+    response = _get_list_history_by_did(
+        rest_client, auth_token, vo, mock_scope.external, name, dest_rse, params={'limit': '', 'offset': ''}
+    )
+    assert response.status_code == 200
+    assert len(_parse_stream(response)) == 10
+
+
+def test_api_list_history_by_did_unknown_rse_returns_404(vo, rest_client, auth_token, mock_scope):
+    response = _get_list_history_by_did(rest_client, auth_token, vo, mock_scope.external, did_name_generator(), rse_name_generator())
+    assert response.status_code == 404
+
+
+def test_api_list_history_by_did_bad_scope_name_returns_400(vo, rest_client, auth_token, rse_factory):
+    dest_rse, _ = rse_factory.make_mock_rse()
+
+    response = rest_client.get(
+        f'/requests/history/list/{generate_uuid()}/{dest_rse}',
+        headers=headers(auth(auth_token), vohdr(vo), accept(Mime.JSON_STREAM)),
+    )
+    assert response.status_code == 400
+
+
+def test_api_list_history_by_did_empty_returns_200_empty_body(vo, rest_client, auth_token, rse_factory, mock_scope):
+    dest_rse, _ = rse_factory.make_mock_rse()
+
+    response = _get_list_history_by_did(rest_client, auth_token, vo, mock_scope.external, did_name_generator(), dest_rse)
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == ''
+
+
+def test_api_list_history_by_did_wrong_accept_returns_406(vo, rest_client, auth_token, rse_factory, mock_scope):
+    dest_rse, _ = rse_factory.make_mock_rse()
+
+    response = _get_list_history_by_did(
+        rest_client, auth_token, vo, mock_scope.external, did_name_generator(), dest_rse, mime=Mime.JSON
+    )
+    assert response.status_code == 406
+
+
+@pytest.mark.noparallel(reason='temporarily replaces the VO schema module')
+def test_api_list_history_by_did_slash_in_name_first_slash_schema(vo, rest_client, auth_token, rse_factory, mock_scope, db_session, monkeypatch):
+    dest_rse, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = f'dir/{generate_uuid()}'
+    _add_request_history(dest_rse_id, scope=mock_scope, name=name, session=db_session)
+    db_session.commit()
+
+    # the generic schema's SCOPE_NAME_REGEXP splits on the first slash
+    monkeypatch.setitem(rucio.common.schema.schema_modules, vo, importlib.import_module('rucio.common.schema.generic'))
+    response = _get_list_history_by_did(rest_client, auth_token, vo, mock_scope.external, name, dest_rse)
+
+    assert response.status_code == 200
+    assert [row['name'] for row in _parse_stream(response)] == [name]
+
+
+@pytest.mark.noparallel(reason='temporarily replaces the VO schema module')
+def test_api_list_history_by_did_slash_in_name_last_slash_schema(vo, rest_client, auth_token, rse_factory, mock_scope, db_session, monkeypatch):
+    dest_rse, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = f'dir/{generate_uuid()}'
+    _add_request_history(dest_rse_id, scope=mock_scope, name=name, session=db_session)
+    db_session.commit()
+
+    # the multi-VO schema's SCOPE_NAME_REGEXP splits on the last slash
+    monkeypatch.setitem(rucio.common.schema.schema_modules, vo, importlib.import_module('rucio.common.schema.generic_multi_vo'))
+    response = _get_list_history_by_did(rest_client, auth_token, vo, mock_scope.external, name, dest_rse)
+
+    assert response.status_code == 200
+    assert _parse_stream(response) == []
+
+
+def test_client_list_history_by_did_end_to_end(rucio_client, rse_factory, mock_scope, db_session):
+    dest_rse, dest_rse_id = rse_factory.make_mock_rse(session=db_session)
+    name = did_name_generator()
+    _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, state=RequestState.FAILED, created_at=datetime(2024, 1, 1),
+        session=db_session
+    )
+    older_failed = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, state=RequestState.FAILED, created_at=datetime(2024, 1, 2),
+        session=db_session
+    )
+    newest_submitted = _add_request_history(
+        dest_rse_id, scope=mock_scope, name=name, created_at=datetime(2024, 1, 3), session=db_session
+    )
+    db_session.commit()
+
+    rows = list(rucio_client.list_requests_history_by_did(
+        name=name,
+        rse=dest_rse,
+        scope=mock_scope.external,
+        request_states=['F', 'S'],
+        created_after=datetime(2023, 12, 31),
+        created_before=datetime(2024, 1, 4),
+        limit=2,
+    ))
+    assert [row['id'] for row in rows] == [newest_submitted.id, older_failed.id]
+    assert isinstance(rows[0]['created_at'], datetime)
+
+
+def test_client_list_history_by_did_unknown_rse_raises(rucio_client, mock_scope):
+    with pytest.raises(RSENotFound):
+        rucio_client.list_requests_history_by_did(name=did_name_generator(), rse=rse_name_generator(), scope=mock_scope.external)


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
Added `list_requests_history_by_did` via core, gateway, REST and the python client. The new endpoint returns a stream with the content type `application/x-json-stream`. It returns newest-first, with optional query parameters and a default `limit` of 10. As said in the issue, it's probably gonna be pretty slow on some instances, so this is intended for debugging and it's a known limitation.

I also added comprehensive tests for the database operations, client and rest gateway.

There are a few things I would like to note:
- There is a sort of breaking change I wasn't sure if I should mark as a breaking change or not. I kept clear of the existing endpoints as much as possible to preserve existing behavior, but the new path is gonna be called `/requests/history/list/<scope>/<name>/<rse>` which means that the old endpoint will not allow a `scope` called 'list'. I assumed this was fine because it also happens for `history`, but please let me know if you want to use a different name here.
- While doing this, I noticed that already are some list endpoints for this functionality (`/requests/list` and `/requests/history/list`. These are the live requests and history tables. I assume these 2 are complementary for some monitoring, but they could be replaced with this new endpoint with the query parameters. That would mean making the scope optional + the sort order configurable. I think this is worth it, but it's a big change, deprecating the old requests and making this new one the intended endpoint for this, so it's not really my choice to make. **If you do think this is a good idea, I can make the filters optional and create a follow-up issue.**
- For the `request_states` I kept it consistent with the other requests, but I find it a bit odd to use `F` or `S` for that stuff, especially since the response has the actual state name, e.g. `FAILED`. Let me know if you want me to change that.
- I also did a few refactorings, where code was pretty much duplicated, but I would like to pursue an issue where the project standardizes that. I'll probably open a discussion on doing this, as there's currently a lot of duplicated code everywhere that do similar things.

Also tested via curl:
<img width="2074" height="251" alt="image" src="https://github.com/user-attachments/assets/e9457391-dba2-4275-9b42-5e005e3a770f" />

Closes: #8051

## AI usage disclosure
Claude Code assisted with research, writing code and drafting. I reproduced, verified, reviewed, understand and stand by all changes (as described in the Rucio AI Policy).

## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [x] This PR closes #8051
      <!-- Every PR requires an issue; if none exists yet, please create one
           first. GitHub links the PR to the issue and closes it on merge.
           In the rare case the issue should remain open after the merge,
           write "Related to #____" here instead and briefly say why in the
           description. -->
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
