### PR TITLE
fix(Testing): Batch suspicious declarations in `test_replica_recoverer`

### DIFF
--- a/tests/test_replica_recoverer.py
+++ b/tests/test_replica_recoverer.py
@@ -160,22 +160,25 @@ class TestReplicaRecoverer:
         # tmp_file13   unavailable                              suspicious (available)                    scope_declarebad            testtypedryrun
         # ----------------------------------------------------------------------------------------------------------------------------------------------------
 
-        for replica in replicalist_scope_mock:
-            suspicious_pfns = replica['rses'][self.rse4suspicious_id]
-            # Declare each file as suspicious multiple times, apart from tmp_file12, which
-            # should only be declared suspicious once. tmp_file12 is used to test the
-            # creation of rules by the daemon.
-            if replica['name'] == self.tmp_file12.name:
+        # Each file is declared suspicious 3 times except for tmp_file12. The same file
+        # cannot be declared suspicious more than once in the same second. But all the
+        # files can be declared suspicious in the same second, so one sleep per pass is
+        # enough rather than one per declaration.
+        all_replicas = (replicalist_scope_mock + replicalist_scope_declarebad
+                        + replicalist_scope_nopolicy + replicalist_scope_ignore)
+        for i in range(3):
+            for replica in all_replicas:
+                # tmp_file12 is declared suspicious only once. It is used to test the creation of rules by the daemon.
+                if i > 0 and replica['name'] == self.tmp_file12.name:
+                    continue
+                suspicious_pfns = replica['rses'][self.rse4suspicious_id]
                 print("Declaring suspicious file replica: " + suspicious_pfns[0])
                 # The reason must contain the word "checksum", so that the replica can be declared bad.
                 replica_client.declare_suspicious_file_replicas([suspicious_pfns[0], ], 'checksum')
-                sleep(1)
-            else:
-                for i in range(3):
-                    print("Declaring suspicious file replica: " + suspicious_pfns[0])
-                    # The reason must contain the word "checksum", so that the replica can be declared bad.
-                    replica_client.declare_suspicious_file_replicas([suspicious_pfns[0], ], 'checksum')
-                    sleep(1)
+            sleep(1)
+
+        for replica in replicalist_scope_mock:
+            suspicious_pfns = replica['rses'][self.rse4suspicious_id]
             if replica['name'] == self.tmp_file2.name:
                 print("Declaring bad file replica: " + suspicious_pfns[0])
                 replica_client.declare_bad_file_replicas([suspicious_pfns[0], ], 'checksum')
@@ -196,13 +199,6 @@ class TestReplicaRecoverer:
                 update_replica_state(self.rse4recovery_id, mock_scope, self.tmp_file12.name, ReplicaState.UNAVAILABLE)
 
         for replica in replicalist_scope_declarebad:
-            suspicious_pfns = replica['rses'][self.rse4suspicious_id]
-            #  Declare each file as suspicious multiple times
-            for i in range(3):
-                print("Declaring suspicious file replica: " + suspicious_pfns[0])
-                # The reason must contain the word "checksum", so that the replica can be declared bad.
-                replica_client.declare_suspicious_file_replicas([suspicious_pfns[0], ], 'checksum')
-                sleep(1)
             if replica['name'] == self.tmp_file7.name:
                 print("Updating replica state as unavailable: " + replica['rses'][self.rse4recovery_id][0])
                 update_replica_state(self.rse4recovery_id, self.scope_declarebad, self.tmp_file7.name, ReplicaState.UNAVAILABLE)
@@ -217,25 +213,11 @@ class TestReplicaRecoverer:
                 update_replica_state(self.rse4recovery_id, self.scope_declarebad, self.tmp_file13.name, ReplicaState.UNAVAILABLE)
 
         for replica in replicalist_scope_nopolicy:
-            suspicious_pfns = replica['rses'][self.rse4suspicious_id]
-            #  Declare each file as suspicious multiple times
-            for i in range(3):
-                print("Declaring suspicious file replica: " + suspicious_pfns[0])
-                # The reason must contain the word "checksum", so that the replica can be declared bad.
-                replica_client.declare_suspicious_file_replicas([suspicious_pfns[0], ], 'checksum')
-                sleep(1)
             if replica['name'] == self.tmp_file8.name:
                 print("Updating replica state as unavailable: " + replica['rses'][self.rse4recovery_id][0])
                 update_replica_state(self.rse4recovery_id, self.scope_nopolicy, self.tmp_file8.name, ReplicaState.UNAVAILABLE)
 
         for replica in replicalist_scope_ignore:
-            suspicious_pfns = replica['rses'][self.rse4suspicious_id]
-            #  Declare each file as suspicious multiple times
-            for i in range(3):
-                print("Declaring suspicious file replica: " + suspicious_pfns[0])
-                # The reason must contain the word "checksum", so that the replica can be declared bad.
-                replica_client.declare_suspicious_file_replicas([suspicious_pfns[0], ], 'checksum')
-                sleep(1)
             if replica['name'] == self.tmp_file10.name:
                 print("Updating replica state as unavailable: " + replica['rses'][self.rse4recovery_id][0])
                 update_replica_state(self.rse4recovery_id, self.scope_ignore, self.tmp_file10.name, ReplicaState.UNAVAILABLE)


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
The current setup slept 1s after each of its 37 suspicious-replica declarations. The sleep is required because `created_at` is part of `BAD_REPLICAS_STATE_PK` and only has second precision on MySQL and Oracle, so one replica's repeated declarations must land in distinct seconds. But, different replicas can share a second, so declaring every replica once per pass: 37 sleeps become 3.

The runtime drops from 72.5s to 37.9s. Verified on postgres14 and mysql8.


## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [x] This PR closes #8760
      <!-- Every PR requires an issue; if none exists yet, please create one
           first. GitHub links the PR to the issue and closes it on merge.
           In the rare case the issue should remain open after the merge,
           write "Related to #____" here instead and briefly say why in the
           description. -->
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
