### PR TITLE
fix(Testing): Skip unnecessary Alembic migration tests #7009

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -73,6 +73,7 @@ Individual contributors to the source code
 - Riccardo Di Maio <riccardodimaio11@gmail.com>, 2024-2025
 - Karanjot Singh <karanjot.singh@cern.ch>, 2025-2026
 - Vlad Galuska <vlad.galuska21@gmail.com>, 2026
+- Abhinav <1899abhinav@gmail.com>, 2026
 
 Organisations employing contributors
 ------------------------------------

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -143,11 +143,28 @@ else
 fi
 
 if test ${alembic}; then
-    echo 'Running full alembic migration'
-    ALEMBIC_CONFIG="$RUCIO_HOME/etc/alembic.ini" tools/alembic_migration.sh
-    if [ $? != 0 ]; then
-        echo 'Failed to run alembic migration!'
-        exit 1
+    ALEMBIC_CHANGED=false
+    MERGE_BASE=""
+    if git rev-parse --verify upstream/master >/dev/null 2>&1; then
+        MERGE_BASE=$(git merge-base upstream/master HEAD)
+    elif git rev-parse --verify origin/master >/dev/null 2>&1; then
+        MERGE_BASE=$(git merge-base origin/master HEAD)
+    fi
+    if [ -n "$MERGE_BASE" ]; then
+        CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" -- lib/rucio/db/sqla/models.py lib/rucio/db/sqla/migrate_repo/versions/)
+        if [ -n "$CHANGED_FILES" ]; then
+            ALEMBIC_CHANGED=true
+        fi
+    fi
+    if [ "$ALEMBIC_CHANGED" = true ]; then
+        echo 'Running full alembic migration'
+        ALEMBIC_CONFIG="$RUCIO_HOME/etc/alembic.ini" tools/alembic_migration.sh
+        if [ $? != 0 ]; then
+            echo 'Failed to run alembic migration!'
+            exit 1
+        fi
+    else
+        echo 'Skipping alembic migration (no changes to models or migration scripts)'
     fi
 fi
 


### PR DESCRIPTION
Closes: #7009 

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description

Alembic migration tests now run only when `models.py` or migration scripts changed, instead of on every test run.

Added change detection using `git merge-base` (same approach as the repo's existing `checkout_ancestor_commit` action). The `-a` flag continues to skip Alembic as before. When no relevant database changes are found, a clear skip message is printed and `tools/alembic_migration.sh` is not invoked.

## Checklist

- [x] This PR closes #7009
- [x] Tests cover the change, or no tests are needed (explain why in the description)
      - 15 acceptance scenarios tested: no changes, unrelated files, docs only, tests only, models.py changed, new/modified/deleted migration files, multiple migrations, combined changes, and `-a` flag
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
      - No documentation change needed; this is a CI/test infrastructure change
- [x] Database migrations are included, or the change touches no database schema
      - No database schema change; only the test runner logic is modified
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>

