### PR TITLE
feat(Policies): Simplify parsing of scope and name from URLs

### DIFF
--- a/etc/docker/test/extra/rucio.conf
+++ b/etc/docker/test/extra/rucio.conf
@@ -27,6 +27,6 @@ WSGIProcessGroup rucio
 
  WSGIScriptAlias /  /opt/rucio/lib/rucio/web/rest/main.py
 
- AllowEncodedSlashes on
+ AllowEncodedSlashes NoDecode
 
 </VirtualHost>

--- a/lib/rucio/common/schema/__init__.py
+++ b/lib/rucio/common/schema/__init__.py
@@ -25,8 +25,6 @@ from rucio.common import config, exception
 from rucio.common.constants import DEFAULT_VO
 from rucio.common.plugins import check_policy_module_version
 from rucio.common.schema.schema_ref import SchemaRef
-from rucio.db.sqla.constants import DatabaseOperationType
-from rucio.db.sqla.session import db_session
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -35,9 +33,6 @@ LOGGER = logging.getLogger('policy')
 
 # dictionary of schema modules for each VO
 schema_modules: dict[str, "ModuleType"] = {}
-
-# list of unique SCOPE_NAME_REGEXP values from all schemas
-scope_name_regexps: list[str] = []
 
 
 # cached function to check for multivo
@@ -101,8 +96,6 @@ if not _is_multivo():
         raise exception.ErrorLoadingPolicyPackage(policy)
 
     schema_modules[DEFAULT_VO] = module
-    if hasattr(module, 'SCOPE_NAME_REGEXP'):
-        scope_name_regexps.append(module.SCOPE_NAME_REGEXP)
 
 
 def load_schema_for_vo(vo: str) -> None:
@@ -188,42 +181,3 @@ def get_schema_value(key: str, vo: str = DEFAULT_VO) -> Any:
     if not hasattr(schema_modules[vo], key):
         return _resolve_references(getattr(_get_generic_schema_module(), key), vo)
     return _resolve_references(getattr(schema_modules[vo], key), vo)
-
-
-def get_scope_name_regexps() -> list[str]:
-    """ returns a list of all unique SCOPE_NAME_REGEXPs from all schemas """
-
-    if len(scope_name_regexps) == 0:
-        # load schemas for all VOs here and add unique scope_name_regexps to list
-        from rucio.core.vo import list_vos
-        with db_session(DatabaseOperationType.READ) as session:
-            vos = list_vos(session=session)
-        for vo in vos:
-            if vo['vo'] not in schema_modules:
-                load_schema_for_vo(vo['vo'])
-            scope_name_regexp = schema_modules[vo['vo']].SCOPE_NAME_REGEXP
-            if scope_name_regexp not in scope_name_regexps:
-                scope_name_regexps.append(scope_name_regexp)
-    return scope_name_regexps
-
-
-def insert_scope_name(urls: tuple[str, ...]) -> tuple[str, str]:
-    """
-    given a tuple of URLs for webpy with '%s' as a placeholder for
-    SCOPE_NAME_REGEXP, return a finalised tuple of URLs that will work for all
-    SCOPE_NAME_REGEXPs in all schemas
-    """
-
-    regexps = get_scope_name_regexps()
-    result = []
-    for i in range(0, len(urls), 2):
-        if "%s" in urls[i]:
-            # add a copy for each unique SCOPE_NAME_REGEXP
-            for scope_name_regexp in regexps:
-                result.append(urls[i] % scope_name_regexp)
-                result.append(urls[i + 1])
-        else:
-            # pass through unmodified
-            result.append(urls[i])
-            result.append(urls[i + 1])
-    return tuple(result)

--- a/lib/rucio/common/schema/generic.py
+++ b/lib/rucio/common/schema/generic.py
@@ -370,8 +370,6 @@ ACCOUNT_ATTRIBUTE = {"description": "Account attribute",
                      "type": "string",
                      "pattern": r'^[a-zA-Z0-9-_\\/\\.]{1,30}$'}
 
-SCOPE_NAME_REGEXP = r"/([^/]+)/(.*)"
-
 DISTANCE = {"description": "RSE distance",
             "type": "object",
             "properties": {

--- a/lib/rucio/common/schema/generic_multi_vo.py
+++ b/lib/rucio/common/schema/generic_multi_vo.py
@@ -344,8 +344,6 @@ ACCOUNT_ATTRIBUTE = {"description": "Account attribute",
                      "type": "string",
                      "pattern": r'^[a-zA-Z0-9-_\\/\\.]{1,30}$'}
 
-SCOPE_NAME_REGEXP = '/(.*)/(.*)'
-
 DISTANCE = {"description": "RSE distance",
             "type": "object",
             "properties": {

--- a/lib/rucio/web/rest/flaskapi/v1/common.py
+++ b/lib/rucio/web/rest/flaskapi/v1/common.py
@@ -15,8 +15,6 @@
 import itertools
 import json
 import logging
-import os
-import re
 from configparser import NoOptionError, NoSectionError
 from functools import wraps
 from time import time
@@ -33,7 +31,6 @@ from werkzeug.wrappers import Request, Response
 from rucio.common import config
 from rucio.common.constants import DEFAULT_VO, HTTPMethod
 from rucio.common.exception import CannotAuthenticate, DatabaseException, IdentityError, RucioException, UnsupportedRequestedContentType
-from rucio.common.schema import get_schema_value
 from rucio.common.utils import generate_uuid, render_json
 from rucio.core.vo import map_vo
 from rucio.gateway.authentication import validate_auth_token
@@ -50,8 +47,6 @@ if TYPE_CHECKING:
 
 ResponseTypeVar = TypeVar('ResponseTypeVar', bound=flask.wrappers.Response)
 
-RUCIO_HTTPD_ENCODED_SLASHES_NO_DECODE = os.environ.get('RUCIO_HTTPD_ENCODED_SLASHES_NO_DECODE',
-                                                       'false').lower() == 'true'
 _DEFAULT = object()
 
 
@@ -232,8 +227,8 @@ def check_accept_header_wrapper_flask(
 
 def parse_scope_name(scope_name: str, vo: Optional[str]) -> tuple[str, ...]:
     """
-    Parses the given scope_name according to the schema's
-    SCOPE_NAME_REGEXP and returns a (scope, name) tuple.
+    Parses the given scope_name. The scope should be separated from the name
+    by a forward slash, with any other slashes encoded.
 
     :param scope_name: the scope_name string to be parsed.
     :param vo: the vo currently in use.
@@ -241,30 +236,12 @@ def parse_scope_name(scope_name: str, vo: Optional[str]) -> tuple[str, ...]:
     :returns: a (scope, name) tuple.
     """
 
-    if RUCIO_HTTPD_ENCODED_SLASHES_NO_DECODE:
-        if scope_name.count('/') != 1:
-            # scope and name are always separated by a single slash ('/', unencoded) in the request.
-            # If the server is configured with the 'NoDecode' option, other slashes will be encoded.
-            # This is just a sanity check that should never happen.
-            raise ValueError(f"Could not parse '{scope_name}' ({scope_name=}) with encoded '/' into scope and name.")
-
-        scope, name = scope_name.split('/', 1)
-        name = unquote_plus(name)
-
-        return scope, name
-
-    if not vo:
-        vo = DEFAULT_VO
-
-    # The ':' in DID is replaced by '/', also an '/' is added. Why?
-    pattern = get_schema_value('SCOPE_NAME_REGEXP', vo)
-    text = '/' + scope_name
-
-    scope_regex = re.match(pattern, text)
-    if scope_regex is None:
-        raise ValueError(f"Could not parse '{text}' ({scope_name=}) with pattern '{pattern}' into scope and name.")
-
-    scope, name = scope_regex.group(1, 2)
+    slash = scope_name.find('/')
+    if slash < 0:
+        raise ValueError(f"Could not parse '{scope_name}' ({scope_name=}) with encoded '/' into scope and name.")
+    scope = scope_name[:slash]
+    name = scope_name[slash + 1:]
+    name = unquote_plus(name)
     return scope, name
 
 

--- a/tests/test_meta_did.py
+++ b/tests/test_meta_did.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from rucio.common.utils import generate_uuid as uuid
+from rucio.tests.common import did_name_generator
 
 
 @pytest.mark.dirty
@@ -29,7 +29,7 @@ class TestMetaDIDClient:
         tmp_scope = 'mock'
 
         # Add a dataset
-        tmp_dataset = 'dsn_%s' % uuid()
+        tmp_dataset = did_name_generator('dataset')
 
         did_client.add_dataset(scope=tmp_scope, name=tmp_dataset)
 
@@ -48,7 +48,7 @@ class TestMetaDIDClient:
         tmp_scope = 'mock'
 
         # Add a dataset
-        tmp_dataset = 'dsn_%s' % uuid()
+        tmp_dataset = did_name_generator('dataset')
 
         did_client.add_dataset(scope=tmp_scope, name=tmp_dataset)
 


### PR DESCRIPTION
Closes: #7519

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
<!-- Required. Summarise WHAT this PR changes. The WHY should already be
     covered by the linked issue and its discussion. A sufficiently detailed
     commit message may be reused here. If a checklist item below does not
     apply to this PR, briefly say why here. -->

This PR removes the old complex code for extracting scope and name from URLs in the REST API and instead extracts them by simply splitting at a '/' separator. This depends on the server having the `AllowEncodedSlashes` option set to `NoDecode` to ensure that any other slashes in the name will be encoded. This behaviour has always been an option but now that we have this setting always present in the server container (see https://github.com/rucio/containers/pull/470 ) we intend to make it the only option and remove the old code that uses `SCOPE_NAME_REGEXP`.

Tests and documentation have not been updated as this change is merely a simplification of the code and should not have externally visible effects.

With `NoDecode` set on the server and **without** this change, many BelleII tests fail because BelleII includes a leading slash on the DID names which is not handled correctly in that case. **With** this change, the vast majority of the BelleII tests pass again, though two tests in `test_meta_did.py` fail. These appear to be failing because they use a DID that does not comply with the BelleII schema, so I am not sure how they were ever able to pass when using the BelleII policy package. Possibly some unintended quirk of the old code caused them to pass. I am not a BelleII person so I am not sure how best to fix this, but I am open to suggestions.

I am not sure what is happening with the other (non-BelleII) test failures. I didn't see the ATLAS failure in my own repo so it might be nothing to do with this. And the linter's suggestion looks bizarre to me.

## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [X] This PR closes #7519
      <!-- Every PR requires an issue; if none exists yet, please create one
           first. GitHub links the PR to the issue and closes it on merge.
           In the rare case the issue should remain open after the merge,
           write "Related to #____" here instead and briefly say why in the
           description. -->
- [X] Tests cover the change, or no tests are needed (explain why in the description)
- [X] Documentation is updated (link the docs PR here), or no documentation change is needed
- [X] Database migrations are included, or the change touches no database schema
- [X] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
