### PR TITLE
8750 OIDC expected OIDC scope wrongly enforced on externally issued access tokens

### DIFF
--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -952,10 +952,10 @@ def validate_jwt(json_web_token: str, *, session: "Session") -> dict[str, Any]:
         oidc_client = OIDC_CLIENTS[issuer]
         issuer_keys = oidc_client.keyjar.get_issuer_keys(issuer)
         JWS().verify_compact(json_web_token, issuer_keys)
-        # if there is no audience and scope information,
+        # if there is no audience information,
         # try to get it from IdP introspection endpoint
-        # TO-BE-REMOVED - once all IdPs support scope and audience in token claims !!!
-        if not token_dict['authz_scope'] or not token_dict['audience']:
+        # TO-BE-REMOVED - once all IdPs support audience in token claims !!!
+        if not token_dict['audience']:
             clprocess = subprocess.Popen(['curl', '-s', '-L', '-u', '%s:%s'  # noqa: S607
                                           % (oidc_client.client_id, oidc_client.client_secret),
                                           '-d', 'token=%s' % (json_web_token),
@@ -968,9 +968,9 @@ def validate_jwt(json_web_token: str, *, session: "Session") -> dict[str, Any]:
             except Exception:
                 pass
         METRICS.counter(name='JSONWebToken.valid').inc()
-        # if token is valid and coming from known issuer --> check aud and scope and save it if unknown
-        if token_dict['authz_scope'] and token_dict['audience']:
-            if all_oidc_req_claims_present(token_dict['authz_scope'], token_dict['audience'], EXPECTED_OIDC_SCOPE, EXPECTED_OIDC_AUDIENCE):
+        # if token is valid and coming from known issuer --> check aud
+        if token_dict['audience']:
+            if all_oidc_req_claims_present(None, token_dict['audience'], None, EXPECTED_OIDC_AUDIENCE):
                 # save the token in Rucio DB giving the permission to use it for Rucio operations
                 __save_validated_token(json_web_token, token_dict, session=session)
             else:

--- a/lib/rucio/core/oidc.py
+++ b/lib/rucio/core/oidc.py
@@ -920,19 +920,25 @@ def __save_validated_token(token, valid_dict, extra_dict=None, *, session: "Sess
 @transactional_session
 def validate_jwt(json_web_token: str, *, session: "Session") -> dict[str, Any]:
     """
-    Verifies signature and validity of a JSON Web Token.
-    Gets the issuer public keys from the oidc_client
-    and verifies the validity of the token.
-    Used only for external tokens, not known to Rucio DB.
+    Validate an externally-issued JWT access token and save it to the Rucio database.
+
+    This function performs the mandatory validation steps for a Resource Server (RS)
+    as defined in RFC 9068 ("JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens").
+
+    **RFC 9068 §4 (Validating JWT Access Tokens)**:
+    The required checks for a Resource Server are:
+        iss (issuer), aud (audience), exp (expiration), JWT signature.
+
+    Authentication: the Rucio identity is (sub, iss), NOT scope.
 
     :param json_web_token: the JWT string to verify
 
     :returns: dictionary { account: <account name>,
-                           identity: <identity>,
-                           lifetime: <token lifetime>,
-                           audience: <audience>,
-                           authz_scope: <authz_scope> }
-              if successful.
+                        identity: <identity>,
+                        lifetime: <token lifetime>,
+                        audience: <audience>,
+                        authz_scope: <authz_scope> }
+            if successful.
     :raises: CannotAuthenticate if unsuccessful
     """
 


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
Ahere to RFC 9068 §4 (Validating JWT Access Tokens) and remove the scope check in external jwt verification.
check of logic
```
>>> from rucio.common.utils import all_oidc_req_claims_present
>>> from rucio.core.oidc import EXPECTED_OIDC_AUDIENCE, EXPECTED_OIDC_SCOPE
>>> audience = 'rucio-server.jlab.org'
>>> EXPECTED_OIDC_AUDIENCE
'rucio-server.jlab.org'
>>> all_oidc_req_claims_present(None, audience, None, EXPECTED_OIDC_AUDIENCE)
True
```



## Checklist

- [X] This PR closes #8750 
- [X] Tests cover the change, or no tests are needed (explain why in the description)
- [X] Documentation is updated (link the docs PR here), or no documentation change is needed
- [X] Database migrations are included, or the change touches no database schema
- [X] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
