### PR TITLE
fix(packaging): correct script.py.mako path in MANIFEST.server.in

### DIFF
--- a/MANIFEST.server.in
+++ b/MANIFEST.server.in
@@ -10,7 +10,7 @@ include bin/*
 include tools/bootstrap.py
 include tools/reset_database.py
 include tools/merge_rucio_configs.py
-include lib/rucio/db/migrate_repo/script.py.mako
+include lib/rucio/db/sqla/migrate_repo/script.py.mako
 recursive-include lib/rucio/db/sqla/migrate_repo/versions *.py
 recursive-include bin *
 recursive-include etc/ *.template

--- a/tests/test_manifest_paths.py
+++ b/tests/test_manifest_paths.py
@@ -1,0 +1,92 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Sanity checks for the MANIFEST.*.in files used by tools/build_sdist_wheel.sh
+to build the rucio/clients/webui sdists and wheels.
+
+These are plain path-existence checks against the repository working tree,
+so they don't require a database or any running services, unlike most of
+the rest of the test suite.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+MANIFEST_FILES = [
+    "MANIFEST.client.in",
+    "MANIFEST.server.in",
+    "MANIFEST.webui.in",
+]
+
+# Only "include <path>" and "recursive-include <dir> <patterns>" directives name
+# a concrete file or directory that must exist; "prune", "global-exclude" and
+# bare "include MANIFEST.in" (which is a distutils convention, not a repo path)
+# are intentionally not checked here.
+INCLUDE_RE = re.compile(r"^include\s+(?P<path>\S+)\s*$")
+RECURSIVE_INCLUDE_RE = re.compile(r"^recursive-include\s+(?P<path>\S+)\s+")
+
+
+def _referenced_paths(manifest_text):
+    """Yield every concrete file/directory path referenced by an
+    `include` or `recursive-include` directive in a MANIFEST.*.in file."""
+    for line in manifest_text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line == "include MANIFEST.in":
+            # Distutils boilerplate, not a path in this repo.
+            continue
+        m = INCLUDE_RE.match(line)
+        if m:
+            yield m.group("path")
+            continue
+        m = RECURSIVE_INCLUDE_RE.match(line)
+        if m:
+            yield m.group("path")
+
+
+@pytest.mark.parametrize("manifest_name", MANIFEST_FILES)
+def test_manifest_referenced_paths_exist(manifest_name):
+    """Every file/directory referenced by `include`/`recursive-include` in a
+    MANIFEST.*.in file must actually exist in the repository working tree.
+
+    Regression test for the `script.py.mako` migration template being silently
+    dropped from the server sdist/wheel because MANIFEST.server.in referenced
+    the old pre-reorganization path `lib/rucio/db/migrate_repo/script.py.mako`
+    instead of the current `lib/rucio/db/sqla/migrate_repo/script.py.mako`.
+    """
+    manifest_path = REPO_ROOT / manifest_name
+    manifest_text = manifest_path.read_text()
+
+    missing = []
+    for rel_path in _referenced_paths(manifest_text):
+        if "*" in rel_path or "?" in rel_path:
+            # Glob pattern, e.g. "include bin/*": must match at least one file.
+            if not list(REPO_ROOT.glob(rel_path)):
+                missing.append(rel_path)
+            continue
+        # Strip trailing slash used for directories, e.g. "include tests/".
+        candidate = REPO_ROOT / rel_path.rstrip("/")
+        if not candidate.exists():
+            missing.append(rel_path)
+
+    assert not missing, (
+        f"{manifest_name} references path(s) that do not exist in the repo: "
+        f"{missing}"
+    )


### PR DESCRIPTION
## Problem

`MANIFEST.server.in` includes the Alembic/SQLAlchemy migration template `script.py.mako` via:

```
include lib/rucio/db/migrate_repo/script.py.mako
```

But the `migrate_repo` directory was moved under `lib/rucio/db/sqla/` at some point (the sibling line correctly references the new location: `recursive-include lib/rucio/db/sqla/migrate_repo/versions *.py`). The `include` line for `script.py.mako` was never updated, so it points at a path that no longer exists.

`setuptools`/`distutils` silently ignores `include` directives that don't match any file, so this doesn't raise an error during build — it just quietly drops `script.py.mako` from the packaged server sdist/wheel. `tools/build_sdist_wheel.sh` copies `MANIFEST.server.in` to `MANIFEST.in` before invoking `python3 -m build` for the server package, so this manifest directly governs what ships in the published `rucio` package.

Fixes #7325 (the file originally cited there, `MANIFEST.in.rucio`, has since been split into `MANIFEST.client.in` / `MANIFEST.server.in` / `MANIFEST.webui.in`, but the same missing-`sqla/`-segment bug persists in the current `MANIFEST.server.in`).

## Fix

One-line change:

```diff
-include lib/rucio/db/migrate_repo/script.py.mako
+include lib/rucio/db/sqla/migrate_repo/script.py.mako
```

## Test

Added `tests/test_manifest_paths.py`, a small database-independent test (rucio's main `tests/` suite needs a live DB/server environment via `conftest.py`, which isn't appropriate for a pure packaging check). It parses all three `MANIFEST.*.in` files for `include`/`recursive-include` directives and asserts every referenced file, directory, or glob pattern actually resolves against the repo working tree.

- Confirmed the new test fails against the unfixed manifest with the exact original symptom: `MANIFEST.server.in references path(s) that do not exist in the repo: ['lib/rucio/db/migrate_repo/script.py.mako']`.
- Confirmed it passes with the fix applied.
- All 3 parametrized cases (client/server/webui manifests) pass after the fix.
