### PR TITLE
fix: correct mako script path in MANIFEST.server.in

### DIFF
--- a/MANIFEST.server.in
+++ b/MANIFEST.server.in
@@ -10,7 +10,7 @@ include bin/*
 include tools/bootstrap.py
 include tools/reset_database.py
 include tools/merge_rucio_configs.py
-include lib/rucio/db/migrate_repo/script.py.mako
+include lib/rucio/db/sqla/migrate_repo/script.py.mako
 recursive-include lib/rucio/db/sqla/migrate_repo/versions *.py
 recursive-include bin *
 recursive-include etc/ *.template


### PR DESCRIPTION
## Summary

The path referenced in MANIFEST.server.in for the mako migration script was missing the sqla directory segment.

**Before:**
`include lib/rucio/db/migrate_repo/script.py.mako`

**After:**
`include lib/rucio/db/sqla/migrate_repo/script.py.mako`

The correct path can be verified:
- ✅ lib/rucio/db/sqla/migrate_repo/script.py.mako — exists in the repository
- ❌ lib/rucio/db/migrate_repo/script.py.mako — does NOT exist

Without this fix, the mako template is silently omitted from the server distribution package.

Closes #7325