### PR TITLE
fix(Testing): Poll ActiveMQ instead of sleeping for a fixed time in `test_hermes`

### DIFF
--- a/tests/test_hermes.py
+++ b/tests/test_hermes.py
@@ -61,7 +61,7 @@ class MyListener:
         {
             "table_content": [
                 ("hermes", "services_list", "influx,activemq,elastic,email"),
-                ("hermes", "elastic_endpoint", "http://elasticsearch:9200/ddm_events/_bulk"),
+                ("hermes", "elastic_endpoint", "http://elasticsearch:9200/ddm_events/_bulk?refresh=wait_for"),
                 ("hermes", "influxdb_endpoint", "http://influxdb:8086/api/v2/write?org=rucio&bucket=rucio"),
                 ("hermes", "influxdb_token", "mytoken"),
                 ("messaging-hermes", "destination", "/queue/events"),
@@ -78,7 +78,7 @@ class MyListener:
         {
             "table_content": [
                 ("hermes", "services_list", "influx,activemq,elastic,email"),
-                ("hermes", "elastic_endpoint", "http://elasticsearch:9200/ddm_events/_bulk"),
+                ("hermes", "elastic_endpoint", "http://elasticsearch:9200/ddm_events/_bulk?refresh=wait_for"),
                 ("hermes", "influxdb_endpoint", "http://influxdb:8086/api/v2/write?org=rucio&bucket=rucio"),
                 ("hermes", "influxdb_token", "mytoken"),
                 ("messaging-hermes", "destination", "/queue/events"),
@@ -234,7 +234,11 @@ def test_hermes(core_config_mock, caches_mock, monkeypatch):
     messages = retrieve_messages(50, old_mode=False)
     for message in messages:
         service_dict[message["services"]] += 1
-    time.sleep(20)  # Waiting that all the messages are consumed to check ActiveMQ
+    # Wait until ActiveMQ has delivered every expected message or the worst case scenario 20s
+    for i in range(20):
+        if len(listener.messages) >= len(list_messages):
+            break
+        time.sleep(1)
 
     # Checking influxDB
     assert service_dict["influx"] == 0


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description

The test always slept 20s after Hermes so the STOMP listener could collect messages. Delivery is usually immediate, so wait until listener.messages matches the expected count (1s steps, 20s cap). Also added ?refresh=wait_for to the _bulk url so its blocked until the the docs are visible for _search, to avoid race condition. Previously it wasn't required because the code never searched until the 20s hard sleep expired which always avoided the race condition. With this code, we need the safety net, cause we search before any sleep.

Runtime drops from 50s (25x2) to 15s (7.5x2)

## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [x] This PR closes #8778
      <!-- Every PR requires an issue; if none exists yet, please create one
           first. GitHub links the PR to the issue and closes it on merge.
           In the rare case the issue should remain open after the merge,
           write "Related to #____" here instead and briefly say why in the
           description. -->
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
