### PR TITLE
feat(Policies): remove scopes argument from extract_scope function

### DIFF
--- a/lib/rucio/cli/bin_legacy/rucio.py
+++ b/lib/rucio/cli/bin_legacy/rucio.py
@@ -36,7 +36,7 @@ from tabulate import tabulate
 
 # rucio module has the same name as this executable module, so this rule fails. pylint: disable=no-name-in-module
 from rucio import version
-from rucio.cli.utils import RichCLITheme, RichUtils, exception_handler, get_client, get_scope, scope_exists, setup_gfal2_logger, signal_handler
+from rucio.cli.utils import RichCLITheme, RichUtils, exception_handler, get_client, scope_exists, setup_gfal2_logger, signal_handler
 from rucio.common.client import detect_client_location
 from rucio.common.config import config_get, config_get_float
 from rucio.common.constants import ReplicaState
@@ -51,7 +51,7 @@ from rucio.common.exception import (
 )
 from rucio.common.extra import import_extras
 from rucio.common.test_rucio_server import TestRucioServer
-from rucio.common.utils import Color, StoreAndDeprecateWarningAction, chunks, parse_did_filter_from_string, parse_did_filter_from_string_fe, setup_logger, sizefmt
+from rucio.common.utils import Color, StoreAndDeprecateWarningAction, chunks, extract_scope, parse_did_filter_from_string, parse_did_filter_from_string_fe, setup_logger, sizefmt
 
 if TYPE_CHECKING:
     from rucio.common.types import FileToUploadDict
@@ -151,11 +151,11 @@ def list_dataset_replicas(args, client, logger, console, spinner):
         spinner.start()
 
     if len(args.dids) == 1:
-        scope, name = get_scope(args.dids[0], client)
+        scope, name = extract_scope(args.dids[0])
         dmeta = client.get_metadata(scope, name)
         _fetch_datasets_for_meta(meta=dmeta)
     else:
-        extractdids = (get_scope(did, client) for did in args.dids)
+        extractdids = (extract_scope(did) for did in args.dids)
         splitdids = [{'scope': scope, 'name': name} for scope, name in extractdids]
         for dmeta in client.get_metadata_bulk(dids=splitdids):
             _fetch_datasets_for_meta(meta=dmeta)
@@ -225,7 +225,7 @@ def list_file_replicas(args, client, logger, console, spinner):
         spinner.start()
 
     for did in args.dids:
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         client.get_metadata(scope=scope, name=name)  # Break with Exception before streaming replicas if DID does not exist.
         dids.append({'scope': scope, 'name': name})
 
@@ -346,7 +346,7 @@ def add_dataset(args, client, logger, console, spinner):
     Add a dataset identifier.
     """
 
-    scope, name = get_scope(args.did, client)
+    scope, name = extract_scope(args.did)
     client.add_dataset(scope=scope, name=name, statuses={'monotonic': args.monotonic}, lifetime=args.lifetime)
     print('Added %s:%s' % (scope, name))
     return SUCCESS
@@ -360,7 +360,7 @@ def add_container(args, client, logger, console, spinner):
     Add a container identifier.
     """
 
-    scope, name = get_scope(args.did, client)
+    scope, name = extract_scope(args.did)
     client.add_container(scope=scope, name=name, statuses={'monotonic': args.monotonic}, lifetime=args.lifetime)
     print('Added %s:%s' % (scope, name))
     return SUCCESS
@@ -374,7 +374,7 @@ def attach(args, client, logger, console, spinner):
     Attach a data identifier.
     """
 
-    scope, name = get_scope(args.todid, client)
+    scope, name = extract_scope(args.todid)
     dids = args.dids
     limit = 499
 
@@ -388,7 +388,7 @@ def attach(args, client, logger, console, spinner):
             logger.error("Can't open file '" + dids[0] + "'.")
             raise OSError from error
 
-    dids = [{'scope': get_scope(did, client)[0], 'name': get_scope(did, client)[1]} for did in dids]
+    dids = [{'scope': extract_scope(did)[0], 'name': extract_scope(did)[1]} for did in dids]
     if len(dids) <= limit:
         client.attach_dids(scope=scope, name=name, dids=dids)
     else:
@@ -418,10 +418,10 @@ def detach(args, client, logger, console, spinner):
     Detach data identifier.
     """
 
-    scope, name = get_scope(args.fromdid, client)
+    scope, name = extract_scope(args.fromdid)
     dids = []
     for did in args.dids:
-        cscope, cname = get_scope(did, client)
+        cscope, cname = extract_scope(did)
         dids.append({'scope': cscope, 'name': cname})
     client.detach_dids(scope=scope, name=name, dids=dids)
     print('DIDs successfully detached from %s:%s' % (scope, name))
@@ -440,7 +440,7 @@ def list_dids(args, client, logger, console, spinner):
     table_data = []
 
     try:
-        scope, name = get_scope(args.did[0], client)
+        scope, name = extract_scope(args.did[0])
         if name == '':
             name = '*'
     except InvalidObject:
@@ -555,7 +555,7 @@ def list_files(args, client, logger, console, spinner):
 
     if args.csv:
         for did in args.dids:
-            scope, name = get_scope(did, client)
+            scope, name = extract_scope(did)
             for f in client.list_files(scope=scope, name=name):
                 guid = f['guid']
                 if guid:
@@ -588,7 +588,7 @@ def list_files(args, client, logger, console, spinner):
  </File>'''
 
         for did in args.dids:
-            scope, name = get_scope(did, client)
+            scope, name = extract_scope(did)
             for f in client.list_files(scope=scope, name=name):
                 guid = f['guid']
                 if guid:
@@ -613,7 +613,7 @@ def list_files(args, client, logger, console, spinner):
             totfiles = 0
             totsize = 0
             totevents = 0
-            scope, name = get_scope(did, client)
+            scope, name = extract_scope(did)
             for file in client.list_files(scope=scope, name=name):
                 totfiles += 1
                 totsize += int(file['bytes'])
@@ -657,7 +657,7 @@ def list_content(args, client, logger, console, spinner):
         spinner.start()
 
     for did in args.dids:
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         for content in client.list_content(scope=scope, name=name):
             if cli_config == 'rich':
                 table_data.append([f"{content['scope']}:{content['name']}", Text(content['type'].upper(), style=RichCLITheme.DID_TYPE.get(content['type'].upper(), 'default'))])
@@ -692,7 +692,7 @@ def list_content_history(args, client, logger, console, spinner):
         spinner.start()
 
     for did in args.dids:
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         for content in client.list_content_history(scope=scope, name=name):
             if cli_config == 'rich':
                 table_data.append([f"{content['scope']}:{content['name']}", Text(content['type'].upper(), style=RichCLITheme.DID_TYPE.get(content['type'].upper(), 'default'))])
@@ -722,7 +722,7 @@ def list_parent_dids(args, client, logger, console, spinner):
 
     if args.did:
         table_data = []
-        scope, name = get_scope(args.did, client)
+        scope, name = extract_scope(args.did)
         for dataset in client.list_parent_dids(scope=scope, name=name):
             if cli_config == 'rich':
                 table_data.append([f"{dataset['scope']}:{dataset['name']}", Text(dataset['type'], style=RichCLITheme.DID_TYPE.get(dataset['type'], 'default'))])
@@ -749,7 +749,7 @@ def close(args, client, logger, console, spinner):
     """
 
     for did in args.dids:
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         client.set_status(scope=scope, name=name, open=False)
         print(f'{scope}:{name} has been closed.')
     return SUCCESS
@@ -764,7 +764,7 @@ def reopen(args, client, logger, console, spinner):
     """
 
     for did in args.dids:
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         client.set_status(scope=scope, name=name, open=True)
         print(f'{scope}:{name} has been reopened.')
     return SUCCESS
@@ -785,7 +785,7 @@ def stat(args, client, logger, console, spinner):
 
     output = []
     for i, did in enumerate(args.dids):
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         info = client.get_did(scope=scope, name=name, dynamic_depth='DATASET')
         if cli_config == 'rich':
             if i > 0:
@@ -819,7 +819,7 @@ def erase(args, client, logger, console, spinner):
             logger.warning("This command doesn't support wildcards! Skipping DID: %s" % did)
             continue
         try:
-            scope, name = get_scope(did, client)
+            scope, name = extract_scope(did)
         except RucioException as error:
             logger.warning('DID is in wrong format: %s' % did)
             logger.debug('Error: %s' % error)
@@ -1147,7 +1147,7 @@ def get_metadata(args, client, logger, console, spinner):
 
     output = []
     for i, did in enumerate(args.dids):
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         meta = client.get_metadata(scope=scope, name=name, plugin=plugin)
         if cli_config == 'rich':
             if i > 0:
@@ -1180,7 +1180,7 @@ def set_metadata(args, client, logger, console, spinner):
     value = args.value
     if args.key == 'lifetime':
         value = None if args.value.lower() == 'none' else float(args.value)
-    scope, name = get_scope(args.did, client)
+    scope, name = extract_scope(args.did)
     client.set_metadata(scope=scope, name=name, key=args.key, value=value)
     return SUCCESS
 
@@ -1193,7 +1193,7 @@ def delete_metadata(args, client, logger, console, spinner):
     Delete data identifier metadata
     """
 
-    scope, name = get_scope(args.did, client)
+    scope, name = extract_scope(args.did)
     client.delete_metadata(scope=scope, name=name, key=args.key)
     return SUCCESS
 
@@ -1209,7 +1209,7 @@ def add_rule(args, client, logger, console, spinner):
     dids = []
     rule_ids = []
     for did in args.dids:
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         dids.append({'scope': scope, 'name': name})
     try:
         rule_ids = client.add_replication_rule(dids=dids,
@@ -1273,7 +1273,7 @@ def delete_rule(args, client, logger, console, spinner):
         # Otherwise, trying to extract the scope, name from args.rule_id
         if not args.rses:
             raise InputValidationError('A RSE expression must be specified if you do not provide a rule_id but a DID')
-        scope, name = get_scope(args.rule_id, client)
+        scope, name = extract_scope(args.rule_id)
         rules = client.list_did_rules(scope=scope, name=name)
         if args.rule_account is None:
             account = client.account
@@ -1462,16 +1462,16 @@ def list_rules(args, client, logger, console, spinner):
     if args.rule_id:
         rules = [client.get_replication_rule(args.rule_id)]
     elif args.file:
-        scope, name = get_scope(args.file, client)
+        scope, name = extract_scope(args.file)
         rules = client.list_associated_rules_for_file(scope=scope, name=name)
     elif args.traverse:
-        scope, name = get_scope(args.did, client)
+        scope, name = extract_scope(args.did)
         locks = client.get_dataset_locks(scope=scope, name=name)
         rules = []
         for rule_id in list(set([lock['rule_id'] for lock in locks])):
             rules.append(client.get_replication_rule(rule_id))
     elif args.did:
-        scope, name = get_scope(args.did, client)
+        scope, name = extract_scope(args.did)
         meta = client.get_metadata(scope=scope, name=name)
         rules = client.list_did_rules(scope=scope, name=name)
         try:
@@ -1559,7 +1559,7 @@ def list_rules_history(args, client, logger, console, spinner):
         spinner.update(status='Fetching rules history')
         spinner.start()
 
-    scope, name = get_scope(args.did, client)
+    scope, name = extract_scope(args.did)
     table_data = []
     for rule in client.list_replication_rule_full_history(scope, name):
         if rule['rule_id'] not in rule_dict:
@@ -1924,7 +1924,7 @@ def add_lifetime_exception(args, client, logger, console, spinner):
     containers = []
     datasets = []
     for did in dids:
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         dids_list.append({'scope': scope, 'name': name})
     error_summary = {
         "total_dids": {"description": "Total DIDs", "count": len(dids_list)},
@@ -2003,7 +2003,7 @@ def touch(args, client, logger, console, spinner):
     """
 
     for did in args.dids:
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         client.touch(scope, name, args.rse)
 
 

--- a/lib/rucio/cli/bin_legacy/rucio_admin.py
+++ b/lib/rucio/cli/bin_legacy/rucio_admin.py
@@ -33,7 +33,7 @@ from rich.tree import Tree
 from tabulate import tabulate
 
 from rucio import version
-from rucio.cli.utils import RichCLITheme, RichUtils, exception_handler, get_client, get_scope, setup_gfal2_logger, signal_handler
+from rucio.cli.utils import RichCLITheme, RichUtils, exception_handler, get_client, setup_gfal2_logger, signal_handler
 from rucio.common.constants import RseAttr
 from rucio.common.exception import (
     InputValidationError,
@@ -43,7 +43,7 @@ from rucio.common.exception import (
     RucioException,
 )
 from rucio.common.extra import import_extras
-from rucio.common.utils import StoreAndDeprecateWarningAction, chunks, clean_pfns, construct_non_deterministic_pfn, get_bytes_value_from_string, parse_response, render_json, setup_logger, sizefmt
+from rucio.common.utils import StoreAndDeprecateWarningAction, chunks, clean_pfns, construct_non_deterministic_pfn, extract_scope, get_bytes_value_from_string, parse_response, render_json, setup_logger, sizefmt
 from rucio.rse import rsemanager as rsemgr
 
 EXTRA_MODULES = import_extras(['argcomplete'])
@@ -969,7 +969,7 @@ def reevaluate_did_for_subscription(args, client, logger, console, spinner):
 
     """
     for did in args.dids.split(','):
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         client.set_metadata(scope, name, 'is_new', True)
     return SUCCESS
 
@@ -1102,7 +1102,7 @@ def declare_bad_file_replicas(args, client, logger, console, spinner):
     bad_files_pfns = []
     for bad_file in bad_files:
         if bad_file.find('://') == -1:
-            scope, name = get_scope(bad_file, client)
+            scope, name = extract_scope(bad_file)
             did_info = client.get_did(scope, name)
             if did_info['type'].upper() != 'FILE' and not args.allow_collection:
                 msg = f'DID {scope}:{name} is a collection and --allow-collection was not specified.'
@@ -1224,7 +1224,7 @@ def list_pfns(args, client, logger, console, spinner):
     rse = args.rse
     protocol = args.protocol
     for input_did in dids:
-        scope, name = get_scope(input_did, client)
+        scope, name = extract_scope(input_did)
         replicas = [rep for rep in client.list_replicas([{'scope': scope, 'name': name}, ], schemes=[protocol, ])]
         if rse in replicas[0]['rses'] and replicas[0]['rses'][rse]:
             print(replicas[0]['rses'][rse][0])
@@ -1367,7 +1367,7 @@ def set_tombstone(args, client, logger, console, spinner):
     dids = [dids] if ',' not in dids else dids.split(',')
     replicas = []
     for did in dids:
-        scope, name = get_scope(did, client)
+        scope, name = extract_scope(did)
         replicas.append({'scope': scope, 'name': name, 'rse': rse})
     client.set_tombstone(replicas)
     logger.info('Set tombstone successfully on: %s' % args.dids)

--- a/lib/rucio/cli/did.py
+++ b/lib/rucio/cli/did.py
@@ -18,10 +18,10 @@ import click
 from rich.text import Text
 from tabulate import tabulate
 
-from rucio.cli.utils import RichCLITheme, RichUtils, get_scope, scope_exists
+from rucio.cli.utils import RichCLITheme, RichUtils, scope_exists
 from rucio.common.config import config_get
 from rucio.common.exception import InputValidationError, InvalidObject, RucioException
-from rucio.common.utils import chunks, parse_did_filter_from_string_fe
+from rucio.common.utils import chunks, extract_scope, parse_did_filter_from_string_fe
 
 
 @click.group()
@@ -57,7 +57,7 @@ def list_(ctx: click.Context, did_pattern: str, recursive: bool, filter_: str, s
             ctx.obj.spinner.start()
 
         table_data = []
-        scope, name = get_scope(did_pattern, ctx.obj.client)
+        scope, name = extract_scope(did_pattern)
         for dataset in ctx.obj.client.list_parent_dids(scope=scope, name=name):
             if ctx.obj.use_rich:
                 table_data.append([f"{dataset['scope']}:{dataset['name']}", Text(dataset['type'], style=RichCLITheme.DID_TYPE.get(dataset['type'], 'default'))])
@@ -75,7 +75,7 @@ def list_(ctx: click.Context, did_pattern: str, recursive: bool, filter_: str, s
         table_data = []
 
         try:
-            scope, name = get_scope(did_pattern, ctx.obj.client)
+            scope, name = extract_scope(did_pattern)
             if name == '':
                 name = '*'
         except InvalidObject:
@@ -126,7 +126,7 @@ def show(ctx: click.Context, dids: tuple[str, ...]) -> None:
 
     output = []
     for i, did in enumerate(dids):
-        scope, name = get_scope(did, ctx.obj.client)
+        scope, name = extract_scope(did)
         info = ctx.obj.client.get_did(scope=scope, name=name, dynamic_depth='DATASET')
         if ctx.obj.use_rich:
             if i > 0:
@@ -155,7 +155,7 @@ def show(ctx: click.Context, dids: tuple[str, ...]) -> None:
 @click.pass_context
 def add_(ctx: click.Context, did_name: str, dtype: Literal['container', 'dataset'], monotonic: bool, lifetime: Optional[int]) -> None:
     """Create a new collection-type DID"""
-    scope, name = get_scope(did_name, ctx.obj.client)
+    scope, name = extract_scope(did_name)
     if dtype == "container":
         ctx.obj.client.add_container(scope=scope, name=name, statuses={'monotonic': monotonic}, lifetime=lifetime)
     else:
@@ -176,16 +176,16 @@ def update(ctx: click.Context, dids: tuple[str, ...], rse: Optional[str], operat
     if operation == "touch":
         for did in dids:
             # TODO check that RSE is present
-            scope, name = get_scope(did, ctx.obj.client)
+            scope, name = extract_scope(did)
             ctx.obj.client.touch(scope, name, rse)
     elif operation == "open":
         for did in dids:
-            scope, name = get_scope(did, ctx.obj.client)
+            scope, name = extract_scope(did)
             ctx.obj.client.set_status(scope=scope, name=name, open=True)
             print(f'{scope}:{name} has been reopened.')
     elif operation == "close":
         for did in dids:
-            scope, name = get_scope(did, ctx.obj.client)
+            scope, name = extract_scope(did)
             ctx.obj.client.set_status(scope=scope, name=name, open=False)
             print(f'{scope}:{name} has been closed.')
     else:
@@ -207,7 +207,7 @@ def remove(ctx: click.Context, dids: tuple[str, ...], undo: bool) -> None:
             ctx.obj.logger.warning("This command doesn't support wildcards! Skipping DID: %s" % did)
             continue
         try:
-            scope, name = get_scope(did, ctx.obj.client)
+            scope, name = extract_scope(did)
         except RucioException as error:
             ctx.obj.logger.warning('DID is in wrong format: %s' % did)
             ctx.obj.logger.debug('Error: %s' % error)
@@ -247,7 +247,7 @@ def content_history(ctx: click.Context, dids: tuple[str, ...]) -> None:
         ctx.obj.spinner.start()
 
     for did in dids:
-        scope, name = get_scope(did, ctx.obj.client)
+        scope, name = extract_scope(did)
         for content in ctx.obj.client.list_content_history(scope=scope, name=name):
             if ctx.obj.use_rich:
                 table_data.append([f"{content['scope']}:{content['name']}", Text(content['type'].upper(), style=RichCLITheme.DID_TYPE.get(content['type'].upper(), 'default'))])
@@ -269,7 +269,7 @@ def content_history(ctx: click.Context, dids: tuple[str, ...]) -> None:
 @click.pass_context
 def content_add_(ctx: click.Context, to_did: str, from_file: bool, dids: tuple[str, ...]) -> None:
     """Attach a list [dids] of data identifiers (file or collection-type) to another data identifier (collection-type)"""
-    scope, name = get_scope(to_did, ctx.obj.client)
+    scope, name = extract_scope(to_did)
     limit = 499
 
     if from_file:
@@ -284,7 +284,7 @@ def content_add_(ctx: click.Context, to_did: str, from_file: bool, dids: tuple[s
     else:
         dids_list = list(dids)
 
-    did_objs = [{'scope': get_scope(did, ctx.obj.client)[0], 'name': get_scope(did, ctx.obj.client)[1]} for did in dids_list]
+    did_objs = [{'scope': extract_scope(did)[0], 'name': extract_scope(did)[1]} for did in dids_list]
     if len(did_objs) <= limit:
         ctx.obj.client.attach_dids(scope=scope, name=name, dids=did_objs)
     else:
@@ -311,10 +311,10 @@ def content_add_(ctx: click.Context, to_did: str, from_file: bool, dids: tuple[s
 @click.pass_context
 def content_remove(ctx: click.Context, dids: tuple[str, ...], from_did: str) -> None:
     """Detach [dids], a list of DIDs (file or collection-type) from another Data Identifier (collection type)"""
-    scope, name = get_scope(from_did, ctx.obj.client)
+    scope, name = extract_scope(from_did)
     did_objs = []
     for did in dids:
-        cscope, cname = get_scope(did, ctx.obj.client)
+        cscope, cname = extract_scope(did)
         did_objs.append({'scope': cscope, 'name': cname})
     ctx.obj.client.detach_dids(scope=scope, name=name, dids=did_objs)
     print(f'DIDs successfully detached from {scope}:{name}')
@@ -332,7 +332,7 @@ def content_list_(ctx: click.Context, dids: list[str], short: bool) -> None:
         ctx.obj.spinner.start()
 
     for did in dids:
-        scope, name = get_scope(did, ctx.obj.client)
+        scope, name = extract_scope(did)
         for content in ctx.obj.client.list_content(scope=scope, name=name):
             if ctx.obj.use_rich:
                 table_data.append([f"{content['scope']}:{content['name']}", Text(content['type'].upper(), style=RichCLITheme.DID_TYPE.get(content['type'].upper(), 'default'))])
@@ -365,7 +365,7 @@ def metadata_set(ctx: click.Context, did: str, key: str, value: Union[str, float
     """Define metadata for a DID"""
     if key == 'lifetime':
         value = None if value.lower() == 'none' else float(value)  # type: ignore
-    scope, name = get_scope(did, ctx.obj.client)
+    scope, name = extract_scope(did)
     ctx.obj.client.set_metadata(scope=scope, name=name, key=key, value=value)
 
 
@@ -375,7 +375,7 @@ def metadata_set(ctx: click.Context, did: str, key: str, value: Union[str, float
 @click.pass_context
 def metadata_unset(ctx: click.Context, did: str, key: str) -> None:
     """Remove metadata from a DID"""
-    scope, name = get_scope(did, ctx.obj.client)
+    scope, name = extract_scope(did)
     ctx.obj.client.delete_metadata(scope=scope, name=name, key=key)
 
 
@@ -395,7 +395,7 @@ def metadata_list_(ctx: click.Context, dids: tuple[str, ...], plugin: Optional[s
 
     output = []
     for i, did in enumerate(dids):
-        scope, name = get_scope(did, ctx.obj.client)
+        scope, name = extract_scope(did)
         meta = ctx.obj.client.get_metadata(scope=scope, name=name, plugin=plugin)
         if ctx.obj.use_rich:
             if i > 0:

--- a/lib/rucio/cli/replica.py
+++ b/lib/rucio/cli/replica.py
@@ -21,11 +21,11 @@ import click
 import tabulate
 from rich.text import Text
 
-from rucio.cli.utils import RichCLITheme, RichUtils, get_scope
+from rucio.cli.utils import RichCLITheme, RichUtils
 from rucio.common.client import detect_client_location
 from rucio.common.constants import ReplicaState
 from rucio.common.exception import InputValidationError, InvalidObject
-from rucio.common.utils import chunks, clean_pfns, sizefmt
+from rucio.common.utils import chunks, clean_pfns, extract_scope, sizefmt
 
 if TYPE_CHECKING:
 
@@ -99,7 +99,7 @@ def list_(
         ctx.obj.spinner.start()
 
     for did in dids:
-        scope, name = get_scope(did, ctx.obj.client)
+        scope, name = extract_scope(did)
         ctx.obj.client.get_metadata(scope=scope, name=name)  # Break with Exception before streaming replicas if DID does not exist.
         did_list.append({'scope': scope, 'name': name})
 
@@ -257,11 +257,11 @@ def list_dataset(
             ctx.obj.spinner.start()
 
         if len(dids) == 1:
-            scope, name = get_scope(dids[0], ctx.obj.client)
+            scope, name = extract_scope(dids[0])
             dmeta = ctx.obj.client.get_metadata(scope, name)
             _fetch_datasets_for_meta(meta=dmeta)
         else:
-            extractdids = (get_scope(did, ctx.obj.client) for did in dids)
+            extractdids = (extract_scope(did) for did in dids)
             splitdids = [{'scope': scope, 'name': name} for scope, name in extractdids]
             for dmeta in ctx.obj.client.get_metadata_bulk(dids=splitdids):
                 _fetch_datasets_for_meta(meta=dmeta)
@@ -342,7 +342,7 @@ def remove(ctx: click.Context, dids: tuple[str, ...], rse: str) -> None:
     "Set a replica for removal by adding a tombstone which will mark the replica as ready for deletion by a reaper daemon"
     replicas = []
     for did in dids:
-        scope, name = get_scope(did, ctx.obj.client)
+        scope, name = extract_scope(did)
         replicas.append({'scope': scope, 'name': name, 'rse': rse})
     ctx.obj.client.set_tombstone(replicas)
     msg = f'Set tombstone successfully on: {dids}'
@@ -453,7 +453,7 @@ def update_bad(ctx: click.Context, replicas: tuple[str, ...], reason: str, as_fi
     bad_files_pfns = []
     for bad_file in bad_files:
         if bad_file.find('://') == -1:
-            scope, name = get_scope(bad_file, ctx.obj.client)
+            scope, name = extract_scope(bad_file)
             did_info = ctx.obj.client.get_did(scope, name)
             if did_info['type'].upper() != 'FILE' and not collection:
                 msg = f'DID {scope}:{name} is a collection and --allow-collection was not specified.'

--- a/lib/rucio/cli/rule.py
+++ b/lib/rucio/cli/rule.py
@@ -19,9 +19,9 @@ from rich.padding import Padding
 from rich.text import Text
 from tabulate import tabulate
 
-from rucio.cli.utils import RichCLITheme, RichUtils, get_scope
+from rucio.cli.utils import RichCLITheme, RichUtils
 from rucio.common.exception import DuplicateRule, InputValidationError, RucioException
-from rucio.common.utils import sizefmt
+from rucio.common.utils import extract_scope, sizefmt
 
 
 @click.group()
@@ -70,7 +70,7 @@ def add_(
     did_list = []
     rule_ids = []
     for did in dids:
-        scope, name = get_scope(did, ctx.obj.client)
+        scope, name = extract_scope(did)
         did_list.append({'scope': scope, 'name': name})
     try:
         rule_ids = ctx.obj.client.add_replication_rule(
@@ -138,7 +138,7 @@ def remove(ctx: click.Context, rule_id_dids: str, _all: bool, rses: Optional[str
         # Otherwise, trying to extract the scope, name from args.rule_id
         if not rses:
             raise InputValidationError('A RSE expression must be specified if you do not provide a rule_id but a DID')
-        scope, name = get_scope(rule_id_dids, ctx.obj.client)
+        scope, name = extract_scope(rule_id_dids)
         rules = ctx.obj.client.list_did_rules(scope=scope, name=name)
         if account is None:
             account = ctx.obj.client.account
@@ -261,7 +261,7 @@ def history(ctx: click.Context, did: str) -> None:
         ctx.obj.spinner.update(status='Fetching rules history')
         ctx.obj.spinner.start()
 
-    scope, name = get_scope(did, ctx.obj.client)
+    scope, name = extract_scope(did)
     table_data = []
     for rule in ctx.obj.client.list_replication_rule_full_history(scope, name):
         if rule['rule_id'] not in rule_dict:
@@ -385,18 +385,18 @@ def list_(ctx: click.Context, did: Optional[str], traverse: bool, csv: bool, fil
         ctx.obj.spinner.start()
 
     if file:
-        scope, name = get_scope(file, ctx.obj.client)
+        scope, name = extract_scope(file)
         rules = ctx.obj.client.list_associated_rules_for_file(scope=scope, name=name)
     elif traverse:
         if did is None:
             raise InputValidationError("Must supply a DID to traverse")
-        scope, name = get_scope(did, ctx.obj.client)
+        scope, name = extract_scope(did)
         locks = ctx.obj.client.get_dataset_locks(scope=scope, name=name)
         rules = []
         for rule_id in list(set([lock['rule_id'] for lock in locks])):
             rules.append(ctx.obj.client.get_replication_rule(rule_id))
     elif did:
-        scope, name = get_scope(did, ctx.obj.client)
+        scope, name = extract_scope(did)
         meta = ctx.obj.client.get_metadata(scope=scope, name=name)
         rules = ctx.obj.client.list_did_rules(scope=scope, name=name)
         try:

--- a/lib/rucio/cli/utils.py
+++ b/lib/rucio/cli/utils.py
@@ -53,7 +53,7 @@ from rucio.common.exception import (
     ScopeNotFound,
     UnsupportedOperation,
 )
-from rucio.common.utils import extract_scope, setup_logger
+from rucio.common.utils import setup_logger
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -285,25 +285,6 @@ def scope_exists(client: 'Client', scope: str) -> None:
 
     if scope not in scopes:  # type: ignore - handled by the if isinstance
         raise ScopeNotFound
-
-
-def get_scope(did: str, client: Client) -> tuple[str, str]:
-    try:
-        scope, name = extract_scope(did)
-        return scope, name
-    except TypeError:
-        known_scopes = client.list_scopes()
-        if not len(list(known_scopes)):
-            raise ScopeNotFound
-        if isinstance(known_scopes, dict):
-            scopes = known_scopes.get('scope')  # type: ignore - does not accept 'scope' as a Literal['scope']
-            scope, name = extract_scope(did, scopes)
-        elif isinstance(known_scopes, list):
-            scope, name = extract_scope(did, known_scopes)  # type: ignore - Handled by the isinstance
-        else:
-            raise ScopeNotFound
-
-        return scope, name
 
 
 class RichCLITheme:

--- a/lib/rucio/client/downloadclient.py
+++ b/lib/rucio/client/downloadclient.py
@@ -303,7 +303,6 @@ class DownloadClient:
         logger = self.logger
         trace_custom_fields['uuid'] = generate_uuid()
 
-        scopes = self.client.list_scopes()
         logger(logging.INFO, 'Processing %d item(s) for input' % len(items))
         input_items = []
         for item in items:
@@ -322,7 +321,7 @@ class DownloadClient:
                 logger(logging.DEBUG, did_str)
                 raise InputValidationError('Cannot use PFN download with wildcard in DID')
 
-            did_scope, did_name = extract_scope(did_str, scopes)
+            did_scope, did_name = extract_scope(did_str)
             dest_dir_path = self._prepare_dest_dir(item.get('base_dir', '.'), did_scope, item.get('no_subdir'))
 
             item['scope'] = did_scope
@@ -1348,7 +1347,7 @@ class DownloadClient:
             dids = [dids]
 
         for did_str in dids:
-            scope, did_name = extract_scope(did_str, scopes)
+            scope, did_name = extract_scope(did_str)
             filters['name'] = did_name
             any_did_resolved = False
             for did in self.client.list_dids(scope, filters=filters, did_type='all', long=True):

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -570,7 +570,7 @@ class ScopeExtractionAlgorithms(PolicyPackageAlgorithms):
 
         self.vo = vo
 
-    def extract_scope(self, did: str, scopes: Optional['Sequence[str]'], extract_scope_convention: str) -> 'Sequence[str]':
+    def extract_scope(self, did: str, extract_scope_convention: str = 'def') -> 'Sequence[str]':
         """
         Calls the correct algorithm for scope extraction
         """
@@ -579,7 +579,7 @@ class ScopeExtractionAlgorithms(PolicyPackageAlgorithms):
             fn = super()._get_default_algorithm(ScopeExtractionAlgorithms._algorithm_type, self.vo)
         if fn is None:
             fn = self.get_algorithm(extract_scope_convention)
-        return fn(did, scopes)
+        return fn(did)
 
     @classmethod
     def supports(cls: type[ScopeExtractionAlgorithmsT], extract_scope_convention: str) -> bool:
@@ -597,14 +597,14 @@ class ScopeExtractionAlgorithms(PolicyPackageAlgorithms):
         cls.register('dirac', cls.extract_scope_dirac)
 
     @classmethod
-    def get_algorithm(cls: type[ScopeExtractionAlgorithmsT], extract_scope_convention: str) -> 'Callable[[str, Optional[Sequence[str]]], Sequence[str]]':
+    def get_algorithm(cls: type[ScopeExtractionAlgorithmsT], extract_scope_convention: str) -> 'Callable[[str], Sequence[str]]':
         """
         Looks up a scope extraction algorithm by name
         """
         return super()._get_one_algorithm(cls._algorithm_type, extract_scope_convention)
 
     @classmethod
-    def register(cls: type[ScopeExtractionAlgorithmsT], name: str, fn_extract_scope: 'Callable[[str, Optional[Sequence[str]]], Sequence[str]]') -> None:
+    def register(cls: type[ScopeExtractionAlgorithmsT], name: str, fn_extract_scope: 'Callable[[str], Sequence[str]]') -> None:
         """
         Registers a new scope extraction algorithm
         """
@@ -612,12 +612,11 @@ class ScopeExtractionAlgorithms(PolicyPackageAlgorithms):
         super()._register(cls._algorithm_type, algorithm_dict)
 
     @staticmethod
-    def extract_scope_default(did: str, scopes: Optional['Sequence[str]']) -> 'Sequence[str]':
+    def extract_scope_default(did: str) -> 'Sequence[str]':
         """
         Default scope extraction algorithm. Extracts the scope from the DID.
 
         :param did: The DID to extract the scope from.
-        :param scopes: Not used in the default algorithm.
 
         :returns: A tuple containing the extracted scope and the name.
         """
@@ -643,7 +642,7 @@ class ScopeExtractionAlgorithms(PolicyPackageAlgorithms):
         return scope, name
 
     @staticmethod
-    def extract_scope_dirac(did: str, scopes: Optional['Sequence[str]']) -> 'Sequence[str]':
+    def extract_scope_dirac(did: str) -> 'Sequence[str]':
         # Default dirac scope extract algorithm. Scope is the second element in the LFN or the first one (VO name)
         # if only one element is the result of a split.
         elem = did.rstrip('/').split('/')
@@ -659,7 +658,6 @@ ScopeExtractionAlgorithms._module_init_()
 
 def extract_scope(
         did: str,
-        scopes: Optional['Sequence[str]'] = None,
         default_extract: str = 'def',
         vo: str = DEFAULT_VO
 ) -> 'Sequence[str]':
@@ -667,7 +665,7 @@ def extract_scope(
     extract_scope_convention = config_get('common', 'extract_scope', False, None) or config_get('policy', 'extract_scope', False, None)
     if extract_scope_convention is None or not ScopeExtractionAlgorithms.supports(extract_scope_convention):
         extract_scope_convention = default_extract
-    return scope_extraction_algorithms.extract_scope(did, scopes, extract_scope_convention)
+    return scope_extraction_algorithms.extract_scope(did, extract_scope_convention)
 
 
 def pid_exists(pid: int) -> bool:

--- a/lib/rucio/core/dirac.py
+++ b/lib/rucio/core/dirac.py
@@ -28,7 +28,6 @@ from rucio.common.utils import extract_scope
 from rucio.core.did import add_did, attach_dids_to_dids
 from rucio.core.replica import add_replicas
 from rucio.core.rule import add_rule, list_rules, update_rule
-from rucio.core.scope import list_scopes
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import DIDType
 
@@ -101,10 +100,6 @@ def add_files(
     attachments = []
     if not parents_metadata:
         parents_metadata = {}
-    # The list of scopes is necessary for the extract_scope
-    filter_ = {'scope': InternalScope(scope='*', vo=vo)}
-    scopes = list_scopes(filter_=filter_, session=session)
-    scopes = [scope.external for scope in scopes]
     exist_lfn = []
     try:
         config_lifetime: str = config_get(section='dirac', option='lifetime', default='{}', session=session)
@@ -123,7 +118,7 @@ def add_files(
     for lfn in lfns:
         # First check if the file exists
         filename = lfn['lfn']
-        lfn_scope, _ = extract_scope(filename, scopes, vo=vo)  # type: ignore (https://github.com/rucio/rucio/issues/8188)
+        lfn_scope, _ = extract_scope(filename, vo=vo)  # type: ignore (https://github.com/rucio/rucio/issues/8188)
         lfn_scope = InternalScope(lfn_scope, vo=vo)
 
         exists, did_type = _exists(scope=lfn_scope, name=filename, session=session)
@@ -136,7 +131,7 @@ def add_files(
 
         # The parent must be a dataset. Register it as well as the rule
         dsn_name = parents[0]
-        dsn_scope, _ = extract_scope(dsn_name, scopes, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
+        dsn_scope, _ = extract_scope(dsn_name, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
         dsn_scope = InternalScope(dsn_scope, vo=vo)
         dsn_meta = parents_metadata.get(dsn_name, {})
 
@@ -169,7 +164,7 @@ def add_files(
                     session=session)
             exist_lfn.append(dsn_name)
             parent_name = parents[1]
-            parent_scope, _ = extract_scope(parent_name, scopes, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
+            parent_scope, _ = extract_scope(parent_name, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
             parent_scope = InternalScope(parent_scope, vo=vo)
             attachments.append({'scope': parent_scope, 'name': parent_name, 'dids': [{'scope': dsn_scope, 'name': dsn_name}]})
             rule_extension_list.append((dsn_scope, dsn_name))
@@ -214,7 +209,7 @@ def add_files(
 
         # Now loop over the ascendants of the dataset and ensure containers for them
         for parent in parents[1:]:
-            child_scope, _ = extract_scope(parent, scopes, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
+            child_scope, _ = extract_scope(parent, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
             child_scope = InternalScope(child_scope, vo=vo)
             exists, did_type = _exists(scope=child_scope, name=parent, session=session)
             child_meta = parents_metadata.get(parent, {})
@@ -235,7 +230,7 @@ def add_files(
                         session=session)
                 exist_lfn.append(parent)
                 parent_name = parents[parents.index(parent) + 1]
-                parent_scope, _ = extract_scope(parent_name, scopes, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
+                parent_scope, _ = extract_scope(parent_name, vo=vo)  # type: ignore https://github.com/rucio/rucio/issues/8188
                 parent_scope = InternalScope(parent_scope, vo=vo)
                 attachments.append({'scope': parent_scope, 'name': parent_name, 'dids': [{'scope': child_scope, 'name': parent}]})
     # Finally attach everything

--- a/lib/rucio/gateway/dirac.py
+++ b/lib/rucio/gateway/dirac.py
@@ -16,11 +16,9 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from rucio.common.constants import DEFAULT_VO
 from rucio.common.exception import AccessDenied
-from rucio.common.types import InternalScope
 from rucio.common.utils import extract_scope
 from rucio.core import dirac
 from rucio.core.rse import get_rse_id
-from rucio.core.scope import list_scopes
 from rucio.db.sqla.constants import DatabaseOperationType
 from rucio.db.sqla.session import db_session
 from rucio.gateway.permission import has_permission
@@ -51,12 +49,10 @@ def add_files(
     """
 
     with db_session(DatabaseOperationType.WRITE) as session:
-        filter_ = {'scope': InternalScope(scope='*', vo=vo)}
-        scopes = [scope.external for scope in list_scopes(filter_=filter_, session=session)]
         dids = []
         rses = {}
         for lfn in lfns:
-            scope, name = extract_scope(lfn['lfn'], scopes, vo=vo)  # type: ignore (https://github.com/rucio/rucio/issues/8188)
+            scope, name = extract_scope(lfn['lfn'], vo=vo)  # type: ignore (https://github.com/rucio/rucio/issues/8188)
             dids.append({'scope': scope, 'name': name})
             rse = lfn['rse']
             if rse not in rses:

--- a/tests/rucio/common/test_utils.py
+++ b/tests/rucio/common/test_utils.py
@@ -65,4 +65,4 @@ class TestUtils:
         ]
     )
     def test_default_scope_extraction_algorithm(self, did, scope, name):
-        assert ScopeExtractionAlgorithms.extract_scope_default(did=did, scopes=None) == (scope, name)
+        assert ScopeExtractionAlgorithms.extract_scope_default(did=did) == (scope, name)

--- a/tests/test_belleii.py
+++ b/tests/test_belleii.py
@@ -43,8 +43,8 @@ def test_dirac_addfile(rse_factory, did_factory, root_account, did_client, dirac
 
     # Create replicas on rse1 using addfile in mock scope (not lifetime)
     lfns = [{'lfn': did_name_generator('file'), 'rse': rse1, 'bytes': 1, 'adler32': '0cc737eb', 'guid': generate_uuid()} for _ in range(nbfiles)]
-    files = [{'scope': extract_scope(lfn['lfn'], [])[0], 'name': lfn['lfn']} for lfn in lfns]
-    reps = [{'scope': extract_scope(lfn['lfn'], [])[0], 'name': lfn['lfn'], 'rse': rse1} for lfn in lfns]
+    files = [{'scope': extract_scope(lfn['lfn'])[0], 'name': lfn['lfn']} for lfn in lfns]
+    reps = [{'scope': extract_scope(lfn['lfn'])[0], 'name': lfn['lfn'], 'rse': rse1} for lfn in lfns]
     dirac_client.add_files(lfns=lfns, ignore_availability=False)
     replicas = [rep for rep in replica_client.list_replicas(dids=files)]
     for replica in replicas:
@@ -57,7 +57,7 @@ def test_dirac_addfile(rse_factory, did_factory, root_account, did_client, dirac
             parent = "/".join(directories[0:cnt])
             child = "/".join(directories[0:cnt + 1])
             if parent != '':
-                parent_scope, parent_name = extract_scope(parent, [])
+                parent_scope, parent_name = extract_scope(parent)
                 children = [did['name'] for did in did_client.list_content(parent_scope, parent_name)]
                 assert child in children
 
@@ -65,14 +65,14 @@ def test_dirac_addfile(rse_factory, did_factory, root_account, did_client, dirac
     for lfn in lfns:
         # Check dataset rule
         directory = "/".join(lfn['lfn'].split('/')[:-1])
-        scope, name = extract_scope(directory, [])
+        scope, name = extract_scope(directory)
         rules = [rule for rule in did_client.list_did_rules(scope, name)]
         assert len(rules) == 1
         assert rules[0]['rse_expression'] == 'ANY=true'
         assert rules[0]['expires_at'] is None
 
         # Check file rule
-        scope, name = extract_scope(lfn['lfn'], [])
+        scope, name = extract_scope(lfn['lfn'])
         rules = [rule for rule in did_client.list_did_rules(scope, name)]
         assert len(rules) == 1
         assert rules[0]['rse_expression'] == rse1
@@ -84,15 +84,15 @@ def test_dirac_addfile(rse_factory, did_factory, root_account, did_client, dirac
 
     # Create replicas on rse1 using addfile in user scope (30 days lifetime)
     lfns = [{'lfn': did_name_generator('file', name_prefix='user'), 'rse': rse1, 'bytes': 1, 'adler32': '0cc737eb', 'guid': generate_uuid()} for _ in range(nbfiles)]
-    files = [{'scope': extract_scope(lfn['lfn'], [])[0], 'name': lfn['lfn']} for lfn in lfns]
-    reps = [{'scope': extract_scope(lfn['lfn'], [])[0], 'name': lfn['lfn'], 'rse': rse1} for lfn in lfns]
+    files = [{'scope': extract_scope(lfn['lfn'])[0], 'name': lfn['lfn']} for lfn in lfns]
+    reps = [{'scope': extract_scope(lfn['lfn'])[0], 'name': lfn['lfn'], 'rse': rse1} for lfn in lfns]
     dirac_client.add_files(lfns=lfns, ignore_availability=False)
 
     # Check that the default rules are created
     for lfn in lfns:
         # Check dataset rule
         directory = "/".join(lfn['lfn'].split('/')[:-1])
-        scope, name = extract_scope(directory, [])
+        scope, name = extract_scope(directory)
         rules = [rule for rule in did_client.list_did_rules(scope, name)]
         assert len(rules) == 1
         assert rules[0]['rse_expression'] == 'ANY=true'
@@ -111,8 +111,8 @@ def test_dirac_addfile_with_parents_meta(rse_factory, did_factory, root_account,
     lfn_meta = {'events': 10, 'key1': 'value1'}
     # Create replicas on rse1 using addfile in mock scope (not lifetime)
     lfns = [{'lfn': lfn_name, 'rse': rse1, 'bytes': 1, 'adler32': '0cc737eb', 'guid': generate_uuid(), 'meta': lfn_meta}]
-    files = [{'scope': extract_scope(lfn['lfn'], [])[0], 'name': lfn['lfn']} for lfn in lfns]
-    reps = [{'scope': extract_scope(lfn['lfn'], [])[0], 'name': lfn['lfn'], 'rse': rse1} for lfn in lfns]
+    files = [{'scope': extract_scope(lfn['lfn'])[0], 'name': lfn['lfn']} for lfn in lfns]
+    reps = [{'scope': extract_scope(lfn['lfn'])[0], 'name': lfn['lfn'], 'rse': rse1} for lfn in lfns]
     dataset = "/".join(lfns[0]['lfn'].split('/')[:-1])
     container = "/".join(lfns[0]['lfn'].split('/')[:-2])
     dataset_meta = {'project': 'data13_hip', 'run_number': 300000, 'mykey': 'myvalue'}
@@ -125,13 +125,13 @@ def test_dirac_addfile_with_parents_meta(rse_factory, did_factory, root_account,
 
     # check if metadata if properly created for file and parents
     for lfn in lfns:
-        scope, name = extract_scope(lfn['lfn'], [])
+        scope, name = extract_scope(lfn['lfn'])
         metadata = did_client.get_metadata(scope, name, plugin='ALL')
         assert all(item in metadata.items() for item in lfn_meta.items())
-        dsn_scope, dsn_name = extract_scope(dataset, [])
+        dsn_scope, dsn_name = extract_scope(dataset)
         metadata = did_client.get_metadata(dsn_scope, dsn_name, plugin='ALL')
         assert all(item in metadata.items() for item in dataset_meta.items())
-        con_scope, con_name = extract_scope(container, [])
+        con_scope, con_name = extract_scope(container)
         metadata = did_client.get_metadata(con_scope, con_name, plugin='ALL')
         assert all(item in metadata.items() for item in container_meta.items())
 
@@ -141,7 +141,7 @@ def test_belle2_schema(rse_factory, did_factory, root_account, did_client):
     """ BELLE2 SCHEMA (COMMON): Basic tests on Belle II schema """
     bad_paths = ['invalid_name', '/belle/invalid@/did']
     for path in bad_paths:
-        scope, name = extract_scope(path, [])
+        scope, name = extract_scope(path)
         with pytest.raises(InvalidObject):
             validate_schema('did', {'name': name, 'scope': scope, 'type': 'CONTAINER'})
 


### PR DESCRIPTION
Closes: #8188

*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description

This PR removes the 'scopes' argument from the scope extraction functions. This clarifies the code and also improves efficiency since callers no longer need to obtain this list of scopes, which normally involves at least a database query.

This was always an optional argument that defaults to None, and in many instances the argument was not passed in, so implementations will not have been relying on this. However, this will break compatibility with policy packages that implement this function and include the argument in their declaration without a default value. This can be seen in the failing ATLAS and BelleII VO tests. Such packages will need to be updated to work with this change.

Alternatively, we could avoid breaking compatibility and still get the efficiency saving by leaving the argument in place but always passing None. However I think it is cleaner to remove it altogether than to keep an argument that is never actually used.

Corresponding docs PR: https://github.com/rucio/documentation/pull/891

Tests have not been updated as calling the function without the scopes list is already common in the code so we know this works.

<!-- Required. Summarise WHAT this PR changes. The WHY should already be
     covered by the linked issue and its discussion. A sufficiently detailed
     commit message may be reused here. If a checklist item below does not
     apply to this PR, briefly say why here. -->


## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [X] This PR closes #8188 
      <!-- Every PR requires an issue; if none exists yet, please create one
           first. GitHub links the PR to the issue and closes it on merge.
           In the rare case the issue should remain open after the merge,
           write "Related to #____" here instead and briefly say why in the
           description. -->
- [X] Tests cover the change, or no tests are needed (explain why in the description)
- [X] Documentation is updated (link the docs PR here), or no documentation change is needed
- [X] Database migrations are included, or the change touches no database schema
- [X] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
