### PR TITLE
feat(Core): Suspend rules stuck too many times #8743

### DIFF
--- a/lib/rucio/core/lock.py
+++ b/lib/rucio/core/lock.py
@@ -394,6 +394,7 @@ def successful_transfer(scope: InternalScope, name: str, rse_id: str, nowait: bo
             pass
         elif rule.locks_replicating_cnt == 0 and rule.state == RuleState.REPLICATING:
             rule.state = RuleState.OK
+            rucio.core.rule.reset_stuck_state(rule)
             # Try to update the DatasetLocks
             if rule.grouping != RuleGrouping.NONE:
                 stmt = select(

--- a/lib/rucio/core/rule.py
+++ b/lib/rucio/core/rule.py
@@ -36,7 +36,7 @@ import rucio.core.did
 import rucio.core.lock  # import get_replica_locks, get_files_and_replica_locks_of_dataset
 import rucio.core.replica  # import get_and_lock_file_replicas, get_and_lock_file_replicas_for_dataset
 from rucio.common.cache import MemcacheRegion
-from rucio.common.config import config_get
+from rucio.common.config import config_get, config_get_int
 from rucio.common.constants import DEFAULT_ACTIVITY, DEFAULT_VO, POLICY_ALGORITHM_TYPES_LITERAL, RseAttr
 from rucio.common.exception import (
     DataIdentifierNotFound,
@@ -1250,6 +1250,39 @@ def delete_rule(
             transfer_core.cancel_transfers(transfers_to_cancel)
 
 
+def reset_stuck_state(rule: models.ReplicationRule) -> None:
+    """
+    Reset the STUCK bookkeeping when a rule reaches OK; not on REPLICATING.
+
+    :param rule: The rule object.
+    """
+    rule.stuck_at = None
+    rule.stuck_cnt = 0
+
+
+@read_session
+def _stuck_rule_suspend_reason(
+    rule: models.ReplicationRule,
+    *,
+    session: "Session"
+) -> Optional[str]:
+    """
+    Suspend after two weeks STUCK, or `rules/stuck_cnt_to_suspend` attempts if set.
+
+    :param rule:    The rule object.
+    :param session: The database session in use.
+    :returns:       A short description of the criterion that fired, or None.
+    """
+    if rule.stuck_at is not None and rule.stuck_at < (datetime.utcnow() - timedelta(days=14)):
+        return 'STUCK since %s' % rule.stuck_at
+
+    stuck_cnt_to_suspend = config_get_int('rules', 'stuck_cnt_to_suspend', default=0, session=session)
+    if stuck_cnt_to_suspend > 0 and (rule.stuck_cnt or 0) >= stuck_cnt_to_suspend:
+        return 'STUCK after %d repair attempts' % rule.stuck_cnt
+
+    return None
+
+
 @transactional_session
 def repair_rule(
     rule_id: str,
@@ -1286,13 +1319,14 @@ def repair_rule(
         rule = session.execute(stmt).scalar_one()
         rule.updated_at = datetime.utcnow()
 
-        # Check if rule is longer than 2 weeks in STUCK
+        # STUCK for too long, or too many attempts?
         if rule.stuck_at is None:
             rule.stuck_at = datetime.utcnow()
-        if rule.stuck_at < (datetime.utcnow() - timedelta(days=14)):
+        suspend_reason = _stuck_rule_suspend_reason(rule, session=session)
+        if suspend_reason is not None:
             rule.state = RuleState.SUSPENDED
             insert_rule_history(rule=rule, recent=True, longterm=False, session=session)
-            logger(logging.INFO, 'Replication rule %s has been SUSPENDED', rule_id)
+            logger(logging.INFO, 'Replication rule %s has been SUSPENDED (%s)', rule_id, suspend_reason)
             return
 
         # Evaluate the RSE expression to see if there is an alternative RSE anyway
@@ -1561,10 +1595,9 @@ def repair_rule(
                     models.DatasetLock.state: LockState.STUCK
                 })
                 session.execute(stmt)
-            # TODO: Increase some kind of Stuck Counter here, The rule should at some point be SUSPENDED
+            # Keep stuck_at across the episode, count the attempt
+            rule.stuck_cnt = (rule.stuck_cnt or 0) + 1
             return
-
-        rule.stuck_at = None
 
         if rule.locks_replicating_cnt > 0:
             logger(logging.INFO, 'Rule %s [%d/%d/%d] state=REPLICATING', str(rule.id), rule.locks_ok_cnt, rule.locks_replicating_cnt, rule.locks_stuck_cnt)
@@ -1586,6 +1619,7 @@ def repair_rule(
 
         rule.state = RuleState.OK
         rule.error = None
+        reset_stuck_state(rule)
         # Insert rule history
         insert_rule_history(rule=rule, recent=True, longterm=False, session=session)
         logger(logging.INFO, 'Rule %s [%d/%d/%d] state=OK', str(rule.id), rule.locks_ok_cnt, rule.locks_replicating_cnt, rule.locks_stuck_cnt)
@@ -2517,6 +2551,7 @@ def update_rules_for_lost_replica(
             pass
         elif rule.locks_replicating_cnt == 0 and rule.locks_stuck_cnt == 0:
             rule.state = RuleState.OK
+            reset_stuck_state(rule)
             if rule.grouping != RuleGrouping.NONE:
                 stmt = update(
                     models.DatasetLock
@@ -3554,6 +3589,7 @@ def __evaluate_did_detach(
                 pass
             elif rule.locks_replicating_cnt == 0 and rule.locks_stuck_cnt == 0:
                 rule.state = RuleState.OK
+                reset_stuck_state(rule)
                 if rule.grouping != RuleGrouping.NONE:
                     stmt = update(
                         models.DatasetLock
@@ -3839,6 +3875,7 @@ def __evaluate_did_attach(
                                 session.execute(stmt)
                         elif rule.locks_replicating_cnt == 0 and rule.locks_stuck_cnt == 0:
                             rule.state = RuleState.OK
+                            reset_stuck_state(rule)
                             if rule.grouping != RuleGrouping.NONE:
                                 stmt = update(
                                     models.DatasetLock

--- a/lib/rucio/db/sqla/migrate_repo/versions/1f4a1b2c3d4e_added_stuck_cnt_column_to_rules.py
+++ b/lib/rucio/db/sqla/migrate_repo/versions/1f4a1b2c3d4e_added_stuck_cnt_column_to_rules.py
@@ -1,0 +1,43 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+''' added stuck_cnt column to rules '''
+
+import sqlalchemy as sa
+from alembic import context
+from alembic.op import add_column, drop_column
+
+# Alembic revision identifiers
+revision = '1f4a1b2c3d4e'
+down_revision = '3b943000da18'
+
+
+def upgrade():
+    '''
+    Upgrade the database to this revision
+    '''
+
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        schema = context.get_context().version_table_schema if context.get_context().version_table_schema else ''
+        add_column('rules', sa.Column('stuck_cnt', sa.Integer, server_default='0'), schema=schema)
+
+
+def downgrade():
+    '''
+    Downgrade the database to the previous revision
+    '''
+
+    if context.get_context().dialect.name in ['oracle', 'mysql', 'postgresql']:
+        schema = context.get_context().version_table_schema if context.get_context().version_table_schema else ''
+        drop_column('rules', 'stuck_cnt', schema=schema)

--- a/lib/rucio/db/sqla/models.py
+++ b/lib/rucio/db/sqla/models.py
@@ -1202,6 +1202,7 @@ class ReplicationRule(BASE, ModelBase):
                                                                 values_callable=lambda obj: [e.value for e in obj]),
                                                            default=RuleNotification.NO)
     stuck_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    stuck_cnt: Mapped[int] = mapped_column(Integer, default=0)
     purge_replicas: Mapped[bool] = mapped_column(Boolean(name='RULES_PURGE_REPLICAS_CHK', create_constraint=True),
                                                  default=False)
     ignore_availability: Mapped[bool] = mapped_column(Boolean(name='RULES_IGNORE_AVAILABILITY_CHK', create_constraint=True),

--- a/tests/test_rule_stuck.py
+++ b/tests/test_rule_stuck.py
@@ -1,0 +1,62 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from rucio.core.rule import _stuck_rule_suspend_reason, reset_stuck_state
+from rucio.db.sqla import models
+
+
+def _rule(stuck_days_ago=None, stuck_cnt=0):
+    rule = models.ReplicationRule()
+    rule.stuck_at = None if stuck_days_ago is None else datetime.utcnow() - timedelta(days=stuck_days_ago)
+    rule.stuck_cnt = stuck_cnt
+    return rule
+
+
+class TestStuckRuleSuspension:
+    """
+    The STUCK -> SUSPENDED decision, rucio#8743
+    """
+
+    def test_two_week_timer_still_suspends(self, db_session):
+        """ REPLICATION RULE (CORE): A rule STUCK for more than two weeks is suspended """
+        assert _stuck_rule_suspend_reason(_rule(stuck_days_ago=1), session=db_session) is None
+        assert _stuck_rule_suspend_reason(_rule(stuck_days_ago=15), session=db_session) is not None
+
+    def test_attempt_counter_is_off_by_default(self, db_session):
+        """ REPLICATION RULE (CORE): The attempt based policy does nothing unless it is configured """
+        assert _stuck_rule_suspend_reason(_rule(stuck_days_ago=1, stuck_cnt=99), session=db_session) is None
+
+    @pytest.mark.parametrize("core_config_mock", [{"table_content": [
+        ('rules', 'stuck_cnt_to_suspend', 3),
+    ]}], indirect=True)
+    @pytest.mark.parametrize("caches_mock", [{"caches_to_mock": [
+        'rucio.core.config.REGION',
+    ]}], indirect=True)
+    def test_attempt_counter_suspends_when_configured(self, db_session, core_config_mock, caches_mock):
+        """ REPLICATION RULE (CORE): A rule that stays STUCK for too many repair attempts is suspended """
+        assert _stuck_rule_suspend_reason(_rule(stuck_days_ago=1, stuck_cnt=2), session=db_session) is None
+        assert _stuck_rule_suspend_reason(_rule(stuck_days_ago=1, stuck_cnt=3), session=db_session) is not None
+        assert _stuck_rule_suspend_reason(_rule(stuck_days_ago=1, stuck_cnt=5), session=db_session) is not None
+
+    def test_reset_forgets_the_stuck_history(self, db_session):
+        """ REPLICATION RULE (CORE): Reaching OK clears both the timer and the attempt counter """
+        rule = _rule(stuck_days_ago=15, stuck_cnt=7)
+        reset_stuck_state(rule)
+        assert rule.stuck_at is None
+        assert rule.stuck_cnt == 0
+        assert _stuck_rule_suspend_reason(rule, session=db_session) is None


### PR DESCRIPTION
Addresses #8743.

What was fixed: `repair_rule` cleared `stuck_at` as soon as the rule was no longer STUCK,
including when it only went back to REPLICATING. Nothing counted the repair attempts either,
and the line still has the old comment `# TODO: Increase some kind of Stuck Counter here`.

Outcome: `stuck_at` is now cleared only when the rule reaches OK. That is done by
`reset_stuck_state`, called from the five places where a rule becomes OK (four in
`core/rule.py`, one in `core/lock.py`), so the 14 day timer covers the whole time the rule was
stuck. A new `rules.stuck_cnt` column counts the repair attempts that left the rule STUCK, and
the rule is suspended once that count reaches `rules/stuck_cnt_to_suspend`. That setting is 0
by default, so nothing changes unless it is set, and the 14 day rule still works as before.
`_stuck_rule_suspend_reason` makes the choice, and the reason it gives is printed in the log.

Before and after, for a rule flipping between STUCK and REPLICATING:

    before:  stuck_at reset on every flip, so "STUCK for 14 days" is never true and the rule
             loops indefinitely
    after:   Replication rule <id> has been SUSPENDED (STUCK since <date>)
    cnt = 3: Replication rule <id> has been SUSPENDED (STUCK after 3 repair attempts)

`tests/test_rule_stuck.py` covers the four cases, as a separate module because `test_rule.py`
builds a `RuleClient()` at import time and needs a running server.