### PR TITLE
fix(Clients): Use a custom type to handle null/bool/str union types

### DIFF
--- a/lib/rucio/cli/rse.py
+++ b/lib/rucio/cli/rse.py
@@ -19,7 +19,7 @@ from rich.padding import Padding
 from rich.text import Text
 from rich.tree import Tree
 
-from rucio.cli.utils import RichCLITheme, RichUtils
+from rucio.cli.utils import RichCLITheme, RichUtils, StrOrBoolType
 from rucio.common.exception import InputValidationError
 from rucio.common.utils import sizefmt
 
@@ -203,7 +203,7 @@ def remove(ctx: click.Context, rse_name: str) -> None:
 @rse.command("update")
 @click.argument("rse-name")
 @click.option('--key', help='Setting key', required=True)
-@click.option('--value', help='Setting value', required=True)
+@click.option('--value', help='Setting value', required=True, type=StrOrBoolType())
 @click.pass_context
 def update(ctx: click.Context, rse_name: str, key: str, value: str) -> None:
     """
@@ -213,14 +213,8 @@ def update(ctx: click.Context, rse_name: str, key: str, value: str) -> None:
     Example:
         $ rucio rse update my-rse --option availability_write True
     """
-    param_value = value
-    if value in ['true', 'True', 'TRUE', '1']:
-        param_value = True
-    if value in ['false', 'False', 'FALSE', '0']:
-        param_value = False
-    params = {key: param_value}
+    params = {key: value}
     ctx.obj.client.update_rse(rse_name, parameters=params)
-
     print_value = value if str(value).lower() not in ['', 'none', 'null'] else '[WIPED]'
     print(f'Updated RSE {rse_name} settings {key} to {print_value}')
 

--- a/lib/rucio/cli/utils.py
+++ b/lib/rucio/cli/utils.py
@@ -256,6 +256,25 @@ class Arguments(dict):
     __delattr__ = dict.__delitem__
 
 
+class StrOrBoolType(click.ParamType):
+    name = "text|bool"
+
+    def convert(
+            self,
+            value: Union[str, bool, None],
+            param: "Optional[click.Parameter]",
+            ctx: "Optional[click.Context]",
+    ) -> Optional[Union[str, bool]]:
+        if value is None:
+            return None
+        try:
+            return click.BOOL.convert(value, param, ctx)
+        except click.BadParameter:
+            if isinstance(value, str):
+                return value
+            raise
+
+
 class JSONType(click.ParamType):
     name = "json"
 

--- a/tests/test_cli_client_structure.py
+++ b/tests/test_cli_client_structure.py
@@ -22,6 +22,7 @@ import pytest
 from click.testing import CliRunner
 
 from rucio.cli.command import main as rucio_cli
+from rucio.cli.utils import StrOrBoolType
 from rucio.common.exception import RucioException
 from rucio.common.utils import generate_uuid
 from rucio.tests.common import account_name_generator, execute, file_generator, rse_name_generator, scope_name_generator, with_each_cli_renderer
@@ -1158,3 +1159,16 @@ def test_rse_distance_bidirectional(rucio_client, rse_factory):
     assert exitcode == 0
     assert rucio_client.get_distance(rse_name_6, rse_name_5)[0]['distance'] == distance
     assert rucio_client.get_distance(rse_name_5, rse_name_6)[0]['distance'] == distance
+
+
+@pytest.mark.parametrize(
+        "input_value, expected_result",
+        [
+            ("true", True), ("True", True), ("t", True), ("1", True), (None, None),
+            ("false", False), ("False", False), ("f", False), ("0", False),
+            ("Hello", "Hello"), ("Value", "Value"), ("12345", "12345"), ("gdklf", "gdklf")
+         ]
+)
+def test_str_or_bool_type(input_value, expected_result):
+    t = StrOrBoolType()
+    assert t.convert(input_value, None, None) == expected_result


### PR DESCRIPTION
*By submitting this PR, I confirm I have followed the [Contributing Guide](https://rucio.cern.ch/documentation/contributing/).*

## Description
Introduces a custom subclass of `click.ParamType` that if a type can be handled as a bool, uses it as a bool, or otherwise treats it as a string. Applies this new subclass to the `--value` parameter of `rucio rse update` to avoid doing parsing in the command. 

AI (qwen3.8-30b) was used to help identify places where this type could be used and double check that `rse update` was the only dropin replacement. 

## Checklist
<!-- Every box should be ticked before merge. Tick a box if the item is done
     OR does not apply to this PR (briefly say why in the description). -->

- [x] This PR Closes: #8453
- [x] Tests cover the change, or no tests are needed (explain why in the description)
- [x] Documentation is updated (link the docs PR here), or no documentation change is needed
- [x] Database migrations are included, or the change touches no database schema
- [x] This PR contains no breaking changes, or the breaking change is described
      in the description and the commit follows conventional commits

## Notes for contributors

- **Commit trailers**: Please also link the issue in the commit message (see
  the Contributing Guide): use `Closes: #____` on the commit that resolves
  the issue, and `Issue: #____` on intermediate commits or if the issue
  should remain open.
- **Reviewer**: After submitting, assign a reviewer if you know who is
  appropriate for the touched components; otherwise leave it empty and one
  will be assigned.
- **Stale PRs**: PRs with failing tests or an unresponsive author will be
  closed promptly.

## Additional notes for reviewer

*Note: This OPTIONAL section is only relevant for the REVIEWER, please leave it in the PR*

<details>
<summary>Reviewer template </summary>
Reviewers should copy&paste the code-block below and fill it out for APPROVED pull requests.
If the PR does not meet the standards the project sets out, the reasons should be WELL EXPLAINED in a CHANGE REQUEST (The answers below do not need to be answered in that case)

- **Confidence in review**: I am confident in my review concerning the components this PR touches: [*High 🟢, Medium 🟡 Low 🔴*]
- **Confidence in scope**: I am confident that this fits into the scope of the project and should be included: [*High 🟢, Medium 🟡, Low 🔴*]
  - For Medium and Low, explain in notes why this should be included
- **Quality**: The approach is sound, maintainable and addresses the issue in the best way: [*Agree 🟢*]
- **Security**: This PR does NOT require increased attention in terms of security (E.g. new dependencies): [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes.
- **Backwards compatibility**: This PR does NOT introduce backwards compatibility breaking changes: [*Agree 🟢, Disagree 🔴*]
  - If *Disagree* explain in notes
- **Testing**: This PR is well tested: [*Agree 🟢*]
- **Documentation**: Relevant documentation or comments are updated or not required: [*Agree 🟢*]



```
- **Confidence in review**: High 🟢 Medium 🟡 Low 🔴
- **Confidence in scope**: High 🟢 Medium 🟡 Low 🔴
- **Quality**: Agree 🟢
- **Security**: Agree 🟢 Disagree 🔴
- **Backwards compatibility**: Agree 🟢 Disagree 🔴
- **Testing**: Agree 🟢
- **Documentation**: Agree 🟢

# Notes for merger



```
</details>
